### PR TITLE
fix(desktop): copy selected chat text again

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/clipboard.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/clipboard.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { mirrorSelection, terminalClipboardIntent } from './clipboard'
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges()
+  document.body.replaceChildren()
+})
 
 const key = (init: Partial<KeyboardEvent> & { key: string }) =>
   ({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, type: 'keydown', ...init }) as KeyboardEvent
@@ -54,19 +59,59 @@ describe('mirrorSelection', () => {
     const textarea = document.createElement('textarea')
     textarea.className = 'xterm-helper-textarea'
     el.appendChild(textarea)
+    document.body.appendChild(el)
 
     return { el, textarea }
   }
 
-  it('puts the selection where the OS copy command can find it', () => {
+  it('puts the selection where the OS copy command can find it while the terminal is focused', () => {
     const { el, textarea } = host()
+    textarea.focus()
     mirrorSelection(el, 'npm run check')
 
     expect(textarea.value).toBe('npm run check')
+    expect(textarea.selectionStart).toBe(0)
+    expect(textarea.selectionEnd).toBe('npm run check'.length)
+  })
+
+  it('keeps the text staged but does not steal the document selection when chat owns focus', () => {
+    const { el, textarea } = host()
+    const outside = document.createElement('textarea')
+    document.body.appendChild(outside)
+    outside.focus()
+
+    mirrorSelection(el, 'stale terminal scrap')
+
+    expect(textarea.value).toBe('stale terminal scrap')
+    // No `select()` — caret may sit at the end after the value write, but the
+    // range must stay collapsed so the OS copy command still sees chat text.
+    expect(textarea.selectionStart).toBe(textarea.selectionEnd)
+    expect(document.activeElement).toBe(outside)
+  })
+
+  it('does not clobber a live chat highlight even if the terminal still has focus', () => {
+    const { el, textarea } = host()
+    textarea.focus()
+
+    const outside = document.createElement('span')
+    outside.textContent = 'chat text'
+    document.body.appendChild(outside)
+    const range = document.createRange()
+    range.selectNodeContents(outside)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    mirrorSelection(el, 'terminal scrap')
+
+    expect(textarea.value).toBe('terminal scrap')
+    expect(textarea.selectionStart).toBe(textarea.selectionEnd)
+    expect(selection.toString()).toBe('chat text')
   })
 
   it('clears the mirror when the selection goes away', () => {
     const { el, textarea } = host()
+    textarea.focus()
     mirrorSelection(el, 'something')
     mirrorSelection(el, '')
 

--- a/apps/desktop/src/app/right-sidebar/terminal/clipboard.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/clipboard.ts
@@ -51,6 +51,12 @@ export function terminalClipboardIntent(
 // CoreBrowserTerminal.ts:531). Without it `webContents.copy()` — what the Edit
 // menu, ⌘C, and the right-click Copy item all call — finds no DOM selection and
 // copies nothing.
+//
+// `textarea.select()` replaces the document's live range. Only claim it while
+// the terminal owns focus AND nothing outside the terminal is highlighted —
+// otherwise a leftover terminal scrap wins ⌘C over text the user just
+// selected in chat. The terminal's own ⌘C key handler still copies via
+// writeClipboardText when focus is on the canvas path.
 export function mirrorSelection(host: HTMLElement, text: string) {
   const textarea = host.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
 
@@ -65,5 +71,18 @@ export function mirrorSelection(host: HTMLElement, text: string) {
   }
 
   textarea.value = text
+
+  if (!host.contains(document.activeElement)) {
+    return
+  }
+
+  const live = window.getSelection()
+  const foreign =
+    live && !live.isCollapsed && live.anchorNode != null && !host.contains(live.anchorNode)
+
+  if (foreign) {
+    return
+  }
+
   textarea.select()
 }

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-selection.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-selection.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { hasTextSelection } from './user-message'
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges()
+  document.body.replaceChildren()
+})
+
+describe('hasTextSelection', () => {
+  it('is false with nothing highlighted', () => {
+    expect(hasTextSelection()).toBe(false)
+  })
+
+  it('is true once the user has a live range', () => {
+    const node = document.createElement('span')
+    node.textContent = 'copy me'
+    document.body.appendChild(node)
+
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    expect(hasTextSelection()).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -16,6 +16,13 @@ import { cn } from '@/lib/utils'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
 
+/** True when the user has a live text highlight (drag-select / triple-click). */
+export function hasTextSelection(): boolean {
+  const selection = window.getSelection()
+
+  return Boolean(selection && !selection.isCollapsed && selection.toString().length > 0)
+}
+
 export function StickyHumanMessageContainer({
   attachments,
   children,
@@ -279,10 +286,16 @@ export const UserMessage: FC<{
               <div
                 className="relative w-full"
                 onContextMenu={
-                  // Right-click is the desktop stand-in for iOS touch-and-hold.
+                  // Right-click is the desktop stand-in for iOS touch-and-hold —
+                  // but only when there's nothing selected. A live highlight
+                  // keeps the native Copy menu (and ⌘C) instead of the picker.
                   readOnly || !reactionsEnabled
                     ? undefined
                     : event => {
+                        if (hasTextSelection()) {
+                          return
+                        }
+
                         event.preventDefault()
                         setPickerOpen(true)
                       }
@@ -295,7 +308,9 @@ export const UserMessage: FC<{
                     aria-expanded={bodyClamped ? expanded : undefined}
                     className={cn(bubbleClassName, !bodyClamped && 'cursor-default')}
                     onClick={() => {
-                      if (!bodyClamped) {
+                      // Drag-select ends on mouseup→click; don't collapse the
+                      // clamp just because the highlight finished.
+                      if (hasTextSelection() || !bodyClamped) {
                         return
                       }
 
@@ -310,12 +325,29 @@ export const UserMessage: FC<{
                 ) : (
                   // Always editable — clicking opens the edit composer even while a
                   // turn streams; sending the edit reverts (interrupt + rewind).
+                  // A live text highlight wins: finishing a drag-select must not
+                  // open the editor and throw the selection away.
                   <ActionBarPrimitive.Edit asChild>
                     <button
                       aria-label={copy.editMessage}
                       className={bubbleClassName}
-                      onClick={() => triggerHaptic('selection')}
-                      onPointerDown={() => notifyThreadEditOpen()}
+                      onClick={event => {
+                        if (hasTextSelection()) {
+                          event.preventDefault()
+                          event.stopPropagation()
+
+                          return
+                        }
+
+                        triggerHaptic('selection')
+                      }}
+                      onPointerDown={() => {
+                        if (hasTextSelection()) {
+                          return
+                        }
+
+                        notifyThreadEditOpen()
+                      }}
                       title={copy.editMessage}
                       type="button"
                     >

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1008,6 +1008,15 @@ button,
   user-select: none;
 }
 
+/* User bubbles are <button>s (click → edit), so the rule above would kill
+   drag-to-select and leave ⌘C with nothing to grab. Message text stays
+   selectable; chrome controls outside the bubble keep user-select: none. */
+[data-slot='aui_user-message-root'] button,
+[data-slot='aui_user-message-root'] [role='button'] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 img,
 picture,
 video,


### PR DESCRIPTION
## Summary
- User bubbles are buttons, so global `user-select: none` blocked drag-select; override it under the bubble root and skip react/edit handlers when text is highlighted
- Terminal `mirrorSelection` no longer steals the document selection (and ⌘C) while chat has a live highlight

## Test plan
- [ ] Drag-select text in a user bubble; ⌘C copies it
- [ ] Right-click selected user-bubble text → native Copy menu (not reaction picker)
- [ ] Finish a drag-select without opening the edit composer
- [ ] Select assistant text and ⌘C while a terminal tab has leftover selection
- [ ] Terminal ⌘C / Edit → Copy still works when the terminal is focused