### PR TITLE
fix(config): preserve scalar model id when setting model sub-keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4860,6 +4860,16 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+    # Normalize a scalar ``model`` key before writing sub-keys so that
+    # ``hermes config set model.provider openai`` doesn't silently
+    # destroy the model id when ``model`` is a bare string shorthand
+    # (e.g. ``model: gpt-4o``).  Without this _set_nested replaces the
+    # scalar with an empty dict, dropping the model id permanently.
+    _model_key = key.strip().lower()
+    if _model_key.startswith("model."):
+        _model_val = user_config.get("model")
+        if isinstance(_model_val, str) and _model_val:
+            user_config["model"] = {"default": _model_val}
     # Guard against #74995: a single-segment key that names an existing
     # mapping would silently overwrite the entire section with a scalar
     # (e.g. ``hermes config set model gpt-5.6-sol`` when model already

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -658,3 +658,33 @@ class TestMappingGuard:
         import yaml as _yaml
         parsed = _yaml.safe_load(_read_config(_isolated_hermes_home))
         assert parsed["model"] == "claude-opus-4"
+
+
+class TestScalarModelSubKeyPreservation:
+    """#75426: setting model.provider when model is a scalar must not lose the model id."""
+
+    def test_scalar_model_id_preserved_after_provider_write(self, _isolated_hermes_home):
+        """Seed model: gpt-4o, then set model.provider → model.default must survive."""
+        import yaml
+
+        set_config_value("model", "gpt-4o")
+        set_config_value("model.provider", "openai")
+
+        raw = _read_config(_isolated_hermes_home)
+        parsed = yaml.safe_load(raw)
+        model = parsed["model"]
+        assert model["default"] == "gpt-4o", f"model.default lost: {model}"
+        assert model["provider"] == "openai"
+
+    def test_scalar_model_id_preserved_after_api_key_write(self, _isolated_hermes_home):
+        """model.api_key must also preserve the existing scalar model id."""
+        import yaml
+
+        set_config_value("model", "claude-sonnet")
+        # model.api_key is a sub-key (has a dot), so it stays in config.yaml
+        set_config_value("model.api_key", "sk-test")
+
+        raw = _read_config(_isolated_hermes_home)
+        parsed = yaml.safe_load(raw)
+        assert parsed["model"]["default"] == "claude-sonnet"
+        assert parsed["model"]["api_key"] == "sk-test"


### PR DESCRIPTION
## Summary
`hermes config set model.<sub-key> <value>` no longer destroys the model id when `model:` is the bare string shorthand — the scalar is promoted to `{"default": <id>}` before the nested write, so both values survive. Previously `_set_nested` replaced the scalar with `{}`, dropping the model id permanently.

This is the second direction of the string-or-dict `config.model` pitfall: the just-merged #75867 guards *mapping → scalar write*; this guards *scalar → dotted write*. Together they close the class.

Salvaged from #75426 by @Baophan00 with authorship preserved (2 commits cherry-picked onto current main; conflicts with the sibling #75867/#75431 hunks in the same function resolved — normalization runs before the mapping guard).

## Changes
- `hermes_cli/config.py`: scalar-model promotion before `model.*` dotted writes (mirrors `_normalize_root_model_keys` at write time).
- `tests/hermes_cli/test_set_config_value.py`: regression test for sub-key preservation.

## Validation
| | Before | After |
|---|---|---|
| `model: gpt-4o` + `set model.provider openai` | id dropped, `model: {provider: openai}` | `model: {default: gpt-4o, provider: openai}` |
| tests/hermes_cli/test_set_config_value.py | — | 80/80 pass |

## Infographic

![scalar model id preserved](https://v3b.fal.media/files/b/0aa48d86/HDhqE8GBEHFVzZUYklJKY_urV7Ho9U.png)
