### PR TITLE
fix(codex): handle completed auxiliary responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1226,11 +1226,19 @@ class _CodexCompletionsAdapter:
 
             event_stream = self._client.responses.create(**stream_kwargs)
             try:
-                final = _consume_codex_event_stream(
-                    event_stream,
-                    model=resp_kwargs.get("model"),
-                    on_event=_on_each_event,
-                )
+                # Some Codex-compatible hosts accept ``stream=True`` but return
+                # a completed Responses object instead of an SSE iterator. Do
+                # not hand that object to the event consumer: typed Responses
+                # (and compatibility shims such as SimpleNamespace) are not
+                # event streams and may not be iterable at all.
+                if hasattr(event_stream, "output"):
+                    final = event_stream
+                else:
+                    final = _consume_codex_event_stream(
+                        event_stream,
+                        model=str(resp_kwargs.get("model") or model),
+                        on_event=_on_each_event,
+                    )
             finally:
                 close_fn = getattr(event_stream, "close", None)
                 if callable(close_fn):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3301,6 +3301,43 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
             codex_runtime._consume_codex_event_stream = original_consume
 
 
+class TestCodexAuxiliaryAdapterCompletedResponse:
+    def test_accepts_completed_response_when_stream_was_requested(self):
+        completed = SimpleNamespace(
+            status="completed",
+            id="resp_completed",
+            output=[SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text="completed response",
+                )],
+            )],
+            usage=SimpleNamespace(
+                input_tokens=11,
+                output_tokens=3,
+                total_tokens=14,
+            ),
+        )
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                assert kwargs["stream"] is True
+                return completed
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.6-terra")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "review this"}],
+        )
+
+        assert response.choices[0].message.content == "completed response"
+        assert response.usage.prompt_tokens == 11
+        assert response.usage.completion_tokens == 3
+        assert response.usage.total_tokens == 14
+
+
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Codex auxiliary Responses adapter no longer crashes when a Codex-compatible endpoint accepts `stream=True` but returns a completed Responses object instead of an SSE iterator — previously every return value went to `_consume_codex_event_stream()`, so a completed `SimpleNamespace`/typed Response died with `TypeError: 'types.SimpleNamespace' object is not iterable`.

Salvage of #74543 by @DocAwk (authorship preserved, clean cherry-pick onto current main). Surfaced with an `openai-codex` GPT model as MoA aggregator, but `_CodexCompletionsAdapter` is shared by other Codex auxiliary tasks. This is the INNER adapter layer of the #74532 / #55933-family cluster; the outer Relay streaming seam is fixed separately in #75854 (salvage of #74031).

## Changes

- `agent/auxiliary_client.py`: use the Responses contract as the discriminator — objects exposing `output` are normalized as completed responses; genuine event streams continue through the existing SSE consumer. (Generic iterability would be wrong: typed SDK `Response` objects are iterable over fields but expose `output`; SDK `Stream` containers are iterable and don't.)
- `tests/agent/test_auxiliary_client.py`: regression coverage for the completed-response-under-stream case.

## Validation

| | Before (main @ e08870f) | After |
|---|---|---|
| `_CodexCompletionsAdapter.create()` w/ completed Responses object | `TypeError` at `codex_runtime.py:1037 for event in event_iter` (live-reproduced) | text extracted, `choices[0].message.content == "done"` |
| Genuine SSE event stream | works | still works (live-verified, no regression) |
| Sabotage run (fix reverted) | — | new regression test fails; 158 others pass |
| `tests/agent/test_auxiliary_client.py` | — | 159/159 pass |

Partially addresses #74532 (remains open until the combined path with #75854 is verified). Closes #74543.

## Infographic

![Codex completed auxiliary response fix](https://v3b.fal.media/files/b/0aa48c75/OLykU25pd__jg-dpzL6Ne_b731020V.png)
