### PR TITLE
fix(npm): restore web's @nous-research/ui 0.18.2 pin and lockfile integrity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18734,7 +18734,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hermes/shared": "file:../apps/shared",
-        "@nous-research/ui": "0.16.0",
+        "@nous-research/ui": "0.18.2",
         "@observablehq/plot": "0.6.17",
         "@react-three/fiber": "9.6.1",
         "@tailwindcss/vite": "4.3.3",
@@ -18772,6 +18772,8 @@
     },
     "web/node_modules/@nous-research/ui": {
       "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@nous-research/ui/-/ui-0.18.2.tgz",
+      "integrity": "sha512-xe//1PjCapafXu5onqnJW50MhAK41LXuHw2KvfHDLiI3TBeqtX4QEm4mTrWZaZ2PRqM6koY/o19fdgisB67LGA==",
       "license": "MIT",
       "dependencies": {
         "@nanostores/react": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hermes/shared": "file:../apps/shared",
-    "@nous-research/ui": "0.16.0",
+    "@nous-research/ui": "0.18.2",
     "@observablehq/plot": "0.6.17",
     "@react-three/fiber": "9.6.1",
     "@tailwindcss/vite": "4.3.3",


### PR DESCRIPTION
## Problem

`nix build .#messaging` fails with `ENOTCACHED` on `@nous-research/ui`. The `web/node_modules/@nous-research/ui` entry in `package-lock.json` lost its `resolved` and `integrity` in `390a1771b`, and `importNpmLock` prefetches from those hashes, so npm reaches for the network inside the sandbox. Every npm-dependent output is affected; it surfaces in `hermes-tui` only because the whole workspace installs in one pass.

`515e88a80` separately set `web/package.json` to `0.16.0` while the lockfile still installs `0.18.2` under `web/`, so `npm ls --depth=0` reports `ELSPROBLEMS`.

## Fix

Restore the two lockfile fields, and put web's pin back to `0.18.2` — the version it has resolved to since `a51a7b9b9`. `0.16.0` ships none of the `hooks/use-*` and `ui/components/*` modules web imports (117 `TS2307`s).

Verified with `nix build .#messaging`, `npm ls --depth=0` and `npm --prefix web run typecheck` on NixOS x86_64-linux.
