### PR TITLE
fix(tool/skills): 修复技能安装时静默删除类别目录导致数据丢失的问题

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2426,6 +2426,153 @@ class TestInstallPathSafety:
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
 
+    def test_install_from_quarantine_rejects_category_bucket_overwrite(self, tmp_path):
+        """Installing a skill whose name matches an existing category directory
+        that contains other skills must NOT silently wipe that entire directory.
+
+        Regression test for GitHub issue #75983: ``hermes skills install … --name
+        research`` deleted the whole ``skills/research/`` category bucket,
+        destroying 16 unrelated skills.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Simulate a user-created category bucket with multiple skills.
+        category = skills_dir / "research"
+        category.mkdir()
+        for skill in ("alpha", "bravo", "charlie"):
+            (category / skill).mkdir()
+            (category / skill / "SKILL.md").write_text(f"name: {skill}")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: research\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="research",
+            files={"SKILL.md": "---\nname: research\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="research",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="Refusing to overwrite category directory"):
+                hub.install_from_quarantine(
+                    q_dir, "research", "", bundle, scan_result,
+                )
+
+        # Verify the category bucket and its skills are intact.
+        assert (category / "alpha" / "SKILL.md").exists()
+        assert (category / "bravo" / "SKILL.md").exists()
+        assert (category / "charlie" / "SKILL.md").exists()
+
+    def test_install_from_quarantine_allows_existing_skill_overwrite(self, tmp_path):
+        """Installing over an existing skill directory (containing SKILL.md) is
+        still allowed — that scenario is already guarded by the lock-file check
+        in do_install()."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Existing skill directory with SKILL.md.
+        existing = skills_dir / "my-skill"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("old content")
+        (existing / "refs").mkdir()
+        (existing / "refs" / "guide.md").write_text("old guide")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: my-skill\n---\nnew")
+        (q_dir / "refs").mkdir()
+        (q_dir / "refs" / "guide.md").write_text("new guide")
+
+        bundle = hub.SkillBundle(
+            name="my-skill",
+            files={"SKILL.md": "---\nname: my-skill\n---\nnew"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="my-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            installed = hub.install_from_quarantine(
+                q_dir, "my-skill", "", bundle, scan_result,
+            )
+
+        # The old directory was replaced by the new one.
+        assert installed.exists()
+        assert (installed / "SKILL.md").read_text().strip() == "---\nname: my-skill\n---\nnew"
+
+    def test_install_from_quarantine_allows_empty_category_dir(self, tmp_path):
+        """Installing into an existing but empty category directory is allowed
+        (no sibling skills to destroy)."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Empty category directory (no skills inside).
+        category = skills_dir / "research"
+        category.mkdir()
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: research\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="research",
+            files={"SKILL.md": "---\nname: research\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="research",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            installed = hub.install_from_quarantine(
+                q_dir, "research", "", bundle, scan_result,
+            )
+
+        assert installed.exists()
+        assert (installed / "SKILL.md").exists()
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3612,6 +3612,30 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
+        # Guard against silent data loss when the install target collides with
+        # an existing category bucket (a directory that holds other skills).
+        # This was reported as GitHub issue #75983: installing a skill with
+        # --name matching an existing category directory caused rmtree to wipe
+        # all sibling skills.  An existing skill installation (a directory that
+        # directly contains SKILL.md) is safe to overwrite — that path is
+        # already guarded by the lock-file check in do_install().  But a
+        # directory that contains *other* skill directories is a category bucket
+        # and must NOT be silently deleted.
+        if install_dir.is_dir() and not (install_dir / "SKILL.md").exists():
+            _skill_dirs_in = [
+                entry.name
+                for entry in install_dir.iterdir()
+                if entry.is_dir()
+                and not entry.name.startswith(".")
+                and any(entry.rglob("SKILL.md"))
+            ]
+            if _skill_dirs_in:
+                raise ValueError(
+                    f"Refusing to overwrite category directory '{install_dir}' "
+                    f"which contains {len(_skill_dirs_in)} skill(s): "
+                    f"{', '.join(sorted(_skill_dirs_in))}. "
+                    f"Use a different --name or install into a subcategory."
+                )
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large


### PR DESCRIPTION
## 背景

修复 #75983: `hermes skills install <url> --name <name>` 在技能名与现有类别目录冲突时，无条件 `rmtree` 删除整个目录，造成 16 个无关技能被静默删除的数据丢失事件。

## 根因分析

`install_from_quarantine()` 在安装技能时，如果目标路径已存在，会直接调用 `shutil.rmtree(install_dir)`。当 `--name` 参数指定的名字恰好是用户手动创建的类别目录（category bucket）名称时，整个类别目录及其下所有技能被无条件删除。

lock.json 的已有检查仅覆盖通过 hub 安装的技能，不追踪用户手动创建的目录，因此此场景完全无防护。

## 修复方式

在 `tools/skills_hub.py` 的 `install_from_quarantine()` 函数中，在 `rmtree` 之前增加类别桶保护逻辑：

1. 检查 `install_dir` 是否存在且是目录，但**不包含顶层 SKILL.md**（说明它不是单个技能目录）
2. 递归搜索该目录下是否存在其他技能子目录（含 SKILL.md 的子目录）
3. 如果存在，抛出 `ValueError` 拒绝安装，并在错误信息中列出受影响的技能名称
4. 如果不存在（空目录或仅含非技能文件），允许继续安装（保持原有行为）

这样既保护了用户的类别桶不被意外删除，又不影响正常技能目录的覆盖安装。

## 验证

- [x] 新增 3 个回归测试全部通过（`TestInstallPathSafety` 类，19 tests pass）
- [x] 完整测试套件通过（`test_skills_hub.py` 163 tests pass）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #75983