### PR TITLE
fix(agent): skip install-tree subdirectory hints

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -27,7 +27,6 @@ import threading
 import time
 import uuid
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -42,7 +41,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
-from agent.runtime_cwd import _is_install_tree
+from agent.runtime_cwd import _is_install_tree, resolve_agent_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -2653,15 +2652,13 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
-    _terminal_cwd = os.getenv("TERMINAL_CWD") or None
-    _configured_install_tree = bool(
-        _terminal_cwd and _is_install_tree(Path(_terminal_cwd).expanduser())
-    )
+    _session_cwd = resolve_agent_cwd()
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=_terminal_cwd,
-        allow_install_tree=(
-            _configured_install_tree or agent.platform in ("cli", "tui")
-        ),
+        working_dir=str(_session_cwd),
+        # Only a session actually rooted in the installation tree may treat
+        # its contributor files as workspace instructions. Platform identity
+        # alone is not authority: a TUI rooted at $HOME can visit this tree.
+        allow_install_tree=_is_install_tree(_session_cwd),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -27,6 +27,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -41,6 +42,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import _is_install_tree
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -2652,9 +2654,14 @@ def init_agent(
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
     _terminal_cwd = os.getenv("TERMINAL_CWD") or None
+    _configured_install_tree = bool(
+        _terminal_cwd and _is_install_tree(Path(_terminal_cwd).expanduser())
+    )
     agent._subdirectory_hints = SubdirectoryHintTracker(
         working_dir=_terminal_cwd,
-        allow_install_tree=bool(_terminal_cwd) or agent.platform in ("cli", "tui"),
+        allow_install_tree=(
+            _configured_install_tree or agent.platform in ("cli", "tui")
+        ),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2651,8 +2651,10 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    _terminal_cwd = os.getenv("TERMINAL_CWD") or None
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=_terminal_cwd,
+        allow_install_tree=bool(_terminal_cwd) or agent.platform in ("cli", "tui"),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,7 +19,6 @@ import uuid
 from collections import deque
 from contextlib import suppress
 from datetime import datetime
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
@@ -2113,13 +2112,13 @@ def _snapshot_primary_runtime(agent):
 
 
 def _init_usage_state(agent):
-    from agent.runtime_cwd import _is_install_tree, scope_terminal_cwd
-    terminal_cwd = scope_terminal_cwd()
+    from agent.runtime_cwd import _is_install_tree, resolve_agent_cwd
+    session_cwd = resolve_agent_cwd()
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=terminal_cwd or None,
-        allow_install_tree=bool(
-            terminal_cwd and _is_install_tree(Path(terminal_cwd).expanduser())
-        ),
+        working_dir=str(session_cwd),
+        # Platform identity alone is not authority: a TUI rooted at $HOME can
+        # visit the install tree. Only an in-tree session root opts in.
+        allow_install_tree=_is_install_tree(session_cwd),
     )
     _set_defaults(agent, _USAGE_STATE)
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ import uuid
 from collections import deque
 from contextlib import suppress
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
@@ -2112,8 +2113,14 @@ def _snapshot_primary_runtime(agent):
 
 
 def _init_usage_state(agent):
-    from agent.runtime_cwd import scope_terminal_cwd
-    agent._subdirectory_hints = SubdirectoryHintTracker(working_dir=scope_terminal_cwd() or None)
+    from agent.runtime_cwd import _is_install_tree, scope_terminal_cwd
+    terminal_cwd = scope_terminal_cwd()
+    agent._subdirectory_hints = SubdirectoryHintTracker(
+        working_dir=terminal_cwd or None,
+        allow_install_tree=bool(
+            terminal_cwd and _is_install_tree(Path(terminal_cwd).expanduser())
+        ),
+    )
     _set_defaults(agent, _USAGE_STATE)
 
 

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -222,7 +222,7 @@ class SubdirectoryHintTracker:
             return False
         if path in self._loaded_dirs:
             return False
-        if _is_install_tree(path):
+        if _is_install_tree(path) and not _is_install_tree(self.working_dir):
             return False
         # Reject paths outside the working directory tree.
         # path.resolve() may differ from working_dir.resolve() due to symlinks,
@@ -261,6 +261,9 @@ class SubdirectoryHintTracker:
         Only loads hints from directories within the working directory tree.
         """
         self._loaded_dirs.add(directory)
+
+        if _is_install_tree(directory) and not _is_install_tree(self.working_dir):
+            return None
 
         # Reject paths outside the working directory tree.
         try:

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _scan_context_content
+from agent.runtime_cwd import _is_install_tree
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +221,8 @@ class SubdirectoryHintTracker:
         except OSError:
             return False
         if path in self._loaded_dirs:
+            return False
+        if _is_install_tree(path):
             return False
         # Reject paths outside the working directory tree.
         # path.resolve() may differ from working_dir.resolve() due to symlinks,

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -82,8 +82,18 @@ class SubdirectoryHintTracker:
             tool_result += hints  # append to the tool result string
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(
+        self,
+        working_dir: Optional[str] = None,
+        *,
+        allow_install_tree: Optional[bool] = None,
+    ):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
+        # Explicit callers may deliberately use a Hermes checkout as their
+        # workspace. A fallback cwd must opt in explicitly (CLI/TUI only).
+        self.allow_install_tree = (
+            working_dir is not None if allow_install_tree is None else allow_install_tree
+        )
         self._loaded_dirs: Set[Path] = set()
         # Content digests already injected — prevents re-sending the same file
         # reachable through symlinks, hardlinks, or duplicated copies.
@@ -222,7 +232,7 @@ class SubdirectoryHintTracker:
             return False
         if path in self._loaded_dirs:
             return False
-        if _is_install_tree(path) and not _is_install_tree(self.working_dir):
+        if _is_install_tree(path) and not self.allow_install_tree:
             return False
         # Reject paths outside the working directory tree.
         # path.resolve() may differ from working_dir.resolve() due to symlinks,
@@ -262,7 +272,7 @@ class SubdirectoryHintTracker:
         """
         self._loaded_dirs.add(directory)
 
-        if _is_install_tree(directory) and not _is_install_tree(self.working_dir):
+        if _is_install_tree(directory) and not self.allow_install_tree:
             return None
 
         # Reject paths outside the working directory tree.

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _read_text_with_timeout, _scan_context_content, _truncate_content
+from agent.runtime_cwd import _is_install_tree
 from agent.search_policy import SEARCH_PRUNE_DIR_NAMES
 
 logger = logging.getLogger(__name__)
@@ -141,7 +142,12 @@ class SubdirectoryHintTracker:
                 return False
         except OSError:
             return False
-        return path not in self._loaded_dirs and self._within_working_dir(path) and not self._is_excluded(path)
+        return (
+            path not in self._loaded_dirs
+            and not _is_install_tree(path)
+            and self._within_working_dir(path)
+            and not self._is_excluded(path)
+        )
 
     def _is_excluded(self, path: Path) -> bool:
         """True when a segment *below* the working dir is an excluded copy dir

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -60,7 +60,12 @@ class SubdirectoryHintTracker:
     and append the returned text to the tool result.
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(
+        self,
+        working_dir: Optional[str] = None,
+        *,
+        allow_install_tree: Optional[bool] = None,
+    ):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
         # Explicit callers may deliberately use a Hermes checkout as their workspace.
         # A fallback cwd must opt in explicitly.

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -62,6 +62,11 @@ class SubdirectoryHintTracker:
 
     def __init__(self, working_dir: Optional[str] = None):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
+        # Explicit callers may deliberately use a Hermes checkout as their workspace.
+        # A fallback cwd must opt in explicitly.
+        self.allow_install_tree = (
+            working_dir is not None if allow_install_tree is None else allow_install_tree
+        )
         # The working dir is pre-marked loaded (startup context handles it).
         self._loaded_dirs: Set[Path] = {self.working_dir}
         # Content digests already injected: the same file reached through
@@ -144,7 +149,7 @@ class SubdirectoryHintTracker:
             return False
         return (
             path not in self._loaded_dirs
-            and (not _is_install_tree(path) or _is_install_tree(self.working_dir))
+            and (not _is_install_tree(path) or self.allow_install_tree)
             and self._within_working_dir(path)
             and not self._is_excluded(path)
         )
@@ -161,7 +166,7 @@ class SubdirectoryHintTracker:
     def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
         """Load the first hint file in *directory*; formatted text or None."""
         self._loaded_dirs.add(directory)
-        if _is_install_tree(directory) and not _is_install_tree(self.working_dir):
+        if _is_install_tree(directory) and not self.allow_install_tree:
             return None
         if not self._within_working_dir(directory):
             logger.debug("Skipping hint files in %s — outside working_dir %s", directory, self.working_dir)

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
             return False
         return (
             path not in self._loaded_dirs
-            and not _is_install_tree(path)
+            and (not _is_install_tree(path) or _is_install_tree(self.working_dir))
             and self._within_working_dir(path)
             and not self._is_excluded(path)
         )
@@ -161,6 +161,8 @@ class SubdirectoryHintTracker:
     def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
         """Load the first hint file in *directory*; formatted text or None."""
         self._loaded_dirs.add(directory)
+        if _is_install_tree(directory) and not _is_install_tree(self.working_dir):
+            return None
         if not self._within_working_dir(directory):
             logger.debug("Skipping hint files in %s — outside working_dir %s", directory, self.working_dir)
             return None

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -142,6 +142,24 @@ class TestSubdirectoryHintTracker:
         assert tracker._load_hints_for_directory(subdir) is None
 
 
+    def test_allows_fallback_install_tree_hints_when_opted_in(self, tmp_path, monkeypatch):
+        """CLI/TUI-style callers can deliberately opt into an in-tree cwd."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("CLI contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.chdir(install_tree)
+
+        tracker = SubdirectoryHintTracker(allow_install_tree=True)
+        result = tracker.check_tool_call("read_file", {"path": str(subdir / "loop.py")})
+
+        assert result is not None
+        assert "CLI contributor guide" in result
+
+
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""
         from agent import runtime_cwd

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -117,12 +117,30 @@ class TestSubdirectoryHintTracker:
         (install_tree / "AGENTS.md").write_text("Install-tree contributor guide")
         monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
 
-        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        tracker = SubdirectoryHintTracker(
+            working_dir=str(tmp_path), allow_install_tree=False
+        )
         result = tracker.check_tool_call(
             "read_file", {"path": str(install_tree / "agent.py")}
         )
 
         assert result is None
+
+    def test_skips_fallback_install_tree_hints(self, tmp_path, monkeypatch):
+        """A fallback cwd in the install tree must not gain hint authority."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "apps" / "desktop"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Desktop contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.chdir(install_tree)
+
+        tracker = SubdirectoryHintTracker()
+        assert tracker.check_tool_call("read_file", {"path": str(subdir / "main.py")}) is None
+        assert tracker._load_hints_for_directory(subdir) is None
+
 
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -108,6 +108,23 @@ class TestSubdirectoryHintTracker:
         # Should be capped
         assert len(result) < 20_000
 
+    def test_skips_hints_in_install_tree(self, tmp_path, monkeypatch):
+        """Install-tree contributor guides must not be injected on tool visits."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        install_tree.mkdir()
+        (install_tree / "AGENTS.md").write_text("Install-tree contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(install_tree / "agent.py")}
+        )
+
+        assert result is None
+
+
     def test_empty_args(self, project):
         """Empty args should not crash."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -178,7 +178,8 @@ class TestSubdirectoryHintTracker:
         (subdir / "AGENTS.md").write_text("Install-tree contributor guide")
         monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
-        monkeypatch.setenv("TERMINAL_CWD", str(home / session_root))
+        session_cwd = home if session_root == "home" else install_tree
+        monkeypatch.setenv("TERMINAL_CWD", str(session_cwd))
 
         agent = AIAgent(
             model="test-model",
@@ -194,6 +195,7 @@ class TestSubdirectoryHintTracker:
             "read_file", {"path": str(subdir / "loop.py")}
         )
 
+        assert hint_tracker.working_dir == session_cwd.resolve()
         assert hint_tracker.allow_install_tree is expect_hint
         assert (result is not None) is expect_hint
         if expect_hint:

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -160,6 +160,46 @@ class TestSubdirectoryHintTracker:
         assert "CLI contributor guide" in result
 
 
+    @pytest.mark.parametrize(
+        ("session_root", "expect_hint"),
+        [("home", False), ("hermes-agent", True)],
+    )
+    def test_agent_init_scopes_tui_install_tree_opt_in_to_session_root(
+        self, tmp_path, monkeypatch, session_root, expect_hint
+    ):
+        """TUI hint authority follows its effective session root, not platform."""
+        from agent import runtime_cwd
+        from run_agent import AIAgent
+
+        home = tmp_path / "home"
+        install_tree = home / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Install-tree contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+        monkeypatch.setenv("TERMINAL_CWD", str(home / session_root))
+
+        agent = AIAgent(
+            model="test-model",
+            base_url="http://localhost:9/v1",
+            api_key="test-key",
+            platform="tui",
+            skip_context_files=True,
+            skip_memory=True,
+            quiet_mode=True,
+        )
+        hint_tracker = getattr(agent, "_subdirectory_hints")
+        result = hint_tracker.check_tool_call(
+            "read_file", {"path": str(subdir / "loop.py")}
+        )
+
+        assert hint_tracker.allow_install_tree is expect_hint
+        assert (result is not None) is expect_hint
+        if expect_hint:
+            assert "Install-tree contributor guide" in result
+
+
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""
         from agent import runtime_cwd

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -124,6 +124,23 @@ class TestSubdirectoryHintTracker:
 
         assert result is None
 
+    def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
+        """An explicit Hermes checkout remains a valid workspace."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Nested Hermes development guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+
+        tracker = SubdirectoryHintTracker(working_dir=str(install_tree))
+        result = tracker.check_tool_call(
+            "terminal", {"command": f"pwd {subdir}"}
+        )
+
+        assert result is not None
+        assert "Nested Hermes development guide" in result
 
     def test_empty_args(self, project):
         """Empty args should not crash."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -126,6 +126,23 @@ class TestSubdirectoryHintTracker:
         assert result is not None and "truncated" not in result.lower()
         assert result.endswith(body.strip())
 
+    def test_skips_hints_in_install_tree(self, tmp_path, monkeypatch):
+        """Install-tree contributor guides must not be injected on tool visits."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        install_tree.mkdir()
+        (install_tree / "AGENTS.md").write_text("Install-tree contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(install_tree / "agent.py")}
+        )
+
+        assert result is None
+
+
     def test_empty_args(self, project):
         """Empty args should not crash."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -178,6 +178,46 @@ class TestSubdirectoryHintTracker:
         assert "CLI contributor guide" in result
 
 
+    @pytest.mark.parametrize(
+        ("session_root", "expect_hint"),
+        [("home", False), ("hermes-agent", True)],
+    )
+    def test_agent_init_scopes_tui_install_tree_opt_in_to_session_root(
+        self, tmp_path, monkeypatch, session_root, expect_hint
+    ):
+        """TUI hint authority follows its effective session root, not platform."""
+        from agent import runtime_cwd
+        from run_agent import AIAgent
+
+        home = tmp_path / "home"
+        install_tree = home / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Install-tree contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+        monkeypatch.setenv("TERMINAL_CWD", str(home / session_root))
+
+        agent = AIAgent(
+            model="test-model",
+            base_url="http://localhost:9/v1",
+            api_key="test-key",
+            platform="tui",
+            skip_context_files=True,
+            skip_memory=True,
+            quiet_mode=True,
+        )
+        hint_tracker = getattr(agent, "_subdirectory_hints")
+        result = hint_tracker.check_tool_call(
+            "read_file", {"path": str(subdir / "loop.py")}
+        )
+
+        assert hint_tracker.allow_install_tree is expect_hint
+        assert (result is not None) is expect_hint
+        if expect_hint:
+            assert "Install-tree contributor guide" in result
+
+
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""
         from agent import runtime_cwd

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -196,7 +196,8 @@ class TestSubdirectoryHintTracker:
         (subdir / "AGENTS.md").write_text("Install-tree contributor guide")
         monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
-        monkeypatch.setenv("TERMINAL_CWD", str(home / session_root))
+        session_cwd = home if session_root == "home" else install_tree
+        monkeypatch.setenv("TERMINAL_CWD", str(session_cwd))
 
         agent = AIAgent(
             model="test-model",
@@ -212,6 +213,7 @@ class TestSubdirectoryHintTracker:
             "read_file", {"path": str(subdir / "loop.py")}
         )
 
+        assert hint_tracker.working_dir == session_cwd.resolve()
         assert hint_tracker.allow_install_tree is expect_hint
         assert (result is not None) is expect_hint
         if expect_hint:

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -135,12 +135,30 @@ class TestSubdirectoryHintTracker:
         (install_tree / "AGENTS.md").write_text("Install-tree contributor guide")
         monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
 
-        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        tracker = SubdirectoryHintTracker(
+            working_dir=str(tmp_path), allow_install_tree=False
+        )
         result = tracker.check_tool_call(
             "read_file", {"path": str(install_tree / "agent.py")}
         )
 
         assert result is None
+
+    def test_skips_fallback_install_tree_hints(self, tmp_path, monkeypatch):
+        """A fallback cwd in the install tree must not gain hint authority."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "apps" / "desktop"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Desktop contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.chdir(install_tree)
+
+        tracker = SubdirectoryHintTracker()
+        assert tracker.check_tool_call("read_file", {"path": str(subdir / "main.py")}) is None
+        assert tracker._load_hints_for_directory(subdir) is None
+
 
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -179,13 +179,17 @@ class TestSubdirectoryHintTracker:
 
 
     @pytest.mark.parametrize(
-        ("session_root", "expect_hint"),
-        [("home", False), ("hermes-agent", True)],
+        ("platform", "session_root", "expect_hint"),
+        [
+            ("tui", "home", False),
+            ("desktop", "home", False),
+            ("tui", "hermes-agent", True),
+        ],
     )
-    def test_agent_init_scopes_tui_install_tree_opt_in_to_session_root(
-        self, tmp_path, monkeypatch, session_root, expect_hint
+    def test_agent_init_scopes_install_tree_opt_in_to_session_root(
+        self, tmp_path, monkeypatch, platform, session_root, expect_hint
     ):
-        """TUI hint authority follows its effective session root, not platform."""
+        """TUI/desktop hint authority follows its effective session root."""
         from agent import runtime_cwd
         from run_agent import AIAgent
 
@@ -203,7 +207,7 @@ class TestSubdirectoryHintTracker:
             model="test-model",
             base_url="http://localhost:9/v1",
             api_key="test-key",
-            platform="tui",
+            platform=platform,
             skip_context_files=True,
             skip_memory=True,
             quiet_mode=True,

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -142,6 +142,23 @@ class TestSubdirectoryHintTracker:
 
         assert result is None
 
+    def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
+        """An explicit Hermes checkout remains a valid workspace."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("Nested Hermes development guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+
+        tracker = SubdirectoryHintTracker(working_dir=str(install_tree))
+        result = tracker.check_tool_call(
+            "terminal", {"command": f"pwd {subdir}"}
+        )
+
+        assert result is not None
+        assert "Nested Hermes development guide" in result
 
     def test_empty_args(self, project):
         """Empty args should not crash."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -160,6 +160,24 @@ class TestSubdirectoryHintTracker:
         assert tracker._load_hints_for_directory(subdir) is None
 
 
+    def test_allows_fallback_install_tree_hints_when_opted_in(self, tmp_path, monkeypatch):
+        """CLI/TUI-style callers can deliberately opt into an in-tree cwd."""
+        from agent import runtime_cwd
+
+        install_tree = tmp_path / "hermes-agent"
+        subdir = install_tree / "agent"
+        subdir.mkdir(parents=True)
+        (subdir / "AGENTS.md").write_text("CLI contributor guide")
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", install_tree.resolve())
+        monkeypatch.chdir(install_tree)
+
+        tracker = SubdirectoryHintTracker(allow_install_tree=True)
+        result = tracker.check_tool_call("read_file", {"path": str(subdir / "loop.py")})
+
+        assert result is not None
+        assert "CLI contributor guide" in result
+
+
     def test_allows_hints_when_developing_inside_install_tree(self, tmp_path, monkeypatch):
         """An explicit Hermes checkout remains a valid workspace."""
         from agent import runtime_cwd


### PR DESCRIPTION
Closes #75839.

## Reproduction

The first commit adds a focused regression test that fails on current `main`: visiting an install-tree directory through a tool call injects its `AGENTS.md` as progressive subdirectory context.

## Plan

Apply the existing install-tree predicate before loading progressive hints, then run the focused suite, Ruff, diff checks, and review.