### PR TITLE
fix(tool_search): surface thin-description MCP tools by name match

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -172,6 +172,94 @@ class TestRetrieval:
         hits = search_catalog(self._fake_catalog(), "github", limit=1)
         assert len(hits) <= 1
 
+    def _ha_style_catalog(self):
+        """Large fixed REST surface + thin-description Assist custom scripts.
+
+        Reproduces #75903: BM25 alone ranks empty-description custom tools
+        past ``limit`` because many REST siblings share get/entity/history
+        tokens and carry long descriptions. Name-match boosts must still
+        surface the exact tool.
+        """
+        from tools.tool_search import CatalogEntry, _tokenize, _entry_search_text
+
+        rest_blob = (
+            "Home Assistant REST API entity state history logbook statistics "
+            "service domain area device registry get list call fire render "
+        )
+        defs = []
+        for base in (
+            "get_state", "list_entities", "get_history", "get_logbook",
+            "get_statistics", "call_service", "get_config", "fire_event",
+            "render_template", "get_services", "get_entity", "entity_history",
+        ):
+            for i in range(14):
+                name = (
+                    f"mcp__backend__{base}"
+                    if i == 0
+                    else f"mcp__backend__{base}_{i}"
+                )
+                defs.append(_td(name, rest_blob + base, {
+                    "entity_id": {"type": "string"},
+                    "history": {"type": "string"},
+                }))
+        # HA-Assist-native custom scripts: name is the only strong signal.
+        defs.append(_td("mcp__backend__mcp_get_house_reference", "", {}))
+        defs.append(_td("mcp__backend__mcp_get_entity_history", "", {}))
+
+        catalog = []
+        for d in defs:
+            fn = d["function"]
+            e = CatalogEntry(
+                name=fn["name"], description=fn["description"],
+                schema=d, source="mcp", source_name="mcp-backend",
+            )
+            e._tokens = _tokenize(_entry_search_text(d))
+            catalog.append(e)
+        return catalog
+
+    def test_search_surfaces_thin_description_custom_script_by_exact_name(self):
+        """#75903 — exact script-key query must beat a noisy REST surface."""
+        from tools.tool_search import search_catalog
+
+        catalog = self._ha_style_catalog()
+        assert len(catalog) >= 150
+
+        hits = search_catalog(catalog, "mcp_get_entity_history", limit=20)
+        names = [h.name for h in hits]
+        assert "mcp__backend__mcp_get_entity_history" in names
+        assert names[0] == "mcp__backend__mcp_get_entity_history"
+
+        hits = search_catalog(catalog, "get_house_reference", limit=20)
+        names = [h.name for h in hits]
+        assert "mcp__backend__mcp_get_house_reference" in names
+        assert names[0] == "mcp__backend__mcp_get_house_reference"
+
+    def test_search_name_substring_not_gated_on_empty_bm25(self):
+        """Name substring boost applies even when BM25 already has hits."""
+        from tools.tool_search import search_catalog
+
+        catalog = self._ha_style_catalog()
+        # Many REST tools score on "entity"/"history"; without always-on
+        # name boosts the custom script ranks near the bottom of ~170 hits.
+        hits = search_catalog(catalog, "mcp_get_entity_history", limit=5)
+        assert hits[0].name == "mcp__backend__mcp_get_entity_history"
+
+    def test_search_matches_camelcase_leaf_name(self):
+        """CamelCase MCP wire names still match snake_case queries."""
+        from tools.tool_search import (
+            CatalogEntry, _tokenize, _entry_search_text, search_catalog,
+        )
+
+        d = _td("mcp__ha__McpGetHouseReference", "Assist script")
+        entry = CatalogEntry(
+            name=d["function"]["name"],
+            description=d["function"]["description"],
+            schema=d, source="mcp", source_name="mcp-ha",
+        )
+        entry._tokens = _tokenize(_entry_search_text(d))
+        hits = search_catalog([entry], "get_house_reference", limit=5)
+        assert [h.name for h in hits] == ["mcp__ha__McpGetHouseReference"]
+
 
 # ---------------------------------------------------------------------------
 # Assembly — the full passthrough/activate decision.

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -332,30 +332,112 @@ class CatalogEntry:
 
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+# Split camelCase / PascalCase identifiers so BM25 can match query terms
+# against MCP tools whose wire names are CamelCase (common for HA Assist
+# intents and some OpenAPI-generated MCP surfaces).
+_CAMEL_BOUNDARY_RE = re.compile(
+    r"([a-z0-9])([A-Z])|([A-Z]+)([A-Z][a-z])"
+)
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+# Name-match boosts layered on top of BM25. These dominate BM25 so an
+# exact / near-exact tool name always outranks a long-description sibling
+# that merely shares common tokens (get/history/entity/...). Substring
+# fallback used to run *only* when BM25 produced zero hits, which buried
+# thin-description custom tools under a large fixed REST surface (#75903).
+_NAME_EXACT_BOOST = 1000.0
+_NAME_LEAF_EXACT_BOOST = 500.0
+_NAME_SUBSTRING_BOOST = 100.0
+_NAME_COMPACT_BOOST = 50.0
+
+
+def _split_ident(text: str) -> str:
+    """Insert spaces at snake/kebab/camel boundaries for tokenization."""
+    if not text:
+        return ""
+    text = (
+        text.replace("_", " ")
+        .replace(".", " ")
+        .replace("-", " ")
+        .replace(":", " ")
+    )
+    return _CAMEL_BOUNDARY_RE.sub(
+        lambda m: f"{m.group(1) or m.group(3)} {m.group(2) or m.group(4)}",
+        text,
+    )
 
 
 def _tokenize(text: str) -> List[str]:
     if not text:
         return []
-    return [t.lower() for t in _TOKEN_RE.findall(text)]
+    return [t.lower() for t in _TOKEN_RE.findall(_split_ident(text))]
+
+
+def _alnum_compact(text: str) -> str:
+    """Lowercase alphanumeric-only form for punctuation-insensitive match."""
+    return _NON_ALNUM_RE.sub("", (text or "").lower())
+
+
+def _name_leaf(name: str) -> str:
+    """Final segment of an MCP-prefixed name (``mcp__srv__tool`` → ``tool``)."""
+    if not name:
+        return ""
+    if "__" in name:
+        return name.rsplit("__", 1)[-1]
+    return name
+
+
+def _name_match_boost(query: str, tool_name: str) -> float:
+    """Return a score boost when ``query`` matches the tool's wire name.
+
+    Matching is checked against the full registry name and its final
+    ``__``-delimited leaf (the raw MCP tool name after Hermes prefixes
+    ``mcp__<server>__``). Compact alphanumeric comparison covers queries
+    that drop underscores (``gethouse reference`` vs ``get_house_reference``).
+    """
+    ql = (query or "").strip().lower()
+    if not ql or not tool_name:
+        return 0.0
+    name_l = tool_name.lower()
+    leaf = _name_leaf(tool_name).lower()
+    if name_l == ql or leaf == ql:
+        return _NAME_EXACT_BOOST if name_l == ql else _NAME_LEAF_EXACT_BOOST
+    if ql in name_l or (leaf and ql in leaf):
+        return _NAME_SUBSTRING_BOOST
+    q_compact = _alnum_compact(ql)
+    if not q_compact:
+        return 0.0
+    name_compact = _alnum_compact(name_l)
+    leaf_compact = _alnum_compact(leaf)
+    if q_compact == name_compact or q_compact == leaf_compact:
+        return _NAME_LEAF_EXACT_BOOST
+    if q_compact in name_compact or (leaf_compact and q_compact in leaf_compact):
+        return _NAME_COMPACT_BOOST
+    return 0.0
 
 
 def _entry_search_text(td: Dict[str, Any]) -> str:
     """Build the search-text blob for a deferrable tool.
 
-    Includes the tool name (with underscores broken into words so BM25 can
-    match against query terms), the description, and the names of the
-    top-level parameters. Schema bodies are deliberately excluded —
-    indexing them adds noise without improving recall in our measurement.
+    Includes the tool name (with snake/camel boundaries broken into words so
+    BM25 can match against query terms), the bare leaf name repeated for
+    weight, the description, and the names of the top-level parameters.
+    Schema bodies are deliberately excluded — indexing them adds noise
+    without improving recall in our measurement.
     """
     fn = td.get("function") or {}
-    name = fn.get("name", "")
+    name = fn.get("name", "") or ""
     desc = fn.get("description", "") or ""
-    params = ((fn.get("parameters") or {}).get("properties") or {})
-    param_names = " ".join(params.keys())
-    # Break snake_case and dotted names into words for BM25.
-    name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
-    return f"{name_words} {desc} {param_names}"
+    if not isinstance(desc, str):
+        desc = str(desc)
+    raw_params = fn.get("parameters") or {}
+    props = raw_params.get("properties") if isinstance(raw_params, dict) else None
+    param_names = " ".join(props.keys()) if isinstance(props, dict) else ""
+    name_words = _split_ident(name)
+    # Leaf (unprefixed MCP tool name) is the form users and models search for
+    # after seeing ``backend__script_key`` style listings.
+    leaf_words = _split_ident(_name_leaf(name))
+    return f"{name_words} {leaf_words} {leaf_words} {desc} {param_names}"
 
 
 def _classify_source(name: str) -> Tuple[str, str]:
@@ -385,6 +467,8 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
         if not name:
             continue
         desc = fn.get("description", "") or ""
+        if not isinstance(desc, str):
+            desc = str(desc)
         source, source_name = _classify_source(name)
         entry = CatalogEntry(
             name=name,
@@ -430,43 +514,50 @@ def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
 
 
 def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> List[CatalogEntry]:
-    """Return the top-``limit`` catalog entries for ``query`` by BM25.
+    """Return the top-``limit`` catalog entries for ``query``.
 
-    Falls back to a stable name-substring match when BM25 yields no hits
-    above zero. That ensures a query like ``"github"`` against a catalog
-    where every tool is named ``github_*`` still returns results — BM25
-    can underperform when query and document share only one token that
-    appears in every document (zero IDF).
+    Ranking is BM25 over name + description + parameter names, with
+    **always-on** name-match boosts:
+
+    * exact full name / final ``__`` leaf
+    * substring of full name or leaf
+    * alphanumeric-compact match (ignores ``_``/``-``)
+
+    Name boosts used to apply only when BM25 returned zero hits. On a large
+    MCP surface (e.g. Home Assistant REST + Assist-exposed custom scripts)
+    BM25 almost always finds *something*, so thin-description custom tools
+    whose names are exact query hits were ranked past ``limit`` and never
+    returned (#75903). Boosts now layer on every candidate so a
+    name-substring query always surfaces the matching tool.
     """
     if not catalog or limit <= 0:
         return []
-    query_tokens = _tokenize(query)
-    if not query_tokens:
+    query = str(query or "").strip()
+    if not query:
         return []
+    query_tokens = _tokenize(query)
 
-    # Precompute doc statistics.
+    # Precompute doc statistics for BM25 (skipped when query has no tokens,
+    # e.g. punctuation-only — name boosts may still match).
     doc_lengths = [len(e._tokens) for e in catalog]
     avg_dl = sum(doc_lengths) / max(len(doc_lengths), 1)
     doc_freq: Dict[str, int] = {}
-    for e in catalog:
-        seen = set(e._tokens)
-        for t in seen:
-            doc_freq[t] = doc_freq.get(t, 0) + 1
+    if query_tokens:
+        for e in catalog:
+            seen = set(e._tokens)
+            for t in seen:
+                doc_freq[t] = doc_freq.get(t, 0) + 1
     n_docs = len(catalog)
 
     scored: List[Tuple[float, CatalogEntry]] = []
     for entry in catalog:
-        s = _bm25_score(query_tokens, entry._tokens, doc_lengths, avg_dl,
-                        doc_freq, n_docs)
+        s = 0.0
+        if query_tokens:
+            s = _bm25_score(query_tokens, entry._tokens, doc_lengths, avg_dl,
+                            doc_freq, n_docs)
+        s += _name_match_boost(query, entry.name)
         if s > 0:
             scored.append((s, entry))
-
-    if not scored:
-        # Substring fallback against the original tool name.
-        ql = query.lower()
-        for entry in catalog:
-            if ql in entry.name.lower():
-                scored.append((0.1, entry))
 
     scored.sort(key=lambda x: x[0], reverse=True)
     return [e for _, e in scored[:limit]]


### PR DESCRIPTION
## What does this PR do?

Fixes `tool_search` ranking so thin/empty-description MCP tools (e.g. Home Assistant Assist-exposed custom scripts) always surface when the query matches their wire name — even on a large fixed REST surface that shares common tokens like `get`/`entity`/`history`.

Previously, name-substring matching only ran when BM25 returned **zero** hits. On a ~200-tool HA/MetaMCP catalog BM25 almost always finds REST siblings first, so exact script-key queries ranked the custom tools past `limit` and never returned them — while `tool_describe` / `tool_call` with the exact name still worked.

## Why

Progressive disclosure is the default (`tools.tool_search: auto`). Models that cannot discover a tool via `tool_search` effectively cannot use it, even though the tool is registered and callable by exact name. The only workaround was disabling tool_search entirely.

## Related Issue

Fixes #75903

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Always layer name-match boosts on BM25 scores:
  - exact full name
  - exact final `__` leaf (raw MCP tool name after `mcp__server__`)
  - substring of full name / leaf
  - alphanumeric-compact match (ignores `_`/`-`)
- Split camelCase / PascalCase when tokenizing search text
- Weight the unprefixed MCP leaf name in the indexed search blob
- Harden description/parameters coercion when building search text
- Regression tests for HA-style thin-description burial (#75903) and camelCase leaf match

## How to Test

```shell
HERMES_PYTHON=/path/to/venv/bin/python scripts/run_tests.sh tests/tools/test_tool_search.py -q
# 30 passed
```

Manual scenario matching #75903:

1. MCP backend with a large fixed REST surface (~150+ tools) plus Assist-exposed scripts named `…__mcp_get_entity_history` / `…__mcp_get_house_reference` with empty or minimal descriptions.
2. Fresh session with `tools.tool_search.enabled: auto`.
3. `tool_search(query="mcp_get_entity_history", limit=20)` → target is rank 1.
4. `tool_search(query="get_house_reference", limit=20)` → target is rank 1.
5. `tool_describe` / `tool_call` with the exact name still work as before.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — no open PR for #75903 (distinct from #72560 mid-session staleness)
- [x] PR contains only changes related to this fix
- [x] `scripts/run_tests.sh tests/tools/test_tool_search.py` → 30 passed
- [x] Added regression tests for the changed behavior
- [x] Tested on macOS, Python 3.13

### Documentation & Housekeeping

- [x] N/A — ranking-only change; tool-search docs still accurate
- [x] No config key changes
- [x] No Cursor / AI trailer in commit