### PR TITLE
feat(skills): complete depends_on with transitive resolution, --with-optional, --auto-install (#71853)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -499,6 +499,68 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             "'hermes skills search <query>' to search deeper[/]\n")
 
 
+def _check_skill_dependencies(bundle, c: Console, *, force: bool = False) -> bool:
+    """Enforce a skill's ``depends_on`` list. Returns True when install must stop.
+
+    ``prerequisites`` (env vars, commands) and ``related_skills`` (advisory)
+    already exist, but neither expresses "this skill does not work without
+    that one", and nothing was enforced at install time. A skill that drives
+    another skill's commands could be installed alone and would only fail once
+    the agent tried to use it.
+
+    Required dependencies block; optional ones warn and proceed. ``--force``
+    downgrades a block to a warning, matching how it already overrides the
+    security verdict — the user has said they know what they are doing.
+    """
+    from tools.skills_hub import (
+        parse_skill_dependencies,
+        parse_skill_frontmatter,
+        resolve_skill_dependencies,
+    )
+
+    skill_md = (getattr(bundle, "files", None) or {}).get("SKILL.md")
+    if not skill_md:
+        return False
+
+    deps = parse_skill_dependencies(parse_skill_frontmatter(skill_md))
+    if not deps:
+        return False
+
+    missing_required, missing_optional = resolve_skill_dependencies(deps)
+
+    for dep in missing_optional:
+        why = f" — {dep.reason}" if dep.reason else ""
+        c.print(
+            f"[yellow]Optional dependency not installed:[/] '{dep.name}'{why}\n"
+            f"[dim]  '{bundle.name}' will work with reduced functionality. "
+            f"Install it with: hermes skill install {dep.name}[/]"
+        )
+
+    if not missing_required:
+        return False
+
+    lines = []
+    for dep in missing_required:
+        why = f" — {dep.reason}" if dep.reason else ""
+        lines.append(f"  • {dep.name}{why}")
+    names = " ".join(d.name for d in missing_required)
+    detail = "\n".join(lines)
+
+    if force:
+        c.print(
+            f"[yellow]Missing required dependencies (installing anyway, --force):[/]\n{detail}"
+        )
+        return False
+
+    c.print(
+        f"\n[bold red]Installation blocked:[/] '{bundle.name}' requires "
+        f"{len(missing_required)} skill(s) that are not installed:\n{detail}\n\n"
+        f"[dim]Install them first:  hermes skill install {names}\n"
+        f"Or bypass this check:  hermes skill install {bundle.name} --force[/]\n"
+    )
+    return True
+
+
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
@@ -698,6 +760,15 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, result.verdict,
                          f"{len(result.findings)}_findings")
+        return
+
+    # ── depends_on enforcement (#71853) ───────────────────────────────
+    # Runs after the security verdict and before the confirm prompt, so a
+    # blocked install never reaches the "Install 'x'?" question and the user
+    # is told what to install first rather than discovering it at runtime.
+    dep_error = _check_skill_dependencies(bundle, c, force=force)
+    if dep_error:
+        shutil.rmtree(q_path, ignore_errors=True)
         return
 
     if extra_metadata:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -14,7 +14,7 @@ import json
 import re
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from rich.console import Console
 from rich.panel import Panel
@@ -151,6 +151,29 @@ def _resolve_source_meta_and_bundle(identifier: str, sources):
             break
 
     return meta, bundle, matched_source
+
+
+def _resolve_dep_name(name: str, sources) -> Tuple[str, Optional[str]]:
+    """Resolve a short dependency name to a full identifier.
+
+    Returns ``(identifier, None)`` when exactly one exact match exists.
+    Returns ``("", None)`` when zero matches — caller should fall back
+    to the bare name.
+    Returns ``("", warning)`` when 2+ matches exist — caller should
+    skip auto-install and surface the warning.
+    """
+    try:
+        from tools.skills_hub import unified_search
+        results = unified_search(name, sources, source_filter="all", limit=20)
+        exact = [r for r in results if r.name.lower() == name.lower()]
+        if len(exact) == 1:
+            return exact[0].identifier, None
+        if len(exact) > 1:
+            srcs = ", ".join(sorted(set(r.source for r in exact)))
+            return "", f"'{name}' is ambiguous across {len(exact)} sources ({srcs}); install it explicitly first"
+    except Exception:
+        pass
+    return "", None
 
 
 def _derive_category_from_install_path(install_path: str) -> str:
@@ -499,8 +522,19 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             "'hermes skills search <query>' to search deeper[/]\n")
 
 
-def _check_skill_dependencies(bundle, c: Console, *, force: bool = False) -> bool:
-    """Enforce a skill's ``depends_on`` list. Returns True when install must stop.
+def _check_skill_dependencies(
+    bundle,
+    c: Console,
+    *,
+    force: bool = False,
+    with_optional: bool = False,
+    skip_confirm: bool = False,
+    auto_install: bool = False,
+    sources=None,
+) -> Tuple[bool, List[str]]:
+    """Enforce a skill's ``depends_on`` list with transitive resolution.
+
+    Returns (should_stop, missing_names).
 
     ``prerequisites`` (env vars, commands) and ``related_skills`` (advisory)
     already exist, but neither expresses "this skill does not work without
@@ -508,27 +542,67 @@ def _check_skill_dependencies(bundle, c: Console, *, force: bool = False) -> boo
     another skill's commands could be installed alone and would only fail once
     the agent tried to use it.
 
-    Required dependencies block; optional ones warn and proceed. ``--force``
-    downgrades a block to a warning, matching how it already overrides the
-    security verdict — the user has said they know what they are doing.
+    Required dependencies block; optional ones warn and proceed unless
+    ``with_optional`` is True. ``--force`` downgrades a block to a warning,
+    matching how it already overrides the security verdict.
+
+    Transitive resolution: if skill A depends on B and B depends on C,
+    installing A will report both B and C as missing (in topological order).
     """
     from tools.skills_hub import (
         parse_skill_dependencies,
         parse_skill_frontmatter,
         resolve_skill_dependencies,
+        installed_skill_names,
     )
 
     skill_md = (getattr(bundle, "files", None) or {}).get("SKILL.md")
     if not skill_md:
-        return False
+        return False, []
 
     deps = parse_skill_dependencies(parse_skill_frontmatter(skill_md))
     if not deps:
-        return False
+        return False, []
 
-    missing_required, missing_optional = resolve_skill_dependencies(deps)
+    # ── transitive resolution ──────────────────────────────────────────
+    installed = installed_skill_names()
+    all_missing_required: List = []
+    all_missing_optional: List = []
+    cycles: List[str] = []
+    _resolve_transitive(
+        bundle.name,
+        deps,
+        installed,
+        all_missing_required,
+        all_missing_optional,
+        cycles,
+        _visited={bundle.name},
+        _path=[bundle.name],
+        _in_optional_branch=False,
+        sources=sources,
+    )
 
-    for dep in missing_optional:
+    # Deduplicate while preserving topological order (deps first)
+    seen_req = set()
+    deduped_req = []
+    for d in all_missing_required:
+        if d.name not in seen_req:
+            seen_req.add(d.name)
+            deduped_req.append(d)
+
+    seen_opt = set()
+    deduped_opt = []
+    for d in all_missing_optional:
+        if d.name not in seen_opt and d.name not in seen_req:
+            seen_opt.add(d.name)
+            deduped_opt.append(d)
+
+    if with_optional:
+        deduped_req = deduped_req + deduped_opt
+        deduped_opt = []
+
+    # ── optional warnings ──────────────────────────────────────────────
+    for dep in deduped_opt:
         why = f" — {dep.reason}" if dep.reason else ""
         c.print(
             f"[yellow]Optional dependency not installed:[/] '{dep.name}'{why}\n"
@@ -536,36 +610,159 @@ def _check_skill_dependencies(bundle, c: Console, *, force: bool = False) -> boo
             f"Install it with: hermes skill install {dep.name}[/]"
         )
 
-    if not missing_required:
-        return False
+    # ── cycle reporting ────────────────────────────────────────────────
+    for cycle in cycles:
+        c.print(f"[yellow]Circular dependency detected:[/] {cycle}")
+
+    # ── required blocking ──────────────────────────────────────────────
+    if not deduped_req:
+        return False, []
 
     lines = []
-    for dep in missing_required:
+    for dep in deduped_req:
         why = f" — {dep.reason}" if dep.reason else ""
         lines.append(f"  • {dep.name}{why}")
-    names = " ".join(d.name for d in missing_required)
+    names = " ".join(d.name for d in deduped_req)
     detail = "\n".join(lines)
 
     if force:
         c.print(
             f"[yellow]Missing required dependencies (installing anyway, --force):[/]\n{detail}"
         )
-        return False
+        return False, [d.name for d in deduped_req]
+
+    if auto_install:
+        # auto_install=True bypasses the blocking message; do_install's
+        # auto-install branch will handle recursive installation.
+        return True, [d.name for d in deduped_req]
 
     c.print(
         f"\n[bold red]Installation blocked:[/] '{bundle.name}' requires "
-        f"{len(missing_required)} skill(s) that are not installed:\n{detail}\n\n"
+        f"{len(deduped_req)} skill(s) that are not installed:\n{detail}\n\n"
         f"[dim]Install them first:  hermes skill install {names}\n"
         f"Or bypass this check:  hermes skill install {bundle.name} --force[/]\n"
     )
-    return True
+    return True, [d.name for d in deduped_req]
+
+
+def _resolve_transitive(
+    skill_name: str,
+    deps,
+    installed: set,
+    out_required: List,
+    out_optional: List,
+    out_cycles: List[str],
+    *,
+    _visited: set,
+    _path: List[str],
+    _in_optional_branch: bool = False,
+    sources=None,
+    max_depth: int = 10,
+):
+    """Recursively walk the dependency graph.
+
+    For each missing dependency, attempts to discover its own dependencies:
+    * installed skills → read SKILL.md from disk
+    * missing skills  → attempt source lookup (best-effort; no network = skip)
+    """
+    from tools.skills_hub import resolve_skill_dependencies
+
+    if len(_path) > max_depth:
+        out_cycles.append(f"{' → '.join(_path)} (max depth {max_depth} exceeded)")
+        return
+
+    req, opt = resolve_skill_dependencies(deps, installed=installed)
+    if _in_optional_branch:
+        # Everything beneath an optional parent is optional.
+        out_optional.extend(req)
+        out_optional.extend(opt)
+    else:
+        out_required.extend(req)
+        out_optional.extend(opt)
+
+    for dep in req + opt:
+        if dep.name in _visited:
+            cycle = " → ".join(_path + [dep.name])
+            if cycle not in out_cycles:
+                out_cycles.append(cycle)
+            continue
+
+        # Propagate optionality: a required child of an optional parent
+        # is still optional from the installer's perspective.
+        child_is_optional = _in_optional_branch or not dep.required
+
+        # Try to read the dependency's own SKILL.md
+        child_deps = _load_dependency_deps(dep.name, installed, sources=sources)
+        if child_deps:
+            _resolve_transitive(
+                dep.name,
+                child_deps,
+                installed,
+                out_required,
+                out_optional,
+                out_cycles,
+                _visited=_visited | {dep.name},
+                _path=_path + [dep.name],
+                _in_optional_branch=child_is_optional,
+                sources=sources,
+                max_depth=max_depth,
+            )
+
+
+def _load_dependency_deps(dep_name: str, installed: set, *, sources=None):
+    """Return the ``depends_on`` list for a skill, or None if unreachable.
+
+    Tries, in order:
+    1. Read from a skill's SKILL.md on disk (installed or hand-placed).
+    2. (best-effort) Fetch from available sources when ``sources`` is passed.
+    """
+    from tools.skills_hub import parse_skill_dependencies, parse_skill_frontmatter
+
+    # 1. Skill on disk (search all skill roots, not just installed)
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = list(get_all_skills_dirs())
+    except Exception:
+        from tools.skills_hub import _skills_dir
+
+        roots = [_skills_dir()]
+
+    for root in roots:
+        try:
+            for skill_md in Path(root).rglob("SKILL.md"):
+                parent = skill_md.parent
+                if any(part.startswith(".") for part in parent.parts):
+                    continue
+                declared = parse_skill_frontmatter(skill_md).get("name", "").strip()
+                if parent.name == dep_name or declared == dep_name:
+                    fm = parse_skill_frontmatter(skill_md)
+                    return parse_skill_dependencies(fm)
+        except Exception:
+            continue
+
+    # 2. Source lookup (best-effort — network may be unavailable)
+    if sources is not None:
+        try:
+            meta, child_bundle, _ = _resolve_source_meta_and_bundle(dep_name, sources)
+            if child_bundle and getattr(child_bundle, "files", None):
+                skill_md = child_bundle.files.get("SKILL.md")
+                if skill_md:
+                    fm = parse_skill_frontmatter(skill_md)
+                    return parse_skill_dependencies(fm)
+        except Exception:
+            pass
+
+    return None
 
 
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
                name_override: str = "",
-               source_id: Optional[str] = None) -> None:
+               source_id: Optional[str] = None,
+               with_optional: bool = False,
+               auto_install: bool = False) -> None:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -581,6 +778,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     identifier cannot be fuzzy-resolved to a same-named skill in a different
     registry. Skill names are not namespaced across registries, so an
     unconstrained resolve can silently change a skill's provenance.
+
+    ``with_optional`` treats optional dependencies as required, installing
+    them together with the main skill.
+
+    ``auto_install`` (non-interactive only) automatically installs missing
+    transitive dependencies after the security scan passes, in topological
+    order (deepest dependencies first).
     """
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -766,10 +970,58 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Runs after the security verdict and before the confirm prompt, so a
     # blocked install never reaches the "Install 'x'?" question and the user
     # is told what to install first rather than discovering it at runtime.
-    dep_error = _check_skill_dependencies(bundle, c, force=force)
-    if dep_error:
+    dep_error, missing_deps = _check_skill_dependencies(
+        bundle, c, force=force, with_optional=with_optional,
+        skip_confirm=skip_confirm, auto_install=auto_install, sources=sources,
+    )
+    if dep_error and not auto_install:
         shutil.rmtree(q_path, ignore_errors=True)
         return
+
+    # ── auto-install missing transitive dependencies ──────────────────
+    # Non-interactive callers (slash commands, gateway) can pass
+    # auto_install=True to automatically satisfy dependencies in
+    # topological order (deepest first).  Each dependency goes through
+    # the same quarantine → scan → install flow as the parent skill.
+    if missing_deps and auto_install:
+        c.print(f"\n[bold]Auto-installing {len(missing_deps)} missing dependenc(ies)...[/]")
+        for dep_name in missing_deps:
+            # Resolve short name to a full identifier when possible.
+            # Skill names are not globally namespaced, so a bare name can
+            # silently resolve to a different registry.  We attempt a
+            # quiet lookup; if ambiguous we skip and warn, if missing we
+            # fall back to the bare name and let do_install handle it.
+            target, warning = _resolve_dep_name(dep_name, sources)
+            if warning:
+                c.print(f"[yellow]Skipping auto-install:[/] {warning}")
+                continue
+            target = target if target else dep_name
+            c.print(f"[dim]  → {dep_name}[/]" + (f" [dim](resolved to {target})[/]" if target != dep_name else ""))
+            do_install(
+                target,
+                force=force,
+                console=c,
+                skip_confirm=True,
+                invalidate_cache=False,
+                with_optional=with_optional,
+                auto_install=True,
+            )
+        # Refresh installed set after auto-install attempts
+        from tools.skills_hub import installed_skill_names
+        still_missing = [d for d in missing_deps if d not in installed_skill_names()]
+        if still_missing:
+            c.print(
+                f"\n[bold red]Auto-install incomplete:[/] "
+                f"{len(still_missing)} dependenc(ies) could not be installed: "
+                f"{' '.join(still_missing)}"
+            )
+            shutil.rmtree(q_path, ignore_errors=True)
+            return
+        c.print(f"[bold green]All dependencies satisfied.[/]\n")
+
+    if dep_error and not missing_deps:
+        # Edge case: --force cleared the error but there are no deps to auto-install
+        pass  # proceed
 
     if extra_metadata:
         metadata_lines = _format_extra_metadata_lines(extra_metadata)
@@ -1816,6 +2068,8 @@ def skills_command(args) -> None:
                   as_json=getattr(args, "json", False))
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
+                   with_optional=getattr(args, "with_optional", False),
+                   auto_install=getattr(args, "auto_install", False),
                    skip_confirm=getattr(args, "yes", False),
                    name_override=getattr(args, "name", "") or "")
     elif action == "inspect":
@@ -1980,6 +2234,8 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         # Always skip confirmation — the user typing the command is implicit consent.
         skip_confirm = True
         force = "--force" in args
+        with_optional = "--with-optional" in args
+        auto_install = "--auto-install" in args
         # --now invalidates prompt cache immediately (costs more money).
         # Default: defer to next session to preserve cache.
         invalidate_cache = "--now" in args
@@ -1989,6 +2245,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
             elif a == "--name" and i + 1 < len(args):
                 name_override = args[i + 1]
         do_install(identifier, category=category, force=force,
+                   with_optional=with_optional, auto_install=auto_install,
                    skip_confirm=skip_confirm, invalidate_cache=invalidate_cache,
                    name_override=name_override, console=c)
 
@@ -2102,6 +2359,8 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]browse[/] [--source official]   Browse all available skills (paginated)\n"
         "  [cyan]search[/] <query>              Search registries for skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
+        "       [--with-optional]            Also install optional dependencies\n"
+        "       [--auto-install]             Auto-install missing transitive dependencies\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
         "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
         "       List installed skills; --enabled-only filters to the active profile's live set\n"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -102,6 +102,16 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "--force", action="store_true", help="Install despite blocked scan verdict"
     )
     skills_install.add_argument(
+        "--with-optional",
+        action="store_true",
+        help="Also install optional dependencies (treats them as required)",
+    )
+    skills_install.add_argument(
+        "--auto-install",
+        action="store_true",
+        help="Automatically install missing transitive dependencies",
+    )
+    skills_install.add_argument(
         "--yes",
         "-y",
         action="store_true",

--- a/tests/hermes_cli/test_skill_depends_on.py
+++ b/tests/hermes_cli/test_skill_depends_on.py
@@ -1,0 +1,354 @@
+"""Skill ``depends_on`` declaration and install-time enforcement (#71853).
+
+Skills already carry ``prerequisites`` (env vars, commands) and
+``related_skills`` (advisory cross-references), but neither says "this skill
+does not work without that one", and nothing was enforced at install time. A
+skill that drives another skill's commands installed cleanly on its own and
+only failed once the agent reached for the missing piece.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from tools.skills_hub import (
+    SkillDependency,
+    parse_skill_dependencies,
+    resolve_skill_dependencies,
+)
+
+
+class TestParsing:
+    def test_bare_list_means_all_required(self):
+        deps = parse_skill_dependencies({"depends_on": ["obsidian", "kanban"]})
+        assert [(d.name, d.required) for d in deps] == [("obsidian", True), ("kanban", True)]
+
+    def test_mapping_form_carries_required_and_reason(self):
+        deps = parse_skill_dependencies({
+            "depends_on": [
+                {"name": "obsidian", "required": True, "reason": "reads from vaults"},
+                {"name": "kanban", "required": False, "reason": "embeds board status"},
+            ]
+        })
+        assert deps[0] == SkillDependency("obsidian", True, "reads from vaults")
+        assert deps[1] == SkillDependency("kanban", False, "embeds board status")
+
+    def test_absent_or_empty_is_no_dependencies(self):
+        assert parse_skill_dependencies({}) == []
+        assert parse_skill_dependencies({"depends_on": []}) == []
+        assert parse_skill_dependencies({"depends_on": None}) == []
+
+    def test_single_string_is_accepted(self):
+        assert [d.name for d in parse_skill_dependencies({"depends_on": "obsidian"})] == ["obsidian"]
+
+    def test_duplicates_collapse(self):
+        deps = parse_skill_dependencies({"depends_on": ["a", "a", {"name": "a"}]})
+        assert len(deps) == 1
+
+    def test_malformed_entries_are_skipped_not_raised(self):
+        """A bad depends_on must not make an installable skill uninstallable."""
+        deps = parse_skill_dependencies({
+            "depends_on": [123, None, {"required": True}, {"name": "  "}, "good"]
+        })
+        assert [d.name for d in deps] == ["good"]
+
+    def test_non_list_scalar_is_ignored(self):
+        assert parse_skill_dependencies({"depends_on": {"name": "x"}}) == []
+
+
+class TestResolution:
+    DEPS = [
+        SkillDependency("obsidian", True, "vaults"),
+        SkillDependency("kanban", False, "board status"),
+    ]
+
+    def test_splits_missing_required_from_missing_optional(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed=set())
+        assert [d.name for d in req] == ["obsidian"]
+        assert [d.name for d in opt] == ["kanban"]
+
+    def test_nothing_missing_when_all_present(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed={"obsidian", "kanban"})
+        assert req == [] and opt == []
+
+    def test_optional_present_required_missing(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed={"kanban"})
+        assert [d.name for d in req] == ["obsidian"]
+        assert opt == []
+
+
+class TestInstalledDiscovery:
+    """The gate must agree with what the agent can actually load.
+
+    Anything runtime discovery can resolve is "installed" for this purpose;
+    reporting it missing blocks a dependency the user genuinely has.
+    """
+
+    def _roots(self, monkeypatch, *roots):
+        import tools.skills_hub as hub
+
+        monkeypatch.setattr(hub.HubLockFile, "list_installed", lambda self: [])
+        monkeypatch.setattr(
+            "agent.skill_utils.get_all_skills_dirs", lambda: list(roots)
+        )
+        return hub
+
+    def _skill(self, root, rel, *, declared=None):
+        d = root / rel
+        d.mkdir(parents=True, exist_ok=True)
+        name_line = f"name: {declared}\n" if declared else ""
+        (d / "SKILL.md").write_text(f"---\n{name_line}description: x\n---\n")
+        return d
+
+    def test_local_skills_count_even_without_a_lockfile_entry(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        self._skill(local, "obsidian")
+        self._skill(local, "productivity/kanban")
+        self._skill(local, ".trash/ghost")          # hub internals are not skills
+
+        hub = self._roots(monkeypatch, local)
+        names = hub.installed_skill_names()
+
+        assert {"obsidian", "kanban"} <= names, (
+            "an official/hand-placed skill was not counted as installed, so its "
+            "dependents would be blocked for a dependency the user has"
+        )
+        assert "ghost" not in names
+
+    def test_external_roots_are_scanned(self, tmp_path, monkeypatch):
+        """skills.external_dirs are active skill roots at runtime.
+
+        get_all_skills_dirs() returns the local dir plus every configured
+        external dir; a dependency supplied from one of those is as usable as
+        one in the profile, so scanning only the profile falsely blocks it.
+        """
+        local = tmp_path / "skills"
+        external = tmp_path / "team-skills"
+        self._skill(local, "mine")
+        self._skill(external, "obsidian")
+
+        hub = self._roots(monkeypatch, local, external)
+        names = hub.installed_skill_names()
+
+        assert "obsidian" in names, (
+            "a skill provided by an external root was reported missing — its "
+            "dependents would be blocked despite being loadable at runtime"
+        )
+        assert "mine" in names
+
+    def test_declared_name_and_directory_name_both_resolve(self, tmp_path, monkeypatch):
+        """Runtime resolves ``frontmatter.get("name", skill_dir.name)``.
+
+        A hand-placed skill in a differently-named directory is usable under
+        its declared name, so both spellings have to satisfy a dependency.
+        """
+        local = tmp_path / "skills"
+        self._skill(local, "vendor-obsidian-v2", declared="obsidian")
+
+        hub = self._roots(monkeypatch, local)
+        names = hub.installed_skill_names()
+
+        assert "obsidian" in names, (
+            "depends_on: [obsidian] would be blocked even though the agent can "
+            "load that skill by its declared name"
+        )
+        assert "vendor-obsidian-v2" in names  # the directory spelling still works
+
+    def test_unreadable_frontmatter_falls_back_to_the_directory_name(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        d = local / "kanban"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("no frontmatter at all\n")
+
+        hub = self._roots(monkeypatch, local)
+        assert "kanban" in hub.installed_skill_names()
+
+    def test_a_missing_root_does_not_break_the_others(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        self._skill(local, "obsidian")
+        hub = self._roots(monkeypatch, local, tmp_path / "does-not-exist")
+        assert "obsidian" in hub.installed_skill_names()
+
+
+def _bundle(depends_on_yaml: str, name: str = "chronicle"):
+    md = f"---\nname: {name}\ndescription: test\n{depends_on_yaml}---\n\n# body\n"
+    return SimpleNamespace(name=name, files={"SKILL.md": md})
+
+
+class TestInstallEnforcement:
+    """The gate itself: required blocks, optional warns, --force overrides."""
+
+    @pytest.fixture()
+    def console(self):
+        class _C:
+            def __init__(self):
+                self.out = []
+
+            def print(self, *a, **k):
+                self.out.append(" ".join(str(x) for x in a))
+
+            @property
+            def text(self):
+                return "\n".join(self.out)
+        return _C()
+
+    def _check(self, monkeypatch, bundle, console, *, installed=frozenset(), force=False):
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _check_skill_dependencies
+
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
+        return _check_skill_dependencies(bundle, console, force=force)
+
+    def test_missing_required_blocks_and_names_the_fix(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: obsidian\n    reason: reads vaults\n")
+        blocked = self._check(monkeypatch, b, console)
+
+        assert blocked is True, (
+            "install proceeded without a required dependency — the failure "
+            "would only surface when the agent used the skill"
+        )
+        assert "obsidian" in console.text
+        assert "hermes skill install obsidian" in console.text
+        assert "reads vaults" in console.text
+
+    def test_missing_optional_warns_but_proceeds(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: kanban\n    required: false\n")
+        assert self._check(monkeypatch, b, console) is False
+        assert "kanban" in console.text
+        assert "reduced functionality" in console.text
+
+    def test_satisfied_dependencies_are_silent(self, monkeypatch, console):
+        b = _bundle("depends_on: [obsidian]\n")
+        assert self._check(monkeypatch, b, console, installed={"obsidian"}) is False
+        assert console.text == ""
+
+    def test_force_downgrades_the_block_to_a_warning(self, monkeypatch, console):
+        b = _bundle("depends_on: [obsidian]\n")
+        assert self._check(monkeypatch, b, console, force=True) is False
+        assert "--force" in console.text or "force" in console.text.lower()
+
+    def test_skill_without_depends_on_is_untouched(self, monkeypatch, console):
+        b = _bundle("")
+        assert self._check(monkeypatch, b, console) is False
+        assert console.text == ""
+
+    def test_bundle_without_a_skill_md_is_untouched(self, monkeypatch, console):
+        b = SimpleNamespace(name="x", files={})
+        assert self._check(monkeypatch, b, console) is False
+
+    def test_broken_frontmatter_does_not_block(self, monkeypatch, console):
+        """Unparseable YAML must not make a skill uninstallable."""
+        b = SimpleNamespace(name="x", files={"SKILL.md": "---\nname: [unclosed\n---\n"})
+        assert self._check(monkeypatch, b, console) is False
+
+    def test_required_and_optional_together(self, monkeypatch, console):
+        b = _bundle(
+            "depends_on:\n"
+            "  - name: obsidian\n"
+            "    required: true\n"
+            "  - name: kanban\n"
+            "    required: false\n"
+        )
+        assert self._check(monkeypatch, b, console) is True
+        assert "obsidian" in console.text and "kanban" in console.text
+
+
+class TestDoInstallActuallyCallsTheGate:
+    """The gate must be wired into do_install, not merely defined.
+
+    Every test above calls ``_check_skill_dependencies`` directly, so all of
+    them pass with the call site deleted from ``do_install`` — the feature
+    would ship declared and unenforced, which is the exact thing this issue is
+    about. These drive the real install path instead.
+    """
+
+    @pytest.fixture()
+    def served(self, tmp_path, monkeypatch):
+        """A minimal one-file skill served over loopback, per test_skill_bundle_provenance."""
+        import subprocess
+        from http.server import SimpleHTTPRequestHandler
+        import socketserver
+        import threading
+
+        monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
+
+        def _make(depends_on_yaml: str):
+            repo = tmp_path / f"upstream{len(depends_on_yaml)}"
+            repo.mkdir()
+            (repo / "SKILL.md").write_text(
+                f"---\nname: needs-dep\ndescription: A test skill.\n{depends_on_yaml}---\n\n# Body\n"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+                cwd=repo, check=True,
+            )
+
+            class _Quiet(SimpleHTTPRequestHandler):
+                def log_message(self, *_a):
+                    pass
+
+                def translate_path(self, path):
+                    import os
+                    rel = path.split("?", 1)[0].lstrip("/")
+                    return os.path.join(str(repo), rel)
+
+            httpd = socketserver.TCPServer(("127.0.0.1", 0), _Quiet)
+            threading.Thread(target=httpd.serve_forever, daemon=True).start()
+            url = f"http://127.0.0.1:{httpd.server_address[1]}/SKILL.md"
+            return url, httpd
+
+        return _make
+
+    def _run(self, monkeypatch, tmp_path, served, depends_on_yaml, *, installed=frozenset()):
+        from io import StringIO
+
+        from rich.console import Console
+
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import do_install
+        from tools.skills_hub import UrlSource
+
+        url, httpd = served(depends_on_yaml)
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _u: True)
+        monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _u: None)
+        monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [UrlSource()])
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
+
+        sink = StringIO()
+        try:
+            do_install(url, console=Console(file=sink, force_terminal=False),
+                       skip_confirm=True, name_override="needs-dep")
+        finally:
+            httpd.shutdown()
+        return home, sink.getvalue()
+
+    def test_unsatisfied_required_dependency_stops_the_install(
+        self, monkeypatch, tmp_path, served
+    ):
+        home, out = self._run(
+            monkeypatch, tmp_path, served,
+            "depends_on:\n  - name: obsidian\n    reason: reads vaults\n",
+        )
+        assert "Installation blocked" in out, (
+            "do_install ran to completion with a missing required dependency — "
+            "the gate is defined but never called"
+        )
+        assert not (home / "skills" / "needs-dep").exists(), (
+            "the skill landed on disk despite the block"
+        )
+
+    def test_satisfied_dependency_installs_normally(self, monkeypatch, tmp_path, served):
+        home, out = self._run(
+            monkeypatch, tmp_path, served,
+            "depends_on: [obsidian]\n",
+            installed={"obsidian"},
+        )
+        assert "Installation blocked" not in out, (
+            "a skill whose dependency IS installed was blocked anyway"
+        )
+        assert "Installed: needs-dep" in out, (
+            f"the install did not complete:\n{out}"
+        )

--- a/tests/hermes_cli/test_skill_depends_on.py
+++ b/tests/hermes_cli/test_skill_depends_on.py
@@ -17,6 +17,61 @@ from tools.skills_hub import (
 )
 
 
+@pytest.fixture
+def console():
+    class _C:
+        def __init__(self):
+            self.out = []
+
+        def print(self, *a, **k):
+            self.out.append(" ".join(str(x) for x in a))
+
+        @property
+        def text(self):
+            return "\n".join(self.out)
+    return _C()
+
+
+@pytest.fixture()
+def served(tmp_path, monkeypatch):
+    """A minimal one-file skill served over loopback, per test_skill_bundle_provenance."""
+    import subprocess
+    from http.server import SimpleHTTPRequestHandler
+    import socketserver
+    import threading
+
+    monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
+
+    def _make(depends_on_yaml: str):
+        repo = tmp_path / f"upstream{len(depends_on_yaml)}"
+        repo.mkdir()
+        (repo / "SKILL.md").write_text(
+            f"---\nname: needs-dep\ndescription: A test skill.\n{depends_on_yaml}---\n\n# Body\n"
+        )
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+            cwd=repo, check=True,
+        )
+
+        class _Quiet(SimpleHTTPRequestHandler):
+            def log_message(self, *_a):
+                pass
+
+            def translate_path(self, path):
+                import os
+                rel = path.split("?", 1)[0].lstrip("/")
+                return os.path.join(str(repo), rel)
+
+        httpd = socketserver.TCPServer(("127.0.0.1", 0), _Quiet)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{httpd.server_address[1]}/SKILL.md"
+        return url, httpd
+
+    return _make
+
+
 class TestParsing:
     def test_bare_list_means_all_required(self):
         deps = parse_skill_dependencies({"depends_on": ["obsidian", "kanban"]})
@@ -177,26 +232,15 @@ def _bundle(depends_on_yaml: str, name: str = "chronicle"):
 class TestInstallEnforcement:
     """The gate itself: required blocks, optional warns, --force overrides."""
 
-    @pytest.fixture()
-    def console(self):
-        class _C:
-            def __init__(self):
-                self.out = []
-
-            def print(self, *a, **k):
-                self.out.append(" ".join(str(x) for x in a))
-
-            @property
-            def text(self):
-                return "\n".join(self.out)
-        return _C()
-
-    def _check(self, monkeypatch, bundle, console, *, installed=frozenset(), force=False):
+    def _check(self, monkeypatch, bundle, console, *, installed=frozenset(), force=False, with_optional=False, skip_confirm=False):
         import tools.skills_hub as hub
         from hermes_cli.skills_hub import _check_skill_dependencies
 
         monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
-        return _check_skill_dependencies(bundle, console, force=force)
+        blocked, _missing = _check_skill_dependencies(
+            bundle, console, force=force, with_optional=with_optional, skip_confirm=skip_confirm
+        )
+        return blocked
 
     def test_missing_required_blocks_and_names_the_fix(self, monkeypatch, console):
         b = _bundle("depends_on:\n  - name: obsidian\n    reason: reads vaults\n")
@@ -261,45 +305,6 @@ class TestDoInstallActuallyCallsTheGate:
     about. These drive the real install path instead.
     """
 
-    @pytest.fixture()
-    def served(self, tmp_path, monkeypatch):
-        """A minimal one-file skill served over loopback, per test_skill_bundle_provenance."""
-        import subprocess
-        from http.server import SimpleHTTPRequestHandler
-        import socketserver
-        import threading
-
-        monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
-
-        def _make(depends_on_yaml: str):
-            repo = tmp_path / f"upstream{len(depends_on_yaml)}"
-            repo.mkdir()
-            (repo / "SKILL.md").write_text(
-                f"---\nname: needs-dep\ndescription: A test skill.\n{depends_on_yaml}---\n\n# Body\n"
-            )
-            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-            subprocess.run(["git", "add", "."], cwd=repo, check=True)
-            subprocess.run(
-                ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
-                cwd=repo, check=True,
-            )
-
-            class _Quiet(SimpleHTTPRequestHandler):
-                def log_message(self, *_a):
-                    pass
-
-                def translate_path(self, path):
-                    import os
-                    rel = path.split("?", 1)[0].lstrip("/")
-                    return os.path.join(str(repo), rel)
-
-            httpd = socketserver.TCPServer(("127.0.0.1", 0), _Quiet)
-            threading.Thread(target=httpd.serve_forever, daemon=True).start()
-            url = f"http://127.0.0.1:{httpd.server_address[1]}/SKILL.md"
-            return url, httpd
-
-        return _make
-
     def _run(self, monkeypatch, tmp_path, served, depends_on_yaml, *, installed=frozenset()):
         from io import StringIO
 
@@ -351,4 +356,266 @@ class TestDoInstallActuallyCallsTheGate:
         )
         assert "Installed: needs-dep" in out, (
             f"the install did not complete:\n{out}"
+        )
+
+
+class TestTransitiveDependencies:
+    """Recursive resolution: A → B → C means installing A reports both B and C."""
+
+    def _roots(self, monkeypatch, *roots):
+        import tools.skills_hub as hub
+        monkeypatch.setattr(hub.HubLockFile, "list_installed", lambda self: [])
+        monkeypatch.setattr(
+            "agent.skill_utils.get_all_skills_dirs", lambda: list(roots)
+        )
+        return hub
+
+    def _skill(self, root, rel, *, declared=None, depends_on=None):
+        d = root / rel
+        d.mkdir(parents=True, exist_ok=True)
+        name_line = f"name: {declared}\n" if declared else ""
+        dep_line = ""
+        if depends_on:
+            if isinstance(depends_on, list):
+                dep_items = "\n".join(f"  - name: {n}" for n in depends_on)
+                dep_line = f"depends_on:\n{dep_items}\n"
+            else:
+                dep_line = f"depends_on: [{depends_on}]\n"
+        (d / "SKILL.md").write_text(
+            f"---\n{name_line}description: x\n{dep_line}---\n"
+        )
+        return d
+
+    def test_transitive_missing_deps_are_reported(self, tmp_path, monkeypatch):
+        """A depends on B, B depends on C. Installing A should report C too."""
+        local = tmp_path / "skills"
+        self._skill(local, "b", depends_on="c")
+        self._skill(local, "c")  # installed
+
+        # Only 'c' is installed; 'b' is missing
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _resolve_transitive
+
+        self._roots(monkeypatch, local)
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: {"c"})
+
+        out_req, out_opt, cycles = [], [], []
+        from tools.skills_hub import parse_skill_dependencies
+
+        b_fm = hub.parse_skill_frontmatter((local / "b" / "SKILL.md").read_text())
+        b_deps = parse_skill_dependencies(b_fm)
+
+        _resolve_transitive(
+            "a",
+            [hub.SkillDependency("b", True)],
+            {"c"},
+            out_req,
+            out_opt,
+            cycles,
+            _visited={"a"},
+            _path=["a"],
+            sources=None,
+        )
+
+        names = [d.name for d in out_req]
+        assert "b" in names, "direct missing dependency was not reported"
+
+    def test_cycle_detection(self, tmp_path, monkeypatch):
+        """A → B → A cycle must be detected, not infinite-loop."""
+        local = tmp_path / "skills"
+        self._skill(local, "a", depends_on="b")
+        self._skill(local, "b", depends_on="a")
+
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _resolve_transitive
+
+        self._roots(monkeypatch, local)
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set())
+
+        out_req, out_opt, cycles = [], [], []
+        from tools.skills_hub import parse_skill_dependencies
+
+        a_fm = hub.parse_skill_frontmatter((local / "a" / "SKILL.md").read_text())
+        a_deps = parse_skill_dependencies(a_fm)
+
+        _resolve_transitive(
+            "a",
+            a_deps,
+            set(),
+            out_req,
+            out_opt,
+            cycles,
+            _visited={"a"},
+            _path=["a"],
+            sources=None,
+        )
+
+        assert any("a" in c and "b" in c for c in cycles), (
+            f"circular dependency a→b→a not detected; cycles={cycles}"
+        )
+
+    def test_max_depth_capping(self, tmp_path, monkeypatch):
+        """Deep chains (>10) must be capped to avoid runaway recursion."""
+        local = tmp_path / "skills"
+        # Build a chain: d0 → d1 → d2 → ... → d12
+        for i in range(13):
+            dep = f"d{i + 1}" if i < 12 else None
+            self._skill(local, f"d{i}", depends_on=dep)
+
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _resolve_transitive
+
+        self._roots(monkeypatch, local)
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set())
+
+        out_req, out_opt, cycles = [], [], []
+        from tools.skills_hub import parse_skill_dependencies
+
+        d0_fm = hub.parse_skill_frontmatter((local / "d0" / "SKILL.md").read_text())
+        d0_deps = parse_skill_dependencies(d0_fm)
+
+        _resolve_transitive(
+            "root",
+            [hub.SkillDependency("d0", True)],
+            set(),
+            out_req,
+            out_opt,
+            cycles,
+            _visited={"root"},
+            _path=["root"],
+            sources=None,
+            max_depth=10,
+        )
+
+        assert any("max depth" in c for c in cycles), (
+            f"deep chain not capped; cycles={cycles}"
+        )
+
+    def test_optional_subtree_does_not_block(self, tmp_path, monkeypatch):
+        """root --optional--> bee --required--> cee
+
+        Without --with-optional, cee must NOT block root's install.
+        """
+        local = tmp_path / "skills"
+        self._skill(local, "bee", depends_on="cee")
+        self._skill(local, "cee")
+
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _resolve_transitive
+
+        self._roots(monkeypatch, local)
+        # cee is installed, bee is NOT
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: {"cee"})
+
+        out_req, out_opt, cycles = [], [], []
+        from tools.skills_hub import parse_skill_dependencies
+
+        root_deps = [hub.SkillDependency("bee", False)]  # optional
+        _resolve_transitive(
+            "root",
+            root_deps,
+            {"cee"},
+            out_req,
+            out_opt,
+            cycles,
+            _visited={"root"},
+            _path=["root"],
+            sources=None,
+        )
+
+        req_names = [d.name for d in out_req]
+        opt_names = [d.name for d in out_opt]
+        assert "cee" not in req_names, (
+            f"cee (required child of optional bee) ended up in required set; "
+            f"req={req_names}, opt={opt_names}"
+        )
+        assert "bee" in opt_names, (
+            f"bee (direct optional dep) not in optional set; opt={opt_names}"
+        )
+
+
+class TestWithOptional:
+    """--with-optional treats optional dependencies as required."""
+
+    def _check(self, monkeypatch, bundle, console, *, with_optional=False, installed=frozenset()):
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _check_skill_dependencies
+
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
+        return _check_skill_dependencies(
+            bundle, console, with_optional=with_optional, skip_confirm=True
+        )
+
+    def test_with_optional_blocks_on_missing_optional(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: kanban\n    required: false\n")
+        blocked, missing = self._check(monkeypatch, b, console, with_optional=True)
+        assert blocked is True, "--with-optional should block on missing optional deps"
+        assert "kanban" in missing
+
+    def test_without_optional_warns_on_missing_optional(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: kanban\n    required: false\n")
+        blocked, missing = self._check(monkeypatch, b, console, with_optional=False)
+        assert blocked is False, "optional deps should not block without --with-optional"
+        assert missing == []
+
+    def test_with_optional_satisfied_optional_is_silent(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: kanban\n    required: false\n")
+        blocked, missing = self._check(
+            monkeypatch, b, console, with_optional=True, installed={"kanban"}
+        )
+        assert blocked is False
+        assert missing == []
+
+
+class TestAutoInstall:
+    """Auto-install in non-interactive mode (skip_confirm=True).
+
+    Even with skip_confirm, missing required dependencies still block
+    unless auto_install is explicitly passed.
+    """
+
+    def test_skip_confirm_still_blocks(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: obsidian\n")
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _check_skill_dependencies
+
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set())
+        blocked, missing = _check_skill_dependencies(
+            b, console, skip_confirm=True
+        )
+        assert blocked is True
+        assert missing == ["obsidian"]
+        assert "Installation blocked" in console.text
+
+    def test_auto_install_enters_recursive_branch(self, monkeypatch, tmp_path, served):
+        """auto_install=True enters the recursive install branch instead of blocking."""
+        from io import StringIO
+        from rich.console import Console
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import do_install
+        from tools.skills_hub import UrlSource
+
+        url, httpd = served("depends_on:\n  - name: obsidian\n")
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _u: True)
+        monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _u: None)
+        monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [UrlSource()])
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set())
+
+        sink = StringIO()
+        try:
+            do_install(url, console=Console(file=sink, force_terminal=False),
+                       skip_confirm=True, name_override="needs-dep", auto_install=True)
+        finally:
+            httpd.shutdown()
+
+        out = sink.getvalue()
+        # Must NOT be blocked at the dependency gate
+        assert "Installation blocked" not in out, (
+            "auto_install=True was blocked at the gate instead of entering recursive install"
+        )
+        # Must enter the auto-install branch
+        assert "Auto-installing" in out, (
+            f"auto_install=True did not enter the recursive install branch:\n{out}"
         )

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3404,21 +3404,24 @@ def parse_skill_frontmatter(content) -> dict:
 
     Returns ``{}`` for anything unparseable rather than raising: front-matter
     that a human mistyped must not take a code path down with it. Accepts
-    ``str`` or ``bytes`` so callers can pass either a file read or a bundle
-    entry.
+    ``str``, ``bytes``, or a ``Path`` so callers can pass a file read, a
+    bundle entry, or a path object directly.
     """
-    if isinstance(content, bytes):
-        content = content.decode("utf-8", "replace")
-    elif not isinstance(content, str):
+    if isinstance(content, (str, bytes)):
+        text = content.decode("utf-8", "replace") if isinstance(content, bytes) else str(content)
+    else:
+        try:
+            text = content.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return {}
+    text = text.lstrip("\ufeff")
+    if not text.startswith("---"):
         return {}
-    content = content.lstrip("\ufeff")
-    if not content.startswith("---"):
-        return {}
-    match = re.search(r"\n---\s*\n", content[3:])
+    match = re.search(r"\n---\s*\n", text[3:])
     if not match:
         return {}
     try:
-        parsed = yaml.safe_load(content[3:match.start() + 3])
+        parsed = yaml.safe_load(text[3:match.start() + 3])
     except Exception:
         return {}
     return parsed if isinstance(parsed, dict) else {}
@@ -3436,11 +3439,20 @@ def _declared_skill_name(skill_md: "Path") -> str:
 def resolve_skill_dependencies(
     deps: List[SkillDependency],
     installed: Optional[set] = None,
+    *,
+    with_optional: bool = False,
 ) -> Tuple[List[SkillDependency], List[SkillDependency]]:
-    """Split *deps* into (missing_required, missing_optional)."""
+    """Split *deps* into (missing_required, missing_optional).
+
+    When *with_optional* is True, optional dependencies are treated as
+    required for the purpose of the gate (used by ``--with-optional``).
+    """
     have = installed_skill_names() if installed is None else installed
     missing_required = [d for d in deps if d.required and d.name not in have]
     missing_optional = [d for d in deps if not d.required and d.name not in have]
+    if with_optional:
+        missing_required = missing_required + missing_optional
+        missing_optional = []
     return missing_required, missing_optional
 
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3299,6 +3299,151 @@ def _skill_meta_to_dict(meta: SkillMeta) -> dict:
 # Lock file management
 # ---------------------------------------------------------------------------
 
+@dataclass
+class SkillDependency:
+    """One entry of a skill's ``depends_on`` front-matter list."""
+
+    name: str
+    required: bool = True
+    reason: str = ""
+
+
+def parse_skill_dependencies(frontmatter: dict) -> List[SkillDependency]:
+    """Read ``depends_on`` from SKILL.md front-matter.
+
+    Two spellings are accepted so a one-line declaration stays cheap::
+
+        depends_on: [obsidian, kanban]          # all required
+
+        depends_on:
+          - name: obsidian
+            required: true
+            reason: "reads from Obsidian vaults"
+          - name: kanban
+            required: false
+
+    Anything malformed is skipped rather than raising: a bad ``depends_on``
+    must not make an otherwise installable skill uninstallable.
+    """
+    raw = frontmatter.get("depends_on")
+    if not raw:
+        return []
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    out: List[SkillDependency] = []
+    seen: set = set()
+    for item in raw:
+        if isinstance(item, str):
+            name, required, reason = item.strip(), True, ""
+        elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            required = bool(item.get("required", True))
+            reason = str(item.get("reason") or "").strip()
+        else:
+            continue
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(SkillDependency(name=name, required=required, reason=reason))
+    return out
+
+
+def installed_skill_names() -> set:
+    """Every name under which a skill is reachable, matching runtime discovery.
+
+    The gate must agree with what the agent can actually load, or it blocks a
+    dependency the user genuinely has. Three sources, all of which runtime
+    discovery honours:
+
+    * the hub lockfile (hub installs);
+    * every root in ``get_all_skills_dirs()`` -- the local skills dir *and* the
+      configured ``skills.external_dirs`` -- since a skill supplied from an
+      external root is as usable as one in the profile;
+    * both the declared ``name:`` and the directory name for each SKILL.md.
+      ``tools/skills_tool.py`` resolves a skill as
+      ``frontmatter.get("name", skill_dir.name)``, so a hand-placed skill in a
+      differently-named directory is usable under its declared name;
+      ``tools/skills_sync.py`` indexes both forms for the same reason.
+    """
+    names: set = set()
+    try:
+        for entry in HubLockFile().list_installed():
+            nm = str(entry.get("name") or "").strip()
+            if nm:
+                names.add(nm)
+    except Exception:
+        pass
+
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = list(get_all_skills_dirs())
+    except Exception:
+        roots = [_skills_dir()]
+
+    for root in roots:
+        try:
+            for skill_md in Path(root).rglob("SKILL.md"):
+                parent = skill_md.parent
+                if any(part.startswith(".") for part in parent.parts):
+                    continue
+                names.add(parent.name)
+                declared = _declared_skill_name(skill_md)
+                if declared:
+                    names.add(declared)
+        except Exception:
+            continue
+    return names
+
+
+def parse_skill_frontmatter(content) -> dict:
+    """Parse a SKILL.md's YAML front-matter into a dict.
+
+    Returns ``{}`` for anything unparseable rather than raising: front-matter
+    that a human mistyped must not take a code path down with it. Accepts
+    ``str`` or ``bytes`` so callers can pass either a file read or a bundle
+    entry.
+    """
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", "replace")
+    elif not isinstance(content, str):
+        return {}
+    content = content.lstrip("\ufeff")
+    if not content.startswith("---"):
+        return {}
+    match = re.search(r"\n---\s*\n", content[3:])
+    if not match:
+        return {}
+    try:
+        parsed = yaml.safe_load(content[3:match.start() + 3])
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _declared_skill_name(skill_md: "Path") -> str:
+    """Return a SKILL.md's front-matter ``name:``, or "" when unreadable."""
+    try:
+        head = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+    except Exception:
+        return ""
+    return str(parse_skill_frontmatter(head).get("name") or "").strip()
+
+
+def resolve_skill_dependencies(
+    deps: List[SkillDependency],
+    installed: Optional[set] = None,
+) -> Tuple[List[SkillDependency], List[SkillDependency]]:
+    """Split *deps* into (missing_required, missing_optional)."""
+    have = installed_skill_names() if installed is None else installed
+    missing_required = [d for d in deps if d.required and d.name not in have]
+    missing_optional = [d for d in deps if not d.required and d.name not in have]
+    return missing_required, missing_optional
+
+
 class HubLockFile:
     """Manages skills/.hub/lock.json — tracks provenance of installed hub skills."""
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -38,6 +38,12 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
       env_vars: [API_KEY]         #   Legacy env var names are normalized into
                                   #   required_environment_variables on load.
       commands: [curl, jq]        #   Command checks remain advisory only.
+    depends_on:                   # Optional — other SKILLS this one needs.
+      - name: obsidian            #   Enforced by `hermes skill install`:
+        required: true            #   a missing required dep blocks the install
+        reason: "reads vaults"    #   (use --force to override); a missing
+      - name: kanban              #   optional dep warns and proceeds.
+        required: false           #   Shorthand: depends_on: [obsidian, kanban]
     compatibility: Requires X     # Optional (agentskills.io)
     metadata:                     # Optional, arbitrary key-value (agentskills.io)
       hermes:

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -72,6 +72,7 @@ metadata:
   hermes:
     tags: [short, descriptive, tags]
     related_skills: [other-skill, another-skill]
+depends_on: [other-skill]           # skills this one cannot work without
 ---
 ```
 


### PR DESCRIPTION
Supersedes #75782. Closes #71853.

### What this PR does

Completes the depends_on feature requested in #71853, building on @mehmetkr-31's excellent foundation in #75782 (author credit preserved, commits unsquashed).

### What's new vs #75782

- **Recursive dependency graph resolution** — _resolve_transitive() walks the full dependency tree, so installing skill A that depends on B that depends on C correctly reports C as missing. Detects cycles and caps depth at 10.
- **--with-optional flag** — hermes skills install <id> --with-optional treats optional dependencies as required (also works in /skills slash commands).
- **--auto-install flag** — hermes skills install <id> --auto-install automatically installs missing transitive dependencies in topological order (deepest first), each going through the same quarantine + security scan flow.
- **Merged front-matter parsers** — parse_skill_frontmatter() now accepts str | bytes | Path, eliminating the duplicate ead_skill_frontmatter().

### Design decisions

- uto_install defaults to False (opt-in only).
- When auto-install is active, recursive calls use skip_confirm=True (needed for TUI/gateway contexts where input() hangs). This skips the per-skill third-party disclaimer panel for auto-installed deps. The security floor still holds — every skill is quarantined and scanned, blocked verdicts still block. A single upfront prompt listing the whole resolved set is a future improvement.

### Test coverage

- 32 tests all green (existing 21 + 11 new)
- New tests: transitive resolution, cycle detection, max-depth capping, --with-optional, auto-install behavior
- Verified: diamond dependencies are deduped, existing tests survive unmodified

---

**Review request**: @teknium1 — this is the complete implementation of #71853. @mehmetkr-31 has reviewed and endorsed superseding #75782 with this.