### PR TITLE
test(tui): wait for profile agent-build threads

### DIFF
--- a/contributors/emails/vadim984@gmail.com
+++ b/contributors/emails/vadim984@gmail.com
@@ -1,0 +1,2 @@
+vadimcomanescu
+# Issue #75955

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -662,7 +662,12 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     server._sessions[sid] = session
     try:
         server._start_agent_build(sid, session)
-        assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
+        build_thread = session["_agent_build_thread"]
+        build_thread.join(timeout=2)
+        assert not build_thread.is_alive()
+        assert built.is_set()
+        assert "agent_error" not in session
     finally:
         server._sessions.pop(sid, None)
 
@@ -717,7 +722,12 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
     server._sessions[sid] = session
     try:
         server._start_agent_build(sid, session)
-        assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
+        build_thread = session["_agent_build_thread"]
+        build_thread.join(timeout=2)
+        assert not build_thread.is_alive()
+        assert built.is_set()
+        assert "agent_error" not in session
     finally:
         server._sessions.pop(sid, None)
 


### PR DESCRIPTION
## What does this PR do?

Makes the two profile-scoped agent-build tests wait for the complete background build lifecycle before their monkeypatches and session state unwind. The tests previously returned as soon as `_make_agent` set a local event, while `_start_agent_build` could still emit `session.info` and execute its final cleanup. That unfinished thread could pollute a later stdout assertion.

The production transport is unchanged. The strict concurrent-writer assertion remains unchanged.

## Related Issue

Fixes #75955

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- wait for each test session’s `agent_ready` completion event
- join the recorded `_agent_build_thread` and assert it terminated
- assert `_make_agent` ran and no `agent_error` was recorded before removing the session
- add the required first-time contributor email mapping

## How to Test

1. On Linux, run `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_tui_gateway_server.py -q`.
2. Confirm the profile-scoped build tests finish their `_agent_build_thread` before teardown.
3. Confirm `test_write_json_serializes_concurrent_writes` retains its strict eight-frame assertion.

## Checklist

### Code

- [x] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass — Linux pull-request CI is the authoritative full-suite run
- [x] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I’ve tested on my platform — validation is delegated to Linux pull-request CI

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — test-only thread lifecycle; production behavior is unchanged
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a test-lifecycle fix. Linux CI provides the acceptance result.
