### PR TITLE
fix(desktop): refuse a second update hand-off while one is already live (salvage #75790)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3036,6 +3036,24 @@ async function handOffWindowsBootstrapRecovery(reason) {
     return false
   }
 
+  const handoffConflict = updateHandoffConflict(HERMES_HOME)
+
+  if (handoffConflict) {
+    // Same hazard as applyUpdates (#75778): a live foreign updater already
+    // owns the marker. Spawning another here would overwrite its claim and
+    // race a second updater over the same install tree. The live updater
+    // is already working on this exact install and will restart us when
+    // it finishes, so treat this the same as a successful hand-off instead
+    // of clobbering it with our own.
+    rememberLog(`[bootstrap] refusing recovery hand-off: ${handoffConflict.message}`)
+    isQuittingForHandoff = true
+    setTimeout(() => {
+      app.quit()
+    }, UPDATE_HANDOFF_DWELL_MS)
+
+    return true
+  }
+
   const updateRoot = resolveUpdateRoot()
   const { branch: configuredBranch } = readDesktopUpdateConfig()
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -189,7 +189,7 @@ import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
-import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
+import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
   buildRelaunchScript,
@@ -2888,6 +2888,19 @@ async function applyUpdates(opts = {}) {
       emitUpdateProgress({ stage: 'manual', message: command, percent: null })
 
       return { ok: true, manual: true, command, hermesRoot: updateRoot }
+    }
+
+    const handoffConflict = updateHandoffConflict(HERMES_HOME)
+
+    if (handoffConflict) {
+      // A different updater already owns the marker — most often a previous
+      // "Update" click whose updater is still alive and parked mid-run.
+      // Spawning another here would overwrite its claim and let two updaters
+      // mutate the checkout at once (#75778); refuse instead.
+      rememberLog(`[updates] refusing hand-off: ${handoffConflict.message}`)
+      emitUpdateProgress({ stage: 'error', message: handoffConflict.message, percent: null })
+
+      return { ok: false, error: 'update-already-running', message: handoffConflict.message }
     }
 
     emitUpdateProgress({

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -24,6 +24,7 @@ import {
   markerPath,
   readLiveUpdateMarker,
   UPDATE_MARKER_MAX_AGE_MS,
+  updateHandoffConflict,
   writeUpdateMarker
 } from './update-marker'
 
@@ -127,4 +128,52 @@ test('writeUpdateMarker + dead pid => self-heals on read', () => {
   const res = readLiveUpdateMarker(home, { kill: DEAD })
   assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
   assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
+})
+
+// ---------------------------------------------------------------------------
+// updateHandoffConflict (#75778)
+//
+// A retried "Update" click must not spawn a second updater over a still-live
+// one — writeUpdateMarker unconditionally overwrites the marker, so an
+// unchecked hand-off clobbers the original updater's claim while it is still
+// alive and mutating the checkout.
+// ---------------------------------------------------------------------------
+
+test('no marker => hand-off is not blocked', () => {
+  const home = tmpHome('conflict-none')
+  assert.equal(updateHandoffConflict(home, { kill: ALIVE }), null)
+})
+
+test('a different live updater already owns the marker => hand-off is blocked', () => {
+  const home = tmpHome('conflict-live')
+  const now = 1_000_000_000_000
+  writeMarker(home, 1010, Math.floor(now / 1000) - 6) // 6s old
+  const conflict = updateHandoffConflict(home, { kill: ALIVE, now: () => now })
+  assert.ok(conflict, 'a live foreign updater must block a new hand-off')
+  assert.equal(conflict.pid, 1010)
+  assert.match(conflict.message, /already running/)
+  assert.match(conflict.message, /PID 1010/)
+  assert.match(conflict.message, /6s/)
+})
+
+test('a dead-pid marker does not block a hand-off (self-heals)', () => {
+  const home = tmpHome('conflict-dead')
+  writeMarker(home, 999999, Math.floor(Date.now() / 1000))
+  assert.equal(updateHandoffConflict(home, { kill: DEAD }), null)
+})
+
+test('an expired marker does not block a hand-off (self-heals)', () => {
+  const home = tmpHome('conflict-expired')
+  const now = 1_000_000_000_000
+  writeMarker(home, 1010, Math.floor((now - UPDATE_MARKER_MAX_AGE_MS - 60_000) / 1000))
+  assert.equal(updateHandoffConflict(home, { kill: ALIVE, now: () => now }), null)
+})
+
+test('minutes-scale elapsed time is formatted as "Nm Ss"', () => {
+  const home = tmpHome('conflict-minutes')
+  const now = 1_000_000_000_000
+  writeMarker(home, 1010, Math.floor(now / 1000) - 125) // 2m 5s old
+  const conflict = updateHandoffConflict(home, { kill: ALIVE, now: () => now })
+  assert.ok(conflict)
+  assert.match(conflict.message, /2m 5s/)
 })

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -136,3 +136,47 @@ export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
     // updater will write its own when it reaches run_update.
   }
 }
+
+/**
+ * Whether a NEW updater hand-off must be refused because a different,
+ * already-alive updater currently owns the marker (#75778).
+ *
+ * `writeUpdateMarker` unconditionally overwrites the marker file. Called
+ * before every hand-off with no conflict check, a user who clicks "Update"
+ * again while a prior updater is still parked mid-run (e.g. "waiting for
+ * Hermes to exit…") clobbers that still-running updater's claim: the
+ * retry's pre-write now names the NEW child, so the OLD process — alive
+ * and mutating the checkout — is no longer recorded as the owner. A second
+ * live updater can then run over the same tree unrecorded, the exact
+ * two-updaters-at-once hazard `UpdateMarkerGuard` in the Rust updater
+ * exists to prevent (apps/bootstrap-installer/src-tauri/src/update.rs).
+ *
+ * Returns the live foreign owner (with a ready-to-show message) when the
+ * hand-off must be refused, or `null` when it's safe to spawn — no marker,
+ * or the existing one is stale/dead and self-heals via
+ * `readLiveUpdateMarker`.
+ */
+export function updateHandoffConflict(
+  hermesHome,
+  opts: {
+    now?: () => number
+    maxAgeMs?: number
+    kill?: typeof process.kill
+  } = {}
+) {
+  const owner = readLiveUpdateMarker(hermesHome, opts)
+
+  if (!owner) {
+    return null
+  }
+
+  const mins = Math.floor(owner.ageMs / 60_000)
+  const secs = Math.floor((owner.ageMs % 60_000) / 1000)
+  const elapsed = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`
+
+  return {
+    pid: owner.pid,
+    ageMs: owner.ageMs,
+    message: `An update is already running (PID ${owner.pid}, started ${elapsed} ago). Wait for it to finish, then try again.`
+  }
+}

--- a/contributors/emails/chelsealong@126.com
+++ b/contributors/emails/chelsealong@126.com
@@ -1,0 +1,1 @@
+chelsealong


### PR DESCRIPTION
## Summary
A retried "Update" click (or an automatic bootstrap-recovery hand-off) can no longer clobber a still-running updater's marker claim — the desktop now refuses the second hand-off while a live foreign updater owns the lock.

Root cause: `writeUpdateMarker()` unconditionally overwrote `HERMES_HOME/.hermes-update-in-progress` before every hand-off. A user retrying Update while a prior updater was alive and parked renamed the marker to the new child's pid, erasing the live updater's recorded ownership — two updaters could then mutate the same checkout, the exact hazard the marker exists to prevent. Contributing factor 4 in #75778's analysis.

Salvages PR #75790 by @chelsealong — both commits cherry-picked cleanly onto current main with authorship preserved.

## Changes
- `apps/desktop/electron/update-marker.ts`: new pure `updateHandoffConflict(hermesHome, opts)` — reports the live foreign marker owner (pid + ready-to-show message) blocking a hand-off, or `null` when safe
- `apps/desktop/electron/main.ts`: guard wired at both hazard sites — `applyUpdates` (retry path: refuse with error + progress event) and `handOffWindowsBootstrapRecovery` (recovery path: quit like a successful hand-off instead of double-spawning; its own comment had already noted the window, unguarded)
- `apps/desktop/electron/update-marker.test.ts`: 5 new unit tests (no marker, live foreign owner, dead-pid self-heal, expired self-heal, minutes-scale formatting)
- `contributors/emails/chelsealong@126.com`: attribution mapping

## Validation
| | Before | After |
|---|---|---|
| Retry click while updater A is live | marker renamed to B, A's claim lost | hand-off refused: "An update is already running (PID …)" |
| Bootstrap recovery during live update | second updater spawned over A | desktop quits; A finishes and restarts it |
| update-marker.test.ts | 10 tests | 15/15 pass |

Contributor's PR body includes a sabotage run proving the new tests fail without the fix. Scope note: this deliberately does not claim the issue's initial duplicate-spawn (0.5s after the first click) — root cause there is still unestablished per the reporter; this fixes the code-provable clobber in the retry and recovery paths.

Addresses the marker-clobber mechanism of #75778 (closes #75790 by salvage).

## Infographic

![Update hand-off: one owner at a time](https://v3b.fal.media/files/b/0aa48db6/tHw45bQOJRj3VIhRUlQam_dTrTGLkO.png)
