### PR TITLE
fix(gateway): preserve internal events during active sessions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2110,8 +2110,8 @@ class MessageEvent:
     # trigger message alone, then prepend this context afterward.
     channel_context: Optional[str] = None
     
-    # Internal flag — set for synthetic events (e.g. background process
-    # completion notifications) that must bypass user authorization checks.
+    # Internal flag — trusted synthetic agent evidence (including completion
+    # notifications). Its text is opaque to gateway user-input/control handlers.
     internal: bool = False
 
     # Free-form per-event metadata.  Adapters may set platform-specific
@@ -5543,7 +5543,9 @@ class BasePlatformAdapter(ABC):
         if not self._message_handler:
             return
 
-        coerce_plaintext_gateway_command(event)
+        is_internal = bool(getattr(event, "internal", False))
+        if not is_internal:
+            coerce_plaintext_gateway_command(event)
 
         # Rewrite ``event.source.thread_id`` via the installed recovery hook
         # (Telegram DM topic mode) so the session key, guard checks, and
@@ -5577,7 +5579,7 @@ class BasePlatformAdapter(ABC):
             # response.  Do NOT use _process_message_background — it manages
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
-            cmd = event.get_command()
+            cmd = None if is_internal else event.get_command()
             from hermes_cli.commands import (
                 is_interrupt_then_dispatch,
                 should_bypass_active_session,
@@ -5641,7 +5643,7 @@ class BasePlatformAdapter(ABC):
             # Same shape as the /approve deadlock fix (PR #4926) — both
             # cases are "agent thread blocked on Event.wait, message must
             # reach the resolver before being treated as a new turn."
-            if not cmd:
+            if not is_internal and not cmd:
                 try:
                     from tools import clarify_gateway as _clarify_mod
                     _has_text_clarify = (
@@ -6545,8 +6547,12 @@ class BasePlatformAdapter(ABC):
         self._text_debounce_store().clear()
 
     def has_pending_interrupt(self, session_key: str) -> bool:
-        """Check if there's a pending interrupt for a session."""
-        return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
+        """Whether a signalled user/control event should interrupt this session."""
+        active = self._active_sessions.get(session_key)
+        if active is None or not active.is_set():
+            return False
+        pending = self._pending_messages.get(session_key)
+        return not bool(getattr(pending, "internal", False))
     
     def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
         """Get and clear any pending message for a session."""

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1108,7 +1108,9 @@ class RecallGuardMiddleware(InboundMiddleware):
             text=recall_text,
             message_type=MessageType.TEXT,
             source=cls._build_source(adapter, group_code, from_account),
-            internal=True,
+            # A recall is explicit cancellation control, not opaque completion
+            # evidence, so it must remain eligible for the interrupt monitor.
+            internal=False,
         )
         # Set pending + signal directly (bypass handle_message to avoid busy-ack).
         # May overwrite a user message pending in the same ~200ms window — acceptable.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8359,6 +8359,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return (enriched_text or text).strip()
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # Internal completions are opaque agent evidence, not user input. Let
+        # the base adapter queue them for the next turn without consulting any
+        # authorization, approval, steer, interrupt, or acknowledgement path.
+        if getattr(event, "internal", False):
+            return False
+
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
@@ -8482,20 +8488,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self._adapter_for_source(event.source)
         if not adapter:
             return False  # let default path handle it
-
-        # --- Internal synthetic events must never interrupt/steer ---
-        # Async-delegation completions (delegate_task(background=true)) and
-        # background-process completions (terminal notify_on_complete) re-enter
-        # the originating session as internal MessageEvents. When the session
-        # is busy, treating them like a user TEXT message means interrupt-mode
-        # (the default busy_text_mode) aborts the active turn AND sends a "⚡
-        # Interrupting current task" ack — exactly the opposite of the design
-        # invariant that a completion surfaces as a NEW turn only when idle and
-        # never splices into a running turn. Fall through to the base adapter,
-        # which queues internal events silently (no interrupt, no ack) so they
-        # cascade after the current turn finishes.
-        if getattr(event, "internal", False):
-            return False
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
@@ -13758,7 +13750,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
         _up_state = self._peek_session_state(_quick_key)
-        if _up_state is not None and _up_state.persistent.update_prompt_pending:
+        if (
+            not is_internal
+            and _up_state is not None
+            and _up_state.persistent.update_prompt_pending
+        ):
             raw = (event.text or "").strip()
             # Accept /approve and /deny as shorthand for yes/no
             cmd = event.get_command()
@@ -13830,13 +13826,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # to the second option, arbitrary text becomes a custom answer). Slash
         # commands still bypass this path so /stop and friends keep working.
         _clarify_mod = None
-        try:
-            from tools import clarify_gateway as _clarify_mod
-            _pending_clarify = _clarify_mod.get_pending_for_session(
-                _quick_key, include_choice_prompts=True,
-            )
-        except Exception:
-            _pending_clarify = None
+        _pending_clarify = None
+        if not is_internal:
+            try:
+                from tools import clarify_gateway as _clarify_mod
+                _pending_clarify = _clarify_mod.get_pending_for_session(
+                    _quick_key, include_choice_prompts=True,
+                )
+            except Exception:
+                _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _clarify_has_audio = bool(self._pending_event_audio_paths(event))
             _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
@@ -13892,13 +13890,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # precedence — /approve there unblocks the waiting tool thread.
         # Slash-confirm only catches /approve when no tool approval is live.
         from tools import slash_confirm as _slash_confirm_mod
-        _pending_confirm = _slash_confirm_mod.get_pending(_quick_key)
+        _pending_confirm = None
         _tool_approval_live = False
-        try:
-            from tools.approval import has_blocking_approval
-            _tool_approval_live = has_blocking_approval(_quick_key)
-        except Exception:
-            _tool_approval_live = False
+        if not is_internal:
+            _pending_confirm = _slash_confirm_mod.get_pending(_quick_key)
+            try:
+                from tools.approval import has_blocking_approval
+                _tool_approval_live = has_blocking_approval(_quick_key)
+            except Exception:
+                _tool_approval_live = False
         if _pending_confirm and not _tool_approval_live:
             _raw_reply = (event.text or "").strip()
             # Accept bang-prefixed replies (`!always`, `!cancel`) verbatim.
@@ -13993,6 +13993,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_running_agent_state(_quick_key)
 
         if self._is_session_running(_quick_key):
+            if is_internal:
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
+
             # Resolve the command once; every command's mid-run behavior is
             # declared on its CommandDef (busy_policy / busy_handler in
             # hermes_cli/commands.py) and dispatched through the single
@@ -14195,7 +14199,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
 
         # Check for commands
-        command = event.get_command()
+        command = None if is_internal else event.get_command()
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,
@@ -24293,7 +24297,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # as user input.  The primary fix is in base.py (commands bypass the
             # active-session guard), but this catches edge cases where command
             # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
+            if (
+                pending
+                and not getattr(pending_event, "internal", False)
+                and pending.strip().startswith("/")
+            ):
                 _pending_parts = pending.strip().split(None, 1)
                 _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
                 if _pending_cmd_word:

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -87,3 +87,31 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     assert adapter._pending_messages == {}
 
 
+@pytest.mark.asyncio
+async def test_internal_text_skips_clarify_bypass_and_stays_queued():
+    """Synthetic evidence must not enter the user clarify-response lane."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=False)
+    event = _event("synthetic completion answer")
+    event.internal = True
+    session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    entry = cm.register("clarify-internal", session_key, "Pick one", ["A", "B"])
+
+    try:
+        await adapter.handle_message(event)
+
+        adapter._message_handler.assert_not_awaited()
+        assert entry.event.is_set() is False
+        assert adapter._pending_messages[session_key] is event
+    finally:
+        _clear_clarify_state()
+

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -367,6 +367,22 @@ class TestNonBypassStillQueued:
             "Regular text should not produce a direct response"
         )
 
+    @pytest.mark.parametrize("text", ["/approve", "restart gateway"])
+    @pytest.mark.asyncio
+    async def test_internal_command_shaped_text_is_queued_opaque(self, text):
+        """Synthetic completion text is agent evidence, never gateway input."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+        event = _make_event(text)
+        event.internal = True
+
+        await adapter.handle_message(event)
+
+        assert adapter._pending_messages[sk] is event
+        assert adapter._pending_messages[sk].text == text
+        assert adapter.sent_responses == []
+
 
 # ---------------------------------------------------------------------------
 # Tests: no active session — commands go through normally

--- a/tests/gateway/test_interrupt_key_match.py
+++ b/tests/gateway/test_interrupt_key_match.py
@@ -76,4 +76,20 @@ class TestInterruptKeyConsistency:
         # Using chat_id → NOT found (this was the bug)
         assert adapter.has_pending_interrupt(source.chat_id) is False
 
+    def test_internal_pending_event_is_not_an_interrupt_signal(self):
+        """Synthetic completion evidence may be queued, never barge in."""
+        adapter = StubAdapter()
+        source = _source("123456", "dm")
+        session_key = build_session_key(source)
+        interrupt_event = asyncio.Event()
+        interrupt_event.set()
+        adapter._active_sessions[session_key] = interrupt_event
+        adapter._pending_messages[session_key] = MessageEvent(
+            text="synthetic completion",
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+        )
+
+        assert adapter.has_pending_interrupt(session_key) is False
 

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -133,3 +133,22 @@ def test_no_pending_approval_does_not_consume_conversational_yes():
     _clear_approval_state()
 
 
+def test_internal_approval_shaped_text_does_not_resolve_blocking_approval():
+    """Synthetic completion output is never dangerous-tool authorization."""
+    _clear_approval_state()
+    runner, adapter = _make_runner()
+    session_key, entry = _register_blocking_approval(runner)
+    event = _make_event("yes")
+    event.internal = True
+
+    handled = asyncio.run(
+        runner._handle_active_session_busy_message(event, session_key)
+    )
+
+    assert handled is False
+    assert entry.event.is_set() is False
+    assert entry.result is None
+    assert event.text == "yes"
+    adapter._send_with_retry.assert_not_awaited()
+    _clear_approval_state()
+

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -149,3 +149,48 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+
+
+@pytest.mark.asyncio
+async def test_internal_command_shaped_completion_drains_into_agent_loop(monkeypatch, tmp_path):
+    """The pending-command safety net must not discard synthetic evidence."""
+    CaptureQueuedNativeImageAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureQueuedNativeImageAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+    session_key = "agent:main:telegram:group:-1001"
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="/approve",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-internal-command-followup",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done-2"
+    assert CaptureQueuedNativeImageAgent.calls == ["hello", "/approve"]

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -9,6 +9,7 @@ duplicate agent.
 """
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -170,6 +171,119 @@ async def test_recent_telegram_followups_append_in_pending_queue():
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
     assert adapter._pending_messages[session_key].text == "part one\npart two"
+
+
+@pytest.mark.asyncio
+async def test_internal_event_does_not_answer_pending_update_prompt(tmp_path):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    event = _make_event(text="y")
+    event.internal = True
+    session_key = build_session_key(event.source)
+    runner._update_prompt_pending[session_key] = True
+    prompt_path = tmp_path / ".update_prompt.json"
+    prompt_path.write_text('{"prompt": "continue?"}', encoding="utf-8")
+    inner = AsyncMock(return_value="agent turn")
+
+    with (
+        patch.object(gateway_run, "_hermes_home", tmp_path),
+        patch.object(GatewayRunner, "_handle_message_with_agent", inner),
+    ):
+        result = await runner._handle_message(event)
+
+    assert result == "agent turn"
+    assert runner._update_prompt_pending[session_key] is True
+    assert prompt_path.exists()
+    assert not (tmp_path / ".update_response").exists()
+    inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_internal_event_does_not_resolve_pending_clarify():
+    from tools import clarify_gateway as clarify_mod
+
+    with clarify_mod._lock:
+        clarify_mod._entries.clear()
+        clarify_mod._session_index.clear()
+        clarify_mod._notify_cbs.clear()
+
+    runner = _make_runner()
+    event = _make_event(text="synthetic completion answer")
+    event.internal = True
+    session_key = build_session_key(event.source)
+    entry = clarify_mod.register(
+        "clarify-internal", session_key, "Continue?", choices=None,
+    )
+    inner = AsyncMock(return_value="agent turn")
+
+    try:
+        with patch.object(GatewayRunner, "_handle_message_with_agent", inner):
+            result = await runner._handle_message(event)
+
+        assert result == "agent turn"
+        assert entry.event.is_set() is False
+        assert entry.response is None
+        assert clarify_mod.get_pending_for_session(session_key) is entry
+        inner.assert_awaited_once()
+    finally:
+        with clarify_mod._lock:
+            clarify_mod._entries.clear()
+            clarify_mod._session_index.clear()
+            clarify_mod._notify_cbs.clear()
+
+
+@pytest.mark.asyncio
+async def test_internal_event_does_not_resolve_or_clear_slash_confirm():
+    from tools import slash_confirm as confirm_mod
+
+    runner = _make_runner()
+    event = _make_event(text="/approve")
+    event.internal = True
+    session_key = build_session_key(event.source)
+    handler = AsyncMock(return_value="reset done")
+    confirm_mod.clear(session_key)
+    confirm_mod.register(session_key, "confirm-internal", "new", handler)
+    inner = AsyncMock(return_value="agent turn")
+
+    try:
+        with patch.object(GatewayRunner, "_handle_message_with_agent", inner):
+            result = await runner._handle_message(event)
+
+        assert result == "agent turn"
+        assert confirm_mod.get_pending(session_key)["confirm_id"] == "confirm-internal"
+        handler.assert_not_awaited()
+        inner.assert_awaited_once()
+    finally:
+        confirm_mod.clear(session_key)
+
+
+@pytest.mark.asyncio
+async def test_internal_event_joins_busy_fifo_without_steering_or_interrupting():
+    runner = _make_runner()
+    event = _make_event(text="synthetic completion")
+    event.internal = True
+    session_key = build_session_key(event.source)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    head = _make_event(text="first queued user reply")
+    adapter._pending_messages[session_key] = head
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    fake_agent.steer.return_value = True
+    runner._running_agents[session_key] = fake_agent
+    runner._running_agents_ts[session_key] = time.time() - 10
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "interrupt"
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.steer.assert_not_called()
+    fake_agent.redirect.assert_not_called()
+    fake_agent.interrupt.assert_not_called()
+    assert adapter._pending_messages[session_key] is head
+    assert runner._session_state(session_key).conversation.queued_events == [event]
 
 
 # ------------------------------------------------------------------

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -43,6 +43,7 @@ from gateway.platforms.yuanbao import (
     QuoteContextMiddleware,
     MediaResolveMiddleware,
     PatchAnchorsMiddleware,
+    RecallGuardMiddleware,
     DispatchMiddleware,
     InboundPipelineBuilder,
     YuanbaoAdapter,
@@ -674,6 +675,25 @@ class TestAutoSetHomeAfterGroupAtGuard:
 
         assert "YUANBAO_HOME_CHANNEL" not in os.environ
         assert not (tmp_path / "config.yaml").exists()
+
+
+def test_recall_control_event_remains_interrupt_eligible():
+    """A user recall is explicit control, not an internal completion."""
+    adapter = make_adapter()
+    session_key = "agent:main:yuanbao:dm:alice"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    RecallGuardMiddleware._interrupt_for_recall(
+        adapter,
+        session_key,
+        recalled_id="msg-recalled",
+        group_code="",
+        from_account="alice",
+    )
+
+    pending = adapter._pending_messages[session_key]
+    assert pending.internal is False
+    assert adapter.has_pending_interrupt(session_key) is True
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- prevent internal synthetic events from being treated as user replies, approvals, interrupts, or slash commands
- preserve pending-input and active-session safety boundaries across gateway platforms
- add focused regression coverage for command, clarify, approval, race, image, and Yuanbao paths

## Tests
- `python -m pytest -q tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_internal_event_bypass_pairing.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_plaintext_approval_routing.py tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_session_race_guard.py tests/test_yuanbao_pipeline.py`
- `python -m compileall -q gateway`
- `git diff --check origin/main...HEAD`