### PR TITLE
feat(desktop): option to disable session tabs

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -28,6 +28,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
+import { sessionTabsEnabled } from '@/store/session-tabs'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeSessionId,
@@ -159,9 +160,10 @@ function useSessionActions({
   const spec = (partial: Omit<ActionItemSpec, 'onSelect'> & { onSelect: () => void }): ActionItemSpec => partial
 
   // OPEN — where else this session can go. A tab surface IS a tab already,
-  // so it only offers the window hop (and its own Close, below).
+  // so it only offers the window hop (and its own Close, below). Hide "Open
+  // in new tab" when the user has disabled session tabs entirely.
   const openItems: ActionItemSpec[] = [
-    ...(surface === 'row' && !alreadyTabbed
+    ...(surface === 'row' && !alreadyTabbed && sessionTabsEnabled()
       ? [
           spec({
             disabled: !sessionId,

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -17,6 +17,7 @@ import { middleClickHandlers } from '@/lib/middle-click'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import { sessionTabsEnabled } from '@/store/session-tabs'
 import { $attentionSessionIds } from '@/store/session-states'
 
 import { SessionStatusDot } from '../session-status-dot'
@@ -169,9 +170,18 @@ function SidebarSessionRowImpl({
         )}
         <SidebarRowBody
           className={cn('z-0 group-hover:pr-12', branchStem && 'pl-3.5')}
-          // Middle-click = open in a new tab (browser muscle memory).
+          // Middle-click = open in a new tab (browser muscle memory). When
+          // session tabs are disabled, fall through to in-place resume — the
+          // row's navigate path is `onResume`, not a no-op openSession navigate.
           {...middleClickHandlers(() => {
             triggerHaptic('selection')
+
+            if (!sessionTabsEnabled()) {
+              onResume()
+
+              return
+            }
+
             openSession(session.id, () => undefined, 'tab')
           })}
           onClick={event => {
@@ -187,11 +197,19 @@ function SidebarSessionRowImpl({
               return
             }
 
-            // ⌘/⌃-click → open in a new tab (stack into main).
+            // ⌘/⌃-click → open in a new tab (stack into main), or in-place
+            // when the user has disabled session tabs.
             if (mod) {
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
+
+              if (!sessionTabsEnabled()) {
+                onResume()
+
+                return
+              }
+
               openSession(session.id, () => undefined, 'tab')
 
               return

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -45,6 +45,7 @@ import {
   refreshActiveProfile
 } from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
+import { sessionTabsEnabled } from '@/store/session-tabs'
 import {
   $activeSessionId,
   $connection,
@@ -501,12 +502,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // project so the new lane is visible.
   //
   // `openTab` is the sidebar "+" behavior: once a chat is loaded, stack a new
-  // tab instead of replacing it (see mainChatOccupied). The composer's
+  // tab instead of replacing it (see mainChatOccupied) — unless the user
+  // disabled session tabs (Settings → Appearance). The composer's
   // "branch off into a new worktree" flow keeps the fresh-draft path — it
   // prefills the MAIN composer right after, so it has to own that surface.
   const startSessionInWorkspace = useCallback(
     (path: null | string, options?: { openTab?: boolean }) => {
-      if (options?.openTab && mainChatOccupied(activeSessionIdRef.current, $selectedStoredSessionId.get())) {
+      if (
+        options?.openTab &&
+        sessionTabsEnabled() &&
+        mainChatOccupied(activeSessionIdRef.current, $selectedStoredSessionId.get())
+      ) {
         void openNewSessionTile('center', { cwd: path, listed: false })
 
         return

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -26,6 +26,7 @@ vi.mock('./routes', () => ({
 }))
 
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import { setSessionTabsEnabled } from '@/store/session-tabs'
 
 import { mainChatOccupied, openSession, openSessionIntentFromModifiers } from './open-session'
 
@@ -76,6 +77,15 @@ describe('openSessionIntentFromModifiers', () => {
     expect(openSessionIntentFromModifiers({ metaKey: true }, 'stack')).toBe('tab')
     expect(openSessionIntentFromModifiers({ metaKey: true, shiftKey: true }, 'stack')).toBe('window')
   })
+
+  it('collapses ⌘/⌃ to base when session tabs are disabled', () => {
+    setSessionTabsEnabled(false)
+    expect(openSessionIntentFromModifiers({ metaKey: true })).toBe('in-place')
+    expect(openSessionIntentFromModifiers({ ctrlKey: true }, 'stack')).toBe('stack')
+    // Window hops stay available.
+    expect(openSessionIntentFromModifiers({ metaKey: true, shiftKey: true })).toBe('window')
+    setSessionTabsEnabled(true)
+  })
 })
 
 describe('openSession', () => {
@@ -91,6 +101,7 @@ describe('openSession', () => {
     reuseBlankDraftTile.mockReset()
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
+    setSessionTabsEnabled(true)
   })
 
   it('in-place focuses an existing tile and does not navigate', () => {
@@ -196,6 +207,33 @@ describe('openSession', () => {
     openSession('s1', navigate, 'window')
     expect(openSessionInNewWindow).not.toHaveBeenCalled()
     expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+  })
+
+  it('tab loads into main when session tabs are disabled', () => {
+    setSessionTabsEnabled(false)
+    focusOpenSession.mockReturnValue(null)
+    openSession('s1', navigate, 'tab')
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('stack loads into main even when occupied if session tabs are disabled', () => {
+    setSessionTabsEnabled(false)
+    $selectedStoredSessionId.set('s0')
+    focusOpenSession.mockReturnValue(null)
+    openSession('s1', navigate, 'stack')
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('window falls back to main when pop-out is unavailable and tabs are off', () => {
+    setSessionTabsEnabled(false)
+    canOpenSessionWindow.mockReturnValue(false)
+    focusOpenSession.mockReturnValue(null)
+    openSession('s1', navigate, 'window')
+    expect(openSessionInNewWindow).not.toHaveBeenCalled()
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
   })
 
   it('no-ops on an empty id', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -15,6 +15,7 @@
  *     the bridge has no session-window support.
  */
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import { sessionTabsEnabled } from '@/store/session-tabs'
 import {
   focusedSessionNeedsRoute,
   focusOpenSession,
@@ -43,7 +44,9 @@ export function mainChatOccupied(activeSessionId: null | string, selectedStoredS
 
 /** Read modifiers the way session rows do — meta OR ctrl for tab, +shift for
  *  window. `base` is what an unmodified select means for the caller: the
- *  sidebar spends main (`in-place`), a palette-style open doesn't (`stack`). */
+ *  sidebar spends main (`in-place`), a palette-style open doesn't (`stack`).
+ *  When session tabs are disabled, ⌘/⌃ collapses to `base` (in-place load)
+ *  instead of stacking a tab; window hops stay available. */
 export function openSessionIntentFromModifiers(
   event?: null | { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean },
   base: OpenSessionIntent = 'in-place'
@@ -59,7 +62,7 @@ export function openSessionIntentFromModifiers(
   }
 
   if (mod) {
-    return 'tab'
+    return sessionTabsEnabled() ? 'tab' : base
   }
 
   return base
@@ -87,8 +90,14 @@ export function openSession(
       return
     }
 
-    // No pop-out support → treat like a new tab.
-    resolved = 'tab'
+    // No pop-out support → treat like a new tab (or main when tabs are off).
+    resolved = sessionTabsEnabled() ? 'tab' : 'in-place'
+  }
+
+  // Users who disable session tabs never want a stacked chat — force every
+  // tab-or-stack intent into main. Explicit window opens already returned above.
+  if (!sessionTabsEnabled() && (resolved === 'tab' || resolved === 'stack')) {
+    resolved = 'in-place'
   }
 
   // A `stack` open arrives from outside the workspace, so unlike a sidebar

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -16,6 +16,7 @@ import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
+import { $sessionTabsEnabled, setSessionTabsEnabled } from '@/store/session-tabs'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -252,6 +253,7 @@ export function AppearanceSettings() {
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
   const reactionsEnabled = useStore($reactionsEnabled)
+  const sessionTabsEnabled = useStore($sessionTabsEnabled)
   const backdrop = useStore($backdrop)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
@@ -490,6 +492,24 @@ export function AppearanceSettings() {
             }
             description={a.reactionsDesc}
             title={a.reactionsTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setSessionTabsEnabled(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={sessionTabsEnabled ? 'on' : 'off'}
+              />
+            }
+            description={a.sessionTabsDesc}
+            title={a.sessionTabsTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -445,6 +445,9 @@ export const en: Translations = {
       backdropDesc: 'The faint statue image behind the conversation.',
       reactionsTitle: 'Message Reactions',
       reactionsDesc: 'iMessage-style emoji tapbacks — react to messages, and Hermes can react to yours.',
+      sessionTabsTitle: 'Session Tabs',
+      sessionTabsDesc:
+        'When on, sidebar + and ⌘/⌃-click open a new tab if main already has a chat. When off, those actions always load into main.',
       embedsTitle: 'Inline Embeds',
       embedsDesc:
         'Rich previews load from third-party sites (YouTube, X, …). Ask shows a placeholder until you allow each one; Always loads them automatically; Off keeps plain links.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -354,6 +354,8 @@ export interface Translations {
       backdropDesc: string
       reactionsTitle: string
       reactionsDesc: string
+      sessionTabsTitle: string
+      sessionTabsDesc: string
       embedsTitle: string
       embedsDesc: string
       embedsAsk: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -437,6 +437,9 @@ export const zh: Translations = {
       backdropDesc: '对话后方那张淡淡的雕像图片。',
       reactionsTitle: '消息回应',
       reactionsDesc: 'iMessage 风格的表情回应 — 你可以给消息添加回应，Hermes 也能回应你的消息。',
+      sessionTabsTitle: '会话标签页',
+      sessionTabsDesc:
+        '开启时，若主聊天已有会话，侧边栏 + 与 ⌘/⌃-点击会打开新标签。关闭时，这些操作始终在主区域加载。',
       embedsTitle: '内嵌预览',
       embedsDesc:
         '富预览会从第三方网站（YouTube、X 等）加载。询问会在你允许前显示占位符；总是会自动加载；关闭则保留纯链接。',

--- a/apps/desktop/src/store/session-tabs.ts
+++ b/apps/desktop/src/store/session-tabs.ts
@@ -1,0 +1,38 @@
+/**
+ * Session tabs preference — whether the desktop may stack a second chat as a
+ * tab instead of loading into main.
+ *
+ * On by default (today's behavior after #71848). Off is a UX preference for
+ * users who never want multi-session tabs: sidebar "+" replaces main, and
+ * ⌘/⌃-click + middle-click on a session row load in-place.
+ *
+ * Presentation-scoped only (desktop AGENTS.md: state lives with its authority).
+ * Does not hide the tab strip or block explicit split/⌘T — those remain available
+ * when the user deliberately opens them.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.sessionTabs.v1'
+
+/** Default true — preserve the current "open a tab when main is occupied" behavior. */
+export const $sessionTabsEnabled = atom<boolean>(
+  typeof window === 'undefined' ? true : storedBoolean(KEY, true)
+)
+
+export function setSessionTabsEnabled(enabled: boolean): void {
+  $sessionTabsEnabled.set(enabled)
+}
+
+/** Sync read for non-React doors (openSession, sidebar "+", openTab gates). */
+export function sessionTabsEnabled(): boolean {
+  return $sessionTabsEnabled.get()
+}
+
+if (typeof window !== 'undefined') {
+  $sessionTabsEnabled.listen(enabled => {
+    persistBoolean(KEY, enabled)
+  })
+}


### PR DESCRIPTION
## What does this PR do?

Adds a desktop preference to **disable session tabs** for users who never want multi-session tab stacking.

When **Session Tabs** is off (Settings → Appearance):
- Sidebar **+** always starts a fresh session in **main** (replaces the current chat / loads into empty main), instead of stacking a tab when main is occupied
- **⌘/⌃-click** and **middle-click** on a sidebar session row load **in-place** (same as a normal click)
- `openSession` `tab` / `stack` intents resolve to **in-place** (command palette, notifications, etc.)
- Context menu **Open in new tab** is hidden

Default remains **on** (current #71848 behavior). Explicit splits / ⌘T are intentionally left alone — this only gates the auto-tab affordances called out in the issue.

## Related Issue

Fixes #75878

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/store/session-tabs.ts` — `$sessionTabsEnabled` (localStorage, default `true`)
- `apps/desktop/src/app/open-session.ts` — modifier intent + `openSession` respect the flag
- `apps/desktop/src/app/contrib/wiring.tsx` — sidebar `+` `openTab` gated on `sessionTabsEnabled()`
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — mod/middle-click fall back to `onResume` when off
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` — hide “Open in new tab” when off
- `apps/desktop/src/app/settings/appearance-settings.tsx` + i18n — Appearance toggle
- `apps/desktop/src/app/open-session.test.ts` — regressions for tabs-off intents

## How to Test

1. Desktop Settings → Appearance → **Session Tabs** defaults to On.
2. With a chat loaded on main, click project/workspace **+** → stacks a new tab (unchanged).
3. Turn **Session Tabs** Off.
4. Click **+** with main occupied → fresh draft lands in **main** (no new tab).
5. ⌘/⌃-click or middle-click a different sidebar session → loads into main, does not stack a tab.
6. Toggle back On → previous auto-tab behavior returns.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(desktop):`)
- [x] I searched for existing PRs (no open PR for #75878 / `tabs_enabled` / disable session tabs)
- [x] My PR contains **only** changes related to this feature
- [x] Focused desktop unit tests: `npm test -- src/app/open-session.test.ts` → **27 passed**
- [x] I've added tests for the new flag behavior
- [x] I've tested on my platform: macOS (unit tests via vitest)

### Documentation & Housekeeping

- [x] Docs N/A (Settings UI copy covers the preference; no config.yaml key — desktop presentation store per `apps/desktop/AGENTS.md`)
- [x] `cli-config.yaml.example` N/A (not a shared config.yaml key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform: pure renderer preference (localStorage); no native APIs
- [x] Tool schemas N/A

## Screenshots / Logs

```
✓ |ui| src/app/open-session.test.ts (27 tests)
```