### PR TITLE
fix(desktop): keep ⌘G/files rails at their default size

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model-absorber.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model-absorber.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { allFixedAbsorberIndex } from './track-model'
+
+describe('allFixedAbsorberIndex', () => {
+  it('picks the last uncapped track', () => {
+    // terminal (uncapped height) + logs (uncapped) → logs absorbs
+    const growable = [0, 1]
+    const max = (i: number) => (i === 0 ? '80vh' : undefined)
+
+    expect(allFixedAbsorberIndex(growable, max)).toBe(1)
+  })
+
+  it('skips a capped last track and picks an earlier uncapped one', () => {
+    // uncapped tool panel + capped files rail at the end of a column
+    const growable = [0, 1]
+    const max = (i: number) => (i === 1 ? '20rem' : undefined)
+
+    expect(allFixedAbsorberIndex(growable, max)).toBe(0)
+  })
+
+  it('refuses to absorb when every fixed track is capped (review/files rail)', () => {
+    // Default right rail: review | preview | files — all declare maxWidth.
+    // Promoting any of them to grow-1 dropped the clamp and ballooned ⌘G/⌘J.
+    const growable = [0, 1, 2]
+    const max = () => '20rem'
+
+    expect(allFixedAbsorberIndex(growable, max)).toBe(-1)
+  })
+
+  it('returns -1 for an empty run', () => {
+    expect(allFixedAbsorberIndex([], () => undefined)).toBe(-1)
+  })
+
+  it('absorbs a lone uncapped track', () => {
+    expect(allFixedAbsorberIndex([3], () => undefined)).toBe(3)
+  })
+
+  it('refuses a lone capped sidebar', () => {
+    // ⌘G alone: only review is visible in the rail — must stay at 237px / max 20rem.
+    expect(allFixedAbsorberIndex([0], () => '20rem')).toBe(-1)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -158,6 +158,36 @@ export const cssMax = (values: (string | null | undefined)[]): string | undefine
  *  are both 28px thick. */
 export const MINIMIZED_TRACK = '1.75rem'
 
+/**
+ * In an all-fixed split, the last uncapped track may absorb leftover space
+ * (terminal/logs stacked at 38vh with nothing else to fill the column). A
+ * CAPPED track must never be the absorber: review/files declare maxWidth
+ * 20rem, and promoting them to grow-1 + dropping the clamp made ⌘G / ⌘J open
+ * a half-window rail and ignore sash-remembered sizes (flex-basis alone
+ * can't hold against grow).
+ *
+ * Returns the child index to absorb, or -1 when every fixed track is capped
+ * (leave dead space — better than a ballooned sidebar).
+ */
+export function allFixedAbsorberIndex(
+  growable: readonly number[],
+  maxAlongAxis: (index: number) => string | undefined
+): number {
+  if (growable.length === 0) {
+    return -1
+  }
+
+  for (let i = growable.length - 1; i >= 0; i--) {
+    const index = growable[i]
+
+    if (!maxAlongAxis(index)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
 export function fixedTrackSize(node: LayoutNode, axis: 'row' | 'column', ctx: TrackContext): string | null {
   if (node.type === 'group') {
     // Ancestor splits must size a minimized zone as its strip, not as its

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -2,8 +2,8 @@
  * Split node renderer — a flex row/column whose 1px seams double as resize
  * sashes (the seam IS the boundary — junction-owned, never doubled). Sizing
  * is the TRACK MODEL (track-model.ts): fixed tracks keep their declared size,
- * flex tracks share the leftover by weight, and an all-fixed run lets its
- * last track absorb the slack (VS Code style).
+ * flex tracks share the leftover by weight, and an all-fixed run lets an
+ * UNCAPPED last track absorb the slack (capped sidebars stay put).
  */
 
 import { useStore } from '@nanostores/react'
@@ -30,6 +30,7 @@ import {
 } from '../store'
 
 import {
+  allFixedAbsorberIndex,
   COLLAPSED_ZONE_PX,
   computedPx,
   cssMax,
@@ -469,8 +470,8 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
   // A run of ONLY fixed tracks can't fill the container (grow-0 all around
   // leaves dead space — e.g. terminal + logs split into two 38vh zones with
-  // the rail above them collapsed). The LAST visible track absorbs the
-  // leftover, VS Code style.
+  // the rail above them collapsed). An UNCAPPED last track absorbs the
+  // leftover; capped sidebars (review/files) keep their max and stay put.
   const isMinimized = (child: LayoutNode) => child.type === 'group' && Boolean(child.minimized)
 
   // SEMANTIC side collapse (titlebar toggles / ⌘B / ⌘J): at the ROOT row,
@@ -508,7 +509,13 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
   const growable = tracks.map((_, i) => i).filter(i => !tracks[i].collapsed && !tracks[i].minimized)
   const allFixed = growable.length > 0 && growable.every(i => tracks[i].track !== null)
-  const absorberIndex = allFixed ? growable[growable.length - 1] : -1
+  // Only an uncapped fixed track may absorb leftover. A maxWidth/maxHeight
+  // sidebar (review, files, sessions) must keep that clamp — otherwise ⌘G
+  // balloons the rail and sash-remembered sizes become a flex-basis that
+  // grow still expands past.
+  const absorberIndex = allFixed
+    ? allFixedAbsorberIndex(growable, i => (horizontal ? tracks[i].sizing?.maxWidth : tracks[i].sizing?.maxHeight))
+    : -1
 
   // Weights are RATIOS, but CSS flex-grow is absolute: a run whose grows sum
   // below 1 fills only that fraction of the leftover (normalize's flatten
@@ -550,6 +557,7 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
     >
       {tracks.map(({ child, collapsed, minimized, narrowCollapsed, sizing, track }, i) => {
         const partner = collapsed ? -1 : seamPartner(i)
+        const absorbs = i === absorberIndex
 
         return (
           <div
@@ -565,16 +573,17 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
                       // grow-0 shrink-1 from its preferred basis (it yields
                       // gracefully on tight windows, floored by min-width);
                       // everything else splits the leftover by weight. In an
-                      // all-fixed run the last track grows into the leftover.
-                      flex: track ? `${i === absorberIndex ? 1 : 0} 1 ${track}` : `${grow(i)} ${grow(i)} 0px`,
+                      // all-fixed run an UNCAPPED last track grows into the
+                      // leftover; capped sidebars stay at their declared size.
+                      flex: track ? `${absorbs ? 1 : 0} 1 ${track}` : `${grow(i)} ${grow(i)} 0px`,
                       // Pane-declared clamps apply along THIS split's axis only
                       // (a rail's width clamp shouldn't constrain its height).
-                      // The absorber drops its max clamp — it exists to fill
-                      // the leftover, and clamping would recreate the gap.
+                      // The absorber is uncapped by selection, so dropping its
+                      // max is a no-op; capped tracks always keep theirs.
                       minWidth: (horizontal && sizing?.minWidth) || 0,
-                      maxWidth: horizontal && i !== absorberIndex ? sizing?.maxWidth : undefined,
+                      maxWidth: horizontal && !absorbs ? sizing?.maxWidth : undefined,
                       minHeight: (!horizontal && sizing?.minHeight) || 0,
-                      maxHeight: horizontal || i === absorberIndex ? undefined : sizing?.maxHeight
+                      maxHeight: horizontal || absorbs ? undefined : sizing?.maxHeight
                     }
             }
           >


### PR DESCRIPTION
## Summary
- All-fixed pane splits no longer promote a capped track (review, files, sessions) to flex-grow or strip its maxWidth/maxHeight
- ⌘G and the file browser open at their declared width again; sash-resized sizes stick across open/close
- Terminal/logs stacks still absorb leftover when uncapped

## Test plan
- [ ] Open a project, hit ⌘G — review rail is ~237px, not half the window
- [ ] Drag the review sash, close with ⌘G, reopen — size matches the drag
- [ ] Same for the files rail (⌘J)
- [ ] Terminal deck / logs still fill leftover height when both are open
- [ ] `npx vitest run src/components/pane-shell/tree/renderer/track-model-absorber.test.ts`