### PR TITLE
fix(qqbot): send standalone cron deliveries as markdown (msg_type 2)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1824,3 +1824,86 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+# ---------------------------------------------------------------------------
+# _send_qqbot standalone payload contracts
+# ---------------------------------------------------------------------------
+
+class _FakeQqbotResponse:
+    def __init__(self, status_code, data=None):
+        self.status_code = status_code
+        self._data = data or {}
+
+    def json(self):
+        return self._data
+
+
+class TestSendQqbotStandalonePayloads:
+    def _run(self, message="**bold**\n- item", extra=None, c2c_status=200):
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = SimpleNamespace(
+            token="secret",
+            extra={"app_id": "app-1", **(extra or {})},
+        )
+        calls = {}
+
+        class _FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def post(self, url, json=None, headers=None):
+                calls.setdefault("posts", []).append(
+                    {"url": url, "json": json, "headers": headers}
+                )
+                if url.endswith("/app/getAppAccessToken"):
+                    return _FakeQqbotResponse(200, {"access_token": "tok-123"})
+                if "/channels/" in url:
+                    return _FakeQqbotResponse(404)
+                if "/v2/users/" in url:
+                    return _FakeQqbotResponse(c2c_status, {"id": "c2c-msg-1"})
+                return _FakeQqbotResponse(200, {"id": "grp-msg-1"})
+
+        with patch("httpx.AsyncClient", _FakeAsyncClient):
+            result = asyncio.run(_send_qqbot(pconfig, "chat-1", message))
+        return result, calls["posts"]
+
+    def test_channel_request_uses_plain_content_payload(self):
+        result, posts = self._run()
+        assert result["success"] is True
+        channel_post = next(
+            p for p in posts if "/channels/" in p["url"]
+        )
+        # Guild channel contract: plain content body only, no markdown.
+        assert channel_post["json"] == {"content": "**bold**\n- item"}
+
+    def test_markdown_fallback_default(self):
+        result, posts = self._run()
+        c2c_post = next(p for p in posts if "/v2/users/" in p["url"])
+        assert c2c_post["json"] == {
+            "markdown": {"content": "**bold**\n- item"}, "msg_type": 2,
+        }
+
+    def test_plain_text_fallback_when_markdown_disabled(self):
+        result, posts = self._run(extra={"markdown_support": False})
+        c2c_post = next(p for p in posts if "/v2/users/" in p["url"])
+        assert c2c_post["json"] == {
+            "content": "**bold**\n- item", "msg_type": 0,
+        }
+
+    def test_group_fallback_uses_same_payload_as_c2c(self):
+        # Group endpoint is reached only when C2C also fails.
+        result, posts = self._run(c2c_status=404)
+        assert result["success"] is True
+        group_post = next(p for p in posts if "/v2/groups/" in p["url"])
+        assert group_post["json"] == {
+            "markdown": {"content": "**bold**\n- item"}, "msg_type": 2,
+        }
+

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2013,6 +2013,11 @@ async def _send_qqbot(pconfig, chat_id, message):
     if not appid or not secret:
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 
+    # Mirror QQAdapter's contract (adapter.py::__init__): markdown is
+    # opt-out via ``markdown_support``, defaulting to enabled. It applies to
+    # C2C/group payloads only — guild channels take plain content bodies.
+    markdown_support = bool(extra.get("markdown_support", True))
+
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             # Step 1: Get access token
@@ -2034,11 +2039,20 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"markdown": {"content": message[:4000]}, "msg_type": 2}
+            # Guild channels accept plain content bodies only — keep this
+            # payload separate from the C2C/group fallback (which may use
+            # markdown msg_type 2), matching QQAdapter._send_guild_text.
+            channel_payload = {"content": message[:4000]}
+            if markdown_support:
+                fallback_payload = {
+                    "markdown": {"content": message[:4000]}, "msg_type": 2,
+                }
+            else:
+                fallback_payload = {"content": message[:4000], "msg_type": 0}
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
+            resp = await client.post(url, json=channel_payload, headers=headers)
             if resp.status_code in {200, 201}:
                 data = resp.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2046,7 +2060,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
             url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
+            resp_c2c = await client.post(url_c2c, json=fallback_payload, headers=headers)
             if resp_c2c.status_code in {200, 201}:
                 data = resp_c2c.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2054,7 +2068,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If C2C also failed, try group endpoint
             url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
+            resp_group = await client.post(url_group, json=fallback_payload, headers=headers)
             if resp_group.status_code in {200, 201}:
                 data = resp_group.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2034,7 +2034,7 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            payload = {"markdown": {"content": message[:4000]}, "msg_type": 2}
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"


### PR DESCRIPTION
## Summary
- `_send_qqbot` (the standalone REST path used when cron delivery has no live gateway adapter) now posts `msg_type: 2` with a `markdown.content` payload instead of `msg_type: 0` plain text.
- This matches the gateway live-adapter path (`_build_text_body`), so QQ renders formatting consistently regardless of which delivery path cron takes.

## Motivation
Cron delivery has two paths: the gateway live adapter (used by the gateway's in-process scheduler, which passes live adapters into `cron/scheduler.py::tick`) and the standalone path (used when a scheduler without adapters — e.g. the desktop web_server scheduler — wins the ticker lock). The standalone path routed through `tools/send_message_tool.py::_send_qqbot`, which sent `msg_type: 0` (plain text). QQ therefore displayed raw markdown syntax (`**bold**`, `### headings`, lists) instead of rendering it, while jobs delivered via the live adapter rendered fine. Users saw markdown "leak" as plain text on some cron deliveries and not others.

## Implementation
- One-line payload change in `_send_qqbot`: `{"content": ..., "msg_type": 0}` → `{"markdown": {"content": ...}, "msg_type": 2}`.
- Custom markdown messages have been available to all QQ bots since 2026-04-23 (no template permission required), and the live-adapter path already uses this exact payload shape successfully.

## Validation
- Direct `_send_qqbot` call with a markdown test message (`**bold**`, `### heading`, `- list`, `> quote`, inline code, link): QQ API accepted (message id returned) and the message rendered as rich text in QQ (user-confirmed).
- Delivery-path log signature unchanged: `delivered to qqbot:...` (standalone, no `via live adapter` suffix) now still produces markdown-typed messages.

## Impact
- Only the standalone QQBot REST send path changes; live-adapter sends are untouched.
- No config change needed; custom markdown is open to all bots.
