### PR TITLE
fix: add setuptools, pillow, mcp to exclude-newer-package whitelist (#75992)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,7 +359,7 @@ override-dependencies = [
   "pynacl>=1.6,<1.7",
 ]
 exclude-newer = "14 days"
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, setuptools = false, pillow = false, mcp = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's


### PR DESCRIPTION
## Summary

`exclude-newer = "14 days"` in `[tool.uv]` filters packages whose PyPI metadata is missing an upload date or falls inside the window. During dependency install, uv filters `setuptools-82.0.0/82.0.1`, `pillow-12.3.0`, and `mcp-1.28.1`, causing resolution to fail. The update writes `.update-incomplete`, and every subsequent launch retries the same filtered resolution and fails again.

## Fix

Add these three packages to `exclude-newer-package` with `false` to exempt them from the date filter, matching the existing pattern for `vercel`, `nemo-relay`, and `huggingface_hub`.

## Before
```toml
exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false }
```

## After
```toml
exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, setuptools = false, pillow = false, mcp = false }
```

Fixes #75992