### PR TITLE
fix(gateway): fall back to launchctl print in _probe_launchd_service_running (#75021 follow-up)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1277,10 +1277,18 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
 def _probe_launchd_service_running() -> bool:
     """Return True when launchd is actively supervising the gateway process.
 
-    ``launchctl list <label>`` returns exit 0 whenever the service definition is
-    registered with launchd — even when ``state = not running`` (macOS 26+).
-    We additionally require a PID in the output to confirm launchd is actually
-    managing a live process, not just holding a static definition.
+    Primary probe is ``launchctl list <label>`` — exit 0 indicates the
+    service definition is registered, and a positive PID in the output
+    confirms launchd is actively managing a live process (not just holding
+    a static definition).
+
+    Fallback: on macOS 26+, ``launchctl list`` may show ``exit = -15`` in
+    column 2 for 5–30 seconds after ``hermes update`` (the previous
+    SIGTERM residue does not refresh in lockstep with the new PID).
+    When ``list`` yields no positive PID we fall back to ``launchctl print``
+    in the active domain — that command reads its view of the service
+    directly from launchd and reports the live ``pid = <N>`` line that
+    ``list`` may not yet have committed. See #75021 follow-up.
     """
     if not get_launchd_plist_path().exists():
         return False
@@ -1292,10 +1300,38 @@ def _probe_launchd_service_running() -> bool:
             timeout=10,
         )
     except subprocess.TimeoutExpired:
+        # ``list`` timing out is the same as no PID found — fall back to print.
+        result = None
+    if result is not None and result.returncode == 0:
+        list_pid = _parse_launchd_pid_from_list_output(result.stdout)
+        if list_pid is not None:
+            return True
+    # Fallback: domain-qualified launchctl print (see #75021).
+    try:
+        domain = _launchd_domain()
+    except Exception:
+        return False
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{domain}/{get_launchd_label()}"],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
     if result.returncode != 0:
         return False
-    return _parse_launchd_pid_from_list_output(result.stdout) is not None
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pid") and "=" in stripped:
+            _, _, val = stripped.partition("=")
+            val = val.strip()
+            try:
+                return int(val) > 0
+            except ValueError:
+                return False
+    return False
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1756,3 +1756,183 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
 
+
+class TestProbeLaunchdServiceRunningFallback:
+    """Regression tests for ``_probe_launchd_service_running()`` (#75021 follow-up).
+
+    On macOS 26+, ``launchctl list <label>`` may show ``exit = -15`` in column 2
+    for 5–30 seconds after ``hermes update`` because the previous SIGTERM residue
+    does not refresh in lockstep with the new PID. The probe must fall back to
+    ``launchctl print`` and trust its ``pid = <N>`` line in that window.
+    """
+
+    def _setup(self, tmp_path, monkeypatch):
+        """Common setup: existing plist + macOS platform."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        # _launchd_domain() caches; reset between tests.
+        gateway_cli._resolved_launchd_domain = None
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+
+    def test_list_with_positive_pid_returns_true_without_print(self, tmp_path, monkeypatch):
+        """Happy path: ``list`` exit 0 with a positive PID -> True, no print probe."""
+        self._setup(tmp_path, monkeypatch)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n    "Label" = "ai.hermes.gateway";\n    "PID" = 12345;\n}',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+        assert all(call[:2] != ["launchctl", "print"] for call in run_calls)
+
+    def test_list_exit_nonzero_falls_back_to_print_with_pid(self, tmp_path, monkeypatch):
+        """The macOS 26+ artifact: ``list`` rc=1 but ``print`` reports a live PID."""
+        self._setup(tmp_path, monkeypatch)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                # rc=1 with no PID column == the SIGTERM residue window
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            if cmd[:2] == ["launchctl", "print"]:
+                # ``_launchd_domain()`` first probes ``gui/<uid>``; let it succeed there
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n    state = running\n    pid = 59038\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+        # Verify the print probe actually happened
+        assert any(call[:2] == ["launchctl", "print"] for call in run_calls)
+
+    def test_list_exit_zero_no_pid_falls_back_to_print(self, tmp_path, monkeypatch):
+        """``list`` rc=0 but no PID field (registered definition, not managing) -> print."""
+        self._setup(tmp_path, monkeypatch)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n    "Label" = "ai.hermes.gateway";\n    "OnDemand" = true;\n}',
+                    stderr="",
+                )
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n    state = running\n    pid = 59038\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+
+    def test_both_list_and_print_report_no_pid_returns_false(self, tmp_path, monkeypatch):
+        """Genuinely down: list has no PID and print has no PID -> False."""
+        self._setup(tmp_path, monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n    "Label" = "ai.hermes.gateway";\n    "OnDemand" = true;\n}',
+                    stderr="",
+                )
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n    state = not running\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is False
+
+    def test_print_pid_zero_is_not_running(self, tmp_path, monkeypatch):
+        """``pid = 0`` in ``print`` output must NOT be treated as running."""
+        self._setup(tmp_path, monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n    state = not running\n    pid = 0\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is False
+
+    def test_no_plist_returns_false_without_running_any_command(self, tmp_path, monkeypatch):
+        """Missing plist -> False without launching subprocess."""
+        # tmp_path has no plist; setup only patches plist helper, write none.
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_plist_path",
+            lambda: tmp_path / "does-not-exist.plist",
+        )
+        run_called = {"v": False}
+
+        def fake_run(*args, **kwargs):
+            run_called["v"] = True
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is False
+        assert run_called["v"] is False
+
+    def test_list_timeout_falls_back_to_print(self, tmp_path, monkeypatch):
+        """``launchctl list`` timing out must not break the probe; print is tried."""
+        self._setup(tmp_path, monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 10))
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n    state = running\n    pid = 59038\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+
+    def test_print_timeout_returns_false(self, tmp_path, monkeypatch):
+        """Both probes timing out -> False."""
+        self._setup(tmp_path, monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 10))
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is False
+


### PR DESCRIPTION
## What & why

Follow-up to #75021.

`hermes_cli/gateway.py:_probe_launchd_service_running()` was the last consumer of the bare `launchctl list <label>` rc/PID heuristic. On macOS 26+, `launchctl list` keeps the previous PID's `exit = -15` (SIGTERM residue) for 5–30 seconds after `hermes update`, even though the new PID is already in column 1.

Result: `hermes status` flickered between UP and DOWN in that window. Consumer scripts (cron health checks, our own `gateway_self_heal.sh` on valve-assistant) saw a false `DOWN` and issued redundant restarts that race `KeepAlive`'s PID-tracking.

The c55e49730 fix in #75021 wired `_get_service_pids()` to fall back to `launchctl print` in the resolved domain. This PR applies the same fix to `_probe_launchd_service_running()` so `hermes status` reports consistently during the post-update window.

## The change

`_probe_launchd_service_running()` now:

1. Tries `launchctl list <label>` first (cheap, single shot). If exit 0 and a positive PID parses out → returns True immediately.
2. Otherwise calls `_launchd_domain()` (already cached, already macOS-26+ aware) and runs `launchctl print <domain>/<label>`.
3. Parses the `pid = <N>` line in print output; returns True iff `N > 0`.
4. `launchctl list` timing out is treated the same as "no PID" — falls through to print, not a hard False.
5. Missing plist still returns False without spawning any subprocess (unchanged).

## Tests

`tests/hermes_cli/test_gateway_service.py::TestProbeLaunchdServiceRunningFallback` — 8 cases:

- `test_list_with_positive_pid_returns_true_without_print` — happy path; no print probe.
- `test_list_exit_nonzero_falls_back_to_print_with_pid` — the macOS 26+ artifact; `list` rc=1, `print` has pid.
- `test_list_exit_zero_no_pid_falls_back_to_print` — `list` rc=0 but no PID field; `print` has pid.
- `test_both_list_and_print_report_no_pid_returns_false` — genuinely down.
- `test_print_pid_zero_is_not_running` — `pid = 0` must NOT count as running.
- `test_no_plist_returns_false_without_running_any_command` — early-out before any subprocess.run.
- `test_list_timeout_falls_back_to_print` — TimeoutExpired on `list` falls through.
- `test_print_timeout_returns_false` — both probes timing out → False.

`scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k TestProbeLaunchdServiceRunningFallback`: **8 passed, 0 failed** (subprocess-wall 0.2s, parallel 24 workers).

Full-file regression: `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py`: **77 passed, 1 failed**. The single failure (`TestGatewaySystemServiceRouting::test_systemd_restart_gracefully_restarts_running_service_and_waits`) is **pre-existing on upstream main** (verified by stashing this branch and re-running) — unrelated systemd path, not touched by this PR.

Adjacent launchd suites (`test_gateway_runtime_health.py`, `test_gateway_proc_fallback.py`) also green under this branch.

## Platforms

- macOS only. The patched function is the macOS branch of `get_gateway_runtime_snapshot()` (the Linux branch is untouched).
- `scripts/check-windows-footguns.py` reports zero new findings on the two changed files (both pre-existing `.write_text()` warnings are on lines I did not touch).

## Relationship to #75021

Direct complement. #75021's `_get_service_pids()` (the sweep helper used by `hermes update`) is fixed in c55e49730. This PR covers the same artifact for the display path (`hermes status` / snapshot consumers).

Local repro is captured in the comment thread on #75021 (comment 5150084455): `launchctl list` shows `48589 -15 ai.hermes.gateway-valve-assistant` while `launchctl print gui/501/...` reports `pid = 48589` / `state = running` — the exact state this patch handles.

Happy to rebase / fold into #75021 if maintainers prefer a single PR.

---

*Filed by an AI agent (MiniMax-M3) operating autonomously on @d.cai's behalf. Local repro + reference comment posted to #75021; patch + tests verified end-to-end on a 3-profile macOS 26 launchd install before submission.*