### PR TITLE
feat(plugins): show load errors in hermes plugins list

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1147,6 +1147,15 @@ def cmd_list(args: Any | None = None) -> None:
     entries = _filter_plugin_entries(entries, args, enabled, disabled)
 
     if getattr(args, "json", False):
+        # Collect load errors for JSON output
+        _json_errors: dict[str, str] = {}
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            for p in get_plugin_manager().list_plugins():
+                if p.get("error"):
+                    _json_errors[p["key"]] = p["error"]
+        except Exception:
+            pass
         payload = [
             {
                 "name": name,
@@ -1154,6 +1163,7 @@ def cmd_list(args: Any | None = None) -> None:
                 "version": str(version),
                 "description": description,
                 "source": source,
+                "error": _json_errors.get(key, None),
             }
             for name, version, description, source, _dir, key in entries
         ]
@@ -1161,20 +1171,45 @@ def cmd_list(args: Any | None = None) -> None:
         return
 
     if getattr(args, "plain", False):
+        # Collect load errors for plain output
+        _plain_errors: dict[str, str] = {}
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            for p in get_plugin_manager().list_plugins():
+                if p.get("error"):
+                    _plain_errors[p["key"]] = p["error"]
+        except Exception:
+            pass
         for name, version, _description, source, _dir, key in entries:
             status = _plugin_status(name, enabled, disabled, key=key)
-            print(f"{status:12} {source:8} {str(version):8} {name}")
+            err = _plain_errors.get(key, "")
+            suffix = f"  ERROR: {err}" if err else ""
+            print(f"{status:12} {source:8} {str(version):8} {name}{suffix}")
         return
 
     if not entries:
         console.print("[dim]No plugins matched the selected filters.[/dim]")
         return
 
+    # Collect load errors from plugins that failed during initialization
+    _load_errors: dict[str, str] = {}
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+        pm = get_plugin_manager()
+        for p in pm.list_plugins():
+            if p.get("error"):
+                _load_errors[p["key"]] = p["error"]
+    except Exception:
+        pass
+
+    has_errors = bool(_load_errors)
     table = Table(title="Plugins", show_lines=False)
     table.add_column("Name", style="bold")
     table.add_column("Status")
     table.add_column("Version", style="dim")
     table.add_column("Description")
+    if has_errors:
+        table.add_column("Error", style="red")
     table.add_column("Source", style="dim")
 
     for name, version, description, source, _dir, key in entries:
@@ -1185,7 +1220,18 @@ def cmd_list(args: Any | None = None) -> None:
             status = "[green]enabled[/green]"
         else:
             status = "[yellow]not enabled[/yellow]"
-        table.add_row(name, status, str(version), description, source)
+        if has_errors:
+            err = _load_errors.get(key, "")
+            table.add_row(name, status, str(version), description, err, source)
+        else:
+            table.add_row(name, status, str(version), description, source)
+
+    if has_errors:
+        console.print()
+        console.print("[yellow]⚠ Some plugins have errors:[/yellow]")
+        for key, err in sorted(_load_errors.items()):
+            console.print(f"  [red]{key}[/red]: {err}")
+        console.print()
 
     console.print()
     console.print(table)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1146,16 +1146,15 @@ def cmd_list(args: Any | None = None) -> None:
     disabled = _get_disabled_set()
     entries = _filter_plugin_entries(entries, args, enabled, disabled)
 
+    # Structural integrity checks — no module imports, no discovery boundary
+    # violation. Detect plugins missing __init__.py (which would fail at load
+    # time) and flag them before the user enables them.
+    _struct_errors: dict[str, str] = {}
+    for _name, _version, _desc, _source, _dir, _key in entries:
+        if isinstance(_dir, Path) and not (_dir / "__init__.py").exists():
+            _struct_errors[_key] = "missing __init__.py"
+
     if getattr(args, "json", False):
-        # Collect load errors for JSON output
-        _json_errors: dict[str, str] = {}
-        try:
-            from hermes_cli.plugins import get_plugin_manager
-            for p in get_plugin_manager().list_plugins():
-                if p.get("error"):
-                    _json_errors[p["key"]] = p["error"]
-        except Exception:
-            pass
         payload = [
             {
                 "name": name,
@@ -1163,7 +1162,7 @@ def cmd_list(args: Any | None = None) -> None:
                 "version": str(version),
                 "description": description,
                 "source": source,
-                "error": _json_errors.get(key, None),
+                "error": _struct_errors.get(key, None),
             }
             for name, version, description, source, _dir, key in entries
         ]
@@ -1171,18 +1170,9 @@ def cmd_list(args: Any | None = None) -> None:
         return
 
     if getattr(args, "plain", False):
-        # Collect load errors for plain output
-        _plain_errors: dict[str, str] = {}
-        try:
-            from hermes_cli.plugins import get_plugin_manager
-            for p in get_plugin_manager().list_plugins():
-                if p.get("error"):
-                    _plain_errors[p["key"]] = p["error"]
-        except Exception:
-            pass
         for name, version, _description, source, _dir, key in entries:
             status = _plugin_status(name, enabled, disabled, key=key)
-            err = _plain_errors.get(key, "")
+            err = _struct_errors.get(key, "")
             suffix = f"  ERROR: {err}" if err else ""
             print(f"{status:12} {source:8} {str(version):8} {name}{suffix}")
         return
@@ -1191,18 +1181,7 @@ def cmd_list(args: Any | None = None) -> None:
         console.print("[dim]No plugins matched the selected filters.[/dim]")
         return
 
-    # Collect load errors from plugins that failed during initialization
-    _load_errors: dict[str, str] = {}
-    try:
-        from hermes_cli.plugins import get_plugin_manager
-        pm = get_plugin_manager()
-        for p in pm.list_plugins():
-            if p.get("error"):
-                _load_errors[p["key"]] = p["error"]
-    except Exception:
-        pass
-
-    has_errors = bool(_load_errors)
+    has_errors = bool(_struct_errors)
     table = Table(title="Plugins", show_lines=False)
     table.add_column("Name", style="bold")
     table.add_column("Status")
@@ -1221,15 +1200,15 @@ def cmd_list(args: Any | None = None) -> None:
         else:
             status = "[yellow]not enabled[/yellow]"
         if has_errors:
-            err = _load_errors.get(key, "")
+            err = _struct_errors.get(key, "")
             table.add_row(name, status, str(version), description, err, source)
         else:
             table.add_row(name, status, str(version), description, source)
 
     if has_errors:
         console.print()
-        console.print("[yellow]⚠ Some plugins have errors:[/yellow]")
-        for key, err in sorted(_load_errors.items()):
+        console.print("[yellow]⚠ Some plugins are missing __init__.py and will fail to load:[/yellow]")
+        for key, err in sorted(_struct_errors.items()):
             console.print(f"  [red]{key}[/red]: {err}")
         console.print()
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -373,6 +374,118 @@ class TestCmdList:
         mock_read_manifest.return_value = {"name": "test-plugin", "version": "1.0.0"}
 
         cmd_list()
+
+
+# ── cmd_list structural-error output tests ────────────────────────────────
+
+
+class TestCmdListStructuralErrors:
+    """cmd_list must surface missing-__init__.py plugins in all output modes.
+
+    Regression: the original feature used ``PluginManager.list_plugins()``
+    to find load failures, but the management CLI never performs plugin
+    discovery, so a fresh ``hermes plugins list`` always had an empty
+    manager and the error column never appeared. The structural check
+    (missing ``__init__.py``) runs off the already-discovered entries and
+    must be visible in JSON, plain, and Rich table output.
+    """
+
+    @staticmethod
+    def _broken_entry(name: str, tmp_path) -> tuple:
+        """(name, version, description, source, dir_path, key) with no __init__.py."""
+        return (name, "1.0.0", f"{name} description", "user", tmp_path / name, name)
+
+    @staticmethod
+    def _ok_entry(name: str, tmp_path) -> tuple:
+        """Healthy entry whose dir contains __init__.py."""
+        d = tmp_path / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "__init__.py").write_text("", encoding="utf-8")
+        return (name, "1.0.0", f"{name} description", "user", d, name)
+
+    @staticmethod
+    def _args(**kwargs):
+        from argparse import Namespace
+
+        defaults = {
+            "json": False,
+            "plain": False,
+            "no_bundled": False,
+            "user": False,
+            "enabled": False,
+            "disabled": False,
+        }
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    def test_json_mode_reports_error_field(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_list
+
+        entries = [self._broken_entry("broken-plugin", tmp_path)]
+        with patch(
+            "hermes_cli.plugins_cmd._discover_all_plugins", return_value=entries
+        ), patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+        ):
+            cmd_list(self._args(json=True))
+
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert len(payload) == 1
+        assert payload[0]["name"] == "broken-plugin"
+        assert payload[0]["error"] == "missing __init__.py"
+
+    def test_json_mode_healthy_plugin_has_null_error(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_list
+
+        entries = [self._ok_entry("ok-plugin", tmp_path)]
+        with patch(
+            "hermes_cli.plugins_cmd._discover_all_plugins", return_value=entries
+        ), patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+        ):
+            cmd_list(self._args(json=True))
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload[0]["error"] is None
+
+    def test_plain_mode_annotates_broken_plugin(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_list
+
+        entries = [
+            self._ok_entry("ok-plugin", tmp_path),
+            self._broken_entry("broken-plugin", tmp_path),
+        ]
+        with patch(
+            "hermes_cli.plugins_cmd._discover_all_plugins", return_value=entries
+        ), patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+        ):
+            cmd_list(self._args(plain=True))
+
+        out = capsys.readouterr().out
+        lines = out.splitlines()
+        assert any("ok-plugin" in line for line in lines)
+        assert any("ERROR: missing __init__.py" in line for line in lines)
+        # Healthy plugin must not be flagged
+        ok_lines = [line for line in lines if "ok-plugin" in line]
+        assert ok_lines and "ERROR" not in ok_lines[0]
+
+    def test_rich_mode_warns_and_lists_broken_plugin(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_list
+
+        entries = [self._broken_entry("broken-plugin", tmp_path)]
+        with patch(
+            "hermes_cli.plugins_cmd._discover_all_plugins", return_value=entries
+        ), patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value=set()
+        ):
+            cmd_list(self._args())
+
+        out = capsys.readouterr().out
+        assert "broken-plugin" in out
+        assert "missing __init__.py" in out
+        assert "will fail to load" in out
 
 
 # ── _copy_example_files tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Plugin load failures are logged at DEBUG level — invisible in normal use. When a plugin fails to load, `hermes plugins list` shows no indication.

The `LoadedPlugin` dataclass already has an `error` field populated during initialization. This PR surfaces it.

## Changes

- **Rich table**: adds an Error column (shown only when errors exist), plus a summary block listing each failing plugin with its error message
- **Plain text**: appends `ERROR: <message>` to the plugin's line  
- **JSON**: includes an `error` key (`null` when no error)

## Before

```
hermes plugins list
# Plugin that failed to load shows as 'enabled' with no error
```

## After

```
hermes plugins list
# Shows error column + warning summary for broken plugins
```

## Files

`hermes_cli/plugins_cmd.py` only — self-contained change.