### PR TITLE
chore: add hans@groupg.org → hansai-art to AUTHOR_MAP

### DIFF
--- a/contributors/emails/hans@groupg.org
+++ b/contributors/emails/hans@groupg.org
@@ -1,0 +1,1 @@
+hansai-art


### PR DESCRIPTION
## Summary
Adds contributor email mapping for @hansai-art (PR #66011).

## Changes
- contributors/emails/hans@groupg.org: new mapping file

## Why
Git author email `hans@groupg.org` does not auto-resolve to GitHub login `hansai-art`. Required for the contributor audit to pass on salvage PR #66011.