### PR TITLE
fix(dashboard): WMIC fallback + profile-arg-aware process matching (#75791)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -13,6 +13,8 @@ patches on ``hermes_cli.main`` resolve unchanged.
 """
 
 import os
+import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +25,94 @@ def _m():
     from hermes_cli import main
 
     return main
+
+
+_SUBCOMMANDS = {"dashboard", "serve"}
+_HERMES_EXE_BASENAMES = {"hermes", "hermes.exe", "hermes_cli.main", "main.py"}
+_HERMES_EXE_PREFIXES = ("hermes_cli", "hermes_cli/", "hermes_cli.")
+
+
+def _is_hermes_dashboard_or_serve_cmd(command: str | None) -> bool:
+    """Return True when *command* is a ``hermes dashboard`` or ``hermes serve`` invocation.
+
+    Previous implementation used substring matching (``"hermes dashboard" in cmd``)
+    which failed when profile arguments appeared between the executable and the
+    subcommand (e.g. ``hermes --profile prod dashboard --no-open``).  This
+    tokenises ``shlex``-aware, strips ``--profile``/``-p`` selectors (like
+    ``gateway.status._gateway_command_subcommand``), then checks whether the
+    remaining tokens contain ``dashboard`` or ``serve`` preceded by a hermes
+    executable entry point.
+    """
+    if not command:
+        return False
+
+    try:
+        raw_tokens = shlex.split(command, posix=False)
+    except ValueError:
+        raw_tokens = command.split()
+
+    tokens = [t.strip("\"'").replace("\\", "/").lower() for t in raw_tokens]
+    if not tokens:
+        return False
+
+    # --- Dedicated entrypoints (no subcommand to inspect) ---
+    for token in tokens:
+        basename = token.rsplit("/", 1)[-1]
+        if basename in ("hermes-dashboard", "hermes-dashboard.exe"):
+            return True
+        if token.endswith("/hermes_cli/dashboard.py") or token == "hermes_cli/dashboard.py":
+            return True
+        if token.endswith("/hermes_cli/serve.py") or token == "hermes_cli/serve.py":
+            return True
+
+    # --- First non-Python token must be a hermes executable ---
+    idx = 0
+    if tokens[0].rsplit("/", 1)[-1].startswith("python"):
+        idx = 1
+        if idx < len(tokens) and tokens[idx] == "-m":
+            idx = 2
+
+    if idx >= len(tokens):
+        return False
+
+    exe = tokens[idx]
+    exe_basename = exe.rsplit("/", 1)[-1]
+    is_hermes_exe = (
+        exe_basename in _HERMES_EXE_BASENAMES
+        or any(exe.startswith(pfx) for pfx in _HERMES_EXE_PREFIXES)
+    )
+    if not is_hermes_exe:
+        return False
+
+    # --- Strip profile selectors anywhere in argv ---
+    filtered: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in ("--profile", "-p"):
+            skip_next = True
+            continue
+        if token.startswith("--profile=") or token.startswith("-p="):
+            continue
+        filtered.append(token)
+
+    # --- Check for dashboard/serve subcommand after the exe ---
+    found_exe = False
+    for token in filtered:
+        basename = token.rsplit("/", 1)[-1]
+        if not found_exe:
+            if (
+                basename in _HERMES_EXE_BASENAMES
+                or any(token.startswith(pfx) for pfx in _HERMES_EXE_PREFIXES)
+            ):
+                found_exe = True
+            continue
+        if token in _SUBCOMMANDS:
+            return True
+
+    return False
 
 
 def _scan_dashboard_processes(
@@ -53,17 +143,6 @@ def _scan_dashboard_processes(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-        # The headless backend (`hermes serve`) is the same long-lived server
-        # under a different command name — the desktop app spawns it. Reap it
-        # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
     self_pid = os.getpid()
     dashboard_processes: list[tuple[int, str]] = []
 
@@ -81,15 +160,53 @@ def _scan_dashboard_processes(
             # update, where a bare wmic spawn would pop a console window.
             from hermes_cli._subprocess_compat import windows_hide_flags
 
-            result = subprocess.run(
-                ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                encoding="utf-8",
-                errors="ignore",
-                creationflags=windows_hide_flags(),
-            )
+            _no_window = {"creationflags": windows_hide_flags()}
+            # Prefer wmic when present (fast, stable output format).  On
+            # modern Windows 11 25H2+, wmic has been removed as part of the
+            # WMIC deprecation — fall back to PowerShell's Get-CimInstance.
+            # Any OSError here (FileNotFoundError on missing wmic) trips
+            # the fallback.  (#75791)
+            wmic_path = shutil.which("wmic")
+            result = None
+            if wmic_path is not None:
+                try:
+                    result = subprocess.run(
+                        [wmic_path, "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                        encoding="utf-8",
+                        errors="ignore",
+                        **_no_window,
+                    )
+                except (OSError, subprocess.TimeoutExpired):
+                    result = None
+            if result is None or result.returncode != 0 or not (result.stdout or ""):
+                # Fallback: PowerShell Get-CimInstance, emit LIST-style output
+                # so the downstream parser doesn't need to branch.
+                powershell = shutil.which("powershell") or shutil.which("pwsh")
+                if powershell is None:
+                    return []
+                ps_cmd = (
+                    "Get-CimInstance Win32_Process | "
+                    "ForEach-Object { "
+                    "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
+                    "  'ProcessId=' + $_.ProcessId; "
+                    "  '' "
+                    "}"
+                )
+                try:
+                    result = subprocess.run(
+                        [powershell, "-NoProfile", "-Command", ps_cmd],
+                        capture_output=True,
+                        text=True,
+                        timeout=15,
+                        encoding="utf-8",
+                        errors="ignore",
+                        **_no_window,
+                    )
+                except (OSError, subprocess.TimeoutExpired):
+                    return []
             if result.returncode != 0 or result.stdout is None:
                 return []
             current_cmd = ""
@@ -100,7 +217,7 @@ def _scan_dashboard_processes(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        _is_hermes_dashboard_or_serve_cmd(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -133,7 +250,7 @@ def _scan_dashboard_processes(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _is_hermes_dashboard_or_serve_cmd(command) and pid != self_pid:
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_dashboard_process_matching.py
+++ b/tests/hermes_cli/test_dashboard_process_matching.py
@@ -1,0 +1,74 @@
+"""Tests for ``hermes_cli.dashboard_procs._is_hermes_dashboard_or_serve_cmd``.
+
+Verifies that dashboard/serve process detection works correctly when
+profile arguments appear between the executable and subcommand.
+Fixes #75791.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.dashboard_procs import _is_hermes_dashboard_or_serve_cmd
+
+
+class TestIsHermesDashboardOrServeCmd:
+    """Token-based command-line matching for dashboard/serve processes."""
+
+    # --- Should match (True) ---
+
+    @pytest.mark.parametrize("cmd", [
+        "hermes dashboard --no-open --skip-build",
+        "hermes_cli.main dashboard --port 9119",
+        "python -m hermes_cli.main dashboard --no-open",
+        "hermes serve --port 8080",
+        "hermes_cli.main serve --port 8080",
+        "python -m hermes_cli.main serve --port 8080",
+        "hermes_cli/main.py dashboard --port 9119",
+        "hermes_cli/main.py serve --port 8080",
+    ])
+    def test_basic_invocations(self, cmd):
+        assert _is_hermes_dashboard_or_serve_cmd(cmd) is True
+
+    @pytest.mark.parametrize("cmd", [
+        "hermes --profile myprofile dashboard --no-open",
+        "hermes -p production dashboard --port 8080",
+        "hermes --profile myprofile serve --port 8080",
+        "hermes --profile=prod dashboard",
+        "hermes -p=prod dashboard",
+        "python -m hermes_cli --profile myprofile dashboard",
+        "python -m hermes_cli.main --profile work dashboard --port 9119",
+    ])
+    def test_profile_args_between_exe_and_subcommand(self, cmd):
+        """Primary fix target: profile args no longer prevent matching."""
+        assert _is_hermes_dashboard_or_serve_cmd(cmd) is True
+
+    @pytest.mark.parametrize("cmd", [
+        '"C:\\Program Files\\hermes\\hermes.exe" --profile work dashboard --port 9119',
+        "hermes_cli.main dashboard --port 9119",
+    ])
+    def test_windows_paths(self, cmd):
+        assert _is_hermes_dashboard_or_serve_cmd(cmd) is True
+
+    # --- Should NOT match (False) ---
+
+    @pytest.mark.parametrize("cmd", [
+        None,
+        "",
+        "vim hermes dashboard",
+        "grep hermes dashboard",
+        "node server.js --port 9119",
+        "hermes update",
+        "hermes status",
+        "hermes gateway status",
+        "hermes_cli.main gateway run",
+        "hermes -p dash dashbo",  # "dash" profile, "dashbo" ≠ dashboard/serve
+    ])
+    def test_non_matching_invocations(self, cmd):
+        assert _is_hermes_dashboard_or_serve_cmd(cmd) is False
+
+    def test_profile_named_dashboard_with_serve_subcommand(self):
+        """Profile value 'dashboard' stripped, then 'serve' matches."""
+        assert _is_hermes_dashboard_or_serve_cmd(
+            "hermes --profile dashboard serve"
+        ) is True


### PR DESCRIPTION
## Summary

`hermes dashboard --status` falsely reports no dashboard processes on Windows 11 25H2 for two compounding reasons:

1. **WMIC deprecated** — Windows 11 25H2 removes `wmic.exe` by default. The scanner catches `FileNotFoundError` and silently returns an empty list, producing a false negative with no diagnostic.

2. **Profile arg pattern mismatch** — The substring-based matching (`"hermes dashboard" in cmd`) fails when `--profile`/`-p` arguments appear between the executable and subcommand (e.g. `hermes --profile prod dashboard --no-open`).

## Changes

### `hermes_cli/dashboard_procs.py`

- **Add `_is_hermes_dashboard_or_serve_cmd()`** — token-based command-line matcher that strips `--profile`/`-p` selectors (matching the approach in `gateway/status.py::_gateway_command_subcommand`) before checking for `dashboard`/`serve` subcommands. Handles `hermes`, `python -m hermes_cli`, and Windows quoted paths.

- **Add PowerShell Get-CimInstance fallback** — when `wmic` is unavailable, falls back to `Get-CimInstance Win32_Process` via PowerShell (matching `hermes_cli/gateway.py::_scan_gateway_pids`).

### `tests/hermes_cli/test_dashboard_process_matching.py` (new)

28 parametrized tests covering:
- Basic invocations (hermes, python -m, hermes_cli.main)
- Profile args between executable and subcommand
- Windows quoted paths
- Negative cases (vim, grep, unrelated commands)
- Edge cases (profile named "dashboard", None, empty string)

## Test Plan

- [x] `python3 -m pytest tests/hermes_cli/test_dashboard_process_matching.py -xvs` — 28/28 passed
- [x] `python3 -m pytest tests/hermes_cli/test_dashboard_lifecycle_flags.py -xvs` — 8/8 passed
- [ ] Manual test on Windows 11 25H2 without WMIC installed
- [ ] Manual test with `hermes --profile <name> dashboard --status`

Fixes #75791