### PR TITLE
fix: reteste Codex apres un quota anticipe

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -384,6 +384,27 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     return None
 
 
+def _is_rate_limited_exhaustion(entry: PooledCredential) -> bool:
+    """Return whether an exhausted entry may recover without re-authentication."""
+    if entry.last_status != STATUS_EXHAUSTED:
+        return False
+    code = getattr(entry, "last_error_code", None)
+    if code == 429 or str(code or "").strip() == "429":
+        return True
+    if str(code or "").strip() in {"401", "403"}:
+        return False
+    reason = str(getattr(entry, "last_error_reason", None) or "").lower()
+    message = str(getattr(entry, "last_error_message", None) or "").lower()
+    markers = (
+        "rate_limit",
+        "rate limit",
+        "usage_limit",
+        "usage limit",
+        "quota",
+    )
+    return any(marker in reason or marker in message for marker in markers)
+
+
 def _normalize_custom_pool_name(name: str) -> str:
     """Normalize a custom provider name for use as a pool key suffix."""
     return name.strip().lower().replace(" ", "-")
@@ -1508,11 +1529,18 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
+    def select(self, *, allow_rate_limited: bool = False) -> Optional[PooledCredential]:
+        """Select a usable credential, optionally probing a quota cooldown."""
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(allow_rate_limited=allow_rate_limited)
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
+    def _available_entries(
+        self,
+        *,
+        clear_expired: bool = False,
+        refresh: bool = False,
+        allow_rate_limited: bool = False,
+    ) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
@@ -1604,9 +1632,13 @@ class CredentialPool:
                 continue
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry)
-                if exhausted_until is not None and now < exhausted_until:
-                    continue
-                if clear_expired:
+                keep_exhausted = exhausted_until is not None and now < exhausted_until
+                if keep_exhausted:
+                    if not (allow_rate_limited and _is_rate_limited_exhaustion(entry)):
+                        continue
+                    # Keep the persisted exhausted marker. The caller is
+                    # probing the provider, not declaring the quota recovered.
+                if clear_expired and not keep_exhausted:
                     cleared = replace(
                         entry,
                         last_status=STATUS_OK,
@@ -1646,8 +1678,17 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Optional[PooledCredential]:
-        available = self._available_entries(clear_expired=True, refresh=refresh)
+    def _select_unlocked(
+        self,
+        *,
+        refresh: bool = True,
+        allow_rate_limited: bool = False,
+    ) -> Optional[PooledCredential]:
+        available = self._available_entries(
+            clear_expired=True,
+            refresh=refresh,
+            allow_rate_limited=allow_rate_limited,
+        )
         if not available:
             self._current_id = None
             self._log_no_available_entries()

--- a/cli.py
+++ b/cli.py
@@ -10489,11 +10489,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         if _name not in merged:
                             merged.append(_name)
                     enabled_override = merged
-                refresh_agent_mcp_tools(
-                    self.agent,
-                    enabled_override=enabled_override,
-                    quiet_mode=True,
-                )
+                # Pass the override only when one was actually computed:
+                # ``enabled_override=None`` now means "every toolset", which
+                # would widen a CLI pinned to a narrow (or empty) selection.
+                refresh_kwargs = {"quiet_mode": True}
+                if enabled_override is not None:
+                    refresh_kwargs["enabled_override"] = enabled_override
+                refresh_agent_mcp_tools(self.agent, **refresh_kwargs)
                 # Keep the CLI's own list in sync with what the agent now uses.
                 if enabled_override is not None:
                     self.enabled_toolsets = enabled_override

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2070,16 +2070,35 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except AuthError as auth_exc:
         # Distinguish a transient rate-limit/quota cap (credentials are fine,
         # re-auth cannot help) from a genuine auth failure (expired/revoked
-        # token). Both fall through to the fallback chain, but the log message
-        # must not mislabel a quota exhaustion as an auth failure (#32790).
+        # token). A quota exhaustion gets a runtime probe before fallback; the
+        # log message must not mislabel it as an auth failure (#32790).
         if is_rate_limited_auth_error(auth_exc):
-            logger.warning("Primary provider rate-limited (429): %s — trying fallback", auth_exc)
+            logger.warning("Primary provider rate-limited (429): %s", auth_exc)
+            try:
+                # Keep a quota-limited primary runtime alive so the first real
+                # request can test whether the provider recovered early. The
+                # existing per-turn fallback cooldown will retry this primary
+                # instead of freezing the session on the fallback provider.
+                runtime = resolve_runtime_provider(probe_rate_limited=True)
+            except Exception as probe_exc:
+                logger.info(
+                    "Primary rate-limit probe unavailable: %s; trying fallback",
+                    probe_exc,
+                )
+                fb_config = _try_resolve_fallback_provider()
+                if fb_config is not None:
+                    return fb_config
+                raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+            logger.info(
+                "Primary provider retained after rate-limit probe: %s",
+                runtime.get("provider"),
+            )
         else:
-            logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
-        fb_config = _try_resolve_fallback_provider()
-        if fb_config is not None:
-            return fb_config
-        raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+            logger.warning("Primary provider auth failed: %s; trying fallback", auth_exc)
+            fb_config = _try_resolve_fallback_provider()
+            if fb_config is not None:
+                return fb_config
+            raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3727,6 +3727,7 @@ def resolve_codex_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    allow_rate_limited: bool = False,
 ) -> Dict[str, Any]:
     """Resolve runtime credentials from Hermes's own Codex token store.
 
@@ -3738,6 +3739,10 @@ def resolve_codex_runtime_credentials(
     pool seed, a partial re-auth, or pool-only restoration from a backup — gets a bare
     HTTP 401 ``Missing Authentication header`` from the wire instead of a usable
     credential. See issue #32992.
+
+    ``allow_rate_limited`` is reserved for an active runtime probe. It admits
+    a credential whose persisted quota cooldown may be stale, while keeping
+    terminal auth failures excluded.
     """
     read_error: Optional[AuthError] = None
     try:
@@ -3758,7 +3763,9 @@ def resolve_codex_runtime_credentials(
             data = None
 
     if data is None:
-        pool_token = _pool_codex_access_token()
+        pool_token = _pool_codex_access_token(
+            allow_rate_limited=allow_rate_limited,
+        )
         if pool_token:
             base_url = (
                 os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
@@ -3911,7 +3918,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     return None
 
 
-def _pool_codex_access_token() -> str:
+def _pool_codex_access_token(*, allow_rate_limited: bool = False) -> str:
     """Return the most-recent usable access_token from the openai-codex pool.
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
@@ -3940,7 +3947,7 @@ def _pool_codex_access_token() -> str:
             # Skip entries currently in an exhaustion cooldown window.
             reset_at = entry.get("last_error_reset_at")
             if isinstance(reset_at, (int, float)) and reset_at > time.time():
-                return False
+                return allow_rate_limited and _codex_entry_is_rate_limited(entry)
             return True
 
         for entry in entries:
@@ -3949,6 +3956,27 @@ def _pool_codex_access_token() -> str:
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""
+
+
+def _codex_entry_is_rate_limited(entry: Dict[str, Any]) -> bool:
+    """Return whether a persisted Codex entry is a recoverable quota failure."""
+    if not isinstance(entry, dict) or entry.get("last_status") != "exhausted":
+        return False
+    code = entry.get("last_error_code")
+    if code == 429 or str(code or "").strip() == "429":
+        return True
+    if str(code or "").strip() in {"401", "403"}:
+        return False
+    reason = str(entry.get("last_error_reason") or "").lower()
+    message = str(entry.get("last_error_message") or "").lower()
+    markers = (
+        "rate_limit",
+        "rate limit",
+        "usage_limit",
+        "usage limit",
+        "quota",
+    )
+    return any(marker in reason or marker in message for marker in markers)
 
 
 # =============================================================================

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1525,6 +1525,7 @@ def resolve_runtime_provider(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
+    probe_rate_limited: bool = False,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 
@@ -1535,6 +1536,10 @@ def resolve_runtime_provider(
     api_mode is derived from the model they are switching TO, not the stale
     persisted default. Other callers can leave it None to preserve existing
     behavior (api_mode derived from config).
+
+    probe_rate_limited: admit a persisted Codex credential marked exhausted
+    only by a recoverable rate-limit/quota, so the caller can test whether the
+    provider recovered before activating a fallback. The default remains false.
     """
     requested_provider = resolve_requested_provider(requested)
 
@@ -1724,7 +1729,10 @@ def resolve_runtime_provider(
     except Exception:
         pool = None
     if pool and pool.has_credentials():
-        entry = pool.select()
+        if probe_rate_limited and provider == "openai-codex":
+            entry = pool.select(allow_rate_limited=True)
+        else:
+            entry = pool.select()
         pool_api_key = ""
         if entry is not None:
             pool_api_key = (
@@ -1811,7 +1819,10 @@ def resolve_runtime_provider(
 
     if provider == "openai-codex":
         try:
-            creds = resolve_codex_runtime_credentials()
+            if probe_rate_limited:
+                creds = resolve_codex_runtime_credentials(allow_rate_limited=True)
+            else:
+                creds = resolve_codex_runtime_credentials()
             return {
                 "provider": "openai-codex",
                 "api_mode": "codex_responses",

--- a/model_tools.py
+++ b/model_tools.py
@@ -366,12 +366,16 @@ def _compute_tool_definitions(
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
-        if os.environ.get("HERMES_KANBAN_TASK") and "kanban" not in effective_enabled_toolsets:
+        if (effective_enabled_toolsets
+                and os.environ.get("HERMES_KANBAN_TASK")
+                and "kanban" not in effective_enabled_toolsets):
             # Dispatcher-spawned workers are scoped by HERMES_KANBAN_TASK and
             # must always receive the lifecycle handoff tools. Assignee
             # profiles may intentionally restrict their normal chat toolsets
             # (for token/cost reasons), but that should not strip the kanban
-            # worker's completion/block/heartbeat surface.
+            # worker's completion/block/heartbeat surface. An EMPTY selection
+            # is excluded above: it is an explicit no-tool barrier, not a
+            # restriction to widen.
             effective_enabled_toolsets.append("kanban")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -69,6 +69,62 @@ def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypat
     assert pool.current().id == "cred-2"
 
 
+def test_probe_selects_rate_limited_codex_but_not_terminal_auth(tmp_path, monkeypatch):
+    """A runtime probe may test quota recovery without bypassing auth failures."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    future_reset = time.time() + 3600
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "quota",
+                        "label": "quota",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "quota-token",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reason": "usage_limit_reached",
+                        "last_error_reset_at": future_reset,
+                    },
+                    {
+                        "id": "terminal",
+                        "label": "terminal",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "terminal-token",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                        "last_error_reset_at": future_reset,
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.select() is None
+
+    probed = pool.select(allow_rate_limited=True)
+    assert probed is not None
+    assert probed.id == "quota"
+    assert probed.last_status == "exhausted"
+    assert [entry.id for entry in pool._available_entries(
+        refresh=False,
+        allow_rate_limited=True,
+    )] == ["quota"]
+
+
 def test_select_clears_expired_exhaustion(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -54,6 +54,51 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         # Should have been called at least twice (primary + fallback)
         assert call_count["n"] >= 2
 
+    def test_rate_limited_primary_is_retained_for_runtime_probe(self, tmp_path, monkeypatch):
+        """A quota cooldown must not freeze the gateway on its fallback."""
+        from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n  provider: minimax-oauth\n"
+            "  model: MiniMax-M3\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        calls = []
+
+        def _mock_resolve(**kwargs):
+            calls.append(kwargs)
+            if not kwargs.get("probe_rate_limited"):
+                raise AuthError(
+                    "quota exhausted",
+                    provider="openai-codex",
+                    code=CODEX_RATE_LIMITED_CODE,
+                    relogin_required=False,
+                )
+            return {
+                "api_key": "codex-token",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "command": None,
+                "args": None,
+                "credential_pool": "codex-pool",
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            result = _resolve_runtime_agent_kwargs()
+
+        assert result["provider"] == "openai-codex"
+        assert result["api_key"] == "codex-token"
+        assert any(call.get("probe_rate_limited") is True for call in calls)
+
     def test_auth_error_no_fallback_raises(self, tmp_path, monkeypatch):
         """When primary fails and no fallback configured, RuntimeError is raised."""
         from hermes_cli.auth import AuthError

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -10,6 +10,7 @@ import pytest
 
 from hermes_cli.auth import (
     AuthError,
+    CODEX_RATE_LIMITED_CODE,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
     _read_codex_tokens,
@@ -192,6 +193,64 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "usable-token"
     assert resolved["source"] == "credential_pool"
+
+
+def test_resolve_codex_runtime_credentials_probe_admits_rate_limit(tmp_path, monkeypatch):
+    """The explicit probe can test an early quota recovery."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "quota-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_reset_at": time.time() + 3600,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = resolve_codex_runtime_credentials(allow_rate_limited=True)
+
+    assert resolved["api_key"] == "quota-token"
+    assert resolved["source"] == "credential_pool"
+
+
+def test_resolve_codex_runtime_credentials_probe_rejects_terminal_auth(tmp_path, monkeypatch):
+    """The quota probe must not bypass a terminal authentication failure."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "terminal-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reason": "token_invalidated",
+                    "last_error_reset_at": time.time() + 3600,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_codex_runtime_credentials(allow_rate_limited=True)
+
+    assert exc_info.value.code != CODEX_RATE_LIMITED_CODE
 
 
 def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -86,6 +86,39 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["source"] == "manual"
 
 
+def test_resolve_runtime_provider_probe_admits_rate_limited_codex(monkeypatch):
+    calls = []
+
+    class _Entry:
+        access_token = "quota-token"
+        source = "manual"
+        base_url = "https://chatgpt.com/backend-api/codex"
+        last_status = "exhausted"
+        last_error_code = 429
+        last_error_reason = "usage_limit_reached"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self, *, allow_rate_limited=False):
+            calls.append(allow_rate_limited)
+            return _Entry() if allow_rate_limited else None
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openai-codex",
+        probe_rate_limited=True,
+    )
+
+    assert calls == [True]
+    assert resolved["provider"] == "openai-codex"
+    assert resolved["api_key"] == "quota-token"
+    assert resolved["credential_pool"] is not None
+
+
 def test_resolve_runtime_provider_nous_pool_uses_env_base_url_override(monkeypatch):
     entry = SimpleNamespace(
         provider="nous",

--- a/tests/test_zero_toolset_model_invariant.py
+++ b/tests/test_zero_toolset_model_invariant.py
@@ -1,0 +1,78 @@
+"""Zero-tool sessions must own no tool at the model layer either.
+
+``enabled_toolsets=[]`` is an explicit barrier: a client that opened a session
+without tools must never see a tool schema reach the model. The kanban
+lifecycle injection (``HERMES_KANBAN_TASK``) deliberately re-adds its toolset
+to a restricted selection, but a selection of NOTHING is a barrier, not a cost
+optimization, so the barrier wins.
+
+These tests run the real toolset pipeline (registry + toolsets + model_tools)
+and a real ``AIAgent``: mocking the tool definitions would prove nothing about
+what actually reaches the model.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+def _tool_names(enabled):
+    from model_tools import get_tool_definitions
+
+    definitions = get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True)
+    return [tool["function"]["name"] for tool in definitions]
+
+
+class TestKanbanInjectionRespectsTheBarrier:
+    def test_empty_selection_stays_empty_under_kanban_task(self) -> None:
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "task-42"}):
+            assert _tool_names([]) == []
+
+    def test_empty_selection_is_empty_without_kanban_task(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "HERMES_KANBAN_TASK"}
+        with patch.dict(os.environ, env, clear=True):
+            assert _tool_names([]) == []
+
+    def test_restricted_selection_still_gets_kanban_tools(self) -> None:
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "task-42"}):
+            names = _tool_names(["todo"])
+        assert any(name.startswith("kanban_") for name in names), names
+
+    def test_absent_selection_is_unaffected(self) -> None:
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "task-42"}):
+            assert len(_tool_names(None)) > 0
+
+
+class TestAgentBuildsWithNoTool:
+    def _agent(self, enabled_toolsets):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            model="test/model",
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            enabled_toolsets=enabled_toolsets,
+            max_iterations=2,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            # Keep the build side-effect free: trajectory dumps write outside
+            # the test's temp home.
+            save_trajectories=False,
+        )
+
+    def test_agent_has_no_tool_under_kanban_task(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"HERMES_KANBAN_TASK": "task-42", "OPENROUTER_API_KEY": "test-key"},
+        ):
+            agent = self._agent([])
+        assert agent.tools == []
+        assert agent.valid_tool_names == set()
+
+    def test_agent_without_selection_has_tools(self) -> None:
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = self._agent(None)
+        assert len(agent.tools) > 0

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -296,3 +296,65 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     t0 = time.time()
     mcp_startup.wait_for_mcp_discovery()
     assert time.time() - t0 < 0.2  # never blocks on the bound when nothing's pending
+
+
+def test_explicit_none_override_lifts_the_previous_restriction(monkeypatch):
+    """``enabled_override=None`` means "all toolsets", not "no override".
+
+    A session that never pinned a scope re-resolves the global config on
+    /reload-mcp. When that config resolves to None (everything enabled), the
+    agent's earlier restriction must be dropped, not silently kept.
+    """
+    agent = _agent(["read_file"], enabled=["file"])
+    seen = {}
+
+    import model_tools
+
+    def _capture(**kw):
+        seen.update(kw)
+        return [_tool("read_file"), _tool("terminal")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _capture)
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent, enabled_override=None)
+
+    assert seen["enabled_toolsets"] is None
+    assert agent.enabled_toolsets is None
+    assert added == {"terminal"}
+
+
+def test_omitted_override_keeps_the_agent_selection(monkeypatch):
+    """The automatic paths pass nothing and must not widen the agent's scope."""
+    agent = _agent(["read_file"], enabled=["file"])
+    seen = {}
+
+    import model_tools
+
+    def _capture(**kw):
+        seen.update(kw)
+        return [_tool("read_file")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _capture)
+
+    mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert seen["enabled_toolsets"] == ["file"]
+    assert agent.enabled_toolsets == ["file"]
+
+
+def test_explicit_empty_override_pins_zero_toolset(monkeypatch):
+    agent = _agent(["read_file"], enabled=["file"])
+    seen = {}
+
+    import model_tools
+
+    def _capture(**kw):
+        seen.update(kw)
+        return []
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _capture)
+
+    mcp_tool.refresh_agent_mcp_tools(agent, enabled_override=[])
+
+    assert seen["enabled_toolsets"] == []
+    assert agent.enabled_toolsets == []

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1167,3 +1167,73 @@ class TestReloadMcpLiftsRestriction:
         # The restriction is gone: the rebuild asked for every toolset.
         assert seen["enabled_toolsets"] is None
         assert agent.enabled_toolsets is None
+
+
+class TestDesktopBranchInheritsScope:
+    """The Desktop branch route is session.create + parent_session_id.
+
+    Without the field, the child must inherit the parent's scope: branching a
+    session opened without tools must not hand back a tooled child.
+    """
+
+    def _parent(self, server, pinned):
+        return {
+            "session_key": "parent-key",
+            "agent": SimpleNamespace(enabled_toolsets=pinned),
+            "create_enabled_toolsets": pinned,
+            "history": [],
+            "history_lock": threading.Lock(),
+        }
+
+    def _create_child(self, server, monkeypatch, parent, params):
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+        server._sessions["p-sid"] = parent
+        resp = _create(server, {"cols": 80, "parent_session_id": "parent-key", **params})
+        assert "error" not in resp, resp
+        sid = resp["result"]["session_id"]
+        _run_deferred_build(server, monkeypatch, sid)
+        return calls, server._sessions[sid]
+
+    def test_child_inherits_the_empty_parent_scope(self, server, monkeypatch) -> None:
+        calls, child = self._create_child(
+            server, monkeypatch, self._parent(server, []), {}
+        )
+        assert child["create_enabled_toolsets"] == []
+        assert calls[-1]["enabled_toolsets_override"] == []
+        assert child["agent"].enabled_toolsets == []
+
+    def test_child_inherits_a_non_empty_parent_scope(self, server, monkeypatch) -> None:
+        calls, child = self._create_child(
+            server, monkeypatch, self._parent(server, ["file"]), {}
+        )
+        assert child["create_enabled_toolsets"] == ["file"]
+        assert calls[-1]["enabled_toolsets_override"] == ["file"]
+
+    def test_unpinned_parent_leaves_the_child_global(self, server, monkeypatch) -> None:
+        calls, child = self._create_child(
+            server, monkeypatch, self._parent(server, None), {}
+        )
+        assert child["create_enabled_toolsets"] is None
+        assert "enabled_toolsets_override" not in calls[-1]
+
+    def test_explicit_field_wins_over_inheritance(self, server, monkeypatch) -> None:
+        calls, child = self._create_child(
+            server, monkeypatch, self._parent(server, []),
+            {"enabled_toolsets": ["file"]},
+        )
+        assert child["create_enabled_toolsets"] == ["file"]
+        assert calls[-1]["enabled_toolsets_override"] == ["file"]
+
+    def test_explicit_field_is_still_validated(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+        server._sessions["p-sid"] = self._parent(server, [])
+        resp = _create(
+            server,
+            {"cols": 80, "parent_session_id": "parent-key", "enabled_toolsets": None},
+        )
+        assert "error" in resp
+        assert not calls

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1301,3 +1301,95 @@ class TestPrebuildInspection:
         result = _show_tools(server, self._session([]))
         assert result["total"] == 0
         assert result["sections"] == []
+
+
+def _known_toolset_name() -> str:
+    from toolsets import get_all_toolsets
+
+    return sorted(get_all_toolsets())[0]
+
+
+class TestUnknownToolsetNames:
+    """A typo must not resolve to "no tools" behind the client's back.
+
+    An unknown name is dropped by the resolver, so ["fiel"] silently became a
+    zero-tool session instead of an error.
+    """
+
+    TARGET = "20260409_030303_ghi789"
+
+    def test_create_rejects_an_unknown_name(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": ["fiel"]})
+        assert "error" in resp
+        assert "result" not in resp
+        assert "fiel" in resp["error"]["message"]
+        assert "unknown toolset" in resp["error"]["message"].lower()
+        assert not calls
+        assert not server._sessions
+
+    def test_resume_rejects_an_unknown_name(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(
+            server, {"session_id": self.TARGET, "enabled_toolsets": ["fiel"]}
+        )
+        assert "error" in resp
+        assert "result" not in resp
+        assert "fiel" in resp["error"]["message"]
+        assert not calls
+        assert not server._sessions
+
+    def test_unknown_name_next_to_a_valid_one_is_rejected(
+        self, server, monkeypatch
+    ) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(
+            server,
+            {"cols": 80, "enabled_toolsets": [_known_toolset_name(), "fiel"]},
+        )
+        assert "error" in resp
+        assert not calls
+        assert not server._sessions
+
+    def test_known_toolset_is_accepted(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+        name = _known_toolset_name()
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": [name]})
+        assert "error" not in resp
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == [name]
+
+    @pytest.mark.parametrize("alias", ["all", "*", "web_tools"])
+    def test_supported_aliases_are_accepted(self, server, monkeypatch, alias) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": [alias]})
+        assert "error" not in resp, resp
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == [alias]
+
+    def test_empty_selection_is_still_accepted(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": []})
+        assert "error" not in resp
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == []

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -231,6 +231,33 @@ class TestSessionCreate:
         assert "error" in resp
         assert not calls
 
+    @pytest.mark.parametrize(
+        "selection",
+        [[1], ["file", None], [{"name": "file"}], [True], [["file"]]],
+    )
+    def test_non_string_items_are_rejected_without_coercion(
+        self, server, monkeypatch, selection
+    ) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": selection})
+        assert "error" in resp
+        assert "result" not in resp
+        assert not calls
+        assert not server._sessions
+
+    def test_string_items_are_trimmed(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": ["  file  ", ""]})
+        assert "error" not in resp
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == ["file"]
+
 
 # ── session.resume ───────────────────────────────────────────────────
 
@@ -306,6 +333,24 @@ class TestSessionResume:
         )
         assert "error" in resp
         assert not calls
+
+    @pytest.mark.parametrize("selection", [[1], ["file", None], [{"name": "file"}]])
+    def test_non_string_items_are_rejected_without_coercion(
+        self, server, monkeypatch, selection
+    ) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(
+            server, {"session_id": self.TARGET, "enabled_toolsets": selection}
+        )
+        assert "error" in resp
+        assert "result" not in resp
+        assert not calls
+        assert not server._sessions
 
     def test_lazy_resume_build_receives_empty_selection(self, server, monkeypatch) -> None:
         _quiet(server, monkeypatch)

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -493,8 +493,7 @@ class TestRebuilds:
         kwargs = server._background_agent_kwargs(agent, "task-1")
         assert kwargs["enabled_toolsets"] == []
 
-    def _reload_mcp(self, server, monkeypatch, agent_toolsets):
-        """Drive reload.mcp on a session and return refresh's enabled_override."""
+    def _reload_mcp(self, server, monkeypatch, agent_toolsets, pinned):
         seen: dict = {}
         fake_mcp = MagicMock()
         fake_mcp.refresh_agent_mcp_tools.side_effect = (
@@ -505,6 +504,7 @@ class TestRebuilds:
         session = {
             "session_key": "k-mcp",
             "agent": SimpleNamespace(enabled_toolsets=agent_toolsets),
+            "create_enabled_toolsets": pinned,
         }
         monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal", "file"])
         monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
@@ -524,12 +524,13 @@ class TestRebuilds:
         return seen
 
     def test_reload_mcp_keeps_empty_selection(self, server, monkeypatch) -> None:
-        assert self._reload_mcp(server, monkeypatch, [])["enabled_override"] == []
+        seen = self._reload_mcp(server, monkeypatch, [], pinned=[])
+        assert seen["enabled_override"] == []
 
     def test_reload_mcp_without_selection_re_resolves_global(
         self, server, monkeypatch
     ) -> None:
-        seen = self._reload_mcp(server, monkeypatch, None)
+        seen = self._reload_mcp(server, monkeypatch, None, pinned=None)
         assert seen["enabled_override"] == ["terminal", "file"]
 
     def test_background_agent_without_selection_uses_global(self, server, monkeypatch) -> None:
@@ -538,6 +539,346 @@ class TestRebuilds:
         agent = SimpleNamespace(enabled_toolsets=None)
         kwargs = server._background_agent_kwargs(agent, "task-2")
         assert kwargs["enabled_toolsets"] == ["terminal", "file"]
+
+
+class TestSessionBranch:
+    class _BranchDB:
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} 2"
+
+        def create_session(self, *a, **k):
+            return None
+
+        def append_message(self, **k):
+            return None
+
+        def set_session_title(self, *a, **k):
+            return None
+
+    def _branch(self, server, monkeypatch, live: dict) -> dict:
+        calls = _capture_builds(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: self._BranchDB())
+        monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+        monkeypatch.setattr(server, "_new_session_key", lambda: "child-key")
+        monkeypatch.setattr(server, "_resolve_model", lambda *a, **k: "m")
+        monkeypatch.setattr(
+            server,
+            "_init_session",
+            lambda sid, key, agent, history, **kw: server._sessions.__setitem__(
+                sid,
+                {"agent": agent, "session_key": key, "history": list(history),
+                 "history_lock": threading.Lock()},
+            ),
+        )
+        ready = threading.Event()
+        ready.set()
+        live.update({
+            "agent_ready": ready,
+            "history_lock": threading.Lock(),
+            "cwd": "/tmp",
+            "cols": 80,
+        })
+        with patch.dict(server._sessions, {"s-parent": live}, clear=True):
+            resp = server.handle_request(
+                {"id": "r-branch", "method": "session.branch",
+                 "params": {"session_id": "s-parent"}}
+            )
+            assert "error" not in resp, resp
+            child = server._sessions[resp["result"]["session_id"]]
+            return {"calls": calls, "child": child, "result": resp["result"]}
+
+    def test_branch_keeps_the_empty_selection(self, server, monkeypatch) -> None:
+        live = {
+            "session_key": "parent-key",
+            "agent": SimpleNamespace(enabled_toolsets=[]),
+            "history": [{"role": "user", "content": "hi"}],
+            "create_enabled_toolsets": [],
+        }
+        out = self._branch(server, monkeypatch, live)
+        assert out["calls"][-1]["enabled_toolsets_override"] == []
+        assert out["child"].get("create_enabled_toolsets") == []
+        assert out["child"]["agent"].enabled_toolsets == []
+
+    def test_branch_without_selection_is_unchanged(self, server, monkeypatch) -> None:
+        live = {
+            "session_key": "parent-key",
+            "agent": SimpleNamespace(enabled_toolsets=["terminal"]),
+            "history": [{"role": "user", "content": "hi"}],
+        }
+        out = self._branch(server, monkeypatch, live)
+        assert out["calls"][-1].get("enabled_toolsets_override") is None
+        assert out["child"].get("create_enabled_toolsets") is None
+
+
+class TestReloadMcpProvenance:
+    """The decision comes from what the client asked, not from the built agent.
+
+    A session created WITHOUT the field already carries a resolved global list
+    on its agent, so reading the agent would wrongly pin it forever.
+    """
+
+    def _reload(self, server, monkeypatch, session_extra: dict):
+        seen: dict = {}
+        fake_mcp = MagicMock()
+        fake_mcp.refresh_agent_mcp_tools.side_effect = (
+            lambda agent, enabled_override=None, **kw: seen.update(
+                {"enabled_override": enabled_override}
+            )
+        )
+        session = {"session_key": "k-mcp", **session_extra}
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal", "file", "mcp_new"])
+        monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+        with patch.dict(server._sessions, {"s-mcp": session}, clear=False), patch.dict(
+            "sys.modules", {"tools.mcp_tool": fake_mcp}
+        ):
+            resp = server.handle_request(
+                {"id": "r-mcp", "method": "reload.mcp",
+                 "params": {"session_id": "s-mcp", "confirm": True}}
+            )
+        assert "error" not in resp
+        return seen
+
+    def test_global_session_re_resolves_config(self, server, monkeypatch) -> None:
+        seen = self._reload(
+            server,
+            monkeypatch,
+            {"agent": SimpleNamespace(enabled_toolsets=["terminal", "file"])},
+        )
+        assert seen["enabled_override"] == ["terminal", "file", "mcp_new"]
+
+    def test_explicitly_empty_session_stays_empty(self, server, monkeypatch) -> None:
+        seen = self._reload(
+            server,
+            monkeypatch,
+            {"agent": SimpleNamespace(enabled_toolsets=[]), "create_enabled_toolsets": []},
+        )
+        assert seen["enabled_override"] == []
+
+    def test_explicit_list_stays_pinned(self, server, monkeypatch) -> None:
+        seen = self._reload(
+            server,
+            monkeypatch,
+            {"agent": SimpleNamespace(enabled_toolsets=["file"]),
+             "create_enabled_toolsets": ["file"]},
+        )
+        assert seen["enabled_override"] == ["file"]
+
+
+TOOLSET_CONFLICT_FRAGMENT = "different toolset selection"
+
+
+def _conflict_error_type():
+    from tui_gateway.compute_host import ToolsetScopeConflictError
+
+    return ToolsetScopeConflictError
+
+
+class TestComputeHostScopeConflicts:
+    def _host(self):
+        from tui_gateway.compute_host import ComputeHost
+
+        return ComputeHost(stdout=io.StringIO())
+
+    def test_existing_session_refuses_incompatible_frame(self, server, monkeypatch) -> None:
+        calls = _capture_builds(server, monkeypatch)
+        agent = SimpleNamespace(enabled_toolsets=["terminal"])
+        session = {
+            "agent": agent,
+            "session_key": "host-key",
+            "history": [],
+            "history_lock": threading.Lock(),
+        }
+        host = self._host()
+        try:
+            with patch.dict(server._sessions, {"host-sid": session}, clear=True):
+                with pytest.raises(
+                    _conflict_error_type(), match=TOOLSET_CONFLICT_FRAGMENT
+                ):
+                    host._ensure_server_session(
+                        server,
+                        {"sid": "host-sid", "session_key": "host-key",
+                         "history": [], "cols": 80, "enabled_toolsets": []},
+                    )
+                # No mutation, no silently tooled agent handed back.
+                assert session["agent"].enabled_toolsets == ["terminal"]
+                assert session.get("create_enabled_toolsets") is None
+        finally:
+            host._executor.shutdown(wait=False)
+        assert calls == []
+
+    def _race(self, server, monkeypatch, second_selection):
+        """Start a build, hold it, then send a second frame on the same sid.
+
+        Returns the host plus the observation hooks, with the first build still
+        blocked so the caller can inspect the lock table mid-race.
+        """
+        state = {
+            "entered": threading.Event(),
+            "release": threading.Event(),
+            "waiting": threading.Event(),
+            "calls": [],
+            "errors": [],
+            "results": [],
+        }
+        calls_lock = threading.Lock()
+
+        def fake_make_agent(sid, key, **kw):
+            with calls_lock:
+                state["calls"].append(kw)
+                first = len(state["calls"]) == 1
+            if first:
+                state["entered"].set()
+                assert state["release"].wait(timeout=10), "test gate never released"
+            return SimpleNamespace(
+                enabled_toolsets=kw.get("enabled_toolsets_override"),
+                model="m", provider="p", session_id=key,
+            )
+
+        monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            server,
+            "_init_session",
+            lambda sid, key, agent, history, **kw: server._sessions.__setitem__(
+                sid,
+                {"agent": agent, "session_key": key, "history": list(history),
+                 "history_lock": threading.Lock()},
+            ),
+        )
+
+        host = self._host()
+        # Signal the exact moment the second caller has registered its interest
+        # in the sid and is about to block: an Event, so no timing guesswork.
+        original_acquire = host._acquire_session_lock
+
+        def spy_acquire(sid):
+            lock, entry = original_acquire(sid)
+            if entry.waiters >= 2:
+                state["waiting"].set()
+            return lock, entry
+
+        host._acquire_session_lock = spy_acquire
+
+        def run(frame):
+            try:
+                state["results"].append(host._ensure_server_session(server, frame))
+            except BaseException as exc:  # noqa: BLE001 - recorded for the assert
+                state["errors"].append(exc)
+
+        base = {"sid": "race-sid", "session_key": "race-key", "history": [], "cols": 80}
+        state["threads"] = (
+            threading.Thread(target=run, args=({**base, "enabled_toolsets": []},)),
+            threading.Thread(
+                target=run, args=({**base, "enabled_toolsets": second_selection},)
+            ),
+        )
+        return host, state
+
+    def _finish_race(self, state) -> None:
+        state["release"].set()
+        for thread in state["threads"]:
+            thread.join(timeout=15)
+        assert all(not t.is_alive() for t in state["threads"])
+
+    def test_concurrent_first_builds_cannot_both_win(self, server, monkeypatch) -> None:
+        """Two incompatible frames on a fresh sid: one builds, the other fails."""
+        host, state = self._race(server, monkeypatch, ["terminal"])
+        first, second = state["threads"]
+        try:
+            with patch.dict(server._sessions, {}, clear=True):
+                first.start()
+                assert state["entered"].wait(timeout=10), "first build never started"
+                second.start()
+                assert state["waiting"].wait(timeout=10), "second caller never queued"
+                self._finish_race(state)
+                assert len(state["errors"]) == 1, (state["errors"], state["results"])
+                assert isinstance(state["errors"][0], _conflict_error_type())
+                assert TOOLSET_CONFLICT_FRAGMENT in str(state["errors"][0])
+                assert len(state["results"]) == 1
+                # The zero-tool builder entered first and must be the one live.
+                assert server._sessions["race-sid"]["agent"].enabled_toolsets == []
+                assert len(state["calls"]) == 1, state["calls"]
+        finally:
+            state["release"].set()
+            host._executor.shutdown(wait=False)
+
+    def test_lock_entry_is_shared_during_the_race_then_evicted(
+        self, server, monkeypatch
+    ) -> None:
+        host, state = self._race(server, monkeypatch, ["terminal"])
+        first, second = state["threads"]
+        try:
+            with patch.dict(server._sessions, {}, clear=True):
+                first.start()
+                assert state["entered"].wait(timeout=10)
+                second.start()
+                assert state["waiting"].wait(timeout=10)
+                # Both callers share ONE entry while the race is on.
+                assert list(host._session_locks) == ["race-sid"]
+                assert host._session_locks["race-sid"].waiters == 2
+                self._finish_race(state)
+                # Winner and loser both released: no per-sid lock leaks.
+                assert host._session_locks == {}
+        finally:
+            state["release"].set()
+            host._executor.shutdown(wait=False)
+
+    def test_lock_table_is_empty_after_a_conflict(self, server, monkeypatch) -> None:
+        _capture_builds(server, monkeypatch)
+        session = {
+            "agent": SimpleNamespace(enabled_toolsets=["terminal"]),
+            "session_key": "host-key",
+            "history": [],
+            "history_lock": threading.Lock(),
+        }
+        host = self._host()
+        try:
+            with patch.dict(server._sessions, {"host-sid": session}, clear=True):
+                with pytest.raises(_conflict_error_type()):
+                    host._ensure_server_session(
+                        server,
+                        {"sid": "host-sid", "session_key": "host-key",
+                         "history": [], "cols": 80, "enabled_toolsets": []},
+                    )
+            assert host._session_locks == {}
+        finally:
+            host._executor.shutdown(wait=False)
+
+    def test_lock_is_released_before_the_turn_runs(self, server, monkeypatch) -> None:
+        """The lock guards ensure/build only, never the model turn after it."""
+        _capture_builds(server, monkeypatch)
+        monkeypatch.setattr(
+            server,
+            "_init_session",
+            lambda sid, key, agent, history, **kw: server._sessions.__setitem__(
+                sid,
+                {"agent": agent, "session_key": key, "history": list(history),
+                 "history_lock": threading.Lock()},
+            ),
+        )
+        host = self._host()
+        try:
+            with patch.dict(server._sessions, {}, clear=True):
+                host._ensure_server_session(
+                    server,
+                    {"sid": "turn-sid", "session_key": "turn-key",
+                     "history": [], "cols": 80, "enabled_toolsets": []},
+                )
+                assert host._session_locks == {}
+                # Whatever the turn does next, the sid is immediately lockable.
+                lock, entry = host._acquire_session_lock("turn-sid")
+                try:
+                    assert lock.acquire(blocking=False)
+                    lock.release()
+                finally:
+                    host._release_session_lock("turn-sid", entry)
+                assert host._session_locks == {}
+        finally:
+            host._executor.shutdown(wait=False)
 
 
 def _reporting_server():

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1006,3 +1006,114 @@ class TestToolsShowReporting:
         server = _reporting_server()
         session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=None)}
         assert _show_tools(server, session)["total"] > 0
+
+
+class TestTurnOwnershipCleanup:
+    """Only the caller that acquired the turn may release it.
+
+    A concurrent frame that is refused (scope conflict) runs the same except
+    block; if that block cleared `running` / `inflight_turn`, it would unlock a
+    session another turn is still using and let a third turn start in parallel.
+    """
+
+    def _host(self):
+        from tui_gateway.compute_host import ComputeHost
+
+        return ComputeHost(stdout=io.StringIO())
+
+    def _live_session(self, server, sid: str, selection):
+        session = {
+            "agent": SimpleNamespace(enabled_toolsets=selection, model="m",
+                                     provider="p", session_id="own-key"),
+            "session_key": "own-key",
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": False,
+            "inflight_turn": None,
+            "last_active": 0.0,
+        }
+        server._sessions[sid] = session
+        return session
+
+    def test_refused_frame_does_not_release_the_owner_turn(
+        self, server, monkeypatch
+    ) -> None:
+        in_turn = threading.Event()
+        release = threading.Event()
+
+        def blocking_submit(request_id, sid, session, text):
+            in_turn.set()
+            assert release.wait(timeout=10), "test gate never released"
+
+        monkeypatch.setattr(server, "_run_prompt_submit", blocking_submit)
+        monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_persist_branch_seed", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+
+        host = self._host()
+        events: list[dict] = []
+        host.emit = events.append
+        owner = threading.Thread(
+            target=host._run_real_turn,
+            args=({"sid": "own-sid", "session_key": "own-key", "request_id": "owner",
+                   "text": "hi", "enabled_toolsets": []},),
+        )
+        try:
+            with patch.dict(server._sessions, {}, clear=True):
+                session = self._live_session(server, "own-sid", [])
+                owner.start()
+                assert in_turn.wait(timeout=10), "owner turn never started"
+
+                # A concurrent, incompatible frame is refused.
+                host._run_real_turn(
+                    {"sid": "own-sid", "session_key": "own-key", "request_id": "intruder",
+                     "text": "hi", "enabled_toolsets": ["terminal"]}
+                )
+                refused = [e for e in events if e.get("request_id") == "intruder"]
+                assert refused and refused[-1]["type"] == "turn.error"
+
+                # The owner's turn state survives the refusal.
+                assert session["running"] is True
+                assert session["inflight_turn"] is not None
+
+                # And a third turn is still locked out while the owner runs.
+                host._run_real_turn(
+                    {"sid": "own-sid", "session_key": "own-key", "request_id": "third",
+                     "text": "hi", "enabled_toolsets": []}
+                )
+                third = [e for e in events if e.get("request_id") == "third"]
+                assert third and third[-1]["type"] == "turn.error"
+                assert "busy" in third[-1]["message"]
+
+                release.set()
+                owner.join(timeout=15)
+                assert not owner.is_alive()
+        finally:
+            release.set()
+            host._executor.shutdown(wait=False)
+
+    def test_owner_still_cleans_up_its_own_failure(self, server, monkeypatch) -> None:
+        def boom(request_id, sid, session, text):
+            raise RuntimeError("turn exploded")
+
+        monkeypatch.setattr(server, "_run_prompt_submit", boom)
+        monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_persist_branch_seed", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+
+        host = self._host()
+        events: list[dict] = []
+        host.emit = events.append
+        try:
+            with patch.dict(server._sessions, {}, clear=True):
+                session = self._live_session(server, "own-sid", [])
+                host._run_real_turn(
+                    {"sid": "own-sid", "session_key": "own-key", "request_id": "owner",
+                     "text": "hi", "enabled_toolsets": []}
+                )
+                assert session["running"] is False
+                assert session["inflight_turn"] is None
+                assert events[-1]["type"] == "turn.error"
+        finally:
+            host._executor.shutdown(wait=False)

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -538,3 +538,85 @@ class TestRebuilds:
         agent = SimpleNamespace(enabled_toolsets=None)
         kwargs = server._background_agent_kwargs(agent, "task-2")
         assert kwargs["enabled_toolsets"] == ["terminal", "file"]
+
+
+def _reporting_server():
+    # Real toolsets/model_tools registry: these RPCs answer from it, so a
+    # mocked hermes_constants would make the answer meaningless.
+    import tui_gateway.server as server
+
+    return server
+
+
+def _list_toolsets(server, method: str, session: dict | None) -> list[dict]:
+    sessions = {"s-report": session} if session is not None else {}
+    with patch.dict(server._sessions, sessions, clear=True):
+        params = {"session_id": "s-report"} if session is not None else {}
+        resp = server._methods[method]("r-report", params)
+    assert "error" not in resp, resp
+    return resp["result"]["toolsets"]
+
+
+def _show_tools(server, session: dict | None) -> dict:
+    sessions = {"s-report": session} if session is not None else {}
+    with patch.dict(server._sessions, sessions, clear=True):
+        params = {"session_id": "s-report"} if session is not None else {}
+        resp = server._methods["tools.show"]("r-show", params)
+    assert "error" not in resp, resp
+    return resp["result"]
+
+
+@pytest.mark.parametrize("method", ["tools.list", "toolsets.list"])
+class TestToolsetReporting:
+    def test_empty_selection_reports_every_toolset_disabled(self, method) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=[])}
+        items = _list_toolsets(server, method, session)
+        assert items, "expected the toolset catalog to be non-empty"
+        assert [i["name"] for i in items if i["enabled"]] == []
+
+    def test_explicit_selection_reports_only_that_toolset(self, method) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=["file"])}
+        items = _list_toolsets(server, method, session)
+        assert [i["name"] for i in items if i["enabled"]] == ["file"]
+
+    def test_absent_selection_still_reports_everything_enabled(self, method) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=None)}
+        items = _list_toolsets(server, method, session)
+        assert all(i["enabled"] for i in items)
+
+    def test_prebuild_session_reports_its_pinned_empty_selection(self, method) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": None, "create_enabled_toolsets": []}
+        items = _list_toolsets(server, method, session)
+        assert [i["name"] for i in items if i["enabled"]] == []
+
+    def test_no_session_keeps_the_global_answer(self, method, monkeypatch) -> None:
+        server = _reporting_server()
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+        items = _list_toolsets(server, method, None)
+        assert all(i["enabled"] for i in items)
+
+    def test_response_shape_is_unchanged(self, method) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=[])}
+        items = _list_toolsets(server, method, session)
+        for item in items:
+            assert {"name", "description", "tool_count", "enabled"} <= set(item)
+            assert isinstance(item["enabled"], bool)
+
+
+class TestToolsShowReporting:
+    def test_empty_selection_shows_no_tool(self) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=[])}
+        result = _show_tools(server, session)
+        assert result["total"] == 0
+        assert result["sections"] == []
+
+    def test_absent_selection_still_shows_tools(self) -> None:
+        server = _reporting_server()
+        session = {"session_key": "k", "agent": SimpleNamespace(enabled_toolsets=None)}
+        assert _show_tools(server, session)["total"] > 0

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1,0 +1,540 @@
+"""Per-session zero-tool barrier for the TUI gateway (JSON-RPC backend).
+
+A client that only wants recommendations (no terminal, no file, no browser)
+must be able to open or reopen a Hermes session that owns NO tools at all,
+without relying on a prompt instruction that the model can ignore.
+
+Contract under test:
+
+1. ``session.create`` / ``session.resume`` accept an optional
+   ``enabled_toolsets`` list. ``[]`` is an explicit value (a session with no
+   tools) and is never collapsed into the "absent" case.
+2. Only ABSENCE of the field keeps the global resolution
+   (``_load_enabled_toolsets``); an explicit ``null`` is rejected.
+3. The selection survives into every agent construction of that session: the
+   deferred build of ``session.create``, the deferred and the eager build of
+   ``session.resume``, the first build inside ``tui_gateway.compute_host``,
+   and any later rebuild of the same session (``/new``, background agents).
+4. The compute-host turn frame carries the field without defaulting it.
+5. Resuming a live session that already holds a different selection fails
+   closed: an explicit error, no mutation, no tooled fallback.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+class _DB:
+    """Minimal SessionDB stand-in for the resume paths."""
+
+    def __init__(self, target: str) -> None:
+        self._target = target
+
+    def get_session(self, _sid):
+        return {"id": self._target, "model": "vendor/cool-model",
+                "model_config": {"provider": "vendor"}}
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def resolve_resume_session_id(self, sid):
+        return sid
+
+    def reopen_session(self, _sid):
+        return None
+
+    def get_resume_conversations(self, _sid):
+        return ([], [])
+
+    def get_ancestor_display_prefix(self, _sid):
+        return []
+
+    def get_messages_as_conversation(self, _sid, include_ancestors=False,
+                                     repair_alternation=False):
+        return []
+
+
+def _quiet(server, monkeypatch) -> None:
+    """Neutralize the side machinery a session build/registration triggers."""
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+
+
+def _capture_builds(server, monkeypatch) -> list[dict]:
+    """Record every ``_make_agent`` call's kwargs; return a stub agent."""
+    calls: list[dict] = []
+
+    def _fake(sid, key, **kw):
+        calls.append(kw)
+        return SimpleNamespace(
+            model="vendor/cool-model",
+            provider="vendor",
+            enabled_toolsets=kw.get("enabled_toolsets_override"),
+            session_id=key,
+        )
+
+    monkeypatch.setattr(server, "_make_agent", _fake)
+    return calls
+
+
+def _run_deferred_build(server, monkeypatch, sid: str) -> None:
+    """Drive the real deferred build with its side machinery stubbed out."""
+    monkeypatch.setattr(server, "_SlashWorker", MagicMock())
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_probe_config_health", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    session = server._sessions[sid]
+    server._start_agent_build(sid, session)
+    ready = session.get("agent_ready")
+    assert ready is not None and ready.wait(timeout=10), "deferred build never finished"
+
+
+# ── _make_agent: the override reaches AIAgent verbatim ────────────────
+
+
+def _agent_kwargs(**make_agent_kwargs) -> dict:
+    # Deliberately NOT the `server` fixture: this one builds through the real
+    # run_agent/model_tools import chain, which needs the real hermes_constants.
+    import tui_gateway.server as server
+
+    fake_cfg = {"agent": {"system_prompt": ""}, "model": {"default": "m"}}
+    with (
+        patch.object(server, "_load_cfg", return_value=fake_cfg),
+        patch.object(server, "_get_db", return_value=MagicMock()),
+        patch.object(server, "_resolve_model", return_value="m"),
+        patch.object(server, "_load_reasoning_config", return_value=None),
+        patch.object(server, "_load_service_tier", return_value=None),
+        patch.object(server, "_load_fallback_model", return_value=None),
+        patch.object(server, "_load_provider_routing", return_value={}),
+        patch.object(server, "_load_enabled_toolsets", return_value=["terminal", "file"]),
+        patch.object(
+            server,
+            "_resolve_runtime_with_fallback",
+            return_value=SimpleNamespace(
+                runtime={"provider": "openai", "base_url": "https://x", "api_key": "k"},
+                used_fallback=False,
+                selected_model="m",
+            ),
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        server._make_agent("sid-x", "key-x", **make_agent_kwargs)
+    return mock_agent.call_args.kwargs
+
+
+class TestMakeAgentOverride:
+    def test_empty_list_reaches_aiagent(self) -> None:
+        assert _agent_kwargs(enabled_toolsets_override=[])["enabled_toolsets"] == []
+
+    def test_non_empty_list_reaches_aiagent(self) -> None:
+        kwargs = _agent_kwargs(enabled_toolsets_override=["file"])
+        assert kwargs["enabled_toolsets"] == ["file"]
+
+    def test_absent_override_keeps_global_resolution(self) -> None:
+        kwargs = _agent_kwargs()
+        assert kwargs["enabled_toolsets"] == ["terminal", "file"]
+
+
+# ── session.create ───────────────────────────────────────────────────
+
+
+def _create(server, params: dict) -> dict:
+    return server.handle_request({"id": "r1", "method": "session.create", "params": params})
+
+
+class TestSessionCreate:
+    def test_deferred_build_receives_empty_selection(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": []})
+        assert "error" not in resp
+        sid = resp["result"]["session_id"]
+        assert resp["result"]["stored_session_id"]
+
+        _run_deferred_build(server, monkeypatch, sid)
+        assert calls and calls[-1]["enabled_toolsets_override"] == []
+        assert server._sessions[sid]["agent"].enabled_toolsets == []
+
+    def test_deferred_build_receives_non_empty_selection(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": ["file"]})
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == ["file"]
+
+    def test_absent_field_leaves_build_untouched(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80})
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert "enabled_toolsets_override" not in calls[-1]
+
+    def test_explicit_null_is_rejected(self, server, monkeypatch) -> None:
+        """null is not absence: it must not silently inherit the global scope."""
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": None})
+        assert "error" in resp
+        assert "result" not in resp
+        assert not calls
+        assert not server._sessions
+
+    def test_non_list_is_rejected(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _create(server, {"cols": 80, "enabled_toolsets": "file"})
+        assert "error" in resp
+        assert not calls
+
+
+# ── session.resume ───────────────────────────────────────────────────
+
+
+def _resume(server, params: dict) -> dict:
+    return server.handle_request({"id": "r2", "method": "session.resume", "params": params})
+
+
+class TestSessionResume:
+    TARGET = "20260409_010101_abc123"
+
+    def test_deferred_resume_build_receives_empty_selection(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(server, {"session_id": self.TARGET, "enabled_toolsets": []})
+        assert "error" not in resp
+        assert resp["result"]["resumed"] == self.TARGET
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert calls[-1]["enabled_toolsets_override"] == []
+
+    def test_deferred_resume_absent_field_unchanged(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(server, {"session_id": self.TARGET})
+        _run_deferred_build(server, monkeypatch, resp["result"]["session_id"])
+        assert "enabled_toolsets_override" not in calls[-1]
+
+    def test_eager_resume_build_receives_empty_selection(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        monkeypatch.setattr(server, "_init_session", lambda *a, **k: {})
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(
+            server,
+            {"session_id": self.TARGET, "eager_build": True, "enabled_toolsets": []},
+        )
+        assert "error" not in resp
+        assert calls and calls[-1]["enabled_toolsets_override"] == []
+
+    def test_explicit_null_is_rejected(self, server, monkeypatch) -> None:
+        """null is not absence: it must not silently inherit the global scope."""
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(server, {"session_id": self.TARGET, "enabled_toolsets": None})
+        assert "error" in resp
+        assert "result" not in resp
+        assert not calls
+        assert not server._sessions
+
+    def test_non_list_is_rejected(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "sanitize_replay_history", lambda h: h)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(
+            server,
+            {"session_id": self.TARGET, "eager_build": True, "enabled_toolsets": "file"},
+        )
+        assert "error" in resp
+        assert not calls
+
+    def test_lazy_resume_build_receives_empty_selection(self, server, monkeypatch) -> None:
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        monkeypatch.setattr(server, "_child_run_active", lambda *a, **k: False)
+        calls = _capture_builds(server, monkeypatch)
+
+        resp = _resume(
+            server, {"session_id": self.TARGET, "lazy": True, "enabled_toolsets": []}
+        )
+        assert "error" not in resp
+        sid = resp["result"]["session_id"]
+        assert server._sessions[sid]["agent"] is None
+        _run_deferred_build(server, monkeypatch, sid)
+        assert calls[-1]["enabled_toolsets_override"] == []
+
+
+class TestLiveSessionConflict:
+    TARGET = "20260409_020202_def456"
+
+    def _live(self, server, monkeypatch, *, agent_toolsets):
+        _quiet(server, monkeypatch)
+        monkeypatch.setattr(server, "_get_db", lambda: _DB(self.TARGET))
+        agent = SimpleNamespace(
+            enabled_toolsets=agent_toolsets,
+            model="vendor/cool-model",
+            provider="vendor",
+            session_id=self.TARGET,
+        )
+        session = {
+            "agent": agent,
+            "session_key": self.TARGET,
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "cwd": "/tmp",
+            "cols": 80,
+            "running": False,
+            "created_at": 0.0,
+            "last_active": 0.0,
+            "inflight_turn": None,
+        }
+        server._sessions["live1"] = session
+        return session
+
+    def test_zero_tool_resume_of_tooled_live_session_fails_closed(
+        self, server, monkeypatch
+    ) -> None:
+        session = self._live(server, monkeypatch, agent_toolsets=["terminal", "file"])
+        resp = _resume(server, {"session_id": self.TARGET, "enabled_toolsets": []})
+        assert "error" in resp
+        assert "result" not in resp
+        # No mutation, no tooled fallback: the live agent keeps its selection.
+        assert session["agent"].enabled_toolsets == ["terminal", "file"]
+        assert session.get("create_enabled_toolsets") is None
+
+    def test_matching_selection_reuses_live_session(self, server, monkeypatch) -> None:
+        self._live(server, monkeypatch, agent_toolsets=[])
+        resp = _resume(server, {"session_id": self.TARGET, "enabled_toolsets": []})
+        assert "error" not in resp
+        assert resp["result"]["resumed"] == self.TARGET
+
+    def test_absent_field_reuses_live_session(self, server, monkeypatch) -> None:
+        self._live(server, monkeypatch, agent_toolsets=["terminal"])
+        resp = _resume(server, {"session_id": self.TARGET})
+        assert "error" not in resp
+        assert resp["result"]["resumed"] == self.TARGET
+
+
+# ── compute host ─────────────────────────────────────────────────────
+
+
+class TestComputeHost:
+    def test_turn_frame_carries_selection(self, server) -> None:
+        session = {
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "attached_images": [],
+            "session_key": "k-frame",
+            "cols": 80,
+            "cwd": "/tmp",
+            "create_enabled_toolsets": [],
+        }
+        frame = server._compute_host_turn_frame("rid", "sid", session, "hi")
+        assert frame["enabled_toolsets"] == []
+
+    def test_turn_frame_omits_default_when_unset(self, server) -> None:
+        session = {
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "attached_images": [],
+            "session_key": "k-frame2",
+            "cols": 80,
+            "cwd": "/tmp",
+        }
+        frame = server._compute_host_turn_frame("rid", "sid", session, "hi")
+        assert frame.get("enabled_toolsets") is None
+
+    def test_host_first_build_receives_selection(self, server, monkeypatch) -> None:
+        from tui_gateway.compute_host import ComputeHost
+
+        calls = _capture_builds(server, monkeypatch)
+        monkeypatch.setattr(
+            server,
+            "_init_session",
+            lambda sid, key, agent, history, **kw: server._sessions.__setitem__(
+                sid,
+                {
+                    "agent": agent,
+                    "session_key": key,
+                    "history": list(history),
+                    "history_lock": threading.Lock(),
+                },
+            ),
+        )
+        host = ComputeHost(stdout=io.StringIO())
+        try:
+            host._ensure_server_session(
+                server,
+                {
+                    "sid": "host-sid",
+                    "session_key": "host-key",
+                    "history": [],
+                    "cols": 80,
+                    "enabled_toolsets": [],
+                },
+            )
+        finally:
+            host._executor.shutdown(wait=False)
+        assert calls and calls[-1]["enabled_toolsets_override"] == []
+
+    def test_host_first_build_without_field_is_unchanged(self, server, monkeypatch) -> None:
+        from tui_gateway.compute_host import ComputeHost
+
+        calls = _capture_builds(server, monkeypatch)
+        monkeypatch.setattr(
+            server,
+            "_init_session",
+            lambda sid, key, agent, history, **kw: server._sessions.__setitem__(
+                sid, {"agent": agent, "session_key": key, "history": list(history),
+                      "history_lock": threading.Lock()},
+            ),
+        )
+        host = ComputeHost(stdout=io.StringIO())
+        try:
+            host._ensure_server_session(
+                server,
+                {"sid": "host-sid2", "session_key": "host-key2", "history": [], "cols": 80},
+            )
+        finally:
+            host._executor.shutdown(wait=False)
+        assert calls[-1].get("enabled_toolsets_override") is None
+
+
+# ── later rebuilds of the same session ───────────────────────────────
+
+
+class TestRebuilds:
+    def test_new_conversation_rebuild_keeps_the_barrier(self, server, monkeypatch) -> None:
+        calls = _capture_builds(server, monkeypatch)
+        monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_config_model_target", lambda *a, **k: "")
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_load_show_reasoning", lambda *a, **k: False)
+        monkeypatch.setattr(server, "_load_tool_progress_mode", lambda *a, **k: "off")
+        session = {
+            "agent": SimpleNamespace(enabled_toolsets=[]),
+            "session_key": "k-new",
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "create_enabled_toolsets": [],
+        }
+        server._reset_session_agent("sid-new", session)
+        assert calls[-1]["enabled_toolsets_override"] == []
+        assert session["create_enabled_toolsets"] == []
+
+    def test_background_agent_inherits_empty_selection(self, server, monkeypatch) -> None:
+        monkeypatch.setattr(server, "_load_cfg", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal", "file"])
+        agent = SimpleNamespace(enabled_toolsets=[])
+        kwargs = server._background_agent_kwargs(agent, "task-1")
+        assert kwargs["enabled_toolsets"] == []
+
+    def _reload_mcp(self, server, monkeypatch, agent_toolsets):
+        """Drive reload.mcp on a session and return refresh's enabled_override."""
+        seen: dict = {}
+        fake_mcp = MagicMock()
+        fake_mcp.refresh_agent_mcp_tools.side_effect = (
+            lambda agent, enabled_override=None, **kw: seen.update(
+                {"enabled_override": enabled_override}
+            )
+        )
+        session = {
+            "session_key": "k-mcp",
+            "agent": SimpleNamespace(enabled_toolsets=agent_toolsets),
+        }
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal", "file"])
+        monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+        with patch.dict(server._sessions, {"s-mcp": session}, clear=False), patch.dict(
+            "sys.modules", {"tools.mcp_tool": fake_mcp}
+        ):
+            resp = server.handle_request(
+                {
+                    "id": "r-mcp",
+                    "method": "reload.mcp",
+                    "params": {"session_id": "s-mcp", "confirm": True},
+                }
+            )
+        assert "error" not in resp
+        return seen
+
+    def test_reload_mcp_keeps_empty_selection(self, server, monkeypatch) -> None:
+        assert self._reload_mcp(server, monkeypatch, [])["enabled_override"] == []
+
+    def test_reload_mcp_without_selection_re_resolves_global(
+        self, server, monkeypatch
+    ) -> None:
+        seen = self._reload_mcp(server, monkeypatch, None)
+        assert seen["enabled_override"] == ["terminal", "file"]
+
+    def test_background_agent_without_selection_uses_global(self, server, monkeypatch) -> None:
+        monkeypatch.setattr(server, "_load_cfg", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal", "file"])
+        agent = SimpleNamespace(enabled_toolsets=None)
+        kwargs = server._background_agent_kwargs(agent, "task-2")
+        assert kwargs["enabled_toolsets"] == ["terminal", "file"]

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1237,3 +1237,67 @@ class TestDesktopBranchInheritsScope:
         )
         assert "error" in resp
         assert not calls
+
+
+class TestPrebuildInspection:
+    """Before the agent exists, inspection must reflect the CURRENT global
+    config, not "everything", while a pinned empty scope still reports none."""
+
+    def _session(self, pinned):
+        session = {"session_key": "k", "agent": None}
+        if pinned is not None:
+            session["create_enabled_toolsets"] = pinned
+        return session
+
+    @pytest.mark.parametrize("method", ["tools.list", "toolsets.list"])
+    def test_unpinned_prebuild_follows_restricted_global(self, method, monkeypatch) -> None:
+        server = _reporting_server()
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+        items = _list_toolsets(server, method, self._session(None))
+        assert [i["name"] for i in items if i["enabled"]] == ["file"]
+
+    @pytest.mark.parametrize("method", ["tools.list", "toolsets.list"])
+    def test_unpinned_prebuild_with_global_none_reports_everything(
+        self, method, monkeypatch
+    ) -> None:
+        server = _reporting_server()
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+        items = _list_toolsets(server, method, self._session(None))
+        assert all(i["enabled"] for i in items)
+
+    @pytest.mark.parametrize("method", ["tools.list", "toolsets.list"])
+    def test_pinned_empty_prebuild_still_reports_none(self, method, monkeypatch) -> None:
+        server = _reporting_server()
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+        items = _list_toolsets(server, method, self._session([]))
+        assert [i["name"] for i in items if i["enabled"]] == []
+
+    def test_tools_show_prebuild_follows_restricted_global(self, monkeypatch) -> None:
+        server = _reporting_server()
+        # Pick a toolset that actually resolves to tools in this environment,
+        # so the assertion measures the restriction and not the registry.
+        from model_tools import get_tool_definitions
+        from toolsets import get_all_toolsets
+
+        restricted = next(
+            (
+                name
+                for name in sorted(get_all_toolsets())
+                if get_tool_definitions(enabled_toolsets=[name], quiet_mode=True)
+            ),
+            None,
+        )
+        assert restricted, "no toolset resolves to tools in this environment"
+
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+        total_global = _show_tools(server, self._session(None))["total"]
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: [restricted])
+        result = _show_tools(server, self._session(None))
+        assert 0 < result["total"] < total_global
+
+    def test_tools_show_prebuild_pinned_empty_is_zero(self, monkeypatch) -> None:
+        server = _reporting_server()
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+        result = _show_tools(server, self._session([]))
+        assert result["total"] == 0
+        assert result["sections"] == []

--- a/tests/tui_gateway/test_zero_toolset_session.py
+++ b/tests/tui_gateway/test_zero_toolset_session.py
@@ -1117,3 +1117,53 @@ class TestTurnOwnershipCleanup:
                 assert events[-1]["type"] == "turn.error"
         finally:
             host._executor.shutdown(wait=False)
+
+
+class TestReloadMcpLiftsRestriction:
+    """reload.mcp on an unpinned session must follow the global config, even
+    when that config resolves to "everything" (None)."""
+
+    def test_global_none_config_lifts_the_agent_restriction(
+        self, server, monkeypatch
+    ) -> None:
+        agent = SimpleNamespace(
+            enabled_toolsets=["file"], disabled_toolsets=None,
+            tools=[], valid_tool_names=set(),
+        )
+        session = {
+            "session_key": "k-mcp",
+            "agent": agent,
+            "create_enabled_toolsets": None,
+        }
+        seen: dict = {}
+
+        import model_tools
+
+        def _defs(**kw):
+            seen.update(kw)
+            return []
+
+        monkeypatch.setattr(model_tools, "get_tool_definitions", _defs)
+        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+        monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: False)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+        import tools.mcp_tool as mcp_tool
+
+        monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", lambda *a, **k: None,
+                            raising=False)
+        monkeypatch.setattr(mcp_tool, "discover_mcp_tools", lambda *a, **k: None,
+                            raising=False)
+
+        with patch.dict(server._sessions, {"s-mcp": session}, clear=False):
+            resp = server.handle_request(
+                {"id": "r-mcp", "method": "reload.mcp",
+                 "params": {"session_id": "s-mcp", "confirm": True}}
+            )
+
+        assert "error" not in resp
+        assert resp["result"]["status"] == "reloaded"
+        # The restriction is gone: the rebuild asked for every toolset.
+        assert seen["enabled_toolsets"] is None
+        assert agent.enabled_toolsets is None

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5514,11 +5514,14 @@ def has_registered_mcp_tools() -> bool:
         return bool(_mcp_tool_server_names)
 
 
+_NO_OVERRIDE = object()
+
+
 def refresh_agent_mcp_tools(
     agent,
     *,
-    enabled_override=None,
-    disabled_override=None,
+    enabled_override=_NO_OVERRIDE,
+    disabled_override=_NO_OVERRIDE,
     quiet_mode: bool = True,
 ) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry.
@@ -5562,9 +5565,18 @@ def refresh_agent_mcp_tools(
     # the user just ENABLED in config is picked up; the agent's stored selection
     # is then updated to match. The automatic paths (between-turns, late-binding)
     # pass nothing and reuse the agent's build-time selection unchanged.
-    if enabled_override is not None or disabled_override is not None:
-        enabled = enabled_override if enabled_override is not None else getattr(agent, "enabled_toolsets", None)
-        disabled = disabled_override if disabled_override is not None else getattr(agent, "disabled_toolsets", None)
+    # A sentinel, not None: ``None`` is a MEANINGFUL override value (every
+    # toolset enabled), so a caller re-resolving an unrestricted global config
+    # must be able to lift the agent's earlier restriction.
+    if enabled_override is not _NO_OVERRIDE or disabled_override is not _NO_OVERRIDE:
+        enabled = (
+            enabled_override if enabled_override is not _NO_OVERRIDE
+            else getattr(agent, "enabled_toolsets", None)
+        )
+        disabled = (
+            disabled_override if disabled_override is not _NO_OVERRIDE
+            else getattr(agent, "disabled_toolsets", None)
+        )
         agent.enabled_toolsets = enabled
         agent.disabled_toolsets = disabled
     else:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -373,6 +373,7 @@ class ComputeHost:
         if not sid:
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "sid required"})
             return
+        owns_turn = False
         try:
             from tui_gateway import server
 
@@ -381,6 +382,7 @@ class ComputeHost:
                 if session.get("running"):
                     self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "session busy"})
                     return
+                owns_turn = True
                 session["running"] = True
                 session["_turn_cancel_requested"] = False
                 session["last_active"] = time.time()
@@ -427,16 +429,20 @@ class ComputeHost:
                 }
             )
         except Exception as exc:
-            try:
-                from tui_gateway import server
+            # Only the caller that actually acquired the turn may release it.
+            # A refused frame (busy session, scope conflict) runs this same
+            # block; clearing here would unlock a turn owned by someone else.
+            if owns_turn:
+                try:
+                    from tui_gateway import server
 
-                session = server._sessions.get(sid)
-                if session is not None:
-                    with session.get("history_lock", threading.Lock()):
-                        session["running"] = False
-                        server._clear_inflight_turn(session)
-            except Exception:
-                pass
+                    session = server._sessions.get(sid)
+                    if session is not None:
+                        with session.get("history_lock", threading.Lock()):
+                            session["running"] = False
+                            server._clear_inflight_turn(session)
+                except Exception:
+                    pass
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
 
     def _acquire_session_lock(self, sid: str) -> tuple[threading.Lock, _SessionLockEntry]:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -426,6 +426,8 @@ class ComputeHost:
                 session["cwd"] = str(frame.get("cwd"))
             if frame.get("profile_home"):
                 session["profile_home"] = str(frame.get("profile_home"))
+            if frame.get("enabled_toolsets") is not None:
+                session["create_enabled_toolsets"] = frame.get("enabled_toolsets")
             if isinstance(frame.get("attached_images"), list):
                 session["attached_images"] = list(frame.get("attached_images") or [])
             return session
@@ -449,6 +451,7 @@ class ComputeHost:
                 reasoning_config_override=frame.get("reasoning_config_override"),
                 service_tier_override=frame.get("service_tier_override"),
                 platform_override=frame.get("source"),
+                enabled_toolsets_override=frame.get("enabled_toolsets"),
                 session_db=session_db,
             )
         finally:
@@ -500,6 +503,7 @@ class ComputeHost:
                 "edit_snapshots": {},
                 "tool_started_at": {},
                 "model_override": frame.get("model_override"),
+                "create_enabled_toolsets": frame.get("enabled_toolsets"),
                 "source": server._sanitize_client_source(frame.get("source")),
                 "transport": self._transport,
             }
@@ -510,6 +514,8 @@ class ComputeHost:
             session["attached_images"] = list(frame.get("attached_images") or [])
         if frame.get("model_override") is not None:
             session["model_override"] = frame.get("model_override")
+        if frame.get("enabled_toolsets") is not None:
+            session["create_enabled_toolsets"] = frame.get("enabled_toolsets")
         return session
 
     def _handle_reload_mcp(self, frame: dict[str, Any]) -> None:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -26,6 +26,29 @@ def now_ns() -> int:
     return time.perf_counter_ns()
 
 
+class _SessionLockEntry:
+    """A per-sid build lock plus the number of callers holding a reference.
+
+    Refcounted so the table cannot grow one entry per session for the life of
+    the host: a caller registers its interest under the guard BEFORE waiting on
+    the lock, and the last one out evicts the entry.
+    """
+
+    __slots__ = ("lock", "waiters")
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.waiters = 0
+
+
+class ToolsetScopeConflictError(RuntimeError):
+    """A turn frame asked for a toolset scope the live session cannot honor.
+
+    Raised instead of mutating the session: an agent's toolset snapshot is
+    fixed at build time, so the only fail-closed answer is to refuse the turn.
+    """
+
+
 @dataclass
 class SpikeAgent:
     """A deterministic AIAgent-shaped object for pipe/interrupt measurements."""
@@ -142,6 +165,8 @@ class ComputeHost:
         self._progress_lock = threading.Lock()
         self._turn_futures: set[concurrent.futures.Future] = set()
         self._turn_futures_lock = threading.Lock()
+        self._session_locks: dict[str, _SessionLockEntry] = {}
+        self._session_locks_guard = threading.Lock()
         self._transport = _HostTransport(self.emit)
         self._heartbeat_secs = (
             float(heartbeat_secs)
@@ -414,11 +439,44 @@ class ComputeHost:
                 pass
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
 
+    def _acquire_session_lock(self, sid: str) -> tuple[threading.Lock, _SessionLockEntry]:
+        with self._session_locks_guard:
+            entry = self._session_locks.get(sid)
+            if entry is None:
+                entry = _SessionLockEntry()
+                self._session_locks[sid] = entry
+            entry.waiters += 1
+            return entry.lock, entry
+
+    def _release_session_lock(self, sid: str, entry: _SessionLockEntry) -> None:
+        with self._session_locks_guard:
+            entry.waiters -= 1
+            if entry.waiters <= 0 and self._session_locks.get(sid) is entry:
+                del self._session_locks[sid]
+
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
+        # Serialized per sid: two concurrent first turns used to build two
+        # agents and let the last writer win, so an incompatible scope could
+        # silently replace a session that was opened without tools. The lock
+        # covers ensure/build only and is dropped before the turn runs.
+        sid = str(frame.get("sid") or "")
+        lock, entry = self._acquire_session_lock(sid)
+        try:
+            with lock:
+                return self._ensure_server_session_locked(server, frame)
+        finally:
+            self._release_session_lock(sid, entry)
+
+    def _ensure_server_session_locked(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")
         key = str(frame.get("session_key") or sid)
         session = server._sessions.get(sid)
         if session is not None:
+            if server._toolset_selection_conflict(session, frame.get("enabled_toolsets")):
+                raise ToolsetScopeConflictError(
+                    "compute host: session is already live with a different "
+                    "toolset selection"
+                )
             session["transport"] = self._transport
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2971,6 +2971,57 @@ class _ToolsetSelectionError(ValueError):
     """``enabled_toolsets`` was sent with a shape the contract doesn't accept."""
 
 
+def _is_known_toolset(name: str) -> bool:
+    """Would ``name`` resolve to something the resolver understands?
+
+    Mirrors the resolver's own vocabulary: built-in and plugin toolsets, the
+    ``all``/``*`` aliases, registry aliases, the legacy ``*_tools`` names, and
+    configured MCP server names.
+    """
+    try:
+        from toolsets import validate_toolset
+    except Exception:
+        return True  # Cannot check: do not invent a rejection.
+    if validate_toolset(name):
+        return True
+    try:
+        from model_tools import _LEGACY_TOOLSET_MAP
+
+        if name in _LEGACY_TOOLSET_MAP:
+            return True
+    except Exception:
+        pass
+    # Plugin toolsets only exist once discovery ran (it is idempotent).
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        if validate_toolset(name):
+            return True
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import read_raw_config
+
+        raw_cfg = read_raw_config()
+        servers = raw_cfg.get("mcp_servers") if isinstance(raw_cfg, dict) else None
+        if isinstance(servers, dict) and name in servers:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _reject_unknown_toolsets(names: list[str]) -> None:
+    unknown = [name for name in names if not _is_known_toolset(name)]
+    if unknown:
+        # A name the resolver drops would otherwise turn into a silent
+        # zero-tool session, so a typo must surface as an error instead.
+        raise _ToolsetSelectionError(
+            "unknown toolset(s): " + ", ".join(unknown)
+        )
+
+
 def _requested_enabled_toolsets(params: dict) -> list[str] | None:
     """The caller's explicit toolset selection, or ``None`` when absent.
 
@@ -2995,7 +3046,9 @@ def _requested_enabled_toolsets(params: dict) -> list[str] | None:
                 "enabled_toolsets entries must be strings; "
                 f"got {type(item).__name__}"
             )
-    return [item.strip() for item in raw if item.strip()]
+    names = [item.strip() for item in raw if item.strip()]
+    _reject_unknown_toolsets(names)
+    return names
 
 
 def _session_toolset_selection(session: dict) -> list[str] | None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3007,6 +3007,22 @@ def _session_toolset_selection(session: dict) -> list[str] | None:
     return list(stored) if stored is not None else None
 
 
+def _effective_toolset_selection(session: dict | None) -> list[str] | None:
+    """What a session's tools resolve to right now, for inspection RPCs.
+
+    A session with no explicit scope and no agent yet has NOT escaped the
+    configured toolsets: it will be built from them, so inspection must answer
+    with the current global resolution rather than with "everything".
+    """
+    if session:
+        selection = _session_toolset_selection(session)
+        if selection is not None:
+            return selection
+        if session.get("agent") is not None:
+            return None
+    return _load_enabled_toolsets()
+
+
 def _reported_toolset_selection(session: dict | None) -> set[str] | None:
     """Toolsets to mark enabled for a client, or ``None`` when all of them are.
 
@@ -3014,9 +3030,7 @@ def _reported_toolset_selection(session: dict | None) -> set[str] | None:
     no toolset at all, while ``None`` is "no explicit scope" and keeps the
     historical "everything is enabled" answer.
     """
-    selection = (
-        _session_toolset_selection(session) if session else _load_enabled_toolsets()
-    )
+    selection = _effective_toolset_selection(session)
     return set(selection) if selection is not None else None
 
 
@@ -15629,11 +15643,7 @@ def _(rid, params: dict) -> dict:
         from model_tools import get_toolset_for_tool, get_tool_definitions
 
         session = _sessions.get(params.get("session_id", ""))
-        enabled = (
-            _session_toolset_selection(session)
-            if session
-            else _load_enabled_toolsets()
-        )
+        enabled = _effective_toolset_selection(session)
         tools = get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True)
         sections = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2986,7 +2986,16 @@ def _requested_enabled_toolsets(params: dict) -> list[str] | None:
             "enabled_toolsets must be a list of toolset names; "
             "omit the field to inherit the configured toolsets"
         )
-    return [str(item).strip() for item in raw if str(item).strip()]
+    # No coercion: str(item) on a number/dict/bool would invent a toolset name
+    # the caller never asked for, and an unknown name resolves to no tools at
+    # all, so the mistake would pass as a scope instead of surfacing.
+    for item in raw:
+        if not isinstance(item, str):
+            raise _ToolsetSelectionError(
+                "enabled_toolsets entries must be strings; "
+                f"got {type(item).__name__}"
+            )
+    return [item.strip() for item in raw if item.strip()]
 
 
 def _session_toolset_selection(session: dict) -> list[str] | None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5921,6 +5921,15 @@ def _(rid, params: dict) -> dict:
         create_enabled_toolsets = _requested_enabled_toolsets(params)
     except _ToolsetSelectionError as exc:
         return _err(rid, 4045, str(exc))
+    if create_enabled_toolsets is None and parent_session_id:
+        # Desktop branches a chat through session.create + parent_session_id.
+        # Without an explicit field the child inherits the parent's scope, or
+        # branching a session opened without tools would return a tooled copy.
+        parent_live = _find_live_session_by_key(parent_session_id)
+        if parent_live is not None:
+            inherited = parent_live[1].get("create_enabled_toolsets")
+            if inherited is not None:
+                create_enabled_toolsets = list(inherited)
 
     ready = threading.Event()
     now = time.time()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1271,6 +1271,9 @@ def _compute_host_turn_frame(rid: str, sid: str, session: dict, text: Any) -> di
         "model_override": session.get("model_override"),
         "reasoning_config_override": session.get("create_reasoning_override"),
         "service_tier_override": session.get("create_service_tier_override"),
+        # `[]` must cross the process boundary as `[]`, never as "unset": the
+        # host builds the session's first agent itself.
+        "enabled_toolsets": session.get("create_enabled_toolsets"),
         "source": _session_source(session),
         "attached_images": attached_images,
     }
@@ -1627,6 +1630,10 @@ def _start_agent_build(sid: str, session: dict) -> None:
                         kw["reasoning_config_override"] = reasoning
                     if (tier := current.get("create_service_tier_override")) is not None:
                         kw["service_tier_override"] = tier
+                # Outside the if/else on purpose: a cold resume restoring its
+                # persisted runtime identity must carry the scope too.
+                if (toolsets := current.get("create_enabled_toolsets")) is not None:
+                    kw["enabled_toolsets_override"] = toolsets
                 agent = _make_agent(sid, key, **kw)
             finally:
                 _clear_session_context(tokens)
@@ -2958,6 +2965,59 @@ def _load_tool_progress_mode() -> str:
         return "all"
     mode = str(raw or "all").strip().lower()
     return mode if mode in {"off", "new", "all", "verbose"} else "all"
+
+
+class _ToolsetSelectionError(ValueError):
+    """``enabled_toolsets`` was sent with a shape the contract doesn't accept."""
+
+
+def _requested_enabled_toolsets(params: dict) -> list[str] | None:
+    """The caller's explicit toolset selection, or ``None`` when absent.
+
+    Only ABSENCE inherits the global resolution. ``null`` is rejected rather
+    than treated as absent: a client asking for a scope must never be handed a
+    fully tooled session because its field serialized to null.
+    """
+    if not isinstance(params, dict) or "enabled_toolsets" not in params:
+        return None
+    raw = params.get("enabled_toolsets")
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, (list, tuple)):
+        raise _ToolsetSelectionError(
+            "enabled_toolsets must be a list of toolset names; "
+            "omit the field to inherit the configured toolsets"
+        )
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _session_toolset_selection(session: dict) -> list[str] | None:
+    agent = session.get("agent")
+    if agent is not None:
+        selection = getattr(agent, "enabled_toolsets", None)
+        return list(selection) if selection is not None else None
+    stored = session.get("create_enabled_toolsets")
+    return list(stored) if stored is not None else None
+
+
+def _toolset_selection_conflict(session: dict, requested: list[str] | None) -> bool:
+    """Would reusing ``session`` silently ignore ``requested``?
+
+    Toolsets are snapshotted once at agent build and never re-read (rebuilding
+    them mid-conversation would break prompt caching), so a live session cannot
+    be re-scoped by a resume. Fail closed instead of handing a tooled agent to
+    a caller that asked for none.
+    """
+    if requested is None:
+        return False
+    current = _session_toolset_selection(session)
+    if current is None:
+        return True
+    return set(current) != set(requested)
+
+
+_TOOLSET_CONFLICT_MESSAGE = (
+    "session is already live with a different toolset selection; "
+    "close it before resuming with enabled_toolsets"
+)
 
 
 def _load_enabled_toolsets() -> list[str] | None:
@@ -4645,8 +4705,13 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
         "max_iterations": _cfg_max_turns(cfg, 25),
-        "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
-        or _load_enabled_toolsets(),
+        # `is not None`, not `or`: an agent scoped to no toolsets must not have
+        # the global selection injected back into its clone.
+        "enabled_toolsets": (
+            list(_agent_toolsets)
+            if (_agent_toolsets := getattr(agent, "enabled_toolsets", None)) is not None
+            else _load_enabled_toolsets()
+        ),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)
@@ -4812,11 +4877,14 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         session.pop("create_reasoning_override", None)
         session.pop("create_service_tier_override", None)
         session.pop("one_turn_model_restore", None)
+        # Deliberately NOT cleared with the runtime pins above: /new must not
+        # hand back a tooled agent to a session opened without tools.
         new_agent = _make_agent(
             sid,
             session["session_key"],
             session_id=session["session_key"],
             platform_override=_session_source(session),
+            enabled_toolsets_override=session.get("create_enabled_toolsets"),
         )
     finally:
         _clear_session_context(tokens)
@@ -4984,6 +5052,7 @@ def _make_agent(
     reasoning_config_override: dict | None = None,
     service_tier_override: str | None = None,
     platform_override: str | None = None,
+    enabled_toolsets_override: list | None = None,
 ):
     # AC-4 test seam: dead unless explicitly armed by the isolated certify
     # harness. Both inline and compute-host paths construct through _make_agent,
@@ -5136,7 +5205,13 @@ def _make_agent(
             if service_tier_override is not None
             else _load_service_tier()
         ),
-        enabled_toolsets=_load_enabled_toolsets(),
+        # `is not None`, not truthiness: `[]` is a real selection (no tools at
+        # all) and must not fall through to the global resolution.
+        enabled_toolsets=(
+            list(enabled_toolsets_override)
+            if enabled_toolsets_override is not None
+            else _load_enabled_toolsets()
+        ),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.
@@ -5820,6 +5895,10 @@ def _(rid, params: dict) -> dict:
         create_service_tier_override = (
             "priority" if is_truthy_value(params.get("fast")) else ""
         )
+    try:
+        create_enabled_toolsets = _requested_enabled_toolsets(params)
+    except _ToolsetSelectionError as exc:
+        return _err(rid, 4045, str(exc))
 
     ready = threading.Event()
     now = time.time()
@@ -5851,6 +5930,7 @@ def _(rid, params: dict) -> dict:
             "model_override": session_model_override,
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
+            "create_enabled_toolsets": create_enabled_toolsets,
             "parent_session_id": parent_session_id,
             "pending_title": title or None,
             "profile_home": str(profile_home) if profile_home is not None else None,
@@ -6079,6 +6159,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    enabled_toolsets: list[str] | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -6092,6 +6173,7 @@ def _deferred_session_record(
         "active_session_lease": lease,
         "cols": cols,
         "created_at": now,
+        "create_enabled_toolsets": enabled_toolsets,
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
         "edit_snapshots": {},
@@ -6156,6 +6238,10 @@ def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")
     if not target:
         return _err(rid, 4006, "session_id required")
+    try:
+        requested_toolsets = _requested_enabled_toolsets(params)
+    except _ToolsetSelectionError as exc:
+        return _err(rid, 4045, str(exc))
     try:
         cols = int(params.get("cols", 80))
     except (TypeError, ValueError):
@@ -6242,6 +6328,8 @@ def _(rid, params: dict) -> dict:
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
+            if _toolset_selection_conflict(live[1], requested_toolsets):
+                return _err(rid, 4045, _TOOLSET_CONFLICT_MESSAGE)
             return _ok(rid, _reuse_live_payload(*live))
 
     # Lazy/watch resume: register the live session WITHOUT building an agent.
@@ -6283,8 +6371,11 @@ def _(rid, params: dict) -> dict:
             close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
             profile_home=profile_home,
             lazy=True,
+            enabled_toolsets=requested_toolsets,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
+            if _toolset_selection_conflict(live[1], requested_toolsets):
+                return _err(rid, 4045, _TOOLSET_CONFLICT_MESSAGE)
             return _ok(rid, _reuse_live_payload(*live))
         # A delegated child mid-run emits no session events of its own — report
         # its liveness from the relay registry so the window shows a busy turn.
@@ -6365,8 +6456,11 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
+            enabled_toolsets=requested_toolsets,
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
+            if _toolset_selection_conflict(live[1], requested_toolsets):
+                return _err(rid, 4045, _TOOLSET_CONFLICT_MESSAGE)
             return _ok(rid, _reuse_live_payload(*live))
 
         _schedule_agent_build(sid)
@@ -6438,6 +6532,7 @@ def _(rid, params: dict) -> dict:
                 session_id=target,
                 session_db=db,
                 platform_override=source,
+                enabled_toolsets_override=requested_toolsets,
                 **stored_runtime_overrides,
             )
         finally:
@@ -6464,6 +6559,8 @@ def _(rid, params: dict) -> dict:
             if lease is not None:
                 lease.release()
             other_sid, other_session = live
+            if _toolset_selection_conflict(other_session, requested_toolsets):
+                return _err(rid, 4045, _TOOLSET_CONFLICT_MESSAGE)
             payload = _live_session_payload(
                 other_sid,
                 other_session,
@@ -6499,6 +6596,10 @@ def _(rid, params: dict) -> dict:
                         "model_override"
                     ]
                 _sessions[sid]["display_history_prefix"] = display_history_prefix
+                # On the record, not just on the built agent, so every later
+                # rebuild of this session re-applies the scope.
+                if requested_toolsets is not None:
+                    _sessions[sid]["create_enabled_toolsets"] = requested_toolsets
                 # Remember the profile home so each turn re-binds HERMES_HOME (the
                 # agent persists to its own db, but mid-turn home reads — memory,
                 # skills — must resolve to the resumed profile too).
@@ -12722,10 +12823,17 @@ def _(rid, params: dict) -> dict:
                 from tools.mcp_tool import refresh_agent_mcp_tools
 
                 # Explicit reload: re-resolve enabled toolsets so a server the
-                # user just enabled in config this session is picked up.
+                # user just enabled in config this session is picked up. An
+                # explicitly scoped session keeps its own list instead, or the
+                # reload would re-tool a session opened without tools.
+                _agent_toolsets = getattr(agent, "enabled_toolsets", None)
                 refresh_agent_mcp_tools(
                     agent,
-                    enabled_override=_load_enabled_toolsets(),
+                    enabled_override=(
+                        list(_agent_toolsets)
+                        if _agent_toolsets is not None
+                        else _load_enabled_toolsets()
+                    ),
                     quiet_mode=True,
                 )
             except Exception as _exc:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9149,11 +9149,13 @@ def _(rid, params: dict) -> dict:
     try:
         tokens = _set_session_context(new_key)
         try:
+            branch_toolsets = session.get("create_enabled_toolsets")
             agent = _make_agent(
                 new_sid,
                 new_key,
                 session_id=new_key,
                 platform_override=source,
+                enabled_toolsets_override=branch_toolsets,
             )
         finally:
             _clear_session_context(tokens)
@@ -9167,6 +9169,10 @@ def _(rid, params: dict) -> dict:
         )
         if new_sid in _sessions:
             _sessions[new_sid]["active_session_lease"] = lease
+            # A branch inherits the parent's scope: the copy of a session
+            # opened without tools must not come back tooled.
+            if branch_toolsets is not None:
+                _sessions[new_sid]["create_enabled_toolsets"] = branch_toolsets
     except Exception as e:
         if lease is not None:
             lease.release()
@@ -12836,15 +12842,16 @@ def _(rid, params: dict) -> dict:
                 from tools.mcp_tool import refresh_agent_mcp_tools
 
                 # Explicit reload: re-resolve enabled toolsets so a server the
-                # user just enabled in config this session is picked up. An
-                # explicitly scoped session keeps its own list instead, or the
-                # reload would re-tool a session opened without tools.
-                _agent_toolsets = getattr(agent, "enabled_toolsets", None)
+                # user just enabled in config this session is picked up. The
+                # decision reads the REQUESTED scope on the record, not the
+                # agent: a session opened without the field already carries a
+                # resolved global list on its agent, so reading the agent would
+                # pin it forever and stop honoring config edits.
+                _pinned = session.get("create_enabled_toolsets")
                 refresh_agent_mcp_tools(
                     agent,
                     enabled_override=(
-                        list(_agent_toolsets)
-                        if _agent_toolsets is not None
+                        list(_pinned) if _pinned is not None
                         else _load_enabled_toolsets()
                     ),
                     quiet_mode=True,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2998,6 +2998,19 @@ def _session_toolset_selection(session: dict) -> list[str] | None:
     return list(stored) if stored is not None else None
 
 
+def _reported_toolset_selection(session: dict | None) -> set[str] | None:
+    """Toolsets to mark enabled for a client, or ``None`` when all of them are.
+
+    ``set()`` and ``None`` must stay apart: an empty set is a session scoped to
+    no toolset at all, while ``None`` is "no explicit scope" and keeps the
+    historical "everything is enabled" answer.
+    """
+    selection = (
+        _session_toolset_selection(session) if session else _load_enabled_toolsets()
+    )
+    return set(selection) if selection is not None else None
+
+
 def _toolset_selection_conflict(session: dict, requested: list[str] | None) -> bool:
     """Would reusing ``session`` silently ignore ``requested``?
 
@@ -15564,11 +15577,7 @@ def _(rid, params: dict) -> dict:
         from toolsets import get_all_toolsets, get_toolset_info
 
         session = _sessions.get(params.get("session_id", ""))
-        enabled = (
-            set(getattr(session["agent"], "enabled_toolsets", []) or [])
-            if session
-            else set(_load_enabled_toolsets() or [])
-        )
+        enabled = _reported_toolset_selection(session)
 
         items = []
         for name in sorted(get_all_toolsets().keys()):
@@ -15580,7 +15589,7 @@ def _(rid, params: dict) -> dict:
                     "name": name,
                     "description": info["description"],
                     "tool_count": info["tool_count"],
-                    "enabled": name in enabled if enabled else True,
+                    "enabled": True if enabled is None else name in enabled,
                     "tools": info["resolved_tools"],
                 }
             )
@@ -15596,7 +15605,7 @@ def _(rid, params: dict) -> dict:
 
         session = _sessions.get(params.get("session_id", ""))
         enabled = (
-            getattr(session["agent"], "enabled_toolsets", None)
+            _session_toolset_selection(session)
             if session
             else _load_enabled_toolsets()
         )
@@ -15704,11 +15713,7 @@ def _(rid, params: dict) -> dict:
         from toolsets import get_all_toolsets, get_toolset_info
 
         session = _sessions.get(params.get("session_id", ""))
-        enabled = (
-            set(getattr(session["agent"], "enabled_toolsets", []) or [])
-            if session
-            else set(_load_enabled_toolsets() or [])
-        )
+        enabled = _reported_toolset_selection(session)
 
         items = []
         for name in sorted(get_all_toolsets().keys()):
@@ -15720,7 +15725,7 @@ def _(rid, params: dict) -> dict:
                     "name": name,
                     "description": info["description"],
                     "tool_count": info["tool_count"],
-                    "enabled": name in enabled if enabled else True,
+                    "enabled": True if enabled is None else name in enabled,
                 }
             )
         return _ok(rid, {"toolsets": items})


### PR DESCRIPTION
## Pourquoi

OpenAI peut remettre un quota avant la date de cooldown persistée par Hermes. Le runtime ne doit donc pas rester figé sur MiniMax-M3 jusqu'à cette date.

## Changement

- conserve Codex comme provider primaire après un 429 de quota récupérable ;
- reprobe explicitement les credentials Codex marquées épuisées avant de conserver le fallback ;
- exclut toujours les erreurs terminales 401 et 403 de ce reprobe ;
- couvre la sélection du pool, la résolution Codex, la résolution runtime et le fallback du gateway.

## Validation

- 278 tests ciblés passent ;
- le gateway Windows persistant charge le worktree de cette branche ;
- la tâche Diego_Hermes_Gateway est Running et WhatsApp est connected.

## Limites connues

Le test concurrentiel xAI échoue séparément sous Windows avec PermissionError ; il est hors périmètre de ce correctif. Le reset réel du quota OpenAI reste dépendant du service externe.