### PR TITLE
fix(desktop): keep fuller pending assistant over empty inflight shell

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import type { ChatMessage } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -394,6 +394,56 @@ describe('reconcileResumeMessages', () => {
 
     expect(out.attachmentRefs).toBeUndefined()
   })
+
+  // #75825: switching sessions mid-stream can re-hydrate an empty inflight shell
+  // at the same ordinal as the live stream row that still holds the full reply.
+  it('prefers a richer local pending assistant over an empty projection shell', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', 'hello from stream', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', '', { pending: true })
+    ]
+
+    const reconciled = reconcileResumeMessages(next, previous)
+
+    expect(reconciled[1]).toMatchObject({ id: 'assistant-stream-live', pending: true })
+    expect(chatMessageText(reconciled[1])).toBe('hello from stream')
+  })
+
+  it('prefers a richer local pending assistant when the projection lags mid-stream', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', 'hello world', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', 'hello', { pending: true })
+    ]
+
+    const reconciled = reconcileResumeMessages(next, previous)
+
+    expect(chatMessageText(reconciled[1])).toBe('hello world')
+    expect(reconciled[1].id).toBe('assistant-stream-live')
+  })
+
+  it('does not override when the authoritative assistant has advanced further', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', 'hello', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', 'hello world', { pending: true })
+    ]
+
+    const reconciled = reconcileResumeMessages(next, previous)
+
+    expect(chatMessageText(reconciled[1])).toBe('hello world')
+    expect(reconciled[1].id).toBe('assistant-stream-sess')
+  })
 })
 
 describe('preserveLocalPendingTurnMessages', () => {
@@ -598,6 +648,55 @@ describe('preserveLocalPendingTurnMessages', () => {
       '3-user-stored',
       'user-optimistic'
     ])
+  })
+
+  // #75825: an empty inflight projection shell at the same ordinal must not
+  // discard the local pending assistant that still holds the streamed content.
+  // Replace the shell (do not append) so the transcript shows one reply.
+  it('replaces an empty inflight shell with a fuller local pending assistant', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', 'partial answer so far', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', '', { pending: true })
+    ]
+
+    const preserved = preserveLocalPendingTurnMessages(next, previous)
+
+    expect(preserved.map(message => message.id)).toEqual(['1-user', 'assistant-stream-live'])
+    expect(chatMessageText(preserved[1])).toBe('partial answer so far')
+    expect(preserved[1].pending).toBe(true)
+  })
+
+  it('replaces a lagging same-id shell with the fuller local pending body', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', 'full streamed content', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', '', { pending: true })
+    ]
+
+    const preserved = preserveLocalPendingTurnMessages(next, previous)
+
+    expect(preserved.map(message => message.id)).toEqual(['1-user', 'assistant-stream-sess'])
+    expect(chatMessageText(preserved[1])).toBe('full streamed content')
+  })
+
+  it('still drops local pending when authoritative text is at least as complete', () => {
+    const previous = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', 'partial', { pending: true })
+    ]
+    const next = [
+      msg('1-user', 'user', 'question'),
+      msg('assistant-stream-sess', 'assistant', 'partial and more', { pending: true })
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -250,7 +250,26 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     const nextText = chatMessageText(message).trim()
     const previousText = chatMessageText(previous)
     const previousVisibleText = textWithoutEmbeddedImages(previousText)
+    const previousTrimmed = previousVisibleText.trim()
     let preserved = message
+
+    // #75825: resume can project an empty (or lagging) inflight assistant shell
+    // at the same role-ordinal as the live stream row that still holds the full
+    // streamed text. Prefer that richer pending row instead of painting the
+    // shell — otherwise the reply vanishes until restart. Only when the local
+    // text is a strict extension of the authoritative text (or the shell is
+    // empty), so a different turn at the same ordinal cannot hijack the slot.
+    const previousPendingAssistant =
+      previous.role === 'assistant' &&
+      (previous.pending === true || previous.id.startsWith('assistant-stream-'))
+    const previousIsRicherPending =
+      previousPendingAssistant &&
+      previousTrimmed.length > nextText.length &&
+      (nextText.length === 0 || previousTrimmed.startsWith(nextText))
+
+    if (previousIsRicherPending) {
+      return previous
+    }
 
     const sameText = nextText === previousVisibleText || nextText === previousText.trim()
 
@@ -262,7 +281,7 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // row is by definition not settled.
     const sameTurn =
       sameText ||
-      (nextText.length > 0 && previousVisibleText.length > 0 && nextText.startsWith(previousVisibleText.trim()))
+      (nextText.length > 0 && previousTrimmed.length > 0 && nextText.startsWith(previousTrimmed))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)
@@ -315,8 +334,10 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
  * history window. Preserve only the newest optimistic user row: compression
  * rewrites past context, so older `user-*` rows in a warm cache are stale
  * history, not in-flight work. The latest authoritative user confirms whether
- * that tail has persisted; any authoritative assistant at the same ordinal
- * supersedes the local stream.
+ * that tail has persisted. An authoritative assistant at the same ordinal
+ * supersedes the local stream only when it is at least as complete; an empty
+ * or lagging inflight shell must not discard a fuller local pending reply
+ * (#75825).
  *
  * Gateway bookkeeping markers (the model-switch / personality notices written
  * by tui_gateway/server.py) are persisted as role=user but are not user turns.
@@ -378,6 +399,9 @@ export function preserveLocalPendingTurnMessages(
 
   const latestAuthoritativeUser = [...nextMessages].reverse().find(message => message.role === 'user')
   const preserved: ChatMessage[] = []
+  // Authoritative id → richer local pending row. Replacing (not appending)
+  // avoids painting both the empty inflight shell and the full stream bubble.
+  const replacements = new Map<string, ChatMessage>()
 
   for (const message of previousMessages) {
     if (isGatewaySystemMarker(message)) {
@@ -392,7 +416,23 @@ export function preserveLocalPendingTurnMessages(
     const isPendingAssistant =
       message.role === 'assistant' && (message.pending === true || message.id.startsWith('assistant-stream-'))
 
-    if ((!isOptimisticUser && !isPendingAssistant) || nextIds.has(message.id)) {
+    if (!isOptimisticUser && !isPendingAssistant) {
+      continue
+    }
+
+    // Same id already present: still prefer a strictly more complete local
+    // pending body over an empty/stale shell that reused the stream id.
+    if (nextIds.has(message.id)) {
+      if (isPendingAssistant) {
+        const existing = nextMessages.find(candidate => candidate.id === message.id)
+        const localText = chatMessageText(message).trim()
+        const existingText = existing ? chatMessageText(existing).trim() : localText
+
+        if (existing && localText.length > existingText.length) {
+          replacements.set(message.id, message)
+        }
+      }
+
       continue
     }
 
@@ -412,6 +452,16 @@ export function preserveLocalPendingTurnMessages(
 
     if (authoritative) {
       if (isPendingAssistant) {
+        // Keep the local pending row when it has content the authoritative
+        // row lacks (e.g. an empty inflight projection shell). #75825
+        const localText = chatMessageText(message).trim()
+        const authoritativeText = chatMessageText(authoritative).trim()
+
+        if (authoritativeText.length >= localText.length) {
+          continue
+        }
+
+        replacements.set(authoritative.id, message)
         continue
       }
 
@@ -423,7 +473,10 @@ export function preserveLocalPendingTurnMessages(
     preserved.push(message)
   }
 
-  return preserved.length ? [...nextMessages, ...preserved] : nextMessages
+  const withReplacements =
+    replacements.size > 0 ? nextMessages.map(message => replacements.get(message.id) ?? message) : nextMessages
+
+  return preserved.length ? [...withReplacements, ...preserved] : withReplacements
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop transcript bug where switching sessions while a turn streams (or right as it completes) can leave the assistant reply missing from the UI until restart, even though the streamed content was still held in the local slice.

When resuming, reconciliation merges stored history + the backend `inflight` projection (fixed id `assistant-stream-${sessionId}`, often empty or lagging) with local pending messages. `preserveLocalPendingTurnMessages` previously dropped the local pending assistant whenever *any* authoritative assistant existed at the same role-ordinal — including an empty projection shell — so the fuller streamed row was discarded and nothing repopulated it after stream events had stopped.

## Related Issue

Fixes #75825

Related but not duplicated:
- #67879 — compressed running-session REST authority (different failure mode)
- #72151 — RAF flush on busy session switch (blank until turn ends)
- #71877 — post-turn hydration vs next-turn stream race
- #70209 — completed `assistant-stream-*` resurrection via `pending` flag

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `reconcileResumeMessages`: prefer a richer local pending assistant when the authoritative/projected text is empty or a strict prefix of the local stream text
- `preserveLocalPendingTurnMessages`: when a same-ordinal authoritative assistant is less complete, **replace** that shell with the local pending row (do not append a second bubble); same-id shells get the same completeness preference
- Regression tests for empty shell, lagging mid-stream shell, same-id shell, and “authoritative already further ahead”

## How to Test

```bash
cd apps/desktop
../../node_modules/.bin/vitest run --project ui \
  src/app/session/hooks/use-session-actions/utils.test.ts
```

Expected: **50 passed**

Manual:
1. Start a turn in session A; switch to B while the assistant is still streaming (or right as it completes).
2. Switch back to A (repeat A↔B a few times).
3. Transcript should keep the assistant reply for the in-flight/recent turn — not user-only until restart.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs (none open for #75825; related desktop reconcile PRs cover different symptoms)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A: Desktop-only TypeScript change
- [x] I've added tests for my changes
- [x] Focused Desktop UI tests pass on macOS

### Documentation & Housekeeping

- [x] Docs / config / AGENTS — N/A (no user-facing API or config change)
- [x] Cross-platform: renderer reconciliation only