### PR TITLE
fix(tui): stop session workspace migration to unrelated git repos

### DIFF
--- a/tests/tui_gateway/test_session_cwd_follow.py
+++ b/tests/tui_gateway/test_session_cwd_follow.py
@@ -29,7 +29,7 @@ def repo_with_worktree(tmp_path):
     _git(repo, "init", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "t")
-    (repo / "README.md").write_text("hi\n")
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "init")
 
@@ -87,6 +87,32 @@ def test_browsing_outside_a_repo_is_not_a_move(session, repo_with_worktree, tmp_
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     terminal_tool.record_session_cwd(session["session_key"], str(scratch))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(repo)
+
+
+def test_a_non_git_workspace_is_not_hijacked_by_visiting_a_repo(
+    session, repo_with_worktree, tmp_path
+):
+    """A non-git workspace must not be re-homed when a tool call steps into a
+    git repo: browsing in to read a file or run a command is a visit, not a
+    relocation. Otherwise the first git directory the agent touches (e.g. its
+    own install checkout) hijacks a home-directory session.
+    """
+    repo, _ = repo_with_worktree
+    home = tmp_path / "home"  # a plain, non-git workspace
+    home.mkdir()
+    session["cwd"] = str(home)
+    terminal_tool.record_session_cwd(session["session_key"], str(repo))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(home)
+
+
+def test_a_deleted_directory_is_not_a_move(session, repo_with_worktree, tmp_path):
+    repo, _ = repo_with_worktree
+    terminal_tool.record_session_cwd(session["session_key"], str(tmp_path / "gone"))
 
     assert server._reconcile_session_cwd_from_terminal(session) is False
     assert session["cwd"] == str(repo)

--- a/tests/tui_gateway/test_session_cwd_follow.py
+++ b/tests/tui_gateway/test_session_cwd_follow.py
@@ -118,6 +118,52 @@ def test_a_deleted_directory_is_not_a_move(session, repo_with_worktree, tmp_path
     assert session["cwd"] == str(repo)
 
 
+def test_an_unrelated_repo_is_not_a_move(session, repo_with_worktree, tmp_path):
+    """Git workspace A visiting unrelated git repo B is a visit, not a re-home.
+
+    Only checkouts sharing the same common .git dir (the shape `git worktree
+    add` produces) count as a relocation; `cd ~/other-project && git log`
+    must not re-anchor the chat onto the foreign repo.
+    """
+    repo, _ = repo_with_worktree
+    other = tmp_path / "other"
+    other.mkdir()
+    _git(other, "init", "-b", "main")
+    _git(other, "config", "user.email", "t@example.com")
+    _git(other, "config", "user.name", "t")
+    (other / "x.txt").write_text("x\n", encoding="utf-8")
+    _git(other, "add", ".")
+    _git(other, "commit", "-m", "init")
+    terminal_tool.record_session_cwd(session["session_key"], str(other))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(repo)
+
+
+def test_an_explicit_workspace_is_never_overridden(session, repo_with_worktree):
+    """A user-chosen cwd must survive even a legitimate same-repo worktree move."""
+    repo, worktree = repo_with_worktree
+    session["explicit_cwd"] = True
+    terminal_tool.record_session_cwd(session["session_key"], str(worktree))
+
+    assert server._reconcile_session_cwd_from_terminal(session) is False
+    assert session["cwd"] == str(repo)
+
+
+def test_a_settle_adopted_cwd_can_keep_following(session, repo_with_worktree):
+    """The settle marker keeps a session following the agent across worktrees."""
+    repo, worktree = repo_with_worktree
+    terminal_tool.record_session_cwd(session["session_key"], str(worktree))
+    assert server._reconcile_session_cwd_from_terminal(session) is True
+    assert session["explicit_cwd"] is True
+    assert session["cwd_from_settle"] is True
+
+    # Agent moves back to the primary checkout: still follows.
+    terminal_tool.record_session_cwd(session["session_key"], str(repo))
+    assert server._reconcile_session_cwd_from_terminal(session) is True
+    assert session["cwd"] == str(repo)
+
+
 def test_remote_backends_do_not_reanchor(session, repo_with_worktree, monkeypatch):
     """A remote cwd names a path on the host, not one this gateway can probe."""
     repo, worktree = repo_with_worktree

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2346,7 +2346,14 @@ def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
     # The worktree ROOT, not the common repo root: folding worktrees together
     # here is exactly what hides the move we're looking for.
     landed = _git_repo_root_for_cwd(resolved)
-    if not landed or landed == _git_repo_root_for_cwd(current):
+    current_root = _git_repo_root_for_cwd(current)
+    # A relocation is a move between two DIFFERENT git working trees. When the
+    # session's own workspace is not in a git repo, the agent stepping into one
+    # to read a file or run a command is a browsing visit, not a re-home:
+    # adopting it would hijack a non-git workspace onto whatever repo a tool
+    # call touched first (e.g. a home-directory session pinned to the checkout
+    # it read a file from).
+    if not landed or not current_root or landed == current_root:
         return False
 
     session["cwd"] = resolved

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2319,13 +2319,24 @@ def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
     A plain `cd` is deliberately NOT a workspace move (see
     ``_apply_project_workspace``): browsing to /tmp to read a log must not
     re-home the chat. What we adopt here is narrower — the session's recorded
-    cwd is in a DIFFERENT git working tree than its workspace. That is a
-    relocation by any reading, and it is the only shape this reconciles.
+    cwd is in a DIFFERENT working tree of the SAME repository (the shape
+    ``git worktree add`` produces). Everything else — a non-git workspace
+    stepping into a repo, or a git workspace visiting an unrelated repo — is
+    a browsing visit, and a user's explicitly chosen workspace is never
+    overridden at all.
 
     Local backends only: a remote/SSH cwd names a path on the host, which this
     gateway can neither stat nor probe with git.
     """
     if not session or not _is_local_terminal_backend():
+        return False
+
+    # A workspace the user (or GUI) explicitly chose is never overridden by
+    # where the agent's terminal happened to settle — only another explicit
+    # action (`_set_session_cwd`, a project switch) moves it. A cwd this very
+    # function adopted is marked `cwd_from_settle` so a session can keep
+    # following the agent through successive worktrees.
+    if session.get("explicit_cwd") and not session.get("cwd_from_settle"):
         return False
 
     try:
@@ -2356,10 +2367,23 @@ def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
     if not landed or not current_root or landed == current_root:
         return False
 
+    # And only between checkouts of the SAME repository — the shape a real
+    # `git worktree add` produces (linked worktrees share the common .git
+    # dir). Settling in an UNRELATED repo (`cd ~/other-project && git log`)
+    # is likewise a visit: adopting it would re-home the chat onto whatever
+    # foreign repo the terminal last touched.
+    landed_common = _git_common_repo_root_for_cwd(resolved)
+    current_common = _git_common_repo_root_for_cwd(current)
+    if not landed_common or landed_common != current_common:
+        return False
+
     session["cwd"] = resolved
     # The session works here now, so this is its workspace — a desktop chat
-    # whose cwd was an unpersisted launch artifact earns a real row.
+    # whose cwd was an unpersisted launch artifact earns a real row. The
+    # settle marker keeps this adoption overridable by the NEXT settle while
+    # still yielding to a user's explicit choice (see the guard above).
     session["explicit_cwd"] = True
+    session["cwd_from_settle"] = True
     _register_session_cwd(session)
 
     with _session_db(session) as db:
@@ -2657,6 +2681,9 @@ def _set_session_cwd(session: dict, cwd: str) -> str:
     # An explicit user choice — persist it as the workspace (and let a later
     # lazy row creation persist it too, not the launch-dir fallback).
     session["explicit_cwd"] = True
+    # A user's choice supersedes any earlier settle-adopted cwd: from here on
+    # the terminal wandering must not move the workspace again.
+    session["cwd_from_settle"] = False
     _register_session_cwd(session)
     with _session_db(session) as db:
         if db is not None:
@@ -5494,6 +5521,8 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
 
     session["cwd"] = resolved
     session["explicit_cwd"] = True
+    # An explicit project switch supersedes any earlier settle-adopted cwd.
+    session["cwd_from_settle"] = False
     _register_session_cwd(session)
 
     with _session_db(session) as db:


### PR DESCRIPTION
# fix(gateway): stop session workspace hijack — same-repo worktree follows only, explicit cwd never overridden

Fixes #72776

## Summary

`_reconcile_session_cwd_from_terminal()` re-homed a session onto **any** git repo the terminal touched:

- non-git workspace → `_git_repo_root_for_cwd(current)` is `None` → guard never fired → first repo visited hijacked the session (reported case; confirmed on Windows Desktop + local gateway by @frankzzziii);
- git workspace A → unrelated git repo B also re-anchored (confirmed by @Johnny-xuan on macOS Desktop);
- and it stomped `explicit_cwd`, overriding a user-chosen workspace.

## Relation to PR #72787

This PR **incorporates #72787** — @PRATHAMESH75's commit (`current_root` guard + non-git regression test) is cherry-picked with authorship preserved. As the issue-thread review noted, that guard alone is partial: it still allows repo A → unrelated repo B re-anchoring. This branch supersedes #72787 by adding the common-repo-identity check the thread requested; #72787 can be closed with credit once this merges.

## Changes

- **`current_root` guard** (from #72787): a non-git workspace stepping into a repo is a browsing visit, not a relocation.
- **Common-repo identity check**: reconcile only when the settled cwd and the workspace share the same common `.git` dir (`--git-common-dir`) — exactly the shape a real `git worktree add` produces. Unrelated repos never re-anchor, per @Johnny-xuan's proposal in the thread.
- **`explicit_cwd` is never overridden**: reconcile bails when the workspace was explicitly chosen. A settle-adopted cwd is marked `cwd_from_settle` so the session can keep following the agent across worktrees; the marker is cleared by `_set_session_cwd` and the GUI project-switch path, so an explicit choice sticks afterwards.
- Docstring updated to match the narrowed contract.

### Class audit

`explicit_cwd = True` is set at 3 sites: the reconciler (now marked `cwd_from_settle`), `_set_session_cwd`, and the project-switch handler (both now clear the marker). No other callers of `_git_repo_root_for_cwd` perform migrations; `_heal_dead_cwd` only collapses deleted paths upward and is unaffected.

## Validation

`tests/tui_gateway/test_session_cwd_follow.py` — 12 passed (real on-disk git repos/worktrees):

- new: `test_a_non_git_workspace_is_not_hijacked_by_visiting_a_repo` (from #72787), `test_a_deleted_directory_is_not_a_move` (from #72787), `test_an_unrelated_repo_is_not_a_move`, `test_an_explicit_workspace_is_never_overridden`, `test_a_settle_adopted_cwd_can_keep_following`
- pre-existing follow/worktree/subdir/browsing/remote tests all still pass — legitimate `git worktree add` following is preserved.

Sabotage-verified: with `tui_gateway/server.py` reverted to origin/main, all 4 new regression tests FAIL; with the fix they pass. `ruff check` clean. Branch rebased onto current main (behind-count 0, diff shows only the two touched files).


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48f7f/ONO6dmDY_puzcmUE537cJ_M8rCYBlP.png)
