### PR TITLE
fix: SOUL.md identity respected during live CLI conversations with custom providers

### DIFF
--- a/.fix-75108.md
+++ b/.fix-75108.md
@@ -1,0 +1,1 @@
+# Work in progress — fix for #75108


### PR DESCRIPTION
Fixes #75108

When using a custom Ollama provider, SOUL.md is loaded and assembled into the system prompt correctly, but its identity instructions are not consistently reflected in the model's responses during live CLI conversations.

Work in progress — root cause analysis and fix coming in the next commit.