### PR TITLE
fix(openviking): avoid tenant assertions for api keys

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -11,8 +11,8 @@ Config via environment variables (profile-scoped via each profile's .env)
 or a linked OpenViking CLI config:
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
-  OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
+  OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (explicit; unset by default)
+  OPENVIKING_USER      — Tenant user for local/trusted mode (explicit; unset by default)
   OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
 
 Capabilities:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -262,11 +262,13 @@ class _VikingClient:
                  agent: Optional[str] = None):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        # Account/user are local/trusted-mode tenant identity. API-key requests
-        # omit these headers by default; trusted-mode retry may send them only
-        # after OpenViking explicitly asks for asserted tenant identity.
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = user or os.environ.get("OPENVIKING_USER", "default")
+        # OpenViking 0.4 api_key mode derives tenant identity from the user/admin
+        # key and rejects ordinary clients that assert X-OpenViking-Account/User.
+        # Keep account/user empty by default so the trusted-identity retry path
+        # cannot send spurious "default"/"default" assertions; trusted/root
+        # deployments can still pass them explicitly or via environment.
+        self._account = account if account is not None else os.environ.get("OPENVIKING_ACCOUNT", "")
+        self._user = user if user is not None else os.environ.get("OPENVIKING_USER", "")
         self._agent = agent if agent is not None else os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
         self._httpx = _get_httpx()
         if self._httpx is None:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import plugins.memory.openviking as openviking_plugin
-from plugins.memory.openviking import OpenVikingMemoryProvider
+from plugins.memory.openviking import OpenVikingMemoryProvider, _VikingClient
 
 
 def _write_skill(skills_dir, name, body="Do the thing."):
@@ -125,6 +125,60 @@ def make_prefetch_provider(monkeypatch, responses, **env):
 
 def wait_prefetch(provider, query="What should we recall?", session_id="session-test"):
     return provider.prefetch(query, session_id=session_id)
+
+
+class TestVikingClientHeaders:
+    def test_api_key_requests_do_not_assert_tenant_by_default(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient("http://openviking.test", api_key="user-key")
+
+        headers = client._headers()
+
+        assert headers["X-API-Key"] == "user-key"
+        assert headers["Authorization"] == "Bearer user-key"
+        assert headers["X-OpenViking-Actor-Peer"] == "hermes"
+        assert "X-OpenViking-Account" not in headers
+        assert "X-OpenViking-User" not in headers
+
+    def test_api_key_trusted_retry_sends_no_spurious_tenant(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient("http://openviking.test", api_key="user-key")
+
+        retry_headers = client._headers(include_tenant=True)
+
+        assert "X-OpenViking-Account" not in retry_headers
+        assert "X-OpenViking-User" not in retry_headers
+
+    def test_api_key_trusted_retry_can_send_explicit_tenant(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient(
+            "http://openviking.test",
+            api_key="root-key",
+            account="default",
+            user="alice",
+        )
+
+        default_headers = client._headers()
+        retry_headers = client._headers(include_tenant=True)
+
+        assert "X-OpenViking-Account" not in default_headers
+        assert "X-OpenViking-User" not in default_headers
+        assert retry_headers["X-OpenViking-Account"] == "default"
+        assert retry_headers["X-OpenViking-User"] == "alice"
+
+    def test_trusted_mode_without_api_key_sends_configured_tenant(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "default")
+        monkeypatch.setenv("OPENVIKING_USER", "alice")
+        client = _VikingClient("http://openviking.test")
+
+        headers = client._headers()
+
+        assert headers["X-OpenViking-Account"] == "default"
+        assert headers["X-OpenViking-User"] == "alice"
+        assert "X-API-Key" not in headers
 
 
 class TestOpenVikingSummaryUriNormalization:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -8,7 +8,11 @@ from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import plugins.memory.openviking as openviking_plugin
-from plugins.memory.openviking import OpenVikingMemoryProvider, _VikingClient
+from plugins.memory.openviking import (
+    OpenVikingMemoryProvider,
+    _OpenVikingHTTPError,
+    _VikingClient,
+)
 
 
 def _write_skill(skills_dir, name, body="Do the thing."):
@@ -125,6 +129,76 @@ def make_prefetch_provider(monkeypatch, responses, **env):
 
 def wait_prefetch(provider, query="What should we recall?", session_id="session-test"):
     return provider.prefetch(query, session_id=session_id)
+
+
+class _FakeResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+
+def _trusted_identity_error():
+    return _OpenVikingHTTPError(
+        "Trusted mode requests must include X-OpenViking-Account", 400
+    )
+
+
+class TestVikingClientTrustedIdentityRetry:
+    """Exercise _send_with_trusted_identity_retry end to end (GET/POST/DELETE
+    and multipart uploads all share this retry wrapper)."""
+
+    def _run_retry(self, client, *, multipart=False):
+        seen = []
+
+        def send(headers):
+            seen.append(dict(headers))
+            if len(seen) == 1:
+                raise _trusted_identity_error()
+            return _FakeResponse({"result": {"ok": True}})
+
+        result = client._send_with_trusted_identity_retry(send, multipart=multipart)
+        assert result == {"result": {"ok": True}}
+        assert len(seen) == 2
+        return seen
+
+    def test_retry_sends_no_spurious_tenant(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient("http://openviking.test", api_key="user-key")
+
+        seen = self._run_retry(client)
+
+        for headers in seen:
+            assert "X-OpenViking-Account" not in headers
+            assert "X-OpenViking-User" not in headers
+
+    def test_retry_sends_explicit_tenant_when_configured(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient(
+            "http://openviking.test", api_key="root-key", account="default", user="alice"
+        )
+
+        seen = self._run_retry(client)
+
+        assert "X-OpenViking-Account" not in seen[0]
+        assert seen[1]["X-OpenViking-Account"] == "default"
+        assert seen[1]["X-OpenViking-User"] == "alice"
+
+    def test_retry_multipart_strips_content_type_and_tenant(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+        monkeypatch.delenv("OPENVIKING_USER", raising=False)
+        client = _VikingClient("http://openviking.test", api_key="user-key")
+
+        seen = self._run_retry(client, multipart=True)
+
+        for headers in seen:
+            assert "Content-Type" not in headers
+            assert "X-OpenViking-Account" not in headers
 
 
 class TestVikingClientHeaders:

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -313,8 +313,11 @@ for the default profile that is `~/.hermes/.env`, and for named profiles use
 ```text
 OPENVIKING_ENDPOINT=http://127.0.0.1:1933
 # OPENVIKING_API_KEY=...
-# OPENVIKING_ACCOUNT=default
-# OPENVIKING_USER=default
+# Local/trusted mode only — explicit tenant identity (unset by default).
+# api_key deployments must leave these unset: the server derives the tenant
+# from the key and rejects client-asserted X-OpenViking-Account/User headers.
+# OPENVIKING_ACCOUNT=...
+# OPENVIKING_USER=...
 # OPENVIKING_AGENT=hermes
 ```
 


### PR DESCRIPTION
## Summary
- OpenViking 0.4 api_key mode derives tenant identity from the presented user/admin key and rejects ordinary clients that assert `X-OpenViking-Account` / `X-OpenViking-User` (403).
- `_VikingClient` defaulted both values to `"default"`, so the trusted-identity retry path (`include_tenant=True`) attached spurious `default`/`default` tenant assertions to api-key requests, turning the retry into a hard 403 for api_key deployments.
- Default `account`/`user` to empty unless explicitly configured; trusted/root deployments keep the previous behavior via explicit args or `OPENVIKING_ACCOUNT` / `OPENVIKING_USER`.

## Behavior note
- Trusted mode (no api key) no longer falls back to an implicit `default` tenant. Deployments that relied on the fallback should set `OPENVIKING_ACCOUNT` / `OPENVIKING_USER` explicitly.

## Test plan
- New `TestVikingClientHeaders` covers: api-key requests send no tenant headers by default; the trusted retry sends no spurious tenant when unconfigured; an explicitly configured tenant is still sent on retry (root keys); trusted mode sends the configured tenant.
- `pytest tests/openviking_plugin/test_openviking.py` — 24 passed.