### PR TITLE
feat(openviking): enforce peer-only sessions and add viking_remember_shared

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -81,6 +81,7 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 | `viking_read` | Read content at a viking:// URI (abstract/overview/full) |
 | `viking_browse` | Filesystem-style navigation (list/tree/stat) |
 | `viking_remember` | Store a fact directly with OpenViking `content/write` |
+| `viking_remember_shared` | Store a fact in the SHARED user root, visible to all agent peers |
 | `viking_forget` | Delete one exact `viking://` memory file URI |
 | `viking_add_resource` | Ingest URLs/docs into the knowledge base |
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -3117,6 +3117,18 @@ class OpenVikingMemoryProvider(MemoryProvider):
             thread.start()
 
     def _session_needs_commit(self, sid: str, turn_count: int) -> bool:
+        # Fail-closed: only sessions confirmed peer-only may be committed.
+        # Committing an unverified sid via a bare POST could auto-create it
+        # with the server-default memory policy.
+        with self._session_state_lock:
+            ensured = sid in self._ensured_peer_sessions
+        if not ensured:
+            if turn_count > 0:
+                logger.warning(
+                    "OpenViking refusing to commit session %s: not peer-only ensured",
+                    sid,
+                )
+            return False
         # Already-committed sessions never need a second commit, regardless of
         # the turn counter — a racing sync_turn can re-increment _turn_count
         # after a commit+reset, so the committed-guard must win over turn_count.
@@ -4130,22 +4142,33 @@ class OpenVikingMemoryProvider(MemoryProvider):
             sid = str(session_id or self._session_id).strip()
             if not sid:
                 return
+
+        # Fail-closed BEFORE any accounting: a session that cannot be
+        # confirmed peer-only must not accumulate turn count or pending
+        # markers — otherwise on_session_end would still /commit the
+        # unverified session, and a bare commit POST can auto-create it with
+        # the server-default policy (leaking extraction into the shared root).
+        ensured_sid = self._ensure_peer_session(sid)
+        if not ensured_sid:
+            logger.warning(
+                "OpenViking sync_turn skipped: session %s is not peer-only ensured "
+                "(refusing to write into a default-policy session)",
+                sid,
+            )
+            return
+        if ensured_sid != sid:
+            # Rotated: attribute the turn (and the eventual commit) to the
+            # effective peer-only session, mirroring on_session_switch.
+            with self._session_state_lock:
+                if self._session_id == sid:
+                    self._session_id = ensured_sid
+
+        with self._session_state_lock:
             self._turn_count += 1
 
-        self._mark_session_pending(sid)
+        self._mark_session_pending(ensured_sid)
 
         def _sync():
-            # Fail-closed: never write into a session that isn't confirmed
-            # peer-only — a bare messages POST would auto-create it with the
-            # server default policy and leak extraction into the shared root.
-            ensured_sid = self._ensure_peer_session(sid)
-            if not ensured_sid:
-                logger.warning(
-                    "OpenViking sync_turn skipped: session %s is not peer-only ensured "
-                    "(refusing to write into a default-policy session)",
-                    sid,
-                )
-                return
             next_batch_index = 0
 
             def _post_unsent_messages_individually(client: _VikingClient) -> None:
@@ -4235,7 +4258,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                             return
                     logger.warning("OpenViking sync_turn failed: %s", retry_error)
 
-        self._spawn_writer(sid, _sync, name="openviking-sync")
+        self._spawn_writer(ensured_sid, _sync, name="openviking-sync")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Commit the session to trigger memory extraction.

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -535,6 +535,23 @@ REMEMBER_SCHEMA = {
     },
 }
 
+REMEMBER_SHARED_SCHEMA = {
+    "name": "viking_remember_shared",
+    "description": (
+        "Store a fact in the OpenViking SHARED layer (user/default/memories), visible to ALL "
+        "peers of this OpenViking user. Use ONLY for facts all agents should share; agent-private "
+        "operational notes belong in viking_remember. Routed through a self-only session "
+        "(self=true, peer=false, message without peer_id) so the extraction lands at user root."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The shared fact to remember."},
+        },
+        "required": ["content"],
+    },
+}
+
 FORGET_SCHEMA = {
     "name": "viking_forget",
     "description": (
@@ -1897,6 +1914,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._committed_session_ids: Set[str] = set()
         self._committed_session_lock = threading.Lock()
         self._pending_marked_sids: Set[str] = set()
+        # Sessions confirmed (or created) with the peer-only memory policy
+        # {self=false, peer=true, working_memory=true}. sync_turn writers skip
+        # any sid not in this set so a default-policy session can never be
+        # auto-created by a bare messages POST (which would route extracted
+        # memories into the shared user root). See peer-routing-policy-test.md.
+        self._ensured_peer_sessions: Set[str] = set()
         # Connection settings and _client are one published state. Serialize
         # refreshes so callers never observe a new config with the old client.
         self._client_refresh_lock = threading.Lock()
@@ -2285,6 +2308,98 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     warning_callback=warning_callback,
                 )
 
+    # -- Peer-only session enforcement (strict-isolation architecture) ---------
+    #
+    # Production architecture (2026-07-29 decision, see peer-routing-policy-test.md):
+    #   - Hermes auto-captured sessions MUST use memory_policy self=false/peer=true,
+    #     so extracted memories land in user/default/peers/hermes only.
+    #   - user/default/memories (user root) is reserved for explicit shared memory
+    #     (viking_remember_shared, self-only sessions).
+    #   - A bare messages POST auto-creates a session with the server default
+    #     (self=true, peer=true) which would leak user-fact memories into the
+    #     shared root — so every session must be explicitly ensured BEFORE the
+    #     first message write.
+    _PEER_ONLY_POLICY: Dict[str, Any] = {
+        "self": {"enabled": False},
+        "peer": {"enabled": True},
+        "working_memory": {"enabled": True},
+    }
+    _SELF_ONLY_SHARED_POLICY: Dict[str, Any] = {
+        "self": {"enabled": True},
+        "peer": {"enabled": False},
+        "working_memory": {"enabled": False},
+    }
+    def _peer_session_rotation_prefix(self) -> str:
+        agent = getattr(self, "_agent", None) or "hermes"
+        return f"{agent}-p2-"
+
+    @staticmethod
+    def _session_policy_is_peer_only(session: Dict[str, Any]) -> bool:
+        mp = session.get("memory_policy") or {}
+        self_enabled = (mp.get("self") or {}).get("enabled", True)
+        peer_enabled = (mp.get("peer") or {}).get("enabled", True)
+        return self_enabled is False and peer_enabled is True
+
+    def _ensure_peer_session(self, sid: str) -> Optional[str]:
+        """Ensure *sid* exists with the peer-only memory policy.
+
+        Returns the effective session id to write under, or None when the
+        server cannot confirm/create it (callers must then SKIP the write —
+        fail-closed so nothing lands in a default-policy session).
+
+        - sid missing            -> create it with _PEER_ONLY_POLICY
+        - sid exists, peer-only  -> reuse
+        - sid exists, wrong policy -> rotate to <agent>-p2-<sid> (old session
+          stays read-only) and ensure that instead
+        """
+        sid = str(sid or "").strip()
+        if not sid:
+            return None
+        with self._session_state_lock:
+            if sid in self._ensured_peer_sessions:
+                return sid
+        client = self._ensure_client()
+        if not client:
+            return None
+        effective = sid
+        for _attempt in range(2):  # original id + one rotation
+            session: Optional[Dict[str, Any]] = None
+            try:
+                resp = client.get(f"/api/v1/sessions/{effective}")
+                unwrapped = self._unwrap_result(resp)
+                if isinstance(unwrapped, dict) and unwrapped.get("session_id"):
+                    session = unwrapped
+            except Exception:
+                session = None  # 404 or transport error -> try create path
+            if session is not None:
+                if self._session_policy_is_peer_only(session):
+                    break
+                logger.warning(
+                    "OpenViking session %s exists with non-peer-only memory_policy=%s; "
+                    "rotating to %s (old session left read-only)",
+                    effective,
+                    json.dumps(session.get("memory_policy")),
+                    f"{self._peer_session_rotation_prefix()}{effective}",
+                )
+                effective = f"{self._peer_session_rotation_prefix()}{effective}"
+                continue
+            try:
+                client.post(
+                    "/api/v1/sessions",
+                    {"session_id": effective, "memory_policy": self._PEER_ONLY_POLICY},
+                )
+                break
+            except Exception as e:
+                logger.warning(
+                    "OpenViking peer-only session create failed for %s: %s", effective, e
+                )
+                return None
+        else:
+            return None
+        with self._session_state_lock:
+            self._ensured_peer_sessions.add(effective)
+        return effective
+
     def initialize(self, session_id: str, **kwargs) -> None:
         settings = _resolve_connection_settings(_load_hermes_openviking_config())
         self._endpoint = settings["endpoint"]
@@ -2345,6 +2460,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._conn_snapshot = (
                 self._endpoint, self._api_key, self._account, self._user, self._agent,
             )
+            ensured_sid = self._ensure_peer_session(self._session_id)
+            if ensured_sid:
+                self._session_id = ensured_sid
             self._recover_pending_sessions()
 
         # Register as the last active provider for atexit safety net
@@ -2674,11 +2792,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "role": "assistant",
             "parts": [self._text_part(assistant_content)],
         }
+        user_message: Dict[str, Any] = {
+            "role": "user",
+            "parts": [self._text_part(user_content)],
+        }
         if self._agent:
+            # peer_id on BOTH roles: the server's peer-routing fallback
+            # resolves the unique peer from peer-owner (role=user) messages,
+            # and peer-only sessions need every message scoped to our peer.
             assistant_message["peer_id"] = self._agent
+            user_message["peer_id"] = self._agent
         return {
             "messages": [
-                {"role": "user", "parts": [self._text_part(user_content)]},
+                user_message,
                 assistant_message,
             ]
         }
@@ -3865,7 +3991,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def payload_message(role: str, parts: List[Dict[str, Any]]) -> Dict[str, Any]:
             payload: Dict[str, Any] = {"role": role, "parts": parts}
-            if role == "assistant" and assistant_peer_id:
+            # Tag user AND assistant messages with our peer: with the peer-only
+            # session policy the extractor's fallback resolves the unique peer
+            # from peer-owner (role=user) messages, so user messages must carry
+            # the peer too (assistant-only tagging is not sufficient).
+            if role in {"user", "assistant"} and assistant_peer_id:
                 payload["peer_id"] = assistant_peer_id
             return payload
 
@@ -4005,11 +4135,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._mark_session_pending(sid)
 
         def _sync():
+            # Fail-closed: never write into a session that isn't confirmed
+            # peer-only — a bare messages POST would auto-create it with the
+            # server default policy and leak extraction into the shared root.
+            ensured_sid = self._ensure_peer_session(sid)
+            if not ensured_sid:
+                logger.warning(
+                    "OpenViking sync_turn skipped: session %s is not peer-only ensured "
+                    "(refusing to write into a default-policy session)",
+                    sid,
+                )
+                return
             next_batch_index = 0
 
             def _post_unsent_messages_individually(client: _VikingClient) -> None:
                 nonlocal next_batch_index
-                path = f"/api/v1/sessions/{sid}/messages"
+                path = f"/api/v1/sessions/{ensured_sid}/messages"
                 while next_batch_index < len(batch_messages):
                     if _sync_trace_enabled():
                         logger.info(
@@ -4034,13 +4175,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
                             logger.info(
                                 "OpenViking sync_turn trace: POST "
                                 "/api/v1/sessions/%s/messages/batch range=%d:%d payload=%s",
-                                sid,
+                                ensured_sid,
                                 next_batch_index,
                                 batch_end,
                                 json.dumps(payload, ensure_ascii=False),
                             )
                         try:
-                            client.post(f"/api/v1/sessions/{sid}/messages/batch", payload)
+                            client.post(f"/api/v1/sessions/{ensured_sid}/messages/batch", payload)
                         except Exception as batch_error:
                             if next_batch_index:
                                 raise
@@ -4056,7 +4197,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
                 self._post_session_turn(
                     client,
-                    sid,
+                    ensured_sid,
                     user_content[:4000],
                     self._message_text(assistant_content)[:4000],
                 )
@@ -4174,6 +4315,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 self._session_id = new_id
                 self._turn_count = 0
 
+        # Ensure the NEW session exists with the peer-only memory policy before
+        # any turn is written to it. If the server can't confirm/create it the
+        # sid stays unensured and sync_turn writers will skip (fail-closed).
+        if rotate:
+            ensured_new = self._ensure_peer_session(new_id)
+            if ensured_new and ensured_new != new_id:
+                with self._session_state_lock:
+                    if self._session_id == new_id:
+                        self._session_id = ensured_new
+
         if compression:
             # Discard both old and new session IDs so the profile is re-injected
             # after in-place or forked compression. The key stored in
@@ -4250,6 +4401,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             READ_SCHEMA,
             BROWSE_SCHEMA,
             REMEMBER_SCHEMA,
+            REMEMBER_SHARED_SCHEMA,
             FORGET_SCHEMA,
             ADD_RESOURCE_SCHEMA,
         ]
@@ -4267,6 +4419,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return self._tool_browse(args)
             elif tool_name == "viking_remember":
                 return self._tool_remember(args)
+            elif tool_name == "viking_remember_shared":
+                return self._tool_remember_shared(args)
             elif tool_name == "viking_forget":
                 return self._tool_forget(args)
             elif tool_name == "viking_add_resource":
@@ -4592,6 +4746,40 @@ class OpenVikingMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.error("OpenViking content/write failed: %s", e)
             return tool_error(f"Failed to store memory: {e}")
+
+    def _tool_remember_shared(self, args: dict) -> str:
+        """Explicit SHARED-layer remember: routed through a self-only session so
+        the extracted memory lands in user/default/memories (visible to every
+        peer). Never invoked by auto-capture — agent call only."""
+        content = str(args.get("content") or "").strip()
+        if not content:
+            return tool_error("content is required")
+
+        sid = f"shared-{uuid.uuid4().hex[:10]}"
+        try:
+            self._client.post(
+                "/api/v1/sessions",
+                {"session_id": sid, "memory_policy": self._SELF_ONLY_SHARED_POLICY},
+            )
+            self._client.post(
+                f"/api/v1/sessions/{sid}/messages",
+                {
+                    "role": "user",
+                    # No peer_id — shared facts describe the user, not a peer.
+                    "parts": [self._text_part(content[:4000])],
+                },
+            )
+            self._client.post(f"/api/v1/sessions/{sid}/commit", {"keep_recent_count": 0})
+            return json.dumps({
+                "status": "queued",
+                "message": (
+                    f"Shared memory queued via self-only session {sid}; extraction "
+                    "lands in user/default/memories (visible to all peers)."
+                ),
+            })
+        except Exception as e:
+            logger.error("OpenViking remember_shared failed: %s", e)
+            return tool_error(f"Failed to store shared memory: {e}")
 
     def _tool_forget(self, args: dict) -> str:
         uri, error = _validate_forget_memory_uri(args.get("uri"))

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -127,6 +127,42 @@ def wait_prefetch(provider, query="What should we recall?", session_id="session-
     return provider.prefetch(query, session_id=session_id)
 
 
+class _FailClosedClient:
+    """Client stub whose session API always fails; ensure must fail closed."""
+
+    def __init__(self, *args, **kwargs):
+        self.posts = []
+
+    def get(self, path, params=None, **kwargs):
+        raise RuntimeError("session lookup unsupported")
+
+    def post(self, path, payload=None, **kwargs):
+        self.posts.append(path)
+        raise RuntimeError("session create unsupported")
+
+
+class TestPeerOnlySessionGuard:
+    def test_sync_turn_fail_closed_when_session_cannot_be_ensured(self, monkeypatch):
+        client = _FailClosedClient()
+        monkeypatch.setattr(openviking_plugin, "_VikingClient", lambda *a, **k: client)
+        provider = OpenVikingMemoryProvider()
+        provider._client = cast(Any, client)
+        provider._endpoint = "http://openviking.test"
+        provider._api_key = ""
+        provider._account = "default"
+        provider._user = "default"
+        provider._agent = "hermes"
+        provider._session_id = "session-x"
+
+        provider.sync_turn("hello", "hi")
+        assert provider._drain_writers("session-x", timeout=5.0)
+
+        # The write must be skipped entirely: nothing may land in a
+        # default-policy session.
+        assert "session-x" not in provider._ensured_peer_sessions
+        assert not any("messages/batch" in p for p in client.posts)
+
+
 class TestOpenVikingSummaryUriNormalization:
     def test_normalize_summary_uri_maps_pseudo_files_to_parent_directory(self):
         assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/.overview.md") == "viking://user/hermes"

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -226,6 +226,10 @@ class TestOpenVikingSkillQuerySafety:
         provider._user = "default"
         provider._agent = "hermes"
         provider._session_id = "session-1"
+        # Local peer-only guard: sync_turn refuses to write into sessions that
+        # were not ensured with the peer-only memory policy. Mark the session
+        # as ensured so this test exercises the content-filtering behavior.
+        provider._ensured_peer_sessions.add("session-1")
         skill_message = (
             '[IMPORTANT: The user has invoked the "skill-creator" skill, indicating they want '
             "you to follow its instructions. The full skill content is loaded below.]\n\n"
@@ -248,6 +252,10 @@ class TestOpenVikingSkillQuerySafety:
                             "parts": [
                                 {"type": "text", "text": "make a skill for release triage"},
                             ],
+                            # Local strict-isolation architecture tags BOTH
+                            # user and assistant messages with peer_id so
+                            # extraction lands in the actor's peer tree.
+                            "peer_id": "hermes",
                         },
                         {
                             "role": "assistant",

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -141,9 +141,32 @@ class _FailClosedClient:
         raise RuntimeError("session create unsupported")
 
 
+class _PolicyAwareClient:
+    """Fake client with a session registry so ensure/create/rotate run for real."""
+
+    def __init__(self, *args, **kwargs):
+        self.calls = []  # (method, path, payload)
+        self.sessions = {}  # sid -> memory_policy
+
+    def get(self, path, params=None, **kwargs):
+        self.calls.append(("get", path, params))
+        prefix = "/api/v1/sessions/"
+        if path.startswith(prefix):
+            sid = path[len(prefix):]
+            if sid in self.sessions:
+                return {"result": {"session_id": sid, "memory_policy": self.sessions[sid]}}
+        raise RuntimeError("404 not found")
+
+    def post(self, path, payload=None, **kwargs):
+        payload = payload or {}
+        self.calls.append(("post", path, payload))
+        if path == "/api/v1/sessions":
+            self.sessions[payload["session_id"]] = payload.get("memory_policy")
+        return {"result": {}}
+
+
 class TestPeerOnlySessionGuard:
-    def test_sync_turn_fail_closed_when_session_cannot_be_ensured(self, monkeypatch):
-        client = _FailClosedClient()
+    def _provider(self, monkeypatch, client, sid):
         monkeypatch.setattr(openviking_plugin, "_VikingClient", lambda *a, **k: client)
         provider = OpenVikingMemoryProvider()
         provider._client = cast(Any, client)
@@ -152,7 +175,12 @@ class TestPeerOnlySessionGuard:
         provider._account = "default"
         provider._user = "default"
         provider._agent = "hermes"
-        provider._session_id = "session-x"
+        provider._session_id = sid
+        return provider
+
+    def test_sync_turn_fail_closed_when_session_cannot_be_ensured(self, monkeypatch):
+        client = _FailClosedClient()
+        provider = self._provider(monkeypatch, client, "session-x")
 
         provider.sync_turn("hello", "hi")
         assert provider._drain_writers("session-x", timeout=5.0)
@@ -161,6 +189,55 @@ class TestPeerOnlySessionGuard:
         # default-policy session.
         assert "session-x" not in provider._ensured_peer_sessions
         assert not any("messages/batch" in p for p in client.posts)
+
+        # And the accounting must not have happened either: on_session_end
+        # must not /commit the unverified session (regression test for the
+        # fail-closed-too-late review finding).
+        provider.on_session_end([])
+        assert not any("commit" in p for p in client.posts)
+
+    def test_sync_turn_creates_peer_only_session_then_commits_it(self, monkeypatch):
+        client = _PolicyAwareClient()
+        provider = self._provider(monkeypatch, client, "session-new")
+
+        provider.sync_turn("hello", "hi")
+        assert provider._drain_writers("session-new", timeout=5.0)
+        provider.on_session_end([])
+
+        posts = [(p, pl) for (m, p, pl) in client.calls if m == "post"]
+        paths = [p for p, _ in posts]
+        create_idx = paths.index("/api/v1/sessions")
+        batch_idx = paths.index("/api/v1/sessions/session-new/messages/batch")
+        commit_idx = paths.index("/api/v1/sessions/session-new/commit")
+        assert create_idx < batch_idx < commit_idx
+        assert posts[create_idx][1]["memory_policy"] == provider._PEER_ONLY_POLICY
+
+    def test_sync_turn_rotates_wrong_policy_session_and_commits_effective(self, monkeypatch):
+        client = _PolicyAwareClient()
+        # Pre-existing session with the server-default policy must be rotated.
+        client.sessions["session-rot"] = {
+            "self": {"enabled": True},
+            "peer": {"enabled": True},
+        }
+        provider = self._provider(monkeypatch, client, "session-rot")
+
+        provider.sync_turn("hello", "hi")
+        rotated = "hermes-p2-session-rot"
+        assert provider._drain_writers(rotated, timeout=5.0)
+        provider.on_session_end([])
+
+        paths = [p for (m, p, _) in client.calls if m == "post"]
+        assert "/api/v1/sessions" in paths
+        create_payload = next(
+            pl for (m, p, pl) in client.calls if m == "post" and p == "/api/v1/sessions"
+        )
+        assert create_payload["session_id"] == rotated
+        assert create_payload["memory_policy"] == provider._PEER_ONLY_POLICY
+        # Writes and the commit target the rotated effective session only —
+        # the wrong-policy original stays untouched.
+        assert f"/api/v1/sessions/{rotated}/messages/batch" in paths
+        assert f"/api/v1/sessions/{rotated}/commit" in paths
+        assert not any(p.startswith("/api/v1/sessions/session-rot/") for p in paths)
 
 
 class TestOpenVikingSummaryUriNormalization:

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -290,7 +290,9 @@ Context database by Volcengine (ByteDance) with filesystem-style knowledge hiera
 | **Data storage** | Self-hosted (local or cloud) |
 | **Cost** | Free (open-source, AGPL-3.0) |
 
-**Tools (6):** `viking_search` (semantic search), `viking_read` (tiered: abstract/overview/full), `viking_browse` (filesystem navigation), `viking_remember` (store facts), `viking_forget` (delete a memory file by exact `viking://` URI), `viking_add_resource` (ingest URLs/docs)
+**Tools (7):** `viking_search` (semantic search), `viking_read` (tiered: abstract/overview/full), `viking_browse` (filesystem navigation), `viking_remember` (store facts in the agent's own peer tree), `viking_remember_shared` (store facts in the shared user root, visible to all agent peers), `viking_forget` (delete a memory file by exact `viking://` URI), `viking_add_resource` (ingest URLs/docs)
+
+Auto-captured session memories are isolated per agent peer (peer-only sessions); only facts explicitly stored via `viking_remember_shared` land in the shared user root visible to every peer.
 
 **Setup:**
 ```bash


### PR DESCRIPTION
## Summary
Multi-agent OpenViking deployments (e.g. two agents sharing one OpenViking user) need strict per-agent memory isolation with an explicit shared layer. Today `sync_turn` writes session messages with a bare POST, which auto-creates sessions under the server-default memory policy (`self=true, peer=true`); OpenViking then extracts user-fact memories into the shared user root, leaking one agent's memories to every peer.

This PR:
- **Ensures** every auto-captured session exists with a peer-only memory policy (`self=false, peer=true, working_memory=true`) *before* the first message write. Sessions that already exist with the wrong policy are rotated to `<agent>-p2-<sid>` and left read-only.
- **Fails closed**: if the session cannot be confirmed/created peer-only, the write is skipped entirely rather than risking a leak into the shared root.
- Tags **both** user and assistant messages with `peer_id` so extraction lands in the actor's own peer tree.
- Adds a `viking_remember_shared` tool as the explicit channel for facts meant for the shared user root (routed through a self-only session: `self=true, peer=false`, messages without `peer_id`).

Battle-tested in production since 2026-07-29 on a two-agent (Hermes + Codex) deployment with peer-isolation acceptance checks (cross-peer reads 403, shared layer visible to both, zero leakage on recall).

## Behavior note
- `sync_turn` now adds `peer_id` to user messages as well (previously assistant-only); the existing skill-safety test expectation is updated accordingly.
- Session rotation prefix derives from the configured agent name (`OPENVIKING_AGENT`), defaulting to `hermes`.

## Test plan
- New `TestPeerOnlySessionGuard`: fail-closed skip when the session cannot be ensured peer-only (no `messages/batch` POST is attempted).
- Updated `test_sync_turn_stores_only_slash_skill_user_instruction` for peer-tagged user messages and the ensure precondition.
- `pytest tests/openviking_plugin/` — 21 passed.