### PR TITLE
docs(kanban): document profile-owned notification delivery in multi-gateway setups

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -904,6 +904,30 @@ hermes kanban notify-unsubscribe t_abcd \
 
 A subscription removes itself automatically once the task reaches `done` or `archived`; no cleanup needed.
 
+### Multi-profile setups: delivery is profile-owned
+
+In a one-gateway-per-profile deployment (one dispatcher, separate gateway
+processes for `writer`, `admin`, etc. — see the [multi-gateway
+guide](https://github.com/NousResearch/hermes-agent/blob/main/docs/kanban/multi-gateway.md)),
+dispatch and delivery have separate owners:
+
+- **Dispatch stays single-owner.** Exactly one gateway keeps
+  `kanban.dispatch_in_gateway: true` and runs the dispatcher; every other
+  gateway sets it to `false`.
+- **Notification delivery is profile-owned.** Every gateway — including
+  non-dispatch ones — runs the notifier and polls only subscriptions stamped
+  with a profile whose platform adapters it hosts. A task created from the
+  `writer` profile's Telegram gets its `completed`/`blocked` message delivered
+  by the `writer` gateway, even though the `default` gateway did the
+  dispatching.
+- **Legacy subscriptions** created before profile stamping (no
+  `notifier_profile` on the row) are delivered only by the gateway that holds
+  the actual dispatcher singleton lock, so two gateways never race for them.
+
+Duplicate delivery across gateways is prevented by the atomic per-event claim
+in the board DB. No relays, credential sharing, or extra dispatchers are
+needed — each profile gateway simply delivers through its own adapters.
+
 ## Runs — one row per attempt
 
 A task is a logical unit of work; a **run** is one attempt to execute it. When the dispatcher claims a ready task it creates a row in `task_runs` and points `tasks.current_run_id` at it. When that attempt ends — completed, blocked, crashed, timed out, spawn-failed, reclaimed — the run row closes with an `outcome` and the task's pointer clears. A task that's been attempted three times has three `task_runs` rows.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -664,6 +664,26 @@ hermes kanban notify-unsubscribe t_abcd \
 
 订阅在任务达到 `done` 或 `archived` 后自动移除；无需清理。
 
+### 多 profile 部署：投递按 profile 归属
+
+在每个 profile 一个 gateway 的部署中（单一调度器，`writer`、`admin` 等各自
+运行独立的 gateway 进程 —— 参见[多 gateway 指南](https://github.com/NousResearch/hermes-agent/blob/main/docs/kanban/multi-gateway.md)），
+调度与投递的归属是分开的：
+
+- **调度保持单一所有者。** 只有一个 gateway 保持
+  `kanban.dispatch_in_gateway: true` 并运行调度器；其余 gateway 都设为
+  `false`。
+- **通知投递按 profile 归属。** 每个 gateway —— 包括非调度 gateway ——
+  都运行通知器，且只轮询标记了其所托管 profile 的订阅。从 `writer`
+  profile 的 Telegram 创建的任务，其 `completed`/`blocked` 消息由
+  `writer` gateway 投递，即使调度是由 `default` gateway 完成的。
+- **遗留订阅**（在 profile 标记之前创建、行上没有 `notifier_profile`
+  的订阅）只由实际持有调度器单例锁的 gateway 投递，因此两个 gateway
+  永远不会争抢它们。
+
+board 数据库中的原子化逐事件认领可防止跨 gateway 的重复投递。不需要中继、
+凭证共享或额外的调度器 —— 每个 profile gateway 只通过它自己的适配器投递。
+
 ## 运行记录 —— 每次尝试一行
 
 任务是一个逻辑工作单元；**运行**是执行它的一次尝试。当调度器认领一个就绪任务时，它在 `task_runs` 中创建一行，并将 `tasks.current_run_id` 指向它。当该尝试结束时 —— 完成、阻塞、崩溃、超时、启动失败、回收 —— 运行行以 `outcome` 关闭，任务的指针清除。被尝试三次的任务有三行 `task_runs`。


### PR DESCRIPTION
## Summary
Documents the profile-owned kanban notification delivery model shipped in PR #75592 — the website kanban docs now explain how notifications work in one-dispatcher / many-profile-gateway deployments.

## Changes
- `website/docs/user-guide/features/kanban.md`: new "Multi-profile setups: delivery is profile-owned" subsection under Gateway notifications — dispatch stays single-owner, every gateway delivers its own profiles' subscriptions, legacy unstamped rows go through the confirmed dispatcher-lock owner, duplicate delivery prevented by the atomic event claim.
- `website/i18n/zh-Hans/.../kanban.md`: same subsection in Simplified Chinese.

## Validation
| | Result |
|---|---|
| `npx docusaurus build` | SUCCESS (en + zh-Hans; only pre-existing unrelated anchor warnings) |

## Infographic

![Kanban profile-owned notification delivery](https://v3b.fal.media/files/b/0aa48d68/66qfjhlFmUBwJKWrnzXH0_EIpMfr1q.png)
