### PR TITLE
ci: skip Desktop E2E + Docker on tests-only PRs — cuts critical path ~8m→~3m for 17% of commits

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -15,6 +15,9 @@ outputs:
   python:
     description: Run Python tests / ruff / ty / windows-footguns.
     value: ${{ steps.classify.outputs.python }}
+  python_prod:
+    description: Python changes outside tests/ — gates product jobs (Desktop E2E, Docker).
+    value: ${{ steps.classify.outputs.python_prod }}
   frontend:
     description: Run the TypeScript testing matrix + desktop build.
     value: ${{ steps.classify.outputs.frontend }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       python: ${{ steps.classify.outputs.python }}
+      python_prod: ${{ steps.classify.outputs.python_prod }}
       frontend: ${{ steps.classify.outputs.frontend }}
       site: ${{ steps.classify.outputs.site }}
       scan: ${{ steps.classify.outputs.scan }}
@@ -89,7 +90,11 @@ jobs:
   e2e-desktop:
     name: Desktop E2E
     needs: detect
-    if: needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true'
+    # python_prod (not python): the Playwright suite exercises the built app
+    # + `hermes serve` backend, which never import anything under tests/.
+    # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
+    # single job in the workflow — while still running the full pytest lanes.
+    if: needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true'
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:
@@ -137,8 +142,10 @@ jobs:
     needs: detect
     # Trusted main pushes run docker.yml directly so its container-publish
     # environment secrets never cross this reusable-workflow call. PR runs
-    # remain build/test-only and secret-free.
-    if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.docker_meta == 'true')
+    # remain build/test-only and secret-free. Gated on python_prod (not
+    # python): the image copies installed code, never tests/ — tests-only
+    # PRs skip the build.
+    if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.docker_meta == 'true')
     uses: ./.github/workflows/docker.yml
 
   supply-chain:

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -9,6 +9,10 @@ booleans (one per lane) to ``$GITHUB_OUTPUT`` and stdout. The
 Lanes:
 
 * ``python``      — pytest / ruff / ty / footguns.
+* ``python_prod`` — Python changes OUTSIDE tests/ — gates jobs that ship or
+  run the product (Desktop E2E backend, Docker image) but never import the
+  test suite. A tests-only PR keeps ``python`` (pytest must run) while
+  skipping those product jobs.
 * ``docker_meta`` — Dockerfiles etc.
 * ``frontend``    — TS typecheck matrix + desktop build.
 * ``site``        — Docusaurus + generated skill docs.
@@ -74,6 +78,18 @@ def _py_irrelevant(p: str) -> bool:
     return _is_docs(p) or p in _ROOT_NPM or p.startswith(_PY_SKIP) or p.startswith(_DOCKER_META)
 
 
+def _py_test_only(p: str) -> bool:
+    """Is ``p`` inside the test suite (never shipped / imported by the product)?
+
+    Product jobs (Desktop E2E's ``hermes serve`` backend, the Docker image)
+    run installed code — nothing under ``tests/`` is packaged or importable
+    there. scripts/run_tests.sh and run_tests_parallel.py are deliberately
+    NOT test-only: they are runner infrastructure, and a bad edit there can
+    mask real failures, so they stay conservative (python_prod=true).
+    """
+    return p.startswith("tests/")
+
+
 def _is_scan(p: str) -> bool:
     return p.endswith(_SCAN_EXTS) or p in _SCAN_FILES
 
@@ -100,6 +116,7 @@ def classify(files: list[str]) -> dict[str, bool]:
     files = [f.strip() for f in files if f.strip()]
     ret = {
         "python": any(not _py_irrelevant(f) for f in files),
+        "python_prod": any(not _py_irrelevant(f) and not _py_test_only(f) for f in files),
         "docker_meta":  any(f.startswith(_DOCKER_META) for f in files),
         "frontend": any(f.startswith(_FRONTEND) or f in _ROOT_NPM for f in files),
         "site": any(f.startswith(_SITE) for f in files),
@@ -111,6 +128,7 @@ def classify(files: list[str]) -> dict[str, bool]:
     }
     if not files or any(f.startswith(".github/") for f in files):
         ret["python"] = True
+        ret["python_prod"] = True
         ret["docker_meta"] = True
         ret["frontend"] = True
         ret["site"] = True

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -23,6 +23,7 @@ ci_review_files = _mod.ci_review_files
 
 DEFAULT = {
     "python": True,
+    "python_prod": True,
     "frontend": True,
     "docker_meta": True,
     "site": True,
@@ -34,9 +35,12 @@ DEFAULT = {
 }
 
 
-def _lanes(python=False, frontend=False, site=False, scan=False, deps=False, npm_lock=False, mcp_catalog=False, docker_meta=False, ci_review=False) -> dict[str, bool]:
+def _lanes(python=False, frontend=False, site=False, scan=False, deps=False, npm_lock=False, mcp_catalog=False, docker_meta=False, ci_review=False, python_prod=None) -> dict[str, bool]:
+    # python_prod tracks python except for tests-only diffs; default it to
+    # python so the majority of cases don't need to spell it out.
     return {
         "python": python,
+        "python_prod": python if python_prod is None else python_prod,
         "frontend": frontend,
         "docker_meta": docker_meta,
         "site": site,
@@ -67,6 +71,22 @@ CASES = {
     "unknown toplevel → python": (["Makefile"], _lanes(python=True)),
     "mixed docs+python → python": (["README.md", "agent/x.py"], _lanes(python=True, scan=True)),
     "mixed docs+frontend → frontend": (["README.md", "apps/x.tsx"], _lanes(frontend=True)),
+    # tests-only diffs: pytest lanes stay ON, product jobs (Desktop E2E,
+    # Docker) gate on python_prod and skip.
+    "tests-only → python without python_prod": (
+        ["tests/agent/test_foo.py", "tests/conftest.py"],
+        _lanes(python=True, python_prod=False, scan=True),
+    ),
+    "tests + prod source → both lanes": (
+        ["tests/agent/test_foo.py", "agent/x.py"],
+        _lanes(python=True, scan=True),
+    ),
+    # Runner infrastructure is NOT tests-only — a bad runner edit can mask
+    # real failures, so it keeps the conservative full lane set.
+    "test runner script → python_prod stays on": (
+        ["scripts/run_tests_parallel.py"],
+        _lanes(python=True, scan=True),
+    ),
     # Supply-chain lanes
     ".pth file → scan": (["evil.pth"], _lanes(python=True, scan=True)),
     "setup.py → scan": (["setup.py"], _lanes(python=True, scan=True)),


### PR DESCRIPTION
## Summary
Tests-only PRs stop paying for Desktop E2E (5.2m — the longest CI job) and the Docker build: a new `python_prod` classifier lane gates product jobs on product code, cutting the critical path from ~8m to ~3m on 17% of commits (replay over the last 231 on main).

Context: the test-suite prune halved Python execution (slices now ~2.3m each), which moved CI's critical path to Desktop E2E + Docker — both of which run on every python-lane PR yet never consume `tests/` (Playwright drives the built app + `hermes serve`; the image copies installed code).

## Changes
- `scripts/ci/classify_changes.py`: new `python_prod` lane = python minus tests-only diffs; runner infra (`scripts/run_tests.sh`, `run_tests_parallel.py`) deliberately NOT tests-only (a bad runner edit can mask failures)
- `.github/workflows/ci.yml`: `e2e-desktop` and `docker` gate on `python_prod || frontend`; every pytest/lint lane still gates on `python`
- `.github/actions/detect-changes/action.yml`: expose the new output
- `tests/ci/test_classify_changes.py`: tests-only / mixed / runner-infra / fail-open cases

## Validation
| Gate | Result |
|---|---|
| tests/ci | 83 passed |
| Real-entrypoint E2E (stdin→outputs) | tests-only→prod=false; prod/mixed/.github/empty→prod=true (fail-open holds) |
| 231-commit main replay | 39 commits (17%) skip both jobs; 0 commits lose a lane they previously ran except the two product jobs by design |
| workflow YAML | parses clean |

Note: this PR touches `.github/` so its own CI run fails open (all lanes on) — the skip behavior shows up on the first tests-only PR after merge.

## Infographic

![ci path filter infographic](https://v3b.fal.media/files/b/0aa48d4b/5CEqowI3-OKyqHuk9CywB_4mfYUfkn.png)
