### PR TITLE
fix(transport): emit top-level reasoning_effort for Ollama Cloud custom providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -431,6 +431,46 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
+        # Ollama Cloud: top-level reasoning_effort. The ollama-cloud provider
+        # profile (plugins/model-providers/ollama-cloud) handles this when the
+        # profile is loaded, but custom provider entries (e.g. "ollama-launch")
+        # bypass the profile path and land here. Ollama Cloud's
+        # /v1/chat/completions endpoint accepts top-level ``reasoning_effort``
+        # with values {low, medium, high, max, none} and IGNORES
+        # extra_body.reasoning — so without this block the effort setting is
+        # silently dropped and every chat runs at the server default.
+        # Detection mirrors the ollama-cloud profile: model id ends with
+        # ":cloud" (the Ollama Cloud naming convention) and the base_url points
+        # at an Ollama-compatible server.
+        _base_url_lower = str(params.get("base_url") or "").lower()
+        _is_ollama_cloud = (
+            ":cloud" in (model or "").lower()
+            and (
+                "ollama.com" in _base_url_lower
+                or "127.0.0.1:11434" in _base_url_lower
+                or "localhost:11434" in _base_url_lower
+            )
+        )
+        if _is_ollama_cloud and reasoning_config and isinstance(reasoning_config, dict):
+            _oc_thinking_off = reasoning_config.get("enabled") is False
+            if not _oc_thinking_off:
+                _oc_effort = (reasoning_config.get("effort") or "").strip().lower()
+                # Ollama Cloud accepts {low, medium, high, max, none}. Map
+                # Hermes' wider set onto it the same way the ollama-cloud
+                # profile does: xhigh/max/ultra → max, low/medium/high pass
+                # through, minimal → low. Anything else is omitted so the
+                # model applies its own default rather than HTTP 400.
+                if _oc_effort in {"xhigh", "max", "ultra"}:
+                    _oc_effort = "max"
+                elif _oc_effort in {"low", "medium", "high"}:
+                    pass  # passthrough
+                elif _oc_effort == "minimal":
+                    _oc_effort = "low"
+                else:
+                    _oc_effort = ""  # omit — let the server decide
+                if _oc_effort:
+                    api_kwargs["reasoning_effort"] = _oc_effort
+
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

Emit top-level `reasoning_effort` for Ollama Cloud models reached through custom provider entries (e.g. `ollama-launch`), so the user's effort selection actually reaches the backend instead of being silently dropped.

Fixes #75871.

## Problem

Ollama Cloud's `/v1/chat/completions` endpoint only honors the top-level `reasoning_effort` field. The registered `ollama-cloud` provider profile handles this — it maps the effort onto the top-level field. But custom provider entries like `ollama-launch` don't match a registered profile name, so `get_provider_profile()` returns `None` and the request falls through to the legacy flag-based path in `ChatCompletionsTransport.build_kwargs`. That path only emits `extra_body.reasoning`, which Ollama Cloud ignores — so every chat runs at the server default regardless of the configured effort.

The value is persisted correctly in the session DB and reported back to the UI via `_session_info`, so the bug is invisible from the surface: the UI shows "max" while the backend receives nothing it can act on.

## Measured impact

Same prompt, same model, only the request shape differs:

| Request shape | reasoning length | effective |
|---|---|---|
| top-level `reasoning_effort: "max"` | ~5400 chars | yes |
| `extra_body.reasoning` only (pre-fix) | ~1000 chars | no — server default |
| no reasoning field at all | ~700 chars | server default |

The "extra_body only" shape matches the no-field baseline, confirming the field is dropped.

## Fix

Add an Ollama Cloud branch to the legacy flag-based path, mirroring the mapping the `ollama-cloud` profile already uses:

- detect via model id `:cloud` suffix + base_url on an Ollama-compatible host (`ollama.com` or the local `127.0.0.1:11434` / `localhost:11434`)
- map `xhigh`/`max`/`ultra` → `max`, `low`/`medium`/`high` passthrough, `minimal` → `low` (matching the profile's accepted set: `low`, `medium`, `high`, `max`, `none`)
- emit as top-level `reasoning_effort`
- skip when thinking is explicitly disabled, and omit the field for unrecognized efforts so the server applies its own default rather than 400

The registered-profile path is unchanged — this only fills the gap for custom provider entries that bypass it.

## Test plan

- [x] `tests/agent/transports/` — 216 passed
- [x] `tests/run_agent/test_provider_parity.py` — 54 passed
- [x] `tests/agent/test_custom_provider_extra_body.py` — 2 passed
- [x] E2E against live `glm-5.2:cloud` via `ollama-launch` — `effort=high` now produces ~4700 chars of reasoning (was ~1000 pre-fix), matching the top-level field behavior