### PR TITLE
fix(desktop): unbrick macOS updates and bound the reinstall repair loop

### DIFF
--- a/apps/desktop/electron/bootstrap-repair-guard.test.ts
+++ b/apps/desktop/electron/bootstrap-repair-guard.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { decideBootstrapRepair } from './bootstrap-repair-guard'
+
+test('first soft attempt with alive backend returns soft restart', () => {
+  const decision = decideBootstrapRepair({
+    attempt: 1,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(decision.hardReinstall, false)
+  assert.equal(decision.attempt, 1)
+  assert.match(decision.reason, /still alive/)
+  assert.match(decision.reason, /1\/3/)
+})
+
+test('first attempt with dead backend still returns soft restart', () => {
+  const decision = decideBootstrapRepair({
+    attempt: 1,
+    primaryBackendAlive: false
+  })
+
+  assert.equal(decision.hardReinstall, false)
+  assert.match(decision.reason, /has exited/)
+})
+
+test('soft restart budget exhausts at maxSoftAttempts+1 and escalates', () => {
+  const decision = decideBootstrapRepair({
+    attempt: 4,
+    maxSoftAttempts: 3,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(decision.hardReinstall, true)
+  assert.equal(decision.attempt, 4)
+  assert.match(decision.reason, /exceeds soft-restart budget/)
+})
+
+test('attempt exactly at maxSoftAttempts is still soft', () => {
+  const decision = decideBootstrapRepair({
+    attempt: 3,
+    maxSoftAttempts: 3,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(decision.hardReinstall, false)
+  assert.equal(decision.attempt, 3)
+})
+
+test('custom maxSoftAttempts is honored', () => {
+  const soft = decideBootstrapRepair({
+    attempt: 5,
+    maxSoftAttempts: 10,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(soft.hardReinstall, false)
+
+  const hard = decideBootstrapRepair({
+    attempt: 11,
+    maxSoftAttempts: 10,
+    primaryBackendAlive: false
+  })
+
+  assert.equal(hard.hardReinstall, true)
+})
+
+test('default maxSoftAttempts is 3', () => {
+  // Probe the default indirectly: attempt 4 with no override must escalate.
+  const decision = decideBootstrapRepair({
+    attempt: 4,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(decision.hardReinstall, true)
+})
+
+test('fractional or zero attempts are clamped to 1', () => {
+  const zeroDecision = decideBootstrapRepair({
+    attempt: 0,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(zeroDecision.attempt, 1)
+  assert.equal(zeroDecision.hardReinstall, false)
+
+  const fractionalDecision = decideBootstrapRepair({
+    attempt: 2.7,
+    primaryBackendAlive: true
+  })
+
+  assert.equal(fractionalDecision.attempt, 2)
+  assert.equal(fractionalDecision.hardReinstall, false)
+})
+
+test('alive=false on a high attempt number still escalates (defense in depth)', () => {
+  // A dead backend should normally be handled by the renderer before it
+  // reaches the repair path, but if it does reach us with a high attempt
+  // count we still escalate — never silently keep soft-restarting.
+  const decision = decideBootstrapRepair({
+    attempt: 5,
+    maxSoftAttempts: 3,
+    primaryBackendAlive: false
+  })
+
+  assert.equal(decision.hardReinstall, true)
+})

--- a/apps/desktop/electron/bootstrap-repair-guard.ts
+++ b/apps/desktop/electron/bootstrap-repair-guard.ts
@@ -1,0 +1,122 @@
+/**
+ * Repair-loop guard for the desktop bootstrap.
+ *
+ * Why this exists
+ * ───────────────
+ * Hermes desktop can request a "repair" of its bundled backend when the
+ * renderer observes a transient backend failure (see issue #74874). The
+ * classic failure fingerprint:
+ *
+ *   1. Backend Python process hits a transient GIL stall (e.g. heavy
+ *      import, MCP discovery, a long-running agent turn).
+ *   2. The renderer's WebSocket can't deliver the `gateway.ready` frame
+ *      in time and treats the socket as dead.
+ *   3. Renderer calls `hermes:bootstrap:repair`.
+ *   4. Bootstrap unconditionally force-reinstalls the venv, restarting
+ *      the backend — which stalls again for the same reason.
+ *   5. Renderer reports dead backend → another repair → infinite loop.
+ *
+ * The desktop should distinguish:
+ *   - "the venv/install is genuinely broken" → hard reinstall is correct
+ *   - "the runtime is healthy but temporarily stalled" → restart only,
+ *     NOT a destructive reinstall that drops the venv
+ *
+ * What this module does
+ * ─────────────────────
+ * A pure decision helper. Given the current repair attempt count and a
+ * hint about whether the live backend process still looks alive, return
+ * whether the next repair should:
+ *   - `hardReinstall: true`  → run the installer, recreate the venv
+ *   - `hardReinstall: false` → restart the existing backend, keep the venv
+ *
+ * Cap on soft restarts is bounded so an actually-corrupted install still
+ * eventually escalates to a hard reinstall after repeated stalls — the
+ * guard prevents the *unbounded* reinstall loop, not all reinstalls.
+ *
+ * The module is intentionally pure (no I/O, no logging, no global state)
+ * so it is unit-testable in isolation. Wiring into `main.ts` lives there.
+ */
+
+export type RepairDecision =
+  | {
+      /** Run the installer (recreate venv). Caller bypasses the active runtime. */
+      hardReinstall: true
+      /** Human-readable rationale for the desktop log. */
+      reason: string
+      /** 1-indexed repair attempt number for diagnostics. */
+      attempt: number
+    }
+  | {
+      /** Skip the installer; restart the existing backend only. */
+      hardReinstall: false
+      reason: string
+      attempt: number
+    }
+
+export type RepairDecisionInput = {
+  /**
+   * 1-indexed count of how many repair attempts have happened in this
+   * failure episode. The first repair is `attempt === 1`; a successful
+   * boot resets the counter (see `main.ts`'s bootstrap completion path).
+   */
+  attempt: number
+  /**
+   * Soft-restart budget before escalation to a hard reinstall. Defaults
+   * to 3: three "just restart" attempts, then a real reinstall. Bounded
+   * so a corrupt install still gets fixed; high enough that a GIL
+   * stall no longer loops the user into a 30-minute reinstall cycle.
+   */
+  maxSoftAttempts?: number
+  /**
+   * Whether the live backend process (the one we are about to tear down
+   * to honour the repair request) still looks alive. A process whose
+   * `exitCode !== null` or `signalCode !== null` has actually exited;
+   * a process with both null is either still running or stalled — and a
+   * stall is exactly the case the soft-restart path is for.
+   */
+  primaryBackendAlive: boolean
+}
+
+/**
+ * Decide the next repair action.
+ *
+ * Decision matrix:
+ *   attempt ≤ maxSoftAttempts AND alive   → soft restart (don't reinstall)
+ *   attempt ≤ maxSoftAttempts AND dead    → soft restart (process exited,
+ *                                            but we don't yet trust that
+ *                                            the install is corrupt; restart
+ *                                            once to confirm)
+ *   attempt >  maxSoftAttempts            → hard reinstall (give up on the
+ *                                            current install)
+ *
+ * "Alive" being true does NOT force a soft restart on every call: the
+ * attempt counter still increments, so an actually-broken install that
+ * keeps respawning a child but never announces READY still escalates
+ * after `maxSoftAttempts` cycles.
+ */
+export function decideBootstrapRepair(input: RepairDecisionInput): RepairDecision {
+  const maxSoftAttempts = input.maxSoftAttempts ?? 3
+  const attempt = Math.max(1, Math.floor(input.attempt))
+  const alive = Boolean(input.primaryBackendAlive)
+
+  if (attempt > maxSoftAttempts) {
+    return {
+      hardReinstall: true,
+      attempt,
+      reason:
+        `repair attempt ${attempt} exceeds soft-restart budget ` +
+        `(${maxSoftAttempts}); escalating to hard reinstall`
+    }
+  }
+
+  return {
+    hardReinstall: false,
+    attempt,
+    reason: alive
+      ? `repair attempt ${attempt}/${maxSoftAttempts}: primary backend process ` +
+        `still alive (likely transient stall, see #74874); restarting only, ` +
+        `skipping installer`
+      : `repair attempt ${attempt}/${maxSoftAttempts}: primary backend process ` +
+        `has exited; restarting before escalating to reinstall`
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -47,6 +47,7 @@ import {
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
+import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
@@ -1099,6 +1100,14 @@ let bootstrapAbortController = null
 // repair can force the installer without destroying provenance about how the
 // install was created. Cleared once the reinstall is under way.
 let bootstrapRepairRequested = false
+// Counter for in-flight repair attempts. Reset on a clean boot completion
+// (see runBootstrap -> ensureRuntime resolve path). Each successive repair
+// in the same failure episode increments this; once it crosses
+// MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS the guard escalates from "soft restart"
+// to "hard reinstall" so a transient backend stall (issue #74874) stops
+// looping the user through a destructive venv reinstall.
+let bootstrapRepairAttempt = 0
+const MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS = 3
 let connectionConfigCache = null
 let connectionConfigCacheMtime = null
 const hermesLog = []
@@ -4037,6 +4046,7 @@ async function ensureRuntime(backend) {
     // The repair request has been honoured by reaching the installer; clear it
     // so a later boot isn't forced through bootstrap again.
     bootstrapRepairRequested = false
+    bootstrapRepairAttempt = 0
 
     const bootstrapResult = await runBootstrap({
       installStamp: backend.installStamp,
@@ -8547,6 +8557,13 @@ async function startHermes() {
       error: null
     })
 
+    // A successful boot (including a soft restart that the repair-guard
+    // chose over a hard reinstall, see #74874) means any in-flight repair
+    // attempt counter has been honoured — reset it so the next genuine
+    // failure starts fresh from attempt 1 instead of inheriting the
+    // accumulated count of the resolved episode.
+    bootstrapRepairAttempt = 0
+
     return {
       baseUrl,
       mode: 'local',
@@ -9628,9 +9645,41 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
   // transient backend errors on a perfectly healthy install, and deleting the
   // marker in that case stranded the app in first-run setup with no way back
   // (#72166). The explicit flag carries the intent instead.
-  rememberLog('[bootstrap] repair requested by renderer; forcing reinstall + clearing latched failure')
+  bootstrapRepairAttempt += 1
 
-  bootstrapRepairRequested = true
+  // Probe the live backend process so the guard can distinguish "venv is
+  // genuinely broken" (force reinstall) from "backend is just transiently
+  // stalled under GIL pressure" (#74874 — `event loop stalled` followed by
+  // `ws ready frame send failed`, then renderer keeps reporting dead).
+  const primaryProc = backendConnectionState.getProcess()
+
+  const primaryBackendAlive = Boolean(
+    primaryProc &&
+    (primaryProc as { exitCode?: number | null }).exitCode === null &&
+    (primaryProc as { signalCode?: string | null }).signalCode === null
+  )
+
+  const repairDecision = decideBootstrapRepair({
+    attempt: bootstrapRepairAttempt,
+    maxSoftAttempts: MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS,
+    primaryBackendAlive
+  })
+
+  rememberLog(
+    `[bootstrap] repair requested by renderer; forcing reinstall + clearing latched failure ` +
+      `(attempt=${repairDecision.attempt}/${MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS}, ` +
+      `primaryBackendAlive=${primaryBackendAlive}, ` +
+      `hardReinstall=${repairDecision.hardReinstall}): ${repairDecision.reason}`
+  )
+
+  // The guard may decide the install is healthy enough that a restart
+  // (without touching the venv) is the right answer. Translate that into
+  // the existing flag: if the guard said "soft restart", we skip the
+  // "bypass active runtime" path inside startHermes() and fall through
+  // to the normal restart branch, which just kills the current child
+  // and respawns it against the same venv. See #74874 — this is what
+  // breaks the infinite reinstall loop the user hit.
+  bootstrapRepairRequested = repairDecision.hardReinstall
   bootstrapFailure = null
   backendStartFailure = null
   remoteReauthFailure = null

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -200,7 +200,7 @@ import {
   sandboxPreflight
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
-import { spawnUpdaterProcess } from './updater-process'
+import { resolveStagedUpdaterBinary, spawnUpdaterProcess } from './updater-process'
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
@@ -2602,26 +2602,14 @@ let isQuittingForHandoff = false
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
 
-// Resolve the staged updater binary. The Tauri installer copies itself to
-// HERMES_HOME/hermes-setup.exe on a successful install (see
-// apps/bootstrap-installer paths::copy_self_to_hermes_home). That binary owns
-// ALL repo mutation — running `hermes update` + rebuilding the desktop — so
-// the desktop never touches its own bits while running. Returns null when the
-// updater isn't staged (e.g. a dev/source run that never went through the
-// installer); callers degrade gracefully.
-//
-// hermes-setup is the Tauri Windows-installer self-copy path. On macOS/Linux
-// the drag-and-drop .app uses applyUpdatesPosixInApp instead, so a stale
-// hermes-setup (e.g. from an old macOS install, #74836) must not route the
-// update into the Windows-style handoff.
+// Resolve the staged updater binary the desktop may hand an update to. On
+// Windows that binary owns ALL repo mutation — running `hermes update` +
+// rebuilding the desktop — so the desktop never touches its own bits while
+// running. macOS/Linux stage the same binary but deliberately do not use it;
+// see resolveStagedUpdaterBinary for the policy and for #74836. Returns null
+// whenever no hand-off applies; callers degrade gracefully.
 function resolveUpdaterBinary() {
-  if (!IS_WINDOWS) {
-    return null
-  }
-
-  const candidate = path.join(HERMES_HOME, 'hermes-setup.exe')
-
-  return fileExists(candidate) ? candidate : null
+  return resolveStagedUpdaterBinary(HERMES_HOME, { fileExists, isWindows: IS_WINDOWS })
 }
 
 function repairMacUpdaterHelper(updater) {
@@ -2849,12 +2837,13 @@ async function applyUpdates(opts = {}) {
     const updater = resolveUpdaterBinary()
 
     if (!updater && !IS_WINDOWS) {
-      // macOS/Linux drag-install: no staged Tauri hermes-setup. Unlike Windows
-      // (where a venv-shim file lock forces the quit→hand-off→rebuild dance),
-      // there's no mandatory file locking here, so the desktop can drive the
-      // whole update itself: `hermes update` (backend) + `hermes desktop
-      // --build-only` (OS-aware GUI rebuild), then swap the running .app bundle
-      // with the freshly built one and relaunch.
+      // macOS/Linux: never hand off, staged hermes-setup or not — the resolver
+      // returns null there by policy. Unlike Windows (where a venv-shim file
+      // lock forces the quit→hand-off→rebuild dance), there's no mandatory file
+      // locking here, so the desktop can drive the whole update itself:
+      // `hermes update` (backend) + `hermes desktop --build-only` (OS-aware GUI
+      // rebuild), then swap the running .app bundle with the freshly built one
+      // and relaunch.
       return await applyUpdatesPosixInApp(opts)
     }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2609,9 +2609,17 @@ let quitConfirmedWithActiveWork = false
 // the desktop never touches its own bits while running. Returns null when the
 // updater isn't staged (e.g. a dev/source run that never went through the
 // installer); callers degrade gracefully.
+//
+// hermes-setup is the Tauri Windows-installer self-copy path. On macOS/Linux
+// the drag-and-drop .app uses applyUpdatesPosixInApp instead, so a stale
+// hermes-setup (e.g. from an old macOS install, #74836) must not route the
+// update into the Windows-style handoff.
 function resolveUpdaterBinary() {
-  const name = IS_WINDOWS ? 'hermes-setup.exe' : 'hermes-setup'
-  const candidate = path.join(HERMES_HOME, name)
+  if (!IS_WINDOWS) {
+    return null
+  }
+
+  const candidate = path.join(HERMES_HOME, 'hermes-setup.exe')
 
   return fileExists(candidate) ? candidate : null
 }

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict'
 import type { SpawnOptions } from 'node:child_process'
+import path from 'node:path'
 
 import { test } from 'vitest'
 
-import { spawnUpdaterProcess } from './updater-process'
+import { resolveStagedUpdaterBinary, spawnUpdaterProcess } from './updater-process'
 
 test('spawnUpdaterProcess hides the updater console and detaches the child on Windows', () => {
   const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
@@ -59,4 +60,50 @@ test('spawnUpdaterProcess preserves updater options off Windows', () => {
   )
 
   assert.deepEqual(capturedOptions, { detached: true, stdio: 'ignore' })
+})
+
+test('resolveStagedUpdaterBinary hands Windows the staged installer it finds', () => {
+  const home = 'C:\\Users\\hermes\\AppData\\Local\\hermes'
+  const staged = path.join(home, 'hermes-setup.exe')
+  const probed: string[] = []
+
+  const resolved = resolveStagedUpdaterBinary(home, {
+    fileExists: (candidate) => {
+      probed.push(candidate)
+
+      return candidate === staged
+    },
+    isWindows: true
+  })
+
+  assert.equal(resolved, staged)
+  assert.deepEqual(probed, [staged])
+})
+
+test('resolveStagedUpdaterBinary returns null off Windows even when hermes-setup is staged (#74836)', () => {
+  const home = '/Users/hermes/.hermes'
+  let probes = 0
+
+  const resolved = resolveStagedUpdaterBinary(home, {
+    // The installer stages hermes-setup on macOS/Linux too, so "it exists" is
+    // the normal case — and precisely the one that must not win.
+    fileExists: () => {
+      probes += 1
+
+      return true
+    },
+    isWindows: false
+  })
+
+  assert.equal(resolved, null)
+  assert.equal(probes, 0)
+})
+
+test('resolveStagedUpdaterBinary returns null on Windows when nothing is staged', () => {
+  const resolved = resolveStagedUpdaterBinary('C:\\Users\\hermes\\AppData\\Local\\hermes', {
+    fileExists: () => false,
+    isWindows: true
+  })
+
+  assert.equal(resolved, null)
 })

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -1,10 +1,64 @@
 import { spawn, type SpawnOptions } from 'node:child_process'
+import { statSync } from 'node:fs'
+import path from 'node:path'
 
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 export interface UpdaterChild {
   pid?: number
   unref: () => void
+}
+
+export interface ResolveStagedUpdaterBinaryDeps {
+  isWindows?: boolean
+  fileExists?: (candidate: string) => boolean
+}
+
+function stagedFileExists(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Decide which staged installer binary — if any — may be handed an update.
+ *
+ * The Tauri installer self-copies into HERMES_HOME on *every* platform
+ * (`hermes-setup.exe` on Windows, `hermes-setup` elsewhere — see
+ * apps/bootstrap-installer `paths::installer_dest` and
+ * `bootstrap::copy_self_to_hermes_home`), so finding that binary on macOS or
+ * Linux is expected, not leftover junk.
+ *
+ * Handing an update to it is nonetheless a Windows-only policy. Windows needs
+ * the quit -> hand-off -> rebuild dance because a venv shim file lock keeps the
+ * running desktop from rewriting its own bits; macOS and Linux have no such
+ * lock and update in place through applyUpdatesPosixInApp(). Off Windows the
+ * hand-off therefore buys nothing and costs a great deal: a staged binary older
+ * than the hand-off protocol holds the update marker, spawns `hermes update`,
+ * and that child refuses its own parent — wedging the in-app Update button for
+ * good, with no route (update, re-download, reinstall) to a newer binary
+ * (#74836). Returning null off Windows is what routes those platforms to the
+ * in-app updater.
+ *
+ * Null on Windows too when nothing is staged (a dev/source run, or a CLI
+ * install that never went through the installer); callers degrade gracefully.
+ */
+export function resolveStagedUpdaterBinary(
+  hermesHome: string,
+  deps: ResolveStagedUpdaterBinaryDeps = {}
+): string | null {
+  const isWindows = deps.isWindows ?? process.platform === 'win32'
+
+  if (!isWindows) {
+    return null
+  }
+
+  const fileExists = deps.fileExists ?? stagedFileExists
+  const candidate = path.join(hermesHome, 'hermes-setup.exe')
+
+  return fileExists(candidate) ? candidate : null
 }
 
 export interface SpawnUpdaterProcessDeps {

--- a/contributors/emails/fboutboul@free.fr
+++ b/contributors/emails/fboutboul@free.fr
@@ -1,0 +1,1 @@
+zakhounet


### PR DESCRIPTION
Salvages two desktop-updater fixes onto current main: the macOS/Linux stale `hermes-setup` bypass that unbricks the in-app Update button, and the bounded bootstrap-repair guard that breaks the renderer-led destructive reinstall loop.

## Summary

- **#74909 by @ms-alan** — `resolveUpdaterBinary()` picked up a staged `hermes-setup` on every platform, routing macOS into the Windows-style quit→hand-off→rebuild dance; a stale binary (predating `applyUpdatesPosixInApp`) permanently broke in-app updates. Non-Windows now always returns `null`, so macOS/Linux use `applyUpdatesPosixInApp`.
- **ms-alan/hermes-agent#1 by @zakhounet** — follow-up on the same fix: extracts the decision into a pure `resolveStagedUpdaterBinary()` helper in `updater-process.ts`, documents the bypass as an explicit policy (the staged binary is *expected* on all platforms because the installer self-copies into `HERMES_HOME`; declining to hand it an update off Windows is deliberate), and adds 3 resolver tests.
- **#75012 by @Kewe63** — bounded bootstrap repair policy. The renderer's Repair button treated every transient backend GIL stall as a fatal venv fault, forcing reinstall + restart in an endless loop (#74874). New pure `decideBootstrapRepair()` guard (`bootstrap-repair-guard.ts` + 8 tests): soft restarts (skip installer) for attempts ≤ 3, escalates to hard reinstall after; counter resets on `backend.ready`.

## Changes

- `apps/desktop/electron/updater-process.ts` — new pure `resolveStagedUpdaterBinary()` (Windows-only staged updater policy)
- `apps/desktop/electron/updater-process.test.ts` — +3 resolver tests
- `apps/desktop/electron/bootstrap-repair-guard.ts` — new `decideBootstrapRepair()` pure helper
- `apps/desktop/electron/bootstrap-repair-guard.test.ts` — 8 tests
- `apps/desktop/electron/main.ts` — updater resolver delegates to the helper; `hermes:bootstrap:repair` wires the guard (attempt counter, live-process probe, soft/hard translation into `bootstrapRepairRequested`)
- `contributors/emails/` — mappings for zakhounet and Kewe63

**Soft-path fall-through verification (the point the competing PR failed on):** on a soft decision, `bootstrapRepairRequested` stays `false` and the handler calls `resetHermesConnection()`, which invalidates `backendConnectionState` and `stopBackendChild()`s the old child — then the renderer's reload re-drives `startHermes()`, which (with the flag false and the runtime usable) takes the `createActiveBackend()` branch and **respawns the backend against the same venv** rather than leaving it torn down or re-entering the installer. Hard escalation sets the flag so `startHermes()` bypasses the usable runtime into the installer; both `bootstrapRepairRequested` and the attempt counter are cleared once the installer runs or `backend.ready` is reached. Verified by reading the wiring at `main.ts` (`hermes:bootstrap:repair`, `resetHermesConnection`, backend selection ladder, `backend.ready` reset).

Both PRs cherry-picked cleanly onto current main (no conflicts).

## Validation

- `npx vitest run electron/updater-process.test.ts electron/bootstrap-repair-guard.test.ts` — **13/13 passed** (5 updater incl. 3 new resolver tests; 8 repair-guard)
- `npx tsc --noEmit` from `apps/desktop` — clean (exit 0)
- Pre-push stale-base gate: base 0 behind `origin/main`; diff shows only the intended files

Fixes #74836
Fixes #74874

Credit: @ms-alan (original macOS updater bypass, #74909), @zakhounet (resolver policy + tests, ms-alan/hermes-agent#1), @Kewe63 (bootstrap repair guard, #75012). All commits cherry-picked with original authorship preserved.


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48ccc/SCw_HV7FwCNmKu8QHgVcS_nsV9JbHW.png)
