### PR TITLE
fix(gateway): extend systemd startup deadline until READY

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -61,6 +61,7 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.systemd_notify import SystemdStartupDeadline
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -25023,6 +25024,45 @@ def _shutdown_gateway_health_export(runner: Any) -> None:
         logger.debug("gateway health OTLP export shutdown failed", exc_info=True)
 
 
+async def _discover_mcp_and_start_runner(
+    runner: GatewayRunner,
+) -> tuple[bool, SystemdStartupDeadline]:
+    """Start the runner and keep its systemd startup deadline active."""
+    deadline = SystemdStartupDeadline(
+        config_enabled=runner.config.systemd_watchdog_seconds > 0
+    )
+    deadline.start()
+    try:
+        # Keep the event loop responsive while a configured MCP server is slow
+        # or unreachable. The deadline task can therefore continue notifying
+        # systemd throughout MCP discovery and sequential adapter startup.
+        try:
+            from tools.mcp_tool import discover_mcp_tools
+
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, discover_mcp_tools)
+        except Exception as exc:
+            logger.debug("MCP tool discovery failed: %s", exc)
+        success = await runner.start()
+    except BaseException:
+        await deadline.stop()
+        raise
+    if not success:
+        await deadline.stop()
+    return success, deadline
+
+
+async def _complete_systemd_startup(
+    deadline: SystemdStartupDeadline,
+    runner: GatewayRunner,
+) -> None:
+    """Stop deadline extension immediately before the runtime READY signal."""
+    await deadline.stop()
+    start_watchdog = getattr(runner, "_start_systemd_watchdog", None)
+    if callable(start_watchdog):
+        start_watchdog()
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -25467,22 +25507,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     _ensure_windows_gateway_venv_imports()
 
-    # MCP tool discovery — run in an executor so the asyncio event loop
-    # stays responsive even when a configured MCP server is slow or
-    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
-    # internally; calling it from the loop thread would freeze platform
-    # heartbeats (Discord shard, Telegram polling) until it returned.
-    # See #16856.
+    # MCP discovery and adapter startup run under a renewable systemd startup
+    # deadline when the opt-in watchdog unit owns the notify environment.
     try:
-        from tools.mcp_tool import discover_mcp_tools
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
-    except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
-
-    # Start the gateway
-    try:
-        success = await runner.start()
+        (
+            success,
+            systemd_startup_deadline,
+        ) = await _discover_mcp_and_start_runner(runner)
     except BaseException:
         _shutdown_gateway_health_export(runner)
         raise
@@ -25500,6 +25531,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception:
         pass
     if runner.should_exit_cleanly:
+        await systemd_startup_deadline.stop()
         _shutdown_gateway_health_export(runner)
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
@@ -25514,6 +25546,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             raise SystemExit(runner.exit_code)
         return True
     if not runner._running:
+        await systemd_startup_deadline.stop()
         # Startup was intentionally aborted by restart/shutdown before entering
         # running mode; preserve that lifecycle path without starting cron.
         try:
@@ -25599,11 +25632,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     housekeeping_thread.start()
 
     # READY is emitted only after adapters, cron, and housekeeping have all
-    # reached their running boundary. Missing config/systemd runtime state
-    # leaves the watchdog disabled without changing gateway behavior.
-    start_watchdog = getattr(runner, "_start_systemd_watchdog", None)
-    if callable(start_watchdog):
-        start_watchdog()
+    # reached their running boundary. Stop startup extensions immediately
+    # before the runtime watchdog sends READY=1.
+    await _complete_systemd_startup(systemd_startup_deadline, runner)
 
     # Wait for shutdown
     await runner.wait_for_shutdown()

--- a/gateway/systemd_notify.py
+++ b/gateway/systemd_notify.py
@@ -57,6 +57,83 @@ def watchdog_interval_seconds() -> Optional[float]:
     return interval
 
 
+def _watchdog_pid_matches_current_process() -> bool:
+    """Reject a WATCHDOG_PID inherited from another process."""
+    raw_pid = os.environ.get("WATCHDOG_PID", "").strip()
+    if not raw_pid:
+        return True
+    try:
+        return int(raw_pid) == os.getpid()
+    except (TypeError, ValueError):
+        return False
+
+
+class SystemdStartupDeadline:
+    """Extend startup while a watchdog-enabled Type=notify unit initializes."""
+
+    def __init__(
+        self,
+        *,
+        config_enabled: bool = True,
+        interval_seconds: float = 30.0,
+        extend_seconds: int = 60,
+    ) -> None:
+        self._config_enabled = bool(config_enabled)
+        self._interval_seconds = max(0.01, float(interval_seconds))
+        self._extend_usec = max(1, int(extend_seconds * 1_000_000))
+        self._task: Optional[asyncio.Task[None]] = None
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self._config_enabled
+            and watchdog_interval_seconds() is not None
+            and _watchdog_pid_matches_current_process()
+        )
+
+    @property
+    def task(self) -> Optional[asyncio.Task[None]]:
+        return self._task
+
+    def start(self) -> bool:
+        """Start repeatedly extending systemd's startup deadline."""
+        if not self.enabled:
+            return False
+        if self._task is not None and not self._task.done():
+            return True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        self._task = asyncio.create_task(
+            self._run(), name="hermes-systemd-startup-deadline"
+        )
+        return True
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                notify(f"EXTEND_TIMEOUT_USEC={self._extend_usec}")
+                await asyncio.sleep(self._interval_seconds)
+        except asyncio.CancelledError:
+            return
+
+    async def stop(self) -> None:
+        """Cancel startup notifications without emitting runtime state."""
+        task = self._task
+        self._task = None
+        if task is None or task is asyncio.current_task():
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
+
 class SystemdWatchdog:
     """Feed systemd while the asyncio event loop continues to make progress."""
 

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
 
 import pytest
@@ -53,6 +54,56 @@ def test_notify_uses_nonblocking_datagram_send(monkeypatch):
 
     assert notify_mod.notify("READY=1") is True
     assert calls[0] == ("setblocking", False)
+
+
+def test_startup_deadline_rejects_mismatched_watchdog_pid(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid() + 1))
+
+    from gateway.systemd_notify import SystemdStartupDeadline
+
+    assert SystemdStartupDeadline().enabled is False
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_repeats_until_stopped(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    deadline = notify_mod.SystemdStartupDeadline(
+        interval_seconds=0.01, extend_seconds=1
+    )
+
+    assert deadline.start() is True
+    await asyncio.sleep(0.025)
+    await deadline.stop()
+    count_after_stop = len(calls)
+    await asyncio.sleep(0.02)
+
+    assert calls.count("EXTEND_TIMEOUT_USEC=1000000") >= 2
+    assert len(calls) == count_after_stop
+    assert deadline.task is None
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_is_inert_when_config_disabled(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+
+    from gateway.systemd_notify import SystemdStartupDeadline
+
+    deadline = SystemdStartupDeadline(config_enabled=False)
+    assert deadline.enabled is False
+    assert deadline.start() is False
+    await deadline.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_systemd_watchdog_lifecycle.py
+++ b/tests/gateway/test_systemd_watchdog_lifecycle.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 import pytest
 
 from gateway.config import GatewayConfig
-from gateway.run import GatewayRunner, start_gateway
+from gateway.run import (
+    GatewayRunner,
+    _complete_systemd_startup,
+    _discover_mcp_and_start_runner,
+    start_gateway,
+)
 from tests.gateway.restart_test_helpers import make_restart_runner
 
 
@@ -50,5 +55,82 @@ def test_runner_starts_watchdog_only_after_running(monkeypatch):
     watchdog = _FakeWatchdog.instances[-1]
     assert watchdog.config_enabled is True
     assert watchdog.calls == ["start", "ready:Hermes Gateway running"]
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stays_active_until_ready_boundary(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start")
+            return True
+
+        def _start_systemd_watchdog(self):
+            order.append("watchdog.ready")
+            return True
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr(
+        "tools.mcp_tool.discover_mcp_tools",
+        lambda: order.append("mcp.discover"),
+    )
+
+    runner = _Runner()
+    success, deadline = await _discover_mcp_and_start_runner(runner)
+    assert success is True
+    assert order == [
+        "deadline.init:True",
+        "deadline.start",
+        "mcp.discover",
+        "runner.start",
+    ]
+
+    await _complete_systemd_startup(deadline, runner)
+    assert order[-2:] == ["deadline.stop", "watchdog.ready"]
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stops_when_runner_start_fails(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start")
+            raise RuntimeError("startup failed")
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        await _discover_mcp_and_start_runner(_Runner())
+
+    assert order[-1] == "deadline.stop"
 
 

--- a/tests/gateway/test_systemd_watchdog_lifecycle.py
+++ b/tests/gateway/test_systemd_watchdog_lifecycle.py
@@ -104,6 +104,38 @@ async def test_startup_deadline_stays_active_until_ready_boundary(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_startup_deadline_stops_when_runner_returns_false(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start:false")
+            return False
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+
+    success, deadline = await _discover_mcp_and_start_runner(_Runner())
+
+    assert success is False
+    assert deadline is not None
+    assert order[-2:] == ["runner.start:false", "deadline.stop"]
+
+
+@pytest.mark.asyncio
 async def test_startup_deadline_stops_when_runner_start_fails(monkeypatch):
     order: list[str] = []
 


### PR DESCRIPTION
## Summary

- keep a watchdog-enabled systemd `Type=notify` gateway's startup deadline alive with `EXTEND_TIMEOUT_USEC` while MCP discovery and platform adapters initialize
- stop deadline extension immediately before the runtime watchdog emits `READY=1`
- preserve existing behavior when the systemd watchdog is disabled or the notify environment belongs to another PID

## Why

Gateway startup can legitimately exceed a systemd manager's default start timeout. MCP discovery may wait on a cross-process lock and then perform its own bounded discovery, while platform adapters connect sequentially with independent timeouts. A fixed `TimeoutStartSec` would either remain too short for valid startup paths or override a host administrator's longer policy.

This change uses systemd's renewable startup deadline protocol instead. It sends an initial extension immediately, renews it every 30 seconds with a 60-second window, and cancels the task on runner failure, explicit early exits, or directly before `READY=1`.

## Tests

- `python -m pytest tests/gateway -k 'systemd or startup' -q -o 'addopts='` — 43 passed, 2 skipped
- `python -m pytest tests/hermes_cli/test_gateway*.py -q -o 'addopts='` — 162 passed
- focused startup/systemd suite — 25 passed
- `ruff check` on changed files — passed
- `git diff --check` and `py_compile` — passed
