### PR TITLE
fix(config): guard against scalar overwrite of mapping sections (#74995)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4866,14 +4866,21 @@ def set_config_value(key: str, value: str, force: bool = False):
         _existing = user_config.get(key)
         if isinstance(_existing, dict):
             if key == "model":
-                # Redirect bare-model shorthand to model.default while
-                # keeping every sibling mapping key intact.
-                key = "model.default"
-                print(
-                    f"✓ Redirecting bare 'model' to 'model.default' "
-                    f"(preserving {len(_existing)} existing model sub-key(s))"
-                )
-                # value was already coerced above; proceed to _set_nested
+                if force:
+                    # --force: allow destructive section overwrite.
+                    print(
+                        f"⚠ Replacing entire 'model' section with a scalar "
+                        f"(discarding {len(_existing)} existing sub-key(s))"
+                    )
+                else:
+                    # Redirect bare-model shorthand to model.default while
+                    # keeping every sibling mapping key intact.
+                    key = "model.default"
+                    print(
+                        f"✓ Redirecting bare 'model' to 'model.default' "
+                        f"(preserving {len(_existing)} existing model sub-key(s))"
+                    )
+                    # value was already coerced above; proceed to _set_nested
             elif not force:
                 _sub = [k for k in _existing if isinstance(k, str)]
                 print(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4782,8 +4782,12 @@ def set_config_value(key: str, value: str, force: bool = False):
         key: Dotted config path (e.g. ``terminal.backend``).
         value: String value (auto-coerced to bool/int/float when matching).
         force: When True, skip the unknown-key warning — useful for scripted
-            writes of keys the running version doesn't recognize yet. The CLI
-            exposes this via ``hermes config set --force``.
+            writes of keys the running version doesn't recognize yet — AND
+            authorize destructive replacement of a mapping section by a
+            scalar (e.g. ``--force model gpt-x`` replaces the whole ``model:``
+            mapping). Without --force, scalar writes over mapping sections are
+            refused (bare ``model`` is redirected to ``model.default``). The
+            CLI exposes this via ``hermes config set --force``.
     """
     if is_managed():
         managed_error("set configuration values")
@@ -5089,7 +5093,8 @@ def config_command(args):
             print("  hermes config set terminal.backend docker")
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             print()
-            print("  --force: skip the unknown-key notice for unrecognized keys")
+            print("  --force: skip the unknown-key notice for unrecognized keys,")
+            print("           and allow a scalar to replace a whole mapping section")
             sys.exit(1)
         set_config_value(key, value, force=force)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4856,6 +4856,56 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+    # Guard against #74995: a single-segment key that names an existing
+    # mapping would silently overwrite the entire section with a scalar
+    # (e.g. ``hermes config set model gpt-5.6-sol`` when model already
+    # contains default/provider/context_length).  Bare ``model`` is a
+    # documented shorthand — redirect to ``model.default`` and preserve
+    # siblings.  All other mapping sections are rejected unless --force.
+    if "." not in key:
+        _existing = user_config.get(key)
+        if isinstance(_existing, dict):
+            if key == "model":
+                # Redirect bare-model shorthand to model.default while
+                # keeping every sibling mapping key intact.
+                key = "model.default"
+                print(
+                    f"✓ Redirecting bare 'model' to 'model.default' "
+                    f"(preserving {len(_existing)} existing model sub-key(s))"
+                )
+                # value was already coerced above; proceed to _set_nested
+            elif not force:
+                _sub = [k for k in _existing if isinstance(k, str)]
+                print(
+                    f"✗ Cannot set '{key}' to a scalar — '{key}' is a "
+                    f"configuration section with {len(_sub)} sub-key(s).",
+                    file=sys.stderr,
+                )
+                if _sub:
+                    _sub_list = ", ".join(_sub[:8])
+                    print(f"  Sub-keys: {_sub_list}", file=sys.stderr)
+                    if len(_sub) > 8:
+                        print(
+                            f"  ... and {len(_sub) - 8} more",
+                            file=sys.stderr,
+                        )
+                print(
+                    "  Use a dotted path to set a specific leaf key:",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    hermes config set {key}.<sub-key> <value>",
+                    file=sys.stderr,
+                )
+                print(
+                    "  Or use --force to replace the entire section:",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    hermes config set --force {key} {value!r}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -643,3 +643,17 @@ class TestMappingGuard:
         parsed = _yaml.safe_load(_read_config(_isolated_hermes_home))
         assert parsed["model"]["default"] == "claude-opus-4"
         assert parsed["model"]["provider"] == "openai-api"
+
+    def test_model_force_overwrites_entire_section(self, _isolated_hermes_home):
+        """hermes config set --force model <id> → overwrite entire section."""
+        self._write_config(_isolated_hermes_home, {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "openai-api",
+                "context_length": 128_000,
+            }
+        })
+        set_config_value("model", "claude-opus-4", force=True)
+        import yaml as _yaml
+        parsed = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert parsed["model"] == "claude-opus-4"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -564,3 +564,82 @@ class TestDisplaySkinTouch:
 
         set_config_value("display.skin", "neon")
         assert (skins / "neon.yaml").read_text() == body
+
+
+# ---------------------------------------------------------------------------
+# Mapping guard — regression tests for #74995
+# ---------------------------------------------------------------------------
+
+class TestMappingGuard:
+    """``hermes config set <section> <scalar>`` must not silently destroy an
+    existing mapping.  Bare ``model`` is a documented shorthand — redirect to
+    ``model.default``.  All other mapping sections are refused without --force.
+    """
+
+    def _write_config(self, tmp_path, data: dict):
+        import yaml as _yaml
+        (tmp_path / "config.yaml").write_text(_yaml.dump(data))
+
+    def test_bare_model_shorthand_preserves_siblings(self, _isolated_hermes_home):
+        """hermes config set model <id> → model.default, siblings survive."""
+        self._write_config(_isolated_hermes_home, {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "openai-api",
+                "context_length": 128_000,
+                "base_url": "https://api.example.com/v1",
+            }
+        })
+        set_config_value("model", "claude-sonnet-4-20250514")
+        config_text = _read_config(_isolated_hermes_home)
+        import yaml as _yaml
+        parsed = _yaml.safe_load(config_text)
+        assert parsed["model"]["default"] == "claude-sonnet-4-20250514"
+        assert parsed["model"]["provider"] == "openai-api"
+        assert parsed["model"]["context_length"] == 128_000
+        assert parsed["model"]["base_url"] == "https://api.example.com/v1"
+
+    def test_bare_model_shorthand_creates_default_when_none(self, _isolated_hermes_home):
+        """Bare model shorthand still works when config is empty (legacy behaviour)."""
+        set_config_value("model", "gpt-5.6-sol")
+        assert "gpt-5.6-sol" in _read_config(_isolated_hermes_home)
+
+    def test_non_model_mapping_is_refused(self, _isolated_hermes_home):
+        """hermes config set terminal bash → refuse, terminal has sub-keys."""
+        self._write_config(_isolated_hermes_home, {
+            "terminal": {
+                "backend": "docker",
+                "docker_image": "python:3.12",
+                "shell": "bash",
+            }
+        })
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("terminal", "zsh")
+        assert exc.value.code == 1
+
+    def test_non_model_mapping_force_overwrites(self, _isolated_hermes_home):
+        """hermes config set --force terminal bash → proceed, section wiped."""
+        self._write_config(_isolated_hermes_home, {
+            "terminal": {
+                "backend": "docker",
+                "shell": "bash",
+            }
+        })
+        set_config_value("terminal", "zsh", force=True)
+        import yaml as _yaml
+        parsed = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert parsed["terminal"] == "zsh"
+
+    def test_model_default_dotted_path_is_not_guarded(self, _isolated_hermes_home):
+        """model.default is already a dotted path — guard must not fire."""
+        self._write_config(_isolated_hermes_home, {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "openai-api",
+            }
+        })
+        set_config_value("model.default", "claude-opus-4")
+        import yaml as _yaml
+        parsed = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert parsed["model"]["default"] == "claude-opus-4"
+        assert parsed["model"]["provider"] == "openai-api"


### PR DESCRIPTION
## Summary
`hermes config set <section> <scalar>` can no longer silently wipe an entire mapping section (#74995) — the destructive case is refused, the documented bare-`model` shorthand is redirected to `model.default` (write-preserving), and `--force` remains the explicit escape hatch for intentional replacement.

Root cause: `set_config_value` ran `_set_nested` with no guard; `model` is a known key so not even the unknown-key notice fired — `config set model x` replaced the whole `model:` mapping with a string and exited 0.

Four PRs landed on this bug; this salvages #75409 by @Baophan00 (most complete: redirect + `--force` escape + tests), with first-submitter credit for the winning design to #71387. #75002 and #75016 were closed as superseded. Complementary to #75426 (the opposite direction of the string-or-dict model pitfall), which is being salvaged separately.

Follow-up commit documents the widened `--force` contract (docstring + CLI help), addressing the sweeper's flag.

## Changes
- `hermes_cli/config.py`: mapping-overwrite guard in `set_config_value` + bare-`model` → `model.default` redirect + `--force` bypass; docstring/help updated.
- `tests/hermes_cli/test_set_config_value.py`: 6 new guard tests.
- Authorship: @Baophan00's 2 commits cherry-picked onto current main.

## Validation
| | Before | After |
|---|---|---|
| `config set model x` (model is mapping) | whole section wiped, exit 0 | redirected to `model.default`, mapping intact |
| `config set gateway y` (mapping) | wiped | refused with error |
| `config set --force gateway y` | wiped | replaced (explicit) |
| tests/hermes_cli/test_set_config_value.py | — | 77/77 pass |

Note: PR #75409's CI red was `test_update_eol_churn` — unrelated, pre-existing on that head; not present in this salvage's targeted runs.

## Infographic

![config mapping sections protected](https://v3b.fal.media/files/b/0aa48cb5/RZ5XJDSWR31j20jT3wpTK_4L8chzCT.png)
