### PR TITLE
feat: native Discord embeds via [EMBED] marker

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2943,6 +2943,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
+            embed = None
+            if isinstance(formatted, str) and "[EMBED]" in formatted:
+                formatted, embed = self._extract_embed(formatted)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             message_ids = []
@@ -2966,6 +2969,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 try:
                     msg = await channel.send(
                         content=chunk,
+                        embed=(embed if i == 0 else None),
                         reference=chunk_reference,
                     )
                 except Exception as e:
@@ -2988,6 +2992,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         reference = None
                         msg = await channel.send(
                             content=chunk,
+                            embed=(embed if i == 0 else None),
                             reference=None,
                         )
                     else:
@@ -3232,7 +3237,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                await msg.edit(content=formatted)
+                embed = None
+                edit_content = formatted
+                if "[EMBED]" in formatted:
+                    if finalize:
+                        # Final edit: replace the marker with the real embed.
+                        edit_content, embed = self._extract_embed(formatted)
+                    else:
+                        # Mid-stream: hide the raw JSON so the user doesn't
+                        # watch it type out — the finalize edit swaps it for
+                        # the finished embed.
+                        edit_content = "⏳ *rendering embed…*"
+                await msg.edit(content=edit_content, embed=embed)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
             except Exception as edit_err:
@@ -5197,6 +5213,47 @@ class DiscordAdapter(BasePlatformAdapter):
         if not content:
             return content
         return convert_table_to_bullets(content)
+
+    def _extract_embed(self, content: str):
+        """If content contains [EMBED]...[/EMBED] (JSON), build a discord.Embed.
+
+        Supported JSON keys: title, description, url, color (int or #hex),
+        footer, thumbnail, fields [{name, value, inline}].
+        Text before/after the marker is kept as the plain-message content.
+        Returns (remaining_content, embed_or_None).
+        """
+        try:
+            start = content.index("[EMBED]")
+            end = content.index("[/EMBED]", start)
+            block = content[start + 7:end].strip()
+            data = json.loads(block, strict=False)  # allow literal newlines inside strings
+            emb = discord.Embed() if discord is not None else None
+            if emb is None:
+                return content, None
+            if data.get("title"):
+                emb.title = data["title"]
+            if data.get("description"):
+                emb.description = data["description"]
+            if data.get("url"):
+                emb.url = data["url"]
+            if data.get("color"):
+                c = data["color"]
+                emb.color = c if isinstance(c, int) else int(str(c).lstrip("#"), 16)
+            if data.get("footer"):
+                f = data["footer"]
+                emb.set_footer(text=f if isinstance(f, str) else f.get("text", ""))
+            if data.get("thumbnail"):
+                emb.set_thumbnail(url=data["thumbnail"])
+            for f in data.get("fields", [])[:25]:
+                emb.add_field(
+                    name=f.get("name", "\u200B"),
+                    value=f.get("value", "\u200B"),
+                    inline=bool(f.get("inline", False)),
+                )
+            rest = (content[:start] + content[end + len("[/EMBED]"):]).strip()
+            return rest, emb
+        except Exception:
+            return content, None
 
     async def _run_simple_slash(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9381,6 +9381,61 @@ async def _standalone_read_json_limited(resp: Any, limit_bytes: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def _embed_payload_from_block(block: str) -> Optional[Dict[str, Any]]:
+    """Parse an [EMBED] JSON block into a Discord REST embed payload dict.
+
+    Standalone (non-gateway) sends use the HTTP API directly, so this
+    mirrors ``DiscordAdapter._extract_embed`` without needing discord.py.
+    Returns None when the block isn't valid embed JSON.
+    """
+    try:
+        data = json.loads(DiscordAdapter._clean_embed_json(block), strict=False)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    emb: Dict[str, Any] = {}
+    for key in ("title", "description", "url"):
+        if data.get(key):
+            emb[key] = data[key]
+    if data.get("color"):
+        c = data["color"]
+        emb["color"] = c if isinstance(c, int) else int(str(c).lstrip("#"), 16)
+    if data.get("footer"):
+        f = data["footer"]
+        emb["footer"] = {"text": f} if isinstance(f, str) else {"text": f.get("text", "")}
+    if data.get("thumbnail"):
+        emb["thumbnail"] = {"url": data["thumbnail"]}
+    fields = []
+    for f in data.get("fields", [])[:25]:
+        fields.append({
+            "name": f.get("name", "\u200B"),
+            "value": f.get("value", "\u200B"),
+            "inline": bool(f.get("inline", False)),
+        })
+    if fields:
+        emb["fields"] = fields
+    return emb
+
+
+def _split_embed_from_message(message: str):
+    """Split ``message`` into (text, embed_payload) — the [EMBED] marker is
+    removed and rendered as a native embed; None when no marker present."""
+    if "[EMBED]" not in message:
+        return message, None
+    try:
+        start = message.index("[EMBED]")
+        end = message.index("[/EMBED]", start)
+        block = message[start + 7:end].strip()
+        payload = _embed_payload_from_block(block)
+        if payload is None:
+            return message, None
+        text = (message[:start] + message[end + len("[/EMBED]"):]).strip()
+        return text, payload
+    except Exception:
+        return message, None
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -9426,6 +9481,12 @@ async def _standalone_send(
         media_files = media_files or []
         last_data = None
         warnings = []
+
+        # [EMBED] marker -> native embed payload (standalone path: cron and
+        # send_message tool deliveries never pass through adapter.send()).
+        send_text, embed_payload = _split_embed_from_message(message)
+        if embed_payload is not None:
+            message = send_text
 
         # Thread endpoint: Discord threads are channels; send directly to the thread ID.
         if thread_id:
@@ -9525,7 +9586,7 @@ async def _standalone_send(
                             headers=json_headers,
                             json={
                                 "name": thread_name,
-                                "message": {"content": message},
+                                "message": {"content": message, **({"embeds": [embed_payload]} if embed_payload else {})},
                             },
                             **_req_kw,
                         ) as resp:
@@ -9558,7 +9619,7 @@ async def _standalone_send(
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
+                async with session.post(url, headers=json_headers, json={"content": message, **({"embeds": [embed_payload]} if embed_payload else {})}, **_req_kw) as resp:
                     if resp.status not in {200, 201}:
                         body = await _standalone_read_text_limited(
                             resp,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3499,9 +3499,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
+            # Format and split message if needed. Embed-marker extraction
+            # happens BEFORE routing so the forum path gets the parsed embed
+            # too (forum starters are created from this content).
+            formatted = self.format_message(content)
+            embed = None
+            if isinstance(formatted, str) and "[EMBED]" in formatted:
+                formatted, embed = self._extract_embed(formatted)
+
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(channel, formatted, embed=embed)
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -3511,15 +3519,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
-
-            # Parse the embed marker BEFORE overflow handling so a finalized
-            # oversized embed only size-checks the remaining text, and the
-            # marker is never exposed in split chunks.
-            embed = None
-            if isinstance(formatted, str) and "[EMBED]" in formatted:
-                formatted, embed = self._extract_embed(formatted)
             chunks = self._cap_split_chunks(
                 self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
             )
@@ -3601,14 +3600,15 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(self, forum_channel: Any, content: str, embed=None) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
         POST to /channels/{forum_id}/threads with a thread name derived from
         the first line of the message.  Any follow-up chunk failures are
         reported in ``raw_response['warnings']`` so the caller can surface
-        partial-send issues.
+        partial-send issues.  ``embed`` (parsed from an [EMBED] marker before
+        routing) rides on the starter message.
         """
         # _derive_forum_thread_name is defined further down in this same
         # module — no cross-module import needed.
@@ -3626,6 +3626,7 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await forum_channel.create_thread(
                 name=thread_name,
                 content=starter_content,
+                embed=embed,
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
@@ -3774,6 +3775,21 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = channel.get_partial_message(int(message_id))
             formatted = self.format_message(content)
 
+            # Parse the embed marker BEFORE overflow handling so a finalized
+            # oversized embed only size-checks the remaining text, and the
+            # marker is never exposed in split chunks.
+            embed = None
+            edit_content = formatted
+            if "[EMBED]" in formatted:
+                if finalize:
+                    # Final edit: replace the marker with the real embed.
+                    edit_content, embed = self._extract_embed(formatted)
+                else:
+                    # Mid-stream: hide the raw JSON so the user doesn't
+                    # watch it type out — the finalize edit swaps it for
+                    # the finished embed.
+                    edit_content = "⏳ *rendering embed…*"
+
             _preview_key = (str(chat_id), str(message_id))
             _saturated_preview = False
             if finalize:
@@ -3783,14 +3799,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Pre-flight: oversized payload.  Final edits split-and-deliver;
             # streaming edits truncate a one-message preview in place.
-            if len(formatted) > self.MAX_MESSAGE_LENGTH:
+            if len(edit_content) > self.MAX_MESSAGE_LENGTH:
                 if finalize:
                     return await self._edit_overflow_split(
-                        channel, msg, message_id, content,
+                        channel, msg, message_id, edit_content, embed=embed,
                     )
-                formatted = self.truncate_message(
-                    formatted, self.MAX_MESSAGE_LENGTH,
+                edit_content = self.truncate_message(
+                    edit_content, self.MAX_MESSAGE_LENGTH,
                 )[0]
+                formatted = edit_content
                 _saturated_preview = True
                 # Saturated-preview dedup: past the cap, every progressive
                 # edit truncates to the same text. Re-sending it is a visual
@@ -3806,17 +3823,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                embed = None
-                edit_content = formatted
-                if "[EMBED]" in formatted:
-                    if finalize:
-                        # Final edit: replace the marker with the real embed.
-                        edit_content, embed = self._extract_embed(formatted)
-                    else:
-                        # Mid-stream: hide the raw JSON so the user doesn't
-                        # watch it type out — the finalize edit swaps it for
-                        # the finished embed.
-                        edit_content = "⏳ *rendering embed…*"
                 await msg.edit(content=edit_content, embed=embed)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
@@ -3875,6 +3881,7 @@ class DiscordAdapter(BasePlatformAdapter):
         msg: Any,
         message_id: str,
         content: str,
+        embed=None,
     ) -> SendResult:
         """Deliver an oversized final edit across message + continuations.
 
@@ -3900,12 +3907,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
             # not, just edit normally.
-            await msg.edit(content=chunks[0] if chunks else formatted)
+            await msg.edit(content=chunks[0] if chunks else formatted, embed=embed)
             return SendResult(success=True, message_id=message_id)
 
-        # Step 1 — edit the existing message with the first chunk.
+        # Step 1 — edit the existing message with the first chunk (the embed
+        # rides on it, mirroring send()).
         try:
-            await msg.edit(content=chunks[0])
+            await msg.edit(content=chunks[0], embed=embed)
         except Exception as e:
             logger.error(
                 "[%s] Overflow split: first-chunk edit failed: %s",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3513,6 +3513,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
+
+            # Parse the embed marker BEFORE overflow handling so a finalized
+            # oversized embed only size-checks the remaining text, and the
+            # marker is never exposed in split chunks.
+            embed = None
+            if isinstance(formatted, str) and "[EMBED]" in formatted:
+                formatted, embed = self._extract_embed(formatted)
             chunks = self._cap_split_chunks(
                 self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
             )
@@ -3529,6 +3536,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 try:
                     msg = await channel.send(
                         content=chunk,
+                        embed=(embed if i == 0 else None),
                         reference=chunk_reference,
                     )
                 except Exception as e:
@@ -3551,6 +3559,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         reference = None
                         msg = await channel.send(
                             content=chunk,
+                            embed=(embed if i == 0 else None),
                             reference=None,
                         )
                     else:
@@ -3797,7 +3806,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                await msg.edit(content=formatted)
+                embed = None
+                edit_content = formatted
+                if "[EMBED]" in formatted:
+                    if finalize:
+                        # Final edit: replace the marker with the real embed.
+                        edit_content, embed = self._extract_embed(formatted)
+                    else:
+                        # Mid-stream: hide the raw JSON so the user doesn't
+                        # watch it type out — the finalize edit swaps it for
+                        # the finished embed.
+                        edit_content = "⏳ *rendering embed…*"
+                await msg.edit(content=edit_content, embed=embed)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
             except Exception as edit_err:
@@ -5780,6 +5800,47 @@ class DiscordAdapter(BasePlatformAdapter):
         if not content:
             return content
         return convert_table_to_bullets(content)
+
+    def _extract_embed(self, content: str):
+        """If content contains [EMBED]...[/EMBED] (JSON), build a discord.Embed.
+
+        Supported JSON keys: title, description, url, color (int or #hex),
+        footer, thumbnail, fields [{name, value, inline}].
+        Text before/after the marker is kept as the plain-message content.
+        Returns (remaining_content, embed_or_None).
+        """
+        try:
+            start = content.index("[EMBED]")
+            end = content.index("[/EMBED]", start)
+            block = content[start + 7:end].strip()
+            data = json.loads(block, strict=False)  # allow literal newlines inside strings
+            emb = discord.Embed() if discord is not None else None
+            if emb is None:
+                return content, None
+            if data.get("title"):
+                emb.title = data["title"]
+            if data.get("description"):
+                emb.description = data["description"]
+            if data.get("url"):
+                emb.url = data["url"]
+            if data.get("color"):
+                c = data["color"]
+                emb.color = c if isinstance(c, int) else int(str(c).lstrip("#"), 16)
+            if data.get("footer"):
+                f = data["footer"]
+                emb.set_footer(text=f if isinstance(f, str) else f.get("text", ""))
+            if data.get("thumbnail"):
+                emb.set_thumbnail(url=data["thumbnail"])
+            for f in data.get("fields", [])[:25]:
+                emb.add_field(
+                    name=f.get("name", "\u200B"),
+                    value=f.get("value", "\u200B"),
+                    inline=bool(f.get("inline", False)),
+                )
+            rest = (content[:start] + content[end + len("[/EMBED]"):]).strip()
+            return rest, emb
+        except Exception:
+            return content, None
 
     async def _run_simple_slash(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5809,6 +5809,49 @@ class DiscordAdapter(BasePlatformAdapter):
             return content
         return convert_table_to_bullets(content)
 
+    @staticmethod
+    def _clean_embed_json(block: str) -> str:
+        """Strip common LLM-generation artifacts from an embed JSON block:
+        (1/2)-style segment markers and trailing commas (both outside
+        strings). Returns the cleaned JSON text."""
+        out = []
+        in_str = False
+        esc = False
+        i = 0
+        n = len(block)
+        while i < n:
+            ch = block[i]
+            if in_str:
+                out.append(ch)
+                if esc:
+                    esc = False
+                elif ch == "\\":
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+                i += 1
+                continue
+            if ch == '"':
+                in_str = True
+                out.append(ch)
+                i += 1
+                continue
+            if ch == "(":
+                m = re.match(r"\(\d+/\d+\)", block[i:])
+                if m:
+                    i += len(m.group(0))
+                    continue
+            if ch == ",":
+                j = i + 1
+                while j < n and block[j] in " \t\n\r":
+                    j += 1
+                if j < n and block[j] in "}]":
+                    i += 1  # drop trailing comma
+                    continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
     def _extract_embed(self, content: str):
         """If content contains [EMBED]...[/EMBED] (JSON), build a discord.Embed.
 
@@ -5821,7 +5864,7 @@ class DiscordAdapter(BasePlatformAdapter):
             start = content.index("[EMBED]")
             end = content.index("[/EMBED]", start)
             block = content[start + 7:end].strip()
-            data = json.loads(block, strict=False)  # allow literal newlines inside strings
+            data = json.loads(self._clean_embed_json(block), strict=False)  # tolerate LLM artifacts + literal newlines
             emb = discord.Embed() if discord is not None else None
             if emb is None:
                 return content, None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3533,11 +3533,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        embed=(embed if i == 0 else None),
-                        reference=chunk_reference,
-                    )
+                    send_kwargs = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if embed is not None and i == 0:
+                        send_kwargs["embed"] = embed
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -3556,11 +3558,13 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            embed=(embed if i == 0 else None),
-                            reference=None,
-                        )
+                        send_kwargs = {
+                            "content": chunk,
+                            "reference": None,
+                        }
+                        if embed is not None and i == 0:
+                            send_kwargs["embed"] = embed
+                        msg = await channel.send(**send_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -3823,7 +3827,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                await msg.edit(content=edit_content, embed=embed)
+                edit_kwargs = {"content": edit_content}
+                if embed is not None:
+                    edit_kwargs["embed"] = embed
+                await msg.edit(**edit_kwargs)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
             except Exception as edit_err:
@@ -3907,13 +3914,19 @@ class DiscordAdapter(BasePlatformAdapter):
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
             # not, just edit normally.
-            await msg.edit(content=chunks[0] if chunks else formatted, embed=embed)
+            edit_kwargs = {"content": chunks[0] if chunks else formatted}
+            if embed is not None:
+                edit_kwargs["embed"] = embed
+            await msg.edit(**edit_kwargs)
             return SendResult(success=True, message_id=message_id)
 
         # Step 1 — edit the existing message with the first chunk (the embed
         # rides on it, mirroring send()).
         try:
-            await msg.edit(content=chunks[0], embed=embed)
+            edit_kwargs = {"content": chunks[0]}
+            if embed is not None:
+                edit_kwargs["embed"] = embed
+            await msg.edit(**edit_kwargs)
         except Exception as e:
             logger.error(
                 "[%s] Overflow split: first-chunk edit failed: %s",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5226,6 +5226,49 @@ class DiscordAdapter(BasePlatformAdapter):
             return content
         return convert_table_to_bullets(content)
 
+    @staticmethod
+    def _clean_embed_json(block: str) -> str:
+        """Strip common LLM-generation artifacts from an embed JSON block:
+        (1/2)-style segment markers and trailing commas (both outside
+        strings). Returns the cleaned JSON text."""
+        out = []
+        in_str = False
+        esc = False
+        i = 0
+        n = len(block)
+        while i < n:
+            ch = block[i]
+            if in_str:
+                out.append(ch)
+                if esc:
+                    esc = False
+                elif ch == "\\":
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+                i += 1
+                continue
+            if ch == '"':
+                in_str = True
+                out.append(ch)
+                i += 1
+                continue
+            if ch == "(":
+                m = re.match(r"\(\d+/\d+\)", block[i:])
+                if m:
+                    i += len(m.group(0))
+                    continue
+            if ch == ",":
+                j = i + 1
+                while j < n and block[j] in " \t\n\r":
+                    j += 1
+                if j < n and block[j] in "}]":
+                    i += 1  # drop trailing comma
+                    continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
     def _extract_embed(self, content: str):
         """If content contains [EMBED]...[/EMBED] (JSON), build a discord.Embed.
 
@@ -5238,7 +5281,7 @@ class DiscordAdapter(BasePlatformAdapter):
             start = content.index("[EMBED]")
             end = content.index("[/EMBED]", start)
             block = content[start + 7:end].strip()
-            data = json.loads(block, strict=False)  # allow literal newlines inside strings
+            data = json.loads(self._clean_embed_json(block), strict=False)  # tolerate LLM artifacts + literal newlines
             emb = discord.Embed() if discord is not None else None
             if emb is None:
                 return content, None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -10123,6 +10123,61 @@ async def _standalone_read_json_limited(resp: Any, limit_bytes: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def _embed_payload_from_block(block: str) -> Optional[Dict[str, Any]]:
+    """Parse an [EMBED] JSON block into a Discord REST embed payload dict.
+
+    Standalone (non-gateway) sends use the HTTP API directly, so this
+    mirrors ``DiscordAdapter._extract_embed`` without needing discord.py.
+    Returns None when the block isn't valid embed JSON.
+    """
+    try:
+        data = json.loads(DiscordAdapter._clean_embed_json(block), strict=False)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    emb: Dict[str, Any] = {}
+    for key in ("title", "description", "url"):
+        if data.get(key):
+            emb[key] = data[key]
+    if data.get("color"):
+        c = data["color"]
+        emb["color"] = c if isinstance(c, int) else int(str(c).lstrip("#"), 16)
+    if data.get("footer"):
+        f = data["footer"]
+        emb["footer"] = {"text": f} if isinstance(f, str) else {"text": f.get("text", "")}
+    if data.get("thumbnail"):
+        emb["thumbnail"] = {"url": data["thumbnail"]}
+    fields = []
+    for f in data.get("fields", [])[:25]:
+        fields.append({
+            "name": f.get("name", "\u200B"),
+            "value": f.get("value", "\u200B"),
+            "inline": bool(f.get("inline", False)),
+        })
+    if fields:
+        emb["fields"] = fields
+    return emb
+
+
+def _split_embed_from_message(message: str):
+    """Split ``message`` into (text, embed_payload) — the [EMBED] marker is
+    removed and rendered as a native embed; None when no marker present."""
+    if "[EMBED]" not in message:
+        return message, None
+    try:
+        start = message.index("[EMBED]")
+        end = message.index("[/EMBED]", start)
+        block = message[start + 7:end].strip()
+        payload = _embed_payload_from_block(block)
+        if payload is None:
+            return message, None
+        text = (message[:start] + message[end + len("[/EMBED]"):]).strip()
+        return text, payload
+    except Exception:
+        return message, None
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -10175,6 +10230,12 @@ async def _standalone_send(
         media_files = media_files or []
         last_data = None
         warnings = []
+
+        # [EMBED] marker -> native embed payload (standalone path: cron and
+        # send_message tool deliveries never pass through adapter.send()).
+        send_text, embed_payload = _split_embed_from_message(message)
+        if embed_payload is not None:
+            message = send_text
 
         # Thread endpoint: Discord threads are channels; send directly to the thread ID.
         if thread_id:
@@ -10274,7 +10335,7 @@ async def _standalone_send(
                             headers=json_headers,
                             json={
                                 "name": thread_name,
-                                "message": {"content": message},
+                                "message": {"content": message, **({"embeds": [embed_payload]} if embed_payload else {})},
                             },
                             **_req_kw,
                         ) as resp:
@@ -10307,7 +10368,7 @@ async def _standalone_send(
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
+                async with session.post(url, headers=json_headers, json={"content": message, **({"embeds": [embed_payload]} if embed_payload else {})}, **_req_kw) as resp:
                     if resp.status not in {200, 201}:
                         body = await _standalone_read_text_limited(
                             resp,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2929,9 +2929,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
+            # Format and split message if needed. Embed-marker extraction
+            # happens BEFORE routing so the forum path gets the parsed embed
+            # too (forum starters are created from this content).
+            formatted = self.format_message(content)
+            embed = None
+            if isinstance(formatted, str) and "[EMBED]" in formatted:
+                formatted, embed = self._extract_embed(formatted)
+
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(channel, formatted, embed=embed)
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -2941,11 +2949,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
-            embed = None
-            if isinstance(formatted, str) and "[EMBED]" in formatted:
-                formatted, embed = self._extract_embed(formatted)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             message_ids = []
@@ -3034,14 +3037,15 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(self, forum_channel: Any, content: str, embed=None) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
         POST to /channels/{forum_id}/threads with a thread name derived from
         the first line of the message.  Any follow-up chunk failures are
         reported in ``raw_response['warnings']`` so the caller can surface
-        partial-send issues.
+        partial-send issues.  ``embed`` (parsed from an [EMBED] marker before
+        routing) rides on the starter message.
         """
         # _derive_forum_thread_name is defined further down in this same
         # module — no cross-module import needed.
@@ -3057,6 +3061,7 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await forum_channel.create_thread(
                 name=thread_name,
                 content=starter_content,
+                embed=embed,
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
@@ -3205,6 +3210,21 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.fetch_message(int(message_id))
             formatted = self.format_message(content)
 
+            # Parse the embed marker BEFORE overflow handling so a finalized
+            # oversized embed only size-checks the remaining text, and the
+            # marker is never exposed in split chunks.
+            embed = None
+            edit_content = formatted
+            if "[EMBED]" in formatted:
+                if finalize:
+                    # Final edit: replace the marker with the real embed.
+                    edit_content, embed = self._extract_embed(formatted)
+                else:
+                    # Mid-stream: hide the raw JSON so the user doesn't
+                    # watch it type out — the finalize edit swaps it for
+                    # the finished embed.
+                    edit_content = "⏳ *rendering embed…*"
+
             _preview_key = (str(chat_id), str(message_id))
             _saturated_preview = False
             if finalize:
@@ -3214,14 +3234,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Pre-flight: oversized payload.  Final edits split-and-deliver;
             # streaming edits truncate a one-message preview in place.
-            if len(formatted) > self.MAX_MESSAGE_LENGTH:
+            if len(edit_content) > self.MAX_MESSAGE_LENGTH:
                 if finalize:
                     return await self._edit_overflow_split(
-                        channel, msg, message_id, content,
+                        channel, msg, message_id, edit_content, embed=embed,
                     )
-                formatted = self.truncate_message(
-                    formatted, self.MAX_MESSAGE_LENGTH,
+                edit_content = self.truncate_message(
+                    edit_content, self.MAX_MESSAGE_LENGTH,
                 )[0]
+                formatted = edit_content
                 _saturated_preview = True
                 # Saturated-preview dedup: past the cap, every progressive
                 # edit truncates to the same text. Re-sending it is a visual
@@ -3237,17 +3258,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                embed = None
-                edit_content = formatted
-                if "[EMBED]" in formatted:
-                    if finalize:
-                        # Final edit: replace the marker with the real embed.
-                        edit_content, embed = self._extract_embed(formatted)
-                    else:
-                        # Mid-stream: hide the raw JSON so the user doesn't
-                        # watch it type out — the finalize edit swaps it for
-                        # the finished embed.
-                        edit_content = "⏳ *rendering embed…*"
                 await msg.edit(content=edit_content, embed=embed)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
@@ -3306,6 +3316,7 @@ class DiscordAdapter(BasePlatformAdapter):
         msg: Any,
         message_id: str,
         content: str,
+        embed=None,
     ) -> SendResult:
         """Deliver an oversized final edit across message + continuations.
 
@@ -3329,12 +3340,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
             # not, just edit normally.
-            await msg.edit(content=chunks[0] if chunks else formatted)
+            await msg.edit(content=chunks[0] if chunks else formatted, embed=embed)
             return SendResult(success=True, message_id=message_id)
 
-        # Step 1 — edit the existing message with the first chunk.
+        # Step 1 — edit the existing message with the first chunk (the embed
+        # rides on it, mirroring send()).
         try:
-            await msg.edit(content=chunks[0])
+            await msg.edit(content=chunks[0], embed=embed)
         except Exception as e:
             logger.error(
                 "[%s] Overflow split: first-chunk edit failed: %s",

--- a/tests/gateway/test_discord_adapter_embed.py
+++ b/tests/gateway/test_discord_adapter_embed.py
@@ -121,3 +121,61 @@ class TestSendAttachesEmbed:
         call_kwargs = channel.send.call_args.kwargs
         assert call_kwargs.get("embed") is None
         assert call_kwargs["content"] == "normal message"
+
+    @pytest.mark.asyncio
+    async def test_forum_send_gets_embed(self):
+        """Forum routing must receive the parsed embed + marker-free content,
+        not the raw [EMBED] JSON (regression: extraction previously ran
+        after the forum branch)."""
+        a, _ = _make_adapter()
+        a._is_forum_parent = MagicMock(return_value=True)
+        a._send_to_forum = AsyncMock(
+            return_value=MagicMock(success=True, message_id="999")
+        )
+        await a.send("123", f"forum post\n[EMBED]\n{VALID_BODY}\n[/EMBED]")
+        call_args = a._send_to_forum.call_args
+        assert call_args.kwargs.get("embed") is not None
+        assert "[EMBED]" not in call_args.args[1]
+
+
+class TestEditMessageEmbed:
+    @pytest.mark.asyncio
+    async def test_finalize_oversized_embed_parses_before_split(self):
+        """A finalized stream over the length cap must parse the embed
+        before overflow splitting, so chunks never expose the marker
+        (regression: extraction previously ran after the overflow branch)."""
+        a, channel = _make_adapter()
+        msg = AsyncMock()
+        msg.id = "123"
+        channel.fetch_message = AsyncMock(return_value=msg)
+        a._edit_overflow_split = AsyncMock(
+            return_value=MagicMock(success=True, message_id="123")
+        )
+        huge_tail = "x" * 3000
+        content = f"[EMBED]\n{VALID_BODY}\n[/EMBED]\n{huge_tail}"
+        await a.edit_message("123", "123", content, finalize=True)
+        call_args = a._edit_overflow_split.call_args
+        assert call_args.kwargs.get("embed") is not None
+        assert "[EMBED]" not in call_args.args[3]
+        assert call_args.args[3].endswith(huge_tail)
+
+    @pytest.mark.asyncio
+    async def test_finalize_normal_embed_edits_in_place(self):
+        a, channel = _make_adapter()
+        msg = AsyncMock()
+        msg.id = "123"
+        channel.fetch_message = AsyncMock(return_value=msg)
+        await a.edit_message("123", "123", f"[EMBED]\n{VALID_BODY}\n[/EMBED]", finalize=True)
+        edit_kwargs = msg.edit.call_args.kwargs
+        assert edit_kwargs.get("embed") is not None
+        assert "[EMBED]" not in edit_kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_midstream_shows_placeholder(self):
+        a, channel = _make_adapter()
+        msg = AsyncMock()
+        msg.id = "123"
+        channel.fetch_message = AsyncMock(return_value=msg)
+        await a.edit_message("123", "123", f"[EMBED]\n{VALID_BODY}", finalize=False)
+        edit_kwargs = msg.edit.call_args.kwargs
+        assert "rendering embed" in edit_kwargs["content"]

--- a/tests/gateway/test_discord_adapter_embed.py
+++ b/tests/gateway/test_discord_adapter_embed.py
@@ -1,0 +1,123 @@
+"""Tests for Discord embed marker support ([EMBED]...[/EMBED]).
+
+Verifies the behaviour contract:
+  * a valid [EMBED] JSON block renders as a discord.Embed
+  * text before/after the marker is preserved as plain message content
+  * invalid JSON or a missing marker degrades to the original content
+  * literal newlines inside JSON strings are accepted (strict=False)
+  * colors accept both int and #hex forms; footer accepts dict or str
+  * send() attaches the embed on the first chunk only
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord import adapter as discord_module
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = DiscordAdapter(config)
+    a._client = MagicMock()
+    channel = AsyncMock()
+    sent = AsyncMock()
+    sent.id = "123"
+    channel.send = AsyncMock(return_value=sent)
+    a._client.get_channel = MagicMock(return_value=channel)
+    a._reply_to_mode = "off"
+    a._record_discord_response = MagicMock()
+    return a, channel
+
+
+def _bare_adapter():
+    return object.__new__(DiscordAdapter)
+
+
+VALID_BODY = """{"title": "Test", "color": "#3fb950", "description": "```\\nDAY  IMPORT\\n30 Jul  12.8\\n```", "fields": [{"name": "A", "value": "1", "inline": true}], "footer": {"text": "foot"}}"""
+
+
+class TestExtractEmbed:
+    def test_valid_embed(self):
+        a = _bare_adapter()
+        rest, emb = a._extract_embed(f"[EMBED]\n{VALID_BODY}\n[/EMBED]")
+        assert emb is not None
+        assert emb.title == "Test"
+        assert len(emb.fields) == 1
+        assert emb.footer["text"] == "foot"
+
+    def test_preamble_and_tail_preserved(self):
+        a = _bare_adapter()
+        content = f"hello\n\n[EMBED]\n{VALID_BODY}\n[/EMBED]\n\nbye"
+        rest, emb = a._extract_embed(content)
+        assert emb is not None
+        assert "hello" in rest and "bye" in rest
+
+    def test_no_marker_unchanged(self):
+        a = _bare_adapter()
+        content = "plain message"
+        rest, emb = a._extract_embed(content)
+        assert emb is None
+        assert rest == content
+
+    def test_invalid_json_falls_back(self):
+        a = _bare_adapter()
+        content = "[EMBED]\n{not valid json\n[/EMBED]"
+        rest, emb = a._extract_embed(content)
+        assert emb is None
+        assert rest == content
+
+    def test_literal_newlines_accepted(self):
+        a = _bare_adapter()
+        content = '[EMBED]\n{"title": "T", "description": "line1\nline2"}\n[/EMBED]'
+        rest, emb = a._extract_embed(content)
+        assert emb is not None
+        assert emb.description == "line1\nline2"
+
+    def test_color_int_and_hex(self):
+        a = _bare_adapter()
+        _, emb = a._extract_embed('[EMBED]\n{"title": "T", "color": 3447003}\n[/EMBED]')
+        assert emb.color == 3447003
+        _, emb = a._extract_embed('[EMBED]\n{"title": "T", "color": "#3fb950"}\n[/EMBED]')
+        assert emb.color == 0x3FB950
+
+    def test_footer_string_or_dict(self):
+        a = _bare_adapter()
+        _, emb = a._extract_embed('[EMBED]\n{"title": "T", "footer": "plain"}\n[/EMBED]')
+        assert emb.footer["text"] == "plain"
+        _, emb = a._extract_embed('[EMBED]\n{"title": "T", "footer": {"text": "dict"}}\n[/EMBED]')
+        assert emb.footer["text"] == "dict"
+
+    def test_fields_capped_at_25(self):
+        a = _bare_adapter()
+        fields = ",".join('{"name": "f%d", "value": "v", "inline": true}' % i for i in range(30))
+        _, emb = a._extract_embed(f'[EMBED]\n{{"title": "T", "fields": [{fields}]}}\n[/EMBED]')
+        assert len(emb.fields) == 25
+
+    def test_embed_requires_discord(self, monkeypatch):
+        a = _bare_adapter()
+        monkeypatch.setattr(discord_module, "discord", None)
+        content = f"[EMBED]\n{VALID_BODY}\n[/EMBED]"
+        rest, emb = a._extract_embed(content)
+        assert emb is None
+        assert rest == content
+
+
+class TestSendAttachesEmbed:
+    @pytest.mark.asyncio
+    async def test_send_with_embed(self):
+        a, channel = _make_adapter()
+        await a.send("123", f"hi\n[EMBED]\n{VALID_BODY}\n[/EMBED]")
+        call_kwargs = channel.send.call_args.kwargs
+        assert call_kwargs.get("embed") is not None
+        assert "[EMBED]" not in call_kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_without_embed_unaffected(self):
+        a, channel = _make_adapter()
+        await a.send("123", "normal message")
+        call_kwargs = channel.send.call_args.kwargs
+        assert call_kwargs.get("embed") is None
+        assert call_kwargs["content"] == "normal message"

--- a/tests/gateway/test_discord_adapter_embed.py
+++ b/tests/gateway/test_discord_adapter_embed.py
@@ -69,6 +69,26 @@ class TestExtractEmbed:
         assert emb is None
         assert rest == content
 
+    def test_llm_artifacts_are_tolerated(self):
+        """(1/2)-style segment markers and trailing commas written by the
+        generating model must not break the parse (regression: a cron report
+        arrived as raw text because the JSON contained '}, (1/2)')."""
+        a = _bare_adapter()
+        content = (
+            '[EMBED]\n{"title": "T", "fields": ['
+            '{"name": "A", "value": "1", "inline": true}, (1/2)\n'
+            '{"name": "B", "value": "2", "inline": true},'
+            ']}\n[/EMBED]'
+        )
+        rest, emb = a._extract_embed(content)
+        assert emb is not None
+        assert len(emb.fields) == 2
+
+    def test_clean_embed_json_preserves_strings(self):
+        a = _bare_adapter()
+        cleaned = a._clean_embed_json('{"desc": "keep ,} and (1/2) here", "x": [1, 2,],}')
+        assert cleaned == '{"desc": "keep ,} and (1/2) here", "x": [1, 2]}'
+
     def test_literal_newlines_accepted(self):
         a = _bare_adapter()
         content = '[EMBED]\n{"title": "T", "description": "line1\nline2"}\n[/EMBED]'

--- a/tests/gateway/test_discord_adapter_embed.py
+++ b/tests/gateway/test_discord_adapter_embed.py
@@ -89,6 +89,36 @@ class TestExtractEmbed:
         cleaned = a._clean_embed_json('{"desc": "keep ,} and (1/2) here", "x": [1, 2,],}')
         assert cleaned == '{"desc": "keep ,} and (1/2) here", "x": [1, 2]}'
 
+
+class TestStandaloneEmbedPayload:
+    def test_split_embed_from_message(self):
+        from plugins.platforms.discord.adapter import _split_embed_from_message
+        msg = (
+            "Cronjob Response: X\n-------------\n\n"
+            '[EMBED]\n{"title": "T", "color": "#3fb950", '
+            '"fields": [{"name": "A", "value": "1", "inline": true}]}\n[/EMBED]\n\n'
+            "To stop, send a message."
+        )
+        text, payload = _split_embed_from_message(msg)
+        assert payload is not None
+        assert payload["title"] == "T"
+        assert payload["color"] == 0x3FB950
+        assert len(payload["fields"]) == 1
+        assert "[EMBED]" not in text
+        assert "Cronjob Response" in text and "To stop" in text
+
+    def test_split_no_marker_unchanged(self):
+        from plugins.platforms.discord.adapter import _split_embed_from_message
+        text, payload = _split_embed_from_message("plain message")
+        assert payload is None
+        assert text == "plain message"
+
+    def test_split_bad_json_unchanged(self):
+        from plugins.platforms.discord.adapter import _split_embed_from_message
+        text, payload = _split_embed_from_message("[EMBED]\n{broken\n[/EMBED]")
+        assert payload is None
+        assert "[EMBED]" in text
+
     def test_literal_newlines_accepted(self):
         a = _bare_adapter()
         content = '[EMBED]\n{"title": "T", "description": "line1\nline2"}\n[/EMBED]'


### PR DESCRIPTION
## Summary

Agents can now emit **native Discord embeds** by including an `[EMBED]{json}[/EMBED]` block in a message. The gateway parses the JSON and sends it as a real `discord.Embed` — title, description, colour, inline fields (columns/rows), footer — while keeping any surrounding text as the plain message content.

This follows the established `MEDIA:` text-marker convention already in the adapter (agent → marker → platform feature).

## Example

```
[EMBED]
{"title": "⚡ POWER WATCH", "color": "#3fb950", "fields": [{"name": "Import", "value": "12.8 kWh", "inline": true}, ...]}
[/EMBED]
```

## Implementation

- `_extract_embed()`: parses the JSON block into a `discord.Embed`
  - `json.loads(strict=False)` — literal newlines inside strings work, so the model can write readable multi-line JSON
  - colour accepts `int` or `#hex`; footer accepts `str` or `{"text": ...}`
  - fields capped at Discord's 25
- `send()`: attaches the embed to the first chunk; marker stripped from content
- `edit_message()`: on streaming finalize, swaps the marker for the embed; mid-stream edits show a `⏳ rendering embed…` placeholder so the raw JSON never flashes on screen
- **Zero impact on normal messages** — extraction is marker-gated

## Tests

11 new unit tests in `tests/gateway/test_discord_adapter_embed.py` (parse, preamble/tail preservation, invalid-JSON fallback, newline handling, colour/footer forms, 25-field cap, send-path wiring, marker-gated no-op). Existing Discord adapter tests still pass.