### PR TITLE
feat(desktop): add explicit local service mode

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -48,6 +48,33 @@ hermes update
 
 ---
 
+## Service Mode (local diagnostics)
+
+Packaged Desktop builds ask whether Hermes should start normally, start in
+Service Mode, or quit. **Start normally** is the safe default and does not open
+a Chrome DevTools Protocol (CDP) endpoint. **Start in Service Mode** is an
+explicit, temporary opt-in for local UI inspection: after an active risk
+acknowledgement, Hermes relaunches with a dynamically selected CDP port bound
+only to `127.0.0.1`.
+
+> [!WARNING]
+> CDP has no user authentication. Any local program that can discover and
+> reach the endpoint can potentially read rendered Hermes content, execute
+> renderer JavaScript, trigger UI actions, and call exposed preload APIs. Do
+> not open passwords, credentials, or especially sensitive content while
+> Service Mode is active. Quit Hermes and start normally when diagnostics are
+> complete.
+
+The acknowledgement is never saved. Its relaunch grant can be consumed once
+and expires after 60 seconds; after a successful relaunch, Service Mode remains
+active only until Hermes exits. The status bar shows `SERVICE` with the actual
+loopback endpoint and a locked `LOCAL` or `REMOTE` execution-boundary indicator.
+These safety indicators remain visible even when optional status-bar content is
+hidden. Stale grants and runtime markers are removed during startup and
+shutdown so they cannot report false activity.
+
+---
+
 ## Requirements
 
 The installer handles everything for you (Python 3.11+, a portable Git, ripgrep).

--- a/apps/desktop/electron/dev-cdp.ts
+++ b/apps/desktop/electron/dev-cdp.ts
@@ -7,13 +7,17 @@
  * and read the live DOM from. Every one of those scripts already defaults to
  * 9222, so a dev-server run opens 9222 and they just work.
  *
+ * This module owns only the source-tree developer path. Packaged builds remain
+ * closed to environment-variable opt-in here; their separately-audited,
+ * one-shot user-confirmed path lives in `service-mode.ts`.
+ *
  * If you are running a dev server you are already executing arbitrary local
  * JS — vite's module graph and every postinstall in node_modules — so a
  * loopback debugging port does not meaningfully widen that. `perf:serve`
- * already opens one unconditionally. What must never happen is a *packaged*
- * app exposing it, which is the one hard gate here.
+ * already opens one unconditionally. A packaged app must never be opened by an
+ * environment variable, which is the hard gate here.
  *
- *  - packaged build              → always closed, whatever the env says.
+ *  - packaged build              → closed through this developer path.
  *  - no HERMES_DESKTOP_DEV_SERVER → closed (an unpackaged `electron .` against
  *    dist/ is how the packaged app gets smoke tested; it should behave like
  *    the packaged app).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -168,6 +168,17 @@ import {
   revalidateRemoteConnection
 } from './remote-liveness'
 import {
+  buildServiceModeRelaunchArgs,
+  consumeServiceModeGrant,
+  removeServiceModeState,
+  resolveServiceModeActivation,
+  resolveServiceModePrompt,
+  waitForDevToolsActivePort,
+  writeServiceModeGrant,
+  writeServiceModeState
+} from './service-mode'
+import type { ServiceModeRuntimeState } from './service-mode'
+import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -288,26 +299,56 @@ if (REMOTE_DISPLAY_REASON) {
   )
 }
 
-// Renderer debugging port. On for dev-server runs (`hgui` / `npm run dev`) so
-// the CDP tooling in scripts/ can attach; never for a packaged build — see
-// electron/dev-cdp.ts. Must run before app `ready` like the switches above;
-// Chromium binds it at launch.
-const DEV_CDP = resolveDevCdpPort({ env: process.env, isPackaged: IS_PACKAGED, devServer: DEV_SERVER })
+// Renderer debugging. Source-tree dev runs keep the existing fixed-port path.
+// A packaged build may open CDP only through a short-lived, one-shot grant that
+// the native startup prompt writes before relaunch. The grant is consumed before
+// Chromium starts, and the service port is dynamic to make collisions impossible.
+const SERVICE_MODE_GRANT_PATH = path.join(app.getPath('userData'), 'service-mode-grant.json')
+const SERVICE_MODE_STATE_PATH = path.join(app.getPath('userData'), 'service-mode.json')
+const DEVTOOLS_ACTIVE_PORT_PATH = path.join(app.getPath('userData'), 'DevToolsActivePort')
 
-if (DEV_CDP.port) {
-  app.commandLine.appendSwitch('remote-debugging-port', String(DEV_CDP.port))
-  // Loopback only. Chromium already defaults to 127.0.0.1, but say it out loud
-  // so a future edit can't widen it by omission.
+const SERVICE_MODE = resolveServiceModeActivation({
+  argv: process.argv,
+  grant: consumeServiceModeGrant(SERVICE_MODE_GRANT_PATH),
+  isPackaged: IS_PACKAGED,
+  now: Date.now()
+})
+
+let serviceModeRuntime: ServiceModeRuntimeState | null = null
+
+if (SERVICE_MODE.active) {
+  // Never accept a stale Chromium publication from a prior crash.
+  fs.rmSync(DEVTOOLS_ACTIVE_PORT_PATH, { force: true })
+  app.commandLine.appendSwitch('remote-debugging-port', '0')
   app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
-  console.log(
-    `[hermes] renderer debugging on http://127.0.0.1:${DEV_CDP.port} — anything that can reach it ` +
-      'can run code in the renderer. HERMES_DESKTOP_CDP_PORT=off to disable.'
+  console.warn(
+    '[hermes] service mode authorized for this launch; renderer debugging will bind to a dynamic 127.0.0.1 port.'
   )
 } else {
-  const why = describeDevCdpDecision(DEV_CDP)
+  // A prior Service Mode crash or normal quit can leave Chromium's publication
+  // file behind even though the listener is gone. Packaged Standard Mode removes
+  // it so external diagnostics never mistake stale metadata for an active CDP.
+  if (IS_PACKAGED) {
+    fs.rmSync(DEVTOOLS_ACTIVE_PORT_PATH, { force: true })
+  }
 
-  if (why) {
-    console.warn(`[hermes] ${why}`)
+  const devCdp = resolveDevCdpPort({ env: process.env, isPackaged: IS_PACKAGED, devServer: DEV_SERVER })
+
+  if (devCdp.port) {
+    app.commandLine.appendSwitch('remote-debugging-port', String(devCdp.port))
+    // Loopback only. Chromium already defaults to 127.0.0.1, but say it out loud
+    // so a future edit can't widen it by omission.
+    app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
+    console.log(
+      `[hermes] renderer debugging on http://127.0.0.1:${devCdp.port} — anything that can reach it ` +
+        'can run code in the renderer. HERMES_DESKTOP_CDP_PORT=off to disable.'
+    )
+  } else {
+    const why = describeDevCdpDecision(devCdp)
+
+    if (why) {
+      console.warn(`[hermes] ${why}`)
+    }
   }
 }
 
@@ -11728,7 +11769,133 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
-app.whenReady().then(() => {
+async function choosePackagedStartMode(): Promise<'continue' | 'handoff' | 'quit'> {
+  if (!IS_PACKAGED || SERVICE_MODE.active) {
+    return 'continue'
+  }
+
+  // This path runs after the packaged process acquired the single-instance
+  // lock. Standard startup is therefore the authority for this userData and
+  // clears any runtime marker left by a crashed or force-exited Service run.
+  removeServiceModeState(SERVICE_MODE_STATE_PATH)
+
+  while (true) {
+    const result = await dialog.showMessageBox({
+      buttons: ['Start normally', 'Start in Service Mode', 'Quit'],
+      cancelId: 2,
+      checkboxChecked: false,
+      checkboxLabel:
+        'I understand that local programs can read Hermes content and control this window while Service Mode is active.',
+      defaultId: 0,
+      detail:
+        'Service Mode opens a Chrome DevTools Protocol endpoint on 127.0.0.1 for this app run only. ' +
+        'Never expose it to LAN or Tailscale. Avoid displaying passwords or other sensitive content during diagnostics.',
+      message: 'How should Hermes start?',
+      noLink: true,
+      type: 'question'
+    })
+
+    const action = resolveServiceModePrompt(result)
+
+    if (action === 'standard') {
+      return 'continue'
+    }
+
+    if (action === 'quit') {
+      app.quit()
+
+      return 'quit'
+    }
+
+    if (action === 'retry') {
+      await dialog.showMessageBox({
+        buttons: ['Back'],
+        detail: 'Select the acknowledgement checkbox before starting Service Mode.',
+        message: 'Acknowledgement required',
+        type: 'warning'
+      })
+
+      continue
+    }
+
+    try {
+      const grant = writeServiceModeGrant(SERVICE_MODE_GRANT_PATH)
+      app.relaunch({ args: buildServiceModeRelaunchArgs(process.argv.slice(1), grant.token) })
+      app.exit(0)
+
+      return 'handoff'
+    } catch (error) {
+      await dialog.showMessageBox({
+        buttons: ['Back'],
+        detail: `Hermes could not create the one-time Service Mode grant: ${error?.message || error}`,
+        message: 'Service Mode could not start',
+        type: 'error'
+      })
+    }
+  }
+}
+
+async function initializeServiceModeRuntime(): Promise<boolean> {
+  if (!SERVICE_MODE.active) {
+    return true
+  }
+
+  const port = await waitForDevToolsActivePort(DEVTOOLS_ACTIVE_PORT_PATH)
+
+  if (!port) {
+    dialog.showErrorBox(
+      'Service Mode could not start',
+      'Chromium did not publish a valid local debugging port. Hermes will close instead of continuing with an uncertain diagnostic state.'
+    )
+    app.exit(1)
+
+    return false
+  }
+
+  serviceModeRuntime = {
+    active: true,
+    host: '127.0.0.1',
+    pid: process.pid,
+    port,
+    startedAt: Date.now()
+  }
+
+  try {
+    writeServiceModeState(SERVICE_MODE_STATE_PATH, serviceModeRuntime)
+  } catch (error) {
+    dialog.showErrorBox(
+      'Service Mode could not start',
+      `Hermes could not publish its local diagnostic state: ${error?.message || error}`
+    )
+    app.exit(1)
+
+    return false
+  }
+
+  await dialog.showMessageBox({
+    buttons: ['Continue'],
+    detail:
+      `CDP is listening only on 127.0.0.1:${port}. Local programs can read visible Hermes content and control the renderer. ` +
+      'Do not expose this port to a network or display sensitive information during diagnostics. Quitting Hermes ends Service Mode.',
+    message: 'Service Mode is active',
+    type: 'warning'
+  })
+
+  return true
+}
+
+ipcMain.handle(
+  'hermes:service-mode',
+  () => serviceModeRuntime ?? { active: false, host: '127.0.0.1', pid: null, port: null, startedAt: null }
+)
+
+app.whenReady().then(async () => {
+  const launchChoice = await choosePackagedStartMode()
+
+  if (launchChoice !== 'continue' || !(await initializeServiceModeRuntime())) {
+    return
+  }
+
   const systemCa = installWindowsSystemCaTrust(tls)
 
   if (systemCa.applied) {
@@ -11851,6 +12018,13 @@ app.on('before-quit', event => {
   // exactly as it was.
   if (heldQuitForActiveWork(event)) {
     return
+  }
+
+  removeServiceModeState(SERVICE_MODE_STATE_PATH, process.pid)
+  serviceModeRuntime = null
+
+  if (SERVICE_MODE.active) {
+    fs.rmSync(DEVTOOLS_ACTIVE_PORT_PATH, { force: true })
   }
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -72,6 +72,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     }
   },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),
+  getServiceMode: () => ipcRenderer.invoke('hermes:service-mode'),
   getConnectionConfig: profile => ipcRenderer.invoke('hermes:connection-config:get', profile),
   saveConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:save', payload),
   applyConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:apply', payload),

--- a/apps/desktop/electron/service-mode.test.ts
+++ b/apps/desktop/electron/service-mode.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Security contract for the packaged Desktop service mode.
+ *
+ * Run with: npx vitest run --project electron electron/service-mode.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  buildServiceModeRelaunchArgs,
+  consumeServiceModeGrant,
+  parseDevToolsActivePort,
+  removeServiceModeState,
+  resolveServiceModePrompt,
+  SERVICE_MODE_ARG_PREFIX,
+  SERVICE_MODE_GRANT_TTL_MS,
+  waitForDevToolsActivePort,
+  writeServiceModeGrant,
+  writeServiceModeState
+} from './service-mode'
+import { resolveServiceModeActivation } from './service-mode'
+
+const NOW = Date.UTC(2026, 6, 31, 12, 0, 0)
+const TOKEN = 'a'.repeat(64)
+
+function grant(overrides = {}) {
+  return {
+    expiresAt: NOW + SERVICE_MODE_GRANT_TTL_MS,
+    token: TOKEN,
+    ...overrides
+  }
+}
+
+test('a packaged launch stays closed without a one-time grant', () => {
+  assert.deepEqual(resolveServiceModeActivation({ argv: ['Hermes'], grant: null, isPackaged: true, now: NOW }), {
+    active: false,
+    reason: 'not-requested'
+  })
+})
+
+test('a packaged launch accepts a matching unexpired one-time grant', () => {
+  assert.deepEqual(
+    resolveServiceModeActivation({
+      argv: ['Hermes', `${SERVICE_MODE_ARG_PREFIX}${TOKEN}`],
+      grant: grant(),
+      isPackaged: true,
+      now: NOW
+    }),
+    { active: true, reason: null }
+  )
+})
+
+test('a packaged launch rejects a raw argument without the matching grant', () => {
+  assert.deepEqual(
+    resolveServiceModeActivation({
+      argv: ['Hermes', `${SERVICE_MODE_ARG_PREFIX}${TOKEN}`],
+      grant: null,
+      isPackaged: true,
+      now: NOW
+    }),
+    { active: false, reason: 'missing-grant' }
+  )
+})
+
+test('a packaged launch rejects mismatched and expired grants', () => {
+  const argv = ['Hermes', `${SERVICE_MODE_ARG_PREFIX}${TOKEN}`]
+
+  assert.equal(
+    resolveServiceModeActivation({ argv, grant: grant({ token: 'b'.repeat(64) }), isPackaged: true, now: NOW }).active,
+    false
+  )
+  assert.equal(
+    resolveServiceModeActivation({ argv, grant: grant({ expiresAt: NOW - 1 }), isPackaged: true, now: NOW }).active,
+    false
+  )
+})
+
+test('service mode cannot be enabled in a source-tree run', () => {
+  assert.deepEqual(
+    resolveServiceModeActivation({
+      argv: ['electron', `${SERVICE_MODE_ARG_PREFIX}${TOKEN}`],
+      grant: grant(),
+      isPackaged: false,
+      now: NOW
+    }),
+    { active: false, reason: 'not-packaged' }
+  )
+})
+
+test('relaunch args replace stale service tokens instead of accumulating them', () => {
+  const args = buildServiceModeRelaunchArgs(['--foo', `${SERVICE_MODE_ARG_PREFIX}${'b'.repeat(64)}`, '--bar'], TOKEN)
+
+  assert.deepEqual(args, ['--foo', '--bar', `${SERVICE_MODE_ARG_PREFIX}${TOKEN}`])
+})
+
+test('a service grant is private and consumed exactly once', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-service-mode-'))
+  const grantPath = path.join(dir, 'service-mode-grant.json')
+
+  try {
+    const created = writeServiceModeGrant(grantPath, NOW)
+    const mode = fs.statSync(grantPath).mode & 0o777
+
+    assert.match(created.token, /^[a-f0-9]{64}$/)
+    assert.equal(created.expiresAt, NOW + SERVICE_MODE_GRANT_TTL_MS)
+    assert.equal(mode, 0o600)
+    assert.deepEqual(consumeServiceModeGrant(grantPath), created)
+    assert.equal(fs.existsSync(grantPath), false)
+    assert.equal(consumeServiceModeGrant(grantPath), null)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+test('a malformed service grant is removed instead of becoming reusable', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-service-mode-'))
+  const grantPath = path.join(dir, 'service-mode-grant.json')
+
+  try {
+    fs.writeFileSync(grantPath, '{not-json', { mode: 0o600 })
+    assert.equal(consumeServiceModeGrant(grantPath), null)
+    assert.equal(fs.existsSync(grantPath), false)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+test('DevToolsActivePort parsing accepts only a usable dynamic port', () => {
+  assert.equal(parseDevToolsActivePort('49152\n/devtools/browser/abc\n'), 49152)
+
+  for (const value of ['', '0\n', '80\n', '70000\n', '9222.5\n', 'garbage\n']) {
+    assert.equal(parseDevToolsActivePort(value), null, `expected ${JSON.stringify(value)} to be refused`)
+  }
+})
+
+test('dynamic port discovery waits for Chromium and times out closed', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-service-mode-'))
+  const activePortPath = path.join(dir, 'DevToolsActivePort')
+
+  try {
+    const writer = setTimeout(() => fs.writeFileSync(activePortPath, '49152\n/devtools/browser/abc\n'), 10)
+    assert.equal(await waitForDevToolsActivePort(activePortPath, { pollMs: 2, timeoutMs: 100 }), 49152)
+    clearTimeout(writer)
+    fs.rmSync(activePortPath, { force: true })
+    assert.equal(await waitForDevToolsActivePort(activePortPath, { pollMs: 2, timeoutMs: 10 }), null)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+test('the startup prompt defaults to standard and requires acknowledgement for service mode', () => {
+  assert.equal(resolveServiceModePrompt({ checkboxChecked: false, response: 0 }), 'standard')
+  assert.equal(resolveServiceModePrompt({ checkboxChecked: true, response: 0 }), 'standard')
+  assert.equal(resolveServiceModePrompt({ checkboxChecked: false, response: 1 }), 'retry')
+  assert.equal(resolveServiceModePrompt({ checkboxChecked: true, response: 1 }), 'service')
+  assert.equal(resolveServiceModePrompt({ checkboxChecked: true, response: 2 }), 'quit')
+})
+
+test('the runtime marker is private and only its owning process removes it during shutdown', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-service-mode-'))
+  const statePath = path.join(dir, 'service-mode.json')
+  const state = { active: true as const, host: '127.0.0.1' as const, pid: 42, port: 49152, startedAt: NOW }
+
+  try {
+    writeServiceModeState(statePath, state)
+    assert.equal(fs.statSync(statePath).mode & 0o777, 0o600)
+    assert.deepEqual(JSON.parse(fs.readFileSync(statePath, 'utf8')), state)
+
+    removeServiceModeState(statePath, 41)
+    assert.equal(fs.existsSync(statePath), true)
+
+    removeServiceModeState(statePath, 42)
+    assert.equal(fs.existsSync(statePath), false)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+test('a Standard startup removes a stale runtime marker regardless of its former owner', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-service-mode-'))
+  const statePath = path.join(dir, 'service-mode.json')
+
+  try {
+    writeServiceModeState(statePath, {
+      active: true,
+      host: '127.0.0.1',
+      pid: 42,
+      port: 49152,
+      startedAt: NOW
+    })
+
+    removeServiceModeState(statePath)
+    assert.equal(fs.existsSync(statePath), false)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})

--- a/apps/desktop/electron/service-mode.ts
+++ b/apps/desktop/electron/service-mode.ts
@@ -1,0 +1,237 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SERVICE_MODE_ARG_PREFIX = '--hermes-service-mode-token='
+const SERVICE_MODE_GRANT_TTL_MS = 60_000
+const TOKEN_PATTERN = /^[a-f0-9]{64}$/
+
+type ServiceModeClosedReason =
+  'expired-grant' | 'invalid-grant' | 'invalid-request' | 'missing-grant' | 'not-packaged' | 'not-requested'
+
+type ServiceModeDecision = { active: true; reason: null } | { active: false; reason: ServiceModeClosedReason }
+
+interface ServiceModeGrant {
+  expiresAt: number
+  token: string
+}
+
+interface ServiceModeActivationInput {
+  argv: readonly string[]
+  grant: null | ServiceModeGrant
+  isPackaged: boolean
+  now: number
+}
+
+function requestedToken(argv: readonly string[]): null | string {
+  const arg = argv.find(value => value.startsWith(SERVICE_MODE_ARG_PREFIX))
+
+  return arg ? arg.slice(SERVICE_MODE_ARG_PREFIX.length) : null
+}
+
+function equalToken(left: string, right: string): boolean {
+  if (!TOKEN_PATTERN.test(left) || !TOKEN_PATTERN.test(right)) {
+    return false
+  }
+
+  return timingSafeEqual(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'))
+}
+
+/**
+ * Authorize the packaged renderer debugger from a short-lived, one-shot grant.
+ * A command-line argument by itself is deliberately insufficient.
+ */
+function resolveServiceModeActivation({
+  argv,
+  grant,
+  isPackaged,
+  now
+}: ServiceModeActivationInput): ServiceModeDecision {
+  const token = requestedToken(argv)
+
+  if (!token) {
+    return { active: false, reason: 'not-requested' }
+  }
+
+  if (!isPackaged) {
+    return { active: false, reason: 'not-packaged' }
+  }
+
+  if (!TOKEN_PATTERN.test(token)) {
+    return { active: false, reason: 'invalid-request' }
+  }
+
+  if (!grant) {
+    return { active: false, reason: 'missing-grant' }
+  }
+
+  if (!Number.isFinite(grant.expiresAt) || grant.expiresAt < now) {
+    return { active: false, reason: 'expired-grant' }
+  }
+
+  if (!equalToken(token, grant.token)) {
+    return { active: false, reason: 'invalid-grant' }
+  }
+
+  return { active: true, reason: null }
+}
+
+function buildServiceModeRelaunchArgs(argv: readonly string[], token: string): string[] {
+  return [...argv.filter(value => !value.startsWith(SERVICE_MODE_ARG_PREFIX)), `${SERVICE_MODE_ARG_PREFIX}${token}`]
+}
+
+function resolveServiceModePrompt({
+  checkboxChecked,
+  response
+}: {
+  checkboxChecked: boolean
+  response: number
+}): 'quit' | 'retry' | 'service' | 'standard' {
+  if (response === 0) {
+    return 'standard'
+  }
+
+  if (response === 1) {
+    return checkboxChecked ? 'service' : 'retry'
+  }
+
+  return 'quit'
+}
+
+function writeServiceModeGrant(filePath: string, now = Date.now()): ServiceModeGrant {
+  const grant = {
+    expiresAt: now + SERVICE_MODE_GRANT_TTL_MS,
+    token: randomBytes(32).toString('hex')
+  }
+
+  const tempPath = `${filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 })
+
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(grant)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    fs.renameSync(tempPath, filePath)
+    fs.chmodSync(filePath, 0o600)
+  } finally {
+    fs.rmSync(tempPath, { force: true })
+  }
+
+  return grant
+}
+
+/** Read then unlink even malformed content, so no grant can be replayed. */
+function consumeServiceModeGrant(filePath: string): null | ServiceModeGrant {
+  let raw: null | string = null
+
+  try {
+    raw = fs.readFileSync(filePath, 'utf8')
+  } catch {
+    return null
+  } finally {
+    fs.rmSync(filePath, { force: true })
+  }
+
+  try {
+    const value = JSON.parse(raw)
+
+    if (!value || typeof value !== 'object' || typeof value.token !== 'string' || typeof value.expiresAt !== 'number') {
+      return null
+    }
+
+    return { expiresAt: value.expiresAt, token: value.token }
+  } catch {
+    return null
+  }
+}
+
+interface ServiceModeRuntimeState {
+  active: true
+  host: '127.0.0.1'
+  pid: number
+  port: number
+  startedAt: number
+}
+
+function writeServiceModeState(filePath: string, state: ServiceModeRuntimeState): void {
+  const tempPath = `${filePath}.${state.pid}.${randomBytes(6).toString('hex')}.tmp`
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 })
+
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(state)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    fs.rmSync(filePath, { force: true })
+    fs.renameSync(tempPath, filePath)
+    fs.chmodSync(filePath, 0o600)
+  } finally {
+    fs.rmSync(tempPath, { force: true })
+  }
+}
+
+function removeServiceModeState(filePath: string, ownerPid?: number): void {
+  if (ownerPid === undefined) {
+    // A packaged Standard startup owns the single-instance lock and can safely
+    // clear any marker left by a crashed or force-exited prior Service Mode run.
+    fs.rmSync(filePath, { force: true })
+
+    return
+  }
+
+  try {
+    const state = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+
+    if (state?.pid === ownerPid) {
+      fs.rmSync(filePath, { force: true })
+    }
+  } catch {
+    // Shutdown cleanup is deliberately PID-bound; malformed or foreign state
+    // is left for the next authoritative Standard startup to clear.
+  }
+}
+
+function parseDevToolsActivePort(raw: string): null | number {
+  const port = Number(raw.split(/\r?\n/, 1)[0]?.trim())
+
+  return Number.isInteger(port) && port >= 1024 && port <= 65535 ? port : null
+}
+
+async function waitForDevToolsActivePort(
+  filePath: string,
+  { pollMs = 25, timeoutMs = 5_000 }: { pollMs?: number; timeoutMs?: number } = {}
+): Promise<null | number> {
+  const deadline = Date.now() + Math.max(0, timeoutMs)
+
+  while (Date.now() <= deadline) {
+    try {
+      const port = parseDevToolsActivePort(fs.readFileSync(filePath, 'utf8'))
+
+      if (port) {
+        return port
+      }
+    } catch {
+      // Chromium has not published the file yet.
+    }
+
+    if (Date.now() >= deadline) {
+      break
+    }
+
+    await new Promise(resolve => setTimeout(resolve, Math.max(1, pollMs)))
+  }
+
+  return null
+}
+
+export {
+  buildServiceModeRelaunchArgs,
+  consumeServiceModeGrant,
+  parseDevToolsActivePort,
+  removeServiceModeState,
+  resolveServiceModeActivation,
+  resolveServiceModePrompt,
+  SERVICE_MODE_ARG_PREFIX,
+  SERVICE_MODE_GRANT_TTL_MS,
+  waitForDevToolsActivePort,
+  writeServiceModeGrant,
+  writeServiceModeState
+}
+export type { ServiceModeDecision, ServiceModeGrant, ServiceModeRuntimeState }

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -720,7 +720,6 @@ function TitlebarSlot({ area, className, style }: TitlebarSlotProps) {
 
 export function ContribController() {
   const sidebarOpen = useStore($sidebarOpen)
-  const statusbarVisible = useStore($statusbarVisible)
 
   return (
     <SidebarProvider
@@ -786,11 +785,10 @@ export function ContribController() {
           {/* "Close running tab?" — the busy/input-blocked tile close gate. */}
           <SessionTileCloseConfirm />
 
-          {/* The REAL statusbar (model pill, command center, agents, …) with
-              statusBar.left/right contributions merged in. Unmounted — not
-              just hidden — while toggled off, so its 15s status poll and the
-              per-turn readouts stop with it. */}
-          {statusbarVisible && <WiredPane part="statusbar" />}
+          {/* The statusbar surface stays mounted so locked safety indicators
+              (execution boundary and active Service Mode) remain visible even
+              when the user's whole-bar preference suppresses optional items. */}
+          <WiredPane part="statusbar" />
         </div>
       </ContribWiring>
     </SidebarProvider>

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -15,6 +15,7 @@ import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $freshDraftReady, $gatewayState } from '@/store/session'
+import { $statusbarVisible } from '@/store/statusbar-prefs'
 
 import { ChatView } from '../chat'
 import { ChatSidebar } from '../chat/sidebar'
@@ -78,6 +79,7 @@ export const StatusbarSurface = memo(function StatusbarSurface({
 }) {
   const gatewayState = useStore($gatewayState)
   const freshDraftReady = useStore($freshDraftReady)
+  const statusbarVisible = useStore($statusbarVisible)
   const { inferenceStatus, statusSnapshot } = useStatusSnapshot(gatewayState, actions.requestGateway)
   const extraLeftItems = useStatusbarContributions('left')
   const extraRightItems = useStatusbarContributions('right')
@@ -98,7 +100,7 @@ export const StatusbarSurface = memo(function StatusbarSurface({
     toggleCommandCenter: actions.toggleCommandCenter
   })
 
-  return <StatusbarControls items={statusbarItems} leftItems={leftStatusbarItems} />
+  return <StatusbarControls items={statusbarItems} leftItems={leftStatusbarItems} lockedOnly={!statusbarVisible} />
 })
 
 /** The workspace pane: the real route table (chat + full-page views + plugin

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
@@ -9,6 +9,7 @@ import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
+import { resolveExecutionBoundary } from '@/lib/execution-boundary'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
@@ -125,6 +126,33 @@ export function useStatusbarItems({
   const backendUpdateApply = useStore($backendUpdateApply)
   const desktopVersion = useStore($desktopVersion)
   const connection = useStore($connection)
+
+  const [serviceMode, setServiceMode] = useState<null | {
+    active: boolean
+    host: '127.0.0.1'
+    port: number | null
+  }>(null)
+
+  useEffect(() => {
+    let current = true
+
+    void window.hermesDesktop
+      .getServiceMode()
+      .then(state => {
+        if (current) {
+          setServiceMode(state)
+        }
+      })
+      .catch(() => {
+        if (current) {
+          setServiceMode({ active: false, host: '127.0.0.1', port: null })
+        }
+      })
+
+    return () => {
+      current = false
+    }
+  }, [])
 
   // The FOCUSED session (interacted tile, else the primary — the same
   // derivation the titlebar title follows): every session-scoped readout
@@ -303,34 +331,63 @@ export function useStatusbarItems({
     copy
   ])
 
-  const connectionItem = useMemo<StatusbarItem | null>(() => {
-    if (connection?.mode !== 'remote' || !connection.remoteHost) {
-      return null
-    }
+  const connectionItem = useMemo<StatusbarItem>(() => {
+    const boundary = resolveExecutionBoundary(connection)
+    const host = boundary.host
 
-    const ssh = connection.remoteKind === 'ssh'
-    const cloud = connection.remoteKind === 'cloud'
+    const label =
+      boundary.kind === 'local'
+        ? 'LOCAL'
+        : boundary.kind === 'ssh'
+          ? host
+            ? copy.connectionSsh(host)
+            : 'SSH'
+          : boundary.kind === 'cloud'
+            ? host
+              ? copy.connectionCloud(host)
+              : 'CLOUD'
+            : host
+              ? copy.connectionRemote(host)
+              : 'REMOTE'
 
     return {
       className: cn(
         'px-2 -ml-1 font-medium',
-        ssh ? 'bg-primary text-primary-foreground' : 'bg-accent text-accent-foreground'
+        boundary.kind === 'ssh' ? 'bg-primary text-primary-foreground' : 'bg-accent text-accent-foreground'
       ),
       icon: <Terminal className="size-3" />,
       id: 'connection',
-      label: ssh
-        ? copy.connectionSsh(connection.remoteHost)
-        : cloud
-          ? copy.connectionCloud(connection.remoteHost)
-          : copy.connectionRemote(connection.remoteHost),
-      // Label already names the host — no "click to manage" tip lecture.
+      label,
+      lockedVisible: true,
+      title:
+        boundary.kind === 'local'
+          ? 'Agent tools, terminal commands, and files run on this computer.'
+          : `Agent tools, terminal commands, and files run on ${host || 'the remote gateway'}.`,
       to: `${SETTINGS_ROUTE}?tab=gateway`
     }
-  }, [connection?.mode, connection?.remoteHost, connection?.remoteKind, copy])
+  }, [connection, copy])
+
+  const serviceModeItem = useMemo<StatusbarItem | null>(() => {
+    if (!serviceMode?.active || !serviceMode.port) {
+      return null
+    }
+
+    return {
+      className: 'bg-destructive px-2 font-semibold text-destructive-foreground',
+      detail: `${serviceMode.host}:${serviceMode.port}`,
+      id: 'service-mode',
+      label: 'SERVICE',
+      lockedVisible: true,
+      title:
+        'Service Mode is active. Local programs can read Hermes content and control the renderer. Quitting Hermes closes the endpoint.',
+      variant: 'text'
+    }
+  }, [serviceMode])
 
   const coreLeftStatusbarItems = useMemo<readonly StatusbarItem[]>(
     () => [
-      ...(connectionItem ? [connectionItem] : []),
+      ...(serviceModeItem ? [serviceModeItem] : []),
+      connectionItem,
       {
         className: `w-7 justify-center px-0${commandCenterOpen ? ' bg-accent/55 text-foreground' : ''}`,
         icon: <Command className="size-3.5" />,
@@ -456,6 +513,7 @@ export function useStatusbarItems({
       inferenceStatus?.reason,
       openAgents,
       projectName,
+      serviceModeItem,
       subagentsFailed,
       subagentsRunning,
       toggleCommandCenter

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -80,14 +80,25 @@ export type SetStatusbarItemGroup = (id: string, items: readonly StatusbarItem[]
 interface StatusbarControlsProps extends ComponentProps<'footer'> {
   leftItems?: readonly StatusbarItem[]
   items?: readonly StatusbarItem[]
+  /** Keep the safety-critical execution boundary visible while the user's
+   *  whole-bar preference suppresses every optional status item. */
+  lockedOnly?: boolean
 }
 
-export function StatusbarControls({ className, leftItems = [], items = [], ...props }: StatusbarControlsProps) {
+export function StatusbarControls({
+  className,
+  leftItems = [],
+  items = [],
+  lockedOnly = false,
+  ...props
+}: StatusbarControlsProps) {
   const navigate = useNavigate()
   const hiddenIds = useStore($statusbarHiddenIds)
 
   const visible = (item: StatusbarItem) =>
-    !item.hidden && (item.lockedVisible || !item.toggleLabel || !hiddenIds.includes(item.id))
+    !item.hidden &&
+    (!lockedOnly || item.lockedVisible === true) &&
+    (item.lockedVisible || !item.toggleLabel || !hiddenIds.includes(item.id))
 
   return (
     <ContextMenu>
@@ -123,8 +134,8 @@ export function StatusbarControls({ className, leftItems = [], items = [], ...pr
 
 /** Right-click the bar to choose what it shows. Lists every item that named
  *  itself with `toggleLabel`, in bar order (left cluster then right), so the
- *  menu reads like the surface it edits. Hiding the whole bar lives at the
- *  bottom — VS Code puts it on the same context menu. */
+ *  menu reads like the surface it edits. The whole-bar preference lives at the
+ *  bottom; locked safety indicators remain in a minimal bar when it is off. */
 function StatusbarVisibilityMenu({
   hiddenIds,
   items,
@@ -185,7 +196,7 @@ function StatusbarVisibilityMenu({
   )
 }
 
-/** The live ⌘⇧S hint on the hide row — the way back once the bar is gone. */
+/** The live ⌘⇧S hint on the hide row — the way back to the complete bar. */
 function StatusbarHideHint() {
   const hint = useKeybindHint('view.toggleStatusbar')
 

--- a/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
@@ -38,10 +38,13 @@ const item = (id: string, label: string, extra: Partial<StatusbarItem> = {}): St
   ...extra
 })
 
-function bar(items: StatusbarItem[]) {
+function bar(
+  items: StatusbarItem[],
+  { leftItems = [], lockedOnly = false }: { leftItems?: StatusbarItem[]; lockedOnly?: boolean } = {}
+) {
   render(
     <MemoryRouter>
-      <StatusbarControls items={items} />
+      <StatusbarControls items={items} leftItems={leftItems} lockedOnly={lockedOnly} />
     </MemoryRouter>
   )
 
@@ -126,6 +129,20 @@ describe('statusbar item visibility', () => {
 })
 
 describe('whole-bar visibility', () => {
+  it('keeps only locked safety indicators visible when the full status bar is hidden', () => {
+    const statusbar = bar(
+      [item('gateway-health', 'Gateway'), item('service-mode', 'SERVICE', { lockedVisible: true })],
+      {
+        leftItems: [item('execution-boundary', 'LOCAL', { lockedVisible: true })],
+        lockedOnly: true
+      }
+    )
+
+    expect(within(statusbar).getByText('LOCAL')).toBeTruthy()
+    expect(within(statusbar).getByText('SERVICE')).toBeTruthy()
+    expect(within(statusbar).queryByText('Gateway')).toBeNull()
+  })
+
   it('hides the bar from the context menu, leaving the keybind as the way back', async () => {
     const statusbar = bar([item('gateway-health', 'Gateway')])
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -10,6 +10,14 @@ import type { QuickEntryStatePush, QuickEntryStatus, QuickEntrySubmitPayload } f
 
 export {}
 
+export interface HermesServiceModeState {
+  active: boolean
+  host: '127.0.0.1'
+  pid: number | null
+  port: number | null
+  startedAt: number | null
+}
+
 declare global {
   interface Window {
     hermesDesktop: {
@@ -85,6 +93,7 @@ declare global {
         onShown: (callback: () => void) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
+      getServiceMode: () => Promise<HermesServiceModeState>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>
       saveConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>
       applyConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>

--- a/apps/desktop/src/lib/execution-boundary.test.ts
+++ b/apps/desktop/src/lib/execution-boundary.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveExecutionBoundary } from './execution-boundary'
+
+describe('resolveExecutionBoundary', () => {
+  it('always identifies the local execution boundary', () => {
+    expect(resolveExecutionBoundary(null)).toEqual({ host: null, kind: 'local' })
+    expect(resolveExecutionBoundary({ mode: 'local' })).toEqual({ host: null, kind: 'local' })
+  })
+
+  it('identifies URL, SSH, and Cloud remote boundaries with their host', () => {
+    expect(resolveExecutionBoundary({ mode: 'remote', remoteHost: 'mosquito-nas.local', remoteKind: 'url' })).toEqual({
+      host: 'mosquito-nas.local',
+      kind: 'remote'
+    })
+    expect(resolveExecutionBoundary({ mode: 'remote', remoteHost: 'operator@nas', remoteKind: 'ssh' })).toEqual({
+      host: 'operator@nas',
+      kind: 'ssh'
+    })
+    expect(resolveExecutionBoundary({ mode: 'remote', remoteHost: 'agent.example', remoteKind: 'cloud' })).toEqual({
+      host: 'agent.example',
+      kind: 'cloud'
+    })
+  })
+
+  it('still exposes an unknown remote boundary instead of falling back to local', () => {
+    expect(resolveExecutionBoundary({ mode: 'remote' })).toEqual({ host: null, kind: 'remote' })
+  })
+})

--- a/apps/desktop/src/lib/execution-boundary.ts
+++ b/apps/desktop/src/lib/execution-boundary.ts
@@ -1,0 +1,20 @@
+interface ExecutionBoundaryConnection {
+  mode?: 'local' | 'remote'
+  remoteHost?: string
+  remoteKind?: 'cloud' | 'ssh' | 'url'
+}
+
+interface ExecutionBoundary {
+  host: string | null
+  kind: 'cloud' | 'local' | 'remote' | 'ssh'
+}
+
+export function resolveExecutionBoundary(connection: ExecutionBoundaryConnection | null): ExecutionBoundary {
+  if (connection?.mode !== 'remote') {
+    return { host: null, kind: 'local' }
+  }
+
+  const kind = connection.remoteKind === 'ssh' || connection.remoteKind === 'cloud' ? connection.remoteKind : 'remote'
+
+  return { host: connection.remoteHost?.trim() || null, kind }
+}

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,10 +3,9 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
+// Whole-bar preference, VS Code's `workbench.statusBar.visible`. Off by default:
+// optional items are opt-in while locked safety indicators remain mounted;
+// `view.toggleStatusbar` or the ⌘K row restores the complete bar.
 export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
 
 export function toggleStatusbarVisible() {

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -32,6 +32,31 @@ hermes desktop
 
 That uses your current config, keys, sessions, and skills.
 
+## Service Mode (local diagnostics)
+
+Packaged Desktop builds ask whether Hermes should start normally, start in
+Service Mode, or quit. **Start normally** is the safe default and does not open
+a Chrome DevTools Protocol (CDP) endpoint. **Start in Service Mode** is an
+explicit, temporary opt-in for local UI inspection: after you actively
+acknowledge the risk, Hermes relaunches with a dynamically selected CDP port
+bound only to `127.0.0.1`.
+
+:::warning
+CDP has no user authentication. Any local program that can discover and reach
+the endpoint can potentially read rendered Hermes content, execute renderer
+JavaScript, trigger UI actions, and call exposed preload APIs. Do not open
+passwords, credentials, or especially sensitive content while Service Mode is
+active. Quit Hermes and start normally when diagnostics are complete.
+:::
+
+The acknowledgement is never saved. Its relaunch grant can be consumed once
+and expires after 60 seconds; after a successful relaunch, Service Mode remains
+active only until Hermes exits. The status bar shows `SERVICE` with the actual
+loopback endpoint and a locked `LOCAL` or `REMOTE` execution-boundary indicator.
+These safety indicators remain visible even when optional status-bar content is
+hidden. Stale grants and runtime markers are removed during startup and
+shutdown so they cannot report false activity.
+
 ## What's in the app
 
 The desktop app is organized as a chat-first window with a left sidebar for navigation. It's built to allow managing multiple simultaneous agent conversations, configuring messaging providers, creating artifacts, browsing projects' folder structures, and working on multiple projects at once.
@@ -54,7 +79,7 @@ The bar along the bottom of the chat shows live session state and exposes quick 
 
 - **Per-session YOLO toggle** — flip YOLO on or off for just this session (matching the TUI). YOLO bypasses the dangerous-command approval prompts, so know what you're turning off — see [Security → YOLO Mode](./security.md#yolo-mode).
 - **Context-usage meter** — a live "% full" meter of the session's context window. Click it to open the **Context Usage** popover with a token breakdown by category (system prompt, tool definitions, skills, memory, rules, MCP, subagent definitions, and the conversation itself) so you can see exactly what's eating the window before compression kicks in.
-- **Customizable items** — right-click the status bar (**Show in status bar**) to choose what appears: the context meter, workspace, model, approvals, turn/session timers, terminal, Command Center, backend version, and more — or hide the bar entirely (**Cmd/Ctrl+Shift+S** toggles it).
+- **Customizable items** — right-click the status bar (**Show in status bar**) to choose what appears: the context meter, workspace, model, approvals, turn/session timers, terminal, Command Center, backend version, and more — or hide all optional status-bar content (**Cmd/Ctrl+Shift+S** toggles it). Safety-locked indicators for active Service Mode and the local/remote execution boundary remain visible.
 
 Chatting against a Hermes instance on another machine instead of the bundled local backend? See [Connecting to a remote backend](#connecting-to-a-remote-backend) below — and for the full picture of how the remote-hosted dashboard connection works (the auth gate, the `/api/ws` chat socket, and WebSocket close-code triage), see [Web Dashboard → Connecting Hermes Desktop to a remote backend](./features/web-dashboard.md#connecting-hermes-desktop-to-a-remote-backend).
 


### PR DESCRIPTION
## Summary

- add an explicit packaged-app startup chooser for Standard mode, Service Mode, or Quit
- require a non-persistent risk acknowledgement before enabling packaged Chrome DevTools Protocol access
- gate the relaunch with a 60-second, one-time 256-bit grant and bind Chromium only to a dynamic IPv4 loopback endpoint
- expose active Service Mode and the local/remote execution boundary in locked status indicators
- keep those safety indicators visible when optional status-bar content is disabled
- document the startup path, trust boundary, lifetime, indicators, and safe-use guidance in the Desktop README and user guide

## Security properties

- packaged builds remain closed unless the Hermes-owned startup prompt creates a valid grant
- the existing source-tree development CDP path remains separate and cannot enable packaged builds
- Chromium receives `remote-debugging-address=127.0.0.1` and `remote-debugging-port=0`; no fixed, LAN, wildcard, or Tailscale binding is used
- grants are short-lived, single-use, removed on consumption, and never persisted as a preference
- startup fails closed if Chromium does not publish a valid local port or runtime state cannot be published
- stale grants, `DevToolsActivePort`, and stale runtime markers are cleaned so they cannot signal false activity
- normal shutdown cleanup remains PID-bound; a new authoritative packaged startup clears a stale marker left by a prior crashed process

## UI and execution boundary

- Service Mode displays its actual loopback host and dynamically selected port
- the renderer receives read-only Service Mode state through the preload bridge
- the status bar distinguishes local execution from URL, SSH, and cloud-backed remote execution
- `SERVICE` and `LOCAL`/`REMOTE` are `lockedVisible`; when the whole-bar preference is off, optional items stay hidden while the safety indicators remain mounted

## Verification

- Desktop TypeScript checks
- focused ESLint: 0 errors (one pre-existing `projectTree` hook dependency warning)
- Prettier on all changed/new code files
- 24/24 focused Electron tests
- 11/11 focused renderer/UI tests
- 636/636 relevant root Python tests through the canonical `scripts/run_tests.sh` wrapper
- production Desktop build
- Docusaurus production build for both configured locales (existing repository-wide link warnings remain)
- `git diff --check origin/main...HEAD`
- independent focused security/logic review: passed with no concerns, logic errors, or suggestions

An isolated, locally signed packaged macOS build was also exercised with separate `HERMES_HOME` and user-data directories:

- a pre-created stale Service Mode marker was removed before the startup prompt
- Service Mode relaunched once after explicit acknowledgement
- `lsof` confirmed an IPv4 listener only on `127.0.0.1:<dynamic-port>`
- the one-time grant was consumed and the runtime marker was owner-only (`0600`)
- with the whole status bar disabled by default, live renderer inspection still showed `SERVICE`, the loopback endpoint, and `LOCAL` while optional items remained absent
- regular Quit stopped the process, closed CDP, and removed the runtime marker

The productive `/Applications/Hermes.app` and the user's real Hermes profile were not modified during these tests.
