### PR TITLE
fix(projects): reject create when primary_path already owns a project

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -145,6 +145,71 @@ def _normalize_path(path: str) -> str:
     return p.rstrip("/\\") or p
 
 
+def _is_windows_style_path(path: str) -> bool:
+    """True for drive-letter, UNC, or any path that Windows treats case-insensitively.
+
+    Matches the identity rules used by ``tui_gateway.project_tree._path_key`` so
+    create-time primary_path dedup and sidebar lane identity agree on Windows
+    spellings even when the host process is POSIX (tests / remote backends).
+    """
+    value = (path or "").strip()
+    if os.name == "nt":
+        return True
+    return bool(re.match(r"^[A-Za-z]:[/\\]", value)) or value.startswith(("\\", "//"))
+
+
+def _path_identity_key(path: str) -> str:
+    """Canonical primary_path comparison key (separator + Windows case).
+
+    Used only for equality checks — stored paths keep their normalized spelling.
+
+    Pure Windows spellings (``E:\\foo``, ``//server/share``) must NOT go through
+    POSIX ``os.path.abspath``: that treats them as relative names and prepends
+    cwd, which would break both identity and Windows-style detection. On a
+    Windows host, ``_normalize_path`` is used so ``.`` / ``..`` resolve as usual.
+    """
+    raw = str(path or "").strip()
+    if not raw:
+        return ""
+    if _is_windows_style_path(raw) and os.name != "nt":
+        # Keep drive/UNC identity without host-cwd pollution.
+        cleaned = raw.replace("\\", "/").rstrip("/")
+        segs = [s for s in cleaned.split("/") if s]
+        return "/".join(s.casefold() for s in segs)
+
+    norm = _normalize_path(raw)
+    segs = [s for s in re.split(r"[/\\]", norm.rstrip("/\\")) if s]
+    if os.name == "nt" or _is_windows_style_path(norm):
+        segs = [s.casefold() for s in segs]
+    return "/".join(segs)
+
+
+def find_project_by_primary_path(
+    conn: sqlite3.Connection,
+    path: str,
+    *,
+    include_archived: bool = False,
+) -> Optional[Project]:
+    """Return the non-archived project whose primary_path is ``path``, if any.
+
+    Comparison uses :func:`_path_identity_key` so equivalent Windows spellings
+    (case / separators / trailing slash) collide. Archived projects are skipped
+    unless ``include_archived`` is set, so a deliberate recreation after archive
+    remains possible.
+    """
+    if not str(path or "").strip():
+        return None
+    key = _path_identity_key(path)
+    if not key:
+        return None
+    for proj in list_projects(conn, include_archived=include_archived):
+        if not proj.primary_path:
+            continue
+        if _path_identity_key(proj.primary_path) == key:
+            return proj
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Connection management
 # ---------------------------------------------------------------------------
@@ -336,6 +401,11 @@ def create_project(
     ``folders`` are normalized to absolute paths. If ``primary_path`` is given
     it is added to the folder set (if not already present) and marked primary;
     otherwise the first folder becomes primary.
+
+    When the resolved primary path already belongs to a non-archived project,
+    raises ``ValueError`` naming that project (CLI / desktop / tools all share
+    this entrypoint). Projects with no primary folder are not constrained by
+    path uniqueness. Archiving frees the path so a fresh project can reuse it.
     """
     name = str(name or "").strip()
     if not name:
@@ -358,6 +428,15 @@ def create_project(
         primary = folder_paths[0]
 
     with write_txn(conn):
+        if primary:
+            # Look up inside the write txn so concurrent creates cannot both
+            # pass a pre-check and insert duplicate primaries.
+            existing = find_project_by_primary_path(conn, primary)
+            if existing is not None:
+                raise ValueError(
+                    f"folder already belongs to project {existing.slug} "
+                    f"({existing.id})"
+                )
         unique = _unique_slug(conn, slug_candidate)
         conn.execute(
             "INSERT INTO projects "

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -57,5 +57,15 @@ def test_rename_and_archive(tmp_path):
         assert len(pdb.list_projects(conn)) == 1
 
 
+def test_create_duplicate_primary_path_is_rejected(capsys, tmp_path):
+    """CLI create surfaces the projects_db primary_path collision (#75820)."""
+    assert _run(["create", "GeoTrace", str(tmp_path)]) == 0
+    assert _run(["create", "GeoTrace", str(tmp_path)]) == 2
+    err = capsys.readouterr().err
+    assert "folder already belongs to project" in err
+    with pdb.connect_closing() as conn:
+        assert len(pdb.list_projects(conn)) == 1
+
+
 
 

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -101,3 +101,93 @@ def test_per_profile_isolation(tmp_path):
         b.close()
 
 
+def test_create_rejects_duplicate_primary_path(conn, tmp_path):
+    """Same primary folder must not seed a second active project (#75820)."""
+    root = tmp_path / "geotrace"
+    root.mkdir()
+    first = pdb.create_project(conn, name="GeoTrace", folders=[str(root)])
+    stored = pdb.get_project(conn, first).primary_path
+    assert stored == pdb._normalize_path(str(root))
+
+    with pytest.raises(ValueError, match=r"folder already belongs to project geotrace"):
+        pdb.create_project(conn, name="GeoTrace Again", folders=[str(root)])
+
+    # Equivalent spelling (trailing slash / abspath) still collides.
+    with pytest.raises(ValueError, match=r"folder already belongs to project"):
+        pdb.create_project(
+            conn,
+            name="GeoTrace Slash",
+            primary_path=str(root) + os.sep,
+        )
+
+    assert len(pdb.list_projects(conn)) == 1
+
+
+def test_create_allows_distinct_primary_paths(conn, tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    pid_a = pdb.create_project(conn, name="A", folders=[str(a)])
+    pid_b = pdb.create_project(conn, name="B", folders=[str(b)])
+    assert pid_a != pid_b
+    assert len(pdb.list_projects(conn)) == 2
+
+
+def test_create_allows_reusing_primary_path_after_archive(conn, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    old = pdb.create_project(conn, name="Old", folders=[str(root)])
+    pdb.archive_project(conn, old)
+
+    new = pdb.create_project(conn, name="New", folders=[str(root)])
+    assert new != old
+    assert pdb.get_project(conn, new).primary_path
+    # Only the new active project is listed by default.
+    assert [p.id for p in pdb.list_projects(conn)] == [new]
+
+
+def test_create_pathless_projects_are_not_path_deduped(conn):
+    """Projects with no primary folder remain free to multiply by name/slug."""
+    a = pdb.create_project(conn, name="Scratch")
+    b = pdb.create_project(conn, name="Scratch")
+    assert a != b
+    assert all(p.primary_path is None for p in pdb.list_projects(conn))
+
+
+def test_path_identity_key_windows_case_and_separators():
+    """Windows-style paths collide on case/separators; POSIX paths stay case-sensitive."""
+    win_a = pdb._path_identity_key(r"E:\JUST_DO_IT\GeoTrace")
+    win_b = pdb._path_identity_key(r"e:/just_do_it/geotrace/")
+    assert win_a == win_b
+
+    posix_a = pdb._path_identity_key("/tmp/GeoTrace")
+    posix_b = pdb._path_identity_key("/tmp/geotrace")
+    # On a Windows host every path is case-insensitive; elsewhere POSIX differs.
+    if os.name == "nt":
+        assert posix_a == posix_b
+    else:
+        assert posix_a != posix_b
+
+
+def test_find_project_by_primary_path_uses_identity_key(conn, tmp_path, monkeypatch):
+    """Lookup matches via identity key even when stored spelling differs."""
+    root = tmp_path / "Repo"
+    root.mkdir()
+    pid = pdb.create_project(conn, name="Repo", folders=[str(root)])
+
+    found = pdb.find_project_by_primary_path(conn, str(root) + os.sep)
+    assert found is not None
+    assert found.id == pid
+
+    # Simulated Windows drive path identity (skip abspath host quirks).
+    monkeypatch.setattr(
+        pdb,
+        "_normalize_path",
+        lambda p: str(p).rstrip("/\\"),
+    )
+    assert pdb._path_identity_key(r"C:\Work\App") == pdb._path_identity_key(
+        r"c:/work/app/"
+    )
+
+


### PR DESCRIPTION
## Summary

`project_create` / `hermes project create` / desktop `projects.create` all call `projects_db.create_project`, which only enforced slug uniqueness. Creating the same folder twice produced multiple active projects with identical `primary_path` (e.g. three "GeoTrace" entries for one Windows path), which multiplies the sidebar duplicate-lane bug (#71837).

This PR rejects a create when the resolved primary path already belongs to a **non-archived** project, with a clear `ValueError` that names the existing project. Path identity matches sidebar rules (separator-agnostic + Windows case-insensitive). Archiving frees the path so deliberate recreation still works. Path-less projects are unchanged.

## Changes

- `hermes_cli/projects_db.py`
  - `_path_identity_key` / `find_project_by_primary_path`
  - `create_project` raises when primary collides (checked inside the write txn)
- Tests for active collision, trailing-slash equivalence, distinct paths, archive reuse, path-less creates, Windows identity keys, and CLI error surface

## Related

Fixes #75820

## Test plan

- [x] `HERMES_PYTHON=… scripts/run_tests.sh tests/hermes_cli/test_projects_db.py tests/hermes_cli/test_projects_cli.py` — **13 passed**
- [x] `ruff check` on touched files — clean
- [x] `git diff --check` — clean
- [x] Re-checked open PRs: no open prior PR for #75820 / create-time primary_path dedup (sidebar-lane dedup PRs are adjacent, not this fix)

## Platform

- macOS (Darwin), Python 3.13, identity arimu1