### PR TITLE
fix(gateway): reap orphans on stop_profile_gateway (#75936)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1583,6 +1583,12 @@ def stop_profile_gateway() -> bool:
     a live orphan still holds the webhook port. In that case fall back to the
     orphan-aware process scan so the replacement reaps the prior instance
     instead of stacking a duplicate on the same port (#51325).
+
+    Even when the pid file is valid and points to the current gateway, older
+    orphans may linger from prior restarts that overwrote the pid file before
+    the old process exited. After killing the recorded PID, also sweep for
+    any remaining orphans so each restart produces at most one live gateway
+    (#75936).
     """
     try:
         from gateway.status import get_running_pid, remove_pid_file
@@ -1620,6 +1626,14 @@ def stop_profile_gateway() -> bool:
 
     if get_running_pid() is None:
         remove_pid_file()
+
+    # Also reap any orphans from prior restarts whose PIDs were overwritten
+    # in the pid file before they exited (#75936).
+    try:
+        _reap_unsupervised_gateway_orphans()
+    except Exception:
+        pass
+
     return True
 
 


### PR DESCRIPTION
## Fixes #75936: macOS gateway restart leaves orphan processes

### Root Cause

`stop_profile_gateway()` only kills the single PID recorded in the pid file. On repeated `hermes gateway restart` calls, the new process overwrites the pid file before the old one exits, making older gateway instances invisible to subsequent stops. Each restart stacked another orphan — observed as N threads and N replies per Discord message.

`_reap_unsupervised_gateway_orphans()` already exists and handles this sweep, but it was only called when the pid file was *missing* (line 1594). When the pid file was *valid* (pointing to the newest instance), the orphan reap never ran.

### Fix

After killing the recorded PID and waiting for it to exit, also call `_reap_unsupervised_gateway_orphans()` to sweep any remaining gateway processes for this profile. The reap function already handles:
- The no-systemd guard (`supports_systemd_services()` check)
- Finding all gateway PIDs for the current profile (`find_gateway_pids()`)
- SIGTERM + SIGKILL escalation with a 5-second deadline

### Changes

- `hermes_cli/gateway.py`: Added orphan reap call after the PID kill sequence in `stop_profile_gateway()`, plus docstring update explaining the new behavior.

### Test Plan

- [x] Syntax check passes
- [ ] Manual test: `hermes gateway restart` twice on macOS → verify only one gateway process running
- [ ] Verify `ps aux | grep hermes_cli.main gateway` shows single PID after restart