### PR TITLE
feat: add trace-derived evaluation tasks

### DIFF
--- a/hermes_cli/evals_cmd.py
+++ b/hermes_cli/evals_cmd.py
@@ -1,0 +1,318 @@
+"""CLI implementation for ``hermes evals``.
+
+This is deliberately an edge command rather than a model tool: task mining and
+validation should not enlarge every agent request's tool schema.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Iterable, Mapping
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.resolver import BaseResolver
+
+from hermes_cli.evals_core import (
+    build_candidate_from_trace,
+    score_run_artifact,
+    validate_manifest,
+)
+
+
+_MAX_MANIFEST_BYTES = 2 * 1024 * 1024
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects ambiguous duplicate mapping keys."""
+
+
+def _construct_unique_mapping(loader, node, deep=False):
+    loader.flatten_mapping(node)
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _open_session_db():
+    from hermes_state import SessionDB
+
+    return SessionDB()
+
+
+def _default_candidate_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "evals" / "candidates"
+
+
+def load_manifest(path: Path) -> Mapping[str, Any]:
+    """Load one bounded YAML task manifest without constructing Python objects."""
+
+    path = path.expanduser()
+    if not path.is_file():
+        raise ValueError(f"manifest is not a file: {path}")
+    size = path.stat().st_size
+    if size > _MAX_MANIFEST_BYTES:
+        raise ValueError(
+            f"manifest exceeds {_MAX_MANIFEST_BYTES} byte safety limit: {path}"
+        )
+    try:
+        loaded = yaml.load(
+            path.read_text(encoding="utf-8"),
+            Loader=_UniqueKeyLoader,
+        )
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ValueError(f"could not read YAML manifest {path}: {exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise ValueError(f"manifest root must be a mapping: {path}")
+    return loaded
+
+
+def _atomic_private_write(
+    path: Path,
+    rendered: str,
+    *,
+    force: bool,
+    label: str,
+) -> Path:
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise ValueError(f"refusing to write through symlink: {path}")
+
+    tmp_path: Path | None = None
+    try:
+        fd, raw_tmp = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        tmp_path = Path(raw_tmp)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, 0o600)
+        if force:
+            # os.replace replaces a symlink entry rather than following it.
+            os.replace(tmp_path, path)
+        else:
+            # Link publication is atomic and cannot overwrite a file that
+            # appears after a check-then-write race.
+            try:
+                os.link(tmp_path, path)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"refusing to overwrite existing {label}: {path}"
+                ) from exc
+            tmp_path.unlink()
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+    return path
+
+
+def write_manifest(path: Path, manifest: Mapping[str, Any], *, force: bool = False) -> Path:
+    """Atomically write a private YAML manifest, refusing symlink targets."""
+
+    rendered = yaml.safe_dump(
+        dict(manifest),
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    return _atomic_private_write(
+        path,
+        rendered,
+        force=force,
+        label="manifest",
+    )
+
+
+def load_run_artifact(path: Path) -> Mapping[str, Any]:
+    path = path.expanduser()
+    if not path.is_file():
+        raise ValueError(f"run artifact is not a file: {path}")
+    if path.stat().st_size > _MAX_MANIFEST_BYTES:
+        raise ValueError(f"run artifact exceeds {_MAX_MANIFEST_BYTES} byte safety limit: {path}")
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read JSON run artifact {path}: {exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise ValueError(f"run artifact root must be a mapping: {path}")
+    return loaded
+
+
+def write_score(path: Path, result: Mapping[str, Any], *, force: bool = False) -> Path:
+    rendered = json.dumps(dict(result), indent=2, sort_keys=True) + "\n"
+    return _atomic_private_write(path, rendered, force=force, label="score")
+
+
+def _manifest_paths(path: Path) -> Iterable[Path]:
+    path = path.expanduser()
+    if path.is_file():
+        yield path
+        return
+    if not path.is_dir():
+        raise ValueError(f"path does not exist: {path}")
+    yield from sorted(
+        candidate
+        for candidate in path.rglob("*")
+        if candidate.is_file() and candidate.suffix.casefold() in {".yaml", ".yml"}
+    )
+
+
+def _cmd_mine(args) -> int:
+    db = _open_session_db()
+    try:
+        resolved = db.resolve_session_id(args.session_id)
+        if not resolved:
+            print(f"Error: session ID or prefix is missing or ambiguous: {args.session_id}")
+            return 2
+        session = db.get_session(resolved)
+        if not session:
+            print(f"Error: session not found: {resolved}")
+            return 2
+        messages = db.get_messages(resolved)
+        manifest = build_candidate_from_trace(
+            session,
+            messages,
+        )
+    except ValueError as exc:
+        print(f"Error: cannot mine session: {exc}")
+        return 2
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+    output = getattr(args, "output", None)
+    path = Path(output) if output else _default_candidate_dir() / f"{manifest['id']}.yaml"
+    try:
+        write_manifest(path, manifest, force=bool(getattr(args, "force", False)))
+    except (OSError, ValueError) as exc:
+        print(f"Error: could not write candidate: {exc}")
+        return 1
+
+    print(f"Candidate written: {path}")
+    print(f"Signals found: {len(manifest.get('signals', []))}")
+    print(
+        "Review required: inspect the sanitized candidate, define task-specific "
+        "checks, then set status: approved."
+    )
+    return 0
+
+
+def _cmd_validate(args) -> int:
+    try:
+        paths = list(_manifest_paths(Path(args.path)))
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 2
+    if not paths:
+        print("Error: no YAML manifests found")
+        return 2
+
+    failed = 0
+    for path in paths:
+        try:
+            manifest = load_manifest(path)
+        except ValueError as exc:
+            print(f"INVALID {path}: {exc}")
+            failed += 1
+            continue
+        result = validate_manifest(manifest)
+        if result.errors:
+            print(f"INVALID {path}")
+            for error in result.errors:
+                print(f"  error: {error}")
+            failed += 1
+            continue
+        if result.warnings:
+            label = "NOT READY" if getattr(args, "ready", False) else "VALID CANDIDATE"
+            print(f"{label} {path}")
+            for warning in result.warnings:
+                print(f"  warning: {warning}")
+            if getattr(args, "ready", False):
+                failed += 1
+        else:
+            print(f"READY {path}")
+    return 1 if failed else 0
+
+
+def _cmd_score(args) -> int:
+    try:
+        manifest = load_manifest(Path(args.task))
+        run = load_run_artifact(Path(args.run))
+        result = score_run_artifact(manifest, run)
+    except ValueError as exc:
+        print(f"Error: cannot score run: {exc}")
+        return 2
+
+    output = getattr(args, "output", None)
+    if output:
+        try:
+            write_score(
+                Path(output),
+                result,
+                force=bool(getattr(args, "force", False)),
+            )
+        except (OSError, ValueError) as exc:
+            print(f"Error: could not write score: {exc}")
+            return 1
+
+    status = str(result["status"])
+    print(
+        f"{status.upper().replace('_', ' ')} {result['task_id']} "
+        f"({result['deterministic']['passed']}/{result['deterministic']['total']} deterministic checks)"
+    )
+    if not output:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    if status == "passed":
+        return 0
+    if status == "needs_judge":
+        return 3
+    return 1
+
+
+def cmd_evals(args) -> int:
+    action = getattr(args, "evals_action", None)
+    if action == "mine":
+        return _cmd_mine(args)
+    if action == "validate":
+        return _cmd_validate(args)
+    if action == "score":
+        return _cmd_score(args)
+    print("Use `hermes evals --help` to see available actions.")
+    return 2

--- a/hermes_cli/evals_core.py
+++ b/hermes_cli/evals_core.py
@@ -1,0 +1,569 @@
+"""Portable evaluation-task manifests for Hermes Agent.
+
+The format is intentionally data-only. It can be produced from local session
+traces, reviewed in Git, and exported to an external runner without adding a
+model tool or changing the conversation loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from importlib import import_module
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence
+
+
+_TASK_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,127}$")
+_ALLOWED_STATUSES = frozenset({"candidate", "approved", "retired"})
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "id",
+        "status",
+        "instruction",
+        "source",
+        "environment",
+        "success",
+        "forbidden",
+        "skills",
+        "signals",
+        "provenance",
+    }
+)
+_DETERMINISTIC_CHECK_FIELDS = {
+    "tool_called": "name",
+    "tool_succeeded": "name",
+    "final_response_contains": "value",
+    "final_response_excludes": "value",
+}
+_CORRECTION_RE = re.compile(
+    r"^\s*(?:no\b|actually\b|that(?:'s| is) (?:wrong|not right)\b|"
+    r"you (?:did not|didn't|haven't|have not|missed|forgot)\b)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Structured validation result suitable for both CLI and tests."""
+
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    @property
+    def valid(self) -> bool:
+        return not self.errors
+
+    @property
+    def ready(self) -> bool:
+        return self.valid and not self.warnings
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(_nonempty_string(item) for item in value)
+
+
+def _redact_trace_text(
+    value: Any,
+    *,
+    limit: int = 2_000,
+    workspace: str | None = None,
+) -> str:
+    """Fail-closed secret/PII/path sanitization for candidate artifacts."""
+
+    redact_sensitive_text = import_module("agent.redact").redact_sensitive_text
+    redact_for_export = import_module(
+        "agent.monitoring.redaction"
+    ).redact_for_export
+    text = str(value or "")
+    text = text.replace(str(Path.home()), "$HOME")
+    if workspace:
+        text = text.replace(workspace, "$WORKSPACE")
+    # The file-read pass emits non-reusable sentinels for token shapes; the
+    # regular pass then catches assignment-style secrets. Monitoring redaction
+    # adds fail-closed PII scrubbing.
+    text = redact_sensitive_text(
+        text,
+        force=True,
+        file_read=True,
+        redact_url_credentials=True,
+    )
+    text = redact_sensitive_text(
+        text,
+        force=True,
+        redact_url_credentials=True,
+    )
+    scrubbed = redact_for_export(text)
+    return str(scrubbed or "")[:limit]
+
+
+def _normalize_user_instruction(content: Any) -> str | None:
+    extractor = import_module(
+        "agent.skill_commands"
+    ).extract_user_instruction_from_skill_message
+    extracted = extractor(content)
+    return extracted if isinstance(extracted, str) and extracted.strip() else None
+
+
+def _task_id_for_candidate(instruction: str, tools: Sequence[str]) -> str:
+    material = json.dumps(
+        {"instruction": instruction, "allowed_tools": sorted(tools)},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:20]
+    return f"trace-{digest}"
+
+
+def _trace_digest(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    workspace: str | None,
+) -> str:
+    """Return an opaque, content-derived trace digest for deduplication."""
+
+    digest = hashlib.sha256()
+    for message in messages:
+        digest.update(str(message.get("role") or "").encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(message.get("tool_name") or "").encode("utf-8"))
+        digest.update(b"\0")
+        content = message.get("content")
+        rendered = content if isinstance(content, str) else repr(content)
+        digest.update(
+            _redact_trace_text(
+                rendered,
+                limit=4096,
+                workspace=workspace,
+            ).encode("utf-8")
+        )
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def _tool_failed(content: Any) -> bool:
+    text = str(content or "").strip()
+    if not text:
+        return False
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        lowered = text.casefold()
+        return any(
+            marker in lowered
+            for marker in ("traceback", "connection refused", "permission denied")
+        )
+    if not isinstance(payload, Mapping):
+        return False
+    if payload.get("success") is False:
+        return True
+    exit_code = payload.get("exit_code")
+    return isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0
+
+
+def _tool_names(messages: Sequence[Mapping[str, Any]]) -> list[str]:
+    names: set[str] = set()
+    for message in messages:
+        tool_name = message.get("tool_name")
+        if _nonempty_string(tool_name):
+            names.add(str(tool_name))
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for call in tool_calls:
+            if not isinstance(call, Mapping):
+                continue
+            function = call.get("function")
+            if isinstance(function, Mapping) and _nonempty_string(function.get("name")):
+                names.add(str(function["name"]))
+    return sorted(names)
+
+
+def build_candidate_from_trace(
+    session: Mapping[str, Any],
+    messages: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Convert one session trace into a sanitized, review-required task candidate.
+
+    The compiler records evidence and proposes verifier criteria, but never
+    approves its own output. Human review must replace or confirm the checks
+    before changing ``status`` to ``approved``.
+    """
+
+    session_id = str(session.get("id") or "")
+    if not session_id:
+        raise ValueError("session id is required")
+
+    selected = [message for message in messages if isinstance(message, Mapping)]
+    workspace = str(session.get("cwd") or "") or None
+    first_instruction = next(
+        (
+            normalized
+            for message in selected
+            if message.get("role") == "user"
+            for normalized in [_normalize_user_instruction(message.get("content"))]
+            if normalized
+        ),
+        None,
+    )
+    if first_instruction is None:
+        raise ValueError("session trace has no user instruction")
+
+    signals: list[dict[str, Any]] = []
+    seen_assistant = False
+    for ordinal, message in enumerate(selected):
+        role = message.get("role")
+        content = message.get("content")
+        if isinstance(content, str) and "[OUT-OF-BAND USER MESSAGE" in content:
+            signals.append(
+                {
+                    "kind": "midturn_user_steering",
+                    "message_ordinal": ordinal,
+                }
+            )
+        if role == "assistant":
+            seen_assistant = True
+        elif role == "tool" and _tool_failed(content):
+            signals.append(
+                {
+                    "kind": "tool_failure",
+                    "message_ordinal": ordinal,
+                    "tool": message.get("tool_name"),
+                }
+            )
+        elif (
+            role == "user"
+            and seen_assistant
+            and isinstance(content, str)
+            and _CORRECTION_RE.search(content)
+        ):
+            signals.append(
+                {
+                    "kind": "user_correction",
+                    "message_ordinal": ordinal,
+                }
+            )
+
+    instruction = _redact_trace_text(first_instruction, workspace=workspace)
+    allowed_tools = _tool_names(selected)
+    source: dict[str, Any] = {
+        "kind": "session_trace",
+        "digest": _trace_digest(selected, workspace=workspace),
+        "message_count": len(selected),
+        "sanitized": True,
+    }
+
+    return {
+        "schema_version": 1,
+        "id": _task_id_for_candidate(instruction, allowed_tools),
+        "status": "candidate",
+        "instruction": instruction,
+        "source": source,
+        "environment": {"allowed_tools": allowed_tools},
+        "success": {
+            "deterministic": [],
+            "judged": [
+                "The requested outcome is supported by real execution evidence.",
+                "The final report does not claim success before verification.",
+            ],
+        },
+        "forbidden": [
+            "Invent command, API, file, or deployment results.",
+            "Treat an unverified intermediate result as task completion.",
+        ],
+        "skills": [],
+        "signals": signals,
+        "provenance": {
+            "source": session.get("source"),
+            "message_count": len(selected),
+            "tool_call_count": session.get("tool_call_count", 0),
+            "has_final_response": any(
+                message.get("role") == "assistant"
+                and _nonempty_string(message.get("content"))
+                for message in selected
+            ),
+        },
+    }
+
+
+def _successful_tool_call(call: Mapping[str, Any]) -> bool:
+    result = call.get("result")
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return False
+    if not isinstance(result, Mapping):
+        return False
+    if result.get("success") is False:
+        return False
+    exit_code = result.get("exit_code")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        return exit_code == 0
+    return result.get("success") is True
+
+
+def score_run_artifact(
+    manifest: Mapping[str, Any], run: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Apply deterministic checks to a recorded run artifact.
+
+    Qualitative criteria are returned for a separate evaluator; this function
+    deliberately does not let the task generator grade its own prose.
+    """
+
+    validation = validate_manifest(manifest)
+    if validation.errors:
+        raise ValueError("invalid task manifest: " + "; ".join(validation.errors))
+    if not validation.ready:
+        raise ValueError("task manifest is not ready: " + "; ".join(validation.warnings))
+    task_id = str(manifest.get("id"))
+    if run.get("task_id") != task_id:
+        raise ValueError("run.task_id does not match manifest id")
+
+    final_response = run.get("final_response")
+    if not isinstance(final_response, str):
+        raise ValueError("run artifact final_response must be a string")
+    raw_calls = run.get("tool_calls")
+    if not isinstance(raw_calls, list):
+        raise ValueError("run artifact tool_calls must be a list")
+    tool_calls: list[Mapping[str, Any]] = []
+    for index, call in enumerate(raw_calls):
+        if not isinstance(call, Mapping) or not _nonempty_string(call.get("name")):
+            raise ValueError(
+                f"run artifact tool_calls[{index}] must be a mapping with a non-empty name"
+            )
+        tool_calls.append(call)
+
+    deterministic = manifest.get("success", {}).get("deterministic", [])
+    results: list[dict[str, Any]] = []
+
+    allowed_tools = set(manifest["environment"]["allowed_tools"])
+    disallowed_tools = sorted(
+        {
+            str(call["name"])
+            for call in tool_calls
+            if str(call["name"]) not in allowed_tools
+        }
+    )
+    results.append(
+        {
+            "index": "policy.allowed_tools",
+            "type": "allowed_tools",
+            "passed": not disallowed_tools,
+            "detail": (
+                "all called tools were allowed"
+                if not disallowed_tools
+                else "disallowed tools called: " + ", ".join(disallowed_tools)
+            ),
+        }
+    )
+
+    for index, check in enumerate(deterministic):
+        check_type = check["type"]
+        passed = False
+        if check_type == "tool_called":
+            passed = any(call.get("name") == check["name"] for call in tool_calls)
+        elif check_type == "tool_succeeded":
+            passed = any(
+                call.get("name") == check["name"] and _successful_tool_call(call)
+                for call in tool_calls
+            )
+        elif check_type == "final_response_contains":
+            passed = str(check["value"]).casefold() in final_response.casefold()
+        elif check_type == "final_response_excludes":
+            passed = str(check["value"]).casefold() not in final_response.casefold()
+        results.append(
+            {
+                "index": index,
+                "type": check_type,
+                "passed": passed,
+            }
+        )
+
+    passed_count = sum(1 for result in results if result["passed"])
+    deterministic_passed = passed_count == len(results)
+    judge_criteria = list(manifest.get("success", {}).get("judged", []))
+    judge_criteria.extend(
+        f"Verify forbidden behavior did not occur: {item}"
+        for item in manifest.get("forbidden", [])
+    )
+    if not deterministic_passed:
+        status = "failed"
+        passed: bool | None = False
+    elif judge_criteria:
+        status = "needs_judge"
+        passed = None
+    else:
+        status = "passed"
+        passed = True
+
+    return {
+        "task_id": task_id,
+        "status": status,
+        "passed": passed,
+        "deterministic": {"passed": passed_count, "total": len(results)},
+        "checks": results,
+        "judge_criteria": judge_criteria,
+    }
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> ValidationResult:
+    """Validate a Hermes evaluation-task manifest.
+
+    Candidates may be structurally valid without being runnable. ``ready`` is
+    true only for approved tasks whose deterministic or judged success checks
+    have been filled in and whose source is marked sanitized.
+    """
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    unknown_fields = sorted(set(manifest) - _TOP_LEVEL_FIELDS)
+    if unknown_fields:
+        errors.append("unknown top-level fields: " + ", ".join(unknown_fields))
+
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    task_id = manifest.get("id")
+    if not isinstance(task_id, str) or not _TASK_ID_RE.fullmatch(task_id):
+        errors.append(
+            "id must be 3-128 lowercase characters using letters, numbers, '.', '_' or '-'"
+        )
+
+    status = manifest.get("status")
+    if status not in _ALLOWED_STATUSES:
+        errors.append("status must be one of: candidate, approved, retired")
+    elif status != "approved":
+        warnings.append("status must be 'approved'")
+
+    if not _nonempty_string(manifest.get("instruction")):
+        errors.append("instruction must be a non-empty string")
+
+    source = manifest.get("source")
+    if not isinstance(source, Mapping):
+        errors.append("source must be a mapping")
+    else:
+        extra_source_fields = sorted(
+            set(source) - {"kind", "sanitized", "digest", "message_count"}
+        )
+        if extra_source_fields:
+            errors.append(
+                "source has unknown fields: " + ", ".join(extra_source_fields)
+            )
+        if not _nonempty_string(source.get("kind")):
+            errors.append("source.kind must be a non-empty string")
+        digest = source.get("digest")
+        if digest is not None and (
+            not isinstance(digest, str)
+            or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest)
+        ):
+            errors.append(
+                "source.digest must be a sha256 digest for session_trace tasks"
+            )
+        message_count = source.get("message_count")
+        if message_count is not None and (
+            not isinstance(message_count, int)
+            or isinstance(message_count, bool)
+            or message_count <= 0
+        ):
+            errors.append("source.message_count must be a positive integer")
+        if source.get("kind") == "session_trace":
+            if digest is None:
+                errors.append(
+                    "source.digest must be a sha256 digest for session_trace tasks"
+                )
+            if message_count is None:
+                errors.append("source.message_count must be a positive integer")
+        if source.get("sanitized") is not True:
+            errors.append("source.sanitized must be true")
+
+    environment = manifest.get("environment")
+    if not isinstance(environment, Mapping):
+        errors.append("environment must be a mapping")
+    else:
+        extra_environment_fields = sorted(set(environment) - {"allowed_tools"})
+        if extra_environment_fields:
+            errors.append(
+                "environment has unknown fields: "
+                + ", ".join(extra_environment_fields)
+            )
+        allowed_tools = environment.get("allowed_tools")
+        if not _string_list(allowed_tools):
+            errors.append("environment.allowed_tools must be a list of non-empty strings")
+        elif isinstance(allowed_tools, list) and len(allowed_tools) != len(
+            set(allowed_tools)
+        ):
+            errors.append("environment.allowed_tools must not contain duplicates")
+
+    success = manifest.get("success")
+    if not isinstance(success, Mapping):
+        errors.append("success must be a mapping")
+    else:
+        extra_success_fields = sorted(set(success) - {"deterministic", "judged"})
+        if extra_success_fields:
+            errors.append(
+                "success has unknown fields: " + ", ".join(extra_success_fields)
+            )
+        deterministic = success.get("deterministic")
+        judged = success.get("judged")
+        if not isinstance(deterministic, list):
+            errors.append("success.deterministic must be a list")
+        else:
+            for index, check in enumerate(deterministic):
+                if not isinstance(check, Mapping):
+                    errors.append(f"success.deterministic[{index}] must be a mapping")
+                    continue
+                check_type = check.get("type")
+                required_field = (
+                    _DETERMINISTIC_CHECK_FIELDS.get(check_type)
+                    if isinstance(check_type, str)
+                    else None
+                )
+                if required_field is None:
+                    allowed = ", ".join(sorted(_DETERMINISTIC_CHECK_FIELDS))
+                    errors.append(
+                        f"success.deterministic[{index}].type must be one of: {allowed}"
+                    )
+                elif not _nonempty_string(check.get(required_field)):
+                    errors.append(
+                        f"success.deterministic[{index}].{required_field} must be a non-empty string"
+                    )
+                else:
+                    extra_fields = sorted(set(check) - {"type", required_field})
+                    if extra_fields:
+                        errors.append(
+                            f"success.deterministic[{index}] has unknown fields: "
+                            + ", ".join(extra_fields)
+                        )
+        if not _string_list(judged):
+            errors.append("success.judged must be a list of non-empty strings")
+        if isinstance(deterministic, list) and isinstance(judged, list):
+            if not deterministic and not judged:
+                warnings.append("at least one success check is required before the task is ready")
+
+    for field in ("forbidden", "skills"):
+        if not _string_list(manifest.get(field)):
+            errors.append(f"{field} must be a list of non-empty strings")
+
+    signals = manifest.get("signals")
+    if signals is not None and not (
+        isinstance(signals, list)
+        and all(isinstance(signal, Mapping) for signal in signals)
+    ):
+        errors.append("signals must be a list of mappings")
+
+    provenance = manifest.get("provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        errors.append("provenance must be a mapping")
+
+    return ValidationResult(tuple(errors), tuple(warnings))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -431,6 +431,7 @@ from typing import Optional
 import functools as _functools
 
 from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
+from hermes_cli.evals_cmd import cmd_evals
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
@@ -470,6 +471,7 @@ from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
+from hermes_cli.subcommands.evals import build_evals_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
@@ -12270,6 +12272,7 @@ def main():
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
     build_monitoring_parser(subparsers, cmd_monitoring=cmd_monitoring)
+    build_evals_parser(subparsers, cmd_evals=cmd_evals)
 
     # =========================================================================
     # claw command  (parser built in hermes_cli/subcommands/claw.py)

--- a/hermes_cli/schemas/hermes.eval-task.v1.schema.json
+++ b/hermes_cli/schemas/hermes.eval-task.v1.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.nousresearch.com/schemas/hermes.eval-task.v1.schema.json",
+  "title": "Hermes Evaluation Task v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "status",
+    "instruction",
+    "source",
+    "environment",
+    "success",
+    "forbidden",
+    "skills"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
+    },
+    "status": {
+      "enum": ["candidate", "approved", "retired"]
+    },
+    "instruction": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "object",
+      "required": ["kind", "sanitized"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "sanitized": { "const": true },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "message_count": { "type": "integer", "minimum": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "session_trace" } } },
+          "then": { "required": ["digest", "message_count"] }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "environment": {
+      "type": "object",
+      "required": ["allowed_tools"],
+      "properties": {
+        "allowed_tools": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "success": {
+      "type": "object",
+      "required": ["deterministic", "judged"],
+      "properties": {
+        "deterministic": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["type", "name"],
+                "properties": {
+                  "type": { "enum": ["tool_called", "tool_succeeded"] },
+                  "name": { "type": "string", "minLength": 1 }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": ["type", "value"],
+                "properties": {
+                  "type": {
+                    "enum": ["final_response_contains", "final_response_excludes"]
+                  },
+                  "value": { "type": "string", "minLength": 1 }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "judged": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "forbidden": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "skills": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "signals": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "provenance": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/hermes_cli/subcommands/evals.py
+++ b/hermes_cli/subcommands/evals.py
@@ -1,0 +1,61 @@
+"""Argument parser for ``hermes evals``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def build_evals_parser(subparsers, *, cmd_evals):
+    parser = subparsers.add_parser(
+        "evals",
+        help="Mine session traces into portable evaluation tasks",
+        description=(
+            "Create sanitized, review-required task candidates from real Hermes "
+            "sessions and validate evaluation corpora."
+        ),
+    )
+    actions = parser.add_subparsers(dest="evals_action")
+
+    mine = actions.add_parser(
+        "mine",
+        help="Convert a session trace into a sanitized task candidate",
+    )
+    mine.add_argument("session_id", help="Exact session ID or unique prefix")
+    mine.add_argument(
+        "--output",
+        type=Path,
+        help="Output YAML path (default: ~/.hermes/evals/candidates/<task-id>.yaml)",
+    )
+
+    mine.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing regular output file; symlinks are always refused",
+    )
+
+    validate = actions.add_parser(
+        "validate",
+        help="Validate one task manifest or every YAML file in a corpus directory",
+    )
+    validate.add_argument("path", type=Path, help="Task YAML file or corpus directory")
+    validate.add_argument(
+        "--ready",
+        action="store_true",
+        help="Fail when a manifest is valid but still requires review or approval",
+    )
+
+    score = actions.add_parser(
+        "score",
+        help="Apply deterministic task checks to a recorded JSON run artifact",
+    )
+    score.add_argument("task", type=Path, help="Approved task YAML manifest")
+    score.add_argument("run", type=Path, help="Recorded run artifact in JSON format")
+    score.add_argument("--output", type=Path, help="Write the score as JSON")
+    score.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing regular score file; symlinks are always refused",
+    )
+
+    parser.set_defaults(func=cmd_evals)
+    return parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,7 +382,7 @@ py-modules = [
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["observability/schemas/*.json"]
+hermes_cli = ["observability/schemas/*.json", "schemas/*.json"]
 # gateway/assets/ ships status_phrases.yaml and the Telegram BotFather
 # screenshot. Without this, sealed venvs (uv2nix) silently lose both —
 # status phrases fall back to the tiny hardcoded set and the Telegram

--- a/tests/hermes_cli/test_evals_core.py
+++ b/tests/hermes_cli/test_evals_core.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import argparse
+import json
+from types import SimpleNamespace
+
+import yaml
+
+
+def test_validate_manifest_accepts_minimal_candidate() -> None:
+    from hermes_cli.evals_core import validate_manifest
+
+    manifest = {
+        "schema_version": 1,
+        "id": "source-reading-001",
+        "status": "candidate",
+        "instruction": "Read the supplied source before answering.",
+        "source": {
+            "kind": "session_trace",
+            "digest": "sha256:" + ("a" * 64),
+            "message_count": 2,
+            "sanitized": True,
+        },
+        "environment": {"allowed_tools": ["web", "session_search"]},
+        "success": {
+            "deterministic": [],
+            "judged": ["Every factual claim is grounded in the supplied source."],
+        },
+        "forbidden": ["Use session history as proof of current source contents."],
+        "skills": ["x-link-resolution-fallback"],
+    }
+
+    result = validate_manifest(manifest)
+
+    assert result.errors == ()
+    assert result.ready is False
+    assert "status must be 'approved'" in result.warnings
+
+
+def test_build_candidate_from_trace_extracts_failure_signals_and_redacts() -> None:
+    from hermes_cli.evals_core import build_candidate_from_trace, validate_manifest
+
+    session = {
+        "id": "session-123",
+        "source": "telegram",
+        "model": "gpt-test",
+        "cwd": "/tmp/project",
+        "tool_call_count": 2,
+        "estimated_cost_usd": 0.25,
+    }
+    messages = [
+        {
+            "id": 10,
+            "role": "user",
+            "content": (
+                "Deploy /tmp/project using token sk-abcdefghijklmnopqrstuvwxyz. "
+                "Contact me at ric@example.com or 630-555-1212. "
+                "Fetch https://alice:hunter2@example.com/callback?api_key=topsecret123."
+            ),
+        },
+        {
+            "id": 11,
+            "role": "assistant",
+            "content": "Done.",
+            "tool_calls": [
+                {"function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "id": 12,
+            "role": "tool",
+            "tool_name": "terminal",
+            "content": '{"success": false, "error": "connection refused"}',
+        },
+        {
+            "id": 13,
+            "role": "user",
+            "content": "No, you did not verify the deployment.",
+        },
+        {
+            "id": 14,
+            "role": "tool",
+            "tool_name": "terminal",
+            "content": (
+                "[OUT-OF-BAND USER MESSAGE — a direct message from the user, "
+                "delivered mid-turn; not tool output]\nStop and verify first.\n"
+                "[/OUT-OF-BAND USER MESSAGE]"
+            ),
+        },
+    ]
+
+    manifest = build_candidate_from_trace(session, messages)
+
+    assert manifest["id"].startswith("trace-")
+    assert "session-123" not in manifest["id"]
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in manifest["instruction"]
+    assert "$WORKSPACE" in manifest["instruction"]
+    assert "[email]" in manifest["instruction"]
+    assert "[phone]" in manifest["instruction"]
+    assert "hunter2" not in manifest["instruction"]
+    assert "topsecret123" not in manifest["instruction"]
+    assert manifest["source"]["message_count"] == 5
+    assert manifest["source"]["digest"].startswith("sha256:")
+    assert "session_id" not in manifest["source"]
+    assert manifest["source"]["sanitized"] is True
+    assert manifest["environment"]["allowed_tools"] == ["terminal"]
+    assert {signal["kind"] for signal in manifest["signals"]} == {
+        "tool_failure",
+        "user_correction",
+        "midturn_user_steering",
+    }
+    assert all("excerpt" not in signal for signal in manifest["signals"])
+    assert validate_manifest(manifest).errors == ()
+
+
+def test_cmd_evals_mine_writes_sanitized_candidate(tmp_path, monkeypatch, capsys) -> None:
+    from hermes_cli import evals_cmd
+
+    class FakeDB:
+        def resolve_session_id(self, value: str) -> str | None:
+            return "session-123" if value == "session" else None
+
+        def get_session(self, session_id: str):
+            return {
+                "id": session_id,
+                "source": "telegram",
+                "model": "gpt-test",
+                "tool_call_count": 1,
+            }
+
+        def get_messages(self, session_id: str):
+            return [
+                {"id": 1, "role": "user", "content": "Check API_KEY=super-secret-value"},
+                {
+                    "id": 2,
+                    "role": "tool",
+                    "tool_name": "terminal",
+                    "content": '{"exit_code": 1, "output": "failed"}',
+                },
+            ]
+
+        def close(self) -> None:
+            pass
+
+    output = tmp_path / "candidate.yaml"
+    monkeypatch.setattr(evals_cmd, "_open_session_db", FakeDB)
+    args = SimpleNamespace(
+        evals_action="mine",
+        session_id="session",
+        output=output,
+        force=False,
+    )
+
+    rc = evals_cmd.cmd_evals(args)
+
+    assert rc == 0
+    payload = yaml.safe_load(output.read_text(encoding="utf-8"))
+    rendered = output.read_text(encoding="utf-8")
+    assert payload["source"]["digest"].startswith("sha256:")
+    assert "session-123" not in rendered
+    assert "super-secret-value" not in rendered
+    assert "Review required" in capsys.readouterr().out
+
+
+def test_cmd_evals_validate_ready_rejects_candidate(tmp_path, capsys) -> None:
+    from hermes_cli.evals_cmd import cmd_evals
+
+    path = tmp_path / "candidate.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "id": "candidate-001",
+                "status": "candidate",
+                "instruction": "Do the work.",
+                "source": {"kind": "manual", "sanitized": True},
+                "environment": {"allowed_tools": []},
+                "success": {"deterministic": [], "judged": ["It worked."]},
+                "forbidden": [],
+                "skills": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    args = SimpleNamespace(evals_action="validate", path=path, ready=True)
+
+    rc = cmd_evals(args)
+
+    assert rc == 1
+    assert "NOT READY" in capsys.readouterr().out
+
+
+def test_build_evals_parser_wires_mine_and_validate() -> None:
+    from hermes_cli.subcommands.evals import build_evals_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    sentinel = object()
+    build_evals_parser(subparsers, cmd_evals=sentinel)
+
+    mined = parser.parse_args(
+        ["evals", "mine", "abc123", "--output", "candidate.yaml"]
+    )
+    validated = parser.parse_args(["evals", "validate", "corpus", "--ready"])
+    scored = parser.parse_args(["evals", "score", "task.yaml", "run.json"])
+
+    assert mined.func is sentinel
+    assert mined.session_id == "abc123"
+    assert mined.output.name == "candidate.yaml"
+    assert validated.func is sentinel
+    assert validated.ready is True
+    assert scored.func is sentinel
+    assert scored.task.name == "task.yaml"
+    assert scored.run.name == "run.json"
+
+
+def test_score_run_artifact_applies_deterministic_checks() -> None:
+    from hermes_cli.evals_core import score_run_artifact
+
+    manifest = {
+        "schema_version": 1,
+        "id": "deploy-check-001",
+        "status": "approved",
+        "instruction": "Deploy and verify the service.",
+        "source": {"kind": "manual", "sanitized": True},
+        "environment": {"allowed_tools": ["terminal"]},
+        "success": {
+            "deterministic": [
+                {"type": "tool_called", "name": "terminal"},
+                {"type": "tool_succeeded", "name": "terminal"},
+                {"type": "final_response_contains", "value": "verified"},
+                {"type": "final_response_excludes", "value": "probably"},
+            ],
+            "judged": [],
+        },
+        "forbidden": [],
+        "skills": [],
+    }
+    run = {
+        "task_id": "deploy-check-001",
+        "final_response": "Deployment verified with a live health check.",
+        "tool_calls": [
+            {"name": "terminal", "result": {"exit_code": 0, "output": "healthy"}}
+        ],
+    }
+
+    result = score_run_artifact(manifest, run)
+
+    assert result["status"] == "passed"
+    assert result["passed"] is True
+    assert result["deterministic"] == {"passed": 5, "total": 5}
+    assert all(check["passed"] for check in result["checks"])
+
+
+def test_score_run_artifact_requires_separate_judge_when_criteria_exist() -> None:
+    from hermes_cli.evals_core import score_run_artifact
+
+    manifest = {
+        "schema_version": 1,
+        "id": "research-001",
+        "status": "approved",
+        "instruction": "Research the claim.",
+        "source": {"kind": "manual", "sanitized": True},
+        "environment": {"allowed_tools": ["web_search"]},
+        "success": {
+            "deterministic": [{"type": "tool_called", "name": "web_search"}],
+            "judged": ["The synthesis is faithful to the sources."],
+        },
+        "forbidden": [],
+        "skills": [],
+    }
+    run = {
+        "task_id": "research-001",
+        "final_response": "A sourced answer.",
+        "tool_calls": [{"name": "web_search", "result": {"success": True}}],
+    }
+
+    result = score_run_artifact(manifest, run)
+
+    assert result["status"] == "needs_judge"
+    assert result["passed"] is None
+    assert result["judge_criteria"] == ["The synthesis is faithful to the sources."]
+
+
+def test_cmd_evals_score_writes_machine_readable_result(tmp_path, capsys) -> None:
+    from hermes_cli.evals_cmd import cmd_evals
+
+    task = tmp_path / "task.yaml"
+    task.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "id": "score-001",
+                "status": "approved",
+                "instruction": "Verify it.",
+                "source": {"kind": "manual", "sanitized": True},
+                "environment": {"allowed_tools": ["terminal"]},
+                "success": {
+                    "deterministic": [{"type": "tool_succeeded", "name": "terminal"}],
+                    "judged": [],
+                },
+                "forbidden": [],
+                "skills": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    run = tmp_path / "run.json"
+    run.write_text(
+        json.dumps(
+            {
+                "task_id": "score-001",
+                "final_response": "Verified.",
+                "tool_calls": [{"name": "terminal", "result": {"exit_code": 0}}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "result.json"
+    args = SimpleNamespace(
+        evals_action="score",
+        task=task,
+        run=run,
+        output=output,
+        force=False,
+    )
+
+    rc = cmd_evals(args)
+
+    assert rc == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "passed"
+    assert "PASSED score-001" in capsys.readouterr().out
+
+
+def test_score_rejects_unapproved_candidate() -> None:
+    import pytest
+
+    from hermes_cli.evals_core import score_run_artifact
+
+    manifest = {
+        "schema_version": 1,
+        "id": "candidate-001",
+        "status": "candidate",
+        "instruction": "Do it.",
+        "source": {"kind": "manual", "sanitized": True},
+        "environment": {"allowed_tools": []},
+        "success": {"deterministic": [], "judged": ["It worked."]},
+        "forbidden": [],
+        "skills": [],
+    }
+
+    with pytest.raises(ValueError, match="not ready"):
+        score_run_artifact(
+            manifest,
+            {"task_id": "candidate-001", "final_response": "Done", "tool_calls": []},
+        )
+
+
+def test_validate_requires_allowed_tools_and_safe_session_provenance() -> None:
+    from hermes_cli.evals_core import validate_manifest
+
+    manifest = {
+        "schema_version": 1,
+        "id": "trace-001",
+        "status": "candidate",
+        "instruction": "Do it.",
+        "source": {
+            "kind": "session_trace",
+            "digest": "not-a-digest",
+            "message_count": True,
+            "sanitized": True,
+        },
+        "environment": {},
+        "success": {"deterministic": [], "judged": ["It worked."]},
+        "forbidden": [],
+        "skills": [],
+    }
+
+    result = validate_manifest(manifest)
+
+    assert "source.digest must be a sha256 digest for session_trace tasks" in result.errors
+    assert "source.message_count must be a positive integer" in result.errors
+    assert "environment.allowed_tools must be a list of non-empty strings" in result.errors
+
+
+def test_candidate_recovers_skill_instruction_and_has_stable_opaque_id() -> None:
+    from hermes_cli.evals_core import build_candidate_from_trace, validate_manifest
+
+    expanded = (
+        '[IMPORTANT: The user has invoked the "code-review" skill. '
+        "The full skill content is loaded below.]\n"
+        "SECRET SKILL BODY THAT MUST NOT BECOME THE TASK\n"
+        "The user has provided the following instruction alongside the skill invocation: "
+        "Review the authentication patch."
+    )
+    messages = [
+        {"id": 1, "role": "user", "content": expanded},
+        {"id": 2, "role": "assistant", "content": "Reviewed."},
+    ]
+
+    first = build_candidate_from_trace({"id": "raw-session-one"}, messages)
+    second = build_candidate_from_trace({"id": "raw-session-two"}, messages)
+
+    assert first["instruction"] == "Review the authentication patch."
+    assert "SECRET SKILL BODY" not in first["instruction"]
+    assert first["id"] == second["id"]
+    assert "raw-session" not in first["id"]
+    assert first["source"]["digest"] == second["source"]["digest"]
+
+    first["future_field"] = True
+    assert validate_manifest(first).errors == (
+        "unknown top-level fields: future_field",
+    )
+
+
+def test_manifest_loader_rejects_duplicate_yaml_keys(tmp_path) -> None:
+    import pytest
+
+    from hermes_cli.evals_cmd import load_manifest
+
+    path = tmp_path / "duplicate.yaml"
+    path.write_text(
+        "schema_version: 1\nstatus: candidate\nstatus: approved\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate key 'status'"):
+        load_manifest(path)
+
+
+def test_score_enforces_allowed_tools_and_surfaces_forbidden_rules() -> None:
+    from hermes_cli.evals_core import score_run_artifact
+
+    manifest = {
+        "schema_version": 1,
+        "id": "policy-001",
+        "status": "approved",
+        "instruction": "Use web search only.",
+        "source": {"kind": "manual", "sanitized": True},
+        "environment": {"allowed_tools": ["web_search"]},
+        "success": {
+            "deterministic": [{"type": "final_response_contains", "value": "done"}],
+            "judged": [],
+        },
+        "forbidden": ["Do not modify local files."],
+        "skills": [],
+    }
+
+    failed = score_run_artifact(
+        manifest,
+        {
+            "task_id": "policy-001",
+            "final_response": "Done.",
+            "tool_calls": [{"name": "terminal", "result": {"exit_code": 0}}],
+        },
+    )
+    assert failed["status"] == "failed"
+    assert failed["checks"][0]["passed"] is False
+    assert "terminal" in failed["checks"][0]["detail"]
+
+    needs_judge = score_run_artifact(
+        manifest,
+        {
+            "task_id": "policy-001",
+            "final_response": "Done.",
+            "tool_calls": [{"name": "web_search", "result": {"success": True}}],
+        },
+    )
+    assert needs_judge["status"] == "needs_judge"
+    assert needs_judge["judge_criteria"] == [
+        "Verify forbidden behavior did not occur: Do not modify local files."
+    ]

--- a/website/docs/user-guide/features/evals.md
+++ b/website/docs/user-guide/features/evals.md
@@ -1,0 +1,161 @@
+---
+title: Evaluation tasks
+sidebar_label: Evaluation tasks
+---
+
+# Evaluation tasks
+
+Hermes can turn real session traces into sanitized, review-required evaluation
+tasks. The task corpus is separate from memory and skills:
+
+- **memory** records durable facts
+- **skills** record reusable procedures
+- **evaluation tasks** prove that an agent still satisfies a behavior contract
+
+The feature is a CLI surface, not a model tool, so it adds no tool-schema cost
+to ordinary conversations.
+
+## Mine a candidate from a session
+
+```bash
+hermes evals mine SESSION_ID_OR_PREFIX
+```
+
+The default output is:
+
+```text
+$HERMES_HOME/evals/candidates/trace-<semantic-digest>.yaml
+```
+
+Use an explicit path when the task belongs to a version-controlled corpus:
+
+```bash
+hermes evals mine SESSION_ID \
+  --output evals/candidates/source-reading-001.yaml
+```
+
+Mining performs forced secret and PII redaction regardless of the normal
+display-redaction setting. Home/workspace paths are replaced, raw session IDs
+and tool-output excerpts are omitted, and provenance uses a SHA-256 digest.
+Candidate files are written with mode `0600`, writes are atomic, existing files
+are not replaced by default, and symlink targets are refused.
+
+A mined task always has `status: candidate`. Hermes records likely signals such
+as failed tool results and corrective user turns, but it does not approve the
+task or invent task-specific ground truth. Review the instruction and signals,
+replace the generic checks with meaningful checks, add applicable skills, then
+set `status: approved`.
+
+Session traces can still contain personal or commercially sensitive prose that
+is outside the known PII and credential patterns. Automated redaction is not
+complete anonymization. Review every candidate before committing or sharing it.
+
+## Validate a task or corpus
+
+```bash
+hermes evals validate evals/candidates/task.yaml
+hermes evals validate evals/approved/ --ready
+```
+
+Normal validation accepts structurally valid candidates and prints their
+warnings. `--ready` exits nonzero unless every task is approved, sanitized, and
+has at least one success criterion.
+
+The portable schema is installed at:
+
+```text
+hermes_cli/schemas/hermes.eval-task.v1.schema.json
+```
+
+## Task format
+
+```yaml
+schema_version: 1
+id: source-reading-001
+status: approved
+instruction: Read the supplied source before answering.
+
+source:
+  kind: manual
+  sanitized: true
+
+environment:
+  allowed_tools: [web_extract, session_search]
+
+success:
+  deterministic:
+    - type: tool_called
+      name: web_extract
+    - type: final_response_excludes
+      value: "I could not open the link"
+  judged:
+    - Every factual claim is supported by the supplied source.
+
+forbidden:
+  - Treat session history as proof of current external contents.
+
+skills:
+  - social-media/x-link-resolution-fallback
+```
+
+Supported deterministic checks in version 1:
+
+| Check | Required field | Meaning |
+|---|---|---|
+| `tool_called` | `name` | The recorded run called the named tool |
+| `tool_succeeded` | `name` | A named tool result reports `success: true` or `exit_code: 0` |
+| `final_response_contains` | `value` | Final response contains the value, case-insensitively |
+| `final_response_excludes` | `value` | Final response omits the value, case-insensitively |
+
+Scoring also applies an implicit policy check: every recorded tool call must be
+listed in `environment.allowed_tools`. Any call outside that list fails the run.
+
+## Score a recorded run
+
+A runner or external harness can emit this JSON artifact:
+
+```json
+{
+  "task_id": "source-reading-001",
+  "final_response": "The source says ...",
+  "tool_calls": [
+    {
+      "name": "web_extract",
+      "result": {"success": true}
+    }
+  ]
+}
+```
+
+Score it with:
+
+```bash
+hermes evals score task.yaml run.json --output result.json
+```
+
+Exit codes:
+
+- `0`: every deterministic check passed and no qualitative judge is required
+- `1`: at least one deterministic check failed
+- `2`: invalid input or task/run mismatch
+- `3`: deterministic checks passed, but a separate evaluator must assess the
+  `judged` criteria or verify a `forbidden` behavior constraint
+
+Hermes intentionally does not self-grade qualitative criteria. `forbidden`
+rules are surfaced to that evaluator rather than silently ignored. Feed the
+criteria and recorded evidence to a fresh evaluator, preferably after all
+deterministic checks pass.
+
+## Recommended lifecycle
+
+1. Mine candidates from corrections, failed tools, or incomplete verification.
+2. Curate the smallest reproducible behavior contract.
+3. Remove irrelevant or sensitive trace material.
+4. Add deterministic checks wherever possible.
+5. Keep gold labels and verifier details hidden from the candidate agent.
+6. Bind the task to relevant skills through `skills`.
+7. Run the corpus before promoting skill, prompt, harness, or model changes.
+8. Keep generation and evaluation in separate contexts.
+
+The candidate compiler is intentionally conservative. It is a provenance and
+curation aid, not an automatic benchmark factory.


### PR DESCRIPTION
## Summary

- add a portable Hermes Evaluation Task v1 manifest and packaged JSON Schema
- add `hermes evals mine`, `validate`, and deterministic `score` commands
- mine privacy-sanitized, human-review-required candidates from real session traces
- enforce approval/readiness, allowed-tool policy, duplicate-key rejection, and independent judging for qualitative/forbidden criteria
- document the trace-to-regression workflow and security boundaries

## Why

This creates a narrow offline evaluation path without adding a model-visible tool or changing the agent loop:

`session trace -> sanitized candidate -> human approval -> run artifact -> deterministic scoring -> regression corpus`

The format is Hermes-native and data-only. Harbor interoperability can be added later without making Harbor a runtime dependency.

## Security and review gates

- mined tasks always start as `candidate`
- raw session IDs and trace excerpts are omitted
- secrets, PII, URL credentials, signed URLs, and local paths are redacted
- writes use private permissions, atomic no-overwrite publication, and refuse symlink targets
- duplicate YAML keys and unknown manifest fields are rejected
- scoring refuses unapproved, unsanitized, retired, or empty-contract tasks
- tool calls outside `environment.allowed_tools` fail deterministically
- judged and forbidden criteria return `needs_judge`; the generator does not grade its own prose

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_evals_core.py tests/hermes_cli/test_completion.py`: 21 passed
- full `scripts/run_tests.sh tests/hermes_cli`: 3,710 passed, 7 platform/environment failures outside changed files
  - one Linux systemd test running on macOS
  - one s6 directory-mode expectation
  - five Git CRLF-normalization tests
- Ruff: passed
- `ty`: passed
- JSON Schema metaschema and Python-validator parity checks: passed
- real-session mining/privacy smoke test: passed
- approved-task scoring smoke test: passed, 3/3 deterministic checks
- `git diff --check`: passed

## Follow-up

A separate PR can add `hermes evals run` for isolated replay and run-artifact capture. This PR intentionally stops at the portable task/compiler/validator/scorer boundary.
