### PR TITLE
fix(compression): index clamps, persisted failure cooldown, user-query preservation, thinking-token estimates

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6264,16 +6264,18 @@ This compaction should PRIORITISE preserving all information related to the focu
                 None,
             )
         first_tail_role = None
+        first_tail_visible_idx: Optional[int] = None
         if tail_messages:
-            first_tail_role = next(
+            first_tail_visible_idx, first_tail_role = next(
                 (
-                    role
-                    for role in (
-                        _template_visible_role(m) for m in tail_messages
+                    (idx, role)
+                    for idx, role in (
+                        (idx, _template_visible_role(m))
+                        for idx, m in enumerate(tail_messages)
                     )
                     if role is not None
                 ),
-                None,
+                (None, None),
             )
         # When the only protected head message is the system prompt, the
         # summary becomes the first *visible* message in the API request
@@ -6300,11 +6302,27 @@ This compaction should PRIORITISE preserving all information related to the focu
         # If no user-role message survives in either the protected head or the
         # preserved tail, the summary MUST carry role="user" so the request
         # always has at least one user turn.
+        #
+        # A bare role check is not enough: the tail's sole surviving user
+        # turn can be image-only (a screenshot with no caption). The newest
+        # image-bearing user message is the ``_strip_historical_media``
+        # anchor and is kept byte-for-byte, so it never gains a text
+        # placeholder — its role is "user" but its text content is empty,
+        # which backends checking for actual query text still reject. Count
+        # only user messages with non-empty text as "surviving"; when the
+        # guard fires, the real (never fabricated) summary text lands in a
+        # role="user" slot, which is always non-empty (falls back to
+        # ``_build_static_fallback_summary`` above when generation fails).
         if not _force_user_leading:
+            def _is_nonempty_user_turn(message: Dict[str, Any]) -> bool:
+                return message.get("role") == "user" and bool(
+                    _content_text_for_contains(message.get("content")).strip()
+                )
+
             _user_survives = any(
-                message.get("role") == "user" for message in compressed
+                _is_nonempty_user_turn(message) for message in compressed
             ) or any(
-                message.get("role") == "user" for message in tail_messages
+                _is_nonempty_user_turn(message) for message in tail_messages
             )
             if not _user_survives:
                 _force_user_leading = True
@@ -6360,9 +6378,27 @@ This compaction should PRIORITISE preserving all information related to the focu
                 ),
             })
 
+        # Default merge target: literal tail index 0. For an ordinary
+        # alternation collision the summary only has to stay *invisible* to
+        # the template, and a leading template-exempt row (bare tool-call
+        # assistant message, tool result) is the ideal carrier — it absorbs
+        # the summary without adding a visible turn, and it leaves the live
+        # tail user message intact as the model's actual prompt. Retargeting
+        # to the first template-visible row here would convert that live
+        # request into the summary carrier for no benefit.
+        #
+        # The forced repair path is the exception. There the merge is not
+        # about alternation but about guaranteeing at least one genuinely
+        # non-empty role="user" message (an image-only or otherwise
+        # text-empty surviving user row). An exempt carrier cannot satisfy
+        # that invariant, so the summary text must land on the
+        # template-visible row itself.
+        _merge_target_idx = 0
+        if _force_user_leading and first_tail_visible_idx is not None:
+            _merge_target_idx = first_tail_visible_idx
         for tail_idx, msg in enumerate(tail_messages):
-            if _merge_summary_into_tail and tail_idx == 0:
-                # Merge the summary into the first (post-strip) tail message.
+            if _merge_summary_into_tail and tail_idx == _merge_target_idx:
+                # Merge the summary into the tail message that collided.
                 old_content = msg.get("content", "")
                 if _force_user_leading and summary_role == "user":
                     # The summary must be part of the first user-visible

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4236,6 +4236,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         end: int,
     ) -> list[tuple[int, str]]:
         """Find handoff summaries inside a compression window."""
+        n = len(messages)
+        # Defensive: clamp bounds so a caller passing an out-of-range end
+        # (e.g. tail-cut returning len(messages)+1 when head_end >= n)
+        # cannot trigger IndexError.  (#75588)
+        start = max(0, min(start, n))
+        end = max(start, min(end, n))
         summaries: list[tuple[int, str]] = []
         for idx in range(start, end):
             content = messages[idx].get("content")
@@ -5005,7 +5011,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # exists to prevent.  Re-align FORWARD (never backward, which would give
         # the floor's message back) so a raised cut skips to the end of the
         # group and the whole call/result pair is summarised together.
-        return self._align_boundary_forward(messages, max(cut_idx, head_end + 1))
+        return min(n, self._align_boundary_forward(messages, max(cut_idx, head_end + 1)))
 
     # ------------------------------------------------------------------
     # ContextEngine: manual /compress preflight

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -764,13 +764,50 @@ def _serialized_length_for_budget(value: Any) -> int:
 # Responses sessions in particular carry ``codex_reasoning_items`` blobs of
 # ``encrypted_content`` that can dominate the serialized session (a measured
 # 214-turn session held ~115K tokens / 27% of its payload there — #55572).
+#
+# ``reasoning_details`` is handled separately (see
+# ``_reasoning_details_text_chars``): its signed/base64 envelope is excluded
+# from the budget, mirroring the preflight estimator's exclusion in
+# ``model_metadata._estimate_message_tokens_without_images`` (#73298).
 _REPLAY_BUDGET_KEYS = (
     "reasoning",
     "reasoning_content",
-    "reasoning_details",
     "codex_reasoning_items",
     "codex_message_items",
 )
+
+
+def _reasoning_details_text_chars(value: Any) -> int:
+    """Textual thinking chars inside a ``reasoning_details`` envelope.
+
+    ``reasoning_details`` carries provider thinking blocks: the actual
+    thinking TEXT plus opaque signed/base64 envelope blobs (Anthropic
+    ``signature``, redacted ``data``, encrypted payloads).  The envelope is
+    never billed at anything near chars/4 by the provider and — on every
+    transport except Codex Responses — is replayed for at most the newest
+    assistant turn, so charging it on every message inflated the tail-budget
+    walk and silently shrank the surviving tail (#73298, second site).
+
+    Count only the thinking text (the #51800 lesson: real reasoning text
+    MUST stay visible to the budget), skip everything else.
+    """
+    if not value:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    total = 0
+    if isinstance(value, dict):
+        value = [value]
+    if isinstance(value, list):
+        for part in value:
+            if isinstance(part, str):
+                total += len(part)
+            elif isinstance(part, dict):
+                for text_key in ("thinking", "text", "summary"):
+                    text = part.get(text_key)
+                    if isinstance(text, str):
+                        total += len(text)
+    return total
 
 
 def _estimate_msg_budget_tokens(msg: dict) -> int:
@@ -804,6 +841,17 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
             tokens += estimate_tokens_rough(str(tc))
     for key in _REPLAY_BUDGET_KEYS:
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+    # reasoning_details: charge only the thinking TEXT, never the signed /
+    # base64 envelope (#73298 second site; mirrors the preflight estimator's
+    # exclusion in model_metadata).  When the same thinking text already rides
+    # in ``reasoning``/``reasoning_content`` (measured byte-identical on
+    # Anthropic-wire sessions), skip it here entirely so the prose is not
+    # charged twice on top of the envelope exclusion.
+    if not (msg.get("reasoning") or msg.get("reasoning_content")):
+        tokens += (
+            _reasoning_details_text_chars(msg.get("reasoning_details"))
+            // _CHARS_PER_TOKEN
+        )
     return tokens
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3011,7 +3011,7 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
     )
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
+        if k in ("_anthropic_content_blocks", "reasoning_details"):
             continue
         if k == "api_content":
             # Always popped before the request is built; only counted when it

--- a/contributors/emails/rkfshakti@gmail.com
+++ b/contributors/emails/rkfshakti@gmail.com
@@ -1,0 +1,1 @@
+rkfshakti

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -115,6 +115,28 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
 )
 
 
+def _record_hygiene_cooldown(gateway, session_id: str, cooldown_seconds: float) -> None:
+    """Persist a session-hygiene compression-failure cooldown to the state DB.
+
+    Uses the same ``compression_failure_cooldown_until`` column and
+    ``record_compression_failure_cooldown`` method that the in-conversation
+    compression path (``agent/context_compressor.py``) already uses, so the
+    cooldown survives gateway restarts (#74136).
+    """
+    import time as _time
+    session_db = getattr(gateway, "_session_db", None)
+    if session_db is None:
+        return
+    session_db = getattr(session_db, "_db", session_db)
+    recorder = getattr(session_db, "record_compression_failure_cooldown", None)
+    if recorder is None:
+        return
+    try:
+        recorder(session_id, _time.time() + cooldown_seconds)
+    except Exception as exc:
+        logger.debug("session hygiene cooldown persist failed: %s", exc)
+
+
 def _status_template_to_regex(template: str) -> str:
     """Compile a compression status template constant into a regex source.
 
@@ -16049,20 +16071,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
                 if _needs_compress:
-                    _cooldowns = getattr(self, "_hygiene_compression_failure_cooldowns", None)
-                    if _cooldowns is None:
-                        _cooldowns = {}
-                        self._hygiene_compression_failure_cooldowns = _cooldowns
-                    _cooldown_key = session_entry.session_id
-                    _cooldown_until = float(_cooldowns.get(_cooldown_key) or 0.0)
-                    if _cooldown_until > time.time():
-                        logger.info(
-                            "Session hygiene: skipping compression for %s; "
-                            "previous failure cooldown active for %.1fs",
-                            _cooldown_key,
-                            max(0.0, _cooldown_until - time.time()),
-                        )
-                        _needs_compress = False
+                    # Use the persistent DB-backed cooldown (same as the
+                    # in-conversation compression path in context_compressor.py)
+                    # so the cooldown survives gateway restarts. The in-memory
+                    # dict was reset on every restart, re-triggering the same
+                    # failing compression and wedging session storage (#74136).
+                    _session_db = getattr(self, "_session_db", None)
+                    if _session_db is not None:
+                        _session_db = getattr(_session_db, "_db", _session_db)
+                        _getter = getattr(_session_db, "get_compression_failure_cooldown", None)
+                        if _getter is not None:
+                            try:
+                                _cooldown_state = _getter(session_entry.session_id)
+                            except Exception:
+                                _cooldown_state = None
+                            if _cooldown_state and _cooldown_state.get("remaining_seconds", 0) > 0:
+                                logger.info(
+                                    "Session hygiene: skipping compression for %s; "
+                                    "previous failure cooldown active for %.1fs",
+                                    session_entry.session_id,
+                                    _cooldown_state["remaining_seconds"],
+                                )
+                                _needs_compress = False
 
                 if _needs_compress:
                     logger.info(
@@ -16233,9 +16263,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             )
                                             _hyg_cleanup_deferred = True
                                             if _hyg_failure_cooldown_seconds >= 0:
-                                                self._hygiene_compression_failure_cooldowns[
-                                                    session_entry.session_id
-                                                ] = time.time() + _hyg_failure_cooldown_seconds
+                                                _record_hygiene_cooldown(
+                                                    self, session_entry.session_id,
+                                                    _hyg_failure_cooldown_seconds,
+                                                )
                                             logger.warning(
                                                 "Session hygiene compression for session %s "
                                                 "made no progress for %.1fs "
@@ -16399,9 +16430,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
                                         if _hyg_failure_cooldown_seconds >= 0:
-                                            self._hygiene_compression_failure_cooldowns[
-                                                session_entry.session_id
-                                            ] = time.time() + _hyg_failure_cooldown_seconds
+                                            _record_hygiene_cooldown(
+                                                self, session_entry.session_id,
+                                                _hyg_failure_cooldown_seconds,
+                                            )
                                         _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
                                         # Force-redact: provider exception text
                                         # may contain credentials; this message

--- a/tests/agent/test_budget_reasoning_details_exclusion.py
+++ b/tests/agent/test_budget_reasoning_details_exclusion.py
@@ -1,0 +1,127 @@
+"""Regression tests for #73298 (second site): the tail-budget walk must not
+charge the signed/base64 ``reasoning_details`` envelope at chars/4.
+
+The preflight estimator (``model_metadata._estimate_message_tokens_without_images``)
+excludes ``reasoning_details`` entirely; ``_estimate_msg_budget_tokens`` in the
+compressor mirrors that for the envelope while — per the #51800 counter-argument —
+still counting actual thinking TEXT when it is not already carried by
+``reasoning``/``reasoning_content``.
+"""
+
+from agent.context_compressor import (
+    _estimate_msg_budget_tokens,
+    _reasoning_details_text_chars,
+)
+
+
+def _signed_thinking_block(thinking_chars: int, sig_chars: int) -> dict:
+    return {
+        "type": "thinking",
+        "thinking": "t" * thinking_chars,
+        "signature": "s" * sig_chars,
+    }
+
+
+class TestBudgetExcludesReasoningDetailsEnvelope:
+    def test_signature_blob_not_charged(self):
+        base = {"role": "assistant", "content": "hello there"}
+        with_envelope = dict(
+            base,
+            reasoning_details=[_signed_thinking_block(0, 40_000)],
+        )
+        plain = _estimate_msg_budget_tokens(base)
+        loaded = _estimate_msg_budget_tokens(with_envelope)
+        # 40K chars of base64 signature would add ~10K phantom tokens at
+        # chars/4. The envelope must be invisible to the budget.
+        assert loaded - plain < 50, (
+            f"signed envelope inflated the budget by {loaded - plain} tokens"
+        )
+
+    def test_thinking_text_still_counted(self):
+        """#51800: real reasoning text must stay visible to the budget when
+        it is not duplicated into reasoning/reasoning_content."""
+        base = {"role": "assistant", "content": "hello there"}
+        with_text = dict(
+            base,
+            reasoning_details=[_signed_thinking_block(8_000, 0)],
+        )
+        plain = _estimate_msg_budget_tokens(base)
+        loaded = _estimate_msg_budget_tokens(with_text)
+        # 8K chars of thinking ≈ 2K tokens at chars/4.
+        assert loaded - plain > 1_000, (
+            "thinking TEXT inside reasoning_details was dropped from the "
+            f"budget (delta {loaded - plain}); only the envelope may be excluded"
+        )
+
+    def test_duplicated_thinking_text_not_double_charged(self):
+        """Anthropic-wire sessions carry the prose byte-identical in both
+        reasoning_content and reasoning_details; charge it once."""
+        prose = "deep thought " * 1_000
+        msg = {
+            "role": "assistant",
+            "content": "hi",
+            "reasoning_content": prose,
+            "reasoning_details": [
+                {"type": "thinking", "thinking": prose, "signature": "s" * 5_000},
+            ],
+        }
+        once = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "hi", "reasoning_content": prose}
+        )
+        both = _estimate_msg_budget_tokens(msg)
+        assert both - once < 100, (
+            f"thinking prose charged twice (delta {both - once} tokens)"
+        )
+
+    def test_codex_reasoning_items_still_charged(self):
+        """Codex Responses genuinely replays these on every request (#55572);
+        the exclusion is scoped to reasoning_details only."""
+        base = {"role": "assistant", "content": "hi"}
+        loaded = dict(
+            base,
+            codex_reasoning_items=[{"encrypted_content": "e" * 20_000}],
+        )
+        assert (
+            _estimate_msg_budget_tokens(loaded) - _estimate_msg_budget_tokens(base)
+            > 4_000
+        )
+
+
+class TestReasoningDetailsTextChars:
+    def test_none_and_empty(self):
+        assert _reasoning_details_text_chars(None) == 0
+        assert _reasoning_details_text_chars([]) == 0
+        assert _reasoning_details_text_chars("") == 0
+
+    def test_string_counts_fully(self):
+        assert _reasoning_details_text_chars("abcd" * 10) == 40
+
+    def test_envelope_keys_skipped(self):
+        blocks = [
+            {"type": "thinking", "thinking": "abc", "signature": "S" * 999},
+            {"type": "redacted_thinking", "data": "D" * 999},
+            {"type": "text", "text": "xy"},
+        ]
+        assert _reasoning_details_text_chars(blocks) == 5
+
+
+class TestPreflightExcludesReasoningDetails:
+    """Regression coverage for the preflight half (#73306 shipped without a
+    test): _estimate_message_tokens_without_images must not count the
+    reasoning_details envelope."""
+
+    def test_preflight_estimate_ignores_reasoning_details(self):
+        from agent.model_metadata import _estimate_message_tokens_without_images
+
+        base = {"role": "assistant", "content": "hello there"}
+        loaded = dict(
+            base,
+            reasoning_details=[_signed_thinking_block(10_000, 40_000)],
+        )
+        plain = _estimate_message_tokens_without_images(base)
+        with_details = _estimate_message_tokens_without_images(loaded)
+        assert with_details - plain < 50, (
+            "preflight estimator counted the reasoning_details payload "
+            f"(delta {with_details - plain} tokens) — compression would fire "
+            "at a fraction of real usage on thinking models (#73298)"
+        )

--- a/tests/agent/test_compressor_tail_cut_oob_fix.py
+++ b/tests/agent/test_compressor_tail_cut_oob_fix.py
@@ -1,0 +1,115 @@
+"""Regression test for #75588 — short tool-only suffix can make context
+compressor scan past messages, causing IndexError in _find_context_summaries()."""
+
+import pytest
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def compressor():
+    """Create a ContextCompressor with mocked dependencies."""
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        c = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+        return c
+
+
+class TestTailCutBoundaryClamp:
+    """Verify that _find_tail_cut_by_tokens never returns > len(messages).
+
+    When a short conversation ends in a tool-call/result group and the
+    protected head alignment reaches the end of the list, the tail-cut
+    function used to return len(messages) + 1, which then caused
+    _find_context_summaries() to index past the array boundary.  (#75588)
+    """
+
+    def _make_tool_group(self, call_id, n_results=1):
+        msgs = [{"role": "assistant", "tool_calls": [{"id": call_id, "type": "function", "function": {"name": "x", "arguments": "{}"}}]}]
+        for i in range(n_results):
+            msgs.append({"role": "tool", "content": f"result {i}", "tool_call_id": call_id})
+        return msgs
+
+    def test_tail_cut_never_exceeds_len_messages(self, compressor):
+        """Simulate the exact bounds from the issue: head_end reaches n,
+        so max(cut_idx, head_end+1) would produce n+1."""
+        # Build a short transcript ending in a tool group
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            *self._make_tool_group("tc1", n_results=2),
+        ]
+        n = len(messages)
+        # Force head_end to cover everything up to n (the protected head
+        # swallowing the entire message list)
+        head_end = n
+        result = compressor._find_tail_cut_by_tokens(messages, head_end)
+        assert result <= n, (
+            f"_find_tail_cut_by_tokens returned {result} for len(messages)={n}; "
+            "it must never exceed len(messages)"
+        )
+
+    def test_tail_cut_with_head_at_last_message(self, compressor):
+        """head_end = n-1 (last message is the only unprotected one)."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "tool", "content": "result", "tool_call_id": "tc1"},
+        ]
+        n = len(messages)
+        result = compressor._find_tail_cut_by_tokens(messages, n - 1)
+        assert result <= n
+
+    def test_tail_cut_with_empty_tail(self, compressor):
+        """head_end = n (no messages available for the tail at all)."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "u"},
+        ]
+        n = len(messages)
+        result = compressor._find_tail_cut_by_tokens(messages, n)
+        assert result <= n
+
+
+class TestFindContextSummariesDefensiveClamp:
+    """Verify that _find_context_summaries clamps its start/end bounds
+    defensively, so it never raises IndexError even with bad caller input."""
+
+    def test_out_of_range_end_does_not_crash(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+        # end > len(messages) should not crash
+        result = ContextCompressor._find_context_summaries(messages, 0, 999)
+        assert result == []
+
+    def test_negative_start_does_not_crash(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+        result = ContextCompressor._find_context_summaries(messages, -10, 1)
+        assert result == []
+
+    def test_start_beyond_end_is_empty(self):
+        messages = [{"role": "user", "content": "hello"}]
+        result = ContextCompressor._find_context_summaries(messages, 50, 100)
+        assert result == []
+
+    def test_find_latest_context_summary_with_bad_bounds(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        idx, body = ContextCompressor._find_latest_context_summary(messages, 0, 999)
+        assert idx is None
+        assert body == ""

--- a/tests/agent/test_compressor_tail_cut_oob_fix.py
+++ b/tests/agent/test_compressor_tail_cut_oob_fix.py
@@ -113,3 +113,68 @@ class TestFindContextSummariesDefensiveClamp:
         idx, body = ContextCompressor._find_latest_context_summary(messages, 0, 999)
         assert idx is None
         assert body == ""
+
+
+class TestCompressEndToEndShortToolSuffix:
+    """compress()-level E2E regression for #75588.
+
+    The unit tests above poke ``_find_tail_cut_by_tokens`` and
+    ``_find_context_summaries`` directly; this class drives the REAL
+    ``compress()`` pipeline over the exact live-shaped transcript from the
+    issue: an 8-message session (system + tool-only suffix) where
+    ``_align_boundary_forward`` slides the protected start to
+    ``len(messages)`` and, pre-fix, ``_find_tail_cut_by_tokens`` returned
+    ``len(messages) + 1`` via the ``head_end + 1`` forward-progress floor.
+
+    With ``compress_start = n`` and ``compress_end = n + 1`` the
+    ``compress_start >= compress_end`` no-op guard does NOT fire, so the
+    out-of-range ``compress_end`` flows into the downstream summary scans —
+    the IndexError observed live.  Post-fix the tail cut is clamped to ``n``,
+    the guard fires, and compress() must: raise nothing, never call the
+    summary LLM, and hand the transcript back unchanged.
+    """
+
+    def _live_shaped_transcript(self):
+        """The reproduced internal bounds from #75588: len(messages)=8,
+        system prompt + a tool-only suffix (mid-run gateway hygiene shape —
+        the parent assistant tool_calls turn was already summarized away)."""
+        return [{"role": "system", "content": "sys"}] + [
+            {"role": "tool", "content": f"result {i}", "tool_call_id": "tc1"}
+            for i in range(7)
+        ]
+
+    def test_compress_short_tool_suffix_no_crash_no_llm_unchanged(self, compressor):
+        import copy
+
+        c = compressor
+        # A previously-compacted session: protect_first_n decays to 0, so the
+        # protected head is just the system prompt; the forward alignment then
+        # walks the tool-only suffix to head_end == len(messages) == 8, and
+        # pre-fix the tail cut returned 9.
+        c.compression_count = 1
+        messages = self._live_shaped_transcript()
+        snapshot = copy.deepcopy(messages)
+
+        # Sanity: this transcript really produces the boundary shape from the
+        # issue (start == n; end must be clamped to n, pre-fix it was n + 1).
+        n = len(messages)
+        start = c._align_boundary_forward(messages, c._protect_head_size(messages))
+        assert start == n, f"fixture drifted: aligned start {start} != n {n}"
+        assert c._find_tail_cut_by_tokens(messages, start) == n
+
+        with patch.object(
+            c, "_generate_summary", return_value="SHOULD NOT BE CALLED"
+        ) as gen:
+            # Must not raise (pre-fix: IndexError scanning past the end of
+            # the list with the unclamped compress_end).
+            out = c.compress(messages, current_tokens=90_000)
+
+        assert gen.call_count == 0, (
+            "compress() invoked the summary LLM even though there is no "
+            "compressible window (compress_start == len(messages)); the "
+            "clamped tail cut should make the no-op guard fire instead."
+        )
+        assert out == snapshot, (
+            "compress() must return the transcript unchanged when the "
+            f"protected head covers the whole list. Got: {out}"
+        )

--- a/tests/agent/test_compressor_zero_user_guard.py
+++ b/tests/agent/test_compressor_zero_user_guard.py
@@ -154,3 +154,123 @@ class TestCompressAlwaysKeepsAUserTurn:
             m.get("content") for m in out if isinstance(m.get("content"), str)
         )
         assert "the latest live user question" in joined
+
+
+def _has_nonempty_user_text(messages: list[dict]) -> bool:
+    """True if some role="user" message carries non-empty text.
+
+    Deliberately narrower than "any message has text": a non-empty
+    ``role="assistant"`` summary does not satisfy backends that require an
+    actual user query, so checking role and content together is the point.
+    """
+    from agent.context_compressor import _content_text_for_contains
+
+    return any(
+        m.get("role") == "user"
+        and _content_text_for_contains(m.get("content")).strip()
+        for m in messages
+    )
+
+
+class TestCompressKeepsANonEmptyUserTurn:
+    """A bare ``role == "user"`` check is not enough: the surviving user
+    message can be image-only (no caption). ``_strip_historical_media``
+    anchors on the newest image-bearing user message and keeps it
+    byte-for-byte — it never gains a text placeholder — so a role-only
+    guard is satisfied while the request still has zero *text* user
+    turns, which is what backends actually reject on.
+    """
+
+    def test_image_only_tail_user_turn_still_yields_non_empty_text(self, compressor):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        c = compressor
+        c.compression_count = 1
+        # No system message and no protected head (compression_count=1
+        # decays protect_first_n to 0), same #58753 shape — except the
+        # only surviving user turn is an image with no caption text.
+        messages = [{"role": "user", "content": "work kanban task 42"}]
+        messages += _tool_turns(0, 12)
+        messages += [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        }]
+
+        mocked = f"{SUMMARY_PREFIX}\nrolled-up summary of the tool work"
+        with patch.object(c, "_generate_summary", return_value=mocked):
+            out = c.compress(messages, current_tokens=90_000)
+
+        hist = _role_hist(out)
+        assert hist.get("user", 0) >= 1
+        assert _has_nonempty_user_text(out), (
+            "REGRESSION: an image-only user turn satisfied the role-only "
+            "zero-user-turn guard, leaving a transcript with a user-role "
+            "message but no actual query text — the exact class of "
+            "request backends reject with 'No user query found in "
+            f"messages'. Output: {out}"
+        )
+
+    def test_image_only_protected_head_still_yields_non_empty_text(self, compressor):
+        """Isolates the ``_user_survives`` text check from the merge-target
+        fix below: here ``compress_start != 0`` and there's no system
+        message, so neither existing force condition
+        (``compress_start == 0`` / ``last_head_role == "system"``) fires on
+        its own — only the broadened (text-aware) survival check does.
+        """
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        c = compressor
+        c.protect_first_n = 1
+        c.protect_last_n = 2
+        c.tail_token_budget = 10
+        c.compression_count = 0
+
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        }]
+        messages += _tool_turns(0, 12)
+
+        mocked = f"{SUMMARY_PREFIX}\nrolled-up summary of the tool work"
+        with patch.object(c, "_generate_summary", return_value=mocked):
+            out = c.compress(messages, current_tokens=90_000)
+
+        assert _has_nonempty_user_text(out), (
+            "REGRESSION: an image-only protected-head user turn satisfied "
+            f"the role-only zero-user-turn guard. Output: {out}"
+        )
+
+    def test_merge_targets_the_colliding_tail_message_not_index_zero(self, compressor):
+        """Template-exempt rows (bare tool-call assistant / tool messages)
+        ahead of the colliding tail user message must not divert the merge:
+        merging into literal tail index 0 would attach the summary to an
+        exempt row and leave the real (image-only) user message untouched
+        and still empty, silently defeating the forced role="user" this
+        block exists to guarantee.
+        """
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        c = compressor
+        c.compression_count = 1  # decays protect_first_n to 0 -> compress_start == 0
+        messages = [{"role": "user", "content": "work kanban task 42"}]
+        messages += _tool_turns(0, 12)
+        messages += [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        }]
+
+        mocked = f"{SUMMARY_PREFIX}\nrolled-up summary of the tool work"
+        with patch.object(c, "_generate_summary", return_value=mocked):
+            out = c.compress(messages, current_tokens=90_000)
+
+        assert _has_nonempty_user_text(out), (
+            "REGRESSION: the summary merged into tail index 0 (a "
+            "template-exempt row) instead of the colliding image-only "
+            f"user message, leaving zero non-empty user turns. Output: {out}"
+        )

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -428,6 +428,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     release_worker = threading.Event()
     cleanup_done = threading.Event()
     fake_db = MagicMock()
+    # The DB-backed cooldown check calls this before compressing; a bare
+    # MagicMock return would be truthy and skip compression entirely.
+    fake_db.get_compression_failure_cooldown.return_value = None
 
     class SlowCompressAgent:
         last_instance = None
@@ -545,7 +548,12 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     assert elapsed < 2.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
-    assert runner._hygiene_compression_failure_cooldowns["sess-timeout"] > time.time()
+    # Cooldown must be persisted to the state DB (survives restart, #74136),
+    # not stashed in an in-memory dict.
+    assert fake_db.record_compression_failure_cooldown.called
+    _cd_args = fake_db.record_compression_failure_cooldown.call_args[0]
+    assert _cd_args[0] == "sess-timeout"
+    assert _cd_args[1] > time.time()
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
@@ -585,6 +593,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
         "</memory_provider_context>"
     )
     fake_db = MagicMock()
+    fake_db.get_compression_failure_cooldown.return_value = None
     async_session_db = SimpleNamespace(
         _db=fake_db,
         get_session=AsyncMock(
@@ -896,3 +905,181 @@ def _make_progress_runner(monkeypatch, tmp_path, agent_cls, cfg_text):
     return runner, adapter, event
 
 
+
+
+# ---------------------------------------------------------------------------
+# Cooldown persistence across gateway restarts (#74136)
+# ---------------------------------------------------------------------------
+
+def _make_cooldown_runner(monkeypatch, tmp_path, agent_cls, session_db, session_id):
+    """Scaffolding for the restart-persistence tests: a fresh GatewayRunner
+    wired to a REAL AsyncSessionDB facade (not a MagicMock) so the hygiene
+    cooldown check/write paths exercise the actual SQLite-backed methods."""
+    from hermes_state import AsyncSessionDB
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "  hygiene_failure_cooldown_seconds: 300\n",
+        encoding="utf-8",
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:dm:12345",
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    # The real async facade over the real SQLite-backed SessionDB — the
+    # production shape.  A SimpleNamespace(_db=MagicMock()) here would let
+    # the assertion pass against methods that don't actually persist.
+    runner._session_db = AsyncSessionDB(session_db)
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+    return runner, adapter, event
+
+
+@pytest.mark.asyncio
+async def test_hygiene_compression_cooldown_survives_gateway_restart(
+    monkeypatch, tmp_path
+):
+    """Regression for #74136: the compression-failure cooldown must be
+    persisted to the state DB, not an in-memory dict on the runner.
+
+    Fail a hygiene compression on runner #1, tear the runner down, build a
+    FRESH runner on the SAME database (simulating a gateway restart), and
+    assert the second runner still honors the cooldown — i.e. it does not
+    re-instantiate a compression agent for the same failing session.
+    """
+    from hermes_state import SessionDB
+
+    session_id = "sess-restart"
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(session_id, "telegram")
+
+        class AbortingCompressAgent:
+            instances = 0
+
+            def __init__(self, **kwargs):
+                type(self).instances += 1
+                self.session_id = kwargs.get("session_id", session_id)
+                self._session_db = kwargs.get("session_db")
+                self._last_compaction_in_place = False
+                self.context_compressor = SimpleNamespace(
+                    bind_session_state=MagicMock(),
+                    _last_compress_aborted=True,
+                    _last_summary_error="aux model exploded",
+                    _last_aux_model_failure_model=None,
+                )
+                self.shutdown_memory_provider = MagicMock()
+                self.close = MagicMock()
+
+            def _compress_context(self, messages, *_args, **_kwargs):
+                # Summary generation failed: compressor aborts and returns
+                # the transcript unchanged.
+                return (messages, None)
+
+        runner1, _adapter1, event1 = _make_cooldown_runner(
+            monkeypatch, tmp_path, AbortingCompressAgent, db, session_id
+        )
+        assert await runner1._handle_message(event1) == "ok"
+        assert AbortingCompressAgent.instances == 1
+
+        # The abort must have persisted a cooldown to the DB.
+        state = db.get_compression_failure_cooldown(session_id)
+        assert state is not None and state["remaining_seconds"] > 0, (
+            "hygiene compression abort did not persist a cooldown to the "
+            f"state DB; got {state!r}"
+        )
+
+        # --- simulate a gateway restart: brand-new runner, same DB ---
+        del runner1
+
+        class ShouldNotRunAgent:
+            instances = 0
+
+            def __init__(self, **kwargs):
+                type(self).instances += 1
+                self.context_compressor = SimpleNamespace(
+                    bind_session_state=MagicMock(),
+                    _last_compress_aborted=False,
+                    _last_aux_model_failure_model=None,
+                )
+                self.shutdown_memory_provider = MagicMock()
+                self.close = MagicMock()
+
+            def _compress_context(self, messages, *_args, **_kwargs):
+                return (messages, None)
+
+        runner2, _adapter2, event2 = _make_cooldown_runner(
+            monkeypatch, tmp_path, ShouldNotRunAgent, db, session_id
+        )
+        assert await runner2._handle_message(event2) == "ok"
+        assert ShouldNotRunAgent.instances == 0, (
+            "REGRESSION (#74136): a fresh GatewayRunner on the same state DB "
+            "re-ran the failing hygiene compression — the failure cooldown "
+            "was lost across the restart (in-memory dict instead of the "
+            "DB-backed record/get methods)."
+        )
+        # The user turn itself still runs; only compression is skipped.
+        assert runner2._run_agent.await_count == 1
+    finally:
+        db.close()


### PR DESCRIPTION
# Salvage: four compression fixes (short-suffix OOB, persisted hygiene cooldown, non-empty user query, reasoning_details phantom weight)

Combines four community compression fixes onto one branch, each cherry-picked with original authorship preserved, plus follow-up hardening commits.

Fixes #75588, Fixes #74136, Fixes #73298

## 1. Clamp tail-cut / summary-scan indices — IndexError on short tool-suffix transcripts (#75588)

Cherry-picked from #75604 by @x7peeps (`2a3a0fd913`):
- `_find_tail_cut_by_tokens` return clamped to `len(messages)` (the `head_end + 1` forward-progress floor could produce `n + 1` when alignment pushed the head to the end of the list).
- `_find_context_summaries` defensively clamps `start`/`end` to `[0, n]`.

**Our follow-up** (`ad19a34ed5`): a `compress()`-level E2E regression driving the real pipeline over the live 8-message transcript shape from the issue (system + tool-only suffix, aligned head == `len(messages)`). Asserts no exception, `_generate_summary` never called when the window is out of range, transcript returned unchanged. Sabotage-verified: reverting the clamps fails the test.

## 2. Persist the session-hygiene compression-failure cooldown (#74136)

Salvaged from open PR #74251 by @rkfshakti (`d56e6793a9`): replaces the in-memory `_hygiene_compression_failure_cooldowns` dict in `gateway/run.py` with the existing DB-backed `record_/get_compression_failure_cooldown` methods (same column the in-conversation compressor uses) at the check, timeout-write, and abort-write sites — so a failing compression no longer re-fires on every gateway restart and wedges session storage.

**Our fix-up** (`a62d45649e`): the PR's tests mocked the DB (`SimpleNamespace(_db=MagicMock())`), which cannot prove restart persistence. Replaced with the production shape — a real on-disk `SessionDB` behind the real `AsyncSessionDB` facade — plus a restart regression test: fail a hygiene compression on runner #1, tear it down, build a fresh `GatewayRunner` on the same database, assert the cooldown is still honored (no compression agent instantiated; the user turn still runs). Sabotage-verified against the in-memory-dict version.

## 3. Preserve a non-empty user query after compression

Cherry-picked from #75514 by @Doud-FR (`f08c32a146`), including the image-only-user-message detection (`_is_nonempty_user_turn`) and its tests. The version on this branch already restricts the merge-into-visible-tail retarget to ONLY the forced non-empty-user repair path (`_force_user_leading`); ordinary alternation merges keep the literal tail index-0 target, so a leading template-exempt row (bare tool-call assistant / tool result) still absorbs the summary without becoming a visible user row. `tests/agent/test_summary_role_template_alternation.py` passes unmodified (all 8 tests, including the `:203` case the unrestricted variant broke).

## 4. Exclude the `reasoning_details` envelope from token estimates (#73298)

Salvaged from open PR #73306 by @JonthanaHanh (`3b24186fb2`): excludes `reasoning_details` from the chars/4 preflight estimate in `_estimate_message_chars` / `_estimate_message_tokens_without_images` (`agent/model_metadata.py`) — the signed/base64 envelope dominated the estimate and made compression fire at ~27% of real usage on thinking models.

**Our companion commit** (`b53842d06c`) covers the second site documented in the #73298 thread: `_REPLAY_BUDGET_KEYS` in `_estimate_msg_budget_tokens` (`agent/context_compressor.py`) charged `reasoning_details` in the tail-budget walk, shrinking the surviving tail (measured: 69 real messages summarized away; up to ~4.8× budget inflation on thinking-heavy histories). Per the #51800 counter-argument, actual thinking TEXT stays visible to the budget — `_reasoning_details_text_chars` counts `thinking`/`text`/`summary` fields and skips `signature`/`data`/encrypted blobs, and skips the text entirely when `reasoning`/`reasoning_content` already carries the identical prose (charged once, not twice). `codex_reasoning_items` remains fully charged (Codex Responses genuinely replays it, #55572). Regression tests for both sites; sabotage-verified.

## Verification

- `tests/agent -k "compress or compaction or summary or alternation or budget or estimat"`: **435 passed, 3 skipped**
- `tests/gateway -k "hygiene or compress or cooldown"`: **182 passed, 1 skipped**
- Alternation and prompt-cache invariants: `test_summary_role_template_alternation.py` + `test_turn_finalizer_interrupt_alternation.py` pass unmodified.
- ruff clean on all touched files.
- Every new regression test sabotage-verified (fails with its fix reverted).

## Scope note

#74449 (explicit-interrupt cancellation) is deliberately **not** included — pending maintainer scope decision.

## Credits

- @x7peeps — #75604 (boundary clamps)
- @rkfshakti — #74251 (persisted hygiene cooldown)
- @Doud-FR — #75514 (non-empty user query guard)
- @JonthanaHanh — #73306 (preflight reasoning_details exclusion)


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48ce6/R-Nv0pb3mrVC_7MS9u37L_zP8WKGoQ.png)
