### PR TITLE
fix(kanban): resume prior worker session on blocked-task respawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8867,6 +8867,47 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+def _resume_session_id_for_task(
+    task_id: str,
+    *,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Return the prior worker session id to resume for ``task_id``, if any.
+
+    Workers stamp ``task_runs.metadata.worker_session_id`` on complete/block
+    (see ``tools.kanban_tools._stamp_worker_session_metadata``). When the
+    dispatcher re-spawns the same task after a block→unblock (or any other
+    respawn), reusing that session preserves the prior run's conversation
+    instead of starting a blank worker (#75830).
+
+    Fail-open: any DB / parse error returns ``None`` so spawn still works
+    as a fresh session. First dispatch has no prior ended run, so it also
+    returns ``None``.
+    """
+    if not task_id:
+        return None
+    try:
+        with connect(board=board) as conn:
+            # Ended runs only — the active claim for *this* spawn has no
+            # worker_session_id yet (stamped on complete/block).
+            runs = list_runs(conn, task_id, include_active=False)
+            for run in reversed(runs):
+                meta = run.metadata if isinstance(run.metadata, dict) else None
+                if not meta:
+                    continue
+                sid = meta.get("worker_session_id")
+                if isinstance(sid, str) and sid.strip():
+                    return sid.strip()
+    except Exception as exc:
+        _log.debug(
+            "kanban worker: resume session lookup failed for %s (%s)",
+            task_id,
+            exc,
+        )
+        return None
+    return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -9029,6 +9070,13 @@ def _default_spawn(
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+    # Resume the prior worker session when this task was blocked (or
+    # otherwise re-spawned). Without --resume the child generates a new
+    # HERMES_SESSION_ID and loses the analysis that led to the block
+    # (#75830). Fail-open: missing stamp / DB error → fresh session.
+    resume_sid = _resume_session_id_for_task(task.id, board=board)
+    if resume_sid:
+        cmd.extend(["--resume", resume_sid])
     cmd.extend([
         "chat",
         "-q", prompt,

--- a/tests/hermes_cli/test_kanban_resume_blocked_session.py
+++ b/tests/hermes_cli/test_kanban_resume_blocked_session.py
@@ -1,0 +1,179 @@
+"""Blocked→unblocked workers must resume the prior worker session (#75830).
+
+Workers stamp ``task_runs.metadata.worker_session_id`` on complete/block.
+``_default_spawn`` must pass ``--resume <sid>`` so a fresh process continues
+the prior conversation instead of starting blank.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _make_task(task_id: str = "t_resume_blocked", *, assignee: str = "default") -> kb.Task:
+    return kb.Task(
+        id=task_id,
+        title="resume blocked",
+        body=None,
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+
+
+def _capture_spawn(monkeypatch, tmp_path, task: kb.Task, *, board=None):
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
+    monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
+
+    captured: dict = {}
+
+    class FakeProc:
+        pid = 9001
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    pid = kb._default_spawn(task, str(workspace), board=board)
+    captured["pid"] = pid
+    return captured
+
+
+def test_resume_session_id_none_when_no_prior_runs(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="first try", assignee="worker")
+    assert kb._resume_session_id_for_task(tid) is None
+
+
+def test_resume_session_id_from_blocked_run_metadata(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs input", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker:1") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="blocked for decision",
+            metadata={"worker_session_id": "20260801_113226_8fb971"},
+        )
+    assert kb._resume_session_id_for_task(tid) == "20260801_113226_8fb971"
+
+
+def test_resume_session_id_prefers_newest_ended_run(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="multi run", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker:1") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="first attempt",
+            metadata={"worker_session_id": "session_old"},
+        )
+        # Re-open as ready for a second claim (simulates unblock → re-dispatch).
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', completed_at = NULL, result = NULL "
+            "WHERE id = ?",
+            (tid,),
+        )
+        conn.commit()
+        assert kb.claim_task(conn, tid, claimer="worker:2") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="second attempt",
+            metadata={"worker_session_id": "session_new"},
+        )
+    assert kb._resume_session_id_for_task(tid) == "session_new"
+
+
+def test_resume_session_id_skips_runs_without_stamp(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="no stamp", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker:1") is not None
+        assert kb.complete_task(conn, tid, result="ok", metadata={"files": 2})
+    assert kb._resume_session_id_for_task(tid) is None
+
+
+def test_resume_session_id_fail_open_on_db_error(monkeypatch, kanban_home):
+    def boom(*_a, **_k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(kb, "connect", boom)
+    assert kb._resume_session_id_for_task("t_any") is None
+
+
+def test_default_spawn_passes_resume_when_prior_session_exists(kanban_home, monkeypatch, tmp_path):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="unblock me", assignee="default")
+        assert kb.claim_task(conn, tid, claimer="worker:1") is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="need design decision",
+            metadata={"worker_session_id": "20260801_113226_8fb971"},
+        )
+
+    (kanban_home / "profiles" / "default").mkdir(parents=True, exist_ok=True)
+    captured = _capture_spawn(monkeypatch, tmp_path, _make_task(tid, assignee="default"))
+
+    assert captured["pid"] == 9001
+    cmd = captured["cmd"]
+    assert "--resume" in cmd
+    assert cmd[cmd.index("--resume") + 1] == "20260801_113226_8fb971"
+    # Resume is a top-level flag, before the chat subcommand.
+    assert cmd.index("--resume") < cmd.index("chat")
+    assert "chat" in cmd
+    assert "-q" in cmd
+
+
+def test_default_spawn_omits_resume_on_first_dispatch(kanban_home, monkeypatch, tmp_path):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fresh", assignee="default")
+
+    (kanban_home / "profiles" / "default").mkdir(parents=True, exist_ok=True)
+    captured = _capture_spawn(monkeypatch, tmp_path, _make_task(tid, assignee="default"))
+
+    assert "--resume" not in captured["cmd"]
+    assert "chat" in captured["cmd"]
+
+
+def test_default_spawn_omits_resume_when_lookup_returns_none(
+    kanban_home, monkeypatch, tmp_path
+):
+    (kanban_home / "profiles" / "default").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(kb, "_resume_session_id_for_task", lambda *_a, **_k: None)
+    captured = _capture_spawn(
+        monkeypatch, tmp_path, _make_task("t_no_resume", assignee="default")
+    )
+    assert "--resume" not in captured["cmd"]


### PR DESCRIPTION
## Summary

When a kanban card is blocked and later unblocked, the dispatcher currently spawns a **fresh** worker with no `--resume`. The prior run's conversation (analysis, decisions, partial work) sits in the session DB under `task_runs.metadata.worker_session_id` but is never wired through, so the new worker re-investigates from a blank slate.

This PR looks up the most recent ended run's `worker_session_id` in `_default_spawn` and passes `--resume <sid>` so the new process continues the same session. Fail-open: missing stamp or DB error keeps today's fresh-session behavior.

Fixes #75830

## Changes

- Add `_resume_session_id_for_task(task_id, board=...)` — scans ended `task_runs` newest-first for `metadata.worker_session_id`
- Wire it into `_default_spawn` as a top-level `--resume` flag before `chat -q`
- Tests for lookup (none / stamp / newest / fail-open) and spawn argv

## Why not #59855 / parent-chain resume?

- **#59855** / open #60472: crash/reclaim resume with opt-in state — different lifecycle
- Open #34422: resumes a **parent** task session for reverse/rework follow-ups — not same-task blocked→unblocked
- Open #33879: storage primitives draft; workers already stamp `worker_session_id` today, so no schema change needed here

## Safety

Resume runs inside the dispatcher's spawn path with the full `HERMES_KANBAN_*` env set (task / db / board / run id / claim lock), so the child remains a tracked writer — not a detached CLI resume of a terminal kanban session.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_kanban_resume_blocked_session.py` — 8 passed
- [x] Related spawn/board/goal tests — 41 passed total with this suite
- [ ] Manual: block a card with real worker work, unblock, confirm log shows resumed session id