### PR TITLE
fix(docker): boot on non-PID-1 runtimes via init dispatcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -400,6 +400,8 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # Recursion is impossible because the shim exec's the venv binary by
 # absolute path (/opt/hermes/.venv/bin/hermes). See the shim source for
 # the opt-out env var (HERMES_DOCKER_EXEC_AS_ROOT=1).
+COPY --chmod=0755 docker/hermes-exec-shim.sh /opt/hermes/bin/hermes
+COPY --chmod=0755 docker/entrypoint-dispatch.sh /opt/hermes/docker/entrypoint-dispatch.sh
 
 # Pre-s6 entrypoint.sh did `source .venv/bin/activate` which exported
 # the venv bin onto PATH; Architecture B's main-wrapper.sh does the
@@ -416,27 +418,37 @@ ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 
-# s6-overlay's /init is PID 1. It sets up the supervision tree, runs
-# /etc/cont-init.d/* (our stage2 hook), starts s6-rc services
-# declared in /etc/s6-overlay/s6-rc.d/, then exec's its remaining
-# argv as the container's "main program" with stdin/stdout/stderr
-# inherited (this is what makes interactive --tui work). When the
-# main program exits, /init begins stage 3 shutdown and the container
-# exits with the program's exit code. Replaces tini — see Phase 2 of
-# docs/plans/2026-05-07-s6-overlay-dynamic-subagent-gateways.md.
+# The image ENTRYPOINT is a tiny dispatcher rather than `/init` directly.
+# When the image really owns PID 1 (normal Docker / Podman), the dispatcher
+# execs `/init` and preserves the full s6 supervision tree. When a platform
+# wraps the image entrypoint under its own PID-1 init (Fly Machines,
+# `docker run --init`, some schedulers), `/init` would abort with
+# `can only run as pid 1`; in that case the dispatcher falls back to
+# `stage2-hook.sh` + `main-wrapper.sh` directly so foreground commands still
+# work. See #38349.
+#
+# On the PID-1 path, s6-overlay's /init sets up the supervision tree, runs
+# /etc/cont-init.d/* (our stage2 hook), starts s6-rc services declared in
+# /etc/s6-overlay/s6-rc.d/, then exec's its remaining argv as the container's
+# "main program" with stdin/stdout/stderr inherited (this is what makes
+# interactive --tui work). When the main program exits, /init begins stage 3
+# shutdown and the container exits with the program's exit code. Replaces
+# tini — see Phase 2 of docs/plans/2026-05-07-s6-overlay-dynamic-subagent-gateways.md.
 #
 # We use the ENTRYPOINT+CMD split rather than CMD alone so the
 # wrapper is prepended to user-supplied args automatically:
 #
-#   docker run <image>                  → /init main-wrapper.sh   (CMD default)
-#   docker run <image> chat -q "hi"     → /init main-wrapper.sh chat -q hi
-#   docker run <image> sleep infinity   → /init main-wrapper.sh sleep infinity
-#   docker run <image> --tui            → /init main-wrapper.sh --tui
+#   docker run <image>                  → entrypoint-dispatch.sh   (CMD default)
+#   docker run <image> chat -q "hi"     → entrypoint-dispatch.sh chat -q hi
+#   docker run <image> sleep infinity   → entrypoint-dispatch.sh sleep infinity
+#   docker run <image> --tui            → entrypoint-dispatch.sh --tui
 #
 # main-wrapper.sh handles arg routing (bare-exec vs. hermes
 # subcommand vs. no-args), drops to the hermes user via s6-setuidgid,
 # and exec's the final program so its exit code becomes the container
-# exit code. Without the wrapper-as-ENTRYPOINT, leading-dash args
-# like `--version` would be intercepted by /init's POSIX shell.
-ENTRYPOINT [ "/init", "/opt/hermes/docker/main-wrapper.sh" ]
+# exit code. The dispatcher preserves that contract across both the
+# supervised PID-1 path and the non-PID-1 fallback path. Without the
+# wrapper-as-ENTRYPOINT, leading-dash args like `--version` would be
+# intercepted by /init's POSIX shell.
+ENTRYPOINT [ "/opt/hermes/docker/entrypoint-dispatch.sh" ]
 CMD [ ]

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# shellcheck shell=sh
+# Entry-point dispatcher for runtimes that may or may not give the image
+# ownership of PID 1.
+#
+# Normal Docker / Podman path: this script is PID 1, so we delegate to
+# s6-overlay's /init exactly as before and keep the full supervision tree.
+#
+# Wrapped-runtime path (Fly Machines, `docker run --init`, some Nomad/K8s
+# setups): the platform's own init is already PID 1 and execs the image
+# entrypoint as a child. s6-overlay aborts there with "can only run as pid 1",
+# so we run the stage2 bootstrap directly and then exec the main wrapper
+# without /init.
+
+set -e
+
+if [ "$$" -eq 1 ]; then
+    exec /init /opt/hermes/docker/main-wrapper.sh "$@"
+fi
+
+echo "[hermes] WARNING: container entrypoint is not PID 1; skipping s6-overlay /init and falling back to direct bootstrap. Supervised services are unavailable in this runtime, but the requested command will still run." >&2
+# /init normally seeds PATH with s6's helpers; the non-PID-1 fallback skips it.
+export PATH="/command:/package/admin/s6/command:${PATH}"
+/opt/hermes/docker/stage2-hook.sh
+exec /opt/hermes/docker/main-wrapper.sh "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,9 +19,10 @@
 # Surface a warning to stderr so anyone still invoking this path
 # sees the migration notice in their logs.
 echo "[hermes] WARNING: docker/entrypoint.sh is a deprecated shim under " \
-    "s6-overlay. The container's real ENTRYPOINT is /init + " \
-    "main-wrapper.sh; this script only runs the stage2 cont-init hook " \
+    "s6-overlay. The container's real ENTRYPOINT is " \
+    "entrypoint-dispatch.sh (which delegates to /init + main-wrapper.sh " \
+    "when PID 1); this script only runs the stage2 cont-init hook " \
     "and does NOT exec the CMD. If you hard-coded docker/entrypoint.sh " \
     "as your ENTRYPOINT, drop the override — docker will use the image's " \
-    "default ENTRYPOINT (/init), which handles bootstrap AND CMD." >&2
+    "default ENTRYPOINT dispatcher, which handles bootstrap AND CMD." >&2
 exec /opt/hermes/docker/stage2-hook.sh "$@"

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -1,15 +1,16 @@
-#!/command/with-contenv sh
+#!/bin/sh
 # shellcheck shell=sh
 # /opt/hermes/docker/main-wrapper.sh — wraps the container's CMD with
 # the same argument-routing logic the pre-s6 entrypoint.sh used. Runs
 # as /init's "main program" (Docker CMD) so it inherits stdin/stdout/
-# stderr from the container.
+# stderr from the container. The non-PID-1 entrypoint fallback also
+# execs this script directly after running the stage2 bootstrap.
 #
-# Shebang note: /init scrubs env before invoking CMD, so a plain
-# `#!/bin/sh` wrapper sees an empty environ and `ENV HERMES_HOME=/opt/data`
-# from the Dockerfile never reaches `hermes`. with-contenv repopulates
-# the env from /run/s6/container_environment before exec'ing, which is
-# what s6-supervised services use too (see main-hermes/run).
+# Env note: /init scrubs env before invoking CMD, so when this wrapper
+# is launched through the supervised path it must rehydrate via
+# with-contenv before touching HERMES_HOME / PATH. On the non-PID-1
+# fallback path the Dockerfile env is still intact, so we skip the
+# re-exec and continue directly.
 #
 # Routing:
 #   no args                       → exec `hermes` (the default)
@@ -18,6 +19,14 @@
 #
 # Drop to hermes via s6-setuidgid, but skip it when already non-root.
 set -e
+
+if [ -z "${HERMES_MAIN_WRAPPER_ENV_READY:-}" ] && \
+   [ -z "${HERMES_HOME:-}" ] && \
+   [ -x /command/with-contenv ]; then
+    export HERMES_MAIN_WRAPPER_ENV_READY=1
+    exec /command/with-contenv sh "$0" "$@"
+fi
+unset HERMES_MAIN_WRAPPER_ENV_READY
 
 drop() { [ "$(id -u)" = 0 ] && set -- s6-setuidgid hermes "$@"; exec "$@"; }
 

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -332,6 +332,10 @@ def _strip_container_argv_prefix(argv: Sequence[str]) -> list[str]:
         # Defensive: an `init` prefix with no wrapper token in argv.
         args = args[1:]
 
+    # Non-PID-1 entrypoints go through the dispatch shim instead of /init.
+    if args and args[0].endswith("entrypoint-dispatch.sh"):
+        args = args[1:]
+
     # The wrapper re-execs `hermes <subcommand>`; peel an explicit hermes.
     if args and Path(args[0]).name == "hermes":
         args = args[1:]

--- a/optional-skills/devops/hermes-s6-container-supervision/SKILL.md
+++ b/optional-skills/devops/hermes-s6-container-supervision/SKILL.md
@@ -63,7 +63,8 @@ If you're just running the Hermes Agent and want to use Docker, see `website/doc
 
 | Path | Role |
 |---|---|
-| `Dockerfile` | s6-overlay install + cont-init.d wiring + `ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]` |
+| `Dockerfile` | s6-overlay install + cont-init.d wiring + `ENTRYPOINT ["/opt/hermes/docker/entrypoint-dispatch.sh"]` |
+| `docker/entrypoint-dispatch.sh` | PID-1 dispatcher: exec's `/init` + main-wrapper when the image owns PID 1; on wrapped runtimes (Fly Machines, `docker run --init`) falls back to stage2-hook + main-wrapper directly, restoring the s6 helper PATH first (#38349). |
 | `docker/stage2-hook.sh` | The "old entrypoint logic" — UID remap, chown, seed, skills sync. Runs as cont-init.d/01-hermes-setup. |
 | `docker/cont-init.d/02-reconcile-profiles` | Calls `hermes_cli.container_boot` on every boot to restore profile gateway slots from the persistent volume. |
 | `docker/main-wrapper.sh` | The container's CMD. Routes user args, drops to hermes via `s6-setuidgid`, exec's the chosen program. |
@@ -81,7 +82,7 @@ The original plan (v1–v3) called for main hermes to run as a supervised s6-rc 
 1. **cont-init.d scripts receive no CMD args** — so the stage2 hook can't parse `docker run <image> chat -q "hi"` to set `HERMES_ARGS` for a service `run` script to consume.
 2. **`/run/s6/basedir/bin/halt` does NOT propagate the exit code** written to `/run/s6-linux-init-container-results/exitcode`. Containers always exit 143 (SIGTERM) regardless. Confirmed by skarnet (s6 author) in [issue #477](https://github.com/just-containers/s6-overlay/issues/477): _"if you want a container shutdown, you need to either have your CMD exit, or, if you have no CMD, write the container exit code you want then call halt"_.
 
-So we use the s6-overlay-native CMD pattern: `ENTRYPOINT ["/init", "/opt/hermes/docker/main-wrapper.sh"]`. /init prepends the wrapper to user args automatically — so `docker run <image> --version` becomes `/init main-wrapper.sh --version`, and `--version` doesn't get intercepted by /init's POSIX shell. The wrapper drops to hermes via `s6-setuidgid`, then exec's the chosen program. The program's exit code becomes the container exit code, exactly matching the pre-s6 tini contract.
+So we use the s6-overlay-native CMD pattern via the dispatcher: `ENTRYPOINT ["/opt/hermes/docker/entrypoint-dispatch.sh"]`, which under PID 1 exec's `/init /opt/hermes/docker/main-wrapper.sh "$@"`. The wrapper is prepended to user args automatically — so `docker run <image> --version` becomes `/init main-wrapper.sh --version`, and `--version` doesn't get intercepted by /init's POSIX shell. The wrapper drops to hermes via `s6-setuidgid`, then exec's the chosen program. The program's exit code becomes the container exit code, exactly matching the pre-s6 tini contract. When the entrypoint is NOT PID 1 (Fly Machines, `docker run --init`), the dispatcher skips `/init` entirely (it would abort with `can only run as pid 1`), restores the s6 helper PATH, runs stage2-hook.sh, and exec's main-wrapper.sh directly — no supervised services on that path (#38349).
 
 Trade-off: main hermes is unsupervised under s6. That exactly matches its behavior under tini (the pre-s6 image). Dashboard supervision is the only **new** guarantee — and per-profile gateways under `/run/service/` get full supervision.
 

--- a/tests/docker/test_smoke.py
+++ b/tests/docker/test_smoke.py
@@ -58,3 +58,30 @@ def test_dashboard_subcommand_present(built_image: str) -> None:
     assert "dashboard" in combined or "usage" in combined, (
         f"dashboard --help output unexpected: {combined[-2000:]!r}"
     )
+
+
+def test_hermes_help_under_wrapped_init(built_image: str) -> None:
+    """``docker run --init --rm <image> --help`` must exit 0.
+
+    Regression guard for #38349: platforms whose own init owns PID 1
+    (Fly Machines, ``docker run --init``, podman on some hosts) exec the
+    image entrypoint as a child.  s6-overlay's ``/init`` hard-aborts
+    there with ``s6-overlay-suexec: fatal: can only run as pid 1``.  The
+    entrypoint dispatcher must detect the non-PID-1 case and fall back
+    to the direct bootstrap path so the requested command still runs.
+    """
+    r = subprocess.run(
+        ["docker", "run", "--init", "--rm", built_image, "--help"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert "can only run as pid 1" not in (r.stdout + r.stderr), (
+        f"s6-overlay-suexec aborted under a wrapped init (#38349): "
+        f"stderr={r.stderr[-2000:]!r}"
+    )
+    assert r.returncode == 0, (
+        f"hermes --help failed under `docker run --init` (exit {r.returncode}): "
+        f"stdout={r.stdout[-2000:]!r} stderr={r.stderr[-2000:]!r}"
+    )
+    assert "Traceback" not in r.stderr, (
+        f"hermes --help produced a traceback under --init: {r.stderr[-2000:]!r}"
+    )

--- a/tests/docker/test_tini_compat_shim.py
+++ b/tests/docker/test_tini_compat_shim.py
@@ -40,11 +40,15 @@ def test_tini_compat_shim_exists(built_image: str) -> None:
     )
 
 
-def test_entrypoint_is_init_not_tini(built_image: str) -> None:
-    """The image's actual ENTRYPOINT must be /init (s6-overlay).
+def test_entrypoint_is_dispatcher_not_tini(built_image: str) -> None:
+    """The image's actual ENTRYPOINT must be the PID-1 dispatcher.
 
-    The tini shim is only for legacy external wrappers; the image's own
-    runtime must continue to use the canonical /init.
+    Since #38349 the ENTRYPOINT is ``entrypoint-dispatch.sh``, which
+    exec's the canonical ``/init`` (s6-overlay) when the image owns
+    PID 1 and falls back to a direct bootstrap on wrapped runtimes
+    (Fly Machines, ``docker run --init``). The tini shim is only for
+    legacy external wrappers; the image's own runtime must route
+    through the dispatcher, never through /usr/bin/tini.
     """
     r = subprocess.run(
         ["docker", "inspect", built_image,
@@ -53,13 +57,24 @@ def test_entrypoint_is_init_not_tini(built_image: str) -> None:
     )
     assert r.returncode == 0, f"docker inspect failed: {r.stderr}"
     entrypoint = r.stdout.strip()
-    assert "/init" in entrypoint, (
-        f"ENTRYPOINT is not /init: {entrypoint!r}"
+    assert "entrypoint-dispatch.sh" in entrypoint, (
+        f"ENTRYPOINT is not the PID-1 dispatcher: {entrypoint!r}"
     )
-    # The entrypoint array should be ["/init", "/opt/hermes/docker/main-wrapper.sh"]
     # /usr/bin/tini should NOT be in the entrypoint.
     assert "tini" not in entrypoint.lower(), (
-        f"ENTRYPOINT references tini instead of /init: {entrypoint!r}"
+        f"ENTRYPOINT references tini instead of the dispatcher: {entrypoint!r}"
+    )
+    # The dispatcher must still hand PID-1 execution to /init inside
+    # the image, preserving the supervision tree.
+    r2 = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "sh", built_image, "-c",
+         "grep -q 'exec /init /opt/hermes/docker/main-wrapper.sh' "
+         "/opt/hermes/docker/entrypoint-dispatch.sh"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert r2.returncode == 0, (
+        "entrypoint-dispatch.sh in the image does not delegate the "
+        f"PID-1 path to /init: stderr={r2.stderr[-500:]!r}"
     )
 
 

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -28,6 +28,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+ENTRYPOINT_DISPATCH = REPO_ROOT / "docker" / "entrypoint-dispatch.sh"
 
 
 # Init-process families this repo accepts as PID 1. ``tini`` /
@@ -109,6 +110,52 @@ def test_dockerfile_installs_an_init_for_zombie_reaping(dockerfile_text):
         f"{', '.join(_KNOWN_INIT_TOKENS)}). Without an init process to "
         "reap orphaned subprocesses, hermes accumulates zombies in Docker "
         "deployments. See issue #15012."
+    )
+
+
+def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
+    """The ENTRYPOINT must preserve a PID-1 init path, even with a dispatcher.
+
+    Installing the init is only half the fix — the container must actually
+    run with it as PID 1.  A shell dispatcher is fine only if it execs the
+    real init when the image owns PID 1; otherwise the shell would become
+    PID 1 and hermes would run without zombie reaping.
+    """
+    # Find the last uncommented ENTRYPOINT line — Docker honours the final one.
+    entrypoint_line = None
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("#"):
+            continue
+        if line.startswith("ENTRYPOINT"):
+            entrypoint_line = line
+
+    assert entrypoint_line is not None, "Dockerfile is missing an ENTRYPOINT directive"
+
+    if any(name in entrypoint_line for name in _KNOWN_INIT_TOKENS):
+        return
+
+    assert "/opt/hermes/docker/entrypoint-dispatch.sh" in entrypoint_line, (
+        f"Unexpected Dockerfile ENTRYPOINT: {entrypoint_line!r}"
+    )
+    assert ENTRYPOINT_DISPATCH.exists(), (
+        "Dockerfile points at entrypoint-dispatch.sh but the script is missing."
+    )
+    dispatcher = ENTRYPOINT_DISPATCH.read_text(encoding="utf-8")
+    assert 'if [ "$$" -eq 1 ]; then' in dispatcher
+    assert "exec /init /opt/hermes/docker/main-wrapper.sh" in dispatcher, (
+        "The entrypoint dispatcher must hand PID-1 execution off to /init; "
+        "otherwise the shell becomes PID 1 and zombies will accumulate."
+    )
+
+
+def test_dispatcher_non_pid1_fallback_restores_s6_helpers_on_path() -> None:
+    """Skipping /init must still expose s6-setuidgid to stage2/main-wrapper."""
+    dispatcher = ENTRYPOINT_DISPATCH.read_text(encoding="utf-8")
+    assert 'export PATH="/command:/package/admin/s6/command:${PATH}"' in dispatcher, (
+        "The non-PID-1 entrypoint fallback skips /init, so it must restore the "
+        "s6 helper directories on PATH before invoking stage2-hook.sh and "
+        "main-wrapper.sh."
     )
 
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -482,7 +482,9 @@ The official image is based on `debian:13.4` and includes:
 
 The image treats `/opt/hermes` as an immutable install tree at runtime. Optional Python extras, Node workspaces, and TUI assets that must be available inside Docker need to be baked during the image build; runtime lazy installs are disabled so supervised gateways and `docker exec hermes …` commands do not try to write dependency artifacts back into the read-only source tree.
 
-The container's `ENTRYPOINT` is s6-overlay's `/init`. On boot it:
+The container's `ENTRYPOINT` is a small dispatcher (`docker/entrypoint-dispatch.sh`). When the container owns PID 1 (normal Docker / Podman), it exec's s6-overlay's `/init` and you get the full supervision tree described below. When a platform wraps the image entrypoint under its own PID-1 init (Fly.io Machines, `docker run --init`, some Nomad/Kubernetes setups), `/init` would abort with `s6-overlay-suexec: fatal: can only run as pid 1` — so the dispatcher instead runs the stage2 bootstrap directly and exec's the main wrapper without s6. On that fallback path the requested command still runs, but supervised services (dashboard, per-profile gateways) are unavailable.
+
+On the PID-1 path, `/init`:
 1. Runs `/etc/cont-init.d/01-hermes-setup` (= `docker/stage2-hook.sh`) as root: optional UID/GID remap, fixes volume ownership, seeds `.env` / `config.yaml` / `SOUL.md` on first boot, runs non-interactive config-schema migrations unless `HERMES_SKIP_CONFIG_MIGRATION=1`, syncs bundled skills.
 2. Runs `/etc/cont-init.d/02-reconcile-profiles` (= `hermes_cli.container_boot`): walks `$HERMES_HOME/profiles/<name>/`, recreates the per-profile gateway s6 service slot under `/run/service/gateway-<profile>/`, and auto-starts only those whose last recorded state was `running` (see [Per-profile gateway supervision](#per-profile-gateway-supervision)).
 3. Starts the static `main-hermes` and `dashboard` s6-rc services.
@@ -493,7 +495,7 @@ The container's `ENTRYPOINT` is s6-overlay's `/init`. On boot it:
    The container exits when this main program exits, with its exit code.
 
 :::warning Breaking change vs. pre-s6 images
-The container ENTRYPOINT is now `/init` (s6-overlay), not `/usr/bin/tini`. All five documented `docker run` invocation patterns (no args, `chat -q "…"`, `sleep infinity`, `bash`, `--tui`) behave identically to the tini-based image. If you have a downstream wrapper that depended on tini-specific signal behavior or hard-coded `/usr/bin/tini --` invocation, pin to the previous image tag.
+The container ENTRYPOINT is now the `entrypoint-dispatch.sh` dispatcher (which delegates to s6-overlay's `/init` under PID 1), not `/usr/bin/tini`. All five documented `docker run` invocation patterns (no args, `chat -q "…"`, `sleep infinity`, `bash`, `--tui`) behave identically to the tini-based image. If you have a downstream wrapper that depended on tini-specific signal behavior or hard-coded `/usr/bin/tini --` invocation, pin to the previous image tag.
 :::
 
 :::warning Privilege model


### PR DESCRIPTION
fix(docker): support non-PID-1 container entrypoints (dispatcher fallback)

Fixes #38349
Supersedes / salvages #43763 (author @konsisumer, attribution preserved on the cherry-picked commit)

## Problem

Since the s6-overlay migration (`v2026.5.28`+), the image ENTRYPOINT is `["/init", "/opt/hermes/docker/main-wrapper.sh"]`. s6-overlay's `s6-overlay-suexec` hard-requires PID 1 and aborts with:

```
s6-overlay-suexec: fatal: can only run as pid 1
```

on any runtime whose own init owns PID 1 and execs the image entrypoint as a child: podman on FreeBSD (original reporter), Fly.io Machines (confirmed crash-loop by @robotoole, pinned to `v2026.5.16` as the only workaround), `docker run --init`, and some Nomad/K8s setups. `HERMES_GATEWAY_NO_SUPERVISE=1` doesn't help — the abort happens before any hermes code runs.

## Fix

- New `docker/entrypoint-dispatch.sh` becomes the image ENTRYPOINT:
  - **PID 1** (normal Docker/Podman): `exec /init main-wrapper.sh "$@"` — supervision tree unchanged.
  - **not PID 1** (wrapped runtimes): warn, restore the s6 helper PATH (`/command:/package/admin/s6/command` — needed for `s6-setuidgid`), run `stage2-hook.sh`, exec `main-wrapper.sh "$@"` directly. Supervised services are unavailable but the requested command runs.
- `main-wrapper.sh` shebang changed to `#!/bin/sh` with a conditional `with-contenv` re-exec, so it works on both the /init path (env scrubbed) and the fallback path (env intact).
- `container_boot._strip_container_argv_prefix` peels the dispatcher token.
- Review follow-ups from the sweeper review of #43763 (second commit):
  - `tests/docker/test_tini_compat_shim.py`: runtime assertion updated for the dispatcher ENTRYPOINT (+ verifies the in-image dispatcher delegates the PID-1 path to /init); `/usr/bin/tini → shim` compat check preserved.
  - `tests/docker/test_smoke.py`: new `docker run --init --rm <image> --help` wrapped-runtime regression.
  - `website/docs/user-guide/docker.md` and `optional-skills/devops/hermes-s6-container-supervision/SKILL.md`: stale `/init`-ENTRYPOINT contracts updated.
  - Superseded static test `tests/test_dockerfile_tini_compat_shim.py` removed (main moved it to `tests/docker/`).

## Validation

- `sh -n` on all three shell scripts; `ruff check` clean on touched Python.
- `pytest tests/tools/test_dockerfile_pid1_reaping.py tests/hermes_cli/test_container_boot.py` → 9 passed.
- `_strip_container_argv_prefix` verified for both `entrypoint-dispatch.sh …` and `/init main-wrapper.sh …` argv shapes.
- **Live container validation** of the actual dispatcher against real s6-overlay v3.2.0.2 (minimal debian:13 harness image):
  - `docker run --rm <img> echo hello` → full s6-rc boot, wrapper receives argv, clean exit ✅
  - `docker run --init --rm <img> echo hello` → fallback path taken, **no `can only run as pid 1`**, `s6-setuidgid` resolvable via restored PATH, command runs, exit 0 ✅
- Field validation: @robotoole tested the dispatcher + PATH line on a production Fly Machine — gateway boots clean on `latest`.

## Notes for the issue close

Once merged, #38349 can be closed: FreeBSD/podman reporter kworr and the Fly.io deployment are both the non-PID-1 case this dispatcher handles. #43763 should be closed as superseded (its content is cherry-picked here with author attribution, plus the review follow-ups it was parked on).


## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa48faf/iHHVZnTihBI8-yZj6llzl_Uia0t8Wg.png)
