### PR TITLE
fix(cli): bound the doctor state.db health probe with a cancellable SQLite deadline (supersedes #72527)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1597,6 +1597,14 @@ def run_doctor(args):
 
             if count is not None:
                 check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+            else:
+                # The file is known to exist (`state_db_path.exists()` above);
+                # only the count is unknown. Say so rather than silently
+                # dropping the row in the worst-case timeout path.
+                check_info(
+                    f"{_DHH}/state.db exists (session count not read — the "
+                    "health check timed out before it returned)"
+                )
 
             if _probe_timed_out:
                 # A deadline is NOT a corruption verdict: nothing is known

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -703,6 +703,59 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+# Wall-clock budget for the read-only state.db health probes in `run_doctor`
+# (#72441). `PRAGMA integrity_check` walks every page of the file, so on a
+# large state.db the probe runs for minutes with no output and no way out.
+# Module-level so tests can monkeypatch it; deliberately NOT a config key or a
+# CLI flag — diagnostics should not need tuning to terminate.
+_STATE_DB_PROBE_DEADLINE_S = 30.0
+
+# Extra slack given to the abandonable boundary on top of the SQLite deadline,
+# so the in-statement cancellation is what normally stops the probe (it closes
+# its connection on the way out) and the thread boundary only fires for work
+# SQLite cannot interrupt at all — a `connect()` or page read wedged in an
+# uninterruptible I/O syscall, e.g. a hung network mount.
+_STATE_DB_PROBE_ABANDON_GRACE_S = 5.0
+
+
+def _run_abandonable(fn, timeout_s: float):
+    """Run ``fn`` on a daemon worker, abandoning it if it outlives the timeout.
+
+    Raises ``TimeoutError`` when ``fn`` has not returned in ``timeout_s``;
+    otherwise returns its result (or re-raises its exception unchanged, so
+    callers keep their existing error handling).
+
+    Two deliberate choices, both load-bearing:
+
+    * ``shutdown(wait=False)`` in a ``finally``, never
+      ``with ThreadPoolExecutor(...) as pool``. The context-manager form calls
+      ``shutdown(wait=True)`` on exit, which blocks until the worker finishes —
+      that would make the timeout merely delay the warning instead of bounding
+      the command.
+    * ``DaemonThreadPoolExecutor`` rather than the stdlib pool. Stdlib workers
+      are registered in ``concurrent.futures.thread._threads_queues``, whose
+      atexit hook joins every worker unconditionally *even after*
+      ``shutdown(wait=False)`` — so an abandoned worker would just move the
+      hang to interpreter exit (see ``tools/daemon_pool.py``).
+    """
+    from concurrent.futures import TimeoutError as _FutureTimeoutError
+
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    pool = DaemonThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="hermes-doctor-state-db"
+    )
+    try:
+        future = pool.submit(fn)
+        try:
+            return future.result(timeout=max(timeout_s, 0.0))
+        except _FutureTimeoutError:
+            future.cancel()
+            raise TimeoutError(f"probe did not finish within {timeout_s:g}s")
+    finally:
+        pool.shutdown(wait=False)
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1499,21 +1552,69 @@ def run_doctor(args):
     if state_db_path.exists():
         try:
             import sqlite3
-            conn = sqlite3.connect(str(state_db_path))
-            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
-            count = cursor.fetchone()[0]
-            conn.close()
-            check_ok(f"{_DHH}/state.db exists ({count} sessions)")
 
-            # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
+            # FTS write-health probe (#50502): `SELECT COUNT(*)` below succeeds
             # even when the FTS index is corrupt and every message write fails
             # through the triggers. `_db_opens_cleanly` now drives a rolled-back
             # write so this otherwise-silent corruption class is surfaced (and
             # repaired in place with --fix).
-            from hermes_state import _db_opens_cleanly, repair_state_db_schema
+            #
+            # Both reads run under a wall-clock bound (#72441): the probe's
+            # `PRAGMA integrity_check` is O(file size), so on a large state.db
+            # `hermes doctor` used to stall here indefinitely with no output.
+            from hermes_state import (
+                DBHealthProbeTimeout,
+                _db_opens_cleanly,
+                repair_state_db_schema,
+            )
 
-            _write_reason = _db_opens_cleanly(state_db_path)
-            if _write_reason is not None:
+            def _read_state_db_health():
+                conn = sqlite3.connect(str(state_db_path))
+                try:
+                    sessions = conn.execute(
+                        "SELECT COUNT(*) FROM sessions"
+                    ).fetchone()[0]
+                finally:
+                    conn.close()
+                try:
+                    reason = _db_opens_cleanly(
+                        state_db_path,
+                        deadline_seconds=_STATE_DB_PROBE_DEADLINE_S,
+                    )
+                except DBHealthProbeTimeout:
+                    return sessions, None, True
+                return sessions, reason, False
+
+            try:
+                count, _write_reason, _probe_timed_out = _run_abandonable(
+                    _read_state_db_health,
+                    _STATE_DB_PROBE_DEADLINE_S + _STATE_DB_PROBE_ABANDON_GRACE_S,
+                )
+            except TimeoutError:
+                # SQLite could not even be interrupted (wedged syscall). The
+                # worker is abandoned, not joined; the session count is unknown.
+                count, _write_reason, _probe_timed_out = None, None, True
+
+            if count is not None:
+                check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+
+            if _probe_timed_out:
+                # A deadline is NOT a corruption verdict: nothing is known
+                # about this database, so the repair path below must not run.
+                # Escalating a timeout to repair_state_db_schema() would send a
+                # healthy-but-large state.db into a rewrite that drops the
+                # messages_fts% schema and VACUUMs.
+                check_warn(
+                    f"{_DHH}/state.db health check timed out after "
+                    f"{_STATE_DB_PROBE_DEADLINE_S:g}s — skipped",
+                    "(the database was not modified; this is not a corruption verdict)",
+                )
+                issues.append(
+                    "state.db health check timed out — the database is large or on "
+                    "slow storage. Run 'hermes sessions repair --check-only' when you "
+                    "can let it run to completion."
+                )
+            elif _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",
                     f"({_write_reason})",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1249,6 +1249,57 @@ def check_macos_full_disk_access() -> None:
         "and restart them once. With Hermes' stable signing identities the "
         "grant survives every update."
     )
+# Wall-clock budget for the read-only state.db health probes in `run_doctor`
+# (#72441). `PRAGMA integrity_check` walks every page of the file, so on a
+# large state.db the probe runs for minutes with no output and no way out.
+# Module-level so tests can monkeypatch it; deliberately NOT a config key or a
+# CLI flag — diagnostics should not need tuning to terminate.
+_STATE_DB_PROBE_DEADLINE_S = 30.0
+
+# Extra slack given to the abandonable boundary on top of the SQLite deadline,
+# so the in-statement cancellation is what normally stops the probe (it closes
+# its connection on the way out) and the thread boundary only fires for work
+# SQLite cannot interrupt at all — a `connect()` or page read wedged in an
+# uninterruptible I/O syscall, e.g. a hung network mount.
+_STATE_DB_PROBE_ABANDON_GRACE_S = 5.0
+
+
+def _run_abandonable(fn, timeout_s: float):
+    """Run ``fn`` on a daemon worker, abandoning it if it outlives the timeout.
+
+    Raises ``TimeoutError`` when ``fn`` has not returned in ``timeout_s``;
+    otherwise returns its result (or re-raises its exception unchanged, so
+    callers keep their existing error handling).
+
+    Two deliberate choices, both load-bearing:
+
+    * ``shutdown(wait=False)`` in a ``finally``, never
+      ``with ThreadPoolExecutor(...) as pool``. The context-manager form calls
+      ``shutdown(wait=True)`` on exit, which blocks until the worker finishes —
+      that would make the timeout merely delay the warning instead of bounding
+      the command.
+    * ``DaemonThreadPoolExecutor`` rather than the stdlib pool. Stdlib workers
+      are registered in ``concurrent.futures.thread._threads_queues``, whose
+      atexit hook joins every worker unconditionally *even after*
+      ``shutdown(wait=False)`` — so an abandoned worker would just move the
+      hang to interpreter exit (see ``tools/daemon_pool.py``).
+    """
+    from concurrent.futures import TimeoutError as _FutureTimeoutError
+
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    pool = DaemonThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="hermes-doctor-state-db"
+    )
+    try:
+        future = pool.submit(fn)
+        try:
+            return future.result(timeout=max(timeout_s, 0.0))
+        except _FutureTimeoutError:
+            future.cancel()
+            raise TimeoutError(f"probe did not finish within {timeout_s:g}s")
+    finally:
+        pool.shutdown(wait=False)
 
 
 def run_doctor(args):
@@ -2062,21 +2113,68 @@ def run_doctor(args):
     if state_db_path.exists():
         try:
             import sqlite3
-            conn = sqlite3.connect(str(state_db_path))
-            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
-            count = cursor.fetchone()[0]
-            conn.close()
-            check_ok(f"{_DHH}/state.db exists ({count} sessions)")
 
-            # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
+            # FTS write-health probe (#50502): `SELECT COUNT(*)` below succeeds
             # even when the FTS index is corrupt and every message write fails
             # through the triggers. `_db_opens_cleanly` now drives a rolled-back
             # write so this otherwise-silent corruption class is surfaced (and
             # repaired in place with --fix).
-            from hermes_state import _db_opens_cleanly, repair_state_db_schema
+            #
+            # Both reads run under a wall-clock bound (#72441): the probe's
+            # `PRAGMA integrity_check` is O(file size), so on a large state.db
+            # `hermes doctor` used to stall here indefinitely with no output.
+            from hermes_state import (
+                DBHealthProbeTimeout,
+                _db_opens_cleanly,
+                repair_state_db_schema,
+            )
 
-            _write_reason = _db_opens_cleanly(state_db_path)
-            if _write_reason is not None:
+            def _read_state_db_health():
+                conn = sqlite3.connect(str(state_db_path))
+                try:
+                    sessions = conn.execute(
+                        "SELECT COUNT(*) FROM sessions"
+                    ).fetchone()[0]
+                finally:
+                    conn.close()
+                try:
+                    reason = _db_opens_cleanly(
+                        state_db_path,
+                        deadline_seconds=_STATE_DB_PROBE_DEADLINE_S,
+                    )
+                except DBHealthProbeTimeout:
+                    return sessions, None, True
+                return sessions, reason, False
+
+            try:
+                count, _write_reason, _probe_timed_out = _run_abandonable(
+                    _read_state_db_health,
+                    _STATE_DB_PROBE_DEADLINE_S + _STATE_DB_PROBE_ABANDON_GRACE_S,
+                )
+            except TimeoutError:
+                # SQLite could not even be interrupted (wedged syscall). The
+                # worker is abandoned, not joined; the session count is unknown.
+                count, _write_reason, _probe_timed_out = None, None, True
+
+            if count is not None:
+                check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+
+            if _probe_timed_out:
+                # A deadline is NOT a corruption verdict: nothing is known
+                # about this database, so the repair path below must not run.
+                # Escalating a timeout to repair_state_db_schema() would start
+                # recovery without evidence that the database is unhealthy.
+                check_warn(
+                    f"{_DHH}/state.db health check timed out after "
+                    f"{_STATE_DB_PROBE_DEADLINE_S:g}s — skipped",
+                    "(the database was not modified; this is not a corruption verdict)",
+                )
+                issues.append(
+                    "state.db health check timed out — the database is large or on "
+                    "slow storage. Run 'hermes sessions repair --check-only' when you "
+                    "can let it run to completion."
+                )
+            elif _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",
                     f"({_write_reason})",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2158,6 +2158,14 @@ def run_doctor(args):
 
             if count is not None:
                 check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+            else:
+                # The file is known to exist (`state_db_path.exists()` above);
+                # only the count is unknown. Say so rather than silently
+                # dropping the row in the worst-case timeout path.
+                check_info(
+                    f"{_DHH}/state.db exists (session count not read — the "
+                    "health check timed out before it returned)"
+                )
 
             if _probe_timed_out:
                 # A deadline is NOT a corruption verdict: nothing is known

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1119,7 +1119,56 @@ def preflight_db_writability(
             _ensure_writable(p)
 
 
-def _db_opens_cleanly(db_path: Path) -> Optional[str]:
+class DBHealthProbeTimeout(Exception):
+    """``_db_opens_cleanly`` hit the wall-clock deadline it was given.
+
+    **This is not a corruption signal.** The probe was cancelled part-way
+    through, so nothing at all is known about the database's health — a
+    healthy-but-large ``state.db`` reaches this path purely because
+    ``PRAGMA integrity_check`` is O(file size). Callers must report it as
+    "health check skipped" and must never escalate it to
+    :func:`repair_state_db_schema`, which backs up and rewrites the file
+    (its last strategy drops the whole ``messages_fts%`` schema and
+    ``VACUUM``s).
+
+    Raised only when a caller passes ``deadline_seconds``; the default
+    ``None`` keeps every existing caller on the original blocking contract.
+    """
+
+
+# SQLite VM instructions between progress-handler callbacks. Small enough
+# that a long ``PRAGMA integrity_check`` polls the deadline continuously
+# (measured: ~400 callbacks in 0.04s on a 36 MB state.db), large enough that
+# the handler costs nothing on a normal probe.
+_PROBE_PROGRESS_INSTRUCTIONS = 1000
+
+
+class _ProbeDeadline:
+    """Progress handler that aborts the running statement past a deadline.
+
+    Returning a non-zero value from a ``set_progress_handler`` callback makes
+    SQLite abandon the statement in flight and raise
+    ``sqlite3.OperationalError("interrupted")``. Unlike a thread timeout this
+    genuinely cancels the scan instead of merely stopping the caller from
+    waiting on it.
+    """
+
+    __slots__ = ("expires_at", "fired")
+
+    def __init__(self, seconds: float) -> None:
+        self.expires_at = time.monotonic() + seconds
+        self.fired = False
+
+    def __call__(self) -> int:
+        if time.monotonic() >= self.expires_at:
+            self.fired = True
+            return 1
+        return 0
+
+
+def _db_opens_cleanly(
+    db_path: Path, *, deadline_seconds: Optional[float] = None
+) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
@@ -1129,8 +1178,43 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
     ``integrity_check`` passing while every ``INSERT INTO messages`` fails
     through the FTS triggers — is reported as unhealthy rather than slipping
     past as a false "ok" (#50502).
+
+    ``deadline_seconds`` (keyword-only, default ``None`` = unbounded, the
+    historical behaviour) installs a SQLite progress handler that interrupts
+    the scan once the wall clock runs out and raises
+    :class:`DBHealthProbeTimeout`. The timeout is raised, never returned, so
+    it can never be mistaken for the "unhealthy reason" string that drives
+    destructive repair (#72441).
     """
+    deadline = (
+        _ProbeDeadline(deadline_seconds) if deadline_seconds is not None else None
+    )
     conn = sqlite3.connect(str(db_path), isolation_level=None)
+    if deadline is not None:
+        conn.set_progress_handler(deadline, _PROBE_PROGRESS_INSTRUCTIONS)
+    try:
+        reason = _run_db_health_probe(conn)
+    finally:
+        conn.close()
+    if deadline is not None and deadline.fired:
+        # An aborted statement surfaces as OperationalError("interrupted"),
+        # which is a sqlite3.DatabaseError and would otherwise be returned as
+        # a corruption reason by one of the handlers below. Report the
+        # cancellation instead — the DB was only read, never judged.
+        raise DBHealthProbeTimeout(
+            "state.db health probe exceeded its "
+            f"{deadline_seconds:g}s deadline; the database was not modified "
+            "and its health is unknown"
+        )
+    return reason
+
+
+def _run_db_health_probe(conn: sqlite3.Connection) -> Optional[str]:
+    """Run the health-probe statements on an already-open connection.
+
+    Split out of :func:`_db_opens_cleanly` so the connection prologue (and any
+    deadline installed on it) is owned by the caller.
+    """
     try:
         # Best-effort tokenizer load: a DB carrying the messages_fts_cjk
         # index needs the cjk_unicode61 extension before any statement can
@@ -1241,8 +1325,6 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)
-    finally:
-        conn.close()
 
 
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2745,7 +2745,55 @@ def _copy_database_snapshot(
             source.close()
 
 
-def _db_opens_cleanly(db_path: Path) -> Optional[str]:
+class DBHealthProbeTimeout(Exception):
+    """``_db_opens_cleanly`` hit the wall-clock deadline it was given.
+
+    **This is not a corruption signal.** The probe was cancelled part-way
+    through, so nothing at all is known about the database's health — a
+    healthy-but-large ``state.db`` reaches this path purely because
+    ``PRAGMA integrity_check`` is O(file size). Callers must report it as
+    "health check skipped" and must never escalate it to
+    :func:`repair_state_db_schema`: a deadline establishes no health result,
+    so starting recovery would be unjustified.
+
+    Raised only when a caller passes ``deadline_seconds``; the default
+    ``None`` keeps every existing caller on the original blocking contract.
+    """
+
+
+# SQLite VM instructions between progress-handler callbacks. Small enough
+# that a long ``PRAGMA integrity_check`` polls the deadline continuously
+# (measured: ~400 callbacks in 0.04s on a 36 MB state.db), large enough that
+# the handler costs nothing on a normal probe.
+_PROBE_PROGRESS_INSTRUCTIONS = 1000
+
+
+class _ProbeDeadline:
+    """Progress handler that aborts the running statement past a deadline.
+
+    Returning a non-zero value from a ``set_progress_handler`` callback makes
+    SQLite abandon the statement in flight and raise
+    ``sqlite3.OperationalError("interrupted")``. Unlike a thread timeout this
+    genuinely cancels the scan instead of merely stopping the caller from
+    waiting on it.
+    """
+
+    __slots__ = ("expires_at", "fired")
+
+    def __init__(self, seconds: float) -> None:
+        self.expires_at = time.monotonic() + seconds
+        self.fired = False
+
+    def __call__(self) -> int:
+        if time.monotonic() >= self.expires_at:
+            self.fired = True
+            return 1
+        return 0
+
+
+def _db_opens_cleanly(
+    db_path: Path, *, deadline_seconds: Optional[float] = None
+) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
@@ -2755,8 +2803,43 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
     ``integrity_check`` passing while every ``INSERT INTO messages`` fails
     through the FTS triggers — is reported as unhealthy rather than slipping
     past as a false "ok" (#50502).
+
+    ``deadline_seconds`` (keyword-only, default ``None`` = unbounded, the
+    historical behaviour) installs a SQLite progress handler that interrupts
+    the scan once the wall clock runs out and raises
+    :class:`DBHealthProbeTimeout`. The timeout is raised, never returned, so
+    it can never be mistaken for the "unhealthy reason" string that drives a
+    recovery workflow (#72441).
     """
+    deadline = (
+        _ProbeDeadline(deadline_seconds) if deadline_seconds is not None else None
+    )
     conn = _connect_repair_durable(db_path)
+    if deadline is not None:
+        conn.set_progress_handler(deadline, _PROBE_PROGRESS_INSTRUCTIONS)
+    try:
+        reason = _run_db_health_probe(conn)
+    finally:
+        conn.close()
+    if deadline is not None and deadline.fired:
+        # An aborted statement surfaces as OperationalError("interrupted"),
+        # which is a sqlite3.DatabaseError and would otherwise be returned as
+        # a corruption reason by one of the handlers below. Report the
+        # cancellation instead — the DB was only read, never judged.
+        raise DBHealthProbeTimeout(
+            "state.db health probe exceeded its "
+            f"{deadline_seconds:g}s deadline; the database was not modified "
+            "and its health is unknown"
+        )
+    return reason
+
+
+def _run_db_health_probe(conn: sqlite3.Connection) -> Optional[str]:
+    """Run the health-probe statements on an already-open connection.
+
+    Split out of :func:`_db_opens_cleanly` so the connection prologue (and any
+    deadline installed on it) is owned by the caller.
+    """
     try:
         # Best-effort tokenizer load: a DB carrying the messages_fts_cjk
         # index needs the cjk_unicode61 extension before any statement can
@@ -2867,8 +2950,6 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)
-    finally:
-        conn.close()
 
 
 def _live_writer_holds_db(db_path: Path) -> bool:

--- a/tests/hermes_cli/test_doctor_state_db_deadline.py
+++ b/tests/hermes_cli/test_doctor_state_db_deadline.py
@@ -130,6 +130,10 @@ def test_doctor_returns_without_waiting_for_a_blocked_probe(monkeypatch, tmp_pat
         f"{_BLOCK_SECONDS:.0f}s — the deadline did not bound the command"
     )
     assert "timed out" in out
+    # The worker is abandoned mid-flight, so the session count never comes
+    # back — but the file demonstrably exists, and that row must not silently
+    # vanish from the report.
+    assert "state.db exists (session count not read" in out
 
 
 def test_probe_timeout_is_reported_as_skipped_not_as_corruption(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor_state_db_deadline.py
+++ b/tests/hermes_cli/test_doctor_state_db_deadline.py
@@ -1,0 +1,240 @@
+"""`hermes doctor` must bound its read-only state.db health probe (#72441).
+
+`_db_opens_cleanly` runs `PRAGMA integrity_check`, which walks every page of
+the file. On a large `state.db` that turned `hermes doctor` into an indefinite
+stall right after it printed `state.db exists (N sessions)`.
+
+Two properties are pinned here, and the second is the one that makes the fix
+safe rather than merely fast:
+
+1. The command returns on a bounded wall clock even when the probe blocks.
+2. A probe deadline is **never** reported as corruption and never escalates to
+   `repair_state_db_schema()`. `sqlite3.OperationalError("interrupted")` — what
+   a progress-handler abort raises — is a `sqlite3.DatabaseError`, so the naive
+   implementation returns "interrupted" as an unhealthy *reason*; under
+   `hermes doctor --fix` that rewrites the database (its last strategy drops
+   the whole `messages_fts%` schema and VACUUMs). A healthy-but-large state.db
+   would be sent into destructive repair merely for being slow.
+"""
+
+import contextlib
+import io
+import sqlite3
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import doctor as doctor_mod
+
+
+# How long the fake probe blocks for in the elapsed-time regression. Large
+# enough that "waited for the probe" and "did not wait for the probe" cannot be
+# confused by CI jitter.
+_BLOCK_SECONDS = 20.0
+
+
+def _isolate_home(monkeypatch, home: Path) -> None:
+    """Point doctor at a temp HERMES_HOME.
+
+    ``run_doctor`` reads the module-level ``HERMES_HOME`` constant cached at
+    import time, NOT the env var, so ``setenv`` alone leaves doctor probing the
+    real ``~/.hermes`` — which on a dev machine is exactly the multi-minute
+    ``PRAGMA integrity_check`` this module is about. Same idiom as
+    ``tests/hermes_cli/test_doctor.py::TestGitHubTokenCheck._isolate_home``.
+    """
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _make_state_db(path: Path, sessions: int = 2, messages: int = 0) -> Path:
+    """Create a minimal, genuinely healthy state.db."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, started_at REAL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY, session_id TEXT, role TEXT,
+                content TEXT, timestamp REAL
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            [(f"s{i}", "test", 0.0) for i in range(sessions)],
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            [("s0", "user", "x" * 200, 0.0) for _ in range(messages)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _run_doctor(**kwargs) -> str:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False, ack=None, **kwargs))
+    return buf.getvalue()
+
+
+def _shrink_deadline(monkeypatch, deadline: float = 0.5, grace: float = 0.5) -> None:
+    monkeypatch.setattr(doctor_mod, "_STATE_DB_PROBE_DEADLINE_S", deadline)
+    monkeypatch.setattr(doctor_mod, "_STATE_DB_PROBE_ABANDON_GRACE_S", grace)
+
+
+def test_doctor_returns_without_waiting_for_a_blocked_probe(monkeypatch, tmp_path):
+    """The elapsed-time regression: doctor must not wait out a wedged probe.
+
+    Fails on `origin/main` (no bound at all) and on the thread-timeout-only
+    shape, where leaving a `with ThreadPoolExecutor(...)` block calls
+    `shutdown(wait=True)` and blocks until the probe finishes anyway.
+    """
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db")
+
+    import hermes_state
+
+    started = []
+
+    def _blocking_probe(db_path, *, deadline_seconds=None):
+        started.append(time.monotonic())
+        time.sleep(_BLOCK_SECONDS)
+        return None
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _blocking_probe)
+    _shrink_deadline(monkeypatch)
+
+    start = time.monotonic()
+    out = _run_doctor()
+    elapsed = time.monotonic() - start
+
+    assert started, "the state.db health probe never ran"
+    assert elapsed < _BLOCK_SECONDS / 2, (
+        f"run_doctor waited {elapsed:.1f}s on a probe that blocks for "
+        f"{_BLOCK_SECONDS:.0f}s — the deadline did not bound the command"
+    )
+    assert "timed out" in out
+
+
+def test_probe_timeout_is_reported_as_skipped_not_as_corruption(monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db", sessions=3)
+
+    import hermes_state
+
+    def _times_out(db_path, *, deadline_seconds=None):
+        raise hermes_state.DBHealthProbeTimeout("deadline reached")
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _times_out)
+    _shrink_deadline(monkeypatch)
+
+    out = _run_doctor()
+
+    assert "state.db exists (3 sessions)" in out
+    assert "timed out" in out
+    assert "not modified" in out
+    # The corruption verdict must not be printed for a timeout.
+    assert "FTS index may be corrupt" not in out
+
+
+def test_probe_timeout_does_not_trigger_repair_under_fix(monkeypatch, tmp_path):
+    """The data-safety invariant: a deadline never escalates to a rewrite."""
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db")
+
+    import hermes_state
+
+    def _times_out(db_path, *, deadline_seconds=None):
+        raise hermes_state.DBHealthProbeTimeout("deadline reached")
+
+    repairs = []
+
+    def _spy_repair(db_path, **kwargs):
+        repairs.append(db_path)
+        return {"repaired": True, "strategy": "spy", "backup_path": None}
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _times_out)
+    monkeypatch.setattr(hermes_state, "repair_state_db_schema", _spy_repair)
+    _shrink_deadline(monkeypatch)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True, ack=None))
+
+    assert repairs == [], (
+        "a health-probe timeout escalated to repair_state_db_schema() — a "
+        "healthy-but-large state.db would be rewritten for being slow"
+    )
+    assert "timed out" in buf.getvalue()
+
+
+def test_progress_handler_cancels_a_real_integrity_check(tmp_path):
+    """No mocks: the deadline is cancellable at the SQLite level.
+
+    A thread timeout cannot stop `PRAGMA integrity_check`; a progress handler
+    can. The same file probes healthy with no deadline, which is what proves
+    the timeout is a cancellation and not a corruption finding.
+    """
+    from hermes_state import DBHealthProbeTimeout, _db_opens_cleanly
+
+    db_path = _make_state_db(tmp_path / "state.db", sessions=1, messages=3000)
+
+    start = time.monotonic()
+    with pytest.raises(DBHealthProbeTimeout) as excinfo:
+        _db_opens_cleanly(db_path, deadline_seconds=0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0
+    # Callers classify corruption by catching sqlite3.DatabaseError (and
+    # OperationalError("interrupted") is one). The timeout signal must sit
+    # outside that hierarchy or it gets swallowed as a corruption reason.
+    assert not isinstance(excinfo.value, sqlite3.Error)
+
+    assert _db_opens_cleanly(db_path) is None
+
+
+def test_no_deadline_preserves_existing_behaviour(tmp_path):
+    """The five `repair_state_db_schema` callers pass no deadline and must be
+    byte-for-byte unaffected: healthy still returns None, damaged still returns
+    the reason string rather than raising."""
+    from hermes_state import _db_opens_cleanly
+
+    healthy = _make_state_db(tmp_path / "state.db", sessions=1, messages=50)
+    assert _db_opens_cleanly(healthy) is None
+
+    broken = tmp_path / "broken.db"
+    broken.write_bytes(b"SQLite format 3\x00" + b"\x00" * 512)
+    reason = _db_opens_cleanly(broken)
+    assert isinstance(reason, str) and reason
+
+
+def test_doctor_reports_a_healthy_db_normally(monkeypatch, tmp_path):
+    """Non-regression: the bound is invisible when the probe finishes."""
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db", sessions=4, messages=100)
+    _shrink_deadline(monkeypatch, deadline=30.0, grace=5.0)
+
+    out = _run_doctor()
+
+    assert "state.db exists (4 sessions)" in out
+    assert "timed out" not in out
+    assert "FTS index may be corrupt" not in out

--- a/tests/hermes_cli/test_doctor_state_db_deadline.py
+++ b/tests/hermes_cli/test_doctor_state_db_deadline.py
@@ -129,6 +129,10 @@ def test_doctor_returns_without_waiting_for_a_blocked_probe(monkeypatch, tmp_pat
         f"{_BLOCK_SECONDS:.0f}s — the deadline did not bound the command"
     )
     assert "timed out" in out
+    # The worker is abandoned mid-flight, so the session count never comes
+    # back — but the file demonstrably exists, and that row must not silently
+    # vanish from the report.
+    assert "state.db exists (session count not read" in out
 
 
 def test_probe_timeout_is_reported_as_skipped_not_as_corruption(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor_state_db_deadline.py
+++ b/tests/hermes_cli/test_doctor_state_db_deadline.py
@@ -1,0 +1,239 @@
+"""`hermes doctor` must bound its read-only state.db health probe (#72441).
+
+`_db_opens_cleanly` runs `PRAGMA integrity_check`, which walks every page of
+the file. On a large `state.db` that turned `hermes doctor` into an indefinite
+stall right after it printed `state.db exists (N sessions)`.
+
+Two properties are pinned here, and the second is the one that makes the fix
+safe rather than merely fast:
+
+1. The command returns on a bounded wall clock even when the probe blocks.
+2. A probe deadline is **never** reported as corruption and never escalates to
+   `repair_state_db_schema()`. `sqlite3.OperationalError("interrupted")` — what
+   a progress-handler abort raises — is a `sqlite3.DatabaseError`, so the naive
+   implementation returns "interrupted" as an unhealthy *reason*; under
+   `hermes doctor --fix` that would start a recovery workflow for a
+   healthy-but-large state.db merely for being slow.
+"""
+
+import contextlib
+import io
+import sqlite3
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import doctor as doctor_mod
+
+
+# How long the fake probe blocks for in the elapsed-time regression. Large
+# enough that "waited for the probe" and "did not wait for the probe" cannot be
+# confused by CI jitter.
+_BLOCK_SECONDS = 20.0
+
+
+def _isolate_home(monkeypatch, home: Path) -> None:
+    """Point doctor at a temp HERMES_HOME.
+
+    ``run_doctor`` reads the module-level ``HERMES_HOME`` constant cached at
+    import time, NOT the env var, so ``setenv`` alone leaves doctor probing the
+    real ``~/.hermes`` — which on a dev machine is exactly the multi-minute
+    ``PRAGMA integrity_check`` this module is about. Same idiom as
+    ``tests/hermes_cli/test_doctor.py::TestGitHubTokenCheck._isolate_home``.
+    """
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _make_state_db(path: Path, sessions: int = 2, messages: int = 0) -> Path:
+    """Create a minimal, genuinely healthy state.db."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, started_at REAL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY, session_id TEXT, role TEXT,
+                content TEXT, timestamp REAL
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            [(f"s{i}", "test", 0.0) for i in range(sessions)],
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            [("s0", "user", "x" * 200, 0.0) for _ in range(messages)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _run_doctor(**kwargs) -> str:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False, ack=None, **kwargs))
+    return buf.getvalue()
+
+
+def _shrink_deadline(monkeypatch, deadline: float = 0.5, grace: float = 0.5) -> None:
+    monkeypatch.setattr(doctor_mod, "_STATE_DB_PROBE_DEADLINE_S", deadline)
+    monkeypatch.setattr(doctor_mod, "_STATE_DB_PROBE_ABANDON_GRACE_S", grace)
+
+
+def test_doctor_returns_without_waiting_for_a_blocked_probe(monkeypatch, tmp_path):
+    """The elapsed-time regression: doctor must not wait out a wedged probe.
+
+    Fails on `origin/main` (no bound at all) and on the thread-timeout-only
+    shape, where leaving a `with ThreadPoolExecutor(...)` block calls
+    `shutdown(wait=True)` and blocks until the probe finishes anyway.
+    """
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db")
+
+    import hermes_state
+
+    started = []
+
+    def _blocking_probe(db_path, *, deadline_seconds=None):
+        started.append(time.monotonic())
+        time.sleep(_BLOCK_SECONDS)
+        return None
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _blocking_probe)
+    _shrink_deadline(monkeypatch)
+
+    start = time.monotonic()
+    out = _run_doctor()
+    elapsed = time.monotonic() - start
+
+    assert started, "the state.db health probe never ran"
+    assert elapsed < _BLOCK_SECONDS / 2, (
+        f"run_doctor waited {elapsed:.1f}s on a probe that blocks for "
+        f"{_BLOCK_SECONDS:.0f}s — the deadline did not bound the command"
+    )
+    assert "timed out" in out
+
+
+def test_probe_timeout_is_reported_as_skipped_not_as_corruption(monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db", sessions=3)
+
+    import hermes_state
+
+    def _times_out(db_path, *, deadline_seconds=None):
+        raise hermes_state.DBHealthProbeTimeout("deadline reached")
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _times_out)
+    _shrink_deadline(monkeypatch)
+
+    out = _run_doctor()
+
+    assert "state.db exists (3 sessions)" in out
+    assert "timed out" in out
+    assert "not modified" in out
+    # The corruption verdict must not be printed for a timeout.
+    assert "FTS index may be corrupt" not in out
+
+
+def test_probe_timeout_does_not_trigger_repair_under_fix(monkeypatch, tmp_path):
+    """The data-safety invariant: a deadline never starts recovery."""
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db")
+
+    import hermes_state
+
+    def _times_out(db_path, *, deadline_seconds=None):
+        raise hermes_state.DBHealthProbeTimeout("deadline reached")
+
+    repairs = []
+
+    def _spy_repair(db_path, **kwargs):
+        repairs.append(db_path)
+        return {"repaired": True, "strategy": "spy", "backup_path": None}
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _times_out)
+    monkeypatch.setattr(hermes_state, "repair_state_db_schema", _spy_repair)
+    _shrink_deadline(monkeypatch)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True, ack=None))
+
+    assert repairs == [], (
+        "a health-probe timeout escalated to repair_state_db_schema() — a "
+        "healthy-but-large state.db would enter recovery merely for being slow"
+    )
+    assert "timed out" in buf.getvalue()
+
+
+def test_progress_handler_cancels_a_real_integrity_check(tmp_path):
+    """No mocks: the deadline is cancellable at the SQLite level.
+
+    A thread timeout cannot stop `PRAGMA integrity_check`; a progress handler
+    can. The same file probes healthy with no deadline, which is what proves
+    the timeout is a cancellation and not a corruption finding.
+    """
+    from hermes_state import DBHealthProbeTimeout, _db_opens_cleanly
+
+    db_path = _make_state_db(tmp_path / "state.db", sessions=1, messages=3000)
+
+    start = time.monotonic()
+    with pytest.raises(DBHealthProbeTimeout) as excinfo:
+        _db_opens_cleanly(db_path, deadline_seconds=0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0
+    # Callers classify corruption by catching sqlite3.DatabaseError (and
+    # OperationalError("interrupted") is one). The timeout signal must sit
+    # outside that hierarchy or it gets swallowed as a corruption reason.
+    assert not isinstance(excinfo.value, sqlite3.Error)
+
+    assert _db_opens_cleanly(db_path) is None
+
+
+def test_no_deadline_preserves_existing_behaviour(tmp_path):
+    """The five `repair_state_db_schema` callers pass no deadline and must be
+    byte-for-byte unaffected: healthy still returns None, damaged still returns
+    the reason string rather than raising."""
+    from hermes_state import _db_opens_cleanly
+
+    healthy = _make_state_db(tmp_path / "state.db", sessions=1, messages=50)
+    assert _db_opens_cleanly(healthy) is None
+
+    broken = tmp_path / "broken.db"
+    broken.write_bytes(b"SQLite format 3\x00" + b"\x00" * 512)
+    reason = _db_opens_cleanly(broken)
+    assert isinstance(reason, str) and reason
+
+
+def test_doctor_reports_a_healthy_db_normally(monkeypatch, tmp_path):
+    """Non-regression: the bound is invisible when the probe finishes."""
+    home = _make_home(tmp_path)
+    _isolate_home(monkeypatch, home)
+    _make_state_db(home / "state.db", sessions=4, messages=100)
+    _shrink_deadline(monkeypatch, deadline=30.0, grace=5.0)
+
+    out = _run_doctor()
+
+    assert "state.db exists (4 sessions)" in out
+    assert "timed out" not in out
+    assert "FTS index may be corrupt" not in out


### PR DESCRIPTION
## What does this PR do?

Supersedes **#72527** (thanks @JonthanaHanh — the diagnosis and the line are right; the *boundary* is what needs replacing) and closes the hang reported in #72441.

`hermes doctor` stalls indefinitely right after printing `state.db exists (N sessions)`. The next statement is `_db_opens_cleanly(state_db_path)` (`hermes_cli/doctor.py`), whose `PRAGMA integrity_check` walks every page of the file — O(file size), with no output and no way to interrupt it. The repo already documents this exact pathology in its own test suite:

> `tests/hermes_cli/test_doctor.py` (`TestGitHubTokenCheck._isolate_home`) — *"On a dev machine with a large state.db that meant a multi-minute `PRAGMA integrity_check` that blew the 300s per-file budget and killed the whole file."*

and already bounds the same scan elsewhere: `hermes_cli/backup.py:320-353,404-441` caps `integrity_check` with a byte ceiling *"because `integrity_check` walks every page … O(file size)"*, falling back to a cheap header/structural probe.

This is built directly to the two changes requested in review on #72527:

> - Use a genuinely cancellable SQLite-level deadline, such as a progress handler that interrupts the integrity scan, rather than a thread timeout alone.
> - Add an elapsed-time regression test for a blocking/over-deadline probe.

**Cross-surface reach — one call site, three surfaces, no extra files touched.** `run_doctor` is the shared implementation for the terminal command (`hermes_cli/main.py:4827-4829`), the Hermes Console `doctor` verb (`hermes_cli/console_engine.py:1279-1281`), and the desktop Command Center maintenance op (`hermes_cli/web_server.py:12581-12584`, `POST /api/ops/doctor`). A wedged probe left the Command Center's Doctor action reporting `running: true` forever.

### Why the thread timeout in #72527 does not bound the command

Its diff submits the probe to a `with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _ex:` block. Leaving that block calls `Executor.shutdown(wait=True)`, which blocks until the probe finishes — so the 30 s `result()` only *delays the warning*. Measured on this branch, with a probe that blocks for 90 s:

| variant | probe blocks | `hermes doctor` wall clock | warns? |
|---|---|---|---|
| `origin/main` | 90 s | **92.4 s** | no |
| `origin/main` + #72527 | 90 s | **92.3 s** | yes, at 30 s — then keeps waiting |
| this PR (defaults) | 90 s | **37.3 s** | yes, at 30 s, and returns |

Switching that to `shutdown(wait=False)` on a *stdlib* pool would not fix it either: stdlib workers are registered in `concurrent.futures.thread._threads_queues`, whose atexit hook joins every worker unconditionally. The hang just moves to interpreter exit. `tools/daemon_pool.py`'s module docstring states this and exists precisely for this case; measured here, a stdlib pool with one abandoned 15 s worker takes **15.08 s** to exit the interpreter after `shutdown(wait=False)`, versus **0.04 s** for `DaemonThreadPoolExecutor`.

### The data-safety invariant (neither the original PR nor the review covers this)

A progress-handler abort raises `sqlite3.OperationalError("interrupted")`, and `OperationalError` **is a subclass of** `sqlite3.DatabaseError`. `_db_opens_cleanly` ends with `except sqlite3.DatabaseError as exc: return str(exc)`, so a naive deadline returns `"interrupted"` as an *unhealthy reason*. In `doctor.py` a non-`None` reason under `--fix` calls `repair_state_db_schema()`, whose escalation path drops the whole `messages_fts%` schema and VACUUMs. **A healthy-but-large `state.db` would be sent into destructive repair merely for being slow.** Verified by building exactly that naive shape locally: `repair_state_db_schema` was called once, on a healthy database, printing `Repaired state.db FTS write health`.

The deadline is therefore surfaced as a new `DBHealthProbeTimeout`, deliberately **outside** the `sqlite3` exception hierarchy so no `except sqlite3.DatabaseError` handler can swallow it as corruption, and doctor reports the check as *skipped* rather than passed or failed.

## Related Issue

Fixes #72441

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_state.py`**
  - `_db_opens_cleanly` gains a keyword-only `deadline_seconds: Optional[float] = None`. The default is the historical unbounded contract, so every existing caller is byte-for-byte unaffected.
  - When a deadline is given, a `_ProbeDeadline` progress handler is installed on the probe connection (1000 VM instructions per callback). Measured: `PRAGMA integrity_check` fires it **170 times** on a 41 MB database and **21 times** on a 700 KB one, so the deadline is polled continuously *through* the scan.
  - New `DBHealthProbeTimeout` (plain `Exception`, not a `sqlite3` error), raised only when the handler actually aborted a statement — never returned as a reason string.
  - The probe statements move into `_run_db_health_probe(conn)` so the connection prologue (and any deadline on it) is owned by the caller. The statement bodies are unchanged.
- **`hermes_cli/doctor.py`**
  - `_STATE_DB_PROBE_DEADLINE_S = 30.0` (matching #72527's chosen budget) and `_STATE_DB_PROBE_ABANDON_GRACE_S = 5.0`, module constants so tests can monkeypatch them. No config key and no CLI flag — a diagnostic should not need tuning in order to terminate.
  - `_run_abandonable(fn, timeout_s)`: `tools.daemon_pool.DaemonThreadPoolExecutor` + explicit `shutdown(wait=False)` in a `finally`. Never `with ThreadPoolExecutor(...)`. This is the belt-and-braces layer for work SQLite cannot interrupt at all — a `connect()` or page read wedged in an uninterruptible I/O syscall, e.g. a hung network mount. The grace means the in-statement cancellation is normally what stops the probe (it closes its connection on the way out) and the thread boundary is the fallback.
  - On timeout: `check_warn` + an entry in `issues` stating the database was **not modified**, and the repair branch is skipped entirely (`elif`), not entered with a `None` reason.
  - The `SELECT COUNT(*) FROM sessions` immediately above the probe now runs inside the same bounded region. Exceptions from it still propagate unchanged to the `is_malformed_db_error` handler, so malformed-schema detection and repair are preserved.
- **`tests/hermes_cli/test_doctor_state_db_deadline.py`** (new file, 6 tests).

### Sibling-site sweep

Root cause: *a read-only `state.db` health probe runs unbounded inside an interactive diagnostic.* Every site of it, and why:

| site | disposition |
|---|---|
| `hermes_cli/doctor.py` `_db_opens_cleanly(state_db_path)` | **covered** — the reported hang |
| `hermes_cli/doctor.py` `SELECT COUNT(*) FROM sessions` (immediately above) | **covered** — same block, same concern, same bounded region |
| `hermes_cli/console_engine.py:1279-1281` (`doctor` console verb) | **covered for free** — delegates to `run_doctor`; file not touched |
| `hermes_cli/web_server.py:12581-12584` (`POST /api/ops/doctor`) | **covered for free** — spawns `hermes doctor`; file not touched |
| `hermes_state.py` ×5 inside `repair_state_db_schema` | **excluded** — they verify whether each repair strategy worked; bounding them would make repair report a false failure |
| `hermes_cli/sessions_cmd.py` (`hermes sessions repair`) | **excluded** — an explicitly requested repair must be allowed to complete |
| `hermes_cli/console_engine.py:1492` (`sessions repair` verb) | **excluded** — mirror of the above |
| `hermes_cli/session_recovery.py:1009` | **excluded** — post-recovery verification of a disposable copy; must be exhaustive |
| `hermes_cli/doctor.py` post-`--fix` re-count and `PRAGMA wal_checkpoint(PASSIVE)` | **excluded** — `should_fix`-only; `PASSIVE` is non-blocking by definition |
| `hermes_cli/backup.py:404-441` | **excluded, cited** — already bounded by a byte ceiling; it is the in-repo precedent that this concern is real |
| `hermes_cli/kanban_db.py` | **excluded** — different database, different command (`hermes kanban repair`), explicit repair path |

All excluded call sites pass no `deadline_seconds` and so keep the exact behaviour they have today.

## How to Test

Reproduce the hang and the fix without a multi-gigabyte database, by making the probe block:

1. On `origin/main`, monkeypatch `hermes_state._db_opens_cleanly` to `time.sleep(90)` and call `run_doctor(Namespace(fix=False, ack=None))` against an isolated `HERMES_HOME`. It returns after **92.4 s** with no warning. Apply #72527's diff and it returns after **92.3 s**, having printed the timeout warning at 30 s. On this branch it returns after **37.3 s**.
2. Real SQLite, no mocks:
   ```python
   from hermes_state import DBHealthProbeTimeout, _db_opens_cleanly
   _db_opens_cleanly(big_db, deadline_seconds=0)   # raises DBHealthProbeTimeout
   _db_opens_cleanly(big_db)                       # returns None — the DB is healthy
   ```
   The same file probing healthy without a deadline is what proves the timeout is a cancellation, not a corruption finding.
3. ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/hermes_cli/test_doctor_state_db_deadline.py tests/hermes_cli/test_doctor.py \
     tests/test_state_db_malformed_repair.py tests/test_hermes_state.py -v
   ```

Results (per file, matching `scripts/run_tests.sh`'s per-file isolation):

| file | result |
|---|---|
| `tests/hermes_cli/test_doctor_state_db_deadline.py` | 6 passed |
| `tests/hermes_cli/test_doctor.py` | 47 passed |
| `tests/test_state_db_malformed_repair.py` | 9 passed |
| `tests/test_hermes_state.py` | 140 passed |
| `tests/hermes_cli/test_doctor_command_install.py` | 3 passed |
| `tests/hermes_cli/test_session_listing.py` | 6 passed |
| `tests/test_sqlite_wal_reset_gate.py` | 19 passed |

New tests:

| test | asserts |
|---|---|
| `test_doctor_returns_without_waiting_for_a_blocked_probe` | the requested elapsed-time regression: with a probe that blocks 20 s, `run_doctor` returns in well under half that |
| `test_probe_timeout_is_reported_as_skipped_not_as_corruption` | the output says the check timed out and the DB was not modified, and never says "FTS index may be corrupt" |
| `test_probe_timeout_does_not_trigger_repair_under_fix` | with `--fix` and a timing-out probe, `repair_state_db_schema` is **never called** |
| `test_progress_handler_cancels_a_real_integrity_check` | real SQLite: `deadline_seconds=0` raises `DBHealthProbeTimeout`, the exception is **not** a `sqlite3.Error`, and the same file returns `None` (healthy) with no deadline |
| `test_no_deadline_preserves_existing_behaviour` | no kwarg: healthy still returns `None`, damaged still returns the reason string rather than raising |
| `test_doctor_reports_a_healthy_db_normally` | non-regression: a healthy DB still prints `state.db exists (N sessions)` with no timeout warning |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent files listed above per-file instead; a flat `pytest tests/` run is not reproducible locally (three runs, three different failure counts), whereas `scripts/run_tests.sh` isolates per file
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `_db_opens_cleanly`, `DBHealthProbeTimeout`, `_ProbeDeadline` and `_run_abandonable`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config key added (deliberately)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `sqlite3.Connection.set_progress_handler` and `DaemonThreadPoolExecutor` are platform-independent; only tested on macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

**Invariant: a health-probe deadline is never a corruption signal and never escalates to repair.**

`_db_opens_cleanly` is the sole input to doctor's "is this database damaged?" decision, and under `--fix` a non-`None` return calls `repair_state_db_schema()`, which backs up and rewrites the file — its last strategy drops the entire `messages_fts%` schema and VACUUMs. A cancelled probe knows *nothing* about the database, so it must be unrepresentable as a reason string.

- **Known-bad input:** a healthy 5 GB `state.db` under `hermes doctor --fix`. `PRAGMA integrity_check` exceeds the deadline, the progress handler aborts it, SQLite raises `OperationalError("interrupted")`. Because that is a `sqlite3.DatabaseError`, the obvious implementation returns `"interrupted"` as the reason and the user's healthy database is rewritten. Reproduced locally against exactly that shape; `repair_state_db_schema` fired once on a healthy DB.
- **Structural guarantee:** the timeout is *raised*, not returned, and `DBHealthProbeTimeout` derives from `Exception`, not from `sqlite3.Error`. No present or future `except sqlite3.DatabaseError` / `except sqlite3.OperationalError` handler inside the probe can reclassify it as damage. `test_progress_handler_cancels_a_real_integrity_check` asserts `not isinstance(exc, sqlite3.Error)` so a later refactor cannot quietly move it under that hierarchy.
- **Future-input coverage:** the raise is keyed off `_ProbeDeadline.fired` — set only when the handler actually returned non-zero — rather than string-matching `"interrupted"`, so a genuinely interrupted statement arising from any *other* cause is still reported as a real reason and is not swallowed. It is also checked after the probe returns, so it holds no matter which of the probe's internal handlers caught the aborted statement first.
- **Negative case:** `test_no_deadline_preserves_existing_behaviour` pins that with no deadline a damaged file still returns its reason string and never raises, so `hermes sessions repair`, `session_recovery`, and the five in-repair verification calls keep the exact contract they have today.
- **Caller-side guarantee:** `test_probe_timeout_does_not_trigger_repair_under_fix` runs `run_doctor(fix=True)` with a timing-out probe and asserts `repair_state_db_schema` is called zero times.

## Related / Positioning

- **#72527** (`JonthanaHanh`) — same line, same 30 s budget, superseded here: its `with ThreadPoolExecutor(...)` boundary calls `shutdown(wait=True)` on exit and so does not bound the command (92.3 s vs 90 s of blocked probe, measured above), it has no test, and it leaves `_write_reason = None` on timeout, which reports a skipped check as a pass.
- **#71933** (`Kyzcreig`) — also edits `_db_opens_cleanly`, but a genuinely different defect: it reclassifies the `except sqlite3.OperationalError` "no such table" branch to distinguish a fresh mid-init file from a store whose FTS trigger outlived its virtual table. This PR deliberately stays out of that block — the deadline is installed in the connection prologue and checked after the probe returns — so the two are independently mergeable and compose correctly (if that new branch is itself interrupted, the post-probe deadline check still converts the result to a timeout rather than a verdict).
