### PR TITLE
fix: relax npm engine constraint to support npm 11.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "typescript-eslint": "8.64.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.0.0",
+        "npm": "<11.12.0 || >=12.0.0"
       }
     },
     "apps/bootstrap-installer": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "engines": {
     "node": ">=20.0.0",
-    "npm": "<11.10.0 || >=12.0.0"
+    "npm": "<11.12.0 || >=12.0.0"
   },
   "allowScripts": {
     "unicode-animations": false,


### PR DESCRIPTION
## Problem

npm 11.11.0 users cannot install workspace dependencies because the `engines.npm` constraint in `package.json` only allows `<11.10.0 || >=12.0.0`, leaving 11.11.x in the gap.

## Fix

Broaden the upper bound from `<11.10.0` to `<11.12.0`.

The `package-lock.json` was auto-updated by npm during the install.