### PR TITLE
fix(cli): report non-interactive sudo availability

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 import importlib.util
-import subprocess  # noqa: F401 — re-exported for tests that monkeypatch status.subprocess to guard against regressions
+import subprocess
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
@@ -31,6 +31,53 @@ def check_mark(ok: bool) -> str:
     if ok:
         return color("✓", Colors.GREEN)
     return color("✗", Colors.RED)
+
+
+def _detect_sudo_status(terminal_env: str) -> tuple[bool, str]:
+    """Return whether sudo is available/configured and a safe description.
+
+    ``SUDO_PASSWORD`` only represents Hermes's password-fed sudo path.  On a
+    local backend, also probe non-interactive sudo so access that currently
+    works without prompting is not reported as disabled.  Remote/sandbox
+    backends cannot be safely inferred by running a command on the local host.
+    """
+    terminal_env = terminal_env.strip().lower() or "local"
+    has_configured_password = "SUDO_PASSWORD" in os.environ
+    sudo_password = os.getenv("SUDO_PASSWORD", "")
+    password_label = (
+        "password configured" if sudo_password else "empty password configured"
+    )
+
+    if terminal_env != "local":
+        return (
+            has_configured_password,
+            password_label if has_configured_password else "password not configured",
+        )
+
+    getuid = getattr(os, "geteuid", None)
+    if callable(getuid) and getuid() == 0:
+        return True, "root"
+
+    if has_configured_password:
+        return True, password_label
+
+    # Avoid spawning platform commands in Termux's lightweight status path.
+    if not _is_termux():
+        try:
+            probe = subprocess.run(
+                ["sudo", "-n", "true"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+                check=False,
+            )
+            if probe.returncode == 0:
+                return True, "available without prompt"
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            pass
+
+    return False, "unavailable"
 
 def redact_key(key: str) -> str:
     """Redact an API key for display.
@@ -450,8 +497,8 @@ def show_status(args):
         print(f"  Persistence:  {'snapshot filesystem' if persist_enabled else 'ephemeral filesystem'}")
         print("  Processes:    live processes do not survive cleanup, snapshots, or sandbox recreation")
 
-    sudo_password = os.getenv("SUDO_PASSWORD", "")
-    print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")
+    sudo_ok, sudo_label = _detect_sudo_status(terminal_env)
+    print(f"  Sudo:         {check_mark(sudo_ok)} {sudo_label}")
 
     # =========================================================================
     # Messaging Platforms

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,6 +3,72 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
+def test_detect_sudo_status_reports_noninteractive_local_sudo(monkeypatch):
+    from hermes_cli import status as status_mod
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setattr(status_mod, "_is_termux", lambda: False)
+    monkeypatch.setattr(status_mod.os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(
+        status_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0),
+    )
+
+    assert status_mod._detect_sudo_status(" LOCAL ") == (
+        True,
+        "available without prompt",
+    )
+
+
+def test_detect_sudo_status_reports_unavailable_local_sudo(monkeypatch):
+    from hermes_cli import status as status_mod
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setattr(status_mod, "_is_termux", lambda: False)
+    monkeypatch.setattr(status_mod.os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(
+        status_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1),
+    )
+
+    assert status_mod._detect_sudo_status("local") == (False, "unavailable")
+
+
+def test_detect_sudo_status_does_not_probe_nonlocal_backend(monkeypatch):
+    from hermes_cli import status as status_mod
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+
+    def _unexpected_probe(*args, **kwargs):
+        raise AssertionError("nonlocal backend must not probe host sudo")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", _unexpected_probe)
+
+    assert status_mod._detect_sudo_status("ssh") == (
+        False,
+        "password not configured",
+    )
+
+
+def test_detect_sudo_status_honors_explicit_empty_password(monkeypatch):
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("SUDO_PASSWORD", "")
+    monkeypatch.setattr(status_mod.os, "geteuid", lambda: 1000, raising=False)
+
+    def _unexpected_probe(*args, **kwargs):
+        raise AssertionError("configured password path must not probe host sudo")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", _unexpected_probe)
+
+    assert status_mod._detect_sudo_status("local") == (
+        True,
+        "empty password configured",
+    )
+
+
 def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     sentinel = "NONSECRET_SENTINEL_VALUE_DO_NOT_PRINT_123456"


### PR DESCRIPTION
## Summary

- make `hermes status` detect sudo that is currently available without prompting on the local terminal backend
- distinguish root, configured password (including an explicit empty password), sudo currently available without prompting, and unavailable sudo
- avoid probing local host sudo for SSH and sandbox terminal backends
- add regression tests for local, nonlocal, and explicit-empty-password paths

## Why

`hermes status` currently reports sudo as disabled whenever `SUDO_PASSWORD` is absent, even when local passwordless sudo works. The terminal tool already supports this case by probing `sudo -n true`, so the status display can disagree with actual terminal capability.

## Test plan

- `python -m pytest -q tests/hermes_cli/test_status.py tests/hermes_cli/test_subprocess_timeouts.py tests/tools/test_terminal_config_env_sync.py`
- `ruff check hermes_cli/status.py tests/hermes_cli/test_status.py`
- manually verified `hermes status` reports `Sudo: ✓ available without prompt` on Linux with `NOPASSWD`

## Platforms tested

- Linux, Python 3.11

No existing issue or PR was found for this status discrepancy.
