### PR TITLE
chore: add contributor email mappings for @Prontsevich

### DIFF
--- a/contributors/emails/prontsevich@gmail.com
+++ b/contributors/emails/prontsevich@gmail.com
@@ -1,0 +1,2 @@
+Prontsevich
+# PR #32811 salvage (ACP background MCP discovery)

--- a/contributors/emails/sergey@3dacademysoftware.com
+++ b/contributors/emails/sergey@3dacademysoftware.com
@@ -1,0 +1,2 @@
+spro-work
+# PR #32811 salvage (ACP background MCP discovery) — same person as Prontsevich


### PR DESCRIPTION
## Summary
Adds contributor email mappings for @Prontsevich / @spro-work ahead of the #32811 salvage, so `check-attribution` passes when those cherry-picked commits land.

- `prontsevich@gmail.com` -> Prontsevich
- `sergey@3dacademysoftware.com` -> spro-work (login verified via the PR commits API; same person)

Merge before the salvage PR.
