### PR TITLE
fix(image_gen): sniff real image format from magic bytes

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -236,19 +236,49 @@ def _images_cache_dir() -> Path:
     return path
 
 
+def _sniff_image_extension(raw: bytes) -> str:
+    """Sniff the real image format from magic bytes.
+
+    ponytail: 12 bytes is enough for all supported formats; no imghdr
+    dependency needed.
+    """
+    if raw[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if raw[:3] == b"\xff\xd8\xff":
+        return "jpg"
+    if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "webp"
+    if raw[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+    return "png"
+
+
 def save_b64_image(
     b64_data: str,
     *,
     prefix: str = "image",
-    extension: str = "png",
+    extension: str = "",
+    data_uri_mime: str = "",
 ) -> Path:
     """Decode base64 image data and write it under ``$HERMES_HOME/cache/images/``.
 
-    Returns the absolute :class:`Path` to the saved file.
+    Extension resolved in priority order:
+    1. Caller-supplied ``extension`` (explicit override)
+    2. ``data_uri_mime`` parsed from ``data:image/...;base64`` prefix
+    3. Magic-byte sniffing on decoded bytes
 
-    Filename format: ``<prefix>_<YYYYMMDD_HHMMSS>_<short-uuid>.<ext>``.
+    Returns the absolute :class:`Path` to the saved file.
     """
     raw = base64.b64decode(b64_data)
+    if not extension:
+        mime_map = {
+            "image/png": "png",
+            "image/jpeg": "jpg",
+            "image/jpg": "jpg",
+            "image/webp": "webp",
+            "image/gif": "gif",
+        }
+        extension = mime_map.get(data_uri_mime, "") or _sniff_image_extension(raw)
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     short = uuid.uuid4().hex[:8]
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -450,8 +450,20 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
             first = images[0]
             try:
                 if first.startswith("data:"):
+                    # Parse MIME from data URI so save_b64_image names
+                    # the file with the correct extension.
+                    mime_header = ""
+                    end = -1
+                    for i, ch in enumerate(first):
+                        if ch in (',', ';'):
+                            end = i
+                            break
+                    if end > 5 and '/' in first[5:end]:
+                        mime_header = first[5:end]
                     b64 = first.split(",", 1)[1] if "," in first else ""
-                    saved_path = save_b64_image(b64, prefix=f"{self._name}_gen")
+                    saved_path = save_b64_image(
+                        b64, prefix=f"{self._name}_gen", data_uri_mime=mime_header,
+                    )
                 else:
                     saved_path = save_url_image(first, prefix=f"{self._name}_gen")
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Problem

`save_b64_image` hardcodes `extension="png"` regardless of actual format. OpenRouter (Gemini 3 Pro Image) returns JPEG data URIs (`data:image/jpeg;base64,...`), but files are saved as `.png` with JPEG bytes. Plugins that validate magic bytes vs extension (e.g. post_discord_message, MIME-sniffing adapters) correctly reject the mismatch.

## Fix

**`agent/image_gen_provider.py`** — Extension resolved in priority order:
1. Caller-supplied `extension` (explicit override, backward-compatible)
2. `data_uri_mime` parsed from `data:image/jpeg;base64` prefix
3. Magic-byte sniff (`_sniff_image_extension` — PNG/JPEG/WEBP/GIF, 12 bytes)

**`plugins/image_gen/openrouter/__init__.py`** — Parses MIME from data URI header, passes to `save_b64_image`.

## Impact

All providers calling `save_b64_image` without explicit extension (OpenRouter, xAI, DeepInfra, OpenAI, OpenAI-codex) now get correct extensions via the magic-byte fallback.

## Verification

```
# Before: JPEG bytes in .png file → downstream rejection
$ file cache/images/openrouter_gen_*.png
JPEG image data  # WRONG: .png suffix, JPEG bytes

# After: correct extension from magic bytes  
$ file cache/images/openrouter_gen_*.jpg
JPEG image data  # CORRECT
```