### PR TITLE
fix(desktop): hide placeholder during IME composition

### DIFF
--- a/apps/desktop/src/app/chat/composer/empty-composer.test.ts
+++ b/apps/desktop/src/app/chat/composer/empty-composer.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { composerPlainText, normalizeComposerEditorDom, renderComposerContents, RICH_INPUT_SLOT } from './rich-editor'
+import {
+  beginComposerComposition,
+  composerPlainText,
+  normalizeComposerEditorDom,
+  renderComposerContents,
+  RICH_INPUT_SLOT
+} from './rich-editor'
 
 function editor(): HTMLDivElement {
   const el = document.createElement('div')
@@ -81,6 +87,14 @@ describe('an emptied composer shows its placeholder again', () => {
 
   it('advertises emptiness for a truly childless editor', () => {
     expect(editor().matches(PLACEHOLDER_SHOWS)).toBe(true)
+  })
+
+  it('hides the placeholder before IME preedit text starts', () => {
+    const el = emptied()
+
+    beginComposerComposition(el)
+
+    expect(el.matches(PLACEHOLDER_SHOWS)).toBe(false)
   })
 
   it('stops advertising it once something is typed', () => {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -57,6 +57,7 @@ import { ActionBadges } from './micro-actions'
 import { chipTypedPathOnSpace, pathifyRefs } from './path-refs'
 import { QueuePanel } from './queue-panel'
 import {
+  beginComposerComposition,
   COMPOSER_PLACEHOLDER_CLASS,
   composerPlainText,
   deleteChipBeforeCaret,
@@ -969,8 +970,9 @@ export function ChatBar({
           // until an unrelated edit forces a sync (#39614).
           flushEditorToDraft(event.currentTarget)
         }}
-        onCompositionStart={() => {
+        onCompositionStart={event => {
           composingRef.current = true
+          beginComposerComposition(event.currentTarget)
         }}
         onDragOver={handleInputDragOver}
         onDrop={handleInputDrop}

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -34,6 +34,14 @@ export const RICH_INPUT_SLOT = 'composer-rich-input'
 export const COMPOSER_PLACEHOLDER_CLASS =
   '[&:is(:empty,[data-empty])]:before:content-[attr(data-placeholder)] [&:is(:empty,[data-empty])]:before:text-muted-foreground/60'
 
+/** IME preedit belongs at the real caret, not after the inline placeholder.
+ * `data-empty` can outlive the first composition events because those input
+ * events are intentionally ignored until compositionend. Hide it up front;
+ * normalizeComposerEditorDom restores it if composition ends empty. */
+export function beginComposerComposition(editor: HTMLElement) {
+  delete editor.dataset.empty
+}
+
 /** Keep that marker in step with the editor root's contents. */
 export function markEditorEmptiness(editor: HTMLElement) {
   if (editor.childNodes.length === 0) {


### PR DESCRIPTION
## Summary

- hide the inline composer placeholder synchronously when IME composition starts
- keep the scaffolding `<br>` and existing empty-state normalization unchanged
- add a DOM regression test for the normalized empty-editor state

Closes #75960

## Root cause

A normalized empty composer contains a scaffolding `<br>` and uses `data-empty` to keep its `::before` placeholder visible. Input events are intentionally skipped while IME composition is active, so that marker remained set until `compositionend`. The placeholder therefore stayed in the inline flow and CJK preedit text appeared after it.

The fix clears only the explicit marker in `compositionstart`. Existing `compositionend` normalization restores it if composition finishes without committed text.

## Changed files

| File | Change |
| --- | --- |
| `apps/desktop/src/app/chat/composer/index.tsx` | Clear the empty marker at IME composition start |
| `apps/desktop/src/app/chat/composer/rich-editor.ts` | Add the focused composition-start DOM helper |
| `apps/desktop/src/app/chat/composer/empty-composer.test.ts` | Assert the placeholder is hidden before preedit begins |

## Test plan

- [x] `npm run test:ui -- src/app/chat/composer` — 36 files, 276 tests passed
- [x] `npm run typecheck`
- [x] `npx eslint src/app/chat/composer/index.tsx src/app/chat/composer/rich-editor.ts src/app/chat/composer/empty-composer.test.ts`
- [x] `npm run build`
