### PR TITLE
fix(agent): deduplicate iteration budget warning

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2069,8 +2069,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
-    print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
-
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2246,6 +2246,25 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
+    def test_does_not_print_duplicate_lifecycle_banner(self, agent, capsys):
+        """The turn finalizer owns iteration-limit status output.
+
+        The summary helper must not also print directly, or delegated runs show
+        both an unscoped banner and the routed ``[subagent-N]`` status line.
+        """
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        capsys.readouterr()
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert "Reached maximum iterations" not in capsys.readouterr().out
+
     def test_summary_retries_share_relay_identity(self, agent):
         agent.client.chat.completions.create.side_effect = [
             _mock_response(content=""),


### PR DESCRIPTION
## Summary

Remove the unconditional console banner from `handle_max_iterations()`. The turn finalizer already owns iteration-limit lifecycle output through `_emit_status()` and `_safe_print()`, so delegated runs currently display the same event twice:

```text
⚠️  Reached maximum iterations (50). Requesting summary...
[subagent-0] ⚠️ Iteration budget exhausted (50/50) — asking model to summarise
```

After this change, the routed `[subagent-N]` status remains and the unscoped duplicate is gone. Summary behavior and the iteration safety cap are unchanged.

## Tests

- Added a regression test proving the summary helper does not print its own lifecycle banner.
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q` — 221 passed
- `scripts/run_tests.sh tests/agent/test_turn_finalizer_iteration_limit_exit.py -q` — 5 passed

## Related

- #19109 proposes adding configuration guidance to iteration-exhaustion messages and currently includes this redundant helper banner among its target sites. If both changes proceed, that PR should avoid reintroducing the direct print.