### PR TITLE
docs(gemini): clarify supported authentication boundaries

### DIFF
--- a/plugins/model-providers/gemini/plugin.yaml
+++ b/plugins/model-providers/gemini/plugin.yaml
@@ -1,5 +1,5 @@
 name: gemini-provider
 kind: model-provider
 version: 1.0.0
-description: Google Gemini (API key + Cloud Code OAuth)
+description: Google Gemini via Google AI Studio API key
 author: Nous Research

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -18,6 +18,10 @@ Hermes Agent supports Google Gemini as a native provider using the **Google AI S
 Set `GOOGLE_API_KEY` or `GEMINI_API_KEY`. Hermes checks both names for the `gemini` provider.
 :::
 
+:::warning A Google AI subscription does not replace API setup
+Google AI Pro and Ultra benefits do **not** authorize Gemini use in Hermes. Hermes requires a [Gemini API key](https://ai.google.dev/gemini-api/docs/api-key), with [API quota and billing](https://ai.google.dev/gemini-api/docs/billing) managed separately. Do not purchase a consumer plan solely to unlock Hermes.
+:::
+
 ## Quick Start
 
 ```bash
@@ -205,6 +209,10 @@ GEMINI_API_KEY=...
 ```
 
 Then run `hermes model` again.
+
+### "Unknown provider 'gemini-oauth'" or "Unknown provider 'google-gemini-cli'"
+
+These provider IDs—and `google-antigravity`—are unsupported. Use `provider: gemini` with `GOOGLE_API_KEY` or `GEMINI_API_KEY`; subscription authentication cannot be reused by Hermes.
 
 ### "This Google API key is on the free tier"
 

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -18,9 +18,24 @@ Hermes Agent supports Google Gemini as a native provider using the **Google AI S
 Set `GOOGLE_API_KEY` or `GEMINI_API_KEY`. Hermes checks both names for the `gemini` provider.
 :::
 
+## Authentication and Billing Boundaries
+
+Google offers several products with Gemini branding, but their credentials, quotas, and billing are separate:
+
+| Product | Authentication and billing | Hermes support |
+|---------|----------------------------|----------------|
+| Gemini app / Google AI Pro or Ultra | Consumer subscription benefits; may include access to the AI Studio UI, but Hermes calls do not use subscription limits | Does not authenticate Hermes |
+| Gemini CLI "Login with Google" | Starting June 18, 2026, Google stopped serving consumer tiers through Gemini CLI; Gemini Code Assist Standard and Enterprise subscriptions are unaffected | Hermes does not import or reuse Gemini CLI OAuth credentials |
+| Google AI Studio / Gemini API | API key with API-specific quota; paid-tier billing is managed separately | Yes — `provider: gemini` |
+| Vertex AI | Google Cloud service account or Application Default Credentials (ADC), with GCP quota and billing | Yes — `provider: vertex` |
+
 :::warning A Google AI subscription does not replace API setup
-Google AI Pro and Ultra benefits do **not** authorize Gemini use in Hermes. Hermes requires a [Gemini API key](https://ai.google.dev/gemini-api/docs/api-key), with [API quota and billing](https://ai.google.dev/gemini-api/docs/billing) managed separately. Do not purchase a consumer plan solely to unlock Hermes.
+Google AI Pro and Ultra [may include access to the AI Studio UI](https://support.google.com/googleone/answer/16105039), but the subscription alone does **not** authenticate the Hermes `gemini` provider. Hermes still requires a [Gemini API key](https://ai.google.dev/gemini-api/docs/api-key). Requests use that key's [API quota and, on paid tiers, separate API billing](https://ai.google.dev/gemini-api/docs/billing), not consumer-subscription limits.
+
+Hermes keeps these routes explicit: `gemini` only reads an AI Studio API key, while `vertex` uses Google Cloud credentials. It never silently substitutes Gemini CLI OAuth, Antigravity, or Vertex credentials for `gemini`.
 :::
+
+Google [ended consumer-account access in Gemini CLI on June 18, 2026](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals). Its [Gemini CLI FAQ](https://geminicli.com/docs/resources/faq/#why-cant-i-use-third-party-software-like-claude-code-openclaw-or-opencode-with-gemini-cli) says the supported, secure methods for third-party coding agents are a Google AI Studio API key or Vertex AI, not reused Gemini CLI OAuth credentials.
 
 ## Quick Start
 
@@ -210,9 +225,14 @@ GEMINI_API_KEY=...
 
 Then run `hermes model` again.
 
-### "Unknown provider 'gemini-oauth'" or "Unknown provider 'google-gemini-cli'"
+### "Unknown provider 'gemini-oauth'", "google-gemini-cli", or "google-antigravity"
 
-These provider IDs—and `google-antigravity`—are unsupported. Use `provider: gemini` with `GOOGLE_API_KEY` or `GEMINI_API_KEY`; subscription authentication cannot be reused by Hermes.
+These provider IDs are unsupported. Remove them from your configuration and choose one of the supported routes:
+
+- `provider: gemini` with `GOOGLE_API_KEY` or `GEMINI_API_KEY` for Google AI Studio
+- `provider: vertex` with Google Cloud credentials for Vertex AI
+
+Do not copy Gemini CLI or Antigravity OAuth tokens into Hermes. Google directs third-party agents to AI Studio or Vertex AI in the [Gemini CLI FAQ](https://geminicli.com/docs/resources/faq/#why-cant-i-use-third-party-software-like-claude-code-openclaw-or-opencode-with-gemini-cli). For accounts governed by the linked [Antigravity terms](https://antigravity.google/terms), Google states that using third-party software, tools, or services to access Antigravity breaches the agreement.
 
 ### "This Google API key is on the free tier"
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -56,8 +56,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
 
-:::warning Google AI Pro and Ultra
-Consumer subscriptions do not authorize the Hermes `gemini` provider. Hermes requires a Google AI Studio API key with separate API quota and billing. See the [Google Gemini guide](/guides/google-gemini).
+:::warning Google authentication and billing are separate
+Google AI Pro and Ultra subscriptions do not authenticate the Hermes `gemini` provider. That provider uses a Google AI Studio API key's quota and, on paid tiers, separate API billing; `vertex` uses separate Google Cloud credentials and billing. Hermes does not import Gemini CLI OAuth credentials or use Antigravity as a provider. Google [ended consumer-account access in Gemini CLI on June 18, 2026](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals). See the [Google Gemini guide](/guides/google-gemini) for the full boundary.
 :::
 
 :::tip Model key alias

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -56,6 +56,10 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
 
+:::warning Google AI Pro and Ultra
+Consumer subscriptions do not authorize the Hermes `gemini` provider. Hermes requires a Google AI Studio API key with separate API quota and billing. See the [Google Gemini guide](/guides/google-gemini).
+:::
+
 :::tip Model key alias
 In the `model:` config section, you can use either `default:` or `model:` as the key name for your model ID. Both `model: { default: my-model }` and `model: { model: my-model }` work identically.
 :::

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -86,6 +86,10 @@ Each entry requires both `provider` and `model`. Entries missing either field ar
 | Hugging Face | `huggingface` | `HF_TOKEN` |
 | Custom endpoint | `custom` | `base_url` + `key_env` (see below) |
 
+:::warning Gemini fallback authentication
+A fallback with `provider: gemini` always uses the configured Google AI Studio key's API quota and, if the key is on a paid tier, its separate API billing—even if you have a Google AI Pro or Ultra subscription. Hermes never substitutes Gemini CLI OAuth, Antigravity, or Vertex AI credentials for this fallback. Without a configured Gemini API key, the entry is skipped instead of switching to a differently billed Google route. See the [Google Gemini guide](/guides/google-gemini).
+:::
+
 ### Custom Endpoint Fallback
 
 For a custom OpenAI-compatible endpoint, add `base_url` and optionally `key_env`:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
@@ -18,6 +18,10 @@ Hermes Agent 通过 **Google AI Studio / Gemini API** 原生支持 Google Gemini
 设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`。Hermes 对 `gemini` provider 会同时检查这两个名称。
 :::
 
+:::warning Google AI 订阅不能替代 API 配置
+Google AI Pro 和 Ultra 权益并不授权在 Hermes 中使用 Gemini。Hermes 需要 [Gemini API 密钥](https://ai.google.dev/gemini-api/docs/api-key)，[API 配额和计费](https://ai.google.dev/gemini-api/docs/billing)需另行管理。请勿仅为解锁 Hermes 而购买消费者订阅。
+:::
+
 ## 快速开始
 
 ```bash
@@ -205,6 +209,10 @@ GEMINI_API_KEY=...
 ```
 
 然后重新运行 `hermes model`。
+
+### "Unknown provider 'gemini-oauth'" 或 "Unknown provider 'google-gemini-cli'"
+
+这些 provider ID 以及 `google-antigravity` 均不受支持。请使用 `provider: gemini`，并设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`；Hermes 无法复用订阅身份验证。
 
 ### "This Google API key is on the free tier"
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/google-gemini.md
@@ -18,9 +18,24 @@ Hermes Agent 通过 **Google AI Studio / Gemini API** 原生支持 Google Gemini
 设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`。Hermes 对 `gemini` provider 会同时检查这两个名称。
 :::
 
+## 身份验证与计费边界
+
+Google 提供多个使用 Gemini 品牌的产品，但它们的凭据、配额和计费彼此独立：
+
+| 产品 | 身份验证与计费 | Hermes 支持情况 |
+|------|----------------|-----------------|
+| Gemini 应用 / Google AI Pro 或 Ultra | 消费者订阅权益；可能包含 AI Studio 界面访问权限，但 Hermes 请求不使用订阅额度 | 不能用于 Hermes 身份验证 |
+| Gemini CLI“使用 Google 登录” | 自 2026 年 6 月 18 日起，Google 不再通过 Gemini CLI 为消费者账号提供服务；Gemini Code Assist Standard 和 Enterprise 订阅不受影响 | Hermes 不导入或复用 Gemini CLI OAuth 凭据 |
+| Google AI Studio / Gemini API | API 密钥，使用 API 专属配额；付费层级的计费单独管理 | 支持 — `provider: gemini` |
+| Vertex AI | Google Cloud 服务账号或应用默认凭据（ADC），使用 GCP 配额和计费 | 支持 — `provider: vertex` |
+
 :::warning Google AI 订阅不能替代 API 配置
-Google AI Pro 和 Ultra 权益并不授权在 Hermes 中使用 Gemini。Hermes 需要 [Gemini API 密钥](https://ai.google.dev/gemini-api/docs/api-key)，[API 配额和计费](https://ai.google.dev/gemini-api/docs/billing)需另行管理。请勿仅为解锁 Hermes 而购买消费者订阅。
+Google AI Pro 和 Ultra [可能包含 AI Studio 界面访问权限](https://support.google.com/googleone/answer/16105039)，但仅凭该订阅无法为 Hermes 的 `gemini` provider 完成身份验证。Hermes 仍需要 [Gemini API 密钥](https://ai.google.dev/gemini-api/docs/api-key)。请求会消耗该密钥的 [API 配额，并在付费层级上单独计费](https://ai.google.dev/gemini-api/docs/billing)，不会占用消费者订阅额度。
+
+Hermes 明确区分这些路径：`gemini` 只读取 AI Studio API 密钥，`vertex` 使用 Google Cloud 凭据。Hermes 不会在使用 `gemini` 时静默改用 Gemini CLI OAuth、Antigravity 或 Vertex 凭据。
 :::
+
+Google 已于 [2026 年 6 月 18 日终止 Gemini CLI 的消费者账号访问](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals)。其 [Gemini CLI 常见问题](https://geminicli.com/docs/resources/faq/#why-cant-i-use-third-party-software-like-claude-code-openclaw-or-opencode-with-gemini-cli)指出，对于第三方编码 Agent，受支持且安全的方式是使用 Google AI Studio API 密钥或 Vertex AI，而不是复用 Gemini CLI OAuth 凭据。
 
 ## 快速开始
 
@@ -210,9 +225,14 @@ GEMINI_API_KEY=...
 
 然后重新运行 `hermes model`。
 
-### "Unknown provider 'gemini-oauth'" 或 "Unknown provider 'google-gemini-cli'"
+### "Unknown provider 'gemini-oauth'"、"google-gemini-cli" 或 "google-antigravity"
 
-这些 provider ID 以及 `google-antigravity` 均不受支持。请使用 `provider: gemini`，并设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`；Hermes 无法复用订阅身份验证。
+这些 provider ID 均不受支持。请从配置中移除它们，并选择以下受支持的路径之一：
+
+- 使用 `provider: gemini` 并设置 `GOOGLE_API_KEY` 或 `GEMINI_API_KEY`，连接 Google AI Studio
+- 使用 `provider: vertex` 并配置 Google Cloud 凭据，连接 Vertex AI
+
+请勿将 Gemini CLI 或 Antigravity OAuth 令牌复制到 Hermes。Google 在 [Gemini CLI 常见问题](https://geminicli.com/docs/resources/faq/#why-cant-i-use-third-party-software-like-claude-code-openclaw-or-opencode-with-gemini-cli)中指出，第三方 Agent 应使用 AI Studio 或 Vertex AI。对于受 [Antigravity 条款](https://antigravity.google/terms)约束的账号，Google 声明，通过第三方软件、工具或服务访问 Antigravity 将违反该协议。
 
 ### "This Google API key is on the free tier"
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -41,13 +41,14 @@ sidebar_position: 1
 | **DeepSeek** | `~/.hermes/.env` 中的 `DEEPSEEK_API_KEY`（provider: `deepseek`） |
 | **Hugging Face** | `~/.hermes/.env` 中的 `HF_TOKEN`（provider: `huggingface`，别名：`hf`） |
 | **Google / Gemini** | `~/.hermes/.env` 中的 `GOOGLE_API_KEY`（或 `GEMINI_API_KEY`）（provider: `gemini`） |
+| **Google Vertex AI** | `hermes model` → "Google Vertex AI"（provider: `vertex`；通过服务账号 JSON 或 ADC 使用 OAuth2，采用 GCP 计费） |
 | **LM Studio** | `hermes model` → "LM Studio"（provider: `lmstudio`，可选 `LM_API_KEY`） |
 | **自定义端点** | `hermes model` → 选择"Custom endpoint"（保存在 `config.yaml`） |
 
 官方 API key 路径请参见专属的 [Google Gemini 指南](/guides/google-gemini)。
 
-:::warning Google AI Pro 和 Ultra
-消费者订阅不授权 Hermes 的 `gemini` provider。Hermes 需要 Google AI Studio API 密钥，API 配额和计费需另行管理。详情请参见 [Google Gemini 指南](/guides/google-gemini)。
+:::warning Google 身份验证与计费彼此独立
+Google AI Pro 和 Ultra 订阅无法为 Hermes 的 `gemini` provider 完成身份验证。该 provider 使用 Google AI Studio API 密钥的配额；若密钥属于付费层级，则 API 费用单独结算。`vertex` 使用独立的 Google Cloud 凭据和计费。Hermes 不导入 Gemini CLI OAuth 凭据，也不将 Antigravity 用作 provider。Google 已于 [2026 年 6 月 18 日终止 Gemini CLI 的消费者账号访问](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals)。完整说明请参见 [Google Gemini 指南](/guides/google-gemini)。
 :::
 
 :::tip 模型 key 别名

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -46,6 +46,10 @@ sidebar_position: 1
 
 官方 API key 路径请参见专属的 [Google Gemini 指南](/guides/google-gemini)。
 
+:::warning Google AI Pro 和 Ultra
+消费者订阅不授权 Hermes 的 `gemini` provider。Hermes 需要 Google AI Studio API 密钥，API 配额和计费需另行管理。详情请参见 [Google Gemini 指南](/guides/google-gemini)。
+:::
+
 :::tip 模型 key 别名
 在 `model:` 配置节中，可以使用 `default:` 或 `model:` 作为模型 ID 的键名。`model: { default: my-model }` 和 `model: { model: my-model }` 效果完全相同。
 :::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/fallback-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/fallback-providers.md
@@ -85,6 +85,10 @@ fallback_model:
 | Hugging Face | `huggingface` | `HF_TOKEN` |
 | 自定义端点 | `custom` | `base_url` + `key_env`（见下文） |
 
+:::warning Gemini 备用身份验证
+使用 `provider: gemini` 的备用项始终消耗所配置 Google AI Studio API 密钥的配额；若密钥属于付费层级，则相关 API 费用会单独结算——即使你拥有 Google AI Pro 或 Ultra 订阅。Hermes 不会在处理该备用项时静默改用 Gemini CLI OAuth、Antigravity 或 Vertex AI 凭据。如果未配置 Gemini API 密钥，该项会被跳过，而不会切换到其他 Google 计费路径。详情请参见 [Google Gemini 指南](/guides/google-gemini)。
+:::
+
 ### 自定义端点备用
 
 对于兼容 OpenAI 的自定义端点，添加 `base_url` 并可选填 `key_env`：


### PR DESCRIPTION
## What does this PR do?

Clarifies Hermes's supported Google Gemini authentication and billing boundaries after Google ended consumer-tier access through Gemini CLI on June 18, 2026.

Google's [Gemini CLI FAQ](https://geminicli.com/docs/resources/faq/#why-cant-i-use-third-party-software-like-claude-code-openclaw-or-opencode-with-gemini-cli) directs third-party coding agents to Google AI Studio API keys or Vertex AI instead of reused CLI OAuth credentials. Google also [ended consumer-tier access through Gemini CLI](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals); for accounts governed by the linked [Antigravity terms](https://antigravity.google/terms), third-party software access breaches the agreement. These sources do not support presenting Gemini CLI or Antigravity OAuth as a Hermes subscription provider.

Accordingly, this PR does not add an unsupported OAuth adapter. It documents the safe current contract: `gemini` remains Google AI Studio API-key-only, `vertex` remains a distinct GCP credential and billing route, and a Gemini fallback never silently substitutes consumer OAuth or another Google billing surface. Existing runtime behavior is unchanged.

This carries forward @Hi1mHam's English and zh-Hans work from #62295 with commit authorship preserved, then updates it for Google's June 2026 changes and the current fallback/provider architecture.

## Related Issue

Fixes #60699

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Correct `plugins/model-providers/gemini/plugin.yaml` so it no longer advertises removed Cloud Code OAuth support.
- Add an English and zh-Hans product/authentication matrix covering the Gemini app and Google AI subscriptions, Gemini CLI, AI Studio/Gemini API, and Vertex AI.
- Add safe migration guidance for stale `gemini-oauth`, `google-gemini-cli`, and `google-antigravity` provider names without recommending token reuse or private endpoints.
- Document that a `provider: gemini` fallback consumes only its configured Gemini API key's quota and any paid-tier API billing, and fails closed when no key is configured.
- Add the missing Vertex AI row to the zh-Hans provider overview so the distinct supported route is actionable.

## How to Test

1. Run the focused provider and fallback contracts:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_gemini_provider.py tests/plugins/model_providers/test_gemini_profile.py tests/providers/test_plugin_discovery.py tests/hermes_cli/test_fallback_config.py tests/run_agent/test_provider_fallback.py -q
   ```
2. Build both documentation locales from a clean output directory:
   ```bash
   cd website
   npx --yes npm@10 ci
   npx --yes npm@10 run build -- --out-dir "$(mktemp -d)"
   ```
3. Confirm the Gemini guide and fallback page render the new authentication warnings in both locales, then run `git diff --check`.

## Validation

- Focused Python suite: **41 passed, 0 failed** across 5 files.
- Docusaurus production build: **passed** for `en` and `zh-Hans`.
- `git diff --check`: **passed**.
- Added Google deprecation, Gemini CLI FAQ, Gemini API key/billing, and Antigravity links were checked against current official sources.
- The docs build reports existing unrelated zh-Hans broken-link and broken-anchor warnings; none originate from the changed Gemini or fallback pages.
- `npm run typecheck` was attempted and still hits existing website baseline errors (`baseUrl` deprecation under TypeScript 6, JSX namespace errors, and the existing `userStories.json` module-resolution error). No TypeScript files change here, and the production build compiles successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open and closed PRs, including #62295 and current OAuth proposals
- [x] My PR contains only changes related to this documentation/provider-metadata correction
- [ ] I've run the full `pytest tests/ -q` suite (focused 41-test provider/fallback suite passed)
- [x] Existing provider and fallback contract tests cover the unchanged runtime behavior; no change-detector test was added for prose
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] I've updated relevant English and zh-Hans documentation
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture or workflow changed
- [x] Cross-platform impact — N/A; documentation and provider metadata only
- [x] Tool descriptions/schemas — N/A; no tool behavior changed

## Screenshots / Logs

Not applicable; both locales were validated through the production documentation build and rendered-output assertions.
