### PR TITLE
fix(agent): preserve /steer through turn-budget enforcement

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1294,12 +1294,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug("Tool output risk callback error: %s", cb_err)
 
-        # ── Per-tool /steer drain ───────────────────────────────────
-        # Same as the sequential path: drain between each collected
-        # result so the steer lands as early as possible.
-        agent._apply_pending_steer_to_tool_results(messages, 1)
-
     # ── Per-turn aggregate budget enforcement ─────────────────────────
+    # Keep /steer pending until the final post-budget drain below.  The model
+    # cannot observe a partial batch, while an early drain can be discarded
+    # when aggregate budget enforcement replaces that tool result.
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
@@ -1368,7 +1366,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 stage=f"invalid tool arguments {function_name}",
             ):
                 return
-            agent._apply_pending_steer_to_tool_results(messages, 1)
             continue
 
         # Tool Search unwrap — see execute_tool_calls_concurrent for full
@@ -1945,12 +1942,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug("Tool output risk callback error: %s", cb_err)
 
-        # ── Per-tool /steer drain ───────────────────────────────────
-        # Drain pending steer BETWEEN individual tool calls so the
-        # injection lands as soon as a tool finishes — not after the
-        # entire batch.  The model sees it on the next API iteration.
-        agent._apply_pending_steer_to_tool_results(messages, 1)
-
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
@@ -1980,6 +1971,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
     # ── Per-turn aggregate budget enforcement ─────────────────────────
+    # Keep /steer pending until the final post-budget drain below.  The model
+    # only receives this batch after all calls finish, and an early drain can
+    # be discarded when aggregate budget enforcement replaces a tool result.
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
         enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -410,6 +410,33 @@ class TestSegmentedDispatchIntegration:
         assert steer_messages == [messages[-1]]
         assert "preserve this steer after budget enforcement" in steer_messages[0]["content"]
 
+    def test_steer_survives_turn_budget_after_malformed_arguments(self, agent):
+        """Malformed arguments still reach the shared post-budget finalizer.
+
+        The parser error itself can exceed a constrained turn budget.  A steer
+        queued before that malformed sequential call must therefore remain
+        pending until after the error result is replaced by the budget preview.
+        """
+        calls = [_tc("terminal", "{not json", call_id="malformed")]
+        messages = []
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        budget = BudgetConfig(
+            default_result_size=10_000,
+            turn_budget=48,
+            preview_size=16,
+        )
+
+        assert _kinds(_plan_tool_batch_segments(calls)) == ["sequential"]
+        assert agent.steer("preserve malformed-call steer after budget enforcement")
+
+        with patch("agent.tool_executor._budget_for_agent", return_value=budget):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        assert len(messages) == 1
+        assert "Truncated:" in messages[0]["content"]
+        assert messages[0]["content"].count(STEER_MARKER_OPEN) == 1
+        assert "preserve malformed-call steer after budget enforcement" in messages[0]["content"]
+
 
 class TestPathCanonicalization:
     """Regression tests for _canonical_path / _extract_parallel_scope_path fixes.

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -27,6 +27,8 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     _should_parallelize_tool_batch,
 )
+from agent.prompt_builder import STEER_MARKER_OPEN
+from tools.budget_config import BudgetConfig
 
 
 def _tc(name="web_search", arguments="{}", call_id=None):
@@ -313,9 +315,8 @@ class TestSegmentedDispatchIntegration:
             assert "cancelled" in m["content"] or "skipped" in m["content"]
 
     def test_steer_lands_exactly_once_in_mixed_batch(self, agent):
-        """Steer is drained once (per-tool drains + one dispatcher-level
-        finalize) — the marker must appear exactly once across the batch,
-        never duplicated by segment boundaries."""
+        """The whole-batch finalizer drains steer once, so the marker cannot
+        be duplicated by segment boundaries."""
         calls = [
             _tc("web_search", '{"query":"a"}', call_id="s1"),
             _tc("web_search", '{"query":"b"}', call_id="s2"),
@@ -334,6 +335,80 @@ class TestSegmentedDispatchIntegration:
         contents = [m["content"] for m in messages]
         hits = [c for c in contents if "focus on the tests" in c]
         assert len(hits) == 1
+
+    @pytest.mark.parametrize(
+        ("calls", "expected_segment_kinds"),
+        [
+            (
+                [
+                    _tc("web_search", '{"query":"large"}', call_id="parallel-large"),
+                    _tc("web_search", '{"query":"small"}', call_id="parallel-small"),
+                ],
+                ["parallel"],
+            ),
+            (
+                [
+                    _tc("terminal", '{"command":"large"}', call_id="sequential-large"),
+                    _tc("terminal", '{"command":"small"}', call_id="sequential-small"),
+                ],
+                ["sequential"],
+            ),
+            (
+                [
+                    _tc("web_search", '{"query":"large"}', call_id="mixed-large"),
+                    _tc("web_search", '{"query":"small"}', call_id="mixed-search-small"),
+                    _tc("terminal", '{"command":"small"}', call_id="mixed-terminal-small"),
+                ],
+                ["parallel", "sequential"],
+            ),
+            (
+                [
+                    _tc("web_search", '{"query":"small"}', call_id="mixed-search-first-small"),
+                    _tc("web_search", '{"query":"small"}', call_id="mixed-search-second-small"),
+                    _tc("terminal", '{"command":"large"}', call_id="mixed-terminal-large"),
+                ],
+                ["parallel", "sequential"],
+            ),
+        ],
+        ids=["parallel", "sequential", "mixed-parallel-large", "mixed-sequential-large"],
+    )
+    def test_steer_survives_turn_budget_in_every_dispatch_path(
+        self, agent, calls, expected_segment_kinds
+    ):
+        """A steer must be appended after aggregate budgeting in direct
+        concurrent, direct sequential, and segmented mixed batches.
+
+        The large result forces ``enforce_turn_budget()`` to replace it.
+        Before the fix, the per-tool drain consumed the steer first, so that
+        replacement silently discarded the canonical marker.
+        """
+        messages = []
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        budget = BudgetConfig(
+            default_result_size=10_000,
+            turn_budget=48,
+            preview_size=16,
+        )
+
+        assert _kinds(_plan_tool_batch_segments(calls)) == expected_segment_kinds
+
+        def fake_handle(name, args, task_id, **kwargs):
+            if kwargs["tool_call_id"].endswith("large"):
+                assert agent.steer("preserve this steer after budget enforcement")
+                return "L" * 1_000
+            return "small"
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=fake_handle),
+            patch("agent.tool_executor._budget_for_agent", return_value=budget),
+        ):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        large_result_index = next(i for i, call in enumerate(calls) if call.id.endswith("large"))
+        assert "Truncated:" in messages[large_result_index]["content"]
+        steer_messages = [m for m in messages if STEER_MARKER_OPEN in m["content"]]
+        assert steer_messages == [messages[-1]]
+        assert "preserve this steer after budget enforcement" in steer_messages[0]["content"]
 
 
 class TestPathCanonicalization:


### PR DESCRIPTION
## Summary
A `/steer` message arriving mid-turn is no longer silently dropped when turn-budget enforcement stubs out the tool result carrying it.

Root cause: both the concurrent and sequential executors drained pending steer text into the just-appended tool result *before* `enforce_turn_budget()` ran; when that result was among the largest and got its `content` replaced with a persisted-file stub, the steer marker went with it — invisible to the model, and the post-budget drain was a no-op because the queue was already consumed.

Fix removes the three pre-budget per-tool drains (concurrent, sequential, sequential invalid-args) and relies on the existing post-budget finalizers, which exist at all three levels including the segmented-batch dispatcher. No API call happens between tools within a batch, so the early drains bought zero visibility — only drop risk.

Salvaged from #66401 by @Xipong with authorship preserved (2 commits cherry-picked onto current main; one trivial conflict resolved against the newer invalid-args flush guard).

## Changes
- `agent/tool_executor.py`: drop pre-budget steer drains at the 3 sites; post-budget drain is now the single injection point.
- `tests/run_agent/test_tool_batch_segmentation.py`: regression matrix — forced budget enforcement x parallel/sequential/mixed-segmented, plus malformed-args path.

## Validation
| | Result |
|---|---|
| tests/run_agent/test_tool_batch_segmentation.py | 22/22 pass |
| Steer + budget-stubbed largest result | marker survives, visible next iteration |

## Infographic

![steer survives budget enforcement](https://v3b.fal.media/files/b/0aa48c62/mJ8I3eYjnKpWlTNAl-sd6_COPaudYP.png)
