### PR TITLE
fix(gateway): /model off the event loop; distribution allowlist enforced; hindsight env file 0600

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2011,7 +2011,7 @@ class GatewaySlashCommandsMixin:
                         lines = [t("gateway.model.switched", model=format_model_for_display(result.new_model))]
                         lines.append(t("gateway.model.provider_label", provider=plabel))
                         mi = result.model_info
-                        from hermes_cli.model_switch import resolve_display_context_length
+                        from hermes_cli.model_switch import resolve_display_context_length_async
                         _sw_config_ctx = None
                         _sw_model_cfg = {}
                         try:
@@ -2025,7 +2025,7 @@ class GatewaySlashCommandsMixin:
                             pass
                         if not isinstance(_sw_model_cfg, dict):
                             _sw_model_cfg = {}
-                        ctx = resolve_display_context_length(
+                        ctx = await resolve_display_context_length_async(
                             result.new_model,
                             result.target_provider,
                             base_url=result.base_url or current_base_url or "",
@@ -2333,7 +2333,7 @@ class GatewaySlashCommandsMixin:
             # Context: always resolve via the provider-aware chain so Codex OAuth,
             # Copilot, and Nous-enforced caps win over the raw models.dev entry.
             mi = result.model_info
-            from hermes_cli.model_switch import resolve_display_context_length
+            from hermes_cli.model_switch import resolve_display_context_length_async
             _sw2_config_ctx = None
             _sw2_model_cfg = {}
             try:
@@ -2347,7 +2347,7 @@ class GatewaySlashCommandsMixin:
                 pass
             if not isinstance(_sw2_model_cfg, dict):
                 _sw2_model_cfg = {}
-            ctx = resolve_display_context_length(
+            ctx = await resolve_display_context_length_async(
                 result.new_model,
                 result.target_provider,
                 base_url=result.base_url or current_base_url or "",

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1840,7 +1840,11 @@ class GatewaySlashCommandsMixin:
                                 enrich_model_switch_warnings_for_gateway,
                             )
 
-                            enrich_model_switch_warnings_for_gateway(
+                            # Offload: merge_preflight_compression_warning()
+                            # calls the sync resolve_display_context_length()
+                            # provider probe ladder — must not run on the loop.
+                            await asyncio.to_thread(
+                                enrich_model_switch_warnings_for_gateway,
                                 result,
                                 _self,
                                 session_key=_session_key,
@@ -2145,7 +2149,11 @@ class GatewaySlashCommandsMixin:
                 enrich_model_switch_warnings_for_gateway,
             )
 
-            enrich_model_switch_warnings_for_gateway(
+            # Offload: merge_preflight_compression_warning() calls the sync
+            # resolve_display_context_length() provider probe ladder — must
+            # not run on the loop.
+            await asyncio.to_thread(
+                enrich_model_switch_warnings_for_gateway,
                 result,
                 self,
                 session_key=session_key,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1058,6 +1058,48 @@ def resolve_display_context_length(
     return None
 
 
+async def resolve_display_context_length_async(
+    model: str,
+    provider: str,
+    base_url: str = "",
+    api_key: str = "",
+    model_info: Optional[ModelInfo] = None,
+    custom_providers: list | None = None,
+    config_context_length: int | None = None,
+    configured_model: str | None = None,
+    configured_provider: str | None = None,
+    configured_base_url: str | None = None,
+) -> Optional[int]:
+    """Async variant of :func:`resolve_display_context_length`.
+
+    The sync version runs two blocking chains: the route comparison in
+    ``should_clear_context_pin`` and the full provider probe ladder in
+    ``get_model_context_length`` (blocking ``requests`` calls to Anthropic
+    ``/v1/models``, Copilot, Nous, Codex, GMI, Ollama, models.dev and
+    OpenRouter).  Async gateway handlers must not run either on the event
+    loop — see ``agent.model_metadata.get_model_context_length_async`` and
+    ``hermes_cli.route_identity.should_clear_context_pin_async``, which
+    offload the same chains for the message path.
+
+    Shares all logic with the sync version — no code duplication.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(
+        resolve_display_context_length,
+        model,
+        provider,
+        base_url=base_url,
+        api_key=api_key,
+        model_info=model_info,
+        custom_providers=custom_providers,
+        config_context_length=config_context_length,
+        configured_model=configured_model,
+        configured_provider=configured_provider,
+        configured_base_url=configured_base_url,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Configured-provider detection for typed model names
 # ---------------------------------------------------------------------------

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -560,10 +560,14 @@ def _copy_dist_payload(
     """
     target.mkdir(parents=True, exist_ok=True)
 
+    owned = set(manifest.owned_paths())
+
     for entry in staged.iterdir():
         name = entry.name
 
         if name in USER_OWNED_EXCLUDE:
+            continue
+        if name not in owned:
             continue
         if name == ENV_TEMPLATE_FILENAME:
             shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -67,7 +67,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
@@ -557,26 +557,16 @@ def _copy_dist_payload(
     ``preserve_config`` is False (fresh install or ``--force-config`` update).
     ``.env.template`` is renamed to ``.env.EXAMPLE`` in the target to avoid
     shadowing a real ``.env``.
+
+    When the manifest declares an explicit ``distribution_owned`` list, only
+    those paths are copied (path-aware: nested entries such as
+    ``skills/research`` or ``cron/digest.json`` are honoured).  When the list
+    is omitted the legacy behaviour is preserved: every staged entry outside
+    ``USER_OWNED_EXCLUDE`` is copied.
     """
     target.mkdir(parents=True, exist_ok=True)
 
-    owned = set(manifest.owned_paths())
-
-    for entry in staged.iterdir():
-        name = entry.name
-
-        if name in USER_OWNED_EXCLUDE:
-            continue
-        if name not in owned:
-            continue
-        if name == ENV_TEMPLATE_FILENAME:
-            shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)
-            continue
-        if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
-            # Leave user's config.yaml alone on update
-            continue
-
-        dest = target / name
+    def _copy_entry(entry: Path, dest: Path) -> None:
         if entry.is_dir():
             if dest.exists():
                 shutil.rmtree(dest)
@@ -592,6 +582,50 @@ def _copy_dist_payload(
             )
         else:
             shutil.copy2(entry, dest)
+
+    explicit_owned = [p.strip().strip("/") for p in manifest.distribution_owned]
+    explicit_owned = [p for p in explicit_owned if p]
+
+    if explicit_owned:
+        # Path-aware allowlist: copy exactly the declared paths.
+        for rel in explicit_owned:
+            rel_parts = PurePosixPath(rel).parts
+            if not rel_parts or rel_parts[0] in USER_OWNED_EXCLUDE:
+                continue
+            if ".." in rel_parts or PurePosixPath(rel).is_absolute():
+                continue
+            src = staged.joinpath(*rel_parts)
+            if not src.exists():
+                continue
+            if len(rel_parts) == 1:
+                name = rel_parts[0]
+                if name == ENV_TEMPLATE_FILENAME:
+                    shutil.copy2(src, target / ENV_EXAMPLE_FILENAME)
+                    continue
+                if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
+                    # Leave user's config.yaml alone on update
+                    continue
+            dest = target.joinpath(*rel_parts)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            _copy_entry(src, dest)
+    else:
+        # Legacy behaviour: no explicit allowlist means the whole staged
+        # payload (minus USER_OWNED_EXCLUDE) is distribution-owned.  Do NOT
+        # narrow to DEFAULT_DIST_OWNED here — existing distributions ship
+        # arbitrary extra top-level paths without declaring them.
+        for entry in staged.iterdir():
+            name = entry.name
+
+            if name in USER_OWNED_EXCLUDE:
+                continue
+            if name == ENV_TEMPLATE_FILENAME:
+                shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)
+                continue
+            if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
+                # Leave user's config.yaml alone on update
+                continue
+
+            _copy_entry(entry, target / name)
 
     # Emit .env.EXAMPLE from manifest if the staged tree didn't ship one
     if manifest.env_requires and not (target / ENV_EXAMPLE_FILENAME).exists():

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -559,15 +559,61 @@ def _embedded_profile_env_path(config: dict[str, Any]):
     return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
 
 
+def _secure_write_profile_env(profile_env, content: str) -> None:
+    """Create/overwrite *profile_env* with owner-only (0600) permissions.
+
+    The file carries the embedded daemon's plaintext LLM API key
+    (``HINDSIGHT_API_LLM_API_KEY``), so it must never be created with the
+    default umask-derived mode. A pre-existing file is tightened *before*
+    the new secret bytes are written.
+    """
+    if profile_env.exists():
+        try:
+            os.chmod(profile_env, 0o600)
+        except OSError:
+            pass
+    fd = os.open(str(profile_env), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def _validate_profile_env_permissions(profile_env) -> None:
+    """Post-write validation: the secret file must be owner-only on POSIX."""
+    if os.name != "posix":
+        # POSIX mode bits do not model Windows ACLs.
+        return
+    import stat
+
+    mode = stat.S_IMODE(profile_env.stat().st_mode)
+    if mode != 0o600:
+        try:
+            os.chmod(profile_env, 0o600)
+        except OSError:
+            pass
+        mode = stat.S_IMODE(profile_env.stat().st_mode)
+        if mode != 0o600:
+            raise PermissionError(
+                f"Embedded Hindsight profile environment is not owner-only: {profile_env}"
+            )
+
+
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
-    profile_env.write_text(
-        "".join(f"{key}={value}\n" for key, value in env_values.items()),
-        encoding="utf-8",
-    )
+    content = "".join(f"{key}={value}\n" for key, value in env_values.items())
+    try:
+        _secure_write_profile_env(profile_env, content)
+        _validate_profile_env_permissions(profile_env)
+    except BaseException:
+        # Never leave a plaintext API key behind in a file whose permissions
+        # could not be verified.
+        try:
+            profile_env.unlink()
+        except OSError:
+            pass
+        raise
     return profile_env
 
 def _sanitize_bank_segment(value: str) -> str:

--- a/tests/gateway/test_model_command_context_offload.py
+++ b/tests/gateway/test_model_command_context_offload.py
@@ -1,0 +1,147 @@
+"""``/model`` context-length resolution must not block the gateway event loop.
+
+Behavioral regression tests for the offload of
+``resolve_display_context_length`` (blocking provider probe ladder) out of the
+async ``/model`` handlers, and for the offload of
+``enrich_model_switch_warnings_for_gateway`` (which reaches the same sync
+resolver via ``merge_preflight_compression_warning``).
+
+These drive the real ``_handle_model_command`` with a mocked switch pipeline —
+no source-reading assertions; reverting either offload makes the corresponding
+test fail because the blocking work lands back on the loop thread.
+"""
+
+import asyncio
+import threading
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.slash_commands as slash_commands
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+    )
+
+
+def _runner_with_store(tmp_path, monkeypatch):
+    """Minimal GatewayRunner harness driving the real /model handler."""
+    import yaml as _yaml
+
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        _yaml.safe_dump({"model": {"default": "old-model", "provider": "openrouter"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.5",
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="sk-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        ),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+    # No expensive-model confirmation detour.
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **k: None,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_one_turn_model_restores = {}
+    runner._running_agents = {}
+    _store = MagicMock()
+    _store.set_model_override = AsyncMock()
+    _store._store = None
+    runner.session_store = None
+    runner._async_session_store = _store
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_context_resolution_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    """The sync resolver must execute on a worker thread when the /model
+    handler resolves the display context length for the switch reply."""
+    from hermes_cli import model_switch
+
+    seen = {}
+    loop_thread = threading.current_thread()
+
+    def _recording_resolver(model, provider, **kwargs):
+        seen.setdefault("threads", []).append(threading.current_thread())
+        return 128000
+
+    monkeypatch.setattr(
+        model_switch, "resolve_display_context_length", _recording_resolver
+    )
+
+    runner = _runner_with_store(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(_event("/model gpt-5.5"))
+
+    assert result is not None and "gpt-5.5" in result
+    assert seen.get("threads"), "handler never resolved the context length"
+    assert all(th is not loop_thread for th in seen["threads"]), (
+        "resolve_display_context_length ran on the event loop thread — "
+        "the /model handler must offload it via "
+        "resolve_display_context_length_async"
+    )
+
+
+@pytest.mark.asyncio
+async def test_warning_enrichment_is_offloaded(tmp_path, monkeypatch):
+    """enrich_model_switch_warnings_for_gateway reaches the same sync resolver
+    via merge_preflight_compression_warning, so the handler must dispatch it
+    through asyncio.to_thread rather than calling it inline on the loop."""
+    from hermes_cli import context_switch_guard
+
+    offloaded = []
+    real_to_thread = asyncio.to_thread
+
+    async def _spy_to_thread(func, /, *args, **kwargs):
+        offloaded.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(slash_commands.asyncio, "to_thread", _spy_to_thread)
+
+    runner = _runner_with_store(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(_event("/model gpt-5.5"))
+
+    assert result is not None and "gpt-5.5" in result
+    assert context_switch_guard.enrich_model_switch_warnings_for_gateway in offloaded, (
+        "enrich_model_switch_warnings_for_gateway must be dispatched via "
+        "asyncio.to_thread (it was called inline on the event loop instead)"
+    )

--- a/tests/hermes_cli/test_model_switch_context_offload.py
+++ b/tests/hermes_cli/test_model_switch_context_offload.py
@@ -1,0 +1,111 @@
+"""``/model`` context-length resolution must not run on the gateway event loop.
+
+``resolve_display_context_length`` runs two blocking chains — the route
+comparison in ``should_clear_context_pin`` and the provider probe ladder in
+``get_model_context_length`` (blocking ``requests`` calls to Anthropic
+``/v1/models``, Copilot, Nous, Codex, GMI, Ollama, models.dev and OpenRouter).
+
+The gateway message path already offloads both (``get_model_context_length_async``,
+``should_clear_context_pin_async``); the ``/model`` slash-command handlers called
+the sync helper directly, freezing the loop for every user on every platform for
+the duration of the probe ladder.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+import agent.model_metadata as model_meta_mod
+from hermes_cli import model_switch
+
+PROBE_SECONDS = 0.4
+
+RESOLVE_ARGS = dict(
+    model="claude-opus-4",
+    provider="anthropic",
+    base_url="",
+    api_key="",
+    custom_providers=None,
+    config_context_length=None,
+)
+
+
+@pytest.fixture
+def slow_probe(monkeypatch):
+    """Stand in for one blocking provider probe inside the resolution chain."""
+    calls = {}
+
+    def _probe(model, **kwargs):
+        calls["thread"] = threading.current_thread()
+        time.sleep(PROBE_SECONDS)
+        return 128000
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length", _probe)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_async_variant_matches_sync(slow_probe):
+    """The async wrapper resolves the same value as the sync helper."""
+    sync_value = model_switch.resolve_display_context_length(**RESOLVE_ARGS)
+    async_value = await model_switch.resolve_display_context_length_async(
+        **RESOLVE_ARGS
+    )
+    assert async_value == sync_value == 128000
+
+
+@pytest.mark.asyncio
+async def test_resolution_runs_off_the_event_loop_thread(slow_probe):
+    """The blocking chain must execute on a worker thread, not the loop thread."""
+    loop_thread = threading.current_thread()
+    await model_switch.resolve_display_context_length_async(**RESOLVE_ARGS)
+    assert slow_probe["thread"] is not loop_thread
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_responsive_during_resolution(slow_probe):
+    """A concurrent heartbeat keeps ticking while the probe ladder runs.
+
+    This is the regression: with the bare sync call the loop stalled for the
+    full probe duration, which is what times out Discord heartbeats and stalls
+    Telegram polling for every other chat.
+    """
+    lags = []
+    stop = asyncio.Event()
+
+    async def heartbeat():
+        interval = 0.02
+        while not stop.is_set():
+            t0 = time.monotonic()
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+            lags.append(time.monotonic() - t0 - interval)
+
+    hb = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0.05)  # let the heartbeat settle
+
+    ctx = await model_switch.resolve_display_context_length_async(**RESOLVE_ARGS)
+
+    stop.set()
+    await hb
+
+    assert ctx == 128000
+    # The loop was never blocked for anything close to the probe duration.
+    assert max(lags) < PROBE_SECONDS / 2, f"event loop stalled {max(lags):.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_gateway_model_handlers_await_the_async_variant():
+    """The ``/model`` handlers must not reach the sync helper again."""
+    import inspect
+
+    from gateway import slash_commands
+
+    source = inspect.getsource(slash_commands)
+    assert "resolve_display_context_length_async(" in source
+    # No bare sync call: every occurrence carries the _async suffix.
+    assert "resolve_display_context_length(" not in source

--- a/tests/hermes_cli/test_model_switch_context_offload.py
+++ b/tests/hermes_cli/test_model_switch_context_offload.py
@@ -97,15 +97,3 @@ async def test_event_loop_stays_responsive_during_resolution(slow_probe):
     # The loop was never blocked for anything close to the probe duration.
     assert max(lags) < PROBE_SECONDS / 2, f"event loop stalled {max(lags):.3f}s"
 
-
-@pytest.mark.asyncio
-async def test_gateway_model_handlers_await_the_async_variant():
-    """The ``/model`` handlers must not reach the sync helper again."""
-    import inspect
-
-    from gateway import slash_commands
-
-    source = inspect.getsource(slash_commands)
-    assert "resolve_display_context_length_async(" in source
-    # No bare sync call: every occurrence carries the _async suffix.
-    assert "resolve_display_context_length(" not in source

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -229,6 +229,77 @@ class TestInstall:
         assert m.name == "installed"
         assert m.source == str(staged)
 
+    def test_install_respects_distribution_owned_allowlist(self, profile_env):
+        """Install must only copy paths listed in distribution_owned."""
+        mf = DistributionManifest(
+            name="restricted",
+            version="0.1.0",
+            distribution_owned=["SOUL.md", "skills"],
+        )
+        staged = _make_staging_dir(profile_env, "restricted", manifest=mf)
+        # Confirm extra files exist in staging
+        assert (staged / "mcp.json").exists(), "mcp.json should exist in staged for this test"
+        assert (staged / "cron").is_dir(), "cron/ should exist in staged for this test"
+
+        plan = install_distribution(str(staged), name="restricted")
+        # Owned paths must be present
+        assert (plan.target_dir / "SOUL.md").read_text() == "I am Source.\n"
+        assert (plan.target_dir / "skills").is_dir()
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").exists()
+        # NOT-owned paths must NOT be copied from staging
+        assert not (plan.target_dir / "mcp.json").exists(), \
+            "mcp.json should NOT be copied (not in distribution_owned)"
+        # cron/ is created by _bootstrap_user_dirs, but the staged cron/ content
+        # must NOT leak through
+        if (plan.target_dir / "cron").exists():
+            cron_content = list((plan.target_dir / "cron").iterdir())
+            assert not cron_content, \
+                f"cron/ should be empty (staged content skipped): {cron_content}"
+        # distribution.yaml is always written by write_manifest
+        assert (plan.target_dir / "distribution.yaml").exists()
+
+    def test_install_default_owned_paths_preserved(self, profile_env):
+        """When distribution_owned is not set, all DEFAULT_DIST_OWNED paths are copied."""
+        staged = _make_staging_dir(profile_env, "default_owned")
+        plan = install_distribution(str(staged), name="default_owned")
+        for path in DEFAULT_DIST_OWNED:
+            full = plan.target_dir / path
+            assert full.exists() or full.is_dir(), \
+                f"DEFAULT_DIST_OWNED '{path}' not found in target"
+
+    def test_update_respects_distribution_owned_allowlist(self, profile_env):
+        """Update must only copy paths listed in distribution_owned."""
+        # 1. Install with full default distribution_owned
+        staged = _make_staging_dir(profile_env, "up_src")
+        plan = install_distribution(str(staged), name="up_restricted")
+        assert (plan.target_dir / "mcp.json").exists(), "baseline: mcp.json should exist"
+
+        # 2. Write a new manifest with restricted distribution_owned
+        restricted_mf = DistributionManifest(
+            name="up_restricted",
+            version="0.2.0",
+            distribution_owned=["SOUL.md", "skills"],
+        )
+        write_manifest(staged, restricted_mf)
+        # Also add a NEW file in the staged dir that is NOT in distribution_owned
+        (staged / "new_config.toml").write_text("[extra]\n")
+        # The manifest on disk needs the new source to match
+        from hermes_cli.profile_distribution import read_manifest as _read
+        m_on_disk = _read(plan.target_dir)
+        m_on_disk.source = str(staged)
+        write_manifest(plan.target_dir, m_on_disk)
+
+        # 3. Update
+        update_distribution("up_restricted", force_config=True)
+
+        # 4. Owned paths should be updated
+        assert (plan.target_dir / "SOUL.md").read_text() == "I am Source.\n"
+        assert (plan.target_dir / "skills").is_dir()
+        # 5. Formerly-owned paths (mcp.json, cron/) should NOT be copied on update
+        #    Note: mcp.json existed before so it stays (not removed). The guard is
+        #    about what gets COPIED, not what's cleaned up.
+        assert not (plan.target_dir / "new_config.toml").exists(), \
+            "new_config.toml should not be copied (not in distribution_owned)"
 
     def test_install_rejects_non_distribution_directory(self, profile_env, tmp_path):
         bogus = tmp_path / "bogus_dir"
@@ -394,9 +465,14 @@ class TestSecurity:
 class TestNestedUserOwnedExcludeNotFiltered:
 
     def test_nested_bin_dir_is_preserved(self, profile_env):
-        """"A distribution shipping tools/bin/ must not have tools/bin/ dropped
+        """A distribution shipping tools/bin/ must not have tools/bin/ dropped
         during install even though 'bin' is in USER_OWNED_EXCLUDE."""
-        staged = _make_staging_dir(profile_env, "src")
+        mf = DistributionManifest(
+            name="nested_bin",
+            version="0.1.0",
+            distribution_owned=list(DEFAULT_DIST_OWNED) + ["tools"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
         (staged / "tools" / "bin").mkdir(parents=True)
         (staged / "tools" / "bin" / "tool.py").write_text("# tool\n")
 
@@ -405,14 +481,17 @@ class TestNestedUserOwnedExcludeNotFiltered:
         assert (plan.target_dir / "tools" / "bin" / "tool.py").exists()
 
     def test_nested_logs_dir_is_preserved(self, profile_env):
-        staged = _make_staging_dir(profile_env, "src")
+        mf = DistributionManifest(
+            name="nested_logs",
+            version="0.1.0",
+            distribution_owned=list(DEFAULT_DIST_OWNED) + ["scripts"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
         (staged / "scripts" / "logs").mkdir(parents=True)
         (staged / "scripts" / "logs" / "run.log").write_text("ok\n")
-
         plan = install_distribution(str(staged), name="nested_logs")
         assert (plan.target_dir / "scripts" / "logs").is_dir()
         assert (plan.target_dir / "scripts" / "logs" / "run.log").read_text() == "ok\n"
-
 
     def test_top_level_user_owned_still_skipped(self, profile_env):
         """Top-level entries in USER_OWNED_EXCLUDE must still be skipped —
@@ -435,6 +514,23 @@ class TestNestedUserOwnedExcludeNotFiltered:
         # so check that the staged file did NOT land there.
         assert not (plan.target_dir / "logs" / "shipped.log").exists(), \
             "staged logs/ content should not leak into target"
+
+    def test_both_nested_and_top_level_coexist(self, profile_env):
+        """Top-level bin/ filtered, but tools/bin/ kept."""
+        mf = DistributionManifest(
+            name="coexist",
+            version="0.1.0",
+            distribution_owned=list(DEFAULT_DIST_OWNED) + ["tools"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+        (staged / "bin").mkdir(exist_ok=True)
+        (staged / "bin" / "top.sh").write_text("# top\n")
+        (staged / "tools" / "bin").mkdir(parents=True)
+        (staged / "tools" / "bin" / "helper.py").write_text("# helper\n")
+
+        plan = install_distribution(str(staged), name="coexist")
+        assert not (plan.target_dir / "bin").exists()
+        assert (plan.target_dir / "tools" / "bin" / "helper.py").exists()
 
 
 # ===========================================================================

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -267,6 +267,49 @@ class TestInstall:
             assert full.exists() or full.is_dir(), \
                 f"DEFAULT_DIST_OWNED '{path}' not found in target"
 
+    def test_install_omitted_allowlist_copies_everything(self, profile_env):
+        """Legacy contract: when distribution_owned is OMITTED, every staged
+        entry outside USER_OWNED_EXCLUDE is copied — the omitted list must NOT
+        silently narrow to DEFAULT_DIST_OWNED."""
+        staged = _make_staging_dir(profile_env, "legacy_all")
+        # Extra top-level payload not covered by DEFAULT_DIST_OWNED
+        (staged / "extra.txt").write_text("bonus\n")
+        (staged / "tools").mkdir()
+        (staged / "tools" / "helper.py").write_text("# helper\n")
+
+        plan = install_distribution(str(staged), name="legacy_all")
+        assert (plan.target_dir / "extra.txt").read_text() == "bonus\n", \
+            "omitted distribution_owned must keep copying undeclared files"
+        assert (plan.target_dir / "tools" / "helper.py").exists(), \
+            "omitted distribution_owned must keep copying undeclared dirs"
+
+    def test_install_allowlist_supports_nested_paths(self, profile_env):
+        """Documented nested entries like skills/research/ and cron/digest.json
+        must select exactly that subtree/file, not be silently dropped."""
+        mf = DistributionManifest(
+            name="nested",
+            version="0.1.0",
+            distribution_owned=["SOUL.md", "skills/research/", "cron/digest.json"],
+        )
+        staged = _make_staging_dir(profile_env, "nested", manifest=mf)
+        (staged / "skills" / "research").mkdir()
+        (staged / "skills" / "research" / "SKILL.md").write_text(
+            "---\nname: research\ndescription: r\n---\n# R\n"
+        )
+        (staged / "cron" / "digest.json").write_text('{"schedule": "0 8 * * *"}')
+
+        plan = install_distribution(str(staged), name="nested")
+        # Nested allowlisted paths are installed
+        assert (plan.target_dir / "skills" / "research" / "SKILL.md").exists()
+        assert (plan.target_dir / "cron" / "digest.json").exists()
+        # Sibling paths under the same parents are NOT dragged along
+        assert not (plan.target_dir / "skills" / "demo").exists(), \
+            "skills/demo is not allowlisted and must not be copied"
+        assert not (plan.target_dir / "cron" / "daily.json").exists(), \
+            "cron/daily.json is not allowlisted and must not be copied"
+        # Unrelated top-level entries stay out too
+        assert not (plan.target_dir / "mcp.json").exists()
+
     def test_update_respects_distribution_owned_allowlist(self, profile_env):
         """Update must only copy paths listed in distribution_owned."""
         # 1. Install with full default distribution_owned

--- a/tests/plugins/memory/test_hindsight_env_perms.py
+++ b/tests/plugins/memory/test_hindsight_env_perms.py
@@ -1,0 +1,80 @@
+"""Regression tests: the embedded Hindsight profile env file carries the
+plaintext ``HINDSIGHT_API_LLM_API_KEY`` and must be created/kept owner-only
+(0600), and must not survive a failed post-write permission validation.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.hindsight import (
+    _embedded_profile_env_path,
+    _materialize_embedded_profile_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    isolated_home = tmp_path / "user-home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: isolated_home))
+    return isolated_home
+
+
+_CONFIG = {
+    "profile": "hermes",
+    "llm_provider": "openai",
+    "llm_model": "gpt-4o-mini",
+}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+def test_fresh_profile_env_is_owner_only_despite_permissive_umask():
+    old_umask = os.umask(0o022)
+    try:
+        profile_env = _materialize_embedded_profile_env(
+            _CONFIG, llm_api_key="sk-hindsight-secret"
+        )
+    finally:
+        os.umask(old_umask)
+
+    assert profile_env.exists()
+    assert stat.S_IMODE(profile_env.stat().st_mode) == 0o600
+    assert "HINDSIGHT_API_LLM_API_KEY=sk-hindsight-secret\n" in profile_env.read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+def test_rewrite_tightens_existing_world_readable_profile_env():
+    profile_env = _embedded_profile_env_path(_CONFIG)
+    profile_env.parent.mkdir(parents=True)
+    profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=stale\n", encoding="utf-8")
+    os.chmod(profile_env, 0o644)
+
+    _materialize_embedded_profile_env(_CONFIG, llm_api_key="sk-current")
+
+    assert stat.S_IMODE(profile_env.stat().st_mode) == 0o600
+    assert "HINDSIGHT_API_LLM_API_KEY=sk-current\n" in profile_env.read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+def test_secret_file_removed_when_permission_validation_fails(monkeypatch):
+    """If the post-write permission check cannot verify 0600, the plaintext
+    key file must not be left behind."""
+    import plugins.memory.hindsight as hs
+
+    def _fail_validation(profile_env):
+        raise PermissionError(f"not owner-only: {profile_env}")
+
+    monkeypatch.setattr(hs, "_validate_profile_env_permissions", _fail_validation)
+
+    with pytest.raises(PermissionError):
+        _materialize_embedded_profile_env(_CONFIG, llm_api_key="sk-doomed")
+
+    assert not _embedded_profile_env_path(_CONFIG).exists(), (
+        "secret env file must be cleaned up when validation fails"
+    )


### PR DESCRIPTION
# salvage: gateway /model loop offload, distribution_owned enforcement, hindsight env perms

Combines three narrowed community fixes onto `main` (branch `salvage/gateway-misc-fixes`).

Fixes #74373

---

## 1. `/model` context-length resolution off the gateway event loop — credit @Drexuxux (#74155)

Cherry-picked as-authored: the sync `resolve_display_context_length()` (route
comparison + provider probe ladder of blocking `requests` calls) was invoked
directly inside the async `/model` handlers in `gateway/slash_commands.py`,
freezing the whole event loop (~2s measured, worse on cold caches). The PR adds
`resolve_display_context_length_async()` — a thin `asyncio.to_thread` wrapper
mirroring the existing `get_model_context_length_async()` /
`should_clear_context_pin_async()` siblings — and awaits it at both handlers.

**Our follow-up commit:**
- Covered the missed path: `enrich_model_switch_warnings_for_gateway()` →
  `merge_preflight_compression_warning()` still called the sync resolver inline
  at both gateway call sites; both now dispatch via `asyncio.to_thread`.
- **Dropped/replaced:** the 4th test used `inspect.getsource()` on
  `gateway.slash_commands` (source-reading tests are banned by AGENTS.md).
  Replaced with behavioral tests in
  `tests/gateway/test_model_command_context_offload.py` that drive the real
  `_handle_model_command` with a mocked switch pipeline and assert (a) the
  resolver runs off the loop thread and (b) the warning enrichment is
  dispatched through a spied `asyncio.to_thread`. The other 3 behavioral tests
  from the PR are kept unchanged.

## 2. `distribution_owned` allowlist enforcement — credit @webtecnica (#74414, issue #74373)

Cherry-picked **only** the allowlist-enforcement commit (`a329bac`):
`_copy_dist_payload()` iterated every staged entry and never consulted the
manifest's `distribution_owned`, making the documented allowlist declaration-only.

**Dropped:** commit `1b82637` (credential_pool/gateway/electron token
write-through) — unrelated to the allowlist bug and introduces a token with no
reader; out of scope for this salvage.

**Our follow-up commit fixed two defects in the cherry-picked filter:**
- *Omitted-list narrowing:* the cherry-picked code filtered through
  `owned_paths()`, which falls back to `DEFAULT_DIST_OWNED` — so distributions
  that omit `distribution_owned` (the common case) would silently stop copying
  undeclared-but-legitimate top-level payload. Restored the legacy contract:
  when the list is omitted, everything outside `USER_OWNED_EXCLUDE` is copied.
  Enforcement now applies only when an explicit allowlist is declared.
- *Path-aware matching:* the top-level name comparison dropped documented
  nested entries like `skills/research/` and `cron/digest.json`. Explicit
  allowlists are now resolved path-aware: nested entries select exactly that
  subtree/file (siblings under the same parent are not dragged along), and
  traversal segments (`..`, absolute paths) and `USER_OWNED_EXCLUDE` roots are
  rejected.
- Regression tests for both (omitted-list legacy behavior, nested-path
  allowlist) on top of the PR's own tests.

**On `Fixes #74373`:** yes — the salvaged behavior resolves the issue. The core
defect (allowlist never consulted from the mutation path) is fixed; unlisted
entries are no longer installed or updated when a manifest declares
`distribution_owned`. The issue's secondary concern (target-only children
removed by wholesale directory replacement) is also addressed by the path-aware
semantics: in the issue's repro (`distribution_owned: [SOUL.md]`), `skills/` is
no longer touched at all, so `skills/local-only/` survives update; and authors
can now scope ownership to `skills/research/` to keep sibling subtrees
user-owned. Wholesale replacement remains only for paths an author explicitly
declares as distribution-owned, which is the documented ownership boundary the
issue asked to make unambiguous.

## 3. Hindsight embedded profile env file permissions — credit @carrion256 (#74236)

Reimplemented as a **minimal fix confined to `plugins/memory/hindsight/`**
(authored by us with `Co-authored-by: carrion256 <carrion256@proton.me>`):
`_materialize_embedded_profile_env()` wrote the plaintext
`HINDSIGHT_API_LLM_API_KEY` via bare `write_text()`, leaving the file with
umask-derived (typically world-readable) permissions.

- File is created/truncated via `os.open(..., O_CREAT|O_TRUNC, 0o600)`; a
  pre-existing file is chmod'd to 0600 **before** the new secret bytes land.
- Post-write validation on POSIX verifies 0600 (with one chmod retry) and
  raises `PermissionError` otherwise.
- On validation failure the secret file is unlinked — no plaintext key is left
  behind with unverified permissions.
- Perms regression tests in `tests/plugins/memory/test_hindsight_env_perms.py`
  (fresh write under a permissive umask, tightening an existing 0644 file,
  cleanup on validation failure).

**Dropped from the PR:** the core `utils.py` atomic-replace opt-out
(`allow_copy_fallback=False`) and the mkstemp/fsync/atomic-rename machinery
plus the daemon-restart metadata plumbing built on it — that changes a shared
core utility for a plugin-local concern and violates the plugin-boundary rule
(plugin fixes touch only `plugins/` + `tests/plugins/`). The 0600 + cleanup
guarantee is achieved without it.

---

### Verification
- `tests/hermes_cli/test_model_switch_context_offload.py`,
  `tests/gateway/test_model_command_context_offload.py`,
  `tests/gateway/test_model_command_async_offload.py`,
  `tests/gateway/test_model_switch_persistence.py`,
  `tests/hermes_cli/test_profile_distribution.py`,
  `tests/plugins/memory/` — **288 passed**.
- `ruff check` clean on all touched files.
- Branch rebased onto current `origin/main` before push.


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48d01/o6MFhsy7Wg-EGpRFDW8E1_3q9wcaZa.png)
