### PR TITLE
fix(desktop): restore workspace startup and enable kanban

### DIFF
--- a/apps/desktop/src/app/right-sidebar/store.test.ts
+++ b/apps/desktop/src/app/right-sidebar/store.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storage = new Map<string, string>()
+
+describe('terminal takeover state', () => {
+  beforeEach(() => {
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('starts closed even when a stale persisted takeover flag exists', async () => {
+    storage.set('hermes.desktop.terminalTakeover', 'true')
+
+    const { $terminalTakeover } = await import('./store')
+
+    expect($terminalTakeover.get()).toBe(false)
+  })
+
+  it('changes only the current session state', async () => {
+    const { $terminalTakeover, setTerminalTakeover } = await import('./store')
+
+    setTerminalTakeover(true)
+
+    expect($terminalTakeover.get()).toBe(true)
+    expect(storage.has('hermes.desktop.terminalTakeover')).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/store.ts
+++ b/apps/desktop/src/app/right-sidebar/store.ts
@@ -1,12 +1,9 @@
 import { atom } from 'nanostores'
 
-import { persistBoolean, storedBoolean } from '@/lib/storage'
-
-const TAKEOVER_KEY = 'hermes.desktop.terminalTakeover'
-
-export const $terminalTakeover = atom(storedBoolean(TAKEOVER_KEY, false))
-
-$terminalTakeover.subscribe(active => persistBoolean(TAKEOVER_KEY, active))
+// Terminal visibility is deliberately session-scoped. Persisting this flag
+// made a terminal opened once become the first screen after every relaunch,
+// and a stale true value could leave the terminal overlay over the app chrome.
+export const $terminalTakeover = atom(false)
 
 export const setTerminalTakeover = (active: boolean) => $terminalTakeover.set(active)
 

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -53,7 +53,29 @@ function loadPersisted(): LayoutNode | null {
 
   // Canonicalize on load: strips stale attributes older code persisted
   // (e.g. explicit headerHidden on lone-pane zones) and re-flattens.
-  return isLayoutNode(parsed) ? normalize(parsed) : null
+  if (!isLayoutNode(parsed)) {
+    return null
+  }
+
+  const normalized = normalize(parsed)
+
+  return normalized ? normalizeStartupTree(normalized) : null
+}
+
+/**
+ * Recover the launch view without discarding the user's layout. The workspace
+ * is the app's navigation surface; if a persisted custom layout left another
+ * pane (most notably the terminal) active in that group, booting into it made
+ * the app look and behave like a terminal-only screen until a layout edit.
+ */
+function normalizeStartupTree(tree: LayoutNode): LayoutNode {
+  const workspaceGroup = findGroupOfPane(tree, 'workspace')
+
+  if (!workspaceGroup || workspaceGroup.active === 'workspace') {
+    return tree
+  }
+
+  return setActivePaneOp(tree, workspaceGroup.id, 'workspace')
 }
 
 function persist(tree: LayoutNode | null) {

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -5,8 +5,8 @@
  * through `ctx.rest` (namespace-scoped to `/api/plugins/kanban`). No new
  * backend, no core edits.
  *
- * Ships OFF by default (`defaultEnabled: false`): it inventories in
- * Settings ▸ Plugins and registers nothing until the user flips the switch.
+ * Ships enabled by default so the official Desktop Kanban page is available
+ * immediately after launch. It remains live-toggleable in Settings ▸ Plugins.
  */
 
 import './kanban.css'
@@ -80,7 +80,7 @@ function KanbanCount() {
 const plugin: HermesPlugin = {
   id: 'kanban',
   name: 'Kanban',
-  defaultEnabled: false,
+  defaultEnabled: true,
   register(ctx) {
     ctx.i18n.register(KANBAN_LOCALES)
     ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket))


### PR DESCRIPTION
## Summary
- Keep terminal takeover state session-scoped instead of restoring a stale persisted overlay on relaunch.
- Normalize the startup pane tree so the workspace view is active when a persisted layout selected another pane.
- Enable the official Desktop Kanban plugin by default so it is available immediately after launch.

## Test plan
- `npm run test:ui -- src/app/right-sidebar/store.test.ts src/contrib/plugin.test.ts src/i18n/plugin-i18n.test.tsx --run`
  - 3 test files passed, 9 tests passed
- `npx eslint src/app/right-sidebar/store.ts src/app/right-sidebar/store.test.ts src/components/pane-shell/tree/store.ts src/plugins/kanban/plugin.tsx`
- `git diff --check`

The i18n test emits existing React `act(...)` warnings but passes.