### PR TITLE
Add LLMExecutionBlocked block signal for llm_execution middleware (#64662)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2305,6 +2305,34 @@ def run_conversation(
                     # interrupt-and-return shape used elsewhere in this loop
                     # (e.g. the retry-backoff interrupt above) rather than the
                     # flag-and-break shape, since there is no retry to resume.
+                    #
+                    # A middleware that calls next_call() before raising may
+                    # already have opened a deferred Relay logical call via
+                    # _perform_api_call's relay_llm.execute(...,
+                    # defer_logical_completion=True); complete_logical_call is a
+                    # no-op if none was opened, so it's safe to call
+                    # unconditionally rather than tracking whether next_call ran.
+                    # Also emit the same terminal api_request_error lifecycle
+                    # hook the other early-exit error paths in this function use
+                    # — pre_api_request already fired before middleware dispatch,
+                    # so without this, enabled observers see a start event with
+                    # no post/error counterpart.
+                    from agent import relay_llm
+                    relay_llm.complete_logical_call(api_request_id, outcome="failed")
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="LLMExecutionBlocked",
+                        error_message=_blocked.reason,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason=_blocked.reason,
+                    )
                     _block_text = (
                         f"This request was blocked before reaching the model: {_blocked.reason}"
                     )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2270,7 +2270,7 @@ def run_conversation(
                         defer_logical_completion=True,
                     )
 
-                from hermes_cli.middleware import run_llm_execution_middleware
+                from hermes_cli.middleware import LLMExecutionBlocked, run_llm_execution_middleware
 
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
@@ -2298,6 +2298,27 @@ def run_conversation(
                         api_call_count=api_call_count,
                         middleware_trace=list(_llm_middleware_trace),
                     )
+                except LLMExecutionBlocked as _blocked:
+                    # A governance/safety middleware intentionally prevented this
+                    # call from reaching the provider — distinct from a provider
+                    # or transport failure. Mirrors the self-contained
+                    # interrupt-and-return shape used elsewhere in this loop
+                    # (e.g. the retry-backoff interrupt above) rather than the
+                    # flag-and-break shape, since there is no retry to resume.
+                    _block_text = (
+                        f"This request was blocked before reaching the model: {_blocked.reason}"
+                    )
+                    close_interrupted_tool_sequence(messages, _block_text)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _block_text,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": f"llm_execution_blocked: {_blocked.reason}",
+                        "llm_execution_blocked_metadata": _blocked.metadata,
+                    }
                 finally:
                     if _redirect_lock is not None:
                         with _redirect_lock:

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -246,7 +246,13 @@ For NeMo Relay adaptive execution middleware, see
   intentionally short-circuiting execution.
 - If execution middleware raises before calling `next_call(...)`, Hermes treats
   that as middleware failure and continues with the remaining middleware chain
-  and base execution.
+  and base execution — **except `hermes_cli.middleware.LLMExecutionBlocked`**,
+  which the runner re-raises explicitly before this fallthrough and which
+  always propagates to the caller instead. Use it when `llm_execution`
+  middleware needs to unconditionally prevent a provider call (budget limits,
+  safety filters, compliance checks) rather than merely fail. See
+  [`docs/plugins/hook-taxonomy.md`](../plugins/hook-taxonomy.md) for the
+  broader mutating-hook contract this belongs to.
 - If execution middleware calls `next_call(...)` successfully and then raises
   during post-processing, Hermes preserves the downstream result and does not
   run the provider or tool a second time.

--- a/docs/plugins/hook-taxonomy.md
+++ b/docs/plugins/hook-taxonomy.md
@@ -58,6 +58,34 @@ domain signal with true interpreter-level events (`SystemExit`,
 the runner is self-documenting — it states, at the point a reviewer is
 reading the runner, "this must not be swallowed by the fallthrough path."
 
+**The `checked_by` envelope.** Deny-path metadata (block/gate decisions, not
+pure observers) may carry a small host-owned convention rather than growing
+new first-class exception fields:
+
+```python
+raise LLMExecutionBlocked(
+    "Session cost budget exceeded",
+    metadata={
+        "checked_by": "budget_guard",       # required on deny-path
+        "decision": "block",
+        "chain": ["budget_guard", "..."],   # optional, order that ran
+    },
+)
+```
+
+- `reason` stays the human/log-facing string; the envelope lives in `metadata`
+  so existing raises and their tests don't churn.
+- `checked_by` is **required on the deny-path**, but a plugin never has to set
+  it itself: the runner backfills it from the raising callback's own
+  registered name (`_run_execution_chain`'s `except LLMExecutionBlocked`
+  site) if the plugin omitted it. The host fills the gap rather than failing
+  closed on a missing key — a bare `raise LLMExecutionBlocked("...")` stays a
+  valid, working call site.
+- `decision` / `chain` are conventions a plugin may set for richer
+  provenance; the runner does not require or backfill them.
+- Pure observer hooks are not part of this envelope — it applies only to
+  deny/gate paths like `llm_execution`.
+
 ### Shape B — First-valid-wins
 
 Used by `#58524` (`classify_api_error`). A hook needs to supply an answer

--- a/docs/plugins/hook-taxonomy.md
+++ b/docs/plugins/hook-taxonomy.md
@@ -1,0 +1,133 @@
+# Mutating Hook Taxonomy
+
+This page covers the **mutating** hook category: callbacks that return a value
+or raise a signal which changes control flow, as distinct from observer hooks
+that are only notified after the fact and cannot alter behavior. See
+[`docs/middleware/README.md`](../middleware/README.md) for the general
+middleware contract (registration, payload shape, execution order) that this
+page builds on.
+
+Originally proposed in
+[NousResearch/hermes-agent#64231](https://github.com/NousResearch/hermes-agent/issues/64231),
+covering `#64662` (`llm_execution` block signal) and `#58524`
+(`classify_api_error`).
+
+## Two shapes, one bucket
+
+Mutating hooks split into two patterns depending on what "mutating" means at
+that call site.
+
+### Shape A — Block signal
+
+Used by `#64662` (`llm_execution`). A hook needs to unconditionally stop an
+operation from proceeding. Raising a plain `Exception` doesn't work: the
+middleware runner's general fallthrough handler catches it and continues with
+the next middleware (or the terminal call) — correct for an unrelated
+failure, but it defeats an intentional block. The fix is a purpose-built
+exception subclass with an explicit re-raise in the runner, positioned
+*before* the general fallthrough.
+
+```python
+class LLMExecutionBlocked(Exception):
+    """Raised by llm_execution middleware to unconditionally prevent an LLM
+    API call from proceeding. The runner re-raises this explicitly before
+    the general fallthrough handler, so raising it from any middleware in
+    the chain reliably propagates to the caller."""
+
+    def __init__(self, reason: str, *, metadata: dict | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.metadata = metadata or {}
+```
+
+Usage:
+
+```python
+def budget_guard(request, next_call, session_id, **ctx):
+    if cost_exceeded(session_id):
+        raise LLMExecutionBlocked(
+            "Session cost budget exceeded",
+            metadata={"budget_usd": 5.0, "session_id": session_id},
+        )
+    return next_call(request)
+```
+
+`Exception`, not `BaseException`: using `BaseException` would conflate a
+domain signal with true interpreter-level events (`SystemExit`,
+`KeyboardInterrupt`). The explicit `except LLMExecutionBlocked: raise` line in
+the runner is self-documenting — it states, at the point a reviewer is
+reading the runner, "this must not be swallowed by the fallthrough path."
+
+### Shape B — First-valid-wins
+
+Used by `#58524` (`classify_api_error`). A hook needs to supply an answer
+that may or may not be given, and the first plugin to answer wins over the
+built-in pipeline. Contract:
+
+- Callback returns `None` to decline (defer to the next plugin, then the
+  built-in pipeline), or a non-`None` classification to answer.
+- **Dispatch is run-all, not short-circuit.** The runner calls *every*
+  registered plugin for that kind, isolating each callback's failures so one
+  plugin crashing or hanging can't silently block the others from running.
+  It then picks the **first valid result** among everything returned, in
+  registration order. `classify_api_error` does not stop calling later
+  plugins once an earlier one answers — the first answer wins, but dispatch
+  itself always runs to completion.
+- If two plugins are both capable of answering, only the first-registered
+  one's result is used. Registration order is the tie-break, worth
+  documenting explicitly at the registration point rather than leaving it
+  implicit — two silent-until-conflict plugins is exactly how #64714's
+  "first-wins transform semantics" issue happened.
+- A hook that specifically wants to *stop* dispatch after its own answer is a
+  different, stricter contract than "first-valid-wins" and must say so
+  explicitly — it is not implied by this shape. `classify_api_error` does not
+  make that request.
+
+(Earlier drafts of this page called this shape "value short-circuit." Renamed
+to first-valid-wins because the dispatch mechanics — run every callback,
+isolate failures, pick the first answer — are not a short-circuit, and the
+old name implied otherwise.)
+
+## Cross-cutting conventions (apply to both shapes)
+
+1. **Keyword-only payload.** Every mutating hook callback takes keyword-only
+   arguments, no positional payload.
+
+2. **Privacy gate.** Any payload field that may carry raw user content or an
+   unredacted provider dump (`error_body`, `error_message`, prompt/message
+   text, etc.) gets called out explicitly in the hook's docstring with a
+   `Privacy:` line. This doesn't try to enforce redaction in the runner — it
+   makes the exposure visible and documented at the point a reviewer or
+   auditor needs it.
+
+3. **Hot-path signaling.** Each hook declares whether it fires on every call
+   (hot) or only on a bounded trigger (cold). This varies *within* the
+   bucket — `llm_execution` is hot (fires on every LLM call),
+   `classify_api_error` is cold (fires only on API failure) — so it can't be
+   inferred from "mutating" alone and needs to be explicit. Proposal: a
+   `HOT_PATH: bool` class attribute or docstring field, giving a cost-guard CI
+   check (flag a new hook missing one) something machine-checkable to key off.
+
+4. **Schema versioning.** Follows whatever field-versioning convention lands
+   in the taxonomy's schema-versioning work; not blocking on it here.
+
+## Applying it to the two known members
+
+| | `#64662` `llm_execution` | `#58524` `classify_api_error` |
+|---|---|---|
+| Shape | A — block signal | B — first-valid-wins |
+| Payload | keyword-only | keyword-only |
+| Privacy-flagged fields | request/prompt content | `error_body`, `error_message` |
+| Hot/cold | **hot** — every LLM call | **cold** — API-failure-triggered only |
+| Dispatch | n/a (raises to abort) | run-all, isolate failures, first valid wins |
+
+## Open questions
+
+- **Shared base class or per-site subclass for Shape A?** `LLMExecutionBlocked`
+  is purpose-named for its call site, matching the existing
+  `_DownstreamExecutionError` naming precedent in
+  `hermes_cli/middleware.py`. Open to a shared base class if a future Shape A
+  member wants a common catch point.
+- **Does this bucket want a name in the `<subsystem>_<noun>_<verb-past>`
+  grammar**, or does "mutating hook" stay a cross-cutting category above that
+  grammar?

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -34,6 +34,41 @@ VALID_MIDDLEWARE: set[str] = {
 }
 
 
+class LLMExecutionBlocked(Exception):
+    """Raised by ``llm_execution`` middleware to unconditionally prevent an LLM
+    API call from proceeding.
+
+    Plain ``Exception`` subclasses raised without calling ``next_call`` are
+    caught by ``_run_execution_chain``'s general fallthrough handler and
+    silently routed to the next middleware (or the terminal call) — the
+    correct behavior for an unrelated failure, but it defeats an intentional
+    block. ``_run_execution_chain`` re-raises ``LLMExecutionBlocked``
+    explicitly before that fallthrough, so raising it from any middleware in
+    the chain — directly, or from code called via ``next_call``'s downstream
+    execution — reliably propagates to the caller of
+    ``run_llm_execution_middleware`` instead of being swallowed.
+
+    Args:
+        reason: Human-readable explanation for the block.
+        metadata: Optional structured data passed to the caller.
+
+    Example::
+
+        def budget_guard(request, next_call, session_id, **ctx):
+            if cost_exceeded(session_id):
+                raise LLMExecutionBlocked(
+                    "Session cost budget exceeded",
+                    metadata={"budget_usd": 5.0, "session_id": session_id},
+                )
+            return next_call(request)
+    """
+
+    def __init__(self, reason: str, *, metadata: Dict[str, Any] | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.metadata = metadata or {}
+
+
 @dataclass
 class RequestMiddlewareResult:
     """Result of applying request middleware to a mutable payload."""
@@ -298,6 +333,11 @@ def _run_execution_chain(
         call_kwargs["next_call"] = next_call
         try:
             return callback(**call_kwargs)
+        except LLMExecutionBlocked:
+            # Explicit re-raise before the general fallthrough below — an
+            # intentional block must not be treated like an unrelated
+            # middleware failure and routed to the next callback in the chain.
+            raise
         except _DownstreamExecutionError as exc:
             raise exc.original
         except Exception as exc:

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -50,7 +50,20 @@ class LLMExecutionBlocked(Exception):
 
     Args:
         reason: Human-readable explanation for the block.
-        metadata: Optional structured data passed to the caller.
+        metadata: Optional structured data passed to the caller. By
+            convention (see docs/plugins/hook-taxonomy.md), deny-path
+            metadata may carry:
+
+            - ``checked_by``: the plugin/middleware that made the block
+              decision. If omitted, ``_run_execution_chain`` backfills it
+              from the raising callback's own registered name — a plugin
+              is never required to set this itself, so existing raises
+              don't need updating.
+            - ``decision``: e.g. ``"block"``.
+            - ``chain``: optional list of middleware names that ran before
+              the block, in order.
+
+            Pure observer hooks are not part of this envelope.
 
     Example::
 
@@ -333,10 +346,17 @@ def _run_execution_chain(
         call_kwargs["next_call"] = next_call
         try:
             return callback(**call_kwargs)
-        except LLMExecutionBlocked:
+        except LLMExecutionBlocked as exc:
             # Explicit re-raise before the general fallthrough below — an
             # intentional block must not be treated like an unrelated
             # middleware failure and routed to the next callback in the chain.
+            # Backfill checked_by from the raising callback's own registered
+            # name if the plugin didn't set it — required on the deny-path
+            # per the checked_by envelope convention, but never fail closed
+            # on a missing key; the host fills it in instead.
+            exc.metadata.setdefault(
+                "checked_by", getattr(callback, "__name__", repr(callback))
+            )
             raise
         except _DownstreamExecutionError as exc:
             raise exc.original

--- a/tests/hermes_cli/test_llm_execution_blocked.py
+++ b/tests/hermes_cli/test_llm_execution_blocked.py
@@ -5,6 +5,9 @@ propagation through a pass-through middleware, multi-level chains, and
 regressions proving normal (non-blocking) middleware behavior is unaffected.
 """
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from hermes_cli import middleware as middleware_module
@@ -241,3 +244,107 @@ class TestCheckedByBackfill:
             run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
 
         assert excinfo.value.metadata["checked_by"] == "budget_guard"
+
+
+def _provider_response():
+    message = SimpleNamespace(
+        content="discarded downstream response",
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(
+        id="fake-response",
+        choices=[choice],
+        model="glm-5.2",
+        usage=None,
+    )
+
+
+@pytest.fixture()
+def loop_agent(tmp_path, monkeypatch):
+    """Minimal real AIAgent with a fully mocked provider and isolated home."""
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="glm-5.3",
+            max_iterations=2,
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            save_trajectories=False,
+            platform="cli",
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _provider_response()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    return agent
+
+
+@pytest.mark.parametrize("call_provider_before_block", [False, True])
+def test_run_conversation_closes_every_blocked_boundary(
+    loop_agent,
+    monkeypatch,
+    call_provider_before_block,
+):
+    """The full loop must terminate cleanly for pre- and post-provider blocks."""
+
+    def route_guard(request, next_call, **kw):
+        if call_provider_before_block:
+            next_call(request)
+        raise LLMExecutionBlocked(
+            "LLM_PROVIDER_ROUTE_MISMATCH",
+            metadata={
+                "requested_model": "glm-5.3",
+                "actual_model": "glm-5.2",
+            },
+        )
+
+    _set_callbacks(monkeypatch, [route_guard])
+
+    with (
+        patch("agent.relay_llm.complete_logical_call") as complete_logical_call,
+        patch.object(loop_agent, "_invoke_api_request_error_hook") as error_hook,
+        patch.object(loop_agent, "_persist_session") as persist_session,
+        patch.object(loop_agent, "_save_trajectory"),
+        patch.object(loop_agent, "_cleanup_task_resources"),
+    ):
+        result = loop_agent.run_conversation(
+            "run the guarded request",
+            conversation_history=[],
+            task_id="blocked-route-test",
+        )
+
+    assert loop_agent.client.chat.completions.create.call_count == int(
+        call_provider_before_block
+    )
+    complete_logical_call.assert_called_once()
+    assert complete_logical_call.call_args.kwargs["outcome"] == "failed"
+    error_hook.assert_called_once()
+    assert error_hook.call_args.kwargs["error_type"] == "LLMExecutionBlocked"
+    assert error_hook.call_args.kwargs["reason"] == "LLM_PROVIDER_ROUTE_MISMATCH"
+    assert persist_session.call_count >= 2
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["error"] == "llm_execution_blocked: LLM_PROVIDER_ROUTE_MISMATCH"
+    assert result["llm_execution_blocked_metadata"] == {
+        "requested_model": "glm-5.3",
+        "actual_model": "glm-5.2",
+        "checked_by": "route_guard",
+    }

--- a/tests/hermes_cli/test_llm_execution_blocked.py
+++ b/tests/hermes_cli/test_llm_execution_blocked.py
@@ -54,7 +54,13 @@ class TestDirectRaise:
             run_llm_execution_middleware({"model": "x"}, terminal)
 
         assert excinfo.value.reason == "budget exceeded"
-        assert excinfo.value.metadata == {"budget_usd": 5.0}
+        # The runner backfills checked_by from the raising callback's own
+        # name when the plugin didn't set it — original metadata is preserved
+        # alongside it, not replaced.
+        assert excinfo.value.metadata == {
+            "budget_usd": 5.0,
+            "checked_by": "blocking_middleware",
+        }
         assert provider_called == [], "terminal provider call must not happen when blocked"
 
     def test_next_call_result_discarded_if_middleware_still_raises(self, monkeypatch):
@@ -187,3 +193,51 @@ class TestRegressionNormalBehaviorUnaffected:
         except LLMExecutionBlocked as caught:
             assert caught.metadata["budget_usd"] == 5.0
             assert caught.metadata["session_id"] == "abc123"
+
+
+class TestCheckedByBackfill:
+    """checked_by envelope convention (docs/plugins/hook-taxonomy.md): required
+    on the deny-path, but a plugin never has to set it itself — the runner
+    backfills it from the raising callback's own registered name."""
+
+    def test_checked_by_backfilled_when_omitted(self, monkeypatch):
+        def budget_guard(request, next_call, **kw):
+            raise LLMExecutionBlocked("budget exceeded")
+
+        _set_callbacks(monkeypatch, [budget_guard])
+
+        with pytest.raises(LLMExecutionBlocked) as excinfo:
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+        assert excinfo.value.metadata["checked_by"] == "budget_guard"
+
+    def test_checked_by_not_overwritten_when_plugin_sets_it(self, monkeypatch):
+        def budget_guard(request, next_call, **kw):
+            raise LLMExecutionBlocked(
+                "budget exceeded", metadata={"checked_by": "amp-governance"}
+            )
+
+        _set_callbacks(monkeypatch, [budget_guard])
+
+        with pytest.raises(LLMExecutionBlocked) as excinfo:
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+        # The plugin's own attribution wins — the runner only fills a gap,
+        # it never overrides an explicit value.
+        assert excinfo.value.metadata["checked_by"] == "amp-governance"
+
+    def test_checked_by_reflects_raising_callback_in_a_multi_middleware_chain(
+        self, monkeypatch
+    ):
+        def observer_like(request, next_call, **kw):
+            return next_call(request)
+
+        def budget_guard(request, next_call, **kw):
+            raise LLMExecutionBlocked("budget exceeded")
+
+        _set_callbacks(monkeypatch, [observer_like, budget_guard])
+
+        with pytest.raises(LLMExecutionBlocked) as excinfo:
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+        assert excinfo.value.metadata["checked_by"] == "budget_guard"

--- a/tests/hermes_cli/test_llm_execution_blocked.py
+++ b/tests/hermes_cli/test_llm_execution_blocked.py
@@ -1,0 +1,189 @@
+"""Tests for LLMExecutionBlocked (#64662).
+
+Covers: the exception's own contract, direct-raise propagation, downstream
+propagation through a pass-through middleware, multi-level chains, and
+regressions proving normal (non-blocking) middleware behavior is unaffected.
+"""
+
+import pytest
+
+from hermes_cli import middleware as middleware_module
+from hermes_cli.middleware import LLMExecutionBlocked, run_llm_execution_middleware
+
+
+def _set_callbacks(monkeypatch, callbacks):
+    monkeypatch.setattr(
+        middleware_module,
+        "_get_middleware_callbacks",
+        lambda kind: list(callbacks),
+    )
+
+
+class TestLLMExecutionBlockedContract:
+    def test_reason_and_metadata(self):
+        exc = LLMExecutionBlocked("budget exceeded", metadata={"budget_usd": 5.0})
+        assert exc.reason == "budget exceeded"
+        assert exc.metadata == {"budget_usd": 5.0}
+        assert str(exc) == "budget exceeded"
+
+    def test_metadata_defaults_to_empty_dict(self):
+        exc = LLMExecutionBlocked("blocked")
+        assert exc.metadata == {}
+
+    def test_is_a_plain_exception(self):
+        exc = LLMExecutionBlocked("blocked")
+        assert isinstance(exc, Exception)
+        with pytest.raises(Exception):
+            raise exc
+
+
+class TestDirectRaise:
+    def test_direct_raise_propagates_without_calling_provider(self, monkeypatch):
+        provider_called = []
+
+        def blocking_middleware(request, next_call, **kw):
+            raise LLMExecutionBlocked("budget exceeded", metadata={"budget_usd": 5.0})
+
+        _set_callbacks(monkeypatch, [blocking_middleware])
+
+        def terminal(request):
+            provider_called.append(request)
+            return {"ok": True}
+
+        with pytest.raises(LLMExecutionBlocked) as excinfo:
+            run_llm_execution_middleware({"model": "x"}, terminal)
+
+        assert excinfo.value.reason == "budget exceeded"
+        assert excinfo.value.metadata == {"budget_usd": 5.0}
+        assert provider_called == [], "terminal provider call must not happen when blocked"
+
+    def test_next_call_result_discarded_if_middleware_still_raises(self, monkeypatch):
+        """A middleware that calls next_call() and then raises must still
+        block — the successful downstream result is not silently returned."""
+
+        def calls_then_blocks(request, next_call, **kw):
+            next_call(request)
+            raise LLMExecutionBlocked("blocked after downstream ran")
+
+        _set_callbacks(monkeypatch, [calls_then_blocks])
+
+        with pytest.raises(LLMExecutionBlocked, match="blocked after downstream ran"):
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+
+class TestDownstreamPropagation:
+    def test_propagates_through_outer_pass_through_middleware(self, monkeypatch):
+        """An outer middleware that only calls next_call() and returns its
+        result must not swallow a block raised further down the chain."""
+
+        def pass_through(request, next_call, **kw):
+            return next_call(request)
+
+        def blocks(request, next_call, **kw):
+            raise LLMExecutionBlocked("blocked downstream")
+
+        _set_callbacks(monkeypatch, [pass_through, blocks])
+
+        with pytest.raises(LLMExecutionBlocked, match="blocked downstream"):
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+    def test_three_deep_chain_block_at_first_stops_all_downstream(self, monkeypatch):
+        called = []
+
+        def first(request, next_call, **kw):
+            raise LLMExecutionBlocked("stopped at first")
+
+        def second(request, next_call, **kw):
+            called.append("second")
+            return next_call(request)
+
+        def third(request, next_call, **kw):
+            called.append("third")
+            return next_call(request)
+
+        _set_callbacks(monkeypatch, [first, second, third])
+
+        provider_called = []
+        with pytest.raises(LLMExecutionBlocked, match="stopped at first"):
+            run_llm_execution_middleware(
+                {"model": "x"}, lambda r: provider_called.append(r) or {"ok": True}
+            )
+
+        assert called == [], "middleware after the block must never run"
+        assert provider_called == [], "terminal provider must never run"
+
+    def test_block_from_terminal_call_propagates_through_chain(self, monkeypatch):
+        """The block can also originate at the terminal provider call itself
+        (e.g. a governance check inside the provider wrapper), not just from
+        a registered middleware callback."""
+
+        def pass_through(request, next_call, **kw):
+            return next_call(request)
+
+        def terminal(request):
+            raise LLMExecutionBlocked("blocked at terminal")
+
+        _set_callbacks(monkeypatch, [pass_through])
+
+        with pytest.raises(LLMExecutionBlocked, match="blocked at terminal"):
+            run_llm_execution_middleware({"model": "x"}, terminal)
+
+
+class TestRegressionNormalBehaviorUnaffected:
+    def test_normal_exception_without_next_call_still_falls_through(self, monkeypatch):
+        """Pre-existing behavior: an ordinary Exception (not
+        LLMExecutionBlocked) from a middleware that never called next_call
+        must still fall through to the next callback, unchanged."""
+
+        def broken(request, next_call, **kw):
+            raise ValueError("unrelated failure")
+
+        def recovers(request, next_call, **kw):
+            return next_call(request)
+
+        _set_callbacks(monkeypatch, [broken, recovers])
+
+        result = run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+        assert result == {"ok": True}
+
+    def test_llm_execution_blocked_not_treated_as_generic_exception(self, monkeypatch):
+        """Regression guard: LLMExecutionBlocked must take the explicit
+        re-raise path, never the general fallthrough — i.e. it must not
+        result in the next callback being invoked."""
+
+        called = []
+
+        def blocks(request, next_call, **kw):
+            raise LLMExecutionBlocked("blocked")
+
+        def would_recover(request, next_call, **kw):
+            called.append("would_recover")
+            return next_call(request)
+
+        _set_callbacks(monkeypatch, [blocks, would_recover])
+
+        with pytest.raises(LLMExecutionBlocked):
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+
+        assert called == [], "fallthrough must not occur for LLMExecutionBlocked"
+
+    def test_no_callbacks_fast_path_unaffected(self, monkeypatch):
+        _set_callbacks(monkeypatch, [])
+        result = run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True, "req": r})
+        assert result == {"ok": True, "req": {"model": "x"}}
+
+    def test_metadata_accessible_on_caught_exception(self, monkeypatch):
+        def blocks(request, next_call, **kw):
+            raise LLMExecutionBlocked(
+                "cost budget exceeded",
+                metadata={"budget_usd": 5.0, "session_id": "abc123"},
+            )
+
+        _set_callbacks(monkeypatch, [blocks])
+
+        try:
+            run_llm_execution_middleware({"model": "x"}, lambda r: {"ok": True})
+            assert False, "expected LLMExecutionBlocked"
+        except LLMExecutionBlocked as caught:
+            assert caught.metadata["budget_usd"] == 5.0
+            assert caught.metadata["session_id"] == "abc123"


### PR DESCRIPTION
## Problem

`llm_execution` middleware that raises a plain `Exception` without calling `next_call()` is currently treated as middleware failure — the runner logs a warning and falls through to the next middleware or the terminal provider call (`hermes_cli/middleware.py`, `_run_execution_chain`'s general fallthrough). This is correct for an unrelated failure, but it means governance, budget, and safety plugins have no supported way to actually **block** an LLM call — the block silently gets bypassed.

## Solution

Add `LLMExecutionBlocked(Exception)` with an explicit `except LLMExecutionBlocked: raise` in `_run_execution_chain`, positioned before the general fallthrough handler. It propagates reliably whether raised directly by a callback or from code called via `next_call`'s downstream execution (verified in tests — direct raise, downstream propagation through a pass-through middleware, and a 3-deep chain).

`agent/conversation_loop.py` catches it at the `run_llm_execution_middleware` call site and returns a synthetic blocked response — mirroring the existing self-contained interrupt-and-return shape already used elsewhere in `run_conversation` (build message, close any dangling tool sequence via `close_interrupted_tool_sequence`, persist the session, return) rather than the flag-and-break-the-loop shape, since there's no retry to resume from a governance block.

Also adds `docs/plugins/hook-taxonomy.md`, documenting the general "mutating hook" contract this belongs to (a block-signal shape and a first-valid-wins shape), covering both this and #58524 (`classify_api_error`). Updates `docs/middleware/README.md`'s existing fallthrough note with the `LLMExecutionBlocked` carve-out so the two docs stay consistent — that note previously stated the fallthrough as an unconditional rule.

Background and full design discussion: #64231

## Changes

- `hermes_cli/middleware.py` — `LLMExecutionBlocked` class + explicit re-raise in `_run_execution_chain`
- `agent/conversation_loop.py` — catch `LLMExecutionBlocked` at the `run_llm_execution_middleware` call site, return a blocked response
- `docs/plugins/hook-taxonomy.md` — new, the mutating-hook contract
- `docs/middleware/README.md` — carve-out note for the new exception
- `tests/hermes_cli/test_llm_execution_blocked.py` — 12 tests: exception contract, direct raise, downstream propagation, 3-deep chain, block-at-terminal-call, and regressions proving normal (non-blocking) middleware behavior is unchanged

## Test plan

- [x] `tests/hermes_cli/test_llm_execution_blocked.py` — 12/12 passing
- [x] `tests/hermes_cli/test_plugins.py` — 35/35 passing (no regression)
- [ ] **No dedicated `run_conversation`-level integration test for the `conversation_loop.py` catch site.** That function's existing tests carry substantial fixture setup, and I'd rather flag this gap explicitly than claim coverage that isn't there — marking this draft partly for that reason. Happy to add one if a reviewer can point at the right fixture pattern to reuse, or take specific direction on the call site itself.

## Example

```python
from hermes_cli.middleware import LLMExecutionBlocked

def budget_guard(request, next_call, session_id, **ctx):
    if cost_exceeded(session_id):
        raise LLMExecutionBlocked(
            "Session cost budget exceeded",
            metadata={"budget_usd": 5.0, "session_id": session_id},
        )
    return next_call(request)
```

## Backward compatibility

Fully backward-compatible. No existing middleware is affected — the new `except LLMExecutionBlocked: raise` clause is a no-op for any callback that doesn't raise it.