### PR TITLE
feat(terminal): session duration notice (#75639)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -212,7 +212,12 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="min-w-44">
                 {allowSession && (
-                  <DropdownMenuItem onSelect={() => void respond('session')}>{copy.allowSession}</DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void respond('session')}>
+                    <span className="flex flex-col">
+                      <span>{copy.allowSession}</span>
+                      <span className="text-[0.6875rem] font-normal text-(--ui-text-tertiary)">{copy.sessionNote}</span>
+                    </span>
+                  </DropdownMenuItem>
                 )}
                 {allowAlways && (
                   <DropdownMenuItem

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2310,6 +2310,7 @@ export const ar = defineLocale({
       command: 'الأمر',
       moreOptions: 'خيارات إضافية',
       allowSession: 'السماح لهذه الجلسة',
+      sessionNote: 'حتى تنتهي هذه المحادثة (جلسة جديدة تمسحها)',
       alwaysAllowMenu: 'السماح دائما',
       jumpToApproval: 'الموافقة مطلوبة',
       reject: 'رفض',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2735,6 +2735,7 @@ export const en: Translations = {
       command: 'Command',
       moreOptions: 'More approval options',
       allowSession: 'Allow this session',
+      sessionNote: 'Until this conversation ends (a new session clears it)',
       alwaysAllowMenu: 'Always allow…',
       jumpToApproval: 'Approval needed',
       reject: 'Reject',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2558,6 +2558,7 @@ export const ja = defineLocale({
       command: 'コマンド',
       moreOptions: 'その他の承認オプション',
       allowSession: 'このセッションで許可',
+      sessionNote: 'この会話が終わるまで（新しいセッションで解除）',
       alwaysAllowMenu: '常に許可…',
       jumpToApproval: '承認が必要',
       reject: '拒否',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2331,6 +2331,7 @@ export interface Translations {
       command: string
       moreOptions: string
       allowSession: string
+      sessionNote: string
       alwaysAllowMenu: string
       jumpToApproval: string
       reject: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2476,6 +2476,7 @@ export const zhHant = defineLocale({
       command: '指令',
       moreOptions: '更多核准選項',
       allowSession: '允許本工作階段',
+      sessionNote: '直到本次對話結束（新工作階段會清除）',
       alwaysAllowMenu: '一律允許…',
       jumpToApproval: '需要核准',
       reject: '拒絕',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2910,6 +2910,7 @@ export const zh: Translations = {
       command: '命令',
       moreOptions: '更多审批选项',
       allowSession: '允许本会话',
+      sessionNote: '直到本次对话结束（新会话会清除）',
       alwaysAllowMenu: '始终允许…',
       jumpToApproval: '需要审批',
       reject: '拒绝',

--- a/cli.py
+++ b/cli.py
@@ -13095,6 +13095,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         selected = state.get("selected", 0)
         show_full = state.get("show_full", False)
 
+        # When the session-scoped approval option is offered, explain how long
+        # a "session" lasts so the user knows the scope of what they approve
+        # (#75639).
+        if "session" in choices and description:
+            description = (
+                f"{description}\n\n"
+                "Session = until this conversation ends "
+                "(starting a new session clears it)."
+            )
+        elif "session" in choices:
+            description = (
+                "Session = until this conversation ends "
+                "(starting a new session clears it)."
+            )
+
         title = "⚠️  Dangerous Command"
         cmd_display = command
         choice_labels = {

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3650,6 +3650,10 @@ class BasePlatformAdapter(ABC):
     _EA_SMART_DENY_LINE: str = (
         "\n\nSmart DENY: owner override applies to this one operation only."
     )
+    _EA_SESSION_NOTE: str = (
+        "\n\nSession = until this conversation ends "
+        "(starting a new session clears it)."
+    )
     _EA_CMD_BUDGET: int = 3000
 
     @staticmethod
@@ -3674,14 +3678,18 @@ class BasePlatformAdapter(ABC):
         command: str,
         description: str = "dangerous command",
         smart_denied: bool = False,
+        session_note: bool = False,
     ) -> str:
         """Shared formatting core for exec-approval prompt text.
 
         Assembles ``_EA_HEADER`` + fenced command preview (truncated to
         ``_EA_CMD_BUDGET``) + ``_EA_REASON_LABEL`` + description, plus
-        ``_EA_SMART_DENY_LINE`` when ``smart_denied``. Button construction
-        stays platform-local; adapters with additional trailing instructions
-        (e.g. reaction legends) append them to this core.
+        ``_EA_SMART_DENY_LINE`` when ``smart_denied`` and ``_EA_SESSION_NOTE``
+        when ``session_note`` (i.e. the platform is offering a
+        session-scoped approval button — the note tells the user how long a
+        "session" lasts). Button construction stays platform-local; adapters
+        with additional trailing instructions (e.g. reaction legends) append
+        them to this core.
         """
         cmd_preview = self._truncate_preview(str(command or ""), self._EA_CMD_BUDGET)
         text = (
@@ -3691,6 +3699,8 @@ class BasePlatformAdapter(ABC):
         )
         if smart_denied:
             text += self._EA_SMART_DENY_LINE
+        elif session_note:
+            text += self._EA_SESSION_NOTE
         return text
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -479,9 +479,14 @@ def _format_exec_approval_fallback(
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
     choices = [f"Reply `{command_prefix}approve` to execute this one operation"]
+    session_note = ""
     if not smart_denied and allow_session:
         choices.append(
             f"`{command_prefix}approve session` to approve this pattern for the session"
+        )
+        session_note = (
+            "\n\n*Session* = until this conversation ends "
+            "(starting a new session clears it)."
         )
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
@@ -489,6 +494,7 @@ def _format_exec_approval_fallback(
     return (
         f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
+        + session_note
     )
 
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6834,6 +6834,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if mention_content:
                 prompt_prefix = f"{mention_content}\n{prompt_prefix}"
             prompt_tail = f"\n```\n**Reason:** {reason_display}"
+            if not smart_denied and allow_session:
+                prompt_tail += (
+                    "\n\n**Session** = until this conversation ends "
+                    "(starting a new session clears it)."
+                )
             truncated_suffix = "\n... [truncated]"
             command_budget = max(0, self.MAX_MESSAGE_LENGTH - len(prompt_prefix) - len(prompt_tail))
             content_cmd_display = str(command or "")

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2049,7 +2049,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 "elements": [
                     {
                         "tag": "markdown",
-                        "content": self._format_exec_approval(command, description, smart_denied),
+                        "content": self._format_exec_approval(
+                            command, description, smart_denied,
+                            session_note=(not smart_denied and allow_session),
+                        ),
                     },
                     {
                         "tag": "action",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2263,7 +2263,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 reaction_legend_parts.append("♾️ = approve always")
         reaction_legend_parts.append("❎ = deny")
         text = (
-            f"{self._format_exec_approval(command, description)}\n\n"
+            f"{self._format_exec_approval(command, description, session_note=(not smart_denied and allow_session))}\n\n"
             f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
             + "\n".join(reaction_legend_parts)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6380,6 +6380,8 @@ class SlackAdapter(BasePlatformAdapter):
             header = ":warning: *Command Approval Required*\n"
             if smart_denied:
                 header += "*Smart DENY:* owner override applies to this one operation only.\n"
+            elif allow_session:
+                header += "*Session* = until this conversation ends (starting a new session clears it).\n"
             reason = f"Reason: {description[:500]}"
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5363,7 +5363,10 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            text = self._format_exec_approval(command, description, smart_denied)
+            text = self._format_exec_approval(
+                command, description, smart_denied,
+                session_note=(not smart_denied and allow_session),
+            )
 
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -147,6 +147,50 @@ class TestCliApprovalUi:
 
 
 
+    def test_approval_panel_shows_session_duration_note(self):
+        """The session-scoped approval option explains how long a "session"
+        lasts so the user knows the scope of what they approve (#75639)."""
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "rm -rf /tmp/example",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "show_full": True,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((100, 40))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+        assert "Session = until this conversation ends" in rendered
+        assert "starting a new session clears it" in rendered
+
+    def test_approval_panel_smart_deny_hides_session_note(self):
+        """Smart DENY offers only once/deny — no session option, no note."""
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "rm -rf /tmp/example",
+            "description": "recursive delete",
+            "choices": ["once", "deny"],
+            "selected": 0,
+            "show_full": True,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((100, 40))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+        assert "until this conversation ends" not in rendered
+
     def test_approval_display_truncates_giant_command_in_view_mode(self):
         """If the user hits /view on a massive command, choices still render.
 

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -134,5 +134,17 @@ class TestApprovalTextFallbackContract:
         assert "`/approve`" in text
         assert "approve session" not in text
         assert "approve always" not in text
+        assert "until this conversation ends" not in text
+
+    def test_session_note_present_when_session_offered(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /", "dangerous deletion", "/",
+            allow_permanent=False,
+        )
+        assert "approve session" in text
+        assert "until this conversation ends" in text
+        assert "starting a new session clears it" in text
 
 

--- a/tests/gateway/test_interactive_prompt_base.py
+++ b/tests/gateway/test_interactive_prompt_base.py
@@ -62,6 +62,29 @@ class TestFormatExecApproval:
         assert "a &amp; b" in text
 
 
+class TestExecApprovalSessionNote:
+    """The session-scoped approval button needs a note explaining how long a
+    "session" lasts (#75639)."""
+
+    def test_session_note_appended_when_session_offered(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("rm -rf /", "scary", session_note=True)
+        assert "Session = until this conversation ends" in text
+        assert "(starting a new session clears it)" in text
+
+    def test_no_session_note_by_default(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("rm -rf /", "scary")
+        assert "until this conversation ends" not in text
+
+    def test_no_session_note_when_smart_denied(self):
+        # Smart DENY only offers once/deny — no session option, no note.
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("rm -rf /", "scary", smart_denied=True, session_note=True)
+        assert "Smart DENY" in text
+        assert "until this conversation ends" not in text
+
+
 class TestFormatChoicePage:
     def test_single_page_no_page_info(self):
         opts, meta = BasePlatformAdapter._format_choice_page([1, 2, 3], 0, 10)

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -152,6 +152,49 @@ class TestTelegramExecApproval:
 
 
     @pytest.mark.asyncio
+    async def test_session_duration_note_in_text_when_session_offered(self):
+        """The prompt text explains how long a "session" lasts when the
+        session-scoped button is offered (#75639)."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        sent = {}
+
+        async def mock_send_message(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=42)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="rm -rf /important",
+            session_key="s", description="dangerous deletion",
+        )
+
+        assert "until this conversation ends" in sent["text"]
+        assert "starting a new session clears it" in sent["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_session_duration_note_when_smart_denied(self):
+        """Smart DENY offers only once/deny — no session note in the text."""
+        adapter = _make_adapter()
+        sent = {}
+
+        async def mock_send_message(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=42)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="rm -rf /important",
+            session_key="s", description="dangerous deletion",
+            smart_denied=True,
+        )
+
+        assert "until this conversation ends" not in sent["text"]
+
+
+    @pytest.mark.asyncio
     async def test_smart_deny_two_buttons_share_one_row(self, monkeypatch):
         """smart_deny yields 2 buttons — they pair into a single readable row."""
         adapter = _make_adapter()

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -13,6 +13,7 @@ const APPROVAL_OPTS = ['once', 'session', 'always', 'deny'] as const
 const APPROVAL_OPTS_NO_ALWAYS = APPROVAL_OPTS.filter(o => o !== 'always')
 const APPROVAL_OPTS_SMART_DENY = ['once', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
+const SESSION_NOTE = 'Session = until this conversation ends (a new session clears it)'
 const CMD_PREVIEW_LINES = 10
 
 type ApprovalChoice = 'always' | 'deny' | 'once' | 'session'
@@ -136,6 +137,10 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
           </Text>
         </Text>
       ))}
+
+      {opts.includes('session') ? (
+        <Text color={t.color.muted}>{SESSION_NOTE}</Text>
+      ) : null}
 
       <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-{opts.length} quick pick · Esc/Ctrl+C deny</Text>
     </Box>


### PR DESCRIPTION
Closes #75639

## What It Does

The dangerous-command approval prompt offers *Allow once / Allow for this session / Add to permanent allowlist*, but the user had no idea **how long a "session" lasts**. This PR adds an explanatory note everywhere the session option is offered:

> Session = until this conversation ends (starting a new session clears it).

The "session" approval stays valid until the current conversation ends — a new session clears the state (`clear_session`).

## Where It Appears

- **CLI** (prompt_toolkit approval panel) — note attached to the description when "session" is available
- **TUI** (`ui-tui` prompts) — note line below the options
- **Desktop/WebUI** — subtitle on the "Allow this session" dropdown item (i18n: en, ar, zh, zh-hant, ja)
- **Gateways** — Telegram, Discord, Slack, Feishu, Matrix (via shared core `_format_exec_approval` with new `session_note` parameter)
- **Text fallback** (`_format_exec_approval_fallback`)

In all cases the note does **not** appear when the session option is not offered (e.g. Smart DENY).

## Tests

- `tests/gateway/test_interactive_prompt_base.py` — note in core, default without note, smart-deny without note
- `tests/gateway/test_telegram_approval_buttons.py` — note in Telegram text when session offered, absent in smart-deny
- `tests/gateway/test_approval_prompt_redaction.py` — note in text fallback
- `tests/cli/test_cli_approval_ui.py` — note in CLI panel when session in choices, absent in smart-deny

91 Python tests and 1458 TUI tests passing (pre-existing failure in `test_approval.py` and `fallback-model.test.ts` unrelated).
