### PR TITLE
fix(desktop): contain reasoning markdown render failures

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -19,6 +19,8 @@ import { generatedImageFromResult } from '@/lib/generated-images'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 
+import { ReasoningRenderBoundary } from './reasoning-render-boundary'
+
 const ImageGenerateTool: FC<ToolCallMessagePartProps> = props => {
   const { args, result } = props
   const aspectRatio = typeof args?.aspect_ratio === 'string' ? args.aspect_ratio : undefined
@@ -242,15 +244,18 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
 const ReasoningTextPart: ReasoningMessagePartComponent = () => {
   const { status, text } = useMessagePartReasoning()
   const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  const displayText = text.trimStart()
 
   return (
-    <MarkdownTextContent
-      containerClassName="text-xs leading-snug text-muted-foreground/85"
-      containerProps={{ 'data-slot': 'aui_reasoning-text' } as ComponentProps<'div'>}
-      disableArtifacts
-      isRunning={status.type === 'running' || messageRunning}
-      text={text.trimStart()}
-    />
+    <ReasoningRenderBoundary text={displayText}>
+      <MarkdownTextContent
+        containerClassName="text-xs leading-snug text-muted-foreground/85"
+        containerProps={{ 'data-slot': 'aui_reasoning-text' } as ComponentProps<'div'>}
+        disableArtifacts
+        isRunning={status.type === 'running' || messageRunning}
+        text={displayText}
+      />
+    </ReasoningRenderBoundary>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/thread/reasoning-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/reasoning-render-boundary.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
+
+import { ReasoningRenderBoundary } from './reasoning-render-boundary'
+
+afterEach(cleanup)
+
+function BrokenReasoningRenderer(): never {
+  throw new RangeError('Maximum call stack size exceeded')
+}
+
+describe('ReasoningRenderBoundary', () => {
+  it('renders reasoning normally while its rich renderer is healthy', () => {
+    const { container } = render(
+      <ReasoningRenderBoundary text="raw reasoning">
+        <div>rich reasoning</div>
+      </ReasoningRenderBoundary>
+    )
+
+    expect(screen.getByText('rich reasoning')).toBeTruthy()
+    expect(container.querySelector('[data-render-fallback="reasoning"]')).toBeNull()
+  })
+
+  it('keeps reasoning readable when the rich renderer overflows', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { container } = render(
+      <ReasoningRenderBoundary text={'first line\nsecond line'}>
+        <BrokenReasoningRenderer />
+      </ReasoningRenderBoundary>
+    )
+
+    const fallback = container.querySelector('[data-render-fallback="reasoning"]')
+
+    expect(fallback?.textContent).toBe('first line\nsecond line')
+    expect(fallback?.classList.contains('whitespace-pre-wrap')).toBe(true)
+    spy.mockRestore()
+  })
+
+  it('contains deeply nested reasoning markdown inside the reasoning part', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const text = `${'> '.repeat(10_000)}still readable`
+
+    const { container } = render(
+      <ReasoningRenderBoundary text={text}>
+        <MarkdownTextContent disableArtifacts isRunning={false} text={text} />
+      </ReasoningRenderBoundary>
+    )
+
+    expect(container.querySelector('[data-render-fallback="reasoning"]')?.textContent).toBe(text)
+    spy.mockRestore()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/reasoning-render-boundary.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/reasoning-render-boundary.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+
+import { ErrorBoundary } from '@/components/error-boundary'
+
+interface ReasoningRenderBoundaryProps {
+  children: ReactNode
+  text: string
+}
+
+/** Keep pathological model-generated reasoning from taking down its message pane.
+ * Rich markdown remains the primary surface; if that renderer throws, the raw
+ * reasoning is still readable and later reasoning parts mount normally. */
+export function ReasoningRenderBoundary({ children, text }: ReasoningRenderBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallback={() => (
+        <div
+          className="wrap-anywhere whitespace-pre-wrap text-xs leading-snug text-muted-foreground/85"
+          data-render-fallback="reasoning"
+          data-slot="aui_reasoning-text"
+        >
+          {text}
+        </div>
+      )}
+      label="reasoning-markdown"
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Keeps malformed or pathologically nested model reasoning from taking down the Desktop message pane when Streamdown overflows during render.

Rich Markdown remains the normal rendering path. A boundary scoped to each reasoning part catches renderer failures, preserves the existing scoped diagnostic log, and shows the raw reasoning as readable plain text. Keeping the boundary local also lets later reasoning parts render normally instead of unwinding into the workspace-level boundary.

The regression test exercises Streamdown itself with 10,000 nested blockquotes and verifies that the raw content remains visible.

## Related Issue

Reported in [Discord support thread: Desktop Workspace Renderer Crash on Fresh Session](https://discord.com/channels/1053877538025386074/1532962664748159197).

Related work: #67257 targets the same reported exception, but its guards execute before React renders Streamdown and therefore cannot catch a render-time overflow. It also includes unrelated Python and Google Workspace changes. This PR is limited to the Desktop reasoning render path and a behavioral reproduction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Wrap `ReasoningTextPart` Markdown rendering in a reasoning-local error boundary.
- Fall back to a plain React text node while preserving whitespace when the rich renderer throws.
- Add coverage for the healthy rich path, an explicit descendant overflow, and an actual Streamdown overflow caused by deeply nested blockquotes.

## How to Test

1. From `apps/desktop`, run `npx vitest run --project ui src/components/assistant-ui/thread/reasoning-render-boundary.test.tsx src/lib/markdown-blocks.test.ts src/components/assistant-ui/markdown-text.test.ts`.
2. Run `npm run typecheck`.
3. Confirm the deeply nested reasoning case renders through `data-render-fallback="reasoning"` while ordinary reasoning still uses the rich renderer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; Desktop-only TypeScript change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or public API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only containment is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused UI regression coverage: 3 files, 44 tests passed.

Desktop TypeScript checks passed for renderer, Electron, and E2E projects. Targeted ESLint, Prettier, and `git diff --check` also passed.