### PR TITLE
fix(slack): keep watchdog reconnect bounded during teardown

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -669,6 +669,41 @@ _SOCKET_CLIENT_TASK_ATTRS = (
 # call must not be able to hold up shutdown indefinitely.
 _SOCKET_TASK_CANCEL_TIMEOUT_S = 3.0
 
+# ``SocketModeClient.close()`` begins with websocket disconnect I/O before it
+# closes the shared aiohttp session. A half-dead transport can wedge that await
+# indefinitely, which strands the watchdog inside teardown and prevents the
+# replacement handler from ever starting.
+_SOCKET_HANDLER_CLOSE_TIMEOUT_S = 3.0
+
+
+def _consume_socket_close_result(task: asyncio.Task) -> None:
+    """Drain a timed-out close task if it eventually finishes."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:  # pragma: no cover - defensive logging
+        logger.debug("[Slack] Timed-out Socket Mode close failed", exc_info=True)
+
+
+async def _await_socket_close(awaitable: Any, timeout: float) -> bool:
+    """Await close work with a strict bound and cancellation-safe cleanup."""
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+    except asyncio.CancelledError:
+        task.cancel()
+        task.add_done_callback(_consume_socket_close_result)
+        raise
+
+    if task not in done:
+        task.cancel()
+        task.add_done_callback(_consume_socket_close_result)
+        return False
+
+    await task
+    return True
+
 
 async def _cancel_socket_tasks(tasks: Any) -> None:
     """Cancel Socket Mode tasks and wait, with a bound, for them to finish.
@@ -1213,7 +1248,31 @@ class SlackAdapter(BasePlatformAdapter):
 
         if handler is not None:
             try:
-                await handler.close_async()
+                closed = await _await_socket_close(
+                    handler.close_async(), _SOCKET_HANDLER_CLOSE_TIMEOUT_S
+                )
+                if not closed:
+                    raise asyncio.TimeoutError
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Slack] Socket Mode handler did not close within %.1fs; "
+                    "continuing reconnect",
+                    _SOCKET_HANDLER_CLOSE_TIMEOUT_S,
+                )
+                session = getattr(client, "aiohttp_client_session", None)
+                close_session = getattr(session, "close", None)
+                if callable(close_session):
+                    try:
+                        close_result = close_session()
+                        if inspect.isawaitable(close_result):
+                            await _await_socket_close(
+                                close_result, _SOCKET_HANDLER_CLOSE_TIMEOUT_S
+                            )
+                    except Exception:  # pragma: no cover - best-effort cleanup
+                        logger.debug(
+                            "[Slack] Timed-out Socket Mode session cleanup failed",
+                            exc_info=True,
+                        )
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning(
                     "[Slack] Error while closing Socket Mode handler: %s",

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -272,7 +272,91 @@ class TestSocketModeTeardown:
 
 
 class TestSocketModeRestart:
+    @pytest.mark.asyncio
+    async def test_parent_cancellation_cancels_inflight_sdk_close(self, adapter):
+        """Gateway shutdown must not orphan a close task spawned by teardown."""
+        old = _FakeHandler()
+        _attach(adapter, old)
+        await asyncio.sleep(0.01)
 
+        close_started = asyncio.Event()
+        close_cancelled = asyncio.Event()
+        release_close = asyncio.Event()
+
+        async def _wait_for_release() -> None:
+            close_started.set()
+            try:
+                await release_close.wait()
+            except asyncio.CancelledError:
+                close_cancelled.set()
+                raise
+
+        old.close_async = _wait_for_release
+        stop_task = asyncio.create_task(adapter._stop_socket_mode_handler())
+        await close_started.wait()
+        stop_task.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await stop_task
+            await asyncio.sleep(0)
+            assert close_cancelled.is_set(), "SDK close task was orphaned"
+        finally:
+            release_close.set()
+
+    @pytest.mark.asyncio
+    async def test_restart_does_not_stall_when_sdk_close_hangs(self, adapter):
+        """A wedged SDK close must not prevent the replacement handler starting."""
+        old = _FakeHandler()
+        old_task = _attach(adapter, old)
+        await asyncio.sleep(0.01)
+
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+        release_session_close = asyncio.Event()
+
+        async def _suppress_cancellation_until_released() -> None:
+            close_started.set()
+            while not release_close.is_set():
+                try:
+                    await release_close.wait()
+                except asyncio.CancelledError:
+                    continue
+
+        old.close_async = _suppress_cancellation_until_released
+
+        async def _session_close_suppresses_cancellation() -> None:
+            old.client.aiohttp_client_session.closed = True
+            while not release_session_close.is_set():
+                try:
+                    await release_session_close.wait()
+                except asyncio.CancelledError:
+                    continue
+
+        old.client.aiohttp_client_session.close = _session_close_suppresses_cancellation
+        started: list[str] = []
+
+        def _fake_start() -> None:
+            started.append("started")
+
+        with (
+            patch.object(_slack_mod, "_SOCKET_HANDLER_CLOSE_TIMEOUT_S", 0.01),
+            patch.object(adapter, "_start_socket_mode_handler", _fake_start),
+        ):
+            restart_task = asyncio.create_task(
+                adapter._restart_socket_mode("transport disconnected")
+            )
+            await asyncio.sleep(0.05)
+            try:
+                assert restart_task.done(), "reconnect remained stuck in SDK close"
+            finally:
+                release_close.set()
+                release_session_close.set()
+                await asyncio.wait_for(restart_task, timeout=0.1)
+
+        assert close_started.is_set()
+        assert old_task.done()
+        assert old.client.aiohttp_client_session.closed
+        assert started == ["started"]
 
     @pytest.mark.asyncio
     async def test_watchdog_restarts_when_transport_disconnected(self, adapter):


### PR DESCRIPTION
## Summary
- bound Slack Socket Mode handler shutdown so a wedged SDK close cannot strand the watchdog
- use strict task deadlines that do not wait indefinitely for cancellation acknowledgement
- best-effort close the old aiohttp session and drain any close task that eventually exits
- add regression coverage where both handler and session shutdown suppress cancellation

## Incident
On 2026-07-31 the live gateway detected a disconnected Slack transport and entered teardown, but never started a replacement handler. The Slack SDK then retried against a closed aiohttp session every ten seconds (`Session is closed`). The watchdog itself remained blocked in teardown.

## Verification
- `python -m pytest tests/gateway/test_slack_socket_reconnect_heal.py -q -o 'addopts='` — 5 passed
- `env -u SLACK_BOT_TOKEN -u SLACK_APP_TOKEN python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_socket_reconnect_heal.py -q -o 'addopts='` — 166 passed (10 existing async-mock warnings)
- `ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_socket_reconnect_heal.py` — passed
- `python -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack_socket_reconnect_heal.py` — passed
- `git diff --check` — passed

The repository-wide suite was also attempted but exceeded the 10-minute execution cap at 21%; it had already reported unrelated failures and logging-test noise outside this Slack change.
