### PR TITLE
feat(holographic): restore SBERT embeddings and backfill

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -275,12 +275,12 @@ class HolographicMemoryProvider(MemoryProvider):
             retriever = self._retriever
 
             if action == "add":
-                fact_id = store.add_fact(
+                result = store.add_fact(
                     args["content"],
                     category=args.get("category", "general"),
                     tags=args.get("tags", ""),
                 )
-                return json.dumps({"fact_id": fact_id, "status": "added"})
+                return json.dumps(result)
 
             elif action == "search":
                 results = retriever.search(

--- a/plugins/memory/holographic/embeddings.py
+++ b/plugins/memory/holographic/embeddings.py
@@ -1,0 +1,88 @@
+"""Optional SBERT embeddings for semantic similarity.
+
+Falls back gracefully when sentence-transformers is not installed.
+No hard dependency — import this module safely in any environment.
+"""
+
+import logging
+import struct
+from typing import Callable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+_EMBED_DIM = 384
+_EMBED_MODEL = "all-MiniLM-L6-v2"
+_cache = None  # SentenceTransformer | None
+
+
+def _load_model():
+    """Lazy-load the SBERT model. Cached after first call."""
+    global _cache
+    if _cache is not None:
+        return _cache
+    try:
+        from sentence_transformers import SentenceTransformer
+
+        _cache = SentenceTransformer(_EMBED_MODEL)
+        logger.info("Loaded SBERT model: %s", _EMBED_MODEL)
+    except ImportError:
+        logger.debug(
+            "sentence-transformers not installed — semantic features disabled"
+        )
+    except Exception as exc:
+        logger.warning("Failed to load SBERT model: %s", exc)
+    return _cache
+
+
+def get_embedder():
+    # type: () -> Optional[Callable[[Sequence[str]], list]]
+    """Return a callable that embeds a batch of texts, or None."""
+    model = _load_model()
+    if model is None:
+        return None
+
+    import numpy as np
+
+    def embed(texts):
+        # type: (Sequence[str]) -> list
+        if isinstance(texts, str):
+            texts = [texts]
+        embeddings = model.encode(
+            list(texts), normalize_embeddings=True, show_progress_bar=False
+        )
+        return [np.asarray(e, dtype=np.float32) for e in embeddings]
+
+    return embed
+
+
+def embedding_dim():
+    # type: () -> int
+    return _EMBED_DIM
+
+
+def pack_vector(vec):
+    # type: (...) -> bytes
+    """Pack a float32 vector into a BLOB."""
+    import numpy as np
+
+    arr = np.asarray(vec, dtype=np.float32)
+    return struct.pack(f"{len(arr)}f", *arr)
+
+
+def unpack_vector(blob):
+    # type: (bytes) -> ...
+    """Unpack a BLOB into a float32 numpy array."""
+    import numpy as np
+
+    n = len(blob) // 4
+    return np.array(struct.unpack(f"{n}f", blob), dtype=np.float32)
+
+
+def cosine_similarity(a, b):
+    # type: (...) -> float
+    """Cosine similarity between two numpy vectors. Both assumed normalized."""
+    import numpy as np
+
+    return float(
+        np.dot(np.asarray(a, dtype=np.float32), np.asarray(b, dtype=np.float32))
+    )

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -45,6 +45,15 @@ class FactRetriever:
         self.jaccard_weight = jaccard_weight
         self.hrr_weight = hrr_weight
 
+        # Check if any facts have SBERT vectors (for cosine rerank)
+        try:
+            row = self.store._conn.execute(
+                "SELECT 1 FROM facts WHERE sbert_vector IS NOT NULL LIMIT 1"
+            ).fetchone()
+            self._has_sbert_vectors = row is not None
+        except Exception:
+            self._has_sbert_vectors = False
+
     def search(
         self,
         query: str,
@@ -100,16 +109,46 @@ class FactRetriever:
             if self.half_life > 0:
                 score *= self._temporal_decay(fact.get("updated_at") or fact.get("created_at"))
 
+            # Stage 3: Cosine similarity boost (when SBERT vectors available)
+            sbert_vector = fact.get("sbert_vector")
+            if self._has_sbert_vectors and sbert_vector:
+                try:
+                    from .embeddings import unpack_vector, cosine_similarity
+                    fact_vec = unpack_vector(sbert_vector)
+                    query_vec = self._get_query_embedding(query)
+                    if query_vec is not None:
+                        cos_sim = cosine_similarity(query_vec, fact_vec)
+                        # Blend: 0.4 * base_score + 0.6 * cosine_score
+                        cos_score = (cos_sim + 1.0) / 2.0  # shift [-1,1] to [0,1]
+                        score = 0.4 * score + 0.6 * cos_score * fact["trust_score"]
+                except Exception:
+                    pass
+
             fact["score"] = score
             scored.append(fact)
 
         # Sort by score descending, return top limit
         scored.sort(key=lambda x: x["score"], reverse=True)
         results = scored[:limit]
-        # Strip raw HRR bytes — callers expect JSON-serializable dicts
+        # Strip raw HRR bytes and SBERT blobs — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
+            fact.pop("sbert_vector", None)
         return results
+
+    def _get_query_embedding(self, query: str):
+        """Get or compute SBERT query embedding (cached per search call)."""
+        if getattr(self, "_query_embedding", None) is not None:
+            return self._query_embedding
+        from .embeddings import get_embedder
+        embed = get_embedder()
+        if embed is None:
+            return None
+        try:
+            self._query_embedding = embed([query])[0]
+            return self._query_embedding
+        except Exception:
+            return None
 
     def probe(
         self,
@@ -187,6 +226,8 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
+        for fact in scored:
+            fact.pop("sbert_vector", None)
         return scored[:limit]
 
     def related(
@@ -255,6 +296,8 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
+        for fact in scored:
+            fact.pop("sbert_vector", None)
         return scored[:limit]
 
     def reason(
@@ -333,6 +376,8 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
+        for fact in scored:
+            fact.pop("sbert_vector", None)
         return scored[:limit]
 
     def contradict(
@@ -476,7 +521,10 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
+        for fact in scored:
+            fact.pop("sbert_vector", None)
         return scored[:limit]
+
 
     def _fts_candidates(
         self,

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -201,7 +201,7 @@ class FactRetriever:
             f"""
             SELECT fact_id, content, category, tags, trust_score,
                    retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
+                   hrr_vector, sbert_vector
             FROM facts
             {where}
             """,
@@ -263,7 +263,7 @@ class FactRetriever:
             f"""
             SELECT fact_id, content, category, tags, trust_score,
                    retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
+                   hrr_vector, sbert_vector
             FROM facts
             {where}
             """,
@@ -344,7 +344,7 @@ class FactRetriever:
             f"""
             SELECT fact_id, content, category, tags, trust_score,
                    retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
+                   hrr_vector, sbert_vector
             FROM facts
             {where}
             """,
@@ -505,7 +505,7 @@ class FactRetriever:
             f"""
             SELECT fact_id, content, category, tags, trust_score,
                    retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
+                   hrr_vector, sbert_vector
             FROM facts
             {where}
             """,

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -657,6 +657,40 @@ class MemoryStore:
 
             return len(rows)
 
+    def backfill_sbert_vectors(self) -> int:
+        """Compute SBERT embeddings for facts that don't have them yet.
+
+        Returns the number of facts processed (0 if sentence-transformers
+        unavailable).
+        """
+        from .embeddings import get_embedder, pack_vector
+
+        embed = get_embedder()
+        if embed is None:
+            return 0
+
+        rows = self._conn.execute(
+            "SELECT fact_id, content FROM facts WHERE sbert_vector IS NULL"
+        ).fetchall()
+        if not rows:
+            return 0
+
+        # Batch-embed all missing facts at once (much faster than one-by-one)
+        ids = [row["fact_id"] for row in rows]
+        texts = [row["content"] for row in rows]
+        vectors = embed(texts)
+
+        with self._lock:
+            for fact_id, vec in zip(ids, vectors):
+                blob = pack_vector(vec)
+                self._conn.execute(
+                    "UPDATE facts SET sbert_vector = ? WHERE fact_id = ?",
+                    (blob, fact_id),
+                )
+            self._conn.commit()
+
+        return len(ids)
+
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS facts (
     helpful_count   INTEGER DEFAULT 0,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    hrr_vector      BLOB
+    hrr_vector      BLOB,
+    sbert_vector    BLOB
 );
 
 CREATE TABLE IF NOT EXISTS entities (
@@ -179,6 +180,8 @@ class MemoryStore:
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        if "sbert_vector" not in columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN sbert_vector BLOB")
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -190,12 +193,13 @@ class MemoryStore:
         content: str,
         category: str = "general",
         tags: str = "",
-    ) -> int:
-        """Insert a fact and return its fact_id.
+    ) -> dict:
+        """Insert a fact. Returns dict with fact_id and status.
 
         Deduplicates by content (UNIQUE constraint). On duplicate, returns
-        the existing fact_id without modifying the row. Extracts entities from
-        the content and links them to the fact.
+        the existing fact_id with status "duplicate". If sentence-transformers
+        is available, also checks semantic similarity — merges near-duplicates
+        (cosine > 0.85) with status "merged".
         """
         with self._lock:
             content = content.strip()
@@ -213,22 +217,67 @@ class MemoryStore:
                 self._conn.commit()
                 fact_id: int = cur.lastrowid  # type: ignore[assignment]
             except sqlite3.IntegrityError:
-                # Duplicate content — return existing id
-                row = self._conn.execute(
-                    "SELECT fact_id FROM facts WHERE content = ?", (content,)
-                ).fetchone()
-                return int(row["fact_id"])
+                return {
+                    "fact_id": self._conn.execute(
+                        "SELECT fact_id FROM facts WHERE content = ?",
+                        (content,),
+                    ).fetchone()["fact_id"],
+                    "status": "duplicate",
+                }
 
             # Entity extraction and linking
             for name in self._extract_entities(content):
                 entity_id = self._resolve_entity(name)
                 self._link_fact_entity(fact_id, entity_id)
 
-            # Compute HRR vector after entity linking
+            # Compute HRR vector
             self._compute_hrr_vector(fact_id, content)
-            self._rebuild_bank(category)
 
-            return fact_id
+            # Semantic dedup: check cosine similarity against existing facts
+            from .embeddings import get_embedder, pack_vector, unpack_vector, cosine_similarity
+            embed = get_embedder()
+            if embed is not None:
+                try:
+                    new_vec = embed([content])[0]
+                    existing = self._conn.execute(
+                        "SELECT fact_id, sbert_vector FROM facts "
+                        "WHERE sbert_vector IS NOT NULL AND fact_id != ?",
+                        (fact_id,),
+                    ).fetchall()
+                    for other_id, other_blob in existing:
+                        other_vec = unpack_vector(other_blob)
+                        sim = cosine_similarity(new_vec, other_vec)
+                        if sim > 0.92:
+                            # Near-duplicate: delete new, bump trust of existing
+                            self._conn.execute(
+                                "DELETE FROM fact_entities WHERE fact_id = ?",
+                                (fact_id,),
+                            )
+                            self._conn.execute(
+                                "DELETE FROM facts WHERE fact_id = ?", (fact_id,)
+                            )
+                            self._conn.commit()
+                            return {
+                                "fact_id": other_id,
+                                "status": "merged",
+                                "merged_with": other_id,
+                                "similarity": round(sim, 3),
+                            }
+                    # No near-duplicate — store the embedding
+                    blob = pack_vector(new_vec)
+                    self._conn.execute(
+                        "UPDATE facts SET sbert_vector = ? WHERE fact_id = ?",
+                        (blob, fact_id),
+                    )
+                    self._conn.commit()
+                except Exception as exc:
+                    logger.warning(
+                        "Semantic dedup check failed for fact %d: %s",
+                        fact_id, exc,
+                    )
+
+            self._rebuild_bank(category)
+            return {"fact_id": fact_id, "status": "added"}
 
     def search_facts(
         self,

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -193,13 +193,11 @@ class MemoryStore:
         content: str,
         category: str = "general",
         tags: str = "",
-    ) -> dict:
-        """Insert a fact. Returns dict with fact_id and status.
+    ) -> int:
+        """Insert a fact and return its fact_id.
 
-        Deduplicates by content (UNIQUE constraint). On duplicate, returns
-        the existing fact_id with status "duplicate". If sentence-transformers
-        is available, also checks semantic similarity — merges near-duplicates
-        (cosine > 0.85) with status "merged".
+        Deduplicates by exact content. When the optional embedder is available,
+        stores an SBERT vector and merges only semantic near-duplicates.
         """
         with self._lock:
             content = content.strip()
@@ -217,13 +215,10 @@ class MemoryStore:
                 self._conn.commit()
                 fact_id: int = cur.lastrowid  # type: ignore[assignment]
             except sqlite3.IntegrityError:
-                return {
-                    "fact_id": self._conn.execute(
-                        "SELECT fact_id FROM facts WHERE content = ?",
-                        (content,),
-                    ).fetchone()["fact_id"],
-                    "status": "duplicate",
-                }
+                return self._conn.execute(
+                    "SELECT fact_id FROM facts WHERE content = ?",
+                    (content,),
+                ).fetchone()["fact_id"]
 
             # Entity extraction and linking
             for name in self._extract_entities(content):
@@ -244,7 +239,17 @@ class MemoryStore:
                         "WHERE sbert_vector IS NOT NULL AND fact_id != ?",
                         (fact_id,),
                     ).fetchall()
+                    new_numbers = tuple(re.findall(r"\b\d+(?:\.\d+)?\b", content))
                     for other_id, other_blob in existing:
+                        other_row = self._conn.execute(
+                            "SELECT content FROM facts WHERE fact_id = ?", (other_id,)
+                        ).fetchone()
+                        other_content = other_row["content"] if other_row else ""
+                        other_numbers = tuple(
+                            re.findall(r"\b\d+(?:\.\d+)?\b", other_content)
+                        )
+                        if new_numbers and other_numbers and new_numbers != other_numbers:
+                            continue
                         other_vec = unpack_vector(other_blob)
                         sim = cosine_similarity(new_vec, other_vec)
                         if sim > 0.92:
@@ -257,12 +262,7 @@ class MemoryStore:
                                 "DELETE FROM facts WHERE fact_id = ?", (fact_id,)
                             )
                             self._conn.commit()
-                            return {
-                                "fact_id": other_id,
-                                "status": "merged",
-                                "merged_with": other_id,
-                                "similarity": round(sim, 3),
-                            }
+                            return other_id
                     # No near-duplicate — store the embedding
                     blob = pack_vector(new_vec)
                     self._conn.execute(
@@ -277,7 +277,7 @@ class MemoryStore:
                     )
 
             self._rebuild_bank(category)
-            return {"fact_id": fact_id, "status": "added"}
+            return fact_id
 
     def search_facts(
         self,

--- a/tests/gateway/test_holographic_embeddings.py
+++ b/tests/gateway/test_holographic_embeddings.py
@@ -1,0 +1,43 @@
+"""Test the embeddings utility module."""
+import numpy as np
+import pytest
+
+from plugins.memory.holographic.embeddings import (
+    cosine_similarity,
+    embedding_dim,
+    get_embedder,
+    pack_vector,
+    unpack_vector,
+)
+
+
+class TestEmbeddingsModule:
+    """Test the embeddings utility module (no model required)."""
+
+    def test_pack_unpack_roundtrip(self):
+        """Vector survives pack -> unpack roundtrip."""
+        vec = np.array([0.1, -0.2, 0.3, 0.0], dtype=np.float32)
+        blob = pack_vector(vec)
+        restored = unpack_vector(blob)
+        assert np.allclose(vec, restored)
+
+    def test_cosine_identical(self):
+        """Cosine of identical normalized vectors is 1.0."""
+        v = np.array([0.5, 0.5], dtype=np.float32)
+        v = v / np.linalg.norm(v)
+        assert abs(cosine_similarity(v, v) - 1.0) < 0.001
+
+    def test_cosine_orthogonal(self):
+        """Cosine of orthogonal unit vectors is 0.0."""
+        a = np.array([1.0, 0.0], dtype=np.float32)
+        b = np.array([0.0, 1.0], dtype=np.float32)
+        assert abs(cosine_similarity(a, b)) < 0.001
+
+    def test_embedding_dim(self):
+        """Embedding dimension is 384."""
+        assert embedding_dim() == 384
+
+    def test_get_embedder_returns_callable_or_none(self):
+        """get_embedder returns either None (no deps) or a callable."""
+        result = get_embedder()
+        assert result is None or callable(result)

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -154,6 +154,35 @@ class TestCloseSemantics:
         assert [f["content"] for f in facts] == ["first lifetime"]
 
 
+class TestSemanticEmbeddings:
+    @staticmethod
+    def _fake_embedder(monkeypatch):
+        import numpy as np
+
+        monkeypatch.setattr(
+            "plugins.memory.holographic.embeddings.get_embedder",
+            lambda: lambda texts: [np.ones(384, dtype=np.float32) for _ in texts],
+        )
+
+    def test_add_fact_persists_sbert_vector(self, db_path, monkeypatch):
+        self._fake_embedder(monkeypatch)
+        with MemoryStore(db_path) as store:
+            fact_id = store.add_fact("durable captured fact")
+            blob = store._conn.execute(
+                "SELECT sbert_vector FROM facts WHERE fact_id = ?", (fact_id,)
+            ).fetchone()["sbert_vector"]
+            assert blob is not None
+            assert len(blob) == 384 * 4
+
+    def test_distinct_numeric_facts_are_not_semantically_merged(self, db_path, monkeypatch):
+        self._fake_embedder(monkeypatch)
+        with MemoryStore(db_path) as store:
+            first = store.add_fact("fact thread=0 seq=0", category="load")
+            second = store.add_fact("fact thread=0 seq=1", category="load")
+            assert first != second
+            assert len(store.list_facts(category="load", limit=10)) == 2
+
+
 class TestConcurrency:
     def test_concurrent_multi_instance_writers(self, db_path):
         """Many instances writing from many threads must never hit


### PR DESCRIPTION
## Summary

- Restore optional SBERT embeddings on `MemoryStore.add_fact()`.
- Restore semantic deduplication and cosine reranking.
- Add explicit `backfill_sbert_vectors()` for existing NULL rows.
- Preserve the current integer `add_fact()` API and hybrid housekeeping boundary.

## Verification

- Focused holographic suite: `41 passed`.
- Live backfill: `47` vectors processed; `0` NULL SBERT vectors remain.
- Live DB: `138` facts; `0` NULL HRR vectors; SQLite integrity `ok`.
- Database backup created before mutation: `~/.hermes/backups/memory_store.db.sbert-20260801-123243`.

## Scope

This PR contains only the focused SBERT recovery. It does not reset or overwrite `origin/son/dev`.
