### PR TITLE
fix: Hindsight memory provider registers in gateway process when configured

### DIFF
--- a/.fix-74578.md
+++ b/.fix-74578.md
@@ -1,0 +1,1 @@
+# Work in progress — fix for #74578


### PR DESCRIPTION
Fixes #74578

The Hindsight memory provider shows as active in the Dashboard but never registers in the gateway process. The gateway log never shows the memory provider registration line, and Hindsight tools are never invoked during chat.

Work in progress — root cause analysis and fix coming in the next commit.