### PR TITLE
fix(credential-pool): source-path write-through to root survives refreshes (#74339)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -28,10 +28,13 @@ from hermes_cli.auth import (
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
+    _global_auth_file_path,
     _load_auth_store,
     _load_provider_state,
+    _load_provider_state_with_source,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
+    _same_path,
     _save_auth_store,
     _save_provider_state,
     _store_provider_state,
@@ -1039,32 +1042,58 @@ class CredentialPool:
         try:
             with _auth_store_lock():
                 auth_store = _load_auth_store()
-                # Decide BEFORE writing whether this profile is reading the
-                # grant from the global root (no own providers.<id> block) vs.
-                # genuinely shadowing it. A pool refresh rotates single-use
-                # OAuth refresh tokens, so a profile that resolved the grant
-                # from root MUST write the rotated chain back to root too —
-                # otherwise root keeps a revoked refresh token and every other
-                # profile reading the stale root grant dies with
-                # refresh_token_reused / invalid_grant once its access token
-                # expires. This mirrors the xAI write-through in
-                # hermes_cli.auth._save_xai_oauth_tokens (#43589); the pool
-                # refresh path is the Codex/xAI analog reported in #48415.
                 _wt_provider_id = {
                     "nous": "nous",
                     "openai-codex": "openai-codex",
                     "xai-oauth": "xai-oauth",
                 }.get(self.provider)
-                write_through_to_root = bool(_wt_provider_id) and not (
-                    isinstance(auth_store.get("providers"), dict)
-                    and isinstance(
-                        auth_store["providers"].get(_wt_provider_id), dict
-                    )
-                )
+                # Resolve state and track which store it came from — the
+                # source path tells us whether this profile genuinely owns
+                # its provider block or is reading from the global root.
+                # #74339: the old key-presence check decided write-through
+                # on whether the profile had ``providers.<id>`` BEFORE the
+                # save — correct for the first refresh but self-sealing
+                # because ``_store_provider_state`` unconditionally creates
+                # that key inside the same function.  Once the profile has
+                # the key, every subsequent refresh silently disables the
+                # root write-through and root keeps a revoked refresh token.
+                #
+                # Fix: use ``_load_provider_state_with_source`` to learn
+                # where the state was resolved from.  When the grant was
+                # resolved from the global root, write back *only* to root
+                # and skip ``_store_provider_state`` for the profile so the
+                # profile does not accrue a shadowing ``providers.<id>``
+                # key that blocks both the root fallback and the write-through
+                # on subsequent calls.
                 if self.provider == "nous":
-                    state = _load_provider_state(auth_store, "nous")
+                    state, source_path = _load_provider_state_with_source(
+                        auth_store, "nous"
+                    )
                     if state is None:
                         return
+                elif self.provider == "openai-codex":
+                    state, source_path = _load_provider_state_with_source(
+                        auth_store, "openai-codex"
+                    )
+                    if not isinstance(state, dict):
+                        return
+                elif self.provider == "xai-oauth":
+                    state, source_path = _load_provider_state_with_source(
+                        auth_store, "xai-oauth"
+                    )
+                    if not isinstance(state, dict):
+                        return
+                else:
+                    return
+
+                global_root = _global_auth_file_path()
+                is_from_root = bool(
+                    source_path is not None
+                    and global_root is not None
+                    and _same_path(source_path, global_root)
+                )
+
+                if self.provider == "nous":
                     state["access_token"] = entry.access_token
                     if entry.refresh_token:
                         state["refresh_token"] = entry.refresh_token
@@ -1082,12 +1111,8 @@ class CredentialPool:
                             state[extra_key] = val
                     if entry.inference_base_url:
                         state["inference_base_url"] = entry.inference_base_url
-                    _store_provider_state(auth_store, "nous", state, set_active=False)
 
                 elif self.provider == "openai-codex":
-                    state = _load_provider_state(auth_store, "openai-codex")
-                    if not isinstance(state, dict):
-                        return
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
                         return
@@ -1096,12 +1121,8 @@ class CredentialPool:
                         tokens["refresh_token"] = entry.refresh_token
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
-                    _store_provider_state(auth_store, "openai-codex", state, set_active=False)
 
                 elif self.provider == "xai-oauth":
-                    state = _load_provider_state(auth_store, "xai-oauth")
-                    if not isinstance(state, dict):
-                        return
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
                         return
@@ -1110,16 +1131,26 @@ class CredentialPool:
                         tokens["refresh_token"] = entry.refresh_token
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
-                    _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
 
-                else:
-                    return
-
-                _save_auth_store(auth_store)
-                if write_through_to_root and _wt_provider_id:
+                if is_from_root and _wt_provider_id:
+                    # Grant was resolved from root — write back to root
+                    # only.  Do NOT call _store_provider_state on the
+                    # profile auth_store (it would create a shadowing
+                    # providers.<id> key that disables write-through on
+                    # the next refresh — #74339).
+                    # _load_provider_state has root fallback, so the
+                    # profile can always read fresh tokens from root
+                    # without needing its own providers block.
                     _write_through_provider_state_to_global_root(
                         _wt_provider_id, state
                     )
+                else:
+                    # Profile genuinely owns this provider — write to
+                    # the profile store as normal.
+                    _store_provider_state(
+                        auth_store, self.provider, state, set_active=False
+                    )
+                    _save_auth_store(auth_store)
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 

--- a/contributors/emails/praneshnikhar@gmail.com
+++ b/contributors/emails/praneshnikhar@gmail.com
@@ -1,0 +1,1 @@
+praneshnikhar

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4471,8 +4471,17 @@ def _save_xai_oauth_tokens(
         # grant through _load_provider_state's fallback. When such a profile
         # refreshes the (rotating) grant, we must write the rotated chain back
         # to root too, or root is left holding a revoked refresh token (#43589).
-        write_through_to_root = not _profile_has_own_xai_oauth_state(auth_store)
-        state = _load_provider_state(auth_store, "xai-oauth") or {}
+        # #74339: the old key-presence check (_profile_has_own_xai_oauth_state)
+        # decided write-through based on whether the profile had a
+        # providers.xai-oauth key BEFORE the save — but _store_provider_state
+        # unconditionally creates that key below. Use
+        # _load_provider_state_with_source to learn where the grant was
+        # resolved from and write back only to that source.
+        state, source_path = _load_provider_state_with_source(
+            auth_store, "xai-oauth"
+        )
+        if state is None:
+            state = {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = auth_mode
@@ -4480,12 +4489,24 @@ def _save_xai_oauth_tokens(
             state["discovery"] = discovery
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
-        _store_provider_state(
-            auth_store, "xai-oauth", state, set_active=set_active
+        global_root = _global_auth_file_path()
+        is_from_root = bool(
+            source_path is not None
+            and global_root is not None
+            and _same_path(source_path, global_root)
         )
-        _save_auth_store(auth_store)
-        if write_through_to_root:
+        if is_from_root:
+            # Grant was resolved from root — write back to root only.
+            # Do NOT call _store_provider_state on the profile auth_store
+            # (it would create a shadowing providers.xai-oauth key that
+            # disables write-through on the next refresh — #74339).
             _write_through_xai_oauth_to_global_root(state)
+        else:
+            # Profile genuinely owns this — write to profile store.
+            _store_provider_state(
+                auth_store, "xai-oauth", state, set_active=set_active
+            )
+            _save_auth_store(auth_store)
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -264,14 +264,6 @@ def test_write_through_fires_on_every_refresh_not_just_first(
     )
 
     provider = "openai-codex"
-    call_count = [0]
-
-    def counting_root_write(provider_id, state):
-        call_count[0] += 1
-
-    monkeypatch.setattr(
-        CP, "_write_through_provider_state_to_global_root", counting_root_write
-    )
     # After patching A's module-level attributes, the bare-name imports in
     # credential_pool.py still hold references to the original functions
     # (``from X import Y`` creates a local binding that does not update when
@@ -280,6 +272,9 @@ def test_write_through_fires_on_every_refresh_not_just_first(
     # are ``agent.credential_pool.__dict__`` — sees the mocked paths.
     monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
     monkeypatch.setattr(CP, "_same_path", lambda a, b: a == b)
+    # Let _write_through_provider_state_to_global_root run for real so it
+    # persists the rotated token pair to the root auth.json — the test
+    # asserts the on-disk values after each refresh.
 
     # ---- REFRESH 1 ----
     _write_store(profile_path, {"version": 1})
@@ -288,7 +283,12 @@ def test_write_through_fires_on_every_refresh_not_just_first(
     )
     pool1 = CredentialPool(provider, [entry1])
     pool1._sync_device_code_entry_to_auth_store(entry1)
-    assert call_count[0] == 1, "refresh 1: write-through must fire (#74339)"
+
+    # Verify root was updated with the rotated tokens from refresh 1.
+    root_store = _read_store(root_path)
+    root_tokens = root_store["providers"]["openai-codex"]["tokens"]
+    assert root_tokens["access_token"] == "ac1"
+    assert root_tokens["refresh_token"] == "rf1"
 
     # After refresh 1 the profile should NOT have a providers.openai-codex
     # block (the fix skipped _store_provider_state because the grant came
@@ -306,8 +306,14 @@ def test_write_through_fires_on_every_refresh_not_just_first(
     )
     pool2 = CredentialPool(provider, [entry2])
     pool2._sync_device_code_entry_to_auth_store(entry2)
-    assert call_count[0] == 2, (
-        "refresh 2: write-through must fire even after a prior sync-back. "
-        "The old code self-disabled here (#74339)"
+
+    # Verify root was updated with the rotated tokens from refresh 2.
+    # The old key-presence check would have silently skipped this write.
+    root_store = _read_store(root_path)
+    root_tokens = root_store["providers"]["openai-codex"]["tokens"]
+    assert root_tokens["access_token"] == "ac2", (
+        "refresh 2: root must carry the rotated token pair. "
+        "The old code self-disabled write-through here (#74339)"
     )
+    assert root_tokens["refresh_token"] == "rf2"
 

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -233,3 +233,81 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
 
+
+def test_write_through_fires_on_every_refresh_not_just_first(
+    profile_and_root, monkeypatch
+):
+    """Write-through to root must fire on the 2nd, 3rd, … refresh too (#74339).
+
+    The old key-presence check decided write-through on whether the *profile*
+    store had ``providers.<id>`` BEFORE the save — a key that
+    ``_store_provider_state()`` unconditionally created.  Net effect: first
+    refresh → write-through fires; every later refresh → silently disabled
+    because the profile now "owned" the block, even though it never
+    performed its own OAuth grant.
+
+    The fix skips ``_store_provider_state`` entirely when the grant was
+    resolved from root, so the profile never accrues a shadowing key and
+    ``_load_provider_state_with_source`` always resolves from root.
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "root-ac", "refresh_token": "root-rf"}
+                }
+            },
+        },
+    )
+
+    provider = "openai-codex"
+    call_count = [0]
+
+    def counting_root_write(provider_id, state):
+        call_count[0] += 1
+
+    monkeypatch.setattr(
+        CP, "_write_through_provider_state_to_global_root", counting_root_write
+    )
+    # After patching A's module-level attributes, the bare-name imports in
+    # credential_pool.py still hold references to the original functions
+    # (``from X import Y`` creates a local binding that does not update when
+    # ``X.Y`` is reassigned).  Patch CP's bindings separately so the
+    # ``_sync_device_code_entry_to_auth_store`` method — whose __globals__
+    # are ``agent.credential_pool.__dict__`` — sees the mocked paths.
+    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(CP, "_same_path", lambda a, b: a == b)
+
+    # ---- REFRESH 1 ----
+    _write_store(profile_path, {"version": 1})
+    entry1 = _entry(
+        provider, id="c1", access_token="ac1", refresh_token="rf1"
+    )
+    pool1 = CredentialPool(provider, [entry1])
+    pool1._sync_device_code_entry_to_auth_store(entry1)
+    assert call_count[0] == 1, "refresh 1: write-through must fire (#74339)"
+
+    # After refresh 1 the profile should NOT have a providers.openai-codex
+    # block (the fix skipped _store_provider_state because the grant came
+    # from root).  This prevents the self-sealing that broke refresh 2+.
+    profile_store = _read_store(profile_path)
+    assert "openai-codex" not in profile_store.get("providers", {}), (
+        "profile must NOT accrue a shadowing providers.<id> block when the "
+        "grant was resolved from root — that key would disable write-through "
+        "on the next refresh (#74339)"
+    )
+
+    # ---- REFRESH 2 (same scenario, rotated tokens) ----
+    entry2 = _entry(
+        provider, id="c2", access_token="ac2", refresh_token="rf2"
+    )
+    pool2 = CredentialPool(provider, [entry2])
+    pool2._sync_device_code_entry_to_auth_store(entry2)
+    assert call_count[0] == 2, (
+        "refresh 2: write-through must fire even after a prior sync-back. "
+        "The old code self-disabled here (#74339)"
+    )
+


### PR DESCRIPTION
## Summary
Credential-pool write-through to the root auth store no longer self-disables after the first refresh — profiles whose OAuth grant resolved from root keep syncing refreshed tokens back to root instead of stranding a revoked single-use refresh token there (#74339).

Root cause: `write_through_to_root` was computed from "profile has no `providers.<id>` block", but `_store_provider_state()` unconditionally created that exact block during the first refresh — so every subsequent refresh saw the self-created block and skipped root, regressing the cross-profile `refresh_token_reused` class (#48415/#43589).

Salvaged from #75438 by @praneshnikhar with authorship preserved (2 commits, cherry-picked onto current main). Supersedes #74542/#74504, which fixed the same bug with a sentinel field that leaked into the root store schema.

## Changes
- `agent/credential_pool.py`: resolve write-through from the *source path* the grant loaded from (root vs profile), not from profile-block existence; never create a shadow profile block for root-resolved grants.
- `hermes_cli/auth.py`: same source-path fix applied to the non-pool xAI path (sibling site).
- `tests/agent/test_credential_pool_oauth_writethrough.py`: two-refresh regression test (write-through must survive refresh #2).
- `contributors/emails/`: mapping for @praneshnikhar.

## Validation
| | Before | After |
|---|---|---|
| Refresh #1 | writes through to root | writes through to root |
| Refresh #2+ | skips root (self-created block) | writes through to root |
| Targeted tests | — | 3/3 pass via scripts/run_tests.sh |

## Infographic

![credential write-through restored](https://v3b.fal.media/files/b/0aa48c52/d-PLB_HU55mKfdinb7CCX_Ec2ukWJ3.png)
