### PR TITLE
fix(moa): unwrap completed responses in the auxiliary streaming path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2664,6 +2664,7 @@ def _relay_sync_stream(
         model_name=str(kwargs.get("model") or fallback_model),
         finalizer=dict,
         metadata=metadata,
+        completed_response_predicate=lambda value: hasattr(value, "choices"),
     )
 _RUNTIME_MAIN_COMPAT_SNAPSHOT: Tuple[Any, ...] = ("", "", "", "", "", "")
 _RUNTIME_MAIN_COMPAT_LOCK = threading.Lock()

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -256,12 +256,23 @@ def stream_current(
     finalizer: Callable[[], Any],
     metadata: dict[str, Any] | None = None,
     defer_logical_completion: bool = False,
+    completed_response_predicate: Callable[[Any], bool] | None = None,
 ) -> Any:
-    """Run a provider stream under the inherited Hermes turn when present."""
+    """Run a provider stream under the inherited Hermes turn when present.
+
+    When ``completed_response_predicate`` is set and the stream_factory returns
+    a complete response instead of an iterator (e.g. AnthropicAuxiliaryClient
+    and other shims that ignore ``stream=True``), unwrap and return the
+    completed response directly. This mirrors the pre-Relay behavior where
+    ``call_llm(stream=True)`` returned the raw response and the consumer's
+    own ``hasattr(stream, "choices")`` check handled it (#11732, #55933) —
+    without the unwrap the response stays trapped as ``final_response`` on the
+    inner ManagedLlmStream and the outer consumer sees an empty stream.
+    """
     turn = relay_runtime.active_turn()
     if turn is None:
         return stream_factory(request)
-    return stream(
+    managed = stream(
         request,
         stream_factory,
         session_id=turn.lease.session_id,
@@ -270,7 +281,17 @@ def stream_current(
         finalizer=finalizer,
         metadata=metadata,
         defer_logical_completion=defer_logical_completion,
+        completed_response_predicate=completed_response_predicate,
     )
+    # In the non-managed path the factory already ran eagerly during __init__,
+    # so a completed response is visible immediately and must surface raw.
+    # In the managed path the factory runs lazily on first pull, so
+    # final_response is still None here and the managed stream is returned.
+    if completed_response_predicate is not None:
+        completed = getattr(managed, "final_response", None)
+        if completed is not None:
+            return completed
+    return managed
 
 
 def stream(

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -247,6 +247,14 @@ async def execute_current_async(
     )
 
 
+def _has_running_event_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
 def stream_current(
     request: dict[str, Any],
     stream_factory: Callable[[dict[str, Any]], Any],
@@ -271,6 +279,17 @@ def stream_current(
     """
     turn = relay_runtime.active_turn()
     if turn is None:
+        return stream_factory(request)
+    if _has_running_event_loop():
+        # Managed provider callbacks execute on the Relay session's event
+        # loop. A nested ManagedLlmStream built here would be synchronously
+        # iterated on that same loop thread, which asyncio forbids
+        # ("Cannot run the event loop while another loop is running").
+        # Return the raw factory result instead: the outer managed stream
+        # already provides Relay tracking for the enclosing attempt, and its
+        # own completed_response_predicate traps a completed response (e.g.
+        # the MoA facade's auxiliary ``call_llm(stream=True)`` returning a
+        # full response when an adapter ignores ``stream=True``).
         return stream_factory(request)
     managed = stream(
         request,

--- a/tests/agent/test_auxiliary_relay.py
+++ b/tests/agent/test_auxiliary_relay.py
@@ -260,3 +260,41 @@ def test_partial_auxiliary_stream_failure_closes_before_recovery(
         turn.lease.host.release_managed_execution(consumer)
 
 
+
+
+def test_auxiliary_stream_unwraps_completed_response(relay_turn):
+    """MoA aggregator on an Anthropic-protocol provider: the client returns a
+    completed response for ``stream=True`` (the adapter ignores the flag), so
+    ``_relay_sync_stream`` must surface it raw for the consumer's
+    ``hasattr(stream, "choices")`` handling — regression of #11732/#55933 via
+    the Relay integration (SimpleNamespace is not iterable)."""
+    _relay, _turn = relay_turn
+    completed = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="aggregated"),
+                finish_reason="stop",
+            )
+        ],
+        model="kimi-k3",
+    )
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: completed)
+        )
+    )
+
+    @auxiliary_client._relay_auxiliary_call
+    def run(task):
+        auxiliary_client._set_relay_auxiliary_route(
+            "kimi-coding",
+            "kimi-k3",
+            "chat_completions",
+        )
+        return auxiliary_client._relay_sync_stream(
+            client,
+            {"model": "kimi-k3", "messages": [], "stream": True},
+        )
+
+    assert run("moa_aggregator") is completed
+

--- a/tests/agent/test_auxiliary_relay.py
+++ b/tests/agent/test_auxiliary_relay.py
@@ -298,3 +298,52 @@ def test_auxiliary_stream_unwraps_completed_response(relay_turn):
 
     assert run("moa_aggregator") is completed
 
+
+
+def test_call_llm_stream_unwraps_completed_response(relay_turn, monkeypatch):
+    """Outermost seam: ``call_llm(stream=True)`` — decorated with
+    ``@_relay_auxiliary_call`` in production, so the Relay context is always
+    set — with an Anthropic-shaped client that ignores ``stream=True`` and
+    returns a completed response (the MoA aggregator on kimi-coding /
+    MiniMax / ZAI / any /anthropic gateway). Must return the raw response for
+    the consumer's ``hasattr(stream, "choices")`` handling, not crash with
+    ``TypeError: 'types.SimpleNamespace' object is not iterable``."""
+    _relay, _turn = relay_turn
+    captured = {}
+    completed = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="aggregated"),
+                finish_reason="stop",
+            )
+        ],
+        model="kimi-k3",
+    )
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return completed
+
+    client = SimpleNamespace(
+        base_url="https://api.kimi.com/coding/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create)),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_get_cached_client",
+        lambda *args, **kwargs: (client, "kimi-k3"),
+    )
+
+    result = auxiliary_client.call_llm(
+        "moa_aggregator",
+        provider="kimi-coding",
+        model="kimi-k3",
+        api_key="sk-test",
+        messages=[{"role": "user", "content": "q"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    assert result is completed
+    assert captured["stream"] is True
+    assert captured["stream_options"] == {"include_usage": True}

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -795,3 +795,77 @@ def test_stream_current_streams_iterators_with_predicate(tmp_path, monkeypatch):
         relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
         relay_runtime._reset_for_tests()
 
+
+
+def _completed_response(content: str = "done") -> SimpleNamespace:
+    return SimpleNamespace(
+        model="test-model",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    role="assistant",
+                    content=content,
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+
+def _choices_predicate(value) -> bool:
+    return hasattr(value, "choices")
+
+
+def test_stream_managed_traps_direct_completed_response(relay_turn):
+    """Managed path: a factory returning a completed response (adapter
+    ignoring stream=True) is trapped as final_response instead of iterated."""
+    relay, turn = relay_turn
+    del relay, turn
+
+    stream = relay_llm.stream(
+        {"model": "test-model", "messages": []},
+        lambda request: _completed_response(),
+        session_id="session-1",
+        name="test-provider",
+        model_name="test-model",
+        finalizer=lambda: {},
+        completed_response_predicate=_choices_predicate,
+    )
+    assert list(stream) == []
+    assert stream.final_response is not None
+    assert stream.final_response.choices[0].message.content == "done"
+
+
+def test_stream_current_inside_managed_callback_returns_raw(relay_turn):
+    """Managed path: an auxiliary stream_current() call made from inside a
+    managed provider callback (the MoA facade's call_llm(stream=True) shape)
+    must return the raw factory result; the outer stream traps a completed
+    response as its final_response instead of crashing on a nested event
+    loop or surfacing an empty stream."""
+    relay, turn = relay_turn
+    del relay, turn
+
+    def outer_factory(request):
+        return relay_llm.stream_current(
+            {"model": "test-model", "messages": []},
+            lambda inner_request: _completed_response(),
+            name="moa-aggregator",
+            model_name="test-model",
+            finalizer=lambda: {},
+            completed_response_predicate=_choices_predicate,
+        )
+
+    stream = relay_llm.stream(
+        {"model": "test-model", "messages": []},
+        outer_factory,
+        session_id="session-1",
+        name="moa",
+        model_name="test-model",
+        finalizer=lambda: {},
+        completed_response_predicate=_choices_predicate,
+    )
+    assert list(stream) == []
+    assert stream.final_response is not None
+    assert stream.final_response.choices[0].message.content == "done"

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -714,3 +714,84 @@ def test_codec_baseline_failure_is_explicit(relay_turn, monkeypatch, caplog):
     assert "ignoring request rewrites" in caplog.text
 
 
+def test_stream_current_unwraps_completed_response(tmp_path, monkeypatch):
+    """Auxiliary streaming (the MoA aggregator) must surface a completed
+    provider response raw instead of crashing when the client ignores
+    ``stream=True`` and returns a response object (AnthropicAuxiliaryClient
+    and other OpenAI-compatible shims).
+
+    Pre-Relay, ``call_llm(stream=True)`` returned the raw response and the
+    consumer's ``hasattr(stream, "choices")`` check handled it (#11732,
+    #55933). The Relay integration wrapped the call in a ManagedLlmStream
+    without threading ``completed_response_predicate``, regressing that path
+    into ``TypeError: 'types.SimpleNamespace' object is not iterable``.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    relay_runtime._reset_for_tests()
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="session-moa",
+        platform="cli",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-moa",
+        task_id="task-moa",
+    )
+    try:
+        completed = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="done"),
+                    finish_reason="stop",
+                )
+            ],
+            model="kimi-k3",
+        )
+        result = relay_llm.stream_current(
+            {"model": "kimi-k3", "stream": True},
+            lambda request: completed,
+            name="kimi-coding",
+            model_name="kimi-k3",
+            finalizer=dict,
+            completed_response_predicate=lambda value: hasattr(value, "choices"),
+        )
+        # Unwrapped raw response — NOT a stream wrapper whose iteration would
+        # have raised TypeError pre-fix.
+        assert result is completed
+    finally:
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+        relay_runtime._reset_for_tests()
+
+
+def test_stream_current_streams_iterators_with_predicate(tmp_path, monkeypatch):
+    """A genuine chunk iterator still flows through as a stream when the
+    completed-response predicate is supplied."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    relay_runtime._reset_for_tests()
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="session-moa",
+        platform="cli",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-moa",
+        task_id="task-moa",
+    )
+    try:
+        result = relay_llm.stream_current(
+            {"model": "m", "stream": True},
+            lambda request: iter([{"delta": "a"}, {"delta": "b"}]),
+            name="provider",
+            model_name="m",
+            finalizer=dict,
+            completed_response_predicate=lambda value: hasattr(value, "choices"),
+        )
+        assert list(result) == [{"delta": "a"}, {"delta": "b"}]
+    finally:
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+        relay_runtime._reset_for_tests()
+


### PR DESCRIPTION
## Summary

MoA aggregators on providers whose auxiliary adapter returns a completed response for `stream=True` (Anthropic-protocol hosts: kimi-coding, MiniMax, ZAI, `anthropic:*`) no longer crash with `TypeError: 'types.SimpleNamespace' object is not iterable` — the completed response is now trapped at the Relay streaming seam and delivered through the `final_response` contract the streaming consumer already reads.

Salvage of #74031 by @AKAZIK-py (authorship preserved, 3 commits cherry-picked onto current main). Root cause: the NeMo Relay integration (14bed44c8) rerouted auxiliary streaming through `_relay_sync_stream` → `stream_current` → `ManagedLlmStream` without threading `completed_response_predicate` — the main streaming path in `chat_completion_helpers.py` passes it, the auxiliary path passed nothing, so completed responses hit `iter()`.

## Changes

- `agent/auxiliary_client.py`: `_relay_sync_stream` passes `completed_response_predicate=lambda v: hasattr(v, "choices")` (identical to the main path).
- `agent/relay_llm.py` (non-managed): `stream_current` accepts/forwards the predicate and eagerly unwraps a completed response so the raw object reaches the caller exactly as pre-Relay.
- `agent/relay_llm.py` (managed): the factory runs on the Relay session's event loop, so the eager unwrap can't fire there; `stream_current` detects a running loop and the completed response is trapped as `final_response` on the managed stream instead of being synchronously iterated (which raised `RuntimeError: Cannot run the event loop while another loop is running`).
- Tests: `tests/agent/test_relay_llm.py` (+155) and `tests/agent/test_auxiliary_relay.py` (+87) cover direct trapping, the outermost `call_llm(stream=True)` seam, and the managed nested path.

## Validation

| | Before (main @ e08870f) | After |
|---|---|---|
| `_relay_sync_stream` w/ completed response (aux context set) | `TypeError: 'types.SimpleNamespace' object is not iterable` (live-reproduced) | raw completed response surfaced, `choices[0].message.content` intact |
| `ManagedLlmStream` non-managed, no predicate | TypeError | 0 chunks, `final_response` set |
| Sabotage run (fix files reverted to main) | — | 5 of 23 tests fail, incl. both new seam tests |
| Full relay test files | — | 23/23 pass |

Closes #74031.

## Infographic

![MoA relay completed-response fix](https://v3b.fal.media/files/b/0aa48c66/9kDeQbsc4-H_3OOrm8d0E_JOnoEqsq.png)
