### PR TITLE
fix(cli): dispatch /status /agents /context /egress inline when agent is busy

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9476,14 +9476,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _should_handle_readonly_dispatch_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when a read-only dispatch-policy command should run immediately.
 
-        Commands like /status, /agents, /context, and /egress have
-        ``busy_policy="dispatch"`` in their CommandDef, meaning the gateway
-        runs them without queuing behind the active turn. The classic CLI
-        ignores this policy and queues them through ``_pending_input`` --
-        ``process_loop`` is blocked inside ``self.chat()``, so the command
-        silently waits until the turn finishes. Dispatching inline on the
-        UI thread shows output immediately. These commands are safe to run
-        concurrently with an active agent -- they only read state.
+        Commands with ``busy_policy="dispatch"`` in their CommandDef are meant
+        to run without queuing behind the active turn. The gateway honors this;
+        the classic CLI ignores it. Derive eligibility from the CommandDef
+        instead of a hard-coded name list so new dispatch-policy commands
+        pick up the behavior automatically.
+
+        A command is safe to dispatch inline when it uses a shared read-only
+        executor (``execute`` is set) or is a known read-only dispatch command
+        (/status, /agents). Commands with ``busy_handler``, ``subcommands``,
+        or ``cli_only`` state toggles are excluded.
         """
         if not text or has_images or not _looks_like_slash_command(text):
             return False
@@ -9491,7 +9493,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.commands import resolve_command
             base = text.split(None, 1)[0].lower().lstrip("/")
             cmd = resolve_command(base)
-            return bool(cmd and cmd.name in {"status", "agents", "context", "egress"})
+            if not cmd or cmd.busy_policy != "dispatch":
+                return False
+            if cmd.gateway_only:
+                return False
+            if cmd.name in {"model", "steer", "background"}:
+                return False
+            # Shared read-only executor path (/profile, /version, /help, /egress)
+            if cmd.execute is not None:
+                return True
+            # Known read-only dispatch commands without an execute attribute
+            if cmd.name in {"status", "agents"}:
+                return True
+            return False
         except Exception:
             return False
 

--- a/cli.py
+++ b/cli.py
@@ -9473,6 +9473,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             return False
 
+    def _should_handle_readonly_dispatch_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True when a read-only dispatch-policy command should run immediately.
+
+        Commands like /status, /agents, /context, and /egress have
+        ``busy_policy="dispatch"`` in their CommandDef, meaning the gateway
+        runs them without queuing behind the active turn. The classic CLI
+        ignores this policy and queues them through ``_pending_input`` --
+        ``process_loop`` is blocked inside ``self.chat()``, so the command
+        silently waits until the turn finishes. Dispatching inline on the
+        UI thread shows output immediately. These commands are safe to run
+        concurrently with an active agent -- they only read state.
+        """
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip("/")
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name in {"status", "agents", "context", "egress"})
+        except Exception:
+            return False
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -15015,6 +15037,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # app, so without this the submitted "/steer <text>" can
                     # linger in the input area (looking unsent) and invite an
                     # accidental re-submit. See issue #34569.
+                    event.app.invalidate()
+                    return
+
+                # Handle read-only dispatch-policy commands (/status, /agents,
+                # /context, /egress) immediately on the UI thread. Same queue
+                # problem as /steer: ``process_loop`` is blocked inside
+                # ``self.chat()``, so queuing through ``_pending_input`` would
+                # silently delay these commands until after the turn finishes.
+                # They are safe to run concurrently with an agent — read-only.
+                if self._should_handle_readonly_dispatch_inline(text, has_images=has_images):
+                    self.process_command(text)
+                    event.app.current_buffer.reset(append_to_history=True)
                     event.app.invalidate()
                     return
 

--- a/cli.py
+++ b/cli.py
@@ -9503,7 +9503,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if cmd.execute is not None:
                 return True
             # Known read-only dispatch commands without an execute attribute
-            if cmd.name in {"status", "agents"}:
+            if cmd.name in {"status", "agents", "context"}:
                 return True
             return False
         except Exception:

--- a/tests/cli/test_cli_readonly_dispatch_inline.py
+++ b/tests/cli/test_cli_readonly_dispatch_inline.py
@@ -1,0 +1,102 @@
+"""Tests for _should_handle_readonly_dispatch_inline — #75835."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_cli():
+    """Create a HermesCLI instance with prompt_toolkit stubbed out."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod.HermesCLI()
+
+
+class TestReadonlyDispatchDetector:
+    """_should_handle_readonly_dispatch_inline gates inline dispatch."""
+
+    # ── Commands that should dispatch inline ──────────────────────────
+
+    @pytest.mark.parametrize("text", [
+        "/status",
+        "/agents",
+        "/tasks",       # alias for /agents
+        "/context",
+        "/ctx",         # alias for /context
+        "/profile",
+        "/version",
+        "/v",           # alias for /version
+        "/help",
+        "/egress",
+    ])
+    def test_detects_readonly_dispatch_commands(self, text):
+        cli = _make_cli()
+        assert cli._should_handle_readonly_dispatch_inline(text) is True
+
+    # ── Commands that must NOT dispatch inline ────────────────────────
+
+    @pytest.mark.parametrize("text", [
+        "/queue hello",     # busy_handler=queue — mutates state
+        "/goal do x",       # busy_handler=goal — mutates state
+        "/subgoal check",   # modifies goal criteria
+        "/yolo",            # changes security mode
+        "/update",          # modifies installation
+        "/model gpt-5",     # handled by dedicated inline handler
+        "/steer text",      # handled by dedicated inline handler
+        "/background task", # handled by dedicated inline handler
+    ])
+    def test_rejects_state_mutating_commands(self, text):
+        cli = _make_cli()
+        assert cli._should_handle_readonly_dispatch_inline(text) is False
+
+    # ── Edge cases ─────────────────────────────────────────────────────
+
+    def test_ignores_non_slash_input(self):
+        cli = _make_cli()
+        assert cli._should_handle_readonly_dispatch_inline("status") is False
+        assert cli._should_handle_readonly_dispatch_inline("") is False
+
+    def test_ignores_with_attached_images(self):
+        cli = _make_cli()
+        assert cli._should_handle_readonly_dispatch_inline("/status", has_images=True) is False
+
+    def test_ignores_unknown_commands(self):
+        cli = _make_cli()
+        assert cli._should_handle_readonly_dispatch_inline("/nonexistent") is False


### PR DESCRIPTION
## Summary

Commands with `busy_policy="dispatch"` in their CommandDef are meant to run immediately, without queuing behind the active turn. The gateway honors this policy. The classic CLI ignores it — queuing through `_pending_input` where `process_loop` is blocked inside `self.chat()`.

Three commands already have inline dispatch: `/model`, `/steer`, `/background`. Four more read-only commands are missing: `/status`, `/agents` (`/tasks`), `/context` (`/ctx`), `/egress`.

## Fix

Add `_should_handle_readonly_dispatch_inline()` that matches these four commands by name, and wire into the UI event handler immediately after the /steer inline path.

These are safe to run concurrently with an active agent — they only read state.