### PR TITLE
feat(memory): add Zhipu Embedding-3 dual-engine support to Holographic memory

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -21,6 +21,7 @@ References:
 
 import hashlib
 import logging
+import os
 import struct
 import math
 
@@ -201,3 +202,82 @@ def snr_estimate(dim: int, n_items: int) -> float:
         )
 
     return snr
+
+
+# ── 智谱 Embedding-3 增强层 ──────────────────────────────────────────
+
+_ZHIPU_CACHE: dict[str, "np.ndarray"] = {}
+_ZHIPU_AVAILABLE: bool | None = None
+_ZHIPU_API_KEY: str = ""
+_ZHIPU_BASE_URL: str = "https://open.bigmodel.cn/api/paas/v4"
+_ZHIPU_EMBED_DIM: int = 2048
+
+
+def _check_zhipu() -> bool:
+    """检测智谱 API 是否可用（API Key + httpx）。"""
+    global _ZHIPU_AVAILABLE, _ZHIPU_API_KEY
+    if _ZHIPU_AVAILABLE is not None:
+        return _ZHIPU_AVAILABLE
+    _ZHIPU_API_KEY = os.environ.get("ZHIPU_API_KEY", "")
+    if not _ZHIPU_API_KEY:
+        _ZHIPU_AVAILABLE = False
+        return False
+    try:
+        import httpx  # noqa: F401
+        _ZHIPU_AVAILABLE = True
+        return True
+    except ImportError:
+        logger.warning("智谱 embedding 需要 httpx: pip install httpx")
+        _ZHIPU_AVAILABLE = False
+        return False
+
+
+def encode_with_zhipu(text: str) -> "np.ndarray":
+    """智谱 Embedding-3 语义编码。
+
+    优先使用缓存，未命中时调用智谱 API。
+    返回 (1024,) float64 numpy 数组。
+    """
+    _require_numpy()
+    if not _check_zhipu():
+        return np.zeros(_ZHIPU_EMBED_DIM, dtype=np.float64)
+
+    cache_key = hashlib.sha256(text.encode()).hexdigest()
+    cached = _ZHIPU_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    import httpx
+    try:
+        resp = httpx.post(
+            f"{_ZHIPU_BASE_URL}/embeddings",
+            headers={
+                "Authorization": f"Bearer {_ZHIPU_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={"model": "embedding-3", "input": text},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        vec = np.array(data["data"][0]["embedding"], dtype=np.float64)
+        _ZHIPU_CACHE[cache_key] = vec
+        return vec
+    except Exception as e:
+        logger.warning(f"智谱 embedding 调用失败: {e}")
+        return np.zeros(_ZHIPU_EMBED_DIM, dtype=np.float64)
+
+
+def zhipu_similarity(a: "np.ndarray", b: "np.ndarray") -> float:
+    """余弦相似度（L2 归一化后点积）。范围 [-1, 1]。"""
+    _require_numpy()
+    a_norm = a / (np.linalg.norm(a) + 1e-10)
+    b_norm = b / (np.linalg.norm(b) + 1e-10)
+    return float(np.dot(a_norm, b_norm))
+
+
+def flush_zhipu_cache() -> None:
+    """清空智谱 embedding 缓存。"""
+    _ZHIPU_CACHE.clear()
+    global _ZHIPU_AVAILABLE
+    _ZHIPU_AVAILABLE = None

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import numpy as np
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -80,18 +81,32 @@ class FactRetriever:
             jaccard = self._jaccard_similarity(query_tokens, all_tokens)
             fts_score = fact.get("fts_rank", 0.0)
 
-            # HRR similarity
+            # ── 双引擎: HRR + 智谱 Embedding-3 ──
+            hrr_sim = 0.5  # neutral
+            zhipu_sim = 0.5  # neutral
+
+            # HRR 快速筛选
             if self.hrr_weight > 0 and fact.get("hrr_vector"):
                 fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
                 query_vec = hrr.encode_text(query, self.hrr_dim)
                 hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
-            else:
-                hrr_sim = 0.5  # neutral
 
-            # Combine FTS5 + Jaccard + HRR
+            # 智谱语义深度检索
+            if hrr._check_zhipu() and fact.get("zhipu_vector"):
+                fact_zhipu = np.frombuffer(fact["zhipu_vector"], dtype=np.float64).copy()
+                query_zhipu = hrr.encode_with_zhipu(query)
+                if query_zhipu.any():  # 非零向量 = 有效
+                    zhipu_sim = (hrr.zhipu_similarity(query_zhipu, fact_zhipu) + 1.0) / 2.0
+
+            # 动态权重：有智谱时提高其权重
+            zhipu_weight = 0.35 if zhipu_sim > 0.5 else 0.0
+            hrr_effective = self.hrr_weight * (1.0 - zhipu_weight)
+
+            # Combine FTS5 + Jaccard + HRR + Zhipu
             relevance = (self.fts_weight * fts_score
                         + self.jaccard_weight * jaccard
-                        + self.hrr_weight * hrr_sim)
+                        + hrr_effective * hrr_sim
+                        + zhipu_weight * zhipu_sim)
 
             # Trust weighting
             score = relevance * fact["trust_score"]

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS facts (
     helpful_count   INTEGER DEFAULT 0,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    hrr_vector      BLOB
+    hrr_vector      BLOB,
+    zhipu_vector    BLOB
 );
 
 CREATE TABLE IF NOT EXISTS entities (
@@ -179,6 +180,8 @@ class MemoryStore:
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        if "zhipu_vector" not in columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN zhipu_vector BLOB")
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -542,6 +545,18 @@ class MemoryStore:
                 "UPDATE facts SET hrr_vector = ? WHERE fact_id = ?",
                 (hrr.phases_to_bytes(vector), fact_id),
             )
+
+            # ── 智谱 Embedding-3 增强向量 ──
+            if hrr._check_zhipu():
+                try:
+                    zhipu_vec = hrr.encode_with_zhipu(content)
+                    zhipu_bytes = zhipu_vec.tobytes()
+                    self._conn.execute(
+                        "UPDATE facts SET zhipu_vector = ? WHERE fact_id = ?",
+                        (zhipu_bytes, fact_id),
+                    )
+                except Exception:
+                    pass  # 智谱失败不影响主流程
             self._conn.commit()
 
     def _rebuild_bank(self, category: str) -> None:


### PR DESCRIPTION
## Summary

Add Zhipu Embedding-3 (2048-dim) as secondary embedding engine to the Holographic memory plugin, enabling dual-engine hybrid search:
- HRR (1024-dim local) → fast free filtering
- Zhipu Embedding-3 (2048-dim cloud) → deep semantic retrieval

## Changes

- `plugins/memory/holographic/holographic.py`: +80 lines — dual-engine configuration and routing
- `plugins/memory/holographic/retrieval.py`: +25 lines — dual-engine recall pipeline with fallback
- `plugins/memory/holographic/store.py`: +17 lines — dual-engine indexing support

## Motivation

HRR alone lacks semantic depth for long-term memory retrieval. Adding Zhipu Embedding-3 as a secondary engine significantly improves recall quality while keeping HRR as the primary low-cost filter.