### PR TITLE
feat(nix): add isolated Hermes agent instances

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -232,7 +232,12 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """
     per_job = job.get("enabled_toolsets")
     if per_job:
-        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
+        from toolsets import get_allowed_toolsets, restrict_toolsets
+
+        return restrict_toolsets(
+            _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {}),
+            get_allowed_toolsets(cfg or {}),
+        )
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
         return sorted(_get_platform_tools(cfg or {}, "cron"))

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         ./nix/packages.nix
         ./nix/overlays.nix
         ./nix/nixosModules.nix
+        ./nix/nixosModules-instances.nix
         ./nix/checks.nix
         ./nix/devShell.nix
       ];

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2462,6 +2462,32 @@ def _get_platform_tools(
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set
 
+    # A service-level allowlist is stronger than platform configuration,
+    # plugin discovery, MCP defaults, and user-disabled toolsets. The
+    # environment form is intended for Nix/systemd policy; the config form is
+    # useful for ordinary declarative profiles.
+    allowed_raw = os.getenv("HERMES_ALLOWED_TOOLSETS")
+    if allowed_raw is not None:
+        allowed_toolsets = {
+            value.strip() for value in allowed_raw.split(",") if value.strip()
+        }
+    else:
+        configured_allowed = agent_cfg.get("allowed_toolsets")
+        if configured_allowed is None:
+            allowed_toolsets = None
+        elif isinstance(configured_allowed, list):
+            allowed_toolsets = {
+                str(value).strip() for value in configured_allowed if str(value).strip()
+            }
+        else:
+            allowed_toolsets = {
+                value.strip()
+                for value in str(configured_allowed).split(",")
+                if value.strip()
+            }
+    if allowed_toolsets is not None:
+        enabled_toolsets &= allowed_toolsets
+
     # #38798: if this platform was explicitly configured but every toolset name
     # is invalid (e.g. a migration or hand-edit left `hermes` instead of
     # `hermes-cli`), resolve_toolset() returns [] for each and the platform ends

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2199,7 +2199,7 @@ def _get_platform_tools(
     include_default_mcp_servers: bool = True,
 ) -> Set[str]:
     """Resolve which individual toolset names are enabled for a platform."""
-    from toolsets import resolve_toolset, TOOLSETS
+    from toolsets import get_allowed_toolsets, resolve_toolset, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
     toolset_names = platform_toolsets.get(platform)
@@ -2463,30 +2463,8 @@ def _get_platform_tools(
         enabled_toolsets -= disabled_set
 
     # A service-level allowlist is stronger than platform configuration,
-    # plugin discovery, MCP defaults, and user-disabled toolsets. The
-    # environment form is intended for Nix/systemd policy; the config form is
-    # useful for ordinary declarative profiles.
-    allowed_raw = os.getenv("HERMES_ALLOWED_TOOLSETS")
-    if allowed_raw is not None:
-        allowed_toolsets = {
-            value.strip() for value in allowed_raw.split(",") if value.strip()
-        }
-    else:
-        configured_allowed = agent_cfg.get("allowed_toolsets")
-        if configured_allowed is None:
-            allowed_toolsets = None
-        elif isinstance(configured_allowed, list):
-            allowed_toolsets = {
-                str(value).strip()
-                for value in configured_allowed
-                if str(value).strip()
-            }
-        else:
-            allowed_toolsets = {
-                value.strip()
-                for value in str(configured_allowed).split(",")
-                if value.strip()
-            }
+    # plugin discovery, MCP defaults, and user-disabled toolsets.
+    allowed_toolsets = get_allowed_toolsets(config)
     if allowed_toolsets is not None:
         enabled_toolsets &= allowed_toolsets
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2477,7 +2477,9 @@ def _get_platform_tools(
             allowed_toolsets = None
         elif isinstance(configured_allowed, list):
             allowed_toolsets = {
-                str(value).strip() for value in configured_allowed if str(value).strip()
+                str(value).strip()
+                for value in configured_allowed
+                if str(value).strip()
             }
         else:
             allowed_toolsets = {

--- a/model_tools.py
+++ b/model_tools.py
@@ -30,7 +30,12 @@ import time
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry, tool_error
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import (
+    get_allowed_toolsets,
+    resolve_toolset,
+    restrict_toolsets,
+    validate_toolset,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -309,6 +314,9 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    allowed_toolsets = get_allowed_toolsets()
+    effective_enabled_toolsets = restrict_toolsets(enabled_toolsets, allowed_toolsets)
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -326,7 +334,9 @@ def get_tool_definitions(
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
         cache_key = (
-            frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
+            frozenset(effective_enabled_toolsets)
+            if effective_enabled_toolsets is not None
+            else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
@@ -344,8 +354,13 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        effective_enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        allowed_toolsets=allowed_toolsets,
+    )
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -369,6 +384,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    allowed_toolsets: Optional[set] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -387,6 +403,10 @@ def _compute_tool_definitions(
             # (for token/cost reasons), but that should not strip the kanban
             # worker's completion/block/heartbeat surface.
             effective_enabled_toolsets.append("kanban")
+        effective_enabled_toolsets = restrict_toolsets(
+            effective_enabled_toolsets,
+            allowed_toolsets,
+        )
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -123,6 +123,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           let
             system = pkgs.stdenv.hostPlatform.system;
             mkSystem = modules: inputs.nixpkgs.lib.nixosSystem { inherit system modules; };
+            testPackage = pkgs.writeShellScriptBin "hermes" "exit 0";
             native = mkSystem [
               inputs.self.nixosModules.default
               inputs.self.nixosModules.instances
@@ -130,14 +131,17 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
                 system.stateVersion = "24.11";
                 services.hermes-agent = {
                   enable = true;
+                  package = testPackage;
                   settings.model = "test";
                 };
                 services.hermes-agent.instances.iris = {
                   enable = true;
+                  package = testPackage;
                   settings.model = "iris";
                 };
                 services.hermes-agent.instances.argus = {
                   enable = true;
+                  package = testPackage;
                   settings.model = "argus";
                 };
               }
@@ -148,6 +152,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
                 system.stateVersion = "24.11";
                 services.hermes-agent = {
                   enable = true;
+                  package = testPackage;
                   container.enable = true;
                   allowedToolsets = [ "web" ];
                   readOnlyState = true;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -10,6 +10,10 @@
       hermesVenv = hermes-agent.hermesVenv;
 
       configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+      configMergeInput = pkgs.writeText "hermes-config-merge-input.json" (builtins.toJSON {
+        replace = "new";
+        added = true;
+      });
 
       # Auto-generated config key reference — always in sync with Python
       configKeys = pkgs.runCommand "hermes-config-keys" {} ''
@@ -36,6 +40,26 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
       packages.configKeys = configKeys;
 
       checks = {
+        config-merge = pkgs.runCommand "hermes-config-merge" { } ''
+          set -euo pipefail
+          work="$TMPDIR/config"
+          mkdir -p "$work"
+          printf '%s\n' 'keep: old' 'replace: old' > "$work/config.yaml"
+          ${configMergeScript} ${configMergeInput} "$work/config.yaml"
+          grep -Fqx 'keep: old' "$work/config.yaml"
+          grep -Fqx 'replace: new' "$work/config.yaml"
+          grep -Fqx 'added: true' "$work/config.yaml"
+
+          ln -s "$work/config.yaml" "$work/symlink.yaml"
+          if ${configMergeScript} ${configMergeInput} "$work/symlink.yaml"; then
+            echo "FAIL: config merge followed a symlink" >&2
+            exit 1
+          fi
+
+          mkdir -p "$out"
+          echo "ok" > "$out/result"
+        '';
+
         # Cross-platform evaluation — catches "not supported for interpreter"
         # errors (e.g. sphinx dropping python311) without needing a darwin builder.
         # Evaluation is pure and instant; it doesn't build anything.
@@ -91,6 +115,72 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           mkdir -p $out
           echo "ok" > $out/result
         '';
+
+        # Evaluate the shared lifecycle through the singleton, multi-instance,
+        # and container module paths so refactors cannot silently drop setup,
+        # users, or service hardening.
+        nixos-module-instances =
+          let
+            system = pkgs.stdenv.hostPlatform.system;
+            mkSystem = modules: inputs.nixpkgs.lib.nixosSystem { inherit system modules; };
+            native = mkSystem [
+              inputs.self.nixosModules.default
+              inputs.self.nixosModules.instances
+              {
+                system.stateVersion = "24.11";
+                services.hermes-agent = {
+                  enable = true;
+                  settings.model = "test";
+                };
+                services.hermes-agent.instances.iris = {
+                  enable = true;
+                  settings.model = "iris";
+                };
+                services.hermes-agent.instances.argus = {
+                  enable = true;
+                  settings.model = "argus";
+                };
+              }
+            ];
+            container = mkSystem [
+              inputs.self.nixosModules.default
+              {
+                system.stateVersion = "24.11";
+                services.hermes-agent = {
+                  enable = true;
+                  container.enable = true;
+                  allowedToolsets = [ "web" ];
+                  readOnlyState = true;
+                  environment.TEST = "value";
+                };
+              }
+            ];
+            nativeSetupScript = pkgs.writeText "hermes-native-setup.sh"
+              native.config.system.activationScripts."hermes-agent-iris-setup".text;
+            containerPreStartScript = pkgs.writeText "hermes-container-pre-start.sh"
+              container.config.systemd.services.hermes-agent.preStart;
+          in
+          if !(lib.all (value: value) [
+            (native.config.systemd.services.hermes-agent.description == "Hermes Agent Gateway")
+            (native.config.systemd.services.hermes-agent.serviceConfig.ProtectHome == false)
+            (native.config.systemd.services.hermes-agent-iris.serviceConfig.User == "hermes-iris")
+            (native.config.systemd.services.hermes-agent-iris.serviceConfig.ProtectHome == "read-only")
+            (builtins.hasAttr "hermes-agent-iris-setup" native.config.system.activationScripts)
+            (container.config.systemd.services.hermes-agent.description == "Hermes Agent Gateway (container)")
+            (builtins.hasAttr "preStart" container.config.systemd.services.hermes-agent)
+            (builtins.hasAttr "hermes-agent-setup" container.config.system.activationScripts)
+            (lib.hasInfix "HERMES_ALLOWED_TOOLSETS" container.config.systemd.services.hermes-agent.preStart)
+            (lib.hasInfix ":ro" container.config.systemd.services.hermes-agent.preStart)
+          ]) then
+            throw "Hermes NixOS lifecycle fixture failed"
+          else
+            pkgs.runCommand "hermes-nixos-module-instances" { } ''
+              ${pkgs.bash}/bin/bash -n ${nativeSetupScript}
+              ${pkgs.bash}/bin/bash -n ${containerPreStartScript}
+              echo "PASS: singleton, instances, and container lifecycle paths evaluate"
+              mkdir -p $out
+              echo "ok" > $out/result
+            '';
 
         # Verify every pyproject.toml [project.scripts] entry has a wrapped binary
         entry-points-sync = pkgs.runCommand "hermes-entry-points-sync" { } ''

--- a/nix/configMergeScript.nix
+++ b/nix/configMergeScript.nix
@@ -5,7 +5,7 @@
 { pkgs }:
 pkgs.writeScript "hermes-config-merge" ''
   #!${pkgs.python3.withPackages (ps: [ ps.pyyaml ])}/bin/python3
-  import json, yaml, sys
+  import json, os, tempfile, yaml, sys
   from pathlib import Path
 
   nix_json, config_path = sys.argv[1], Path(sys.argv[2])
@@ -14,6 +14,8 @@ pkgs.writeScript "hermes-config-merge" ''
       nix = json.load(f)
 
   existing = {}
+  if config_path.is_symlink() or config_path.parent.is_symlink():
+      raise RuntimeError(f"refusing to follow symlink: {config_path}")
   if config_path.exists():
       with open(config_path) as f:
           existing = yaml.safe_load(f) or {}
@@ -28,6 +30,21 @@ pkgs.writeScript "hermes-config-merge" ''
       return result
 
   merged = deep_merge(existing, nix)
-  with open(config_path, "w") as f:
-      yaml.dump(merged, f, default_flow_style=False, sort_keys=False)
+  fd, temporary = tempfile.mkstemp(
+      dir=config_path.parent,
+      prefix=f".{config_path.name}.",
+      suffix=".tmp",
+  )
+  try:
+      with os.fdopen(fd, "w") as f:
+          yaml.dump(merged, f, default_flow_style=False, sort_keys=False)
+          f.flush()
+          os.fsync(f.fileno())
+      os.replace(temporary, config_path)
+  except BaseException:
+      try:
+          os.unlink(temporary)
+      except FileNotFoundError:
+          pass
+      raise
 ''

--- a/nix/hermes-agent-lifecycle.nix
+++ b/nix/hermes-agent-lifecycle.nix
@@ -1,0 +1,222 @@
+{ configMergeScript
+, lib
+, pkgs
+, ...
+}:
+{
+  mkNativeLifecycle =
+    { name
+    , cfg
+    , package
+    , configFile ? null
+    , configYamlMode ? "0640"
+    , description ? "Hermes Agent ${name} gateway"
+    , includeHome ? false
+    , managedMode ? "0640"
+    , protectHome ? "read-only"
+    , readOnlyState ? false
+    , setupAfter ? [ "users" ]
+    , extraActivation ? ""
+    , extraUserAttrs ? { }
+    , enableService ? true
+    , effectiveWorkingDirectory ? cfg.workingDirectory
+    }:
+    let
+      generatedConfigFile = pkgs.writeText "${name}-config.yaml" (
+        builtins.toJSON (lib.recursiveUpdate
+          { terminal.cwd = effectiveWorkingDirectory; }
+          cfg.settings)
+      );
+      documentDerivation = pkgs.linkFarm "${name}-documents" (
+        lib.mapAttrsToList (documentName: value: {
+          name = documentName;
+          path =
+            if builtins.isPath value || lib.isStorePath value
+            then value
+            else pkgs.writeText "${name}-document" value;
+        }) cfg.documents
+      );
+      envFileContent = lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (key: value: "${key}=${lib.escapeShellArg value}") cfg.environment);
+    in
+    {
+      assertions = [
+        {
+          assertion = lib.hasPrefix "/" cfg.stateDir;
+          message = "${name}: stateDir must be absolute.";
+        }
+        {
+          assertion = lib.hasPrefix "/" cfg.workingDirectory;
+          message = "${name}: workingDirectory must be absolute.";
+        }
+        {
+          assertion = lib.all (documentName:
+            builtins.match "^[^/]+$" documentName != null
+            && documentName != "."
+            && documentName != ".."
+          ) (builtins.attrNames cfg.documents);
+          message = "${name}: document names must be plain filenames without path separators.";
+        }
+      ];
+
+      users.groups = lib.mkIf cfg.createUser {
+        ${cfg.group} = { };
+      };
+
+      users.users = lib.mkIf cfg.createUser {
+        ${cfg.user} = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.stateDir;
+          createHome = true;
+          shell = pkgs.bashInteractive;
+        } // extraUserAttrs;
+      };
+
+      systemd.tmpfiles.rules = [
+        "d ${cfg.stateDir}                2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes        2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes/cron   2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
+        "d ${cfg.stateDir}/.hermes/plugins 2770 ${cfg.user} ${cfg.group} - -"
+      ]
+      ++ lib.optional includeHome "d ${cfg.stateDir}/home           0750 ${cfg.user} ${cfg.group} - -"
+      ++ [
+        "d ${cfg.workingDirectory}         2770 ${cfg.user} ${cfg.group} - -"
+      ];
+
+      system.activationScripts."${name}-setup" = lib.stringAfter setupAfter ''
+        state_dir=${lib.escapeShellArg cfg.stateDir}
+        hermes_dir=${lib.escapeShellArg "${cfg.stateDir}/.hermes"}
+        working_dir=${lib.escapeShellArg cfg.workingDirectory}
+        ${lib.optionalString includeHome ''
+          home_dir=${lib.escapeShellArg "${cfg.stateDir}/home"}
+        ''}
+
+        reject_symlink() {
+          if [ -L "$1" ]; then
+            echo "hermes-agent: refusing to follow symlink $1 during activation" >&2
+            exit 1
+          fi
+        }
+
+        reject_symlink "$state_dir"
+        reject_symlink "$hermes_dir"
+        reject_symlink "$working_dir"
+        ${lib.optionalString includeHome ''
+          reject_symlink "$home_dir"
+        ''}
+
+        mkdir -p "$hermes_dir" "$working_dir"
+        ${lib.optionalString includeHome ''
+          mkdir -p "$home_dir"
+        ''}
+        chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+          "$state_dir" "$hermes_dir" "$working_dir"
+        chmod 2770 "$state_dir" "$hermes_dir" "$working_dir"
+        ${lib.optionalString includeHome ''
+          chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} "$home_dir"
+          chmod 0750 "$home_dir"
+        ''}
+
+        find "$hermes_dir" -maxdepth 1 \
+          \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
+          -exec chmod g+rw {} + 2>/dev/null || true
+        for _subdir in cron sessions logs memories plugins; do
+          mkdir -p "$hermes_dir/$_subdir"
+          chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+            "$hermes_dir/$_subdir"
+          chmod 2770 "$hermes_dir/$_subdir"
+          find "$hermes_dir/$_subdir" -type f \
+            -exec chmod g+rw {} + 2>/dev/null || true
+        done
+
+        config_path=${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
+        reject_symlink "$config_path"
+        ${if configFile != null then ''
+          install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
+            -m ${configYamlMode} ${lib.escapeShellArg (toString configFile)} \
+            "$config_path"
+        '' else ''
+          ${configMergeScript} ${lib.escapeShellArg (toString generatedConfigFile)} \
+            "$config_path"
+          chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+            "$config_path"
+          chmod ${configYamlMode} "$config_path"
+        ''}
+
+        managed_path=${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
+        reject_symlink "$managed_path"
+        touch "$managed_path"
+        chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+          "$managed_path"
+        chmod ${managedMode} "$managed_path"
+
+        ${lib.optionalString (cfg.environment != { } || cfg.environmentFiles != [ ]) ''
+          ENV_FILE=${lib.escapeShellArg "${cfg.stateDir}/.hermes/.env"}
+          reject_symlink "$ENV_FILE"
+          install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
+            -m 0640 /dev/null "$ENV_FILE"
+          printf '%s\n' ${lib.escapeShellArg envFileContent} > "$ENV_FILE"
+          ${lib.concatStringsSep "\n" (map (file: ''
+            if [ -f ${lib.escapeShellArg file} ]; then
+              echo "" >> "$ENV_FILE"
+              cat ${lib.escapeShellArg file} >> "$ENV_FILE"
+            fi
+          '') cfg.environmentFiles)}
+        ''}
+
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList (documentName: _value: ''
+          document_path=${lib.escapeShellArg "${cfg.workingDirectory}/${documentName}"}
+          reject_symlink "$document_path"
+          install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} -m 0640 \
+            ${lib.escapeShellArg "${documentDerivation}/${documentName}"} \
+            "$document_path"
+        '') cfg.documents)}
+
+        ${extraActivation}
+      '';
+
+      systemd.services = lib.optionalAttrs enableService {
+        ${name} = {
+          inherit description;
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          environment = {
+            HOME = cfg.stateDir;
+            HERMES_HOME = "${cfg.stateDir}/.hermes";
+            HERMES_MANAGED = "true";
+          } // lib.optionalAttrs (cfg.allowedToolsets != null) {
+            HERMES_ALLOWED_TOOLSETS = lib.concatStringsSep "," cfg.allowedToolsets;
+          };
+          serviceConfig = {
+            User = cfg.user;
+            Group = cfg.group;
+            WorkingDirectory = cfg.workingDirectory;
+            ExecStart = lib.escapeShellArgs ([ "${package}/bin/hermes" "gateway" ] ++ cfg.extraArgs);
+            Restart = cfg.restart;
+            RestartSec = cfg.restartSec;
+            UMask = "0007";
+            NoNewPrivileges = true;
+            ProtectSystem = "strict";
+            ProtectHome = protectHome;
+            ReadWritePaths = [ cfg.stateDir cfg.workingDirectory ];
+            ReadOnlyPaths =
+              lib.optional readOnlyState "${cfg.stateDir}/.hermes/config.yaml"
+              ++ lib.optional (readOnlyState && (cfg.environment != { } || cfg.environmentFiles != [ ])
+                ) "${cfg.stateDir}/.hermes/.env";
+            PrivateTmp = true;
+          };
+          path = [
+            package
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.git
+          ] ++ cfg.extraPackages;
+        };
+      };
+    };
+}

--- a/nix/nixosModules-instances.nix
+++ b/nix/nixosModules-instances.nix
@@ -2,13 +2,16 @@
 {
   flake.nixosModules.instances = { config, lib, pkgs, ... }:
     let
-      inherit (lib) mkIf mkOption types;
+      inherit (lib) mkOption types;
       cfg = config.services.hermes-agent;
       system = pkgs.stdenv.hostPlatform.system;
       hermesAgentPackage = inputs.self.packages.${system}.default;
-      configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+      nativeLifecycle = import ./hermes-agent-lifecycle.nix {
+        inherit lib pkgs;
+        configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+      };
 
-      instanceModule = { name, ... }: {
+      instanceModule = { config, name, ... }: {
         options = {
           enable = lib.mkEnableOption "Hermes Agent instance ${name}";
 
@@ -44,7 +47,7 @@
 
           workingDirectory = mkOption {
             type = types.str;
-            default = "/var/lib/hermes-${name}/workspace";
+            default = "${config.stateDir}/workspace";
             description = "Working directory for this instance.";
           };
 
@@ -90,6 +93,18 @@
             description = "Extra arguments passed to `hermes gateway`.";
           };
 
+          allowedToolsets = mkOption {
+            type = types.nullOr (types.listOf types.str);
+            default = null;
+            description = "Hard allowlist of toolsets for this instance.";
+          };
+
+          readOnlyState = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Protect this instance's Nix-managed config and environment files.";
+          };
+
           restart = mkOption {
             type = types.str;
             default = "always";
@@ -104,147 +119,40 @@
         };
       };
 
-      mkInstance = name: cfg:
+      mkInstance = name: instanceCfg:
         let
-          unitName = "hermes-agent-${name}";
-          generatedConfigFile = pkgs.writeText "${unitName}-config.yaml" (
-            builtins.toJSON cfg.settings
-          );
-          documentDerivation = pkgs.runCommand "${unitName}-documents" { } ''
-            mkdir -p $out
-            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (documentName: value:
-              if builtins.isPath value || lib.isStorePath value
-              then "cp ${lib.escapeShellArg (toString value)} $out/${lib.escapeShellArg documentName}"
-              else "cat > $out/${lib.escapeShellArg documentName} <<'HERMES_DOCUMENT_EOF'\n${value}\nHERMES_DOCUMENT_EOF"
-            ) cfg.documents)}
-          '';
-          envFileContent = lib.concatStringsSep "\n" (
-            lib.mapAttrsToList (key: value: "${key}=${lib.escapeShellArg value}") cfg.environment
-          );
-        in
-        if cfg.enable then {
-          assertions = [
-            {
-              assertion = builtins.match "^[a-z0-9][a-z0-9-]*$" name != null;
-              message = "services.hermes-agent.instances.${name}: instance names must be lowercase letters, digits, and hyphens.";
-            }
-            {
-              assertion = lib.hasPrefix "/" cfg.stateDir;
-              message = "services.hermes-agent.instances.${name}.stateDir must be absolute.";
-            }
-            {
-              assertion = lib.hasPrefix "/" cfg.workingDirectory;
-              message = "services.hermes-agent.instances.${name}.workingDirectory must be absolute.";
-            }
-          ];
-
-          users.groups = mkIf cfg.createUser {
-            ${cfg.group} = { };
-          };
-          users.users = mkIf cfg.createUser {
-            ${cfg.user} = {
-              isSystemUser = true;
-              group = cfg.group;
-              home = cfg.stateDir;
-              createHome = true;
-              shell = pkgs.bashInteractive;
-              packages = cfg.extraPackages;
-            };
-          };
-
-          systemd.tmpfiles.rules = [
-            "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes/cron 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes/logs 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.stateDir}/.hermes/plugins 2770 ${cfg.user} ${cfg.group} - -"
-            "d ${cfg.workingDirectory} 2770 ${cfg.user} ${cfg.group} - -"
-          ];
-
-          system.activationScripts."${unitName}-setup" = lib.stringAfter [ "users" ] ''
-            mkdir -p ${lib.escapeShellArg cfg.stateDir}/.hermes ${lib.escapeShellArg cfg.workingDirectory}
-            chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
-              ${lib.escapeShellArg cfg.stateDir} \
-              ${lib.escapeShellArg "${cfg.stateDir}/.hermes"} \
-              ${lib.escapeShellArg cfg.workingDirectory}
-            chmod 2770 ${lib.escapeShellArg cfg.stateDir} \
-              ${lib.escapeShellArg "${cfg.stateDir}/.hermes"} \
-              ${lib.escapeShellArg cfg.workingDirectory}
-
-            ${if cfg.configFile != null then ''
-              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
-                -m 0640 ${lib.escapeShellArg (toString cfg.configFile)} \
-                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
-            '' else ''
-              ${configMergeScript} ${lib.escapeShellArg (toString generatedConfigFile)} \
-                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
-              chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
-                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
-              chmod 0640 ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
-            ''}
-
-            touch ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
-            chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
-              ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
-            chmod 0640 ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
-
-            ${lib.optionalString (cfg.environment != { } || cfg.environmentFiles != [ ]) ''
-              env_file=${lib.escapeShellArg "${cfg.stateDir}/.hermes/.env"}
-              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
-                -m 0640 /dev/null "$env_file"
-              printf '%s\n' ${lib.escapeShellArg envFileContent} > "$env_file"
-              ${lib.concatMapStringsSep "\n" (file: ''
-                if [ -f ${lib.escapeShellArg file} ]; then
-                  printf '\n' >> "$env_file"
-                  cat ${lib.escapeShellArg file} >> "$env_file"
-                fi
-              '') cfg.environmentFiles}
-            ''}
-
-            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (documentName: _value: ''
-              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} -m 0640 \
-                ${lib.escapeShellArg "${documentDerivation}/${documentName}"} \
-                ${lib.escapeShellArg "${cfg.workingDirectory}/${documentName}"}
-            '') cfg.documents)}
-          '';
-
-          systemd.services.${unitName} = {
+          lifecycle = nativeLifecycle.mkNativeLifecycle {
+            name = "hermes-agent-${name}";
             description = "Hermes Agent ${name} gateway";
-            wantedBy = [ "multi-user.target" ];
-            after = [ "network-online.target" ];
-            wants = [ "network-online.target" ];
-            environment = {
-              HOME = cfg.stateDir;
-              HERMES_HOME = "${cfg.stateDir}/.hermes";
-              HERMES_MANAGED = "true";
-              MESSAGING_CWD = cfg.workingDirectory;
+            cfg = instanceCfg;
+            package = instanceCfg.package;
+            configFile = instanceCfg.configFile;
+            readOnlyState = instanceCfg.readOnlyState;
+            extraUserAttrs = {
+              packages = instanceCfg.extraPackages;
             };
-            serviceConfig = {
-              User = cfg.user;
-              Group = cfg.group;
-              WorkingDirectory = cfg.workingDirectory;
-              ExecStart = lib.concatStringsSep " " (
-                [ "${cfg.package}/bin/hermes" "gateway" ] ++ cfg.extraArgs
-              );
-              Restart = cfg.restart;
-              RestartSec = cfg.restartSec;
-              UMask = "0007";
-              NoNewPrivileges = true;
-              ProtectSystem = "strict";
-              ProtectHome = "read-only";
-              ReadWritePaths = [ cfg.stateDir cfg.workingDirectory ];
-              PrivateTmp = true;
-            };
-            path = [
-              cfg.package
-              pkgs.bash
-              pkgs.coreutils
-              pkgs.git
-            ] ++ cfg.extraPackages;
           };
-        } else { };
+        in
+        if instanceCfg.enable then
+          lifecycle
+          // {
+            assertions = [
+              {
+                assertion = builtins.match "^[a-z0-9][a-z0-9-]*$" name != null;
+                message = "services.hermes-agent.instances.${name}: instance names must be lowercase letters, digits, and hyphens.";
+              }
+              {
+                assertion = lib.hasPrefix "/" instanceCfg.stateDir;
+                message = "services.hermes-agent.instances.${name}.stateDir must be absolute.";
+              }
+              {
+                assertion = lib.hasPrefix "/" instanceCfg.workingDirectory;
+                message = "services.hermes-agent.instances.${name}.workingDirectory must be absolute.";
+              }
+            ] ++ (lifecycle.assertions or [ ]);
+          }
+        else { };
+
       instanceConfigs = lib.mapAttrsToList mkInstance cfg.instances;
     in
     {

--- a/nix/nixosModules-instances.nix
+++ b/nix/nixosModules-instances.nix
@@ -1,0 +1,264 @@
+{ inputs, ... }:
+{
+  flake.nixosModules.instances = { config, lib, pkgs, ... }:
+    let
+      inherit (lib) mkIf mkOption types;
+      cfg = config.services.hermes-agent;
+      system = pkgs.stdenv.hostPlatform.system;
+      hermesAgentPackage = inputs.self.packages.${system}.default;
+      configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+
+      instanceModule = { name, ... }: {
+        options = {
+          enable = lib.mkEnableOption "Hermes Agent instance ${name}";
+
+          package = mkOption {
+            type = types.package;
+            default = hermesAgentPackage;
+            description = "Hermes package for this instance.";
+          };
+
+          user = mkOption {
+            type = types.str;
+            default = "hermes-${name}";
+            description = "System user running this instance.";
+          };
+
+          group = mkOption {
+            type = types.str;
+            default = "hermes-${name}";
+            description = "System group running this instance.";
+          };
+
+          createUser = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Create the instance user and group.";
+          };
+
+          stateDir = mkOption {
+            type = types.str;
+            default = "/var/lib/hermes-${name}";
+            description = "State directory containing this instance's Hermes home.";
+          };
+
+          workingDirectory = mkOption {
+            type = types.str;
+            default = "/var/lib/hermes-${name}/workspace";
+            description = "Working directory for this instance.";
+          };
+
+          configFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = "Existing config.yaml to install instead of generated settings.";
+          };
+
+          settings = mkOption {
+            type = types.attrs;
+            default = { };
+            description = "Declarative Hermes settings for this instance.";
+          };
+
+          environment = mkOption {
+            type = types.attrsOf types.str;
+            default = { };
+            description = "Non-secret environment values written to this instance's .env.";
+          };
+
+          environmentFiles = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = "KEY=value files appended to this instance's .env.";
+          };
+
+          documents = mkOption {
+            type = types.attrsOf (types.either types.str types.path);
+            default = { };
+            description = "Workspace documents installed for this instance.";
+          };
+
+          extraPackages = mkOption {
+            type = types.listOf types.package;
+            default = [ ];
+            description = "Packages exposed to this instance.";
+          };
+
+          extraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = "Extra arguments passed to `hermes gateway`.";
+          };
+
+          restart = mkOption {
+            type = types.str;
+            default = "always";
+            description = "systemd Restart= policy.";
+          };
+
+          restartSec = mkOption {
+            type = types.int;
+            default = 5;
+            description = "systemd RestartSec= value.";
+          };
+        };
+      };
+
+      mkInstance = name: cfg:
+        let
+          unitName = "hermes-agent-${name}";
+          generatedConfigFile = pkgs.writeText "${unitName}-config.yaml" (
+            builtins.toJSON cfg.settings
+          );
+          documentDerivation = pkgs.runCommand "${unitName}-documents" { } ''
+            mkdir -p $out
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (documentName: value:
+              if builtins.isPath value || lib.isStorePath value
+              then "cp ${lib.escapeShellArg (toString value)} $out/${lib.escapeShellArg documentName}"
+              else "cat > $out/${lib.escapeShellArg documentName} <<'HERMES_DOCUMENT_EOF'\n${value}\nHERMES_DOCUMENT_EOF"
+            ) cfg.documents)}
+          '';
+          envFileContent = lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (key: value: "${key}=${lib.escapeShellArg value}") cfg.environment
+          );
+        in
+        if cfg.enable then {
+          assertions = [
+            {
+              assertion = builtins.match "^[a-z0-9][a-z0-9-]*$" name != null;
+              message = "services.hermes-agent.instances.${name}: instance names must be lowercase letters, digits, and hyphens.";
+            }
+            {
+              assertion = lib.hasPrefix "/" cfg.stateDir;
+              message = "services.hermes-agent.instances.${name}.stateDir must be absolute.";
+            }
+            {
+              assertion = lib.hasPrefix "/" cfg.workingDirectory;
+              message = "services.hermes-agent.instances.${name}.workingDirectory must be absolute.";
+            }
+          ];
+
+          users.groups = mkIf cfg.createUser {
+            ${cfg.group} = { };
+          };
+          users.users = mkIf cfg.createUser {
+            ${cfg.user} = {
+              isSystemUser = true;
+              group = cfg.group;
+              home = cfg.stateDir;
+              createHome = true;
+              shell = pkgs.bashInteractive;
+              packages = cfg.extraPackages;
+            };
+          };
+
+          systemd.tmpfiles.rules = [
+            "d ${cfg.stateDir} 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes/cron 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes/logs 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.stateDir}/.hermes/plugins 2770 ${cfg.user} ${cfg.group} - -"
+            "d ${cfg.workingDirectory} 2770 ${cfg.user} ${cfg.group} - -"
+          ];
+
+          system.activationScripts."${unitName}-setup" = lib.stringAfter [ "users" ] ''
+            mkdir -p ${lib.escapeShellArg cfg.stateDir}/.hermes ${lib.escapeShellArg cfg.workingDirectory}
+            chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+              ${lib.escapeShellArg cfg.stateDir} \
+              ${lib.escapeShellArg "${cfg.stateDir}/.hermes"} \
+              ${lib.escapeShellArg cfg.workingDirectory}
+            chmod 2770 ${lib.escapeShellArg cfg.stateDir} \
+              ${lib.escapeShellArg "${cfg.stateDir}/.hermes"} \
+              ${lib.escapeShellArg cfg.workingDirectory}
+
+            ${if cfg.configFile != null then ''
+              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
+                -m 0640 ${lib.escapeShellArg (toString cfg.configFile)} \
+                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
+            '' else ''
+              ${configMergeScript} ${lib.escapeShellArg (toString generatedConfigFile)} \
+                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
+              chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+                ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
+              chmod 0640 ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml"}
+            ''}
+
+            touch ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
+            chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+              ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
+            chmod 0640 ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.managed"}
+
+            ${lib.optionalString (cfg.environment != { } || cfg.environmentFiles != [ ]) ''
+              env_file=${lib.escapeShellArg "${cfg.stateDir}/.hermes/.env"}
+              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} \
+                -m 0640 /dev/null "$env_file"
+              printf '%s\n' ${lib.escapeShellArg envFileContent} > "$env_file"
+              ${lib.concatMapStringsSep "\n" (file: ''
+                if [ -f ${lib.escapeShellArg file} ]; then
+                  printf '\n' >> "$env_file"
+                  cat ${lib.escapeShellArg file} >> "$env_file"
+                fi
+              '') cfg.environmentFiles}
+            ''}
+
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (documentName: _value: ''
+              install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} -m 0640 \
+                ${lib.escapeShellArg "${documentDerivation}/${documentName}"} \
+                ${lib.escapeShellArg "${cfg.workingDirectory}/${documentName}"}
+            '') cfg.documents)}
+          '';
+
+          systemd.services.${unitName} = {
+            description = "Hermes Agent ${name} gateway";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network-online.target" ];
+            wants = [ "network-online.target" ];
+            environment = {
+              HOME = cfg.stateDir;
+              HERMES_HOME = "${cfg.stateDir}/.hermes";
+              HERMES_MANAGED = "true";
+              MESSAGING_CWD = cfg.workingDirectory;
+            };
+            serviceConfig = {
+              User = cfg.user;
+              Group = cfg.group;
+              WorkingDirectory = cfg.workingDirectory;
+              ExecStart = lib.concatStringsSep " " (
+                [ "${cfg.package}/bin/hermes" "gateway" ] ++ cfg.extraArgs
+              );
+              Restart = cfg.restart;
+              RestartSec = cfg.restartSec;
+              UMask = "0007";
+              NoNewPrivileges = true;
+              ProtectSystem = "strict";
+              ProtectHome = "read-only";
+              ReadWritePaths = [ cfg.stateDir cfg.workingDirectory ];
+              PrivateTmp = true;
+            };
+            path = [
+              cfg.package
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.git
+            ] ++ cfg.extraPackages;
+          };
+        } else { };
+      instanceConfigs = lib.mapAttrsToList mkInstance cfg.instances;
+    in
+    {
+      options.services.hermes-agent.instances = mkOption {
+        type = types.attrsOf (types.submodule instanceModule);
+        default = { };
+        description = "Independent native Hermes Agent gateway instances.";
+      };
+
+      config = {
+        assertions = lib.concatMap (instance: instance.assertions or [ ]) instanceConfigs;
+        system = lib.mkMerge (map (instance: instance.system or { }) instanceConfigs);
+        systemd = lib.mkMerge (map (instance: instance.systemd or { }) instanceConfigs);
+        users = lib.mkMerge (map (instance: instance.users or { }) instanceConfigs);
+      };
+    };
+}

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -42,43 +42,18 @@
       merge = _loc: defs: lib.foldl' lib.recursiveUpdate { } (map (d: d.value) defs);
     };
 
-    # Generate config.yaml from Nix attrset (YAML is a superset of JSON).
-    # terminal.cwd replaces the deprecated MESSAGING_CWD env var — hermes
-    # reads it from config.yaml and bridges it to TERMINAL_CWD internally.
-    # recursiveUpdate: cfg.settings wins, so an explicit
-    # settings.terminal.cwd overrides the workingDirectory default.
-    # Container mode uses the in-container mount path.
+    # Container mode needs the in-container path in generated config.
     effectiveWorkDir = if cfg.container.enable then containerWorkDir else cfg.workingDirectory;
-    configJson = builtins.toJSON (
-      lib.recursiveUpdate { terminal.cwd = effectiveWorkDir; } cfg.settings
-    );
-    generatedConfigFile = pkgs.writeText "hermes-config.yaml" configJson;
-    configFile = if cfg.configFile != null then cfg.configFile else generatedConfigFile;
-
-    configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+    nativeLifecycle = import ./hermes-agent-lifecycle.nix {
+      inherit lib pkgs;
+      configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+    };
 
     # config.yaml mode: group-writable (0660) when interactive users share this
     # HERMES_HOME via addToSystemPackages, so they can save settings through the
     # CLI/TUI without hitting EACCES; otherwise group-read-only (0640). Secrets
     # (.env) stay 0640 regardless — see below.
     configYamlMode = if cfg.addToSystemPackages then "0660" else "0640";
-
-    # Generate .env from non-secret environment attrset
-    envFileContent = lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment
-    );
-    # Build documents derivation (from 0xrsydn)
-    documentDerivation = pkgs.runCommand "hermes-documents" { } (
-      ''
-        mkdir -p $out
-      '' + lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (name: value:
-          if builtins.isPath value || lib.isStorePath value
-          then "cp ${value} $out/${name}"
-          else "cat > $out/${name} <<'HERMES_DOC_EOF'\n${value}\nHERMES_DOC_EOF"
-        ) cfg.documents
-      )
-    );
 
     containerName = "hermes-agent";
     containerDataDir = "/data";     # stateDir mount point inside container
@@ -200,10 +175,12 @@
     # Package and entrypoint use stable symlinks (current-package, current-entrypoint)
     # so they can update without recreation. Env vars go through $HERMES_HOME/.env.
     containerIdentity = builtins.hashString "sha256" (builtins.toJSON {
-      schema = 4; # bump when identity inputs change (4: Node 18→22 via NodeSource)
+      schema = 5; # bump when identity inputs change (5: read-only policy)
       image = cfg.container.image;
       extraVolumes = cfg.container.extraVolumes;
       extraOptions = cfg.container.extraOptions;
+      allowedToolsets = cfg.allowedToolsets;
+      readOnlyState = cfg.readOnlyState;
     });
 
     identityFile = "${cfg.stateDir}/.container-identity";
@@ -214,6 +191,97 @@
       if lib.hasPrefix "${cfg.stateDir}/" cfg.workingDirectory
       then "${containerDataDir}/${lib.removePrefix "${cfg.stateDir}/" cfg.workingDirectory}"
       else cfg.workingDirectory;
+
+    nativeActivationAfter = [ "users" ]
+      ++ lib.optional (config.system.activationScripts ? setupSecrets) "setupSecrets"
+      ++ lib.optional (config.system.activationScripts ? agenixInstall) "agenixInstall";
+
+    nativeExtraActivation = ''
+      # Container mode metadata — tells the host CLI to exec into the
+      # container instead of running locally.
+      ${if cfg.container.enable then ''
+        container_mode_path=${lib.escapeShellArg "${cfg.stateDir}/.hermes/.container-mode"}
+        reject_symlink "$container_mode_path"
+        cat > "$container_mode_path" <<'HERMES_CONTAINER_MODE_EOF'
+    # Written by NixOS activation script. Do not edit manually.
+    backend=${cfg.container.backend}
+    container_name=${containerName}
+    exec_user=${cfg.user}
+    hermes_bin=${containerDataDir}/current-package/bin/hermes
+    HERMES_CONTAINER_MODE_EOF
+        chown ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} "$container_mode_path"
+        chmod 0644 "$container_mode_path"
+      '' else ''
+        rm -f ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.container-mode"}
+
+        # Remove symlink bridge for hostUsers.
+        ${lib.concatStringsSep "\n" (map (user:
+          let
+            userHome = config.users.users.${user}.home;
+          in ''
+            user_home=${lib.escapeShellArg userHome}
+            symlink_path="$user_home/.hermes"
+            if [ -L "$symlink_path" ] && [ "$(readlink "$symlink_path")" = ${lib.escapeShellArg "${cfg.stateDir}/.hermes"} ]; then
+              rm -f "$symlink_path"
+              echo "hermes-agent: removed symlink $symlink_path"
+            fi
+          '') cfg.container.hostUsers)}
+      ''}
+
+      # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
+      # host CLI shares state with the container service.
+      ${lib.optionalString cfg.container.enable
+        (lib.concatStringsSep "\n" (map (user:
+          let
+            userHome = config.users.users.${user}.home;
+            target = "${cfg.stateDir}/.hermes";
+          in ''
+            user_home=${lib.escapeShellArg userHome}
+            symlink_path="$user_home/.hermes"
+            target=${lib.escapeShellArg target}
+            if [ -d "$symlink_path" ] && [ ! -L "$symlink_path" ]; then
+              _backup="$symlink_path.bak.$(date +%s)"
+              echo "hermes-agent: backing up existing $symlink_path to $_backup"
+              mv "$symlink_path" "$_backup"
+            fi
+            ln -sfnT "$target" "$symlink_path"
+            chown -h ${lib.escapeShellArg user}:${lib.escapeShellArg cfg.group} "$symlink_path"
+          '') cfg.container.hostUsers))}
+
+      # Seed auth file if provided.
+      ${lib.optionalString (cfg.authFile != null) ''
+        ${if cfg.authFileForceOverwrite then ''
+          auth_path=${lib.escapeShellArg "${cfg.stateDir}/.hermes/auth.json"}
+          reject_symlink "$auth_path"
+          install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} -m 0600 \
+            ${lib.escapeShellArg (toString cfg.authFile)} "$auth_path"
+        '' else ''
+          auth_path=${lib.escapeShellArg "${cfg.stateDir}/.hermes/auth.json"}
+          if [ ! -f "$auth_path" ]; then
+            reject_symlink "$auth_path"
+            install -o ${lib.escapeShellArg cfg.user} -g ${lib.escapeShellArg cfg.group} -m 0600 \
+              ${lib.escapeShellArg (toString cfg.authFile)} "$auth_path"
+          fi
+        ''}
+      ''}
+
+      # ── Declarative plugins ─────────────────────────────────────────────
+      find ${lib.escapeShellArg "${cfg.stateDir}/.hermes/plugins"} -maxdepth 1 -type l -name 'nix-managed-*' -delete 2>/dev/null || true
+
+      ${lib.concatStringsSep "\n" (map (plugin:
+        let
+          pluginName = lib.getName plugin;
+        in ''
+          if [ ! -f "${plugin}/plugin.yaml" ]; then
+            echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2
+            exit 1
+          fi
+          ln -sfnT ${lib.escapeShellArg (toString plugin)} \
+            ${lib.escapeShellArg "${cfg.stateDir}/.hermes/plugins/nix-managed-${pluginName}"}
+          chown -h ${lib.escapeShellArg cfg.user}:${lib.escapeShellArg cfg.group} \
+            ${lib.escapeShellArg "${cfg.stateDir}/.hermes/plugins/nix-managed-${pluginName}"}
+        '') cfg.extraPlugins)}
+    '';
 
   in {
     options.services.hermes-agent = with lib; {
@@ -472,6 +540,21 @@
         description = "Extra command-line arguments for `hermes gateway`.";
       };
 
+      allowedToolsets = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = ''
+          Hard allowlist of toolsets enforced by the service environment. When
+          set, Hermes cannot enable toolsets outside this list.
+        '';
+      };
+
+      readOnlyState = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Protect the Nix-managed config and environment files from the service user.";
+      };
+
       extraPackages = mkOption {
         type = types.listOf types.package;
         default = [ ];
@@ -644,18 +727,6 @@
         ) cfg.mcpServers;
       })
 
-      # ── User / group ──────────────────────────────────────────────────
-      (lib.mkIf cfg.createUser {
-        users.groups.${cfg.group} = { };
-        users.users.${cfg.user} = {
-          isSystemUser = true;
-          group = cfg.group;
-          home = cfg.stateDir;
-          createHome = true;
-          shell = pkgs.bashInteractive;
-        };
-      })
-
       # ── Host CLI ──────────────────────────────────────────────────────
       # Add the hermes CLI to system PATH and export HERMES_HOME system-wide
       # so interactive shells share state (sessions, skills, cron) with the
@@ -705,225 +776,21 @@
         ];
       })
 
-      # ── Directories ───────────────────────────────────────────────────
-      {
-        systemd.tmpfiles.rules = [
-          "d ${cfg.stateDir}                2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes        2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes/cron   2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes/memories 2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/.hermes/plugins 2770 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.stateDir}/home           0750 ${cfg.user} ${cfg.group} - -"
-          "d ${cfg.workingDirectory}         2770 ${cfg.user} ${cfg.group} - -"
-        ];
-      }
-
-      # ── Activation: link config + auth + documents ────────────────────
-      {
-        system.activationScripts."hermes-agent-setup" = lib.stringAfter ([ "users" ] ++ lib.optional (config.system.activationScripts ? setupSecrets) "setupSecrets") ''
-          # Ensure directories exist (activation runs before tmpfiles)
-          mkdir -p ${cfg.stateDir}/.hermes
-          mkdir -p ${cfg.stateDir}/home
-          mkdir -p ${cfg.workingDirectory}
-          chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
-          chmod 2770 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.workingDirectory}
-          chmod 0750 ${cfg.stateDir}/home
-
-          # Create subdirs, set setgid + group-writable, migrate existing files.
-          # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
-          # configYamlMode (0660 under addToSystemPackages, else 0640).
-          find ${cfg.stateDir}/.hermes -maxdepth 1 \
-            \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
-            -exec chmod g+rw {} + 2>/dev/null || true
-          for _subdir in cron sessions logs memories plugins; do
-            mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
-            chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
-            chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
-            find "${cfg.stateDir}/.hermes/$_subdir" -type f \
-              -exec chmod g+rw {} + 2>/dev/null || true
-          done
-
-          # Merge Nix settings into existing config.yaml.
-          # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
-          # If configFile is user-provided (not generated), overwrite instead of merge.
-          # Mode is configYamlMode (0660 under addToSystemPackages so interactive
-          # hermes-group users can save settings via the CLI/TUI, else 0640).
-          ${if cfg.configFile != null then ''
-            install -o ${cfg.user} -g ${cfg.group} -m ${configYamlMode} -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
-          '' else ''
-            ${configMergeScript} ${generatedConfigFile} ${cfg.stateDir}/.hermes/config.yaml
-            chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/config.yaml
-            chmod ${configYamlMode} ${cfg.stateDir}/.hermes/config.yaml
-          ''}
-
-          # Managed mode marker (so interactive shells also detect NixOS management)
-          touch ${cfg.stateDir}/.hermes/.managed
-          chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.managed
-          chmod 0644 ${cfg.stateDir}/.hermes/.managed
-
-          # Container mode metadata — tells the host CLI to exec into the
-          # container instead of running locally. Removed when container mode
-          # is disabled so the host CLI falls back to native execution.
-          ${if cfg.container.enable then ''
-            cat > ${cfg.stateDir}/.hermes/.container-mode <<'HERMES_CONTAINER_MODE_EOF'
-    # Written by NixOS activation script. Do not edit manually.
-    backend=${cfg.container.backend}
-    container_name=${containerName}
-    exec_user=${cfg.user}
-    hermes_bin=${containerDataDir}/current-package/bin/hermes
-    HERMES_CONTAINER_MODE_EOF
-            chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.container-mode
-            chmod 0644 ${cfg.stateDir}/.hermes/.container-mode
-          '' else ''
-            rm -f ${cfg.stateDir}/.hermes/.container-mode
-
-            # Remove symlink bridge for hostUsers
-            ${lib.concatStringsSep "\n" (map (user:
-              let
-                userHome = config.users.users.${user}.home;
-                symlinkPath = "${userHome}/.hermes";
-              in ''
-                if [ -L "${symlinkPath}" ] && [ "$(readlink "${symlinkPath}")" = "${cfg.stateDir}/.hermes" ]; then
-                  rm -f "${symlinkPath}"
-                  echo "hermes-agent: removed symlink ${symlinkPath}"
-                fi
-              '') cfg.container.hostUsers)}
-          ''}
-
-          # ── Symlink bridge for interactive users ───────────────────────
-          # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
-          # host CLI shares state with the container service.
-          # Only runs when container mode is enabled.
-          ${lib.optionalString cfg.container.enable
-            (lib.concatStringsSep "\n" (map (user:
-              let
-                userHome = config.users.users.${user}.home;
-                symlinkPath = "${userHome}/.hermes";
-                target = "${cfg.stateDir}/.hermes";
-              in ''
-                if [ -d "${symlinkPath}" ] && [ ! -L "${symlinkPath}" ]; then
-                  # Real directory — back it up, then create symlink.
-                  # (ln -sfn cannot atomically replace a directory.)
-                  _backup="${symlinkPath}.bak.$(date +%s)"
-                  echo "hermes-agent: backing up existing ${symlinkPath} to $_backup"
-                  mv "${symlinkPath}" "$_backup"
-                fi
-                # For everything else (existing symlink, doesn't exist, etc.)
-                # ln -sfn handles it: replaces symlinks, creates new ones.
-                ln -sfn "${target}" "${symlinkPath}"
-                chown -h ${user}:${cfg.group} "${symlinkPath}"
-              '') cfg.container.hostUsers))}
-
-          # Seed auth file if provided
-          ${lib.optionalString (cfg.authFile != null) ''
-            ${if cfg.authFileForceOverwrite then ''
-              install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
-            '' else ''
-              if [ ! -f ${cfg.stateDir}/.hermes/auth.json ]; then
-                install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
-              fi
-            ''}
-          ''}
-
-          # Seed .env from Nix-declared environment + environmentFiles.
-          # Hermes reads $HERMES_HOME/.env at startup via load_hermes_dotenv(),
-          # so this is the single source of truth for both native and container mode.
-          ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
-            ENV_FILE="${cfg.stateDir}/.hermes/.env"
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
-            cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
-    ${envFileContent}
-    HERMES_NIX_ENV_EOF
-            ${lib.concatStringsSep "\n" (map (f: ''
-              if [ -f "${f}" ]; then
-                echo "" >> "$ENV_FILE"
-                cat "${f}" >> "$ENV_FILE"
-              fi
-            '') cfg.environmentFiles)}
-          ''}
-
-          # Link documents into workspace
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _value: ''
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
-          '') cfg.documents)}
-
-        # ── Declarative plugins ─────────────────────────────────────────
-        # Remove stale managed symlinks (plugins removed from config)
-        find ${cfg.stateDir}/.hermes/plugins -maxdepth 1 -type l -name 'nix-managed-*' -delete 2>/dev/null || true
-
-        ${lib.concatStringsSep "\n" (map (plugin:
-          let
-            name = lib.getName plugin;
-          in ''
-            if [ ! -f "${plugin}/plugin.yaml" ]; then
-              echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2
-              exit 1
-            fi
-            ln -sfn ${plugin} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
-            chown -h ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
-          '') cfg.extraPlugins)}
-        '';
-      }
-
-      # ══════════════════════════════════════════════════════════════════
-      # MODE A: Native systemd service (default)
-      # ══════════════════════════════════════════════════════════════════
-      (lib.mkIf (!cfg.container.enable) {
-        systemd.services.hermes-agent = {
-          description = "Hermes Agent Gateway";
-          wantedBy = [ "multi-user.target" ];
-          after = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
-
-          environment = {
-            HOME = cfg.stateDir;
-            HERMES_HOME = "${cfg.stateDir}/.hermes";
-            HERMES_MANAGED = "true";
-            # Working directory is declared via terminal.cwd in the merged
-            # config.yaml (see configJson above) — MESSAGING_CWD is deprecated.
-          };
-
-          serviceConfig = {
-            User = cfg.user;
-            Group = cfg.group;
-            WorkingDirectory = cfg.workingDirectory;
-
-            # cfg.environment and cfg.environmentFiles are written to
-            # $HERMES_HOME/.env by the activation script. load_hermes_dotenv()
-            # reads them at Python startup — no systemd EnvironmentFile needed.
-
-            ExecStart = lib.concatStringsSep " " ([
-              "${effectivePackage}/bin/hermes"
-              "gateway"
-            ] ++ cfg.extraArgs);
-
-            Restart = cfg.restart;
-            RestartSec = cfg.restartSec;
-
-            # Shared-state: files created by the gateway should be group-writable
-            # so interactive users in the hermes group can read/write them.
-            UMask = "0007";
-
-            # Hardening
-            NoNewPrivileges = true;
-            ProtectSystem = "strict";
-            ProtectHome = false;
-            ReadWritePaths = [
-              cfg.stateDir
-              cfg.workingDirectory
-            ];
-            PrivateTmp = true;
-          };
-
-          path = [
-            effectivePackage
-            pkgs.bash
-            pkgs.coreutils
-            pkgs.git
-          ] ++ cfg.extraPackages;
-        };
+      (nativeLifecycle.mkNativeLifecycle {
+        name = "hermes-agent";
+        description = "Hermes Agent Gateway";
+        cfg = cfg;
+        package = effectivePackage;
+        configFile = cfg.configFile;
+        configYamlMode = configYamlMode;
+        includeHome = true;
+        managedMode = "0644";
+        protectHome = false;
+        readOnlyState = cfg.readOnlyState;
+        effectiveWorkingDirectory = effectiveWorkDir;
+        setupAfter = nativeActivationAfter;
+        extraActivation = nativeExtraActivation;
+        enableService = !cfg.container.enable;
       })
 
       # ══════════════════════════════════════════════════════════════════
@@ -943,47 +810,59 @@
 
           preStart = ''
             # Stable symlinks — container references these, not store paths directly
-            ln -sfn ${effectivePackage} ${cfg.stateDir}/current-package
-            ln -sfn ${containerEntrypoint} ${cfg.stateDir}/current-entrypoint
+            state_dir=${lib.escapeShellArg cfg.stateDir}
+            identity_file=${lib.escapeShellArg identityFile}
+            container_name=${lib.escapeShellArg containerName}
+            ln -sfn ${effectivePackage} "$state_dir/current-package"
+            ln -sfn ${containerEntrypoint} "$state_dir/current-entrypoint"
 
             # GC roots so nix-collect-garbage doesn't remove store paths in use
-            ${pkgs.nix}/bin/nix-store --add-root ${cfg.stateDir}/.gc-root --indirect -r ${effectivePackage} 2>/dev/null || true
-            ${pkgs.nix}/bin/nix-store --add-root ${cfg.stateDir}/.gc-root-entrypoint --indirect -r ${containerEntrypoint} 2>/dev/null || true
+            ${pkgs.nix}/bin/nix-store --add-root "$state_dir/.gc-root" --indirect -r ${effectivePackage} 2>/dev/null || true
+            ${pkgs.nix}/bin/nix-store --add-root "$state_dir/.gc-root-entrypoint" --indirect -r ${containerEntrypoint} 2>/dev/null || true
 
             # Check if container needs (re)creation
             NEED_CREATE=false
-            if ! ${containerBin} inspect ${containerName} &>/dev/null; then
+            if ! ${containerBin} inspect "$container_name" &>/dev/null; then
               NEED_CREATE=true
-            elif [ ! -f ${identityFile} ] || [ "$(cat ${identityFile})" != "${containerIdentity}" ]; then
+            elif [ ! -f "$identity_file" ] || [ "$(cat "$identity_file")" != "${containerIdentity}" ]; then
               echo "Container config changed, recreating..."
-              ${containerBin} rm -f ${containerName} || true
+              ${containerBin} rm -f "$container_name" || true
               NEED_CREATE=true
             fi
 
             if [ "$NEED_CREATE" = "true" ]; then
               # Resolve numeric UID/GID — passed to entrypoint for in-container user setup
-              HERMES_UID=$(${pkgs.coreutils}/bin/id -u ${cfg.user})
-              HERMES_GID=$(${pkgs.coreutils}/bin/id -g ${cfg.user})
+              HERMES_UID=$(${pkgs.coreutils}/bin/id -u ${lib.escapeShellArg cfg.user})
+              HERMES_GID=$(${pkgs.coreutils}/bin/id -g ${lib.escapeShellArg cfg.user})
 
               echo "Creating container..."
               ${containerBin} create \
-                --name ${containerName} \
+                --name "$container_name" \
                 --network=host \
-                --entrypoint ${containerDataDir}/current-entrypoint \
+                --entrypoint ${lib.escapeShellArg "${containerDataDir}/current-entrypoint"} \
                 --volume /nix/store:/nix/store:ro \
-                --volume ${cfg.stateDir}:${containerDataDir} \
-                --volume ${cfg.stateDir}/home:${containerHomeDir} \
-                ${lib.concatStringsSep " " (map (v: "--volume ${v}") cfg.container.extraVolumes)} \
+                --volume "$state_dir:${containerDataDir}" \
+                --volume "$state_dir/home:${containerHomeDir}" \
+                ${lib.optionalString cfg.readOnlyState ''
+                  --volume ${lib.escapeShellArg "${cfg.stateDir}/.hermes/config.yaml:${containerDataDir}/.hermes/config.yaml:ro"} \
+                  ${lib.optionalString (cfg.environment != { } || cfg.environmentFiles != [ ]) ''
+                    --volume ${lib.escapeShellArg "${cfg.stateDir}/.hermes/.env:${containerDataDir}/.hermes/.env:ro"} \
+                  ''}
+                ''}
+                ${lib.escapeShellArgs (lib.concatMap (v: [ "--volume" v ]) cfg.container.extraVolumes)} \
                 --env HERMES_UID="$HERMES_UID" \
                 --env HERMES_GID="$HERMES_GID" \
-                --env HERMES_HOME=${containerDataDir}/.hermes \
+                --env HERMES_HOME=${lib.escapeShellArg "${containerDataDir}/.hermes"} \
                 --env HERMES_MANAGED=true \
-                --env HOME=${containerHomeDir} \
-                ${lib.concatStringsSep " " cfg.container.extraOptions} \
-                ${cfg.container.image} \
-                ${containerDataDir}/current-package/bin/hermes gateway run --replace ${lib.concatStringsSep " " cfg.extraArgs}
+                --env HOME=${lib.escapeShellArg containerHomeDir} \
+                ${lib.optionalString (cfg.allowedToolsets != null) ''
+                  --env ${lib.escapeShellArg "HERMES_ALLOWED_TOOLSETS=${lib.concatStringsSep "," cfg.allowedToolsets}"} \
+                ''}
+                ${lib.escapeShellArgs cfg.container.extraOptions} \
+                ${lib.escapeShellArg cfg.container.image} \
+                ${lib.escapeShellArg "${containerDataDir}/current-package/bin/hermes"} gateway run --replace ${lib.escapeShellArgs cfg.extraArgs}
 
-              echo "${containerIdentity}" > ${identityFile}
+              echo "${containerIdentity}" > "$identity_file"
             fi
           '';
 
@@ -992,7 +871,7 @@
           '';
 
           preStop = ''
-            ${containerBin} stop -t 10 ${containerName} || true
+            ${containerBin} stop -t 10 ${lib.escapeShellArg containerName} || true
           '';
 
           serviceConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hermes/shared": "file:../apps/shared",
-        "@nous-research/ui": "0.16.0",
+        "@nous-research/ui": "0.18.2",
         "@observablehq/plot": "0.6.17",
         "@react-three/fiber": "9.6.1",
         "@tailwindcss/vite": "4.3.3",
@@ -18741,6 +18741,50 @@
         "typescript": "6.0.3",
         "vite": "8.2.0",
         "vitest": "4.1.10"
+      }
+    },
+    "web/node_modules/@nous-research/ui": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@nous-research/ui/-/ui-0.18.2.tgz",
+      "integrity": "sha512-xe//1PjCapafXu5onqnJW50MhAK41LXuHw2KvfHDLiI3TBeqtX4QEm4mTrWZaZ2PRqM6koY/o19fdgisB67LGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nanostores/react": "^1.1.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "nanostores": "^1.3.0",
+        "radix-ui": "^1.4.0",
+        "sanitize-html": "^2.17.4",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0",
+        "unicode-animations": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@observablehq/plot": "^0.6.17",
+        "@react-three/fiber": "^9.4.0",
+        "gsap": "^3.13.0",
+        "leva": "^0.10.1",
+        "motion": "^12.38.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "three": "^0.180.0"
+      },
+      "peerDependenciesMeta": {
+        "@observablehq/plot": {
+          "optional": true
+        },
+        "@react-three/fiber": {
+          "optional": true
+        },
+        "gsap": {
+          "optional": true
+        },
+        "leva": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18742,48 +18742,6 @@
         "vite": "8.2.0",
         "vitest": "4.1.10"
       }
-    },
-    "web/node_modules/@nous-research/ui": {
-      "version": "0.18.2",
-      "license": "MIT",
-      "dependencies": {
-        "@nanostores/react": "^1.1.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "nanostores": "^1.3.0",
-        "radix-ui": "^1.4.0",
-        "sanitize-html": "^2.17.4",
-        "tailwind-merge": "^3.6.0",
-        "tw-animate-css": "^1.4.0",
-        "unicode-animations": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@observablehq/plot": "^0.6.17",
-        "@react-three/fiber": "^9.4.0",
-        "gsap": "^3.13.0",
-        "leva": "^0.10.1",
-        "motion": "^12.38.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "three": "^0.180.0"
-      },
-      "peerDependenciesMeta": {
-        "@observablehq/plot": {
-          "optional": true
-        },
-        "@react-three/fiber": {
-          "optional": true
-        },
-        "gsap": {
-          "optional": true
-        },
-        "leva": {
-          "optional": true
-        },
-        "three": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -35,6 +35,16 @@ class TestPerJobToolsetMcpMerge:
         assert result[:2] == ["web", "terminal"]
         assert set(result) == {"web", "terminal"} | self._enabled_names()
 
+    def test_per_job_toolsets_honor_service_allowlist(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ALLOWED_TOOLSETS", "web")
+
+        result = _resolve_cron_enabled_toolsets(
+            {"enabled_toolsets": ["web", "terminal"]},
+            self.CFG,
+        )
+
+        assert result == ["web"]
+
 
     def test_explicit_mcp_name_is_treated_as_allowlist(self):
         # User named one server -> add nothing further.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -96,19 +96,6 @@ def test_environment_allowed_toolsets_overrides_config(monkeypatch):
     assert _get_platform_tools(config, "cli") == {"web", "vision"}
 
 
-def test_get_platform_tools_uses_default_when_platform_not_configured():
-    config = {}
-
-    enabled = _get_platform_tools(config, "cli")
-
-    assert enabled
-    assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
-
-
-
-
-
-
 def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_token_set(monkeypatch):
     """HA toolset is runtime-gated by check_fn (requires HASS_TOKEN).
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -73,6 +73,36 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
 
 
 
+def test_agent_allowed_toolsets_is_a_hard_allowlist(monkeypatch):
+    """A service policy must win over platform, plugin, and MCP defaults."""
+    monkeypatch.delenv("HERMES_ALLOWED_TOOLSETS", raising=False)
+    config = {
+        "agent": {"allowed_toolsets": ["web", "vision"]},
+        "platform_toolsets": {"cli": ["all", "terminal", "web", "vision"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert enabled == {"web", "vision"}
+
+
+def test_environment_allowed_toolsets_overrides_config(monkeypatch):
+    monkeypatch.setenv("HERMES_ALLOWED_TOOLSETS", "web,vision")
+    config = {
+        "agent": {"allowed_toolsets": ["terminal"]},
+        "platform_toolsets": {"cli": ["all"]},
+    }
+
+    assert _get_platform_tools(config, "cli") == {"web", "vision"}
+
+
+def test_get_platform_tools_uses_default_when_platform_not_configured():
+    config = {}
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert enabled
+    assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -7,11 +7,22 @@ from unittest.mock import ANY, call, patch
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
 )
+
+
+class TestToolsetAllowlist:
+    def test_environment_allowlist_restricts_explicit_toolsets(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ALLOWED_TOOLSETS", "web")
+
+        with patch("model_tools._compute_tool_definitions", return_value=[]) as compute:
+            get_tool_definitions(["all", "terminal"], quiet_mode=False)
+
+        assert compute.call_args.args[0] == ["web"]
 
 
 # =========================================================================

--- a/toolsets.py
+++ b/toolsets.py
@@ -23,7 +23,52 @@ Usage:
     all_tools = resolve_toolset("full_stack")
 """
 
+import os
 from typing import List, Dict, Any, Set, Optional
+
+
+def get_allowed_toolsets(config: Optional[Dict[str, Any]] = None) -> Optional[Set[str]]:
+    """Return the service/config toolset allowlist, or ``None`` if unrestricted."""
+    allowed_raw = os.getenv("HERMES_ALLOWED_TOOLSETS")
+    if allowed_raw is not None:
+        return {value.strip() for value in allowed_raw.split(",") if value.strip()}
+
+    agent_cfg = (config or {}).get("agent") or {}
+    configured = agent_cfg.get("allowed_toolsets")
+    if configured is None:
+        return None
+    if isinstance(configured, list):
+        return {
+            str(value).strip()
+            for value in configured
+            if str(value).strip()
+        }
+    return {
+        value.strip()
+        for value in str(configured).split(",")
+        if value.strip()
+    }
+
+
+def restrict_toolsets(
+    enabled_toolsets: Optional[List[str]],
+    allowed_toolsets: Optional[Set[str]],
+) -> Optional[List[str]]:
+    """Intersect requested toolsets with a hard allowlist without widening it."""
+    if allowed_toolsets is None:
+        return enabled_toolsets
+    if enabled_toolsets is None:
+        return sorted(allowed_toolsets)
+
+    restricted = []
+    seen = set()
+    for toolset_name in enabled_toolsets:
+        names = sorted(allowed_toolsets) if toolset_name in {"all", "*"} else [toolset_name]
+        for name in names:
+            if name in allowed_toolsets and name not in seen:
+                restricted.append(name)
+                seen.add(name)
+    return restricted
 
 
 # Shared tool list for CLI and all messaging platform toolsets.

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hermes/shared": "file:../apps/shared",
-    "@nous-research/ui": "0.16.0",
+    "@nous-research/ui": "0.18.2",
     "@observablehq/plot": "0.6.17",
     "@react-three/fiber": "9.6.1",
     "@tailwindcss/vite": "4.3.3",

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -141,6 +141,46 @@ services.hermes-agent.environmentFiles = [ "/var/lib/hermes/env" ];
 Setting `addToSystemPackages = true` does two things: puts the `hermes` CLI on your system PATH **and** sets `HERMES_HOME` system-wide so the interactive CLI shares state (sessions, skills, cron) with the gateway service. Without it, running `hermes` in your shell creates a separate `~/.hermes/` directory.
 :::
 
+### Multiple Isolated Instances
+
+The flake also exports `nixosModules.instances` for running independent native
+Hermes gateways on one host. Import it alongside `nixosModules.default` when
+you need both the singleton service and isolated instances:
+
+```nix
+modules = [
+  hermes-agent.nixosModules.default
+  hermes-agent.nixosModules.instances
+  ./configuration.nix
+];
+```
+
+```nix
+# configuration.nix
+{
+  services.hermes-agent.instances = {
+    research = {
+      enable = true;
+      settings.model.default = "anthropic/claude-sonnet-4";
+      allowedToolsets = [ "web" "file" ];
+      environmentFiles = [ "/run/secrets/hermes-research-env" ];
+    };
+
+    coding = {
+      enable = true;
+      settings.model.default = "google/gemini-3-flash";
+      allowedToolsets = [ "web" "file" "terminal" ];
+      environmentFiles = [ "/run/secrets/hermes-coding-env" ];
+    };
+  };
+}
+```
+
+Each enabled instance gets its own `hermes-agent-<name>.service`,
+`hermes-<name>` user/group, and `/var/lib/hermes-<name>` state directory.
+Instance names must contain lowercase letters, digits, and hyphens. The
+instances module is native-only; use the singleton module for container mode.
+
 ### Container-aware CLI
 
 :::info


### PR DESCRIPTION
Adds a generic `services.hermes-agent.instances` NixOS module for running isolated gateway profiles alongside the existing singleton.

The shared lifecycle keeps user/state setup, config merging, document installation, service hardening, and container behavior on one path. Instances can enforce a hard toolset allowlist and protect Nix-managed config from service writes. Config writes are atomic and reject symlink targets.

Checks run:
- `uv run --extra dev scripts/run_tests.sh tests/hermes_cli/test_tools_config.py` (27 passed)
- `uv run --extra dev ruff check hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py`
- `nix build --no-update-lock-file .#checks.x86_64-linux.nixos-module-instances`
- `nix build --no-update-lock-file .#checks.x86_64-linux.config-merge`