### PR TITLE
fix(config): refuse to write when config.yaml has YAML syntax errors

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4837,8 +4837,15 @@ def set_config_value(key: str, value: str, force: bool = False):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -5045,8 +5052,15 @@ def unset_config_value(key: str):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     removed = _unset_nested(user_config, key)
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -688,3 +688,39 @@ class TestScalarModelSubKeyPreservation:
         parsed = yaml.safe_load(raw)
         assert parsed["model"]["default"] == "claude-sonnet"
         assert parsed["model"]["api_key"] == "sk-test"
+
+
+class TestMalformedYAMLConfigPreservation:
+    """#75431: config.yaml with YAML syntax errors must not be overwritten."""
+
+    BROKEN_CONFIG = "model: gpt-4o\nterminal:\n  backend: docker\n  broken: [this is invalid YAML"
+
+    def _write_broken_config(self, home):
+        (home / "config.yaml").write_text(self.BROKEN_CONFIG)
+
+    def test_set_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """set_config_value must exit with error, not overwrite the broken config."""
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            set_config_value("agent.max_turns", "50")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        # Original config must remain intact
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG, f"Config was overwritten:\n{raw}"
+
+    def test_unset_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """unset_config_value must exit with error, not overwrite the broken config."""
+        from hermes_cli.config import unset_config_value
+
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            unset_config_value("model")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG


### PR DESCRIPTION
## Summary
`hermes config set`/`unset` no longer wipe the entire config.yaml when the file has a YAML syntax error: the load path's `except Exception: user_config = {}` fallback followed by an atomic full-file write meant one stray character destroyed the whole config with exit 0. Both CLI sites now fail closed — the file is preserved byte-identical and the user is told to fix the syntax.

This extends the exact invariant main already enforces one layer down (`require_readable_config_before_write` refuses to clobber a config that can't be *read*) to files that can't be *parsed*.

Salvaged from #75431 by @Baophan00 with authorship preserved (2 commits cherry-picked onto current main; test-file conflict with the just-merged #75867 mapping-guard tests resolved by keeping both suites).

## Changes
- `hermes_cli/config.py`: parse-failure guard in the set and unset write paths.
- `tests/hermes_cli/test_set_config_value.py`: regression tests asserting byte-identical preservation on both paths.

## Validation
| | Before | After |
|---|---|---|
| `config set x y` with broken YAML | config wiped, exit 0 | refused, file untouched |
| `config unset x` with broken YAML | config wiped | refused, file untouched |
| tests/hermes_cli/test_set_config_value.py | — | 80/80 pass |

## Infographic

![broken yaml no longer wipes config](https://v3b.fal.media/files/b/0aa48d74/Yrmtd0m7iXT8VjaXChMu6_xACTSjKw.png)
