### PR TITLE
fix(processes): bound tail drain after child exit

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import queue
 import signal
 import subprocess
 import sys
@@ -1470,3 +1471,52 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+    def test_chatty_orphan_completes_once_without_poll_or_wait(self, registry):
+        """A descendant that keeps stdout readable must not own completion."""
+        producer = (
+            "import os\n"
+            "if os.fork():\n"
+            "    os.write(1, b'direct-child-exited\\n')\n"
+            "    os._exit(0)\n"
+            "chunk = b'chatty-descendant-tail\\n' * 256\n"
+            "while True:\n"
+            "    os.write(1, chunk)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", producer],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            preexec_fn=os.setsid,
+        )
+        s = _make_session(sid="proc_chatty_orphan")
+        s.process = proc
+        s.pid = proc.pid
+        s.notify_on_complete = True
+        registry._running[s.id] = s
+
+        done = threading.Event()
+
+        def _run():
+            registry._reader_loop(s)
+            done.set()
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        try:
+            assert done.wait(timeout=5.0), (
+                "a continuously writing descendant kept the reader/session alive"
+            )
+            item = registry.completion_queue.get_nowait()
+            assert item["type"] == "completion"
+            assert item["session_id"] == s.id
+            assert item["exit_code"] == 0
+            assert "chatty-descendant-tail" in item["output"]
+            with pytest.raises(queue.Empty):
+                registry.completion_queue.get_nowait()
+        finally:
+            if proc.stdout is not None:
+                proc.stdout.close()
+            t.join(timeout=2.0)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -61,6 +61,11 @@ FINISHED_TTL_SECONDS = 1800     # Keep finished processes for 30 minutes
 MAX_PROCESSES = 64              # Max concurrent tracked processes (LRU pruning)
 MAX_ACTIVE_PROCESS_AGE = 86400  # 24h default — see session_reset.bg_process_max_age_hours (#29177)
 
+# Once a local POSIX child exits, descendants that inherited its stdout pipe
+# no longer own the reader lifecycle. Preserve a bounded tail before finalizing.
+_LOCAL_EXIT_TAIL_DRAIN_SECONDS = 0.6
+_LOCAL_EXIT_TAIL_DRAIN_BYTES = 64 * 1024
+
 # Watch pattern rate limiting — PER SESSION.
 # Hard rule: at most ONE watch-match notification every WATCH_MIN_INTERVAL_SECONDS.
 # Any match arriving inside that cooldown window is dropped and counted as a strike.
@@ -954,11 +959,12 @@ class ProcessRegistry:
         ``notify_on_complete`` would never fire (``_reconcile_local_exit``
         only runs lazily from poll()/wait(), which an autonomous notification
         can't rely on). On POSIX we therefore ``select()`` with a short poll
-        interval and stop draining shortly after the direct child exits, even
-        if the pipe hasn't EOF'd — mirroring the foreground fix in
-        ``tools/environments/base.py::_wait_for_process`` (#8340). Windows
-        pipes don't support select(); the blocking path is kept there and the
-        lazy reconcile in poll()/wait() remains the safety net.
+        interval and, after the direct child exits, drain only a bounded tail
+        by time and bytes even if the pipe remains readable — mirroring the
+        foreground fix in ``tools/environments/base.py::_wait_for_process``
+        (#8340). Windows pipes don't support select(); the blocking path is
+        kept there and the lazy reconcile in poll()/wait() remains the safety
+        net.
         """
         first_chunk = True
         # Incremental decoder: raw pipe reads can split a multibyte UTF-8
@@ -1006,29 +1012,37 @@ class ProcessRegistry:
             if fd is not None:
                 import select as _select
 
-                idle_after_exit = 0
+                tail_deadline = None
+                tail_bytes = 0
                 while True:
+                    if tail_deadline is None and proc.poll() is not None:
+                        tail_deadline = (
+                            time.monotonic() + _LOCAL_EXIT_TAIL_DRAIN_SECONDS
+                        )
+
+                    select_timeout = 0.2
+                    read_size = 4096
+                    if tail_deadline is not None:
+                        remaining_time = tail_deadline - time.monotonic()
+                        remaining_bytes = _LOCAL_EXIT_TAIL_DRAIN_BYTES - tail_bytes
+                        if remaining_time <= 0 or remaining_bytes <= 0:
+                            break
+                        select_timeout = min(select_timeout, remaining_time)
+                        read_size = min(read_size, remaining_bytes)
+
                     try:
-                        ready, _, _ = _select.select([fd], [], [], 0.2)
+                        ready, _, _ = _select.select([fd], [], [], select_timeout)
                     except (ValueError, OSError):
                         break  # fd already closed
                     if ready:
-                        raw = raw_read(4096)
+                        raw = raw_read(read_size)
                         if not raw:
                             break  # true EOF — all writers closed
+                        if tail_deadline is not None:
+                            tail_bytes += len(raw)
                         chunk = decoder.decode(raw)
                         if chunk:
                             _append_chunk(chunk)
-                        idle_after_exit = 0
-                    elif proc.poll() is not None:
-                        # Direct child is gone and the pipe was idle for
-                        # ~200ms. Give it a few more cycles to catch any
-                        # buffered tail, then stop — otherwise we would wait
-                        # forever on a pipe held open by an orphaned
-                        # grandchild (issue #68915).
-                        idle_after_exit += 1
-                        if idle_after_exit >= 3:
-                            break
             else:
                 while True:
                     if raw_read is not None:
@@ -1056,6 +1070,14 @@ class ProcessRegistry:
                 tail = decoder.decode(b"", final=True)
                 if tail:
                     _append_chunk(tail)
+            except Exception:
+                pass
+            # We own the read end only for the direct child's lifecycle.
+            # Closing it releases a descendant that would otherwise block on
+            # a full inherited pipe after the bounded tail drain ends.
+            try:
+                if session.process.stdout is not None:
+                    session.process.stdout.close()
             except Exception:
                 pass
             # Always reap the child to prevent zombie processes.


### PR DESCRIPTION
## Summary

- bound POSIX background-reader ownership to the direct child's lifecycle
- preserve a limited stdout tail after direct-child exit by both time and bytes
- ensure a continuously writing descendant cannot prevent autonomous completion or duplicate the completion event

## Problem

`ProcessRegistry._reader_loop()` already handled descendants that merely held an inherited stdout pipe open. However, if a descendant continuously wrote to that pipe, every `select()` iteration reset the idle counter, so the reader never finalized after the direct child exited. This prevented `notify_on_complete` from firing unless another caller later invoked `poll()` or `wait()`.

## Tests

- `/Users/chufengfan/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tools/test_process_registry.py`
- `/Users/chufengfan/.hermes/hermes-agent/venv/bin/python -m compileall -q tools`
- `git diff --check`

The regression starts a POSIX direct child that exits after forking a continuously writing descendant, invokes the reader without manual `poll()`/`wait()`, and verifies bounded completion, retained tail output, and exactly one queued completion.

## Scope

- POSIX local-process reader path only
- no gateway-specific reconciliation
- no public configuration or schema changes
- Windows behavior remains unchanged
