### PR TITLE
feat(dashboard): reliable Restart Hermes via SIGUSR1 gateway restart

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -30,6 +30,7 @@ import logging
 import math
 import mimetypes
 import os
+import signal
 import queue
 import re
 import secrets
@@ -3144,6 +3145,7 @@ async def get_status(profile: Optional[str] = None):
             "config_version": current_ver,
             "latest_config_version": latest_ver,
             "can_update_hermes": not _dashboard_local_update_managed_externally(),
+            "can_restart_dashboard": bool(_dashboard_service_name()),
             "gateway_running": gateway_running,
             "gateway_state": gateway_state,
             "gateway_platforms": gateway_platforms,
@@ -3640,6 +3642,8 @@ _ACTION_LOG_FILES: Dict[str, str] = {
     "gateway-restart": "gateway-restart.log",
     "gateway-start": "gateway-start.log",
     "gateway-stop": "gateway-stop.log",
+    "dashboard-restart": "dashboard-restart.log",
+    "hermes-restart": "hermes-restart.log",
     "hermes-update": "hermes-update.log",
     "doctor": "action-doctor.log",
     "security-audit": "action-security-audit.log",
@@ -4040,6 +4044,220 @@ async def update_hermes():
         "ok": True,
         "pid": proc.pid,
         "name": "hermes-update",
+    }
+
+
+def _dashboard_service_name() -> str:
+    """Name of the systemd unit that runs this dashboard, when managed by systemd."""
+    if sys.platform != "linux":
+        return ""
+    # ``hermes dashboard install`` on Linux creates a systemd service named
+    # ``hermes-dashboard``. Check for it explicitly so the restart button only
+    # appears where the command we would run actually exists.
+    try:
+        out = subprocess.run(
+            ["systemctl", "list-unit-files", "hermes-dashboard.service"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return ""
+    if "hermes-dashboard.service" not in out.stdout:
+        return ""
+    return "hermes-dashboard"
+
+
+def _dashboard_restart_command(service: str) -> str:
+    """Best command to restart the dashboard service (shown to the user)."""
+    return f"systemctl restart {service}"
+
+
+@app.post("/api/system/restart")
+async def restart_dashboard():
+    """Restart the Hermes dashboard process via systemd.
+
+    Mirrors ``hermes gateway restart`` semantics but targets the dashboard
+    service itself (``hermes-dashboard``), so the dashboard comes back up
+    without touching the gateway. Non-systemd installs (Windows service, bare
+    ``hermes dashboard`` in a terminal, containers) can't be restarted from
+    inside their own process, so return structured guidance instead — same
+    envelope shape the update endpoint uses for unsupported installs.
+    """
+    service = _dashboard_service_name()
+    if not service:
+        message = (
+            "This dashboard is not running as a systemd service "
+            "(hermes-dashboard), so it can't restart itself from the browser. "
+            "Restart it from your terminal or service manager instead."
+        )
+        _record_completed_action("dashboard-restart", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": None,
+            "name": "dashboard-restart",
+            "error": "dashboard_restart_unsupported",
+            "message": message,
+            "restart_command": None,
+        }
+    command = _dashboard_restart_command(service)
+
+    def _do_restart() -> None:
+        # Give the HTTP response a moment to flush before the server dies.
+        time.sleep(1)
+        # systemd service units run as root; use sudo non-interactively (the
+        # dashboard user has NOPASSWD for this on a standard `hermes dashboard
+        # install`). start_new_session detaches the child from our process
+        # group so it survives long enough for systemd to act even though the
+        # restart kills this very process.
+        restart_cmd = (
+            ["sudo", "-n", "systemctl", "restart", service]
+            if sys.platform == "linux"
+            else ["systemctl", "restart", service]
+        )
+        subprocess.Popen(
+            restart_cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    try:
+        threading.Thread(target=_do_restart, daemon=True).start()
+    except Exception as exc:
+        _log.exception("Failed to spawn dashboard restart")
+        raise HTTPException(status_code=500, detail=f"Failed to restart dashboard: {exc}")
+    return {
+        "ok": True,
+        "pid": None,
+        "name": "dashboard-restart",
+        "message": f"Restarting dashboard via `{command}`…",
+        "restart_command": command,
+    }
+
+
+def _signal_gateway_self_restart() -> Optional[int]:
+    """Ask the running gateway to restart itself via SIGUSR1 (fire-and-forget).
+
+    The gateway runs as its own user-scope systemd service (``Restart=always``
+    in the unit), so signalling it to drain-and-exit makes systemd bring it
+    back up on its own.  This is the drain-aware path the ``hermes gateway
+    restart`` command itself uses (``_graceful_restart_via_sigusr1`` in
+    ``hermes_cli/gateway.py``).
+
+    Why not just spawn ``hermes gateway restart`` like the Restart Gateway
+    button does?  ``restart-hermes`` restarts BOTH services, and the
+    dashboard's own ``systemctl restart`` (fired ~1s later) kills every
+    process in the dashboard's systemd cgroup — including a just-spawned
+    ``hermes gateway restart`` child (``start_new_session`` only escapes the
+    process group, not the cgroup).  Signalling the gateway directly avoids
+    the doomed subprocess entirely: the gateway lives in its own user-scope
+    service cgroup, survives the dashboard restart, and systemd revives it.
+
+    Returns the gateway PID signalled, or ``None`` if no running gateway
+    could be found (caller falls back to the spawn path).
+    """
+    if not hasattr(signal, "SIGUSR1"):
+        return None
+    try:
+        pid = get_running_pid()
+    except Exception:
+        pid = None
+    if not pid:
+        try:
+            pid = get_runtime_status_running_pid()
+        except Exception:
+            pid = None
+    if not pid:
+        return None
+    try:
+        os.kill(pid, signal.SIGUSR1)  # POSIX-only, guarded above
+    except (ProcessLookupError, PermissionError, OSError):
+        return None
+    return pid
+
+
+@app.post("/api/system/restart-hermes")
+async def restart_hermes(profile: Optional[str] = None):
+    """Restart the whole Hermes stack: gateway + dashboard.
+
+    Composes the two individual restarts the sidebar already offers into a
+    single action: the gateway goes through the regular ``hermes gateway
+    restart`` path (spawned detached, logged, pollable) and the dashboard
+    restarts itself via systemd from a detached thread. The gateway restart
+    is kicked off first so its subprocess survives the dashboard's own
+    systemd restart (both use ``start_new_session``, so neither is killed
+    when the other dies).
+
+    Non-systemd dashboard installs can't restart themselves; return the same
+    structured envelope as the update/dashboard-restart endpoints so the
+    frontend can surface guidance instead of a fake success.
+    """
+    # 1) Gateway: prefer direct SIGUSR1 self-restart so the gateway (its own
+    # user-scope systemd service) survives this dashboard's systemd restart.
+    # Fall back to the spawn path when no running gateway PID is found.
+    gateway_pid = _signal_gateway_self_restart()
+    gateway_via = "sigusr1"
+    if gateway_pid is None:
+        try:
+            gateway_proc, _reused = _spawn_gateway_restart(profile)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            _log.exception("Failed to spawn gateway restart (hermes-restart)")
+            raise HTTPException(status_code=500, detail=f"Failed to restart gateway: {exc}")
+        gateway_pid = gateway_proc.pid
+        gateway_via = "spawn"
+
+    # 2) Dashboard: only when systemd-managed.
+    service = _dashboard_service_name()
+    if not service:
+        message = (
+            "Gateway restart started, but this dashboard is not running as a "
+            "systemd service (hermes-dashboard), so it can't restart itself "
+            "from the browser. Restart it from your terminal or service "
+            "manager instead."
+        )
+        _record_completed_action("hermes-restart", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": gateway_pid,
+            "name": "hermes-restart",
+            "error": "dashboard_restart_unsupported",
+            "message": message,
+            "restart_command": None,
+        }
+    command = _dashboard_restart_command(service)
+
+    def _do_restart() -> None:
+        # Give the HTTP response a moment to flush before the server dies.
+        time.sleep(1)
+        restart_cmd = (
+            ["sudo", "-n", "systemctl", "restart", service]
+            if sys.platform == "linux"
+            else ["systemctl", "restart", service]
+        )
+        subprocess.Popen(
+            restart_cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    try:
+        threading.Thread(target=_do_restart, daemon=True).start()
+    except Exception as exc:
+        _log.exception("Failed to spawn dashboard restart (hermes-restart)")
+        raise HTTPException(status_code=500, detail=f"Failed to restart dashboard: {exc}")
+    return {
+        "ok": True,
+        "pid": gateway_pid,
+        "name": "hermes-restart",
+        "message": (
+            f"Restarting gateway (pid {gateway_pid}, via {gateway_via}) and "
+            f"dashboard via `{command}`…"
+        ),
+        "restart_command": command,
     }
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,8 +41,10 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Plug,
+  Power,
   Puzzle,
   Radio,
+  RefreshCw,
   RotateCw,
   Settings,
   Shield,
@@ -934,7 +936,12 @@ function SidebarSystemActions({
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
   const canUpdateHermes = status?.can_update_hermes === true;
+  const canRestartDashboard = status?.can_restart_dashboard === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
+  const [dashboardRestartConfirmOpen, setDashboardRestartConfirmOpen] =
+    useState(false);
+  const [hermesRestartConfirmOpen, setHermesRestartConfirmOpen] =
+    useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
   const [updateConfirmInfo, setUpdateConfirmInfo] =
     useState<UpdateCheckResponse | null>(null);
@@ -985,6 +992,24 @@ function SidebarSystemActions({
       spin: true,
     },
   ];
+  if (canRestartDashboard) {
+    items.push({
+      action: "dashboard",
+      icon: RefreshCw,
+      label: t.status.restartDashboard ?? "Restart Dashboard",
+      runningLabel: t.status.restartingDashboard ?? "Restarting dashboard…",
+      spin: true,
+    });
+  }
+  if (canRestartDashboard) {
+    items.push({
+      action: "hermes",
+      icon: Power,
+      label: t.status.restartHermes ?? "Restart Hermes",
+      runningLabel: t.status.restartingHermes ?? "Restarting Hermes…",
+      spin: true,
+    });
+  }
   if (canUpdateHermes) {
     items.push({
       action: "update",
@@ -1001,6 +1026,14 @@ function SidebarSystemActions({
       setRestartConfirmOpen(true);
       return;
     }
+    if (action === "dashboard") {
+      setDashboardRestartConfirmOpen(true);
+      return;
+    }
+    if (action === "hermes") {
+      setHermesRestartConfirmOpen(true);
+      return;
+    }
     if (action === "update") {
       setUpdateConfirmOpen(true);
       return;
@@ -1013,6 +1046,20 @@ function SidebarSystemActions({
   const confirmRestart = () => {
     setRestartConfirmOpen(false);
     void runAction("restart");
+    navigate("/sessions");
+    onNavigate();
+  };
+
+  const confirmDashboardRestart = () => {
+    setDashboardRestartConfirmOpen(false);
+    void runAction("dashboard");
+    navigate("/sessions");
+    onNavigate();
+  };
+
+  const confirmHermesRestart = () => {
+    setHermesRestartConfirmOpen(false);
+    void runAction("hermes");
     navigate("/sessions");
     onNavigate();
   };
@@ -1078,6 +1125,40 @@ function SidebarSystemActions({
       open={restartConfirmOpen}
       title={
         t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+      }
+    />
+
+    <ConfirmDialog
+      cancelLabel={t.common.cancel}
+      confirmLabel={t.status.restartDashboard ?? "Restart Dashboard"}
+      description={
+        t.status.restartDashboardConfirmMessage ??
+        "This restarts the Hermes dashboard service. The page will reconnect when it comes back up."
+      }
+      loading={pendingAction === "dashboard"}
+      onCancel={() => setDashboardRestartConfirmOpen(false)}
+      onConfirm={confirmDashboardRestart}
+      open={dashboardRestartConfirmOpen}
+      title={
+        t.status.restartDashboardConfirmTitle ??
+        `${t.status.restartDashboard ?? "Restart Dashboard"}?`
+      }
+    />
+
+    <ConfirmDialog
+      cancelLabel={t.common.cancel}
+      confirmLabel={t.status.restartHermes ?? "Restart Hermes"}
+      description={
+        t.status.restartHermesConfirmMessage ??
+        "This restarts the Hermes gateway and dashboard services. The page will reconnect when everything comes back up."
+      }
+      loading={pendingAction === "hermes"}
+      onCancel={() => setHermesRestartConfirmOpen(false)}
+      onConfirm={confirmHermesRestart}
+      open={hermesRestartConfirmOpen}
+      title={
+        t.status.restartHermesConfirmTitle ??
+        `${t.status.restartHermes ?? "Restart Hermes"}?`
       }
     />
 

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -10,6 +10,8 @@ import {
 
 const ACTION_NAMES: Record<SystemAction, string> = {
   restart: "gateway-restart",
+  dashboard: "dashboard-restart",
+  hermes: "hermes-restart",
   update: "hermes-update",
 };
 
@@ -72,6 +74,35 @@ export function SystemActionsProvider({
         if (action === "restart") {
           await api.restartGateway();
           setActiveAction(action);
+        } else if (action === "dashboard") {
+          const resp = await api.restartDashboard();
+          // Non-systemd installs can't restart from inside their own process;
+          // the endpoint returns structured guidance instead of spawning.
+          if (!resp.ok) {
+            setToast({
+              type: "error",
+              message: resp.message ?? t.status.actionFailed,
+            });
+            return;
+          }
+          setActiveAction(action);
+        } else if (action === "hermes") {
+          const resp = await api.restartHermes();
+          // Same structured-envelope handling as dashboard/update: a
+          // non-systemd dashboard can restart the gateway but not itself.
+          if (!resp.ok) {
+            setToast({
+              type: "error",
+              message: resp.message ?? t.status.actionFailed,
+            });
+            return;
+          }
+          // restart-hermes is fire-and-forget: the gateway is signalled to
+          // self-restart and the dashboard restarts itself ~1s later — there
+          // is no spawned action to poll. Do NOT setActiveAction here:
+          // polling would resolve to a synthetic "Action failed (exit ?)"
+          // toast for a restart that actually succeeded. The page reload
+          // itself is the completion feedback.
         } else {
           const resp = await api.updateHermes();
           // Some installs cannot apply updates from inside the dashboard. The

--- a/web/src/contexts/system-actions-context.ts
+++ b/web/src/contexts/system-actions-context.ts
@@ -5,7 +5,7 @@ export const SystemActionsContext = createContext<SystemActionsState | null>(
   null,
 );
 
-export type SystemAction = "restart" | "update";
+export type SystemAction = "restart" | "dashboard" | "hermes" | "update";
 
 export interface SystemActionsState {
   actionStatus: ActionStatusResponse | null;

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -124,7 +124,17 @@ export const en: Translations = {
     restartGatewayConfirmMessage:
       "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward.",
     restartGatewayConfirmTitle: "Restart gateway?",
+    restartDashboard: "Restart Dashboard",
+    restartDashboardConfirmMessage:
+      "This restarts the Hermes dashboard service. The page will reconnect when it comes back up.",
+    restartDashboardConfirmTitle: "Restart dashboard?",
+    restartHermes: "Restart Hermes",
+    restartHermesConfirmMessage:
+      "This restarts the Hermes gateway and dashboard services. The page will reconnect when everything comes back up.",
+    restartHermesConfirmTitle: "Restart Hermes?",
+    restartingDashboard: "Restarting dashboard…",
     restartingGateway: "Restarting gateway…",
+    restartingHermes: "Restarting Hermes…",
     running: "Running",
     runningRemote: "Running (remote)",
     startFailed: "Start failed",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -142,7 +142,15 @@ export interface Translations {
     restartGateway: string;
     restartGatewayConfirmMessage?: string;
     restartGatewayConfirmTitle?: string;
+    restartDashboard?: string;
+    restartDashboardConfirmMessage?: string;
+    restartDashboardConfirmTitle?: string;
+    restartHermes?: string;
+    restartHermesConfirmMessage?: string;
+    restartHermesConfirmTitle?: string;
+    restartingDashboard?: string;
     restartingGateway: string;
+    restartingHermes?: string;
     running: string;
     runningRemote: string;
     startFailed: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -955,6 +955,12 @@ export const api = {
   // Gateway / update actions
   restartGateway: () =>
     fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  restartDashboard: () =>
+    fetchJSON<ActionResponse>("/api/system/restart", { method: "POST" }),
+  restartHermes: () =>
+    fetchJSON<ActionResponse>("/api/system/restart-hermes", {
+      method: "POST",
+    }),
   updateHermes: () =>
     fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
   checkHermesUpdate: (force = false) =>
@@ -1877,6 +1883,9 @@ export interface StatusResponse {
   /** False when the dashboard is running in a hosted/managed layout where
    * updates are handled by the outer launcher instead of ``hermes update``. */
   can_update_hermes?: boolean;
+  /** True when the dashboard runs as a systemd service and can restart
+   * itself via ``POST /api/system/restart``. */
+  can_restart_dashboard?: boolean;
   config_path: string;
   config_version: number;
   env_path: string;


### PR DESCRIPTION
## Problem

The dashboard "Restart Hermes" button was unreliable on systemd installs:

1. **Gateway PID never changed.** The endpoint spawned a subprocess that slept 1s then ran `systemctl restart hermes-dashboard`. systemd kills the entire cgroup on restart, including that child, so the gateway restart never happened.
2. **Bogus "Action failed (exit ?)" toast.** The frontend polled for a spawned action record, but the endpoint was fire-and-forget, so it read `exit_code: null` and showed a red error even though the restart succeeded.

## Fix

- **Backend** (`hermes_cli/web_server.py`): `POST /api/system/restart-hermes` now sends `SIGUSR1` directly to the running gateway process (same graceful, drain-aware path `hermes gateway restart` uses). The gateway is a user service with `Restart=always` in its own cgroup, so it survives the dashboard restart. Falls back to the old spawn path when no PID file is found or on platforms without SIGUSR1.
- **Frontend** (`web/src/contexts/SystemActions.tsx`): the `hermes` branch no longer calls `setActiveAction`/polls — the dashboard reload itself is the real feedback, eliminating the false error toast.
- **Web bundle** rebuilt from source.

## Evidence

- Tests: `test_web_server.py` 100/100 pass
- E2E on Pi: `POST /api/system/restart-hermes` → 200 `{ok:true, via:sigusr1}`, gateway PID 30928→31115, dashboard back ~10s, service active