### PR TITLE
fix(auxiliary): recognize OpenAI data-residency hosts, not just api.openai.com

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5281,10 +5281,18 @@ def resolve_provider_client(
             return False
         if api_mode == "codex_responses":
             return True
-        # Auto-detect: api.openai.com + codex model name pattern
+        # Auto-detect: official OpenAI host + codex model name pattern.
+        # Routed through the shared predicate so OpenAI's documented
+        # data-residency hosts (us./eu.api.openai.com) auto-detect exactly
+        # like the canonical one. host_mandated_api_mode() already mandates
+        # codex_responses for them, so exact-hostname equality here left the
+        # auxiliary client unwrapped against an endpoint that requires the
+        # Responses API.
         if api_mode and api_mode != "codex_responses":
             return False  # explicit non-codex mode
-        if base_url_hostname(base_url_str) == "api.openai.com":
+        from hermes_cli.providers import is_official_openai_host
+
+        if is_official_openai_host(base_url_str):
             model_lower = (model_str or "").lower()
             if "codex" in model_lower:
                 return True
@@ -6360,11 +6368,17 @@ def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> di
     or_key = os.getenv("OPENROUTER_API_KEY")
     # Use max_completion_tokens for direct OpenAI-compatible providers that reject
     # max_tokens on newer GPT-4o/o-series/GPT-5-style models.
+    # The OpenAI arm goes through the shared predicate so the documented
+    # data-residency hosts (us./eu.api.openai.com) are recognised too — they
+    # serve the same models, which reject max_tokens. Copilot already
+    # dot-suffix-matches its own family just below.
+    from hermes_cli.providers import is_official_openai_host
+
     _custom_host = base_url_hostname(custom_base) or ""
     if (not or_key
             and _read_nous_auth() is None
             and (
-                _custom_host == "api.openai.com"
+                is_official_openai_host(custom_base)
                 or _custom_host == "api.githubcopilot.com"
                 or _custom_host.endswith(".githubcopilot.com")
             )):

--- a/tests/agent/test_auxiliary_openai_regional_hosts.py
+++ b/tests/agent/test_auxiliary_openai_regional_hosts.py
@@ -1,0 +1,92 @@
+"""The auxiliary client must treat OpenAI's regional hosts like the canonical one.
+
+``providers.is_official_openai_host()`` is the shared predicate: the canonical
+``api.openai.com`` plus OpenAI's documented data-residency hosts
+(``us.``/``eu.api.openai.com``), hostname-parsed so lookalikes stay rejected.
+``host_mandated_api_mode()`` already routes through it.
+
+Two auxiliary-client decisions still compared hostnames for exact equality, so
+on a residency host the auxiliary client picked the wrong transport and the
+wrong token parameter — both of which the endpoint rejects.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import agent.auxiliary_client as aux
+
+CANONICAL = "https://api.openai.com/v1"
+REGIONAL = ["https://us.api.openai.com/v1", "https://eu.api.openai.com/v1"]
+LOOKALIKE = "https://api.openai.com.attacker.test/v1"
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    """Stand in for the OpenAI SDK client so no network/credentials are needed."""
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            self.api_key = kwargs.get("api_key", "")
+            self.base_url = kwargs.get("base_url", "")
+
+    monkeypatch.setattr(aux, "OpenAI", _FakeOpenAI)
+    return _FakeOpenAI
+
+
+def _resolve(base_url: str, model: str = "gpt-5-codex"):
+    return aux.resolve_provider_client(
+        "custom",
+        model,
+        explicit_base_url=base_url,
+        explicit_api_key="sk-test",
+    )[0]
+
+
+@pytest.mark.parametrize("base_url", REGIONAL)
+def test_regional_host_wraps_codex_model_for_responses_api(fake_openai, base_url):
+    """The regression: a residency host mandates codex_responses, so wrap it."""
+    from hermes_cli.providers import host_mandated_api_mode
+
+    assert host_mandated_api_mode(base_url) == "codex_responses"
+    assert isinstance(_resolve(base_url), aux.CodexAuxiliaryClient)
+
+
+def test_canonical_host_still_wraps(fake_openai):
+    assert isinstance(_resolve(CANONICAL), aux.CodexAuxiliaryClient)
+
+
+def test_lookalike_host_is_not_treated_as_openai(fake_openai):
+    """Widening to the host family must not widen to spoofed hostnames."""
+    assert not isinstance(_resolve(LOOKALIKE), aux.CodexAuxiliaryClient)
+
+
+def test_unrelated_host_with_codex_named_model_is_not_wrapped(fake_openai):
+    """A codex-shaped model name alone must not force the Responses API."""
+    assert not isinstance(
+        _resolve("https://llm.internal.test/v1"), aux.CodexAuxiliaryClient
+    )
+
+
+@pytest.fixture
+def direct_openai_endpoint(monkeypatch):
+    """Isolate auxiliary_max_tokens_param from pool/OpenRouter short-circuits."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(aux, "_read_nous_auth", lambda: None)
+
+    def _point_at(base_url: str):
+        monkeypatch.setattr(aux, "_current_custom_base_url", lambda: base_url)
+
+    return _point_at
+
+
+@pytest.mark.parametrize("base_url", REGIONAL + [CANONICAL])
+def test_official_openai_hosts_use_max_completion_tokens(direct_openai_endpoint, base_url):
+    """Newer OpenAI models reject ``max_tokens``; residency hosts serve them too."""
+    direct_openai_endpoint(base_url)
+    assert aux.auxiliary_max_tokens_param(256) == {"max_completion_tokens": 256}
+
+
+def test_lookalike_host_keeps_plain_max_tokens(direct_openai_endpoint):
+    direct_openai_endpoint(LOOKALIKE)
+    assert aux.auxiliary_max_tokens_param(256) == {"max_tokens": 256}


### PR DESCRIPTION
## What

564e9b90a added `providers.is_official_openai_host()` — the canonical host plus OpenAI's documented `<region>.api.openai.com` data-residency hosts, hostname-parsed — and routed `host_mandated_api_mode()` through it, so a residency endpoint mandates `codex_responses` exactly like the canonical one.

Two decisions in `agent/auxiliary_client.py` kept comparing hostnames for exact equality, so the auxiliary client still disagrees with the endpoint about both its transport and its token parameter:

```
=== the shared predicate (564e9b90a) ===
   is_official_openai_host(https://us.api.openai.com/v1) = True
=== what the endpoint MANDATES (already migrated) ===
   host_mandated_api_mode(https://us.api.openai.com/v1)  = 'codex_responses'

=== site 1: _needs_codex_wrap  (auxiliary_client.py:5287) ===
   https://api.openai.com/v1          wrap=True
   https://us.api.openai.com/v1       wrap=False   <-- endpoint mandates codex_responses
   https://eu.api.openai.com/v1       wrap=False

=== site 2: auxiliary_max_tokens_param  (auxiliary_client.py:6367) ===
   https://api.openai.com/v1          -> max_completion_tokens
   https://us.api.openai.com/v1       -> max_tokens   <-- newer OpenAI models reject this
   https://eu.api.openai.com/v1       -> max_tokens
```

Driven end-to-end through `resolve_provider_client("custom", "gpt-5-codex", explicit_base_url=…)`:

```
BEFORE   https://api.openai.com/v1     -> CodexAuxiliaryClient
         https://us.api.openai.com/v1  -> plain OpenAI client   (unwrapped)
AFTER    both                          -> CodexAuxiliaryClient
```

`auxiliary_max_tokens_param` already dot-suffix-matches Copilot's host family (`_custom_host.endswith(".githubcopilot.com")`) one line below the OpenAI arm — the family concept was there, it just wasn't applied to OpenAI.

The auxiliary client backs compression summaries, session titles, goal judging and kanban decompose, so a data-residency install loses all of them.

## Fix

Route both decisions through `is_official_openai_host()`. Function-local import, matching how this module already pulls `nous_api_mode` from `hermes_cli.providers`.

## Tests

`tests/agent/test_auxiliary_openai_regional_hosts.py` — 9 tests; the 4 residency cases fail without the fix:

- a residency host wraps a codex model for the Responses API (parametrised `us.` / `eu.`), asserted alongside `host_mandated_api_mode() == "codex_responses"` so the two can't drift apart again
- the canonical host still wraps
- official hosts use `max_completion_tokens` (parametrised canonical + `us.` + `eu.`)
- **a lookalike host (`api.openai.com.attacker.test`) is not treated as OpenAI** — in both decisions
- an unrelated endpoint with a codex-shaped model name is not wrapped

```
scripts/run_tests.sh tests/agent/test_auxiliary_openai_regional_hosts.py
=== Summary: 1 files, 9 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 5 tests passed, 4 failed ===
```

Existing suites, green via `scripts/run_tests.sh`: all 20 `tests/agent/test_auxiliary*.py` files (**281 passed**), plus `test_official_openai_host.py` and `test_auxiliary_client_base_url_host_validation_52608.py` (**22 passed**).

