### PR TITLE
fix: route feishu thread sends via reply API instead of invalid thread_id receive_id

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4706,36 +4706,6 @@ class FeishuAdapter(BasePlatformAdapter):
                     reply_to=reply_to,
                     metadata=metadata,
                 )
-                # Audio messages may fail with 99992402 when using thread_id routing.
-                # Try replying to the last message in the thread, then fall back to chat_id.
-                if (not self._response_succeeded(message_response)
-                        and getattr(message_response, "code", None) == 99992402
-                        and resolved_message_type == "audio"
-                        and (metadata or {}).get("thread_id")):
-                    # Try reply API with thread_id as reply anchor
-                    thread_msg_id = (metadata or {}).get("reply_to_message_id")
-                    if not thread_msg_id:
-                        thread_msg_id = await self._fetch_last_message_in_thread(
-                            (metadata or {}).get("thread_id")
-                        )
-                    if thread_msg_id:
-                        logger.info("[Feishu] Audio: retrying via reply API in thread")
-                        message_response = await self._feishu_send_with_retry(
-                            chat_id=chat_id,
-                            msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
-                            reply_to=thread_msg_id,
-                            metadata=metadata,
-                        )
-                    if not self._response_succeeded(message_response):
-                        logger.warning("[Feishu] Audio send failed in thread, retrying with chat_id")
-                        message_response = await self._feishu_send_with_retry(
-                            chat_id=chat_id,
-                            msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
-                            reply_to=None,
-                            metadata=None,
-                        )
             return self._finalize_send_result(message_response, "file send failed")
         except Exception as exc:
             logger.error("[Feishu] Failed to send file %s: %s", file_path, exc, exc_info=True)
@@ -4786,34 +4756,44 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # For topic/thread messages that fell back from reply→create, try to
+        # anchor the reply on the last message in the thread so the message
+        # lands in the topic instead of the main chat. Feishu's create API
+        # does not accept thread_id as receive_id_type, so use the reply API.
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+            _thread_msg_id = await self._fetch_last_message_in_thread(_thread_id)
+            if _thread_msg_id:
+                body = self._build_reply_message_body(
+                    content=payload,
+                    msg_type=msg_type,
+                    reply_in_thread=True,
+                    uuid_value=str(uuid.uuid4()),
+                )
+                request = self._build_reply_message_request(_thread_msg_id, body)
+                return await self._run_blocking(self._client.im.v1.message.reply, request)
+            logger.warning(
+                "[Feishu] No last message found in thread %s, "
+                "falling back to chat_id create",
+                _thread_id,
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+            _thread_id = None
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1246,6 +1246,151 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_source_fix_thread_no_anchor_lists_then_replies(self):
+        """Source-level fix: thread send with no reply anchor must list the
+        thread and reply to the last message — never create with thread_id as
+        receive_id."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_123"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                calls.append(("create", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+            def reply(self, request):
+                calls.append(("reply", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_replied"),
+                )
+
+            def list(self, request):
+                calls.append(("list", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        items=[SimpleNamespace(message_id="om_last_in_thread")]
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".js", delete=False) as tmp:
+            tmp.write(b"// test script")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(
+                    adapter.send_document(
+                        chat_id="oc_chat",
+                        file_path=file_path,
+                        metadata={"thread_id": "omt-thread"},
+                    )
+                )
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success, result.error)
+        # list first, then reply — create is NEVER called with thread_id
+        self.assertEqual(calls[0][0], "list")
+        self.assertEqual(calls[1][0], "reply")
+        self.assertEqual(calls[1][1].message_id, "om_last_in_thread")
+        self.assertTrue(calls[1][1].request_body.reply_in_thread)
+        self.assertEqual(len(calls), 2)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_source_fix_thread_no_anchor_no_last_msg_creates_chat_id(self):
+        """Source-level fix: when the thread has no messages to anchor on,
+        fall back to a plain chat_id create (and keep the feishu_user_id:/
+        ou_ receive_id mapping)."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_123"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                calls.append(("create", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+            def list(self, request):
+                calls.append(("list", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(items=[]),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".js", delete=False) as tmp:
+            tmp.write(b"// test script")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(
+                    adapter.send_document(
+                        chat_id="feishu_user_id:ou_user_123",
+                        file_path=file_path,
+                        metadata={"thread_id": "omt-thread"},
+                    )
+                )
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success, result.error)
+        # list found nothing → create with user_id mapping preserved
+        self.assertEqual(calls[0][0], "list")
+        self.assertEqual(calls[1][0], "create")
+        self.assertEqual(calls[1][1].receive_id_type, "user_id")
+        self.assertEqual(calls[1][1].request_body.receive_id, "ou_user_123")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1325,6 +1325,86 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(len(calls), 2)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_source_fix_caption_thread_no_anchor_lists_then_replies(self):
+        """Captioned file/media sends (post payload with media tag) into a
+        thread must route through the same source-level fix: list the thread
+        and reply to the last message, never create with thread_id."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_123"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                calls.append(("create", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+            def reply(self, request):
+                calls.append(("reply", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_caption_replied"),
+                )
+
+            def list(self, request):
+                calls.append(("list", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        items=[SimpleNamespace(message_id="om_last_in_thread")]
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".js", delete=False) as tmp:
+            tmp.write(b"// test script")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(
+                    adapter.send_document(
+                        chat_id="oc_chat",
+                        file_path=file_path,
+                        caption="see the file",
+                        metadata={"thread_id": "omt-thread"},
+                    )
+                )
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success, result.error)
+        # list first, then reply as a post message — create never called
+        self.assertEqual(calls[0][0], "list")
+        self.assertEqual(calls[1][0], "reply")
+        self.assertEqual(calls[1][1].request_body.msg_type, "post")
+        self.assertEqual(calls[1][1].message_id, "om_last_in_thread")
+        self.assertTrue(calls[1][1].request_body.reply_in_thread)
+        self.assertEqual(len(calls), 2)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_source_fix_thread_no_anchor_no_last_msg_creates_chat_id(self):
         """Source-level fix: when the thread has no messages to anchor on,
         fall back to a plain chat_id create (and keep the feishu_user_id:/


### PR DESCRIPTION
### Problem
Sending files/media into a Feishu group thread fails with `[99992402] field validation failed` when the send has no reply anchor. See issue for repro.

### Root cause
The Feishu `message.create` API only accepts `chat_id` / `open_id` / `user_id` as `receive_id`. When media/file delivery carries only `thread_id` (no reply anchor), `_send_raw_message()` built a create request with `receive_id=thread_id`, which the API rejects with `[99992402]`. The existing retry only covered `audio` messages, so file/media sends failed outright.

### Fix
Never build the invalid request. In `_send_raw_message()`, the thread_id fallback branch now:
1. Lists the thread via `ListMessageRequest` (`container_id_type=thread`, `page_size=1`) and replies to the last message with `reply_in_thread=true` (message lands in the topic)
2. If the thread is empty, logs a warning and falls back to a plain `chat_id` create, keeping the `feishu_user_id:` → `user_id` and `ou_` → `open_id` receive_id mapping

This fixes all message types (file/media/audio/captioned post payloads) at the source — no per-type retry guards needed. Credit to @kevinjihk for this approach (comment on the earlier revision).

### Verification
- Added 3 regression tests: `test_source_fix_thread_no_anchor_lists_then_replies` (never calls create with thread_id), `test_source_fix_thread_no_anchor_no_last_msg_creates_chat_id` (empty thread falls back to chat_id with user_id mapping) and `test_source_fix_caption_thread_no_anchor_lists_then_replies` (captioned post path gets the same routing)
- Full `tests/gateway/test_feishu.py` suite: 79 passed
- Live test: sending a `.js` file into a thread now succeeds with no error in gateway logs

Fixes #75939