### PR TITLE
fix(config): refuse writes over corrupt YAML; fix same-URL provider extra_headers shadowing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4837,8 +4837,15 @@ def set_config_value(key: str, value: str, force: bool = False):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -5045,8 +5052,15 @@ def unset_config_value(key: str):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     removed = _unset_nested(user_config, key)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1678,7 +1678,9 @@ def get_custom_provider_extra_headers(
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
-        return normalize_extra_headers(entry.get("extra_headers"))
+        headers = normalize_extra_headers(entry.get("extra_headers"))
+        if headers:
+            return headers
     return {}
 
 

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -15,6 +15,16 @@ from hermes_cli.config import (
 from hermes_cli import models as models_mod
 
 
+def test_normalize_extra_headers_stringifies_and_drops_none():
+    assert normalize_extra_headers({"X-Int": 7, "X-Str": "v", "X-None": None}) == {
+        "X-Int": "7",
+        "X-Str": "v",
+    }
+
+
+def test_normalize_extra_headers_rejects_non_dict_and_empty():
+    for bad in (None, "x", 42, ["a"], {}):
+        assert normalize_extra_headers(bad) == {}
 
 
 def test_normalize_entry_keeps_extra_headers():
@@ -32,14 +42,168 @@ def test_normalize_entry_keeps_extra_headers():
     }
 
 
+def test_normalize_entry_drops_invalid_extra_headers():
+    for bad in ("not-a-dict", {}, 42, ["a"]):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "my-proxy",
+                "base_url": "https://llm.internal.example.com/v1",
+                "extra_headers": bad,
+            }
+        )
+        assert normalized is not None
+        assert "extra_headers" not in normalized
 
 
+def test_normalize_entry_stringifies_values_and_skips_none():
+    normalized = _normalize_custom_provider_entry(
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Int": 7, "X-None": None},
+        }
+    )
+    assert normalized is not None
+    assert normalized["extra_headers"] == {"X-Int": "7"}
 
 
+def test_get_custom_provider_extra_headers_matches_base_url():
+    """Match by normalized base_url returns the entry's extra_headers."""
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"CF-Access-Client-Id": "xxxx.access"},
+        }
+    ]
+    # trailing-slash and case insensitive match, mirroring the TLS helper
+    headers = get_custom_provider_extra_headers(
+        "https://LLM.internal.example.com/v1/",
+        custom_providers=providers,
+    )
+    assert headers == {"CF-Access-Client-Id": "xxxx.access"}
 
 
+def test_get_custom_provider_extra_headers_no_match_returns_empty():
+    """No matching base_url yields empty dict."""
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Secret": "s"},
+        }
+    ]
+    assert get_custom_provider_extra_headers(
+        "https://other.example.com/v1", custom_providers=providers,
+    ) == {}
+    # prefix look-alike host must not match (no substring bypass)
+    assert get_custom_provider_extra_headers(
+        "https://llm.internal.example.com.attacker.test/v1",
+        custom_providers=providers,
+    ) == {}
 
 
+def test_get_custom_provider_extra_headers_preserves_extra_path_segment():
+    """Extra path segment after normalisation is still a mismatch."""
+    providers = [
+        {
+            "base_url": "https://llm.internal.example.com/v1//",
+            "extra_headers": {"Authorization": "secret"},
+        }
+    ]
+    assert get_custom_provider_extra_headers(
+        "https://llm.internal.example.com/v1",
+        custom_providers=providers,
+    ) == {}
+
+
+def test_get_custom_provider_extra_headers_skips_alias_without_headers():
+    """Bug #74465: an earlier entry matching the same URL but without
+    extra_headers must not shadow a later entry that DOES have headers."""
+    providers = [
+        {
+            "name": "direct",
+            "base_url": "http://127.0.0.1:8787/v1",
+            # no extra_headers
+        },
+        {
+            "name": "aether-router",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {"X-Aether-Route": "my-route"},
+        },
+    ]
+    headers = get_custom_provider_extra_headers(
+        "http://127.0.0.1:8787/v1",
+        custom_providers=providers,
+    )
+    assert headers == {"X-Aether-Route": "my-route"}
+
+
+def test_get_custom_provider_extra_headers_skips_empty_header_dict_alias():
+    """An earlier entry with an explicit but empty extra_headers dict must
+    not shadow a later entry that carries real headers."""
+    providers = [
+        {
+            "name": "bare-alias",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {},
+        },
+        {
+            "name": "proxied",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {"Authorization": "Bearer tok"},
+        },
+    ]
+    headers = get_custom_provider_extra_headers(
+        "http://127.0.0.1:8787/v1",
+        custom_providers=providers,
+    )
+    assert headers == {"Authorization": "Bearer tok"}
+
+
+def test_apply_extra_headers_merges_onto_existing_defaults():
+    """apply_custom_provider_extra_headers_to_client_kwargs merges headers,
+    with provider-specific values winning over existing defaults."""
+    client_kwargs = {
+        "api_key": "x",
+        "base_url": "https://llm.internal.example.com/v1",
+        "default_headers": {"User-Agent": "curl/8.7.1", "X-Keep": "1"},
+    }
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"User-Agent": "override", "X-New": "2"},
+        }
+    ]
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs,
+        "https://llm.internal.example.com/v1",
+        custom_providers=providers,
+    )
+    assert client_kwargs["default_headers"] == {
+        "User-Agent": "override",  # provider-specific value wins
+        "X-Keep": "1",             # untouched defaults preserved
+        "X-New": "2",
+    }
+
+
+def test_apply_extra_headers_noop_without_match():
+    """No matching base_url -> no default_headers key added."""
+    client_kwargs = {"api_key": "x", "base_url": "https://other.example.com/v1"}
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Secret": "s"},
+        }
+    ]
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs,
+        "https://other.example.com/v1",
+        custom_providers=providers,
+    )
+    assert "default_headers" not in client_kwargs
 
 
 def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -688,3 +688,38 @@ class TestScalarModelSubKeyPreservation:
         parsed = yaml.safe_load(raw)
         assert parsed["model"]["default"] == "claude-sonnet"
         assert parsed["model"]["api_key"] == "sk-test"
+
+class TestMalformedYAMLConfigPreservation:
+    """#75431: config.yaml with YAML syntax errors must not be overwritten."""
+
+    BROKEN_CONFIG = "model: gpt-4o\nterminal:\n  backend: docker\n  broken: [this is invalid YAML"
+
+    def _write_broken_config(self, home):
+        (home / "config.yaml").write_text(self.BROKEN_CONFIG)
+
+    def test_set_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """set_config_value must exit with error, not overwrite the broken config."""
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            set_config_value("agent.max_turns", "50")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        # Original config must remain intact
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG, f"Config was overwritten:\n{raw}"
+
+    def test_unset_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """unset_config_value must exit with error, not overwrite the broken config."""
+        from hermes_cli.config import unset_config_value
+
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            unset_config_value("model")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG


### PR DESCRIPTION
# Config write safety: preserve config.yaml on YAML errors + fix extra_headers same-URL shadowing

Salvage branch combining two independent config-safety fixes from community PRs.

## 1. Refuse to write when config.yaml has YAML syntax errors (from #75431 by @Baophan00)

`set_config_value()` and `unset_config_value()` both caught YAML parse failures with
`except Exception: user_config = {}` and then proceeded to WRITE — a single YAML syntax
error in config.yaml caused `hermes config set` to silently wipe the entire config and
write only the new key.

Fix: both sites now print a clear error to stderr (pointing at `hermes config edit`)
and `sys.exit(1)`, leaving the existing file untouched. Regression tests verify the
original malformed file is preserved byte-for-byte for both `set` and `unset`.

Note: `require_readable_config_before_write` / `atomic_config_write` (the existing
write-chokepoint) guard *I/O readability* only — they open the file and read 1 byte, no
YAML parse. Folding YAML-validity checking into that chokepoint would change semantics
for all ~15 write sites (some of which legitimately re-serialize after partial reads),
so it's left as a follow-up rather than done inline here. The inline guard at the two
CLI setter sites is the minimal, targeted fix.

## 2. Custom-provider `extra_headers` shadowed by same-URL entry without headers (from #74503 by @webtecnica, commit 0984788bd187)

`get_custom_provider_extra_headers()` returned `normalize_extra_headers(...)` on the
*first* `providers`/`custom_providers` entry matching the base_url — even when that
entry had no `extra_headers` configured. A later same-URL provider entry that *does*
declare headers was silently ignored, so credential-carrying headers (Cloudflare Access
tokens, proxy auth) never reached the client.

Fix: keep scanning when the matched entry's normalized headers are empty; return the
first non-empty match. Verified the bug still exists on current main before applying
(hermes_cli/config.py `get_custom_provider_extra_headers`, ~line 1675). Comes with a
164-line dedicated test file.

Only this one commit was taken from #74503 — the SessionDB lock-patience commits in
that PR are redundant with already-merged 8da8a7887d.

## Note on #74995

No `Fixes #74995` line on purpose: whether empty-`extra_headers` entries should
participate in URL-route identity at all is a separate contract question that needs a
maintainer decision — this branch only fixes the first-match shadowing behavior.

## Testing

- `tests/hermes_cli/test_set_config_value.py` — 36 new lines: malformed-YAML preservation for set + unset (all pass)
- `tests/hermes_cli/test_custom_provider_extra_headers.py` — new file (all pass)
- `tests/hermes_cli/test_config.py`, `test_config_read_guard.py`, `test_config_validation.py` — 84 passed, no regressions

Credits: @Baophan00 (#75431), @webtecnica (#74503) — authorship preserved via cherry-pick.


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48cec/BZGrIjWwExKhf0dbY0gpE_jX7ugSzC.png)
