### PR TITLE
fix(update): prevent stranded update marker on Windows file-lock contention

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -126,7 +126,13 @@ struct UpdateMarkerGuard {
 /// UPDATE_MARKER_MAX_AGE_SECONDS in hermes_cli/update_lock.py — all three read
 /// this one file, so a shorter ceiling in any of them would steal a lock the
 /// others still consider live.
-const UPDATE_MARKER_MAX_AGE_SECS: u64 = 20 * 60;
+///
+/// A full update (git pull + uv sync + desktop rebuild) is typically 2-4
+/// minutes; 5 minutes is a generous ceiling that still self-heals quickly
+/// when a marker is stranded by a Windows file-lock (ERROR_SHARING_VIOLATION)
+/// combined with PID recycling.  The previous 20-minute ceiling left users
+/// blocked for the full duration when `complete()` failed to `DeleteFileW`.
+const UPDATE_MARKER_MAX_AGE_SECS: u64 = 5 * 60;
 
 /// The pid + age of a confirmed-live update holding the marker.
 struct MarkerOwner {
@@ -233,13 +239,39 @@ impl UpdateMarkerGuard {
     /// pid holding a fresh marker — which blocks desktop startup and every
     /// other updater for the full age ceiling. Idempotent: `Drop` still runs
     /// and tolerates an already-removed marker.
+    ///
+    /// On Windows, `DeleteFileW` fails with `ERROR_SHARING_VIOLATION` when
+    /// another process (antivirus, Windows Search indexer, the shutting-down
+    /// Electron renderer) has the file open without `FILE_SHARE_DELETE`.
+    /// Since `exit_after_success` uses `process::exit(0)` which bypasses
+    /// `Drop`, a failed `complete()` leaves the marker stranded until the
+    /// age ceiling expires — which with PID recycling can block every
+    /// subsequent update for 20 minutes.  Retry with exponential backoff
+    /// to ride out transient file-lock contention.
     fn complete(&self) {
         if !self.owned {
             return;
         }
-        if let Err(err) = std::fs::remove_file(&self.path) {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(path = ?self.path, %err, "could not remove completed update marker");
+        // 5 attempts × 200ms backoff = up to ~1s total wait.  Enough for
+        // a briefly-held sharing violation (antivirus scan, index probe)
+        // without noticeably delaying the relaunch.
+        for attempt in 0..5u32 {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => return,
+                Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => return,
+                Err(err) => {
+                    if attempt < 4 {
+                        std::thread::sleep(std::time::Duration::from_millis(200));
+                    } else {
+                        tracing::warn!(
+                            path = ?self.path,
+                            %err,
+                            attempts = attempt + 1,
+                            "could not remove update marker after retries; \
+                             stale detection will self-heal on next launch"
+                        );
+                    }
+                }
             }
         }
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1726,7 +1726,7 @@ function directoryExists(filePath) {
 // How long we'll park the launch waiting for a live update to finish before
 // giving up and starting the backend anyway (belt-and-suspenders alongside the
 // marker's own age ceiling; covers a stuck-but-alive updater).
-const UPDATE_WAIT_TIMEOUT_MS = 20 * 60 * 1000
+const UPDATE_WAIT_TIMEOUT_MS = 5 * 60 * 1000
 const UPDATE_WAIT_POLL_MS = 1000
 // How long the desktop lingers on the "updating, don't reopen" overlay after
 // spawning the detached updater, before it quits to release the venv shim. The

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -24,10 +24,12 @@ import fs from 'fs'
 import path from 'path'
 
 // Even with a live-looking PID, never treat a marker older than this as a live
-// update. A full update (git pull + pip + desktop rebuild) is minutes, not tens
-// of minutes; past this the marker is almost certainly stale (e.g. the OS
-// recycled the pid onto an unrelated process), so the gate self-heals.
-export const UPDATE_MARKER_MAX_AGE_MS = 20 * 60 * 1000
+// update. A full update (git pull + pip + desktop rebuild) is typically 2-4
+// minutes; 5 minutes is generous while still self-healing quickly when a marker
+// is stranded by a Windows file-lock (ERROR_SHARING_VIOLATION) combined with
+// PID recycling.  The previous 20-minute ceiling left users blocked for the
+// full duration when `complete()` failed to `DeleteFileW`.
+export const UPDATE_MARKER_MAX_AGE_MS = 5 * 60 * 1000
 
 export function markerPath(hermesHome) {
   return path.join(hermesHome, '.hermes-update-in-progress')

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -51,8 +51,10 @@ logger = logging.getLogger(__name__)
 # Keep in sync with UPDATE_MARKER_MAX_AGE_MS in
 # apps/desktop/electron/update-marker.ts — the same marker is read by both, and
 # a shorter ceiling here would let Python steal a lock Electron still considers
-# live. A full update (git pull + uv sync + desktop rebuild) is minutes.
-UPDATE_MARKER_MAX_AGE_SECONDS = 20 * 60
+# live.  A full update (git pull + uv sync + desktop rebuild) is typically 2-4
+# minutes; 5 minutes is generous while still self-healing quickly when a marker
+# is stranded by a Windows file-lock combined with PID recycling.
+UPDATE_MARKER_MAX_AGE_SECONDS = 5 * 60
 
 MARKER_NAME = ".hermes-update-in-progress"
 
@@ -228,23 +230,49 @@ class UpdateLock:
         return True
 
     def release(self) -> None:
-        """Drop the marker if this process still owns it. Never raises."""
+        """Drop the marker if this process still owns it. Never raises.
+
+        On Windows, ``read_text`` or ``unlink`` can fail with
+        ``ERROR_SHARING_VIOLATION`` when another process (antivirus, Windows
+        Search indexer) briefly holds the file open.  Since ``self.acquired``
+        is cleared on the first call, a failed cleanup has no retry path
+        through this object — the marker is stranded until the age ceiling
+        expires.  Retry up to 5 times with 200 ms backoff to ride out
+        transient file-lock contention.
+        """
         if not self.acquired:
             return
         self.acquired = False
-        try:
-            raw = self.path.read_text(encoding="utf-8")
-            owner = int(raw.splitlines()[0].strip())
-        except (OSError, IndexError, ValueError):
-            return
-        if owner != os.getpid():
-            # A handoff partner took ownership (e.g. the Tauri updater wrote
-            # its own pid). Leave it alone — it's still a live update.
-            return
-        try:
-            self.path.unlink()
-        except OSError:
-            pass
+        import time as _time
+
+        for _attempt in range(5):
+            try:
+                raw = self.path.read_text(encoding="utf-8")
+                owner = int(raw.splitlines()[0].strip())
+            except (OSError, IndexError, ValueError):
+                # Unreadable or malformed — if we wrote it (acquired=True
+                # was set), assume it's ours and try to unlink anyway.
+                # A corrupt marker must not strand the lock.
+                try:
+                    self.path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                return
+            if owner != os.getpid():
+                # A handoff partner took ownership (e.g. the Tauri updater wrote
+                # its own pid). Leave it alone — it's still a live update.
+                return
+            try:
+                self.path.unlink()
+                return
+            except OSError:
+                if _attempt < 4:
+                    _time.sleep(0.2)
+                else:
+                    logger.warning(
+                        "Could not remove update marker %s after 5 attempts",
+                        self.path,
+                    )
 
     def __enter__(self) -> "UpdateLock":
         self.acquire()

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -224,3 +224,73 @@ class TestHandoffFromOrchestratingUpdater:
         assert lock.acquire() is True
         assert lock.acquired is True
         assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+
+class TestReleaseRetry:
+    """release() retries unlink on Windows file-lock contention."""
+
+    def test_release_retries_unlink_on_transient_failure(self, marker, monkeypatch):
+        """If unlink fails the first time but succeeds on retry, the marker is removed."""
+        import time as _time
+
+        lock = UpdateLock(path=marker)
+        lock.acquire()
+        assert marker.exists()
+
+        call_count = {"n": 0}
+        original_unlink = type(marker).unlink
+
+        def flaky_unlink(self_path, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError(32, "Sharing violation")  # WinError 32
+            return original_unlink(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(type(marker), "unlink", flaky_unlink)
+        # Speed up the test by patching sleep to a no-op
+        monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+        lock.release()
+
+        assert call_count["n"] == 2, "should retry after transient failure"
+        assert not marker.exists(), "marker removed after successful retry"
+
+    def test_release_force_deletes_unreadable_marker(self, marker, monkeypatch):
+        """If the marker can't be read (corrupt/locked), unlink anyway."""
+        lock = UpdateLock(path=marker)
+        lock.acquire()
+        assert marker.exists()
+
+        # Make read_text fail
+        original_read = type(marker).read_text
+
+        def broken_read(*args, **kwargs):
+            raise OSError(32, "Sharing violation")
+
+        monkeypatch.setattr(type(marker), "read_text", broken_read)
+
+        lock.release()
+
+        assert not marker.exists(), "unreadable marker force-deleted"
+
+    def test_release_gives_up_after_max_retries(self, marker, monkeypatch):
+        """If unlink keeps failing, release() gives up after 5 attempts."""
+        import time as _time
+
+        lock = UpdateLock(path=marker)
+        lock.acquire()
+
+        call_count = {"n": 0}
+
+        def always_fail(*args, **kwargs):
+            call_count["n"] += 1
+            raise OSError(32, "Sharing violation")
+
+        monkeypatch.setattr(type(marker), "unlink", always_fail)
+        monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+        # Should not raise even after max retries
+        lock.release()
+
+        assert call_count["n"] == 5, "should try exactly 5 times"
+        assert lock.acquired is False, "acquired is always cleared"


### PR DESCRIPTION
## Problem

On Windows, clicking "Update" in the desktop app consistently fails with *"Update didn't finish. Hermes is still running."* after the first successful update. The `.hermes-update-in-progress` marker file stays on disk and blocks all subsequent attempts until manually deleted.

**Root cause chain:**

1. `UpdateMarkerGuard::complete()` calls `DeleteFileW` → `ERROR_SHARING_VIOLATION` (antivirus, Windows Search indexer, or the shutting-down Electron renderer has the file open)
2. Error is logged and swallowed — one attempt only
3. `exit_after_success()` calls `process::exit(0)` which **bypasses `Drop`** — no second chance
4. Updater exits; Windows recycles its PID within milliseconds
5. Next update: stale marker has a "live" PID (now some unrelated process) → blocked for the full **20-minute** age ceiling

## Fix (3 layers)

| Layer | Change |
|---|---|
| Rust `complete()` | Retry `remove_file` up to 5× with 200ms backoff |
| Python `release()` | Same retry loop + force-delete unreadable markers via `unlink(missing_ok=True)` |
| Age ceiling (all 3 consumers) | 20 min → 5 min (a full update is typically 2–4 min) |

## Files changed

| File | What |
|---|---|
| `apps/bootstrap-installer/src-tauri/src/update.rs` | Retry in `complete()` + lower `UPDATE_MARKER_MAX_AGE_SECS` |
| `hermes_cli/update_lock.py` | Retry in `release()` + lower `UPDATE_MARKER_MAX_AGE_SECONDS` |
| `apps/desktop/electron/update-marker.ts` | Lower `UPDATE_MARKER_MAX_AGE_MS` |
| `apps/desktop/electron/main.ts` | Lower `UPDATE_WAIT_TIMEOUT_MS` to match |
| `tests/hermes_cli/test_update_lock.py` | 3 new tests for retry behavior |

## Tests

All 26 Python tests pass (23 existing + 3 new):

- `test_release_retries_unlink_on_transient_failure` — retry succeeds on 2nd attempt, marker removed
- `test_release_force_deletes_unreadable_marker` — corrupt/locked marker force-deleted  
- `test_release_gives_up_after_max_retries` — graceful give-up after 5 attempts, `acquired` always cleared