### PR TITLE
fix(desktop): preserve local pin intent against stale remote pin pulls

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -138,6 +138,49 @@ describe('watchSessionPins remote pull', () => {
     expect($pinnedSessionIds.get()).toContain('legacy')
   })
 
+  it('does not revert a fresh local pin while the loaded row is still stale (#74570)', async () => {
+    // The row is already loaded and says pinned=false when the user pins.
+    // The pin listener fires reconcile synchronously — before any PATCH — and
+    // the stale row must not win over the local intent.
+    $sessions.set([row('fresh', { pinned: false })])
+    await flush()
+    patch.mockClear()
+
+    $pinnedSessionIds.set(['fresh'])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('fresh')
+    expect(patch).toHaveBeenCalledWith('fresh', true, undefined)
+  })
+
+  it('does not revert a fresh local unpin while the loaded row still says pinned (#74570)', async () => {
+    // Adopt a server-side pin first, so it's held locally and mirrored.
+    $sessions.set([row('sticky', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('sticky')
+    patch.mockClear()
+
+    // User unpins while the loaded row still says pinned=true.
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('sticky')
+    expect(patch).toHaveBeenCalledWith('sticky', false, undefined)
+  })
+
+  it('keeps a deferred pin (row not yet loaded) when a stale page finally arrives', async () => {
+    $pinnedSessionIds.set(['deferred'])
+    await flush()
+    expect(patch).not.toHaveBeenCalled()
+
+    // The page that loads the row still predates our intent.
+    $sessions.set([row('deferred', { pinned: false })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('deferred')
+    expect(patch).toHaveBeenCalledWith('deferred', true, undefined)
+  })
+
   it('ignores a stale page that contradicts a write still in flight', async () => {
     let settle: (v: { ok: boolean }) => void = () => {}
 

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -56,9 +56,11 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
 /**
  * Adopt the server's pin state for every row in the current page.
  *
- * Runs before the push pass so a remote pin is already in the local set by the
- * time we reconcile — it gets marked as mirrored rather than echoed straight
- * back as a redundant PATCH.
+ * Runs after the push pass so local intent is already fenced (`pending` /
+ * `unconfirmed`) by the time the page is read — a fresh local toggle whose
+ * PATCH hasn't landed yet must win over the stale row, not be reverted by it
+ * (#74570). Remote pins adopted here are marked mirrored before the local set
+ * changes, so the re-entrant reconcile doesn't echo them back as a PATCH.
  */
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
@@ -81,14 +83,23 @@ function pullRemotePins(): void {
       continue
     }
 
+    // Local intent still waiting on its PATCH (row unresolved when the push
+    // pass ran) is also newer than the page — never revert it.
+    if (pending.has(pinId) || pending.has(row.id)) {
+      continue
+    }
+
     if (row.pinned && !heldLocally) {
-      pinSession(pinId)
-      // Already true server-side; record it so the push pass doesn't re-PATCH.
+      // Mark mirrored first: pinSession fires the pin listener synchronously,
+      // and the nested reconcile must not see this as a new pin to PATCH.
       mirrored.add(pinId)
+      pinSession(pinId)
     } else if (!row.pinned && heldLocally) {
-      unpinSession(local.has(pinId) ? pinId : row.id)
+      // Same discipline on the way down: forget the mirror before the nested
+      // reconcile runs, or it re-PATCHes pinned=false the server already has.
       mirrored.delete(pinId)
       mirrored.delete(row.id)
+      unpinSession(local.has(pinId) ? pinId : row.id)
     }
   }
 }
@@ -99,8 +110,11 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
-
+  // Push before pull. The pin listener fires synchronously on a local toggle,
+  // so this reconcile runs before the PATCH for that toggle exists anywhere.
+  // The push pass below records the intent (`pending`, then `unconfirmed` via
+  // writePin) — only then may the pull read the page, where those fences stop
+  // the still-stale row from silently reverting the user's action (#74570).
   const current = new Set($pinnedSessionIds.get())
 
   // Unpinned: anything we were tracking that's no longer in the set.
@@ -136,6 +150,8 @@ function reconcile(): void {
       pending.add(id)
     })
   }
+
+  pullRemotePins()
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.


### PR DESCRIPTION
## Summary
Desktop pin/unpin no longer silently reverts: local pin toggles fired `reconcile()` synchronously before any PATCH existed, so `pullRemotePins()` read the still-stale server row and instantly reverted the user's action.

## Changes
- apps/desktop/src/store/session-pin-sync.ts: reconcile reordered push-first / pull-last so the pending/unconfirmed fences cover the gap; pull skips ids with unresolved local toggles; re-entrant `mirrored` bookkeeping fixed so adopted remote state isn't echoed back as redundant PATCHes.

## Validation
3 new regression tests (fresh pin over stale row, fresh unpin, deferred pin vs stale late-loading page), each asserting local state survives AND the correct PATCH fires; sabotage-verified (3 fail on old order); tsc clean; full desktop vitest suite 4098 passed.

Note: overlaps with open #74418 (@dyreckt), which implements the same reorder; this branch adds the pending-id pull fence and the mirrored bookkeeping fix on top. Flagging for the maintainer's vehicle choice — happy to credit/close accordingly.

Fixes #74570

## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48f99/0785ZJ0909c7owshvg4fX_UPBTKfRW.png)
