### PR TITLE
feat(cli): add clarification-first question mode

### DIFF
--- a/agent/question_prompt.py
+++ b/agent/question_prompt.py
@@ -1,0 +1,31 @@
+"""Prompt builder for the /question slash command."""
+
+from __future__ import annotations
+
+
+def build_question_prompt(request: str = "") -> str:
+    """Build the agent seed for /question.
+
+    The slash command itself does not run a special loop. It rewrites the user
+    turn into an instruction that asks the normal agent loop to use the clarify
+    tool repeatedly until the task is actionable.
+    """
+    topic = (request or "").strip()
+    if not topic:
+        topic = "The user invoked /question without an initial topic. First ask what they want clarified."
+
+    return f"""You are in /question mode.
+
+Initial topic/request:
+{topic}
+
+Your objective is to reach actionable clarity before solving, planning, or executing anything.
+
+Rules:
+- Use the clarify tool to ask the user one focused question at a time.
+- If choices would make the answer easier, provide up to 4 concise choices; otherwise ask an open-ended question.
+- After each answer, reassess what is still ambiguous and ask another clarify question if needed.
+- Continue until you have enough information to restate the goal, constraints, success criteria, and next action without guessing.
+- Do not do the actual task yet unless the user explicitly asks you to proceed after clarity is reached.
+- When clarity is reached, summarize the clarified request briefly and ask whether to proceed.
+""".strip()

--- a/cli.py
+++ b/cli.py
@@ -10024,6 +10024,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_cron_command(cmd_original)
         elif canonical == "suggestions":
             self._handle_suggestions_command(cmd_original)
+        elif canonical == "question":
+            self._handle_question_command(cmd_original)
         elif canonical == "blueprint":
             self._handle_blueprint_command(cmd_original)
         elif canonical == "curator":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14413,6 +14413,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 return "Could not start /learn — please try again."
 
+        if canonical == "question":
+            # Rewrite the turn to a clarification-first prompt and fall through
+            # to normal agent processing. This keeps /question on the same
+            # cached system prompt and uses the existing clarify tool rather
+            # than adding a second question engine.
+            from agent.question_prompt import build_question_prompt
+
+            try:
+                event.text = build_question_prompt(event.get_command_args().strip())
+            except Exception:
+                return "Could not start /question — please try again."
+
         if canonical == "init":
             # /init: rewrite the turn to a guidance-laden prompt and fall
             # through to normal agent processing (same fall-through as /learn

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1678,6 +1678,21 @@ class CLICommandsMixin:
             output = f"Suggestions command failed: {e}"
         self._console_print(output)
 
+    def _handle_question_command(self, cmd: str):
+        """Handle /question by seeding a clarification-first agent turn."""
+        from agent.question_prompt import build_question_prompt
+
+        parts = (cmd or "").split(None, 1)
+        request = parts[1].strip() if len(parts) > 1 else ""
+        self._pending_agent_seed = build_question_prompt(request)
+
+        message = "Question mode started — the next turn will clarify the request."
+        printer = getattr(self, "_console_print", None)
+        if printer is None:
+            print(message)
+        else:
+            printer(message)
+
     def _handle_blueprint_command(self, cmd: str):
         """Handle /blueprint — set up an automation from a blueprint template.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -268,6 +268,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("suggestions", "Review suggested automations (accept/dismiss)",
                "Tools & Skills", aliases=("suggest",), args_hint="[accept|dismiss N | catalog]",
                subcommands=("accept", "dismiss", "catalog", "clear")),
+    CommandDef("question", "Clarify a task before taking action", "Session",
+               args_hint="[topic or request]"),
     CommandDef("blueprint", "Set up an automation from a blueprint template",
                "Tools & Skills", aliases=("bp",), args_hint="[name] [slot=value ...]"),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",

--- a/tests/agent/test_question_prompt.py
+++ b/tests/agent/test_question_prompt.py
@@ -1,0 +1,53 @@
+from agent.question_prompt import build_question_prompt
+
+
+def test_question_command_is_registered_for_cli_and_gateway():
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+    cmd = resolve_command("/question")
+
+    assert cmd is not None
+    assert cmd.name == "question"
+    assert cmd.args_hint == "[topic or request]"
+    assert "question" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_question_prompt_uses_clarify_until_actionable():
+    prompt = build_question_prompt("build me a dashboard")
+
+    assert "You are in /question mode" in prompt
+    assert "build me a dashboard" in prompt
+    assert "Use the clarify tool" in prompt
+    assert "one focused question at a time" in prompt
+    assert "Continue until" in prompt
+    assert "Do not do the actual task yet" in prompt
+
+
+def test_question_prompt_without_topic_asks_for_topic_first():
+    prompt = build_question_prompt()
+
+    assert "without an initial topic" in prompt
+    assert "First ask what they want clarified" in prompt
+
+
+def test_cli_question_command_sets_pending_agent_seed(capsys):
+    from types import SimpleNamespace
+
+    from cli import HermesCLI
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    cli = SimpleNamespace(
+        _pending_agent_seed=None,
+        _pending_resume_sessions=None,
+    )
+    cli.process_command = HermesCLI.process_command.__get__(cli, type(cli))
+    cli._handle_question_command = CLICommandsMixin._handle_question_command.__get__(
+        cli,
+        type(cli),
+    )
+
+    assert cli.process_command("/question choose a database") is True
+    assert cli._pending_agent_seed is not None
+    assert "choose a database" in cli._pending_agent_seed
+    assert "Use the clarify tool" in cli._pending_agent_seed
+    assert "Question mode started" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add `/question [topic or request]` as a shared slash command
- route CLI and gateway invocations through the existing clarify tool
- keep the feature on the normal agent loop without adding a new tool or engine

## Verification
- `uv run --with pytest python -m pytest tests/agent/test_question_prompt.py -q` — 4 passed
- surrounding command/gateway suite — 63 passed, 1 pre-existing failure in Slack/Telegram parity (`platform` missing from Slack native slashes)
- `uv run --extra dev ruff check agent/question_prompt.py tests/agent/test_question_prompt.py hermes_cli/commands.py hermes_cli/cli_commands_mixin.py cli.py gateway/run.py` — passed
- `git diff --cached --check` — passed

## Notes
The parity failure is unrelated to this change; this PR does not modify the Telegram/Slack command lists.