### PR TITLE
feat(desktop): open Plugins from Cmd+K

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -385,7 +385,15 @@ const toSessionEntry = (session: SessionRow): SessionEntry => ({
 })
 
 type NonConfigSettingsLabel =
-  'about' | 'archivedChats' | 'gateway' | 'keysSettings' | 'keysTools' | 'mcp' | 'providerAccounts' | 'providerApiKeys'
+  | 'about'
+  | 'archivedChats'
+  | 'gateway'
+  | 'keysSettings'
+  | 'keysTools'
+  | 'mcp'
+  | 'plugins'
+  | 'providerAccounts'
+  | 'providerApiKeys'
 
 const NON_CONFIG_SETTINGS: ReadonlyArray<{
   icon: IconComponent
@@ -417,6 +425,12 @@ const NON_CONFIG_SETTINGS: ReadonlyArray<{
     keywords: ['gateway', 'proxy', 'server', 'webhook', 'env', 'egress proxy', 'iron proxy'],
     labelKey: 'keysSettings',
     tab: 'keys&kview=settings'
+  },
+  {
+    icon: Package,
+    keywords: ['plugins', 'extensions', 'desktop plugins', 'addon', 'add-on'],
+    labelKey: 'plugins',
+    tab: 'plugins'
   },
   { icon: Archive, keywords: ['history', 'archived'], labelKey: 'archivedChats', tab: 'sessions' },
   { icon: Info, keywords: ['version', 'about'], labelKey: 'about', tab: 'about' }


### PR DESCRIPTION
## Summary
- Adds a **Plugins** row to the command palette Settings group
- Deep-links to `/settings?tab=plugins` (same door as the settings sidebar)
- Keywords: plugins, extensions, desktop plugins, addon

## Test plan
- [ ] Cmd+K → type `plugins` → row labeled **Plugins** appears under Settings
- [ ] Select it → Settings opens on the Plugins tab
- [ ] Existing Settings rows (Gateway, About, …) still work
