### PR TITLE
fix(kanban): add atomic expected-state mutation guards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -74,6 +74,9 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "started_at": t.started_at,
         "completed_at": t.completed_at,
         "result": t.result,
+        "current_run_id": t.current_run_id,
+        "claim_lock": t.claim_lock,
+        "claim_expires": t.claim_expires,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
         "model_override": t.model_override,
@@ -117,6 +120,212 @@ def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
         f"unknown --workspace value {value!r}: use scratch, worktree, "
         "worktree:<path>, or dir:<path>"
     )
+
+
+_EXPECT_NULL_WORDS = {"none", "null", "-"}
+_EXPECT_FIELDS = frozenset(
+    {"status", "assignee", "run", "claim", "dependencies", "event"}
+)
+
+
+def _add_expected_state_args(
+    parser: argparse.ArgumentParser, *, primary: bool = True
+) -> None:
+    """Add public compare-and-set options to a mutation parser."""
+    if primary:
+        parser.add_argument(
+            "--expect-status",
+            choices=sorted(kb.VALID_STATUSES),
+            default=None,
+            help="Require the target task's exact status",
+        )
+        parser.add_argument(
+            "--expect-assignee",
+            default=None,
+            metavar="PROFILE|none",
+            help="Require the exact assignee; use 'none' for unassigned",
+        )
+        parser.add_argument(
+            "--expect-run",
+            default=None,
+            metavar="RUN_ID|none",
+            help="Require the exact current run id; use 'none' for no run",
+        )
+        parser.add_argument(
+            "--expect-claim",
+            default=None,
+            metavar="CLAIM|none",
+            help="Require the exact claim lock; use 'none' for no claim",
+        )
+        parser.add_argument(
+            "--expect-dependencies",
+            default=None,
+            metavar="JSON",
+            help=(
+                "Require the exact sorted parent snapshot as JSON, e.g. "
+                "'[{\"id\":\"t_parent\",\"status\":\"done\"}]' or '[]'"
+            ),
+        )
+        parser.add_argument(
+            "--expect-event",
+            default=None,
+            metavar="EVENT_ID|none",
+            help="Require the latest task-event id; use 'none' for no events",
+        )
+    parser.add_argument(
+        "--expect-task-state",
+        action="append",
+        default=[],
+        metavar="TASK_ID=JSON",
+        help=(
+            "Require state for an additional involved task (repeatable). JSON "
+            "fields: status, assignee, run, claim, dependencies, event"
+        ),
+    )
+
+
+def _parse_expected_nullable_int(raw: str, option: str) -> Optional[int]:
+    if raw.strip().lower() in _EXPECT_NULL_WORDS:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{option} must be an integer or 'none'") from exc
+    if value < 0:
+        raise ValueError(f"{option} must be >= 0 or 'none'")
+    return value
+
+
+def _normalize_dependency_snapshot(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise ValueError("expected dependencies must be a JSON array")
+    normalized: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, dict) or set(item) != {"id", "status"}:
+            raise ValueError(
+                "each expected dependency must contain exactly 'id' and 'status'"
+            )
+        raw_task_id = item.get("id")
+        raw_status = item.get("status")
+        if not isinstance(raw_task_id, str) or not raw_task_id.strip():
+            raise ValueError(f"expected dependency {index} has an invalid id")
+        if not isinstance(raw_status, str) or raw_status not in kb.VALID_STATUSES:
+            raise ValueError(
+                f"expected dependency {raw_task_id} has invalid status {raw_status!r}"
+            )
+        task_id = raw_task_id.strip()
+        status = raw_status
+        if task_id in seen:
+            raise ValueError(f"duplicate expected dependency {task_id}")
+        seen.add(task_id)
+        normalized.append({"id": task_id, "status": status})
+    return sorted(normalized, key=lambda item: item["id"])
+
+
+def _normalize_expected_spec(spec: Any) -> dict[str, Any]:
+    if not isinstance(spec, dict) or not spec:
+        raise ValueError("expected task state must be a non-empty JSON object")
+    unknown = sorted(set(spec) - _EXPECT_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown expected-state field(s): {', '.join(unknown)}")
+    normalized: dict[str, Any] = {}
+    for field_name, value in spec.items():
+        if field_name == "status":
+            if value not in kb.VALID_STATUSES:
+                raise ValueError(f"invalid expected status {value!r}")
+        elif field_name == "assignee":
+            if isinstance(value, str) and value.strip().lower() in _EXPECT_NULL_WORDS:
+                value = None
+            elif value is not None:
+                if not isinstance(value, str) or not value.strip():
+                    raise ValueError("expected assignee must be a profile name or null")
+                value = kb._canonical_assignee(value)
+        elif field_name in {"run", "event"}:
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(
+                    f"expected {field_name} must be a non-negative integer or null"
+                )
+        elif field_name == "claim":
+            if isinstance(value, str) and value.strip().lower() in _EXPECT_NULL_WORDS:
+                value = None
+            elif value is not None and (not isinstance(value, str) or not value):
+                raise ValueError("expected claim must be a string or null")
+        elif field_name == "dependencies":
+            value = _normalize_dependency_snapshot(value)
+        normalized[field_name] = value
+    return normalized
+
+
+def _merge_expected_spec(
+    states: dict[str, dict[str, Any]], task_id: str, spec: dict[str, Any]
+) -> None:
+    current = states.setdefault(task_id, {})
+    for field_name, value in spec.items():
+        if field_name in current and current[field_name] != value:
+            raise ValueError(
+                f"conflicting expected {field_name} values for {task_id}"
+            )
+        current[field_name] = value
+
+
+def _expected_states_from_args(
+    args: argparse.Namespace,
+    *,
+    primary_id: Optional[str],
+    allowed_ids: set[str],
+) -> Optional[dict[str, dict[str, Any]]]:
+    states: dict[str, dict[str, Any]] = {}
+    for raw in getattr(args, "expect_task_state", None) or []:
+        task_id, sep, raw_json = raw.partition("=")
+        task_id = task_id.strip()
+        if not sep or not task_id or not raw_json.strip():
+            raise ValueError("--expect-task-state must use TASK_ID=JSON syntax")
+        try:
+            parsed = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"invalid --expect-task-state JSON for {task_id}: {exc.msg}"
+            ) from exc
+        _merge_expected_spec(states, task_id, _normalize_expected_spec(parsed))
+
+    primary: dict[str, Any] = {}
+    if getattr(args, "expect_status", None) is not None:
+        primary["status"] = args.expect_status
+    if getattr(args, "expect_assignee", None) is not None:
+        raw = args.expect_assignee.strip()
+        primary["assignee"] = (
+            None if raw.lower() in _EXPECT_NULL_WORDS else kb._canonical_assignee(raw)
+        )
+    if getattr(args, "expect_run", None) is not None:
+        primary["run"] = _parse_expected_nullable_int(args.expect_run, "--expect-run")
+    if getattr(args, "expect_claim", None) is not None:
+        raw = args.expect_claim
+        primary["claim"] = None if raw.lower() in _EXPECT_NULL_WORDS else raw
+    if getattr(args, "expect_dependencies", None) is not None:
+        try:
+            deps = json.loads(args.expect_dependencies)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid --expect-dependencies JSON: {exc.msg}") from exc
+        primary["dependencies"] = _normalize_dependency_snapshot(deps)
+    if getattr(args, "expect_event", None) is not None:
+        primary["event"] = _parse_expected_nullable_int(
+            args.expect_event, "--expect-event"
+        )
+    if primary:
+        if primary_id is None:
+            raise ValueError("primary expected-state options are not valid here")
+        _merge_expected_spec(states, primary_id, primary)
+
+    unexpected_ids = sorted(set(states) - allowed_ids)
+    if unexpected_ids:
+        raise ValueError(
+            "expected state supplied for task(s) not involved in this mutation: "
+            + ", ".join(unexpected_ids)
+        )
+    return states or None
 
 
 def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
@@ -400,6 +609,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "that require immediate human ops (R3 gate) "
                                "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
+    _add_expected_state_args(p_create, primary=False)
 
     # --- swarm ---
     p_swarm = sub.add_parser(
@@ -477,6 +687,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
     p_assign.add_argument("task_id")
     p_assign.add_argument("profile", help="Profile name (or 'none' to unassign)")
+    _add_expected_state_args(p_assign)
 
     # --- set-model (per-task model/provider override) ---
     p_set_model = sub.add_parser(
@@ -523,6 +734,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--reason", default=None,
         help="Human-readable reason (recorded on the reclaimed event)",
     )
+    _add_expected_state_args(p_reassign)
 
     # --- diagnostics (board-wide health) ---
     p_diag = sub.add_parser(
@@ -550,9 +762,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    _add_expected_state_args(p_link)
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
+    _add_expected_state_args(p_unlink)
 
     # --- claim ---
     p_claim = sub.add_parser(
@@ -571,6 +785,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                            help="Author name (default: $HERMES_PROFILE or 'user')")
     p_comment.add_argument("--max-len", type=int, default=None,
                            help="Trim the stored comment body to this many characters")
+    _add_expected_state_args(p_comment)
 
     # --- attach / attachments / attach-rm ---
     p_attach = sub.add_parser("attach", help="Attach a local file to a task")
@@ -600,6 +815,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_complete.add_argument("--metadata", default=None,
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
+    p_complete.add_argument(
+        "--scheduled-gate",
+        action="store_true",
+        help=(
+            "Atomically complete a scheduled coordination gate without "
+            "promoting it to ready; refuses live claims/runs"
+        ),
+    )
+    _add_expected_state_args(p_complete)
 
     p_edit = sub.add_parser(
         "edit",
@@ -637,12 +861,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
+    _add_expected_state_args(p_block)
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
     p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
     p_schedule.add_argument("--ids", nargs="+", default=None,
                             help="Additional task ids to schedule with the same reason (bulk mode)")
+    _add_expected_state_args(p_schedule)
 
     p_unblock = sub.add_parser(
         "unblock",
@@ -654,6 +880,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
     )
     p_unblock.add_argument("task_ids", nargs="+")
+    _add_expected_state_args(p_unblock)
 
     p_promote = sub.add_parser(
         "promote",
@@ -687,6 +914,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         action="store_true",
         help="Emit machine-readable JSON result",
     )
+    _add_expected_state_args(p_promote)
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
@@ -884,6 +1112,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         action="store_true",
         help="Emit one JSON object per task on stdout",
     )
+    _add_expected_state_args(p_specify)
 
     # --- decompose --- (triage → fan-out via auxiliary LLM + orchestrator)
     p_decompose = sub.add_parser(
@@ -1091,6 +1320,12 @@ def kanban_command(args: argparse.Namespace) -> int:
             return 2
         try:
             return int(handler(args) or 0)
+        except kb.KanbanStateConflict as exc:
+            print(
+                json.dumps(exc.as_dict(), ensure_ascii=False, sort_keys=True),
+                file=sys.stderr,
+            )
+            return 3
         except (ValueError, RuntimeError) as exc:
             print(f"kanban: {exc}", file=sys.stderr)
             return 1
@@ -1495,6 +1730,12 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    parents = tuple(args.parent or ())
+    expected_states = _expected_states_from_args(
+        args,
+        primary_id=None,
+        allowed_ids=set(parents),
+    )
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1508,7 +1749,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             project_id=getattr(args, "project", None),
             tenant=args.tenant,
             priority=args.priority,
-            parents=tuple(args.parent or ()),
+            parents=parents,
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
@@ -1519,6 +1760,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            expected_states=expected_states,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1632,6 +1874,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         comments = kb.list_comments(conn, args.task_id)
         events = kb.list_events(conn, args.task_id)
         parents = kb.parent_ids(conn, args.task_id)
+        dependency_snapshot = kb.dependency_snapshot(conn, args.task_id)
         children = kb.child_ids(conn, args.task_id)
         runs = kb.list_runs(conn, args.task_id, **rsk)
         # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
@@ -1644,6 +1887,14 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "task": _task_to_dict(task),
             "latest_summary": latest_summary,
             "parents": parents,
+            "expected_state": {
+                "status": task.status,
+                "assignee": task.assignee,
+                "run": task.current_run_id,
+                "claim": task.claim_lock,
+                "dependencies": dependency_snapshot,
+                "event": events[-1].id if events else None,
+            },
             "children": children,
             "comments": [
                 {"author": c.author, "body": c.body, "created_at": c.created_at}
@@ -1651,6 +1902,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             ],
             "events": [
                 {
+                    "id": e.id,
                     "kind": e.kind,
                     "payload": e.payload,
                     "created_at": e.created_at,
@@ -1790,8 +2042,13 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids={args.task_id}
+    )
     with kb.connect_closing() as conn:
-        ok = kb.assign_task(conn, args.task_id, profile)
+        ok = kb.assign_task(
+            conn, args.task_id, profile, expected_states=expected_states
+        )
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)
         return 1
@@ -1841,11 +2098,15 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids={args.task_id}
+    )
     with kb.connect_closing() as conn:
         ok = kb.reassign_task(
             conn, args.task_id, profile,
             reclaim_first=bool(getattr(args, "reclaim", False)),
             reason=getattr(args, "reason", None),
+            expected_states=expected_states,
         )
     if not ok:
         print(
@@ -1994,15 +2255,33 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 
 def _cmd_link(args: argparse.Namespace) -> int:
+    involved = {args.parent_id, args.child_id}
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.child_id, allowed_ids=involved
+    )
     with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
+        kb.link_tasks(
+            conn,
+            args.parent_id,
+            args.child_id,
+            expected_states=expected_states,
+        )
     print(f"Linked {args.parent_id} -> {args.child_id}")
     return 0
 
 
 def _cmd_unlink(args: argparse.Namespace) -> int:
+    involved = {args.parent_id, args.child_id}
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.child_id, allowed_ids=involved
+    )
     with kb.connect_closing() as conn:
-        ok = kb.unlink_tasks(conn, args.parent_id, args.child_id)
+        ok = kb.unlink_tasks(
+            conn,
+            args.parent_id,
+            args.child_id,
+            expected_states=expected_states,
+        )
     if not ok:
         print(f"No such link: {args.parent_id} -> {args.child_id}", file=sys.stderr)
         return 1
@@ -2042,8 +2321,17 @@ def _cmd_comment(args: argparse.Namespace) -> int:
             suffix = f"\n\n[trimmed to {args.max_len} chars by --max-len]"
             body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
     author = args.author or _profile_author()
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids={args.task_id}
+    )
     with kb.connect_closing() as conn:
-        kb.add_comment(conn, args.task_id, author, body)
+        kb.add_comment(
+            conn,
+            args.task_id,
+            author,
+            body,
+            expected_states=expected_states,
+        )
     print(f"Comment added to {args.task_id}")
     return 0
 
@@ -2144,6 +2432,25 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     if not ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    scheduled_gate = bool(getattr(args, "scheduled_gate", False))
+    if scheduled_gate and len(ids) != 1:
+        print(
+            "kanban: --scheduled-gate requires exactly one task id",
+            file=sys.stderr,
+        )
+        return 2
+    expected_states = _expected_states_from_args(
+        args,
+        primary_id=ids[0] if len(ids) == 1 else None,
+        allowed_ids=set(ids),
+    )
+    if expected_states and len(ids) != 1:
+        print(
+            "kanban: expected-state guards require exactly one task id; "
+            "guard and complete bulk tasks one at a time",
+            file=sys.stderr,
+        )
+        return 2
     summary = getattr(args, "summary", None)
     raw_meta = getattr(args, "metadata", None)
     # Guard: structured handoff fields are per-run, so they'd be
@@ -2219,6 +2526,8 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                expected_states=expected_states,
+                complete_scheduled_gate=scheduled_gate,
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
@@ -2260,17 +2569,25 @@ def _cmd_block(args: argparse.Namespace) -> int:
     kind = getattr(args, "kind", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids=set(ids)
+    )
+    if expected_states and len(ids) != 1:
+        raise ValueError(
+            "expected-state guards require one block target at a time"
+        )
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
             if not kb.block_task(
                 conn,
                 tid,
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id_for(tid),
+                expected_states=expected_states,
+                comment_author=author if reason else None,
+                comment_body=f"BLOCKED: {reason}" if reason else None,
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -2296,16 +2613,24 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids=set(ids)
+    )
+    if expected_states and len(ids) != 1:
+        raise ValueError(
+            "expected-state guards require one schedule target at a time"
+        )
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
             if not kb.schedule_task(
                 conn,
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id_for(tid),
+                expected_states=expected_states,
+                comment_author=author if reason else None,
+                comment_body=f"SCHEDULED: {reason}" if reason else None,
             ):
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)
@@ -2323,12 +2648,25 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     if reason is not None:
         reason = reason.strip() or None
     author = _profile_author() if reason else None
+    expected_states = _expected_states_from_args(
+        args,
+        primary_id=ids[0] if len(ids) == 1 else None,
+        allowed_ids=set(ids),
+    )
+    if expected_states and len(ids) != 1:
+        raise ValueError(
+            "expected-state guards require one unblock target at a time"
+        )
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            if not kb.unblock_task(
+                conn,
+                tid,
+                expected_states=expected_states,
+                comment_author=author,
+                comment_body=f"UNBLOCK: {reason}" if reason else None,
+            ):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
@@ -2349,6 +2687,14 @@ def _cmd_promote(args: argparse.Namespace) -> int:
             ids.append(tid)
             seen.add(tid)
 
+    expected_states = _expected_states_from_args(
+        args, primary_id=args.task_id, allowed_ids=set(ids)
+    )
+    if expected_states and len(ids) != 1:
+        raise ValueError(
+            "expected-state guards require one promote target at a time"
+        )
+
     results: list[dict[str, object]] = []
     with kb.connect_closing() as conn:
         for tid in ids:
@@ -2359,6 +2705,7 @@ def _cmd_promote(args: argparse.Namespace) -> int:
                 reason=reason,
                 force=bool(args.force),
                 dry_run=bool(args.dry_run),
+                expected_states=expected_states,
             )
             results.append({
                 "task_id": tid,
@@ -2904,10 +3251,22 @@ def _cmd_specify(args: argparse.Namespace) -> int:
         )
         return 2
 
+    expected_states = _expected_states_from_args(
+        args,
+        primary_id=ids[0] if len(ids) == 1 else None,
+        allowed_ids=set(ids),
+    )
+    if expected_states and len(ids) != 1:
+        raise ValueError(
+            "expected-state guards require one specify target at a time"
+        )
+
     ok_count = 0
     fail_count = 0
     for tid in ids:
-        outcome = spec.specify_task(tid, author=author)
+        outcome = spec.specify_task(
+            tid, author=author, expected_states=expected_states
+        )
         if outcome.ok:
             ok_count += 1
         else:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1867,34 +1867,28 @@ def _cmd_show(args: argparse.Namespace) -> int:
         )
         return 2
     with kb.connect_closing() as conn:
-        task = kb.get_task(conn, args.task_id)
-        if not task:
-            print(f"no such task: {args.task_id}", file=sys.stderr)
-            return 1
-        comments = kb.list_comments(conn, args.task_id)
-        events = kb.list_events(conn, args.task_id)
-        parents = kb.parent_ids(conn, args.task_id)
-        dependency_snapshot = kb.dependency_snapshot(conn, args.task_id)
-        children = kb.child_ids(conn, args.task_id)
-        runs = kb.list_runs(conn, args.task_id, **rsk)
-        # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
-        # ``result=``. Surfacing the latest summary here keeps ``show`` from
-        # looking like a no-op when the worker actually did real work.
-        latest_summary = kb.latest_summary(conn, args.task_id)
+        with kb.read_txn(conn):
+            task = kb.get_task(conn, args.task_id)
+            if not task:
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            comments = kb.list_comments(conn, args.task_id)
+            events = kb.list_events(conn, args.task_id)
+            parents = kb.parent_ids(conn, args.task_id)
+            expected_state = kb.expected_state_snapshot(conn, args.task_id)
+            children = kb.child_ids(conn, args.task_id)
+            runs = kb.list_runs(conn, args.task_id, **rsk)
+            # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
+            # ``result=``. Surfacing the latest summary here keeps ``show`` from
+            # looking like a no-op when the worker actually did real work.
+            latest_summary = kb.latest_summary(conn, args.task_id)
 
     if getattr(args, "json", False):
         payload = {
             "task": _task_to_dict(task),
             "latest_summary": latest_summary,
             "parents": parents,
-            "expected_state": {
-                "status": task.status,
-                "assignee": task.assignee,
-                "run": task.current_run_id,
-                "claim": task.claim_lock,
-                "dependencies": dependency_snapshot,
-                "event": events[-1].id if events else None,
-            },
+            "expected_state": expected_state,
             "children": children,
             "comments": [
                 {"author": c.author, "body": c.body, "created_at": c.created_at}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6018,7 +6018,7 @@ def block_task(
                         expected_run_id=expected_run_id,
                     )
                 return False
-            if comment_body:
+            if comment_body and guarded:
                 _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,
@@ -6080,7 +6080,7 @@ def block_task(
                         expected_run_id=expected_run_id,
                     )
                 return False
-            if comment_body:
+            if comment_body and guarded:
                 _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,
@@ -6142,7 +6142,7 @@ def block_task(
                         expected_run_id=expected_run_id,
                     )
                 return False
-            if comment_body:
+            if comment_body and guarded:
                 _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2791,6 +2791,19 @@ def write_txn(conn: sqlite3.Connection):
         _check_file_length_invariant(conn)
 
 
+@contextlib.contextmanager
+def read_txn(conn: sqlite3.Connection):
+    """Hold one consistent SQLite read snapshot across related evidence."""
+    conn.execute("BEGIN")
+    try:
+        yield conn
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    else:
+        conn.execute("COMMIT")
+
+
 class KanbanStateConflict(RuntimeError):
     """Raised when an atomic expected-state guard does not match the board."""
 
@@ -2824,6 +2837,89 @@ def dependency_snapshot(
     return [{"id": row["id"], "status": row["status"]} for row in rows]
 
 
+def latest_event_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
+    """Return the canonical monotonic task-event CAS token."""
+    row = conn.execute(
+        "SELECT MAX(id) AS latest FROM task_events WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None or row["latest"] is None:
+        return None
+    return int(row["latest"])
+
+
+def expected_state_snapshot(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[dict[str, Any]]:
+    """Return canonical expected-state evidence for one task."""
+    row = conn.execute(
+        "SELECT status, assignee, current_run_id, claim_lock "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "status": row["status"],
+        "assignee": row["assignee"],
+        "run": row["current_run_id"],
+        "claim": row["claim_lock"],
+        "dependencies": dependency_snapshot(conn, task_id),
+        "event": latest_event_id(conn, task_id),
+    }
+
+
+def _raise_transition_conflict(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    allowed_statuses: Iterable[str],
+    expected_run_id: Optional[int] = None,
+) -> None:
+    """Raise structured evidence for a guarded intrinsic transition miss."""
+    actual = expected_state_snapshot(conn, task_id)
+    if actual is None:
+        raise KanbanStateConflict(
+            [{
+                "task_id": task_id,
+                "field": "task",
+                "expected": "present",
+                "actual": "missing",
+            }]
+        )
+
+    allowed = sorted(set(allowed_statuses))
+    conflicts: list[dict[str, Any]] = []
+    if actual["status"] not in allowed:
+        conflicts.append(
+            {
+                "task_id": task_id,
+                "field": "status",
+                "expected": {"one_of": allowed},
+                "actual": actual["status"],
+            }
+        )
+    if expected_run_id is not None and actual["run"] != int(expected_run_id):
+        conflicts.append(
+            {
+                "task_id": task_id,
+                "field": "run",
+                "expected": int(expected_run_id),
+                "actual": actual["run"],
+            }
+        )
+    if not conflicts:
+        conflicts.append(
+            {
+                "task_id": task_id,
+                "field": "transition",
+                "expected": "eligible",
+                "actual": "rejected",
+            }
+        )
+    raise KanbanStateConflict(conflicts)
+
+
 def _validate_expected_task_states(
     conn: sqlite3.Connection,
     expected_states: Optional[Mapping[str, Mapping[str, Any]]],
@@ -2846,12 +2942,8 @@ def _validate_expected_task_states(
             raise ValueError(
                 f"unknown expected-state field(s) for {task_id}: {', '.join(unknown)}"
             )
-        row = conn.execute(
-            "SELECT status, assignee, current_run_id, claim_lock "
-            "FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
-        if row is None:
+        actual = expected_state_snapshot(conn, task_id)
+        if actual is None:
             conflicts.append(
                 {
                     "task_id": task_id,
@@ -2861,21 +2953,6 @@ def _validate_expected_task_states(
                 }
             )
             continue
-
-        actual: dict[str, Any] = {
-            "status": row["status"],
-            "assignee": row["assignee"],
-            "run": row["current_run_id"],
-            "claim": row["claim_lock"],
-        }
-        if "dependencies" in expected:
-            actual["dependencies"] = dependency_snapshot(conn, task_id)
-        if "event" in expected:
-            event_row = conn.execute(
-                "SELECT MAX(id) AS latest FROM task_events WHERE task_id = ?",
-                (task_id,),
-            ).fetchone()
-            actual["event"] = event_row["latest"] if event_row else None
 
         for field_name, expected_value in expected.items():
             actual_value = actual[field_name]
@@ -4749,10 +4826,13 @@ def reassign_task(
     """
     profile = _canonical_assignee(profile)
     if expected_states:
+        reservation: Optional[str] = None
+        reserved_row: Optional[sqlite3.Row] = None
         with write_txn(conn):
             _validate_expected_task_states(conn, expected_states)
             row = conn.execute(
-                "SELECT status, claim_lock, worker_pid, assignee "
+                "SELECT status, claim_lock, claim_expires, worker_pid, "
+                "assignee, current_run_id "
                 "FROM tasks WHERE id = ?",
                 (task_id,),
             ).fetchone()
@@ -4769,50 +4849,116 @@ def reassign_task(
                 reclaim_first
                 and (row["status"] == "running" or row["claim_lock"] is not None)
             )
-            if reclaimed:
-                termination = _terminate_reclaimed_worker(
-                    row["worker_pid"], row["claim_lock"]
-                )
-                conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
-                    (task_id,),
-                )
-                run_id = _end_run(
+            if not reclaimed:
+                if row["assignee"] != profile:
+                    conn.execute(
+                        "UPDATE tasks SET assignee = ?, consecutive_failures = 0, "
+                        "last_failure_error = NULL WHERE id = ?",
+                        (profile, task_id),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE tasks SET assignee = ? WHERE id = ?",
+                        (profile, task_id),
+                    )
+                _append_event(conn, task_id, "assigned", {"assignee": profile})
+                return True
+
+            # Reserve the exact claimed run under the validated CAS snapshot,
+            # then release SQLite's board-wide writer lock before signalling or
+            # polling the worker. The synthetic claim keeps dispatchers and
+            # claim renewals from taking this task while termination is in
+            # flight; the final transaction must still own this exact token.
+            reservation = f"reassign:{secrets.token_hex(16)}"
+            reserve_expires = int(time.time()) + RECLAIM_DEFER_GRACE_SECONDS
+            cur = conn.execute(
+                "UPDATE tasks SET claim_lock = ?, claim_expires = ? "
+                "WHERE id = ? AND status = ? AND claim_lock IS ? "
+                "AND current_run_id IS ?",
+                (
+                    reservation,
+                    reserve_expires,
+                    task_id,
+                    row["status"],
+                    row["claim_lock"],
+                    row["current_run_id"],
+                ),
+            )
+            if cur.rowcount != 1:
+                _raise_transition_conflict(
                     conn,
                     task_id,
-                    outcome="reclaimed",
-                    status="reclaimed",
-                    error=(
-                        f"manual_reclaim: {reason or 'reassign'}"
-                        if reason
-                        else f"manual_reclaim lock={row['claim_lock']}"
-                    ),
-                    metadata=termination,
+                    allowed_statuses=(row["status"],),
+                    expected_run_id=row["current_run_id"],
                 )
-                payload = {
-                    "manual": True,
-                    "reason": reason or "reassign",
-                    "prev_lock": row["claim_lock"],
-                }
-                payload.update(termination)
-                _append_event(
-                    conn, task_id, "reclaimed", payload, run_id=run_id
+            if row["current_run_id"] is not None:
+                conn.execute(
+                    "UPDATE task_runs SET claim_lock = ?, claim_expires = ? "
+                    "WHERE id = ? AND ended_at IS NULL",
+                    (reservation, reserve_expires, int(row["current_run_id"])),
                 )
+            reserved_row = row
 
-            if reclaimed or row["assignee"] != profile:
-                conn.execute(
-                    "UPDATE tasks SET assignee = ?, consecutive_failures = 0, "
-                    "last_failure_error = NULL WHERE id = ?",
-                    (profile, task_id),
+        assert reservation is not None and reserved_row is not None
+        termination = _terminate_reclaimed_worker(
+            reserved_row["worker_pid"], reserved_row["claim_lock"]
+        )
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status = ? AND claim_lock = ? "
+                "AND current_run_id IS ?",
+                (
+                    task_id,
+                    reserved_row["status"],
+                    reservation,
+                    reserved_row["current_run_id"],
+                ),
+            )
+            if cur.rowcount != 1:
+                actual = expected_state_snapshot(conn, task_id)
+                raise KanbanStateConflict(
+                    [{
+                        "task_id": task_id,
+                        "field": "reassign_reservation",
+                        "expected": "owned",
+                        "actual": (
+                            "missing" if actual is None
+                            else {
+                                "status": actual["status"],
+                                "run": actual["run"],
+                                "claim": actual["claim"],
+                            }
+                        ),
+                    }]
                 )
-            else:
-                conn.execute(
-                    "UPDATE tasks SET assignee = ? WHERE id = ?",
-                    (profile, task_id),
-                )
+            run_id = _end_run(
+                conn,
+                task_id,
+                outcome="reclaimed",
+                status="reclaimed",
+                error=(
+                    f"manual_reclaim: {reason or 'reassign'}"
+                    if reason
+                    else f"manual_reclaim lock={reserved_row['claim_lock']}"
+                ),
+                metadata=termination,
+            )
+            payload = {
+                "manual": True,
+                "reason": reason or "reassign",
+                "prev_lock": reserved_row["claim_lock"],
+            }
+            payload.update(termination)
+            _append_event(conn, task_id, "reclaimed", payload, run_id=run_id)
+            conn.execute(
+                "UPDATE tasks SET assignee = ?, consecutive_failures = 0, "
+                "last_failure_error = NULL WHERE id = ?",
+                (profile, task_id),
+            )
             _append_event(conn, task_id, "assigned", {"assignee": profile})
-            return True
+        return True
 
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
@@ -5814,6 +5960,7 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    guarded = bool(expected_states)
     recurrences = 0
     with write_txn(conn):
         _validate_expected_task_states(conn, expected_states)
@@ -5822,11 +5969,19 @@ def block_task(
             (task_id,),
         ).fetchone()
         if cur_row is None:
+            if guarded:
+                _raise_transition_conflict(
+                    conn,
+                    task_id,
+                    allowed_statuses=("ready", "running"),
+                    expected_run_id=expected_run_id,
+                )
             return False
         if comment_body:
             if not comment_author or not comment_author.strip():
                 raise ValueError("comment author is required")
-            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
+            if not guarded:
+                _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
@@ -5855,7 +6010,16 @@ def block_task(
                 else (kind, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
+                if guarded:
+                    _raise_transition_conflict(
+                        conn,
+                        task_id,
+                        allowed_statuses=("ready", "running"),
+                        expected_run_id=expected_run_id,
+                    )
                 return False
+            if comment_body:
+                _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -5908,7 +6072,16 @@ def block_task(
                 else (kind, recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
+                if guarded:
+                    _raise_transition_conflict(
+                        conn,
+                        task_id,
+                        allowed_statuses=("ready", "running"),
+                        expected_run_id=expected_run_id,
+                    )
                 return False
+            if comment_body:
+                _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -5961,7 +6134,16 @@ def block_task(
                     (kind, recurrences, task_id, int(expected_run_id)),
                 )
             if cur.rowcount != 1:
+                if guarded:
+                    _raise_transition_conflict(
+                        conn,
+                        task_id,
+                        allowed_statuses=("ready", "running"),
+                        expected_run_id=expected_run_id,
+                    )
                 return False
+            if comment_body:
+                _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2791,6 +2791,108 @@ def write_txn(conn: sqlite3.Connection):
         _check_file_length_invariant(conn)
 
 
+class KanbanStateConflict(RuntimeError):
+    """Raised when an atomic expected-state guard does not match the board."""
+
+    def __init__(self, conflicts: list[dict[str, Any]]):
+        self.conflicts = conflicts
+        super().__init__("kanban task state changed")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "error": "state_conflict",
+            "conflicts": self.conflicts,
+        }
+
+
+_EXPECTED_STATE_FIELDS = frozenset(
+    {"status", "assignee", "run", "claim", "dependencies", "event"}
+)
+
+
+def dependency_snapshot(
+    conn: sqlite3.Connection, task_id: str
+) -> list[dict[str, Any]]:
+    """Return the canonical parent-id/status snapshot used by CAS guards."""
+    rows = conn.execute(
+        "SELECT p.id, p.status FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? ORDER BY p.id",
+        (task_id,),
+    ).fetchall()
+    return [{"id": row["id"], "status": row["status"]} for row in rows]
+
+
+def _validate_expected_task_states(
+    conn: sqlite3.Connection,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]],
+) -> None:
+    """Validate task snapshots while the caller holds ``write_txn``.
+
+    The mapping is ``task_id -> expected fields``. Supported fields are
+    ``status``, ``assignee``, ``run`` (``current_run_id``), ``claim``
+    (``claim_lock``), ``dependencies`` (sorted ``[{id, status}, ...]``), and
+    ``event`` (the latest task-event id, or ``None`` when no event exists).
+    ``None`` is an exact expected value; omission means "do not compare".
+    """
+    if not expected_states:
+        return
+
+    conflicts: list[dict[str, Any]] = []
+    for task_id, expected in expected_states.items():
+        unknown = sorted(set(expected) - _EXPECTED_STATE_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"unknown expected-state field(s) for {task_id}: {', '.join(unknown)}"
+            )
+        row = conn.execute(
+            "SELECT status, assignee, current_run_id, claim_lock "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            conflicts.append(
+                {
+                    "task_id": task_id,
+                    "field": "task",
+                    "expected": "present",
+                    "actual": "missing",
+                }
+            )
+            continue
+
+        actual: dict[str, Any] = {
+            "status": row["status"],
+            "assignee": row["assignee"],
+            "run": row["current_run_id"],
+            "claim": row["claim_lock"],
+        }
+        if "dependencies" in expected:
+            actual["dependencies"] = dependency_snapshot(conn, task_id)
+        if "event" in expected:
+            event_row = conn.execute(
+                "SELECT MAX(id) AS latest FROM task_events WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+            actual["event"] = event_row["latest"] if event_row else None
+
+        for field_name, expected_value in expected.items():
+            actual_value = actual[field_name]
+            if actual_value != expected_value:
+                conflicts.append(
+                    {
+                        "task_id": task_id,
+                        "field": field_name,
+                        "expected": expected_value,
+                        "actual": actual_value,
+                    }
+                )
+
+    if conflicts:
+        raise KanbanStateConflict(conflicts)
+
+
 # ---------------------------------------------------------------------------
 # ID generation
 # ---------------------------------------------------------------------------
@@ -2858,6 +2960,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3067,7 +3170,7 @@ def create_task(
     # and to avoid holding a write lock during the lookup. Race is
     # acceptable: two concurrent creators with the same key might both
     # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
+    if idempotency_key and not expected_states:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
@@ -3104,6 +3207,20 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                _validate_expected_task_states(conn, expected_states)
+                # A guarded idempotent create validates the parent snapshots
+                # and performs the dedup lookup under the same write lock as a
+                # potential insert. This avoids returning an existing row from
+                # a stale precondition or racing a second creator.
+                if idempotency_key and expected_states:
+                    existing = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if existing:
+                        return existing["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3349,7 +3466,13 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
+def assign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
     Refuses to reassign a task that's currently running (claim_lock set).
@@ -3357,6 +3480,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     """
     profile = _canonical_assignee(profile)
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
@@ -3431,10 +3555,17 @@ def set_model_override(
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
@@ -3485,8 +3616,15 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
     return False
 
 
-def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
+def unlink_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> bool:
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
             (parent_id, child_id),
@@ -3541,26 +3679,43 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # Comments & events
 # ---------------------------------------------------------------------------
 
-def add_comment(
+def _add_comment_in_txn(
     conn: sqlite3.Connection, task_id: str, author: str, body: str
+) -> int:
+    """Insert a comment while the caller already holds ``write_txn``."""
+    cur = conn.execute(
+        "INSERT INTO task_comments (task_id, author, body, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (task_id, author.strip(), body.strip(), int(time.time())),
+    )
+    _append_event(
+        conn,
+        task_id,
+        "commented",
+        {"author": author, "len": len(body)},
+    )
+    return int(cur.lastrowid or 0)
+
+
+def add_comment(
+    conn: sqlite3.Connection,
+    task_id: str,
+    author: str,
+    body: str,
+    *,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> int:
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
         raise ValueError("comment author is required")
-    now = int(time.time())
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
-        cur = conn.execute(
-            "INSERT INTO task_comments (task_id, author, body, created_at) "
-            "VALUES (?, ?, ?, ?)",
-            (task_id, author.strip(), body.strip(), now),
-        )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
-        return int(cur.lastrowid or 0)
+        return _add_comment_in_txn(conn, task_id, author, body)
 
 
 def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
@@ -4579,6 +4734,7 @@ def reassign_task(
     *,
     reclaim_first: bool = False,
     reason: Optional[str] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> bool:
     """Reassign a task, optionally reclaiming a stuck running worker first.
 
@@ -4591,6 +4747,73 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    profile = _canonical_assignee(profile)
+    if expected_states:
+        with write_txn(conn):
+            _validate_expected_task_states(conn, expected_states)
+            row = conn.execute(
+                "SELECT status, claim_lock, worker_pid, assignee "
+                "FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            if (
+                not reclaim_first
+                and row["status"] == "running"
+                and row["claim_lock"] is not None
+            ):
+                return False
+
+            reclaimed = bool(
+                reclaim_first
+                and (row["status"] == "running" or row["claim_lock"] is not None)
+            )
+            if reclaimed:
+                termination = _terminate_reclaimed_worker(
+                    row["worker_pid"], row["claim_lock"]
+                )
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                    (task_id,),
+                )
+                run_id = _end_run(
+                    conn,
+                    task_id,
+                    outcome="reclaimed",
+                    status="reclaimed",
+                    error=(
+                        f"manual_reclaim: {reason or 'reassign'}"
+                        if reason
+                        else f"manual_reclaim lock={row['claim_lock']}"
+                    ),
+                    metadata=termination,
+                )
+                payload = {
+                    "manual": True,
+                    "reason": reason or "reassign",
+                    "prev_lock": row["claim_lock"],
+                }
+                payload.update(termination)
+                _append_event(
+                    conn, task_id, "reclaimed", payload, run_id=run_id
+                )
+
+            if reclaimed or row["assignee"] != profile:
+                conn.execute(
+                    "UPDATE tasks SET assignee = ?, consecutive_failures = 0, "
+                    "last_failure_error = NULL WHERE id = ?",
+                    (profile, task_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE tasks SET assignee = ? WHERE id = ?",
+                    (profile, task_id),
+                )
+            _append_event(conn, task_id, "assigned", {"assignee": profile})
+            return True
+
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
@@ -4748,6 +4971,8 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    complete_scheduled_gate: bool = False,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4776,6 +5001,11 @@ def complete_task(
     Any suspected phantom references are recorded as a
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
+
+    ``complete_scheduled_gate`` is the coordination-gate recovery path. It
+    permits only a direct ``scheduled -> done`` transition and rejects any
+    task with a live claim or current run, so the gate is never exposed as
+    dispatchable ``ready`` work.
     """
     now = int(time.time())
 
@@ -4790,6 +5020,7 @@ def complete_task(
         )
         if phantom_cards:
             with write_txn(conn):
+                _validate_expected_task_states(conn, expected_states)
                 _append_event(
                     conn, task_id, "completion_blocked_hallucination",
                     {
@@ -4810,7 +5041,27 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
-        if expected_run_id is None:
+        _validate_expected_task_states(conn, expected_states)
+        if complete_scheduled_gate:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status = 'scheduled'
+                   AND claim_lock IS NULL
+                   AND current_run_id IS NULL
+                """,
+                (result, now, task_id),
+            )
+        elif expected_run_id is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5528,6 +5779,9 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    comment_author: Optional[str] = None,
+    comment_body: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5562,12 +5816,17 @@ def block_task(
         )
     recurrences = 0
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
+        if comment_body:
+            if not comment_author or not comment_author.strip():
+                raise ValueError("comment author is required")
+            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
@@ -5742,6 +6001,7 @@ def promote_task(
     reason: Optional[str] = None,
     force: bool = False,
     dry_run: bool = False,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> tuple[bool, Optional[str]]:
     """Manually promote a `todo` or `blocked` task to `ready`.
 
@@ -5753,40 +6013,41 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
-    if row is None:
-        return False, f"task {task_id} not found"
+    with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
 
-    cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
-        return False, (
-            f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
-        )
-
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
+        cur_status = row["status"]
+        if cur_status not in ("todo", "blocked"):
             return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
+                f"task {task_id} is {cur_status!r}; promote only applies to "
+                f"'todo' or 'blocked'"
             )
 
-    if dry_run:
-        return True, None
+        if not force:
+            parents = conn.execute(
+                "SELECT t.id, t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            unsatisfied = [
+                p["id"] for p in parents
+                if p["status"] not in ("done", "archived")
+            ]
+            if unsatisfied:
+                return False, (
+                    f"unsatisfied parent dependencies: "
+                    f"{', '.join(unsatisfied)} (use --force to override)"
+                )
 
-    with write_txn(conn):
+        if dry_run:
+            return True, None
+
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
@@ -5804,7 +6065,14 @@ def promote_task(
     return True, None
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    comment_author: Optional[str] = None,
+    comment_body: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -5816,6 +6084,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     now = int(time.time())
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
@@ -5863,6 +6132,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         if cur.rowcount != 1:
             return False
+        if comment_body:
+            if not comment_author or not comment_author.strip():
+                raise ValueError("comment author is required")
+            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
@@ -5878,6 +6151,7 @@ def specify_triage_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     author: Optional[str] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -5899,6 +6173,7 @@ def specify_triage_task(
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
             (task_id,),
@@ -6599,6 +6874,9 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    comment_author: Optional[str] = None,
+    comment_body: Optional[str] = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -6607,6 +6885,7 @@ def schedule_task(
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
     with write_txn(conn):
+        _validate_expected_task_states(conn, expected_states)
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -6623,6 +6902,10 @@ def schedule_task(
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
+        if comment_body:
+            if not comment_author or not comment_author.strip():
+                raise ValueError("comment author is required")
+            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
         run_id = _end_run(
             conn, task_id,
             outcome="scheduled", status="scheduled",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6264,14 +6264,24 @@ def unblock_task(
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
     """
+    guarded = bool(expected_states)
     now = int(time.time())
     with write_txn(conn):
         _validate_expected_task_states(conn, expected_states)
-        stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
+        task_row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
-        if stale and stale["current_run_id"]:
+        if task_row is None:
+            return False
+        if comment_body:
+            if not comment_author or not comment_author.strip():
+                raise ValueError("comment author is required")
+            if not guarded:
+                _add_comment_in_txn(conn, task_id, comment_author, comment_body)
+        if task_row["status"] not in ("blocked", "scheduled"):
+            return False
+        if task_row["current_run_id"]:
             conn.execute(
                 """
                 UPDATE task_runs
@@ -6281,7 +6291,7 @@ def unblock_task(
                        claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
-                (now, int(stale["current_run_id"])),
+                (now, int(task_row["current_run_id"])),
             )
         # Re-gate on parent completion before flipping 'blocked' back to
         # 'ready'. Unconditionally setting status='ready' here bypasses the
@@ -6314,10 +6324,8 @@ def unblock_task(
         )
         if cur.rowcount != 1:
             return False
-        if comment_body:
-            if not comment_author or not comment_author.strip():
-                raise ValueError("comment author is required")
-            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
+        if comment_body and guarded:
+            _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
@@ -7066,8 +7074,18 @@ def schedule_task(
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
+    guarded = bool(expected_states)
     with write_txn(conn):
         _validate_expected_task_states(conn, expected_states)
+        if not conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone():
+            return False
+        if comment_body:
+            if not comment_author or not comment_author.strip():
+                raise ValueError("comment author is required")
+            if not guarded:
+                _add_comment_in_txn(conn, task_id, comment_author, comment_body)
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -7084,10 +7102,8 @@ def schedule_task(
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
-        if comment_body:
-            if not comment_author or not comment_author.strip():
-                raise ValueError("comment author is required")
-            _add_comment_in_txn(conn, task_id, comment_author, comment_body)
+        if comment_body and guarded:
+            _add_comment_in_txn(conn, task_id, comment_author or "", comment_body)
         run_id = _end_run(
             conn, task_id,
             outcome="scheduled", status="scheduled",

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -36,7 +36,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from hermes_cli import kanban_db as kb
 
@@ -144,6 +144,7 @@ def specify_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    expected_states: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> SpecifyOutcome:
     """Specify a single triage task and promote it to ``todo``.
 
@@ -239,6 +240,7 @@ def specify_task(
             title=new_title,
             body=new_body,
             author=author or _profile_author(),
+            expected_states=expected_states,
         )
     if not ok:
         # Race: someone else promoted / archived the task between our


### PR DESCRIPTION
## Summary
- add optional expected-state compare-and-set guards to Kanban mutation APIs and CLI commands, with JSON conflict output and no writes on mismatch
- expose reusable status/assignee/run/claim/dependency/event snapshots from `kanban show --json`
- add a direct `scheduled -> done` coordination-gate completion path that refuses live claims or runs and never exposes the gate as `ready`

## Verification
- `python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py hermes_cli/kanban_specify.py`
- `git diff --check HEAD~1..HEAD`
- temporary-board CLI/API probe covering successful full-snapshot mutation, JSON conflicts, no-write rollback for create/assign/reassign/link/unlink/comment/complete/block/schedule/unblock/promote/specify, direct scheduled-gate completion, and live-claim refusal

No tests were added or run per the scoped control-plane task instructions.