### PR TITLE
fix(desktop): put Toggle terminal on the ⌘K on/off pattern

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -13,7 +13,6 @@ import {
   HUD_SURFACE,
   HUD_TEXT
 } from '@/app/floating-hud'
-import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { codiconIcon } from '@/components/ui/codicon'
 import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
@@ -52,7 +51,6 @@ import {
   SlidersHorizontal,
   Starmap,
   Sun,
-  Terminal,
   Users,
   Wrench,
   Zap
@@ -771,14 +769,6 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
                 }
               ]
             : []),
-          {
-            action: 'view.showTerminal',
-            icon: Terminal,
-            id: 'nav-terminal',
-            keywords: ['terminal', 'shell', 'console'],
-            label: t.keybinds.actions['view.showTerminal'],
-            run: () => setTerminalTakeover(true)
-          },
           {
             action: 'nav.settings',
             icon: Settings,

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -36,7 +36,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
-import { FileText, LayoutDashboard, PanelBottom, Zap } from '@/lib/icons'
+import { FileText, LayoutDashboard, PanelBottom, Terminal, Zap } from '@/lib/icons'
 import { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
 import { Codecs, persistentAtom } from '@/lib/persisted'
 import { setYoloEnabled } from '@/lib/yolo-session'
@@ -578,6 +578,19 @@ bindPaneCollapse(
   $terminalTakeover,
   () => setTerminalTakeover(false),
   () => setTerminalTakeover(true)
+)
+// ⌘K door onto the same store the keybind and statusbar pill flip — was a
+// one-way "open" row under Go to, so it never showed on/off and couldn't hide.
+registry.register(
+  paletteToggle({
+    id: 'view.showTerminal',
+    label: 'Toggle terminal',
+    action: 'view.showTerminal',
+    icon: Terminal,
+    keywords: ['terminal', 'shell', 'console', 'pty'],
+    get: () => $terminalTakeover.get(),
+    set: setTerminalTakeover
+  })
 )
 
 // Preview EXISTS only while something is previewed (old-shell semantics:


### PR DESCRIPTION
## Summary
- Terminal was the last binary ⌘K row still on the old path: a one-way "open" under Go to with no live state.
- Routes it through `paletteToggle` next to logs, yolo, status bar, and layout edit so every binary palette toggle shows the underlined on/off note, flips both ways, and keeps the palette open.

## Test plan
- [ ] ⌘K → type `terminal` → row reads **Toggle terminal** with underlined `on`/`off`
- [ ] Select it: terminal opens/hides, palette stays open, note flips
- [ ] Same check for logs / yolo / status bar / layout edit (unchanged)
- [ ] Keybind and statusbar terminal pill still flip the same store