### PR TITLE
fix(cron): treat live-adapter confirmation timeouts as unknown

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1815,46 +1815,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
-                            # #38922: a slow confirmation does NOT necessarily
-                            # mean the send failed — but we must distinguish two
-                            # cases via future.cancel()'s return value:
-                            #
-                            #   cancel() == False -> the coroutine was already
-                            #     running on the gateway loop when the timeout
-                            #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
-                            #
-                            #   cancel() == True -> the scheduled callback never
-                            #     started executing (loop wedged/backlogged for
-                            #     the full 60s), so nothing was sent.  We MUST
-                            #     fall through to the standalone path or the
-                            #     message is silently dropped (worse than a
-                            #     duplicate).
-                            cancelled = future.cancel()
-                            if cancelled:
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    "timed out before the coroutine was dispatched"
-                                )
-                                logger.warning(
-                                    "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
-                                )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
-                                timeout_handled = True
-                            else:
-                                timed_out = True
-                                timeout_handled = True
-                                logger.warning(
-                                    "Job '%s': live adapter send to %s:%s timed out "
-                                    "after 60s; already dispatched (in flight), "
-                                    "assuming delivered (skipping standalone fallback "
-                                    "to avoid duplicate)",
-                                    job["id"], platform_name, chat_id,
-                                )
+                            # #38922: once the live send has been accepted by
+                            # run_coroutine_threadsafe(), a confirmation timeout
+                            # does not reveal whether the coroutine or transport
+                            # side effect started.  Future.cancel() only controls
+                            # the wrapper's cancellation state; its return value
+                            # is not a dispatch or delivery receipt.  Retrying via
+                            # standalone could therefore duplicate an in-flight
+                            # request, so preserve the ambiguity and do not retry.
+                            future.cancel()
+                            timed_out = True
+                            timeout_handled = True
+                            msg = (
+                                f"live adapter send to {platform_name}:{chat_id} "
+                                "timed out after 60s; delivery status unknown "
+                                "(skipping standalone fallback to avoid duplicate)"
+                            )
+                            logger.warning("Job '%s': %s", job["id"], msg)
+                            delivery_errors.append(msg)
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
                             # through to the standalone path so the message is
@@ -1863,10 +1841,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             raise
 
                         if timeout_handled:
-                            # The timeout branch above already decided the
-                            # outcome (assume-delivered if in flight, or
-                            # adapter_ok=False to fall through if never
-                            # dispatched).  send_result is None, so skip the
+                            # The timeout branch above already recorded an
+                            # ambiguous outcome.  send_result is None, so skip
                             # confirmation/thread-fallback inspection below.
                             pass
                         else:
@@ -1926,9 +1902,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # the General lane for private DM topics).  Skip on an in-flight
                 # confirmation timeout: the gateway loop is contended, so each
                 # media send would also block its 30s budget, and the text
-                # payload is already assumed delivered (#38922).  Record the
-                # skipped attachments so the drop is visible rather than silently
-                # lost.
+                # outcome is ambiguous (#38922).  Record the skipped attachments
+                # so the drop is visible rather than silently lost.
                 if adapter_ok and not timed_out and media_files:
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
@@ -1955,6 +1930,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
                     logger.warning("Job '%s': %s", job["id"], msg)
                     delivery_errors.append(msg)
+
+                if timed_out:
+                    # The live Future was scheduled, but no transport receipt
+                    # arrived.  Do not seed/mirror a delivery that is not
+                    # confirmed, and do not enter the standalone retry path.
+                    continue
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1288,53 +1288,67 @@ class TestParallelTick:
 
 
 class TestDeliverResultTimeoutCancelsFuture:
-    """When future.result(timeout=60) raises TimeoutError in the live adapter
-    delivery path, the outcome depends on whether the coroutine was already
-    running.  future.cancel() returning False means it is in flight on the wire
-    (cannot be un-sent) → treat as DELIVERED and skip the standalone fallback to
-    avoid a duplicate (#38922).  future.cancel() returning True means it never
-    started (wedged loop) → nothing was sent, so fall through to standalone or
-    the message is silently dropped.  Regression for #38922.
-    """
+    """A live-adapter confirmation timeout is ambiguous, never a retry signal."""
 
-    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
-        """End-to-end: live adapter confirmation times out past the 60s budget.
-        The fix (#38922) treats the send as already-dispatched/delivered and
-        does NOT run the standalone fallback — otherwise the message is sent
-        twice."""
+    def test_live_adapter_timeout_is_unknown_without_duplicate(self):
+        """Use a real loop/Future so cancel() cannot be mistaken for dispatch state."""
+        import asyncio
+        import threading
+
         from gateway.config import Platform
-        from concurrent.futures import Future
+        from agent.async_utils import safe_schedule_threadsafe as real_schedule
 
-        # Live adapter whose send() coroutine never resolves within the budget
-        adapter = AsyncMock()
-        adapter.send.return_value = MagicMock(success=True)
+        entered = threading.Event()
+        stopped = threading.Event()
+        loop = asyncio.new_event_loop()
+        loop_ready = threading.Event()
+
+        async def blocked_send(*_args, **_kwargs):
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                stopped.set()
+
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=blocked_send)
 
         pconfig = MagicMock()
         pconfig.enabled = True
         mock_cfg = MagicMock()
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
 
-        loop = MagicMock()
-        loop.is_running.return_value = True
+        captured_future = None
+        cancel_returns = []
 
-        # A real concurrent.futures.Future, but we override .result() to raise
-        # TimeoutError exactly like the 60s wait firing in production.  We make
-        # .cancel() return False to simulate the coroutine being ALREADY RUNNING
-        # on the gateway loop (in flight on the wire) — the case where the send
-        # cannot be un-sent and a standalone resend would be a duplicate.
-        captured_future = Future()
-        cancel_calls = []
+        def schedule_with_short_test_timeout(coro, target_loop):
+            nonlocal captured_future
+            future = real_schedule(coro, target_loop)
+            assert future is not None
+            captured_future = future
+            original_result = future.result
+            original_cancel = future.cancel
 
-        def in_flight_cancel():
-            cancel_calls.append(True)
-            return False  # already running — cannot be cancelled
+            def result_with_short_timeout(*, timeout):
+                return original_result(timeout=0.05)
 
-        captured_future.cancel = in_flight_cancel
-        captured_future.result = MagicMock(side_effect=TimeoutError("timed out"))
+            def tracking_cancel():
+                result = original_cancel()
+                cancel_returns.append(result)
+                return result
 
-        def fake_run_coro(coro, _loop):
-            coro.close()
-            return captured_future
+            setattr(future, "result", result_with_short_timeout)
+            setattr(future, "cancel", tracking_cancel)
+            return future
+
+        def run_loop():
+            asyncio.set_event_loop(loop)
+            loop_ready.set()
+            loop.run_forever()
+
+        loop_thread = threading.Thread(target=run_loop, daemon=True)
+        loop_thread.start()
+        assert loop_ready.wait(timeout=1), "event loop did not start"
 
         job = {
             "id": "timeout-job",
@@ -1346,7 +1360,57 @@ class TestDeliverResultTimeoutCancelsFuture:
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
-             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=schedule_with_short_test_timeout), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            try:
+                result = _deliver_result(
+                    job,
+                    "Hello world",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                )
+            finally:
+                assert stopped.wait(timeout=1), "cancelled delivery did not drain"
+                loop.call_soon_threadsafe(loop.stop)
+                loop_thread.join(timeout=1)
+                loop.close()
+
+        assert entered.is_set(), "the real delivery coroutine never entered"
+        assert captured_future is not None
+        # The first call is scheduler-owned; asyncio may call cancel() again
+        # while propagating cancellation from the wrapper to the Task.
+        assert cancel_returns and cancel_returns[0] is True
+        assert captured_future.cancelled(), "timeout should cancel the real Future"
+        assert result is not None
+        assert "delivery status unknown" in result
+        standalone_send.assert_not_awaited()
+
+    def test_live_adapter_scheduling_failure_uses_standalone(self):
+        """A Future that was never created remains eligible for fallback."""
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fail_schedule(coro, _loop):
+            coro.close()
+            return None
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        job = {
+            "id": "schedule-failure-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fail_schedule), \
              patch("tools.send_message_tool._send_to_platform", new=standalone_send):
             result = _deliver_result(
                 job,
@@ -1355,13 +1419,8 @@ class TestDeliverResultTimeoutCancelsFuture:
                 loop=loop,
             )
 
-        # 1. cancel() was attempted (returned False = in flight).
-        assert cancel_calls == [True], "future.cancel() should be attempted on TimeoutError"
-        # 2. Delivery is reported successful (no error string returned).
-        assert result is None, f"expected successful delivery, got error: {result!r}"
-        # 3. The standalone fallback must NOT run — that is the #38922 fix:
-        #    an in-flight confirmation timeout is assume-delivered, not a resend.
-        standalone_send.assert_not_awaited()
+        assert result is None
+        standalone_send.assert_awaited_once()
 
 
 class TestDeliverResultLiveAdapterUnconfirmed:
@@ -1899,5 +1958,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-


### PR DESCRIPTION
## What does this PR do?

Stops cron from using the boolean returned by `concurrent.futures.Future.cancel()` as proof that a live-adapter coroutine never started.

A real `asyncio.run_coroutine_threadsafe()` reproduction shows `cancel() == True` after the delivery coroutine has entered. Cancel-before-loop behavior also differs between Python 3.11.15 and 3.14.6. The boolean is therefore cancellation state, not a dispatch or transport receipt.

After a scheduled live-adapter confirmation timeout, this change performs best-effort cancellation, records `delivery status unknown`, and skips the standalone retry. If scheduling fails before a Future is returned, the existing standalone fallback remains available.

This deliberately favors the no-duplicate invariant for an ambiguous outcome. It does not guarantee delivery or implement durable transport receipts.

## Related Issues and PRs

Related to #38922 and the timeout split introduced by #50018. The real-Future behavior matches the investigation in #51189.

This completes the auditability direction in #70963 for the still-unsafe cancellable branch. It does not close or claim the broader per-target receipt design in #70945.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `cron/scheduler.py`: ignore the cancellation return value, record the timeout as unknown, and skip retry/media/mirroring for that target.
- `tests/cron/test_scheduler.py`: replace the synthetic Future with a real background loop/Future regression and retain coverage for pre-scheduling fallback.

## How to Test

1. Run `scripts/run_tests.sh tests/cron -q`.
2. The timeout regression proves the coroutine entered and the first scheduler-owned `cancel()` returned `True`.
3. Verify the result contains `delivery status unknown` and the standalone sender was not awaited.

## Verification

- `scripts/run_tests.sh tests/cron -q`: 374 passed, 0 failed.
- `scripts/run_tests.sh tests/cron/test_scheduler.py -q`: 64 passed, 0 failed.
- `.venv/bin/ruff check cron/scheduler.py tests/cron/test_scheduler.py`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Full `scripts/run_tests.sh` was attempted but did not complete cleanly in this checkout: the optional ACP extra is not installed (`ModuleNotFoundError: acp`), and unrelated LSP tests hit the live-system signal guard. The focused and package-level cron suites are green.

Tested on macOS, Python 3.11.15.

## Checklist

### Code

- [x] Read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] Searched open and closed issues and PRs; coordinated on #70963 before opening this completion.
- [x] PR contains only the timeout fix and its regression tests.
- [ ] Full test suite passes locally; see the environment blockers above.
- [x] Added regression coverage.
- [x] Tested on macOS with Python 3.11.15.

### Documentation and Housekeeping

- [x] Public documentation update is N/A; no user-facing API or configuration changed.
- [x] `cli-config.yaml.example` update is N/A.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A.
- [x] Cross-platform impact considered; the fix removes version-dependent asyncio cancellation inference.
- [x] Tool description/schema updates are N/A.