### PR TITLE
fix(tools): truncate tool error bodies in logs without dumping twice

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -176,6 +176,33 @@ def clear_session_context() -> None:
     _session_context.session_id = None
 
 
+# Cap exception/detail text written into log messages so large HTTP error
+# bodies (Cloudflare challenge HTML, proxy 502 pages, …) cannot grow gateway
+# stderr without bound. Agent-facing tool returns keep the full string.
+DEFAULT_LOG_DETAIL_LIMIT = 2000
+
+
+def truncate_for_log(text, limit: int = DEFAULT_LOG_DETAIL_LIMIT) -> str:
+    """Return *text* capped at *limit* characters for safe log emission.
+
+    ``str(exception)`` on HTTP clients often embeds the entire response body.
+    Callers should keep the original text for agent-facing tool results and
+    only pass the truncated form to loggers. Prefer omitting ``exc_info=True``
+    at the same sites — the traceback tail re-renders the full exception and
+    would reintroduce the unbounded write (see #75927).
+    """
+    if text is None:
+        return ""
+    s = text if isinstance(text, str) else str(text)
+    if limit <= 0:
+        return ""
+    if len(s) <= limit:
+        return s
+    if limit <= 3:
+        return s[:limit]
+    return s[: limit - 3] + "..."
+
+
 # ---------------------------------------------------------------------------
 # Record factory — injects session_tag into every LogRecord at creation
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -647,6 +647,33 @@ class TestSafeStderr:
             logger.removeHandler(handler)
 
 
+class TestTruncateForLog:
+    """truncate_for_log caps exception bodies before they hit log sinks (#75927)."""
+
+    def test_short_string_unchanged(self):
+        assert hermes_logging.truncate_for_log("short error") == "short error"
+
+    def test_none_becomes_empty(self):
+        assert hermes_logging.truncate_for_log(None) == ""
+
+    def test_exception_coerced_and_truncated(self):
+        body = "x" * 10_000
+        out = hermes_logging.truncate_for_log(RuntimeError(body))
+        assert len(out) == hermes_logging.DEFAULT_LOG_DETAIL_LIMIT
+        assert out.endswith("...")
+        assert out.startswith("x" * 100)
+        # Original exception text remains unbounded for agent-facing returns.
+        assert len(str(RuntimeError(body))) == 10_000
+
+    def test_custom_limit(self):
+        assert hermes_logging.truncate_for_log("abcdefghij", limit=5) == "ab..."
+
+    def test_at_limit_not_truncated(self):
+        limit = hermes_logging.DEFAULT_LOG_DETAIL_LIMIT
+        text = "y" * limit
+        assert hermes_logging.truncate_for_log(text) == text
+
+
 class TestAsyncQueueLogging:
     """File logging runs through a QueueListener so emits never block on the
     cross-process rotation lock (Windows event-loop-stall fix)."""

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -572,6 +572,47 @@ class TestErrorClassification:
         assert "rejected the image" in result["analysis"].lower()
         assert "smaller" in result["analysis"].lower()
 
+    @pytest.mark.asyncio
+    async def test_huge_http_error_body_not_dumped_to_log(self, tmp_path, caplog):
+        """Large HTTP error bodies must not grow gateway/agent logs unboundedly (#75927)."""
+        from hermes_logging import DEFAULT_LOG_DETAIL_LIMIT
+
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        # Simulate openai.APIStatusError carrying a Cloudflare HTML page.
+        huge_body = "<html>" + ("challenge-page" * 50_000) + "</html>"
+        api_error = Exception(f"Error code: 403 - {huge_body}")
+
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=api_error,
+            ),
+            caplog.at_level(logging.ERROR, logger="tools.vision_tools"),
+        ):
+            result = json.loads(
+                await vision_analyze_tool(str(img), "describe", "test/model")
+            )
+
+        # Agent-facing payload still carries the full error string.
+        assert result["success"] is False
+        assert huge_body in result["error"]
+
+        error_records = [
+            r for r in caplog.records if "Error analyzing image" in r.getMessage()
+        ]
+        assert len(error_records) == 1
+        # One truncated line, no traceback re-render of the full body.
+        assert len(error_records[0].getMessage()) < DEFAULT_LOG_DETAIL_LIMIT + 80
+        assert error_records[0].exc_info is None
+        assert huge_body not in error_records[0].getMessage()
+
 
 class TestVisionRegistration:
     def test_vision_analyze_registered_with_schema(self):

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -56,6 +56,7 @@ def _load_fal_client() -> Any:
     return fal_client
 
 
+from hermes_logging import truncate_for_log
 from tools.debug_helpers import DebugSession
 from tools.fal_common import (
     _ManagedFalSyncClient,
@@ -1020,7 +1021,9 @@ def image_generate_tool(
     except Exception as e:
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
         error_msg = f"Error generating image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        # Truncate + drop exc_info so large HTTP bodies are not written twice
+        # (message + traceback tail). Full detail still returned to the agent.
+        logger.error("Error generating image: %s", truncate_for_log(e))
 
         response_data = {
             "success": False,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -57,6 +57,7 @@ from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import display_hermes_home
+from hermes_logging import truncate_for_log
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -3147,12 +3148,20 @@ def text_to_speech_tool(
     except FileNotFoundError as e:
         # Missing dependencies or files
         error_msg = f"TTS dependency missing ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
+        # Truncate + drop exc_info so large error bodies are not written twice
+        # (message + traceback tail). Full detail still returned to the agent.
+        logger.error(
+            "TTS dependency missing (%s): %s", provider, truncate_for_log(e)
+        )
         return tool_error(error_msg, success=False)
     except Exception as e:
         # Unexpected errors
         error_msg = f"TTS generation failed ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
+        # Truncate + drop exc_info so large HTTP bodies are not written twice
+        # (message + traceback tail). Full detail still returned to the agent.
+        logger.error(
+            "TTS generation failed (%s): %s", provider, truncate_for_log(e)
+        )
         return tool_error(error_msg, success=False)
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -63,6 +63,7 @@ def _load_auxiliary_client() -> None:
 
 
 from hermes_constants import get_hermes_dir
+from hermes_logging import truncate_for_log
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
 import sys
@@ -1323,7 +1324,9 @@ async def vision_analyze_tool(
         
     except Exception as e:
         error_msg = f"Error analyzing image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        # Truncate + drop exc_info so large HTTP bodies are not written twice
+        # (message + traceback tail). Full detail still returned to the agent.
+        logger.error("Error analyzing image: %s", truncate_for_log(e))
         
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
@@ -1806,7 +1809,9 @@ async def video_analyze_tool(
 
     except Exception as e:
         error_msg = f"Error analyzing video: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        # Truncate + drop exc_info so large HTTP bodies are not written twice
+        # (message + traceback tail). Full detail still returned to the agent.
+        logger.error("Error analyzing video: %s", truncate_for_log(e))
 
         err_str = str(e).lower()
         if any(hint in err_str for hint in (


### PR DESCRIPTION
## What does this PR do?

Tool error handlers in vision / image generation / TTS interpolated unbounded `str(e)` into a log message **and** passed `exc_info=True`. When the underlying HTTP error carried a large response body (Cloudflare challenge HTML, reverse-proxy 502 pages, etc.), that body was written to the log **twice per failure** — once in the message and again in the traceback tail.

On one install this turned 54 failed `vision_analyze` calls into ~90 MB of unrotated gateway stderr (`StandardErrorPath` / systemd). The repo already truncates tool *results* for operator logs in `agent/tool_executor.py`; these five outer handlers did not.

This PR adds a shared `truncate_for_log()` helper (2 KB default, next to other logging helpers) and applies it at all five sites, **dropping `exc_info=True`** so the traceback cannot re-render the full body. Agent-facing return values keep the full error string.

Related but **not** a duplicate of draft #37681 (that bounds tool error *payloads returned into message history* at the registry dispatch boundary; this PR bounds the *log sink*).

## Related Issue

Fixes #75927

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_logging.py` — add `DEFAULT_LOG_DETAIL_LIMIT` (2000) + public `truncate_for_log()`
- `tools/vision_tools.py` — image + video analyze error handlers: truncate detail, no `exc_info`
- `tools/image_generation_tool.py` — generate error handler: same
- `tools/tts_tool.py` — dependency-missing + generation-failed handlers: same
- `tests/test_hermes_logging.py` — unit tests for `truncate_for_log`
- `tests/tools/test_vision_tools.py` — regression: huge HTTP body still returned to agent, single truncated log line, no `exc_info`

## How to Test

1. Unit helper:
   ```bash
   ./scripts/run_tests.sh tests/test_hermes_logging.py -q
   ```
2. Vision regression (simulates a multi-MB Cloudflare-style body):
   ```bash
   ./scripts/run_tests.sh tests/tools/test_vision_tools.py -q
   ```
3. Optional manual: point `auxiliary.vision` at an endpoint that returns a large HTML error page, call `vision_analyze`, and confirm `gateway.error.log` / stderr gains one short line instead of two multi-MB dumps.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (not raw pytest) for the affected suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — logging-only fix. Test output:

```
tests/test_hermes_logging.py  — 33 passed
tests/tools/test_vision_tools.py — 31 passed (2 skipped)
```