### PR TITLE
fix(bedrock): add Claude Opus 5 to the 1M context table (salvage #75432)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1402,17 +1402,23 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
     # Context windows per Anthropic's official models comparison
     # (https://platform.claude.com/docs/en/about-claude/models/overview).
-    # Fable / Sonnet 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6 have 1M generally
-    # available (no beta header required as of April 2026). Sonnet 4.5 and
-    # Sonnet 4 had their `context-1m-2025-08-07` beta retired on
+    # Fable / Sonnet 5 / Opus 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6 have 1M
+    # generally available (no beta header required as of April 2026). Sonnet
+    # 4.5 and Sonnet 4 had their `context-1m-2025-08-07` beta retired on
     # April 30, 2026, so they are standard 200K; Haiku 4.5 is 200K.
+    # Opus 5 is 1M by default on Bedrock as well, per its model card:
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
     # These 1M entries must match agent/model_metadata.py
-    # DEFAULT_CONTEXT_LENGTHS or the agent compresses context prematurely.
+    # DEFAULT_CONTEXT_LENGTHS or the agent compresses context prematurely;
+    # test_million_token_claude_entries_match_model_metadata enforces the
+    # pairing so a new 1M Claude generation fails the suite instead of
+    # silently inheriting BEDROCK_DEFAULT_CONTEXT_LENGTH (#74263).
     # Keys are matched by longest-substring, so the versioned 4-6/4-7/4-8
     # entries win over the generic "anthropic.claude-opus-4" fallback.
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-fable":        1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-opus-5":       1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -933,10 +933,12 @@ def _extract_provider_from_arn(arn: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude: 1M GA vs 200K. The 1M entries must match agent/model_metadata.py
-    # DEFAULT_CONTEXT_LENGTHS or context compresses early.
+    # DEFAULT_CONTEXT_LENGTHS or context compresses early — Opus 5 reached that table and not this
+    # one, so the offline path resolved 128K for a 1M model (#74263); the pairing is now tested.
     **dict.fromkeys((
-        "anthropic.claude-fable-5", "anthropic.claude-fable", "anthropic.claude-sonnet-5", "anthropic.claude-opus-4-8",
-        "anthropic.claude-opus-4-7", "anthropic.claude-opus-4-6", "anthropic.claude-sonnet-4-6",
+        "anthropic.claude-fable-5", "anthropic.claude-fable", "anthropic.claude-sonnet-5", "anthropic.claude-opus-5",
+        "anthropic.claude-opus-4-8", "anthropic.claude-opus-4-7",
+        "anthropic.claude-opus-4-6", "anthropic.claude-sonnet-4-6",
     ), 1_000_000),
     **dict.fromkeys((
         "anthropic.claude-sonnet-4-5", "anthropic.claude-haiku-4-5", "anthropic.claude-opus-4", "anthropic.claude-sonnet-4",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -706,6 +706,60 @@ class TestBedrockContextLength:
             assert get_bedrock_context_length("anthropic.claude-opus-4-6") == 1_000_000
             mock_probe.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "model_id",
+        (
+            "anthropic.claude-opus-5",
+            "us.anthropic.claude-opus-5",
+            "eu.anthropic.claude-opus-5",
+            "au.anthropic.claude-opus-5",
+            "global.anthropic.claude-opus-5",
+            # Version-suffixed forms: the lookup is a longest-substring match,
+            # so the bare key has to keep winning once a dated revision ships.
+            "anthropic.claude-opus-5-v1:0",
+            "eu.anthropic.claude-opus-5-20260724-v1:0",
+        ),
+    )
+    def test_claude_opus_5_uses_offline_context_table(self, model_id):
+        """Claude Opus 5 keeps its documented 1M window without a probe."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            assert get_bedrock_context_length(model_id) == 1_000_000
+            mock_probe.assert_not_called()
+
+    def test_million_token_claude_entries_match_model_metadata(self):
+        """BEDROCK_CONTEXT_LENGTHS must not drift from DEFAULT_CONTEXT_LENGTHS.
+
+        The Bedrock table's comment already requires its 1M Claude entries to
+        match ``agent.model_metadata.DEFAULT_CONTEXT_LENGTHS``, but nothing
+        enforced it, so ``claude-opus-5`` reached one table and not the other
+        and silently fell through to BEDROCK_DEFAULT_CONTEXT_LENGTH (#74263).
+        Assert the pairing itself rather than a snapshot of today's catalog, so
+        the next 1M Claude generation fails here instead of under-reporting its
+        window by ~8x.
+
+        Dotted aliases (``claude-opus-4.8``) are skipped: Bedrock model IDs use
+        hyphens, so they have no Bedrock counterpart.
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+        mismatched = []
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            for name, expected in DEFAULT_CONTEXT_LENGTHS.items():
+                if not name.startswith("claude-") or expected < 1_000_000 or "." in name:
+                    continue
+                actual = get_bedrock_context_length(f"anthropic.{name}")
+                if actual != expected:
+                    mismatched.append((name, expected, actual))
+            mock_probe.assert_not_called()
+
+        assert not mismatched, (
+            "1M Claude entries missing from BEDROCK_CONTEXT_LENGTHS "
+            f"(model, expected, resolved): {mismatched}"
+        )
+
 
 class TestBedrockContextProbe:
     """Test the live context-window probe that reads the real window from

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1002,6 +1002,51 @@ class TestBedrockContextLength:
             assert get_bedrock_context_length("anthropic.claude-opus-4-6") == 1_000_000
             mock_probe.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "model_id",
+        (
+            "anthropic.claude-opus-5",
+            "us.anthropic.claude-opus-5",
+            "eu.anthropic.claude-opus-5",
+            "global.anthropic.claude-opus-5",
+            # Longest-substring lookup: the bare key must keep winning once a dated revision ships.
+            "anthropic.claude-opus-5-v1:0",
+            "eu.anthropic.claude-opus-5-20260724-v1:0",
+        ),
+    )
+    def test_claude_opus_5_uses_offline_context_table(self, model_id):
+        """Claude Opus 5 keeps its documented 1M window without a probe."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            assert get_bedrock_context_length(model_id, probe=False) == 1_000_000
+            mock_probe.assert_not_called()
+
+    def test_million_token_claude_entries_match_model_metadata(self):
+        """BEDROCK_CONTEXT_LENGTHS must not drift from DEFAULT_CONTEXT_LENGTHS.
+
+        The table's own comment requires the pairing, but nothing enforced it, so
+        ``claude-opus-5`` reached one table and not the other and silently fell through to
+        BEDROCK_DEFAULT_CONTEXT_LENGTH (#74263). Assert the relationship, not a snapshot of
+        today's catalog. DEFAULT_CONTEXT_LENGTHS spells revisions with dots
+        (``claude-opus-4.8``) while Bedrock IDs use hyphens — normalize rather than skip, so a
+        future 1M model that only ever gets a dotted alias cannot escape the check.
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+        mismatched = []
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            for name, expected in DEFAULT_CONTEXT_LENGTHS.items():
+                if not name.startswith("claude-") or expected < 1_000_000:
+                    continue
+                actual = get_bedrock_context_length(f"anthropic.{name.replace('.', '-')}", probe=False)
+                if actual != expected:
+                    mismatched.append((name, expected, actual))
+            mock_probe.assert_not_called()
+
+        assert not mismatched, f"1M Claude entries missing from BEDROCK_CONTEXT_LENGTHS: {mismatched}"
+
 
 class TestBedrockContextProbe:
     """Test the live context-window probe that reads the real window from


### PR DESCRIPTION
## Summary

Bedrock now probes the live model when a region is available, but offline and display paths still use `BEDROCK_CONTEXT_LENGTHS`. That static fallback has no Opus 5 entry, so bare, regional, global, and versioned Opus 5 IDs resolve to 128K instead of their 1M window.

This is the remaining Opus 5 half of #74263; the Sonnet 5 side already landed via #67977.

Fixes #74263

## Root cause

`agent/model_metadata.py::DEFAULT_CONTEXT_LENGTHS` declares `claude-opus-5` as 1M, while the Bedrock fallback table has no matching key. With probing disabled or unavailable, longest-substring lookup finds no match and returns `BEDROCK_DEFAULT_CONTEXT_LENGTH` (128K).

## Fix

- Add `anthropic.claude-opus-5: 1_000_000` to the Bedrock static fallback, sourced from the AWS model card.
- Exercise the production resolver with `probe=False` across bare, `us.`/`eu.`/`au.`/`global.` and version-suffixed IDs.
- Add a behavioral invariant that keeps 1M Claude entries aligned with `DEFAULT_CONTEXT_LENGTHS` without freezing a catalog snapshot.

Salvages #75432, whose author closed it as housekeeping and explicitly invited the work to be carried forward.

## Source

AWS documents Claude Opus 5 on Bedrock with a 1M context window:
https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html

## Validation

- `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py -q`: 69 passed, 5 skipped
- Bedrock/model-metadata call chain (6 files): 218 passed, 5 skipped
- Reverse check: removing the new key fails all 8 regression cases at the 128K fallback
- `ruff check`: passed
- Windows footgun check: passed
- `git diff --check`: passed
