### PR TITLE
feat(cli): numerical session listing and reference (#75663)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11885,7 +11885,10 @@ def main():
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
 
-    sessions_list = sessions_subparsers.add_parser("list", help="List recent sessions")
+    sessions_list = sessions_subparsers.add_parser(
+        "list",
+        help="List recent sessions (numbered — reference a line as #N in delete)",
+    )
     sessions_list.add_argument(
         "--source", help="Filter by source (cli, telegram, discord, etc.)"
     )
@@ -12078,7 +12081,12 @@ def main():
     sessions_delete = sessions_subparsers.add_parser(
         "delete", help="Delete a specific session"
     )
-    sessions_delete.add_argument("session_id", help="Session ID to delete")
+    sessions_delete.add_argument(
+        "session_id",
+        metavar="ID|#N",
+        help="Session ID, unique prefix, or the #N line number shown by "
+        "'hermes sessions list' (e.g. 'hermes sessions delete 3')",
+    )
     sessions_delete.add_argument(
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -55,6 +55,48 @@ def _confirm_prompt(prompt: str) -> bool:
         return False
 
 
+# How far a numeric session reference may reach into the listing. `sessions
+# list` defaults to showing 20 rows; numeric references resolve against the
+# same (unfiltered) listing but allow up to this many so `--limit` listings
+# stay addressable without extra flags.
+_NUMERIC_REF_LIMIT = 1000
+
+
+def _resolve_session_ref(db, ref):
+    """Resolve a ``sessions delete`` argument to a full session ID.
+
+    Accepted forms, in precedence order:
+
+    * a 1-based line number as printed by ``hermes sessions list``
+      (``delete 3`` deletes the third listed session) — resolved against
+      the same default listing the command shows (tool sessions hidden,
+      newest first), so the numbers on screen map 1:1 to delete;
+    * an exact session ID;
+    * a unique session-ID prefix.
+
+    Returns the full ID, or None after printing a targeted error when a
+    numeric reference falls outside the listing.
+    """
+    ref = str(ref).strip()
+    if ref.isdigit():
+        n = int(ref)
+        if n < 1:
+            print(f"Session number {n} is not a valid line number (must be >= 1).")
+            return None
+        rows = db.list_sessions_rich(
+            source=None, exclude_sources=["tool"], limit=_NUMERIC_REF_LIMIT
+        )
+        if n <= len(rows):
+            return rows[n - 1]["id"]
+        print(
+            f"Session number {n} not found — the default listing shows "
+            f"{len(rows)} session(s) (use `hermes sessions list --limit` "
+            "to see more)."
+        )
+        return None
+    return db.resolve_session_id(ref)
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -273,29 +315,29 @@ def cmd_sessions(args, sessions_parser=None):
 
         if has_ws:
             if has_titles:
-                print(f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
+                print(f"{'#':>3}  {'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
+                print("─" * 115)
             else:
-                print(f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 100)
-            for s in sessions:
+                print(f"{'#':>3}  {'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
+                print("─" * 105)
+            for i, s in enumerate(sessions, 1):
                 last_active = _relative_time(s.get("last_active"))
                 ws = _ws_label(s)[:16]
                 if has_titles:
                     title = (s.get("title") or "—")[:26]
-                    print(f"{title:<28} {ws:<18} {last_active:<13} {s['id']}")
+                    print(f"{i:>3}  {title:<28} {ws:<18} {last_active:<13} {s['id']}")
                 else:
                     preview = s.get("preview", "")[:36]
-                    print(f"{preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
+                    print(f"{i:>3}  {preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
             return
 
         if has_titles:
-            print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-            print("─" * 110)
+            print(f"{'#':>3}  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+            print("─" * 115)
         else:
-            print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-            print("─" * 95)
-        for s in sessions:
+            print(f"{'#':>3}  {'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+            print("─" * 100)
+        for i, s in enumerate(sessions, 1):
             last_active = _relative_time(s.get("last_active"))
             preview = (
                 s.get("preview", "")[:38]
@@ -305,10 +347,10 @@ def cmd_sessions(args, sessions_parser=None):
             if has_titles:
                 title = (s.get("title") or "—")[:30]
                 sid = s["id"]
-                print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                print(f"{i:>3}  {title:<32} {preview:<40} {last_active:<13} {sid}")
             else:
                 sid = s["id"]
-                print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                print(f"{i:>3}  {preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
     elif action == "export":
         from hermes_cli.session_filters import (
@@ -778,9 +820,10 @@ def cmd_sessions(args, sessions_parser=None):
         print(f"Exported {exported} session(s) to {output_dir}")
 
     elif action == "delete":
-        resolved_session_id = db.resolve_session_id(args.session_id)
+        resolved_session_id = _resolve_session_ref(db, args.session_id)
         if not resolved_session_id:
-            print(f"Session '{args.session_id}' not found.")
+            if not str(args.session_id).strip().isdigit():
+                print(f"Session '{args.session_id}' not found.")
             return
         if not args.yes:
             if not _confirm_prompt(

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -39,6 +39,118 @@ def test_sessions_delete_accepts_unique_id_prefix(monkeypatch, capsys):
     assert "Deleted session '20260315_092437_c9a6ff'." in output
 
 
+def test_sessions_delete_accepts_numeric_line_number(monkeypatch, capsys):
+    """`hermes sessions delete 2` deletes the 2nd session in the listing."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            captured["list_kwargs"] = kwargs
+            return [
+                {"id": "20260101_000000_aaaaaa", "source": "cli", "title": "first"},
+                {"id": "20260202_000000_bbbbbb", "source": "cli", "title": "second"},
+                {"id": "20260303_000000_cccccc", "source": "cli", "title": "third"},
+            ]
+
+        def resolve_session_id(self, session_id):
+            return None
+
+        def delete_session(self, session_id, **kwargs):
+            captured["deleted"] = session_id
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "sessions", "delete", "2", "--yes"]
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured["deleted"] == "20260202_000000_bbbbbb"
+    assert captured["list_kwargs"]["limit"] == 1000
+    assert "Deleted session '20260202_000000_bbbbbb'." in output
+
+
+def test_sessions_delete_numeric_line_number_out_of_range(monkeypatch, capsys):
+    """A line number beyond the listing is reported, nothing is deleted."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return [
+                {"id": "20260101_000000_aaaaaa", "source": "cli", "title": "first"}
+            ]
+
+        def resolve_session_id(self, session_id):
+            return None
+
+        def delete_session(self, session_id, **kwargs):
+            captured["deleted"] = session_id
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "sessions", "delete", "9", "--yes"]
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "deleted" not in captured
+    assert "Session number 9 not found" in output
+
+
+def test_sessions_list_shows_line_numbers(monkeypatch, capsys):
+    """`hermes sessions list` prefixes each row with a 1-based line number."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return [
+                {
+                    "id": "20260101_000000_aaaaaa",
+                    "source": "cli",
+                    "title": "first",
+                    "preview": "hello",
+                    "last_active": 1_700_000_000.0,
+                },
+                {
+                    "id": "20260202_000000_bbbbbb",
+                    "source": "cli",
+                    "title": "second",
+                    "preview": "world",
+                    "last_active": 1_700_000_100.0,
+                },
+            ]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "list"])
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert " 1  first" in output
+    assert " 2  second" in output
+    assert output.splitlines()[1].startswith("─")
+
+
 def _run_prune(monkeypatch, capsys, argv_tail, candidates=None):
     """Run `hermes sessions prune <argv_tail>` against a FakeDB, capturing
     the filter kwargs passed to list_prune_candidates. Auto-confirms."""

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -423,6 +423,16 @@ hermes sessions delete 20250305_091523_a1b2c3d4
 hermes sessions delete 20250305_091523_a1b2c3d4 --yes
 ```
 
+Instead of copying a full session ID, you can reference a session by its line number from `hermes sessions list` (the `#` column). The number maps 1:1 to the default listing — newest first, tool sessions hidden — so the rows you see on screen are the rows you delete:
+
+```bash
+# Delete the third session shown by `hermes sessions list`
+hermes sessions delete 3
+
+# Unique ID prefixes still work
+hermes sessions delete 20250305_091523_a1b2c3d --yes
+```
+
 ### Rename a Session
 
 ```bash
@@ -737,8 +747,8 @@ not deleted merely because it began before the retention window.
 # Prune sessions older than 90 days
 hermes sessions prune
 
-# Delete a specific session
-hermes sessions delete <session_id>
+# Delete a specific session (by ID, unique prefix, or list line number)
+hermes sessions delete <session_id|#N>
 
 # Export before pruning (backup)
 hermes sessions export backup.jsonl


### PR DESCRIPTION
Closes #75663

## What Changed

`hermes sessions list` now prefixes each row with a number (`#` column), and `hermes sessions delete` accepts that row number in addition to the full ID / unique prefix:

```bash
hermes sessions list          # each row starts with a number
hermes sessions delete 3      # deletes the 3rd session in the listing
hermes sessions delete 20250305_091523_a1b2c3d --yes  # prefixes still work
```

The row number resolves 1:1 against the default `list` listing (newest first, tool sessions hidden), so the rows visible on screen are exactly what delete reaches — up to 1000 sessions, covering `--limit` larger listings.

## Files Changed

- `hermes_cli/sessions_cmd.py` — `_resolve_session_ref` helper (number → ID via `list_sessions_rich`, prefix fallback), `#` column in listing, `delete` using the helper
- `hermes_cli/main.py` — parser help/metavar (`ID|#N`)
- `tests/hermes_cli/test_sessions_delete.py` — 3 new tests (delete by number, out-of-range, numbered listing)
- `website/docs/user-guide/sessions.md` — documentation

## Tests

31 session-related tests passing (including the 3 new ones).
