### PR TITLE
fix(desktop): accept scheme-less host:port in the remote gateway URL field

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -350,6 +350,20 @@ test('normalizeRemoteBaseUrl rejects garbage', () => {
   assert.throws(() => normalizeRemoteBaseUrl('not a url'), /not valid/)
 })
 
+test('normalizeRemoteBaseUrl auto-prepends http:// for scheme-less host:port input', () => {
+  assert.equal(normalizeRemoteBaseUrl('100.64.0.1:9119'), 'http://100.64.0.1:9119')
+  assert.equal(normalizeRemoteBaseUrl('mini.tailnet-1234.ts.net:9119'), 'http://mini.tailnet-1234.ts.net:9119')
+  assert.equal(normalizeRemoteBaseUrl('localhost:9119'), 'http://localhost:9119')
+  assert.equal(normalizeRemoteBaseUrl('gw.example.com'), 'http://gw.example.com')
+  assert.equal(normalizeRemoteBaseUrl('gw.example.com/hermes/'), 'http://gw.example.com/hermes')
+})
+
+test('normalizeRemoteBaseUrl still rejects explicit non-http(s) schemes after scheme-less handling', () => {
+  assert.throws(() => normalizeRemoteBaseUrl('ws://host:9119'), /http:\/\/ or https:\/\//)
+  assert.throws(() => normalizeRemoteBaseUrl('ftp://host:21'), /http:\/\/ or https:\/\//)
+})
+
+
 // --- buildGatewayWsUrl (token) ---
 
 test('buildGatewayWsUrl uses wss for https and bakes the token', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -47,10 +47,20 @@ const RT_COOKIE_VARIANTS = ['__Host-hermes_session_rt', '__Secure-hermes_session
 const PRIVY_SESSION_COOKIE_VARIANTS = ['__Host-privy-token', '__Secure-privy-token', 'privy-token', 'privy-session']
 
 function normalizeRemoteBaseUrl(rawUrl) {
-  const value = String(rawUrl || '').trim()
+  let value = String(rawUrl || '').trim()
 
   if (!value) {
     throw new Error('Remote gateway URL is required.')
+  }
+
+  // Users routinely paste scheme-less "host:port" (a Tailscale IP, a LAN
+  // hostname). Without this, `new URL('100.64.0.1:9119')` either throws or —
+  // worse — parses `host:` as the protocol and produces a baffling
+  // "must be http:// or https://, got myhost:" error. Only a real
+  // `scheme://` prefix opts out, so explicit non-http schemes (ftp://,
+  // file://) still reach the protocol check below and get rejected.
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+    value = `http://${value}`
   }
 
   let parsed

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -21,6 +21,7 @@ import {
   RefreshCw,
   Terminal
 } from '@/lib/icons'
+import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -252,7 +253,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   // syntactically plausible URL. The probe result drives whether we render the
   // OAuth login button or the session-token entry box. The effective auth mode
   // prefers a fresh probe result over the saved value.
-  const trimmedUrl = state.remoteUrl.trim()
+  const trimmedUrl = coerceRemoteUrlScheme(state.remoteUrl)
 
   // The dashboardUrl of the currently-connected cloud instance (the saved
   // cloud connection's remoteUrl), normalized for comparison against each

--- a/apps/desktop/src/components/first-run-remote-form.tsx
+++ b/apps/desktop/src/components/first-run-remote-form.tsx
@@ -7,6 +7,7 @@ import type { DesktopConnectionProbeResult } from '@/global'
 import { useI18n } from '@/i18n'
 import { deriveRemoteAuthProviderShape } from '@/lib/desktop-remote-auth'
 import { AlertCircle, Check, Loader2, LogIn } from '@/lib/icons'
+import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 
 type AuthMode = 'oauth' | 'token'
 type ProbeStatus = 'idle' | 'probing' | 'done' | 'error'
@@ -36,7 +37,7 @@ export function FirstRunRemoteForm({ onBack }: FirstRunRemoteFormProps) {
   const probeSeq = useRef(0)
   const testSeq = useRef(0)
 
-  const trimmedUrl = remoteUrl.trim()
+  const trimmedUrl = coerceRemoteUrlScheme(remoteUrl)
 
   const invalidateTest = useCallback(() => {
     testSeq.current += 1

--- a/apps/desktop/src/lib/remote-url.test.ts
+++ b/apps/desktop/src/lib/remote-url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { coerceRemoteUrlScheme } from './remote-url'
+
+describe('coerceRemoteUrlScheme', () => {
+  it('prepends http:// to scheme-less host:port input', () => {
+    expect(coerceRemoteUrlScheme('100.64.0.1:9119')).toBe('http://100.64.0.1:9119')
+    expect(coerceRemoteUrlScheme('mini.tailnet-1234.ts.net:9119')).toBe('http://mini.tailnet-1234.ts.net:9119')
+    expect(coerceRemoteUrlScheme('localhost:9119')).toBe('http://localhost:9119')
+    expect(coerceRemoteUrlScheme('gw.example.com')).toBe('http://gw.example.com')
+  })
+
+  it('leaves explicitly schemed URLs alone', () => {
+    expect(coerceRemoteUrlScheme('http://host:9119')).toBe('http://host:9119')
+    expect(coerceRemoteUrlScheme('https://gw.example.com/hermes')).toBe('https://gw.example.com/hermes')
+    expect(coerceRemoteUrlScheme('ws://host:9119')).toBe('ws://host:9119')
+    expect(coerceRemoteUrlScheme('ftp://host:21')).toBe('ftp://host:21')
+  })
+
+  it('trims and passes through empty input', () => {
+    expect(coerceRemoteUrlScheme('')).toBe('')
+    expect(coerceRemoteUrlScheme('   ')).toBe('')
+    expect(coerceRemoteUrlScheme('  host:9119  ')).toBe('http://host:9119')
+  })
+})

--- a/apps/desktop/src/lib/remote-url.ts
+++ b/apps/desktop/src/lib/remote-url.ts
@@ -1,0 +1,22 @@
+/**
+ * remote-url.ts
+ *
+ * Renderer-side twin of the scheme coercion in
+ * electron/connection-config.ts `normalizeRemoteBaseUrl()`. Users routinely
+ * paste scheme-less "host:port" (a Tailscale IP, a LAN hostname) into the
+ * remote-gateway URL field; without coercion the renderer's `^https?://`
+ * probe gates never fire and the field just sits idle with no feedback.
+ *
+ * Keep the opt-out regex in sync with the electron side: only a real
+ * `scheme://` prefix skips the http:// prepend, so explicit non-http schemes
+ * (ws://, ftp://) still reach main-process validation and get a clear error.
+ */
+export function coerceRemoteUrlScheme(rawUrl: string): string {
+  const value = String(rawUrl || '').trim()
+
+  if (!value || /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+    return value
+  }
+
+  return `http://${value}`
+}


### PR DESCRIPTION
## Summary
Pasting a scheme-less `host:port` (a Tailscale IP, a LAN hostname) into the desktop app's Remote Gateway URL field now works — `http://` is auto-prepended instead of failing.

Root cause: `normalizeRemoteBaseUrl()` required a full `http(s)://` URL, and the renderer's probe gates (`/^https?:\/\//` in gateway settings + first-run form) silently never fired on scheme-less input, so the field sat idle with no feedback. Real-world report: a user with a Tailscale-reachable Mac mini whose browser could open the dashboard but whose desktop app "tried port number and ip address, no luck".

## Changes
- `apps/desktop/electron/connection-config.ts`: `normalizeRemoteBaseUrl()` prepends `http://` when the input has no `scheme://` prefix. Explicit non-http schemes (`ws://`, `ftp://`) still reach the protocol check and get a clear rejection.
- `apps/desktop/src/lib/remote-url.ts` (new): renderer twin `coerceRemoteUrlScheme()`, kept in sync with the electron-side regex.
- `apps/desktop/src/app/settings/gateway-settings.tsx` + `src/components/first-run-remote-form.tsx`: both probe gates now coerce the URL first, so the debounced `/api/status` probe, sign-in, test, and save all see the coerced URL.
- Tests: `electron/connection-config.test.ts` (+2 tests) and `src/lib/remote-url.test.ts` (new).

## Validation
| | Before | After |
|---|---|---|
| `100.64.0.1:9119` in main | throws "not valid" | `http://100.64.0.1:9119` |
| `100.64.0.1:9119` in renderer | probe never fires (silent) | probe runs, auth UI renders |
| `ws://host:9119` | rejected | still rejected |
| vitest | — | 77/77 (connection-config + remote-url) |

## Infographic

![Desktop scheme-less remote URL fix](https://v3b.fal.media/files/b/0aa48c24/kZm5sUWL8OIz44XBIOMZR_5THNDp6Z.png)
