### PR TITLE
fix(telegram): let pairing-bound DMs past early auth with allowlist

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1039,7 +1039,7 @@ class TelegramAdapter(BasePlatformAdapter):
         operator explicitly opted back into pairing via a platform override
         (resolution rule 1 in ``_get_unauthorized_dm_behavior``).
         """
-        if (getattr(source, "chat_type", None) or "") != "dm":
+        if source.chat_type != "dm":
             return False
 
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
@@ -1146,9 +1146,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if authorized:
             return True
         # Unauthorized DM that the gateway would pair: forward so pairing can run.
-        if self._should_pass_unauthorized_dm_for_pairing(source):
-            return True
-        return False
+        return self._should_pass_unauthorized_dm_for_pairing(source)
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1029,6 +1029,40 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         return any(os.getenv(key, "").strip() for key in keys)
 
+    def _should_pass_unauthorized_dm_for_pairing(self, source) -> bool:
+        """Return True when an unauthorized DM must still reach gateway pairing.
+
+        Early auth (#40863) rejects before event construction. That is correct
+        when unauthorized DMs are ignored, but it must not short-circuit the
+        gateway pairing handshake when ``unauthorized_dm_behavior`` resolves
+        to ``pair`` — including the case where an allowlist is set and the
+        operator explicitly opted back into pairing via a platform override
+        (resolution rule 1 in ``_get_unauthorized_dm_behavior``).
+        """
+        if (getattr(source, "chat_type", None) or "") != "dm":
+            return False
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        behavior_fn = getattr(runner, "_get_unauthorized_dm_behavior", None)
+        if callable(behavior_fn):
+            try:
+                return (
+                    behavior_fn(
+                        Platform.TELEGRAM,
+                        profile=getattr(source, "profile", None),
+                    )
+                    == "pair"
+                )
+            except Exception:
+                logger.debug(
+                    "[Telegram] Failed to resolve unauthorized DM behavior; "
+                    "falling back to adapter-local override",
+                    exc_info=True,
+                )
+
+        extra = getattr(getattr(self, "config", None), "extra", None) or {}
+        return str(extra.get("unauthorized_dm_behavior", "")).strip().lower() == "pair"
+
     def _is_user_authorized_from_message(self, message: Message) -> bool:
         """Check if the sender of a Telegram message is authorized.
 
@@ -1038,6 +1072,8 @@ class TelegramAdapter(BasePlatformAdapter):
         transcript (fixes #40863). It only rejects when it can make the same
         context-aware decision the runner would make. Unknown DMs with no
         allowlist still pass through so the normal pairing flow can run.
+        Unknown DMs with an allowlist still pass through when pairing is the
+        effective unauthorized-DM behavior (explicit platform override).
         """
         source = self._source_from_message_for_auth(message)
         user_id = source.user_id
@@ -1049,6 +1085,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not user_id:
             return True
 
+        authorized: Optional[bool] = None
+
         # Adapter-level allow_from / group_allow_from: when set, they are the
         # sole authority.  Group chats use group_allow_from; DMs use allow_from.
         chat_type = source.chat_type or ""
@@ -1058,49 +1096,59 @@ class TelegramAdapter(BasePlatformAdapter):
             adapter_allow_from = self.config.extra.get("allow_from")
         if adapter_allow_from is not None:
             allowed = _coerce_allow_set(adapter_allow_from)
-            return user_id in allowed or "*" in allowed
+            authorized = user_id in allowed or "*" in allowed
 
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
         # not be treated as a user-id-only shortcut for real messages — only
         # honor an instance-level override (set in tests).
-        callback_auth = self.__dict__.get("_is_callback_user_authorized")
-        if callable(callback_auth):
-            try:
-                return bool(
-                    callback_auth(
-                        user_id,
-                        chat_id=source.chat_id,
-                        chat_type=source.chat_type,
-                        thread_id=source.thread_id,
-                        user_name=source.user_name,
+        if authorized is None:
+            callback_auth = self.__dict__.get("_is_callback_user_authorized")
+            if callable(callback_auth):
+                try:
+                    authorized = bool(
+                        callback_auth(
+                            user_id,
+                            chat_id=source.chat_id,
+                            chat_type=source.chat_type,
+                            thread_id=source.thread_id,
+                            user_name=source.user_name,
+                        )
                     )
-                )
-            except Exception:
-                pass
+                except Exception:
+                    pass
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-        auth_fn = getattr(runner, "_is_user_authorized", None)
-        if callable(auth_fn):
-            # Only make an early decision via the runner when an allowlist
-            # actually exists; otherwise unknown DMs must reach the pairing
-            # flow rather than being default-denied here.
-            if not self._telegram_auth_env_configured():
+        if authorized is None:
+            runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+            auth_fn = getattr(runner, "_is_user_authorized", None)
+            if callable(auth_fn):
+                # Only make an early decision via the runner when an allowlist
+                # actually exists; otherwise unknown DMs must reach the pairing
+                # flow rather than being default-denied here.
+                if not self._telegram_auth_env_configured():
+                    return True
+                try:
+                    authorized = bool(auth_fn(source))
+                except Exception:
+                    logger.debug(
+                        "[Telegram] Falling back to env-only auth for user %s",
+                        user_id,
+                        exc_info=True,
+                    )
+
+        if authorized is None:
+            allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
+            if not allowed_csv:
                 return True
-            try:
-                return bool(auth_fn(source))
-            except Exception:
-                logger.debug(
-                    "[Telegram] Falling back to env-only auth for user %s",
-                    user_id,
-                    exc_info=True,
-                )
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            authorized = "*" in allowed_ids or user_id in allowed_ids
 
-        allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
-        if not allowed_csv:
+        if authorized:
             return True
-        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-        return "*" in allowed_ids or user_id in allowed_ids
+        # Unauthorized DM that the gateway would pair: forward so pairing can run.
+        if self._should_pass_unauthorized_dm_for_pairing(source):
+            return True
+        return False
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -144,6 +144,131 @@ def test_is_user_authorized_from_message_allow_from():
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
+def test_allowlist_dm_with_explicit_pair_behavior_reaches_gateway(monkeypatch):
+    """Allowlist + unauthorized_dm_behavior:pair must not early-drop unknown DMs.
+
+    Regression for the gap left by #40863: early intake rejection discarded
+    unauthorized DMs before gateway pairing could run, even when the operator
+    explicitly set telegram.unauthorized_dm_behavior: pair.
+    """
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            return source.user_id == "111"
+
+        def _get_unauthorized_dm_behavior(self, platform, *, profile=None):
+            assert platform == Platform.TELEGRAM
+            return "pair"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter()
+    adapter._message_handler = runner.handle
+    msg = _make_message(from_user_id=999, chat_id=999, chat_type="private")
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_allowlist_dm_without_pair_behavior_still_early_rejects(monkeypatch):
+    """Allowlist without pairing opt-in keeps the #9337/#40863 silent drop."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            return source.user_id == "111"
+
+        def _get_unauthorized_dm_behavior(self, platform, *, profile=None):
+            return "ignore"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter()
+    adapter._message_handler = runner.handle
+    msg = _make_message(from_user_id=999, chat_id=999, chat_type="private")
+
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_allow_from_dm_with_pair_override_reaches_gateway():
+    """Adapter allow_from + unauthorized_dm_behavior:pair still forwards DMs."""
+    adapter = _make_adapter(
+        allow_from=["111"],
+        unauthorized_dm_behavior="pair",
+    )
+    msg = _make_message(from_user_id=999, chat_id=999, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_allowlist_group_with_pair_behavior_still_early_rejects(monkeypatch):
+    """Pairing is DM-only — unauthorized group senders stay blocked early."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            return source.user_id == "111"
+
+        def _get_unauthorized_dm_behavior(self, platform, *, profile=None):
+            return "pair"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter(group_allow_from=["111"])
+    adapter._message_handler = runner.handle
+    msg = _make_message(from_user_id=999, chat_id=-100, chat_type="group")
+
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_dm_with_pair_behavior_builds_event(monkeypatch):
+    """Unknown DM under pair behavior must reach event construction."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            return source.user_id == "111"
+
+        def _get_unauthorized_dm_behavior(self, platform, *, profile=None):
+            return "pair"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter()
+    adapter._message_handler = runner.handle
+    build_called = False
+    original_build = adapter._build_message_event
+
+    def track_build(*a, **kw):
+        nonlocal build_called
+        build_called = True
+        return original_build(*a, **kw)
+
+    adapter._build_message_event = track_build
+    adapter._enqueue_text_event = lambda event: None
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._cache_replied_media = AsyncMock()
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    adapter._clean_bot_trigger_text = lambda text: text
+    adapter._should_process_message = lambda *a, **kw: True
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(from_user_id=999, chat_id=999, chat_type="private"),
+        effective_message=None,
+    )
+    await adapter._handle_text_message(update, SimpleNamespace())
+    assert build_called is True
+
+
 def test_runner_auth_gets_group_user_allowlist_context(monkeypatch):
     """Group user allowlists need a group-shaped source, not a DM-shaped one."""
     monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_USERS", "111")


### PR DESCRIPTION
## Summary
Unauthorized Telegram DMs now reach the gateway pairing handshake when `unauthorized_dm_behavior: pair` is set, even with an allowlist configured.

After #40863, early auth rejected unauthorized DMs before event construction. That broke the documented case where `TELEGRAM_ALLOWED_USERS` is set **and** `telegram.unauthorized_dm_behavior: pair` (platform override must win over the #9337 allowlist-silence default). This forwards those DMs to the gateway pairing handshake; unauthorized group senders and `ignore` mode stay early-rejected.

Salvage of #75408 by @xxxigm — cherry-picked with authorship preserved, minor cleanup applied.

## Changes
- `plugins/platforms/telegram/adapter.py`: Added `_should_pass_unauthorized_dm_for_pairing()` — checks the effective DM behavior from the adapter side via the runner's `_get_unauthorized_dm_behavior`, with a fallback to adapter-local config. Refactored `_is_user_authorized_from_message()` to use an `authorized: Optional[bool]` accumulator so the pairing check runs after all auth paths resolve.
- `tests/gateway/test_telegram_auth_check.py`: 5 new tests covering pair+allowlist, ignore+allowlist, group rejection, adapter allow_from override, and end-to-end event construction.

## Validation
| | Before | After |
|---|---|---|
| Allowlist + pair behavior | DM silently dropped | DM reaches pairing |
| Allowlist + ignore behavior | DM silently dropped | DM silently dropped (unchanged) |
| Group messages + pair | N/A | Still blocked early (DM-only) |
| No allowlist | DM reaches pairing | DM reaches pairing (unchanged) |
| Test suite | 6 tests | 11 tests (all pass) |

Closes #75408
