### PR TITLE
fix(hindsight): normalize recall tag configuration

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1324,7 +1324,9 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("observation_scopes")
             or os.environ.get("HINDSIGHT_RETAIN_OBSERVATION_SCOPES", "")
         )
-        self._recall_tags = self._config.get("recall_tags") or None
+        self._recall_tags = _normalize_retain_tags(
+            self._config.get("recall_tags")
+        ) or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
             self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")

--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -72,5 +72,13 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             ),
             inline=True,
         ),
+        ProviderField(
+            key="recall_tags",
+            label="Recall tags",
+            kind=KIND_TEXT,
+            description="Comma-separated tags to filter when searching memories.",
+            placeholder="project:hermes, kind:note",
+            inline=True,
+        ),
     ),
 )

--- a/tests/plugins/memory/test_hindsight_config_schema.py
+++ b/tests/plugins/memory/test_hindsight_config_schema.py
@@ -3,6 +3,7 @@
 from plugins.memory.config_schema import (
     KIND_SECRET,
     KIND_SELECT,
+    KIND_TEXT,
     get_provider_config_schema,
 )
 
@@ -18,6 +19,7 @@ def test_hindsight_is_declared():
         "api_url",
         "bank_id",
         "recall_budget",
+        "recall_tags",
     }
 
 
@@ -49,3 +51,12 @@ def test_api_key_is_a_secret_bound_to_env():
     assert api_key.kind == KIND_SECRET
     assert api_key.is_secret is True
     assert api_key.env_key == "HINDSIGHT_API_KEY"
+
+
+def test_recall_tags_is_declared_as_comma_separated_text():
+    provider = get_provider_config_schema("hindsight")
+    assert provider is not None
+
+    recall_tags = next(field for field in provider.fields if field.key == "recall_tags")
+    assert recall_tags.kind == KIND_TEXT
+    assert "comma-separated" in recall_tags.description.lower()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -280,6 +280,43 @@ class TestConfig:
         assert p._observation_scopes == "per_tag"
 
 
+    @pytest.mark.parametrize(
+        ("configured_tags", "expected_tags"),
+        [
+            ("project:hermes, kind:note, project:hermes", ["project:hermes", "kind:note"]),
+            ('["project:hermes", "kind:note", "project:hermes"]', ["project:hermes", "kind:note"]),
+            ([" project:hermes ", "kind:note", "project:hermes"], ["project:hermes", "kind:note"]),
+            (" , ", None),
+            ([], None),
+        ],
+        ids=["csv", "json-list-string", "python-list", "empty-string", "empty-list"],
+    )
+    def test_recall_tags_config_is_normalized(
+        self, provider_with_config, configured_tags, expected_tags
+    ):
+        p = provider_with_config(recall_tags=configured_tags)
+
+        assert p._recall_tags == expected_tags
+
+
+    def test_recall_tags_normalization_does_not_mutate_loaded_config(self, monkeypatch):
+        configured_tags = [" project:hermes ", "kind:note", "project:hermes"]
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "recall_tags": configured_tags,
+        }
+        monkeypatch.setattr("plugins.memory.hindsight._load_config", lambda: config)
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", platform="cli")
+
+        assert config["recall_tags"] is configured_tags
+        assert configured_tags == [" project:hermes ", "kind:note", "project:hermes"]
+        assert p._recall_tags == ["project:hermes", "kind:note"]
+        assert p._recall_tags is not configured_tags
+
+
     def test_custom_config_values(self, provider_with_config):
         p = provider_with_config(
             retain_tags=["tag1", "tag2"],
@@ -500,6 +537,26 @@ class TestPrefetch:
         p.queue_prefetch("test")
         # Should not start a thread
         assert p._prefetch_thread is None
+
+
+    def test_prefetch_and_tool_recall_pass_same_normalized_tags(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags="project:hermes, kind:note, project:hermes",
+            recall_tags_match="all",
+        )
+
+        p.queue_prefetch("automatic recall")
+        p._prefetch_thread.join(timeout=5)
+        assert not p._prefetch_thread.is_alive()
+        prefetch_kwargs = p._client.arecall.call_args.kwargs
+
+        p._client.arecall.reset_mock()
+        p.handle_tool_call("hindsight_recall", {"query": "explicit recall"})
+        tool_kwargs = p._client.arecall.call_args.kwargs
+
+        assert prefetch_kwargs["tags"] == ["project:hermes", "kind:note"]
+        assert tool_kwargs["tags"] == prefetch_kwargs["tags"]
+        assert tool_kwargs["tags_match"] == prefetch_kwargs["tags_match"] == "all"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize Hindsight `recall_tags` supplied as CSV strings or lists
- keep configuration schema and provider behavior consistent
- add focused schema and provider regressions

## Tests
- `python -m pytest -q tests/plugins/memory/test_hindsight_config_schema.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m compileall -q plugins/memory/hindsight`
- `git diff --check origin/main...HEAD`