### PR TITLE
fix(desktop): preview remote HTML over SSH

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
-import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { normalizeOrLocalPreviewTarget, openPreviewTargetInBrowser } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { PREVIEW_PANE_ID } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
@@ -61,13 +61,7 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
 
   const openInBrowser = async () => {
     try {
-      const bridge = window.hermesDesktop?.openPreviewInBrowser
-
-      if (!bridge) {
-        throw new Error('Desktop preview browser bridge is unavailable')
-      }
-
-      await bridge((await resolveTarget()).url)
+      await openPreviewTargetInBrowser(await resolveTarget())
     } catch (error) {
       notifyError(error, t.preview.unavailable)
     }

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
@@ -85,5 +85,52 @@ describe('PreviewPane console state', () => {
     })
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
+  })
+
+  it('renders authenticated remote HTML safely and honors source mode', async () => {
+    const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
+    const setTitlebarToolGroup = vi.fn()
+
+    const target = {
+      dataUrl,
+      kind: 'file' as const,
+      label: 'report.html',
+      path: '/srv/report.html',
+      previewKind: 'html' as const,
+      source: '/srv/report.html',
+      url: 'file:///srv/report.html'
+    }
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(<PreviewPane setTitlebarToolGroup={setTitlebarToolGroup} target={target} />)
+    })
+
+    const iframe = rendered.container.querySelector('iframe')
+    const tools = setTitlebarToolGroup.mock.calls.at(-1)?.[1] ?? []
+
+    expect(rendered.container.querySelector('webview')).toBeNull()
+    expect(iframe?.getAttribute('sandbox')).toBe('')
+    expect(iframe?.getAttribute('referrerpolicy')).toBe('no-referrer')
+    expect(iframe?.getAttribute('srcdoc')).toContain(`default-src 'none'`)
+    expect(iframe?.getAttribute('srcdoc')).toContain('<h1>remote</h1>')
+    expect(tools).not.toEqual(expect.arrayContaining([expect.objectContaining({ id: 'preview-devtools' })]))
+    expect(rendered.container.textContent).not.toContain(dataUrl)
+
+    await act(async () => {
+      rendered.rerender(
+        <PreviewPane
+          setTitlebarToolGroup={setTitlebarToolGroup}
+          target={{ ...target, dataUrl: undefined, renderMode: 'source', transient: true }}
+        />
+      )
+    })
+
+    expect(rendered.container.querySelector('iframe')).toBeNull()
+    const sourceLink = rendered.container.querySelector('a')
+
+    expect(sourceLink?.getAttribute('href')).toBeNull()
+    expect(sourceLink?.getAttribute('target')).toBeNull()
+    expect(fireEvent.click(sourceLink!)).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -1,12 +1,13 @@
 import { useStore } from '@nanostores/react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-controls'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { Bug } from '@/lib/icons'
+import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -153,6 +154,16 @@ export function PreviewPane({
   const isWebPreview =
     target.kind !== 'artifact' &&
     (target.kind === 'url' || (target.previewKind === 'html' && target.renderMode !== 'source'))
+
+  const isRemoteHtmlTarget =
+    target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
+
+  const isRemoteHtml = isRemoteHtmlTarget && target.renderMode !== 'source' && Boolean(target.dataUrl)
+
+  const remoteHtmlDocument = useMemo(
+    () => (isRemoteHtml ? remoteHtmlPreviewDocument(target.dataUrl!) : null),
+    [isRemoteHtml, target.dataUrl]
+  )
 
   const currentLabel = compactUrl(currentUrl)
 
@@ -301,7 +312,7 @@ export function PreviewPane({
     }
 
     const tools: TitlebarTool[] = [
-      ...(isWebPreview
+      ...(isWebPreview && !isRemoteHtml
         ? [
             {
               active: consoleOpen,
@@ -324,7 +335,7 @@ export function PreviewPane({
     setTitlebarToolGroup(TITLEBAR_GROUP_ID, tools)
 
     return () => setTitlebarToolGroup(TITLEBAR_GROUP_ID, [])
-  }, [consoleOpen, consoleState, copy, devtoolsOpen, isWebPreview, setTitlebarToolGroup, toggleDevTools])
+  }, [consoleOpen, consoleState, copy, devtoolsOpen, isRemoteHtml, isWebPreview, setTitlebarToolGroup, toggleDevTools])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -524,7 +535,7 @@ export function PreviewPane({
     consoleState.reset()
     setLoading(true)
 
-    if (!isWebPreview) {
+    if (!isWebPreview || isRemoteHtml) {
       setLoading(false)
 
       return
@@ -617,7 +628,7 @@ export function PreviewPane({
       webview.removeEventListener('did-stop-loading', onStop)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
@@ -628,9 +639,15 @@ export function PreviewPane({
               <Tip label={copy.openTarget(currentUrl)}>
                 <a
                   className="pointer-events-auto inline max-w-full truncate text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
-                  href={currentUrl}
+                  href={isRemoteHtmlTarget ? undefined : currentUrl}
+                  onClick={event => {
+                    if (isRemoteHtmlTarget) {
+                      event.preventDefault()
+                      void openPreviewTargetInBrowser(target).catch(error => notifyError(error, t.preview.unavailable))
+                    }
+                  }}
                   rel="noreferrer"
-                  target="_blank"
+                  target={isRemoteHtmlTarget ? undefined : '_blank'}
                 >
                   {previewLabel || copy.fallbackTitle}
                 </a>
@@ -646,10 +663,19 @@ export function PreviewPane({
           <div
             className={cn(
               'absolute inset-0 flex bg-transparent',
-              (!isWebPreview || loadError) && 'pointer-events-none opacity-0'
+              (isRemoteHtml || !isWebPreview || loadError) && 'pointer-events-none opacity-0'
             )}
             ref={hostRef}
           />
+          {isRemoteHtml && (
+            <iframe
+              className="absolute inset-0 size-full border-0 bg-white"
+              referrerPolicy="no-referrer"
+              sandbox=""
+              srcDoc={remoteHtmlDocument || ''}
+              title={target.label || copy.fallbackTitle}
+            />
+          )}
           {!isWebPreview &&
             (target.kind === 'artifact' ? (
               <ArtifactPreview target={target} />
@@ -666,7 +692,7 @@ export function PreviewPane({
             />
           )}
 
-          {isWebPreview && consoleOpen && (
+          {isWebPreview && !isRemoteHtml && consoleOpen && (
             <PreviewConsolePanel
               consoleBodyRef={consoleBodyRef}
               consoleShouldStickRef={consoleShouldStickRef}

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readDesktopFileDataUrl } = vi.hoisted(() => ({ readDesktopFileDataUrl: vi.fn() }))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode: () => true,
+  readDesktopFileDataUrl,
+  readDesktopFileText: vi.fn()
+}))
+
+import {
+  localPreviewTarget,
+  normalizeOrLocalPreviewTarget,
+  openPreviewTargetInBrowser,
+  remoteHtmlPreviewDocument,
+  validatedRemoteHtmlDataUrl
+} from './local-preview'
+
+const remoteTarget = {
+  kind: 'file' as const,
+  label: 'report.html',
+  path: '/srv/report.html',
+  previewKind: 'html' as const,
+  source: '/srv/report.html',
+  url: 'file:///srv/report.html'
+}
+
+describe('remote HTML previews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => remoteTarget)
+    } as never
+  })
+
+  it('loads bounded authenticated bytes while retaining the canonical file URL', async () => {
+    const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
+    readDesktopFileDataUrl.mockResolvedValue(dataUrl)
+
+    await expect(normalizeOrLocalPreviewTarget('/srv/report.html')).resolves.toEqual({
+      ...remoteTarget,
+      dataUrl
+    })
+    expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
+  })
+
+  it('falls back to source mode when the transport is not canonical HTML', async () => {
+    readDesktopFileDataUrl.mockResolvedValue('data:text/plain;base64,SGVsbG8=')
+
+    await expect(normalizeOrLocalPreviewTarget('/srv/report.html')).resolves.toMatchObject({
+      renderMode: 'source',
+      transient: true,
+      url: 'file:///srv/report.html'
+    })
+  })
+
+  it('rejects malformed base64', () => {
+    expect(validatedRemoteHtmlDataUrl('data:text/html;base64,SGVsbG8=')).toBe('data:text/html;base64,SGVsbG8=')
+    expect(validatedRemoteHtmlDataUrl('data:text/html;base64,SGVsbG8')).toBeNull()
+    expect(validatedRemoteHtmlDataUrl('data:text/html;base64,SGVsbG8%3D')).toBeNull()
+  })
+
+  it('wraps remote HTML in a deny-by-default content policy', () => {
+    const html =
+      '<meta http-equiv="refresh" content="0;url=https://example.test"><a href="https://example.test">remote</a>'
+
+    const document = remoteHtmlPreviewDocument(`data:text/html;base64,${btoa(html)}`)
+
+    expect(document).toContain(`default-src 'none'`)
+    expect(document).toContain(`form-action 'none'`)
+    expect(document).toContain('<a>remote</a>')
+    expect(document).not.toContain('refresh')
+    expect(document).not.toContain('https://example.test')
+  })
+
+  it('decodes remote HTML as UTF-8', () => {
+    const html = '<p>café 😀</p>'
+    const payload = btoa(String.fromCharCode(...new TextEncoder().encode(html)))
+
+    expect(remoteHtmlPreviewDocument(`data:text/html;base64,${payload}`)).toContain(html)
+  })
+
+  it('stages remote HTML before opening it in the system browser', async () => {
+    const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
+    const saveImageBuffer = vi.fn(async (_data: ArrayBuffer | Uint8Array, _ext: string) => '/tmp/report #1?.html')
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser, saveImageBuffer } as never
+
+    await openPreviewTargetInBrowser({ ...remoteTarget, dataUrl })
+
+    expect(new TextDecoder().decode(saveImageBuffer.mock.calls[0]?.[0])).toBe('<h1>remote</h1>')
+    expect(saveImageBuffer).toHaveBeenCalledWith(expect.any(Uint8Array), '.html')
+    expect(openPreviewInBrowser).toHaveBeenCalledWith('file:///tmp/report%20%231%3F.html')
+  })
+
+  it('serializes UNC staging paths as file URLs', async () => {
+    const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
+    const saveImageBuffer = vi.fn(async () => '\\\\server\\share\\report #1.html')
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser, saveImageBuffer } as never
+
+    await openPreviewTargetInBrowser({ ...remoteTarget, dataUrl })
+
+    expect(openPreviewInBrowser).toHaveBeenCalledWith('file://server/share/report%20%231.html')
+  })
+
+  it('preserves backslashes in POSIX local file paths', () => {
+    expect(localPreviewTarget('/tmp/report\\draft.html')?.url).toBe('file:///tmp/report%5Cdraft.html')
+  })
+
+  it('preserves POSIX double-slash file paths', () => {
+    expect(localPreviewTarget('//srv/share/report #1?.html')?.url).toBe('file:////srv/share/report%20%231%3F.html')
+  })
+
+  it('opens ordinary targets without staging them', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    const saveImageBuffer = vi.fn()
+    window.hermesDesktop = { openPreviewInBrowser, saveImageBuffer } as never
+
+    await openPreviewTargetInBrowser(remoteTarget)
+
+    expect(saveImageBuffer).not.toHaveBeenCalled()
+    expect(openPreviewInBrowser).toHaveBeenCalledWith(remoteTarget.url)
+  })
+
+  it('keeps local HTML source browser opens on their existing path', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser } as never
+
+    await openPreviewTargetInBrowser({
+      ...remoteTarget,
+      renderMode: 'source',
+      source: '/tmp/local.html',
+      url: 'file:///tmp/local.html'
+    })
+
+    expect(openPreviewInBrowser).toHaveBeenCalledWith('file:///tmp/local.html')
+  })
+
+  it('does not send failed remote HTML paths to the local browser', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser } as never
+
+    await expect(
+      openPreviewTargetInBrowser({ ...remoteTarget, renderMode: 'source', transient: true })
+    ).rejects.toThrow('Remote HTML preview could not be loaded')
+    expect(openPreviewInBrowser).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -73,6 +73,27 @@ describe('remote HTML previews', () => {
     expect(document).not.toContain('https://example.test')
   })
 
+  it('strips scripts from remote HTML', () => {
+    const html =
+      '<p>safe</p><script>document.body.textContent = "SCRIPT-RAN"</script><template><script>TEMPLATE-SCRIPT</script></template>'
+
+    const document = remoteHtmlPreviewDocument(`data:text/html;base64,${btoa(html)}`)
+
+    expect(document).toContain('<p>safe</p>')
+    expect(document).not.toContain('<script')
+    expect(document).not.toContain('SCRIPT-RAN')
+    expect(document).not.toContain('TEMPLATE-SCRIPT')
+  })
+
+  it('does not create scripts when sanitized HTML is reparsed', () => {
+    const html = '<form><math><mtext></form><form><mglyph><style></math><script>MUTATION-SCRIPT</script>'
+
+    const sanitized = remoteHtmlPreviewDocument(`data:text/html;base64,${btoa(html)}`)
+
+    expect(sanitized).not.toContain('<script')
+    expect(new DOMParser().parseFromString(sanitized ?? '', 'text/html').querySelector('script')).toBeNull()
+  })
+
   it('decodes remote HTML as UTF-8', () => {
     const html = '<p>café 😀</p>'
     const payload = btoa(String.fromCharCode(...new TextEncoder().encode(html)))

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -1,8 +1,11 @@
-import { isDesktopFsRemoteMode, readDesktopFileText } from '@/lib/desktop-fs'
+import { isDesktopFsRemoteMode, readDesktopFileDataUrl, readDesktopFileText } from '@/lib/desktop-fs'
 import type { PreviewTarget } from '@/store/preview'
 
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
 const IMAGE_EXTENSIONS = new Set(['.bmp', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
+// Mirrors `_FS_DATA_URL_MAX_BYTES` in the backend filesystem endpoint.
+const REMOTE_HTML_PREVIEW_MAX_BYTES = 16 * 1024 * 1024
+const REMOTE_HTML_PREVIEW_MAX_BASE64_BYTES = Math.ceil(REMOTE_HTML_PREVIEW_MAX_BYTES / 3) * 4
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   '.c': 'c',
@@ -59,12 +62,111 @@ function joinPath(base: string, rel: string) {
 }
 
 function pathToFileUrl(path: string) {
-  const encoded = path
+  const isWindowsUnc = path.startsWith('\\\\')
+  const normalized = isWindowsUnc || /^[a-z]:[\\/]/i.test(path) ? path.replace(/\\/g, '/') : path
+
+  const encoded = normalized
     .split('/')
     .map(part => encodeURIComponent(part))
     .join('/')
 
+  if (isWindowsUnc) {
+    return `file://${encoded.slice(2)}`
+  }
+
   return `file://${encoded.startsWith('/') ? encoded : `/${encoded}`}`
+}
+
+export function validatedRemoteHtmlDataUrl(value: string): string | null {
+  const prefix = 'data:text/html;base64,'
+
+  if (!value.startsWith(prefix)) {
+    return null
+  }
+
+  const payload = value.slice(prefix.length)
+
+  if (payload.length > REMOTE_HTML_PREVIEW_MAX_BASE64_BYTES || payload.length % 4 !== 0) {
+    return null
+  }
+
+  try {
+    const decoded = atob(payload)
+
+    return decoded.length <= REMOTE_HTML_PREVIEW_MAX_BYTES && btoa(decoded) === payload ? value : null
+  } catch {
+    return null
+  }
+}
+
+export function remoteHtmlPreviewDocument(dataUrl: string): string | null {
+  const validated = validatedRemoteHtmlDataUrl(dataUrl)
+
+  if (!validated) {
+    return null
+  }
+
+  const csp = `default-src 'none'; base-uri 'none'; form-action 'none'; img-src data:; media-src data:; font-src data:; style-src 'unsafe-inline'`
+
+  const html = new TextDecoder().decode(
+    Uint8Array.from(atob(validated.slice(validated.indexOf(',') + 1)), char => char.charCodeAt(0))
+  )
+
+  const document = new DOMParser().parseFromString(html, 'text/html')
+
+  document.querySelectorAll('iframe, frame, object, embed').forEach(element => element.remove())
+  document.querySelectorAll('meta[http-equiv]').forEach(element => {
+    if (element.getAttribute('http-equiv')?.toLowerCase() === 'refresh') {
+      element.remove()
+    }
+  })
+  document.querySelectorAll('*').forEach(element => {
+    for (const attribute of Array.from(element.attributes)) {
+      if (attribute.localName === 'href' || attribute.localName === 'ping') {
+        element.removeAttributeNode(attribute)
+      }
+    }
+  })
+  const policy = document.createElement('meta')
+  policy.httpEquiv = 'Content-Security-Policy'
+  policy.content = csp
+  document.head.prepend(policy)
+
+  return `<!doctype html>${document.documentElement.outerHTML}`
+}
+
+export async function openPreviewTargetInBrowser(target: PreviewTarget): Promise<void> {
+  const bridge = window.hermesDesktop
+
+  if (!bridge?.openPreviewInBrowser) {
+    throw new Error('Desktop preview browser bridge is unavailable')
+  }
+
+  const dataUrl = target.dataUrl && validatedRemoteHtmlDataUrl(target.dataUrl)
+
+  if (!dataUrl) {
+    if (target.transient) {
+      throw new Error('Remote HTML preview could not be loaded')
+    }
+
+    await bridge.openPreviewInBrowser(target.url)
+
+    return
+  }
+
+  if (!bridge.saveImageBuffer) {
+    throw new Error('Desktop preview buffer bridge is unavailable')
+  }
+
+  const decoded = atob(dataUrl.slice(dataUrl.indexOf(',') + 1))
+  const bytes = Uint8Array.from(decoded, char => char.charCodeAt(0))
+  const filePath = await bridge.saveImageBuffer(bytes, '.html')
+
+  if (!filePath) {
+    throw new Error('Could not stage remote HTML preview')
+  }
+
+  await bridge.openPreviewInBrowser(pathToFileUrl(filePath))
 }
 
 export function localPreviewTarget(rawTarget: string, cwd?: string | null): PreviewTarget | null {
@@ -111,6 +213,16 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
 async function enrichPreviewTarget(target: PreviewTarget | null): Promise<PreviewTarget | null> {
   if (!isDesktopFsRemoteMode() || !target || target.kind !== 'file' || target.previewKind === 'image') {
     return target
+  }
+
+  if (target.previewKind === 'html') {
+    try {
+      const dataUrl = validatedRemoteHtmlDataUrl(await readDesktopFileDataUrl(target.path || target.source))
+
+      return dataUrl ? { ...target, dataUrl } : { ...target, renderMode: 'source', transient: true }
+    } catch {
+      return { ...target, renderMode: 'source', transient: true }
+    }
   }
 
   try {

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify'
+
 import { isDesktopFsRemoteMode, readDesktopFileDataUrl, readDesktopFileText } from '@/lib/desktop-fs'
 import type { PreviewTarget } from '@/store/preview'
 
@@ -112,9 +114,15 @@ export function remoteHtmlPreviewDocument(dataUrl: string): string | null {
     Uint8Array.from(atob(validated.slice(validated.indexOf(',') + 1)), char => char.charCodeAt(0))
   )
 
-  const document = new DOMParser().parseFromString(html, 'text/html')
+  const document = new DOMParser().parseFromString(
+    DOMPurify.sanitize(html, {
+      WHOLE_DOCUMENT: true,
+      FORBID_TAGS: ['script', 'template', 'iframe', 'frame', 'object', 'embed'],
+      FORBID_ATTR: ['href', 'xlink:href', 'action', 'formaction', 'target']
+    }),
+    'text/html'
+  )
 
-  document.querySelectorAll('iframe, frame, object, embed').forEach(element => element.remove())
   document.querySelectorAll('meta[http-equiv]').forEach(element => {
     if (element.getAttribute('http-equiv')?.toLowerCase() === 'refresh') {
       element.remove()

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -133,4 +133,24 @@ describe('preview store', () => {
 
     expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2') ?? '').not.toContain('base64')
   })
+
+  it('does not persist remote HTML without its in-memory document', () => {
+    openPreview({ ...fileTarget('/remote/report.html'), dataUrl: 'data:text/html;base64,PGgxPnJlbW90ZTwvaDE+' })
+
+    expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+  })
+
+  it('preserves an explicit HTML source fallback', () => {
+    openPreview({ ...fileTarget('/remote/report.html'), renderMode: 'source' }, 'tool-result')
+
+    expect($previewTarget.get()?.renderMode).toBe('source')
+  })
+
+  it('does not persist transient remote HTML source fallbacks', () => {
+    const target = { ...fileTarget('/remote/report.html'), renderMode: 'source' as const, transient: true }
+
+    openPreview(target, 'tool-result')
+
+    expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+  })
 })

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -39,6 +39,8 @@ export interface PreviewTarget {
   previewKind?: 'binary' | 'html' | 'image' | 'text'
   renderMode?: 'preview' | 'source'
   source: string
+  /** Runtime-only target that cannot be restored from persisted state. */
+  transient?: boolean
   url: string
 }
 
@@ -97,11 +99,16 @@ export const $previewTabs = persistentAtom<PreviewTab[]>(TABS_STORAGE_KEY, [], {
 
     return Array.isArray(parsed) ? parsed.filter(isPreviewTab) : []
   },
-  // Inline image bytes (megabytes) are stripped, and artifact tabs are skipped
-  // entirely — the registry behind them doesn't survive a reload either.
+  // Inline bytes are not restorable. Strip them from images, and skip remote
+  // HTML and artifact tabs that cannot render without their in-memory payload.
   encode: tabs =>
     JSON.stringify(
-      tabs.filter(tab => tab.target.kind !== 'artifact'),
+      tabs.filter(
+        tab =>
+          tab.target.kind !== 'artifact' &&
+          !tab.target.transient &&
+          !(tab.target.previewKind === 'html' && tab.target.dataUrl)
+      ),
       (key, value) => (key === 'dataUrl' ? undefined : value)
     )
 })
@@ -157,7 +164,7 @@ function isFilePreviewSource(source: PreviewRecordSource): boolean {
 }
 
 function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSource): PreviewTarget {
-  if (target.kind !== 'file' || target.previewKind !== 'html') {
+  if (target.kind !== 'file' || target.previewKind !== 'html' || target.renderMode === 'source') {
     return target
   }
 


### PR DESCRIPTION
## What does this PR do?

Remote HTML generated on an SSH backend no longer gets passed to client-local Chromium as a `file://` path.

The renderer fetches the document through the existing authenticated filesystem bridge, validates and UTF-8 decodes the bounded Base64 response, and DOMPurify-sanitizes it into a scriptless sandboxed iframe with a deny-by-default CSP. Explicit system-browser opening stages the decoded document through the existing `saveImageBuffer` bridge before opening the resulting client-local file.

The backend path remains the runtime preview identity. Fetched bytes and failed transient remote previews are not persisted, and backend paths are not exposed as actionable title links. Local HTML, ordinary URLs, artifacts, and explicit source mode keep their existing behavior.

This intentionally supports self-contained HTML only; relative backend sidecar assets are not proxied. Explicit browser opening creates a local staged copy under the existing Desktop staging behavior.

## Related Issue

Fixes #75011

Related: #70296 changes default routing for remote artifact rows. This PR addresses the complementary transport problem for HTML in both the in-app preview and explicit browser-open paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Fetch, validate, UTF-8 decode, and sanitize authenticated remote HTML in `apps/desktop/src/lib/local-preview.ts`.
- Render remote HTML in an empty-sandbox iframe, fail closed on read errors, and keep backend paths out of native link handling.
- Stage explicit browser opens through the existing buffer bridge, including safe POSIX, Windows drive, and UNC file-URL serialization.
- Preserve explicit source mode and exclude byte-bearing or failed transient remote previews from persisted state.
- Add focused regressions for hostile and mutation-prone markup, UTF-8, size/canonical validation, failed reads, persistence, title links, source mode, browser staging, and cross-platform paths.

## How to Test

1. Connect Hermes Desktop to an SSH backend and produce a self-contained HTML file there.
2. Open its in-app preview and verify the rendered document loads without navigating to the backend `file://` path.
3. Use **Open in browser** and verify the staged local document opens; switch to source mode and verify the authenticated source remains available.

Automated verification on CachyOS Linux:

- `npm run check` — passed (typecheck, ESLint with no errors, full UI/Desktop platform suites, production build, unpacked Electron packaging)
- Focused renderer suite — 31/31 passed
- Live Athena-over-SSH smoke test with synthetic HTML — authenticated remote bytes rendered in-app with UTF-8 preserved, an empty iframe sandbox, deny-by-default CSP, script removal, transient restart behavior, and no actionable backend path link
- `git diff --check upstream/main...HEAD` — passed
- `scripts/check-windows-footguns.py --diff upstream/main` — passed
- `scripts/run_tests.sh` — 23,713 passed; one unrelated concurrent-compression timeout failed and reproduces unchanged on `upstream/main` (`tests/agent/test_compression_concurrent_fork.py::test_fence_cancelled_compression_leaves_lock_reacquirable`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the canonical runner has the baseline failure documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, KDE Plasma/Wayland, Electron 40.10.2

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing command or configuration changed
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow contract changed
- [x] Cross-platform impact considered; POSIX, Windows drive, and UNC path behavior has focused coverage
- [x] Tool descriptions/schemas: N/A — no agent tool contract changed

## Screenshots / Logs

N/A — no visual styling changed.
