### PR TITLE
feat(tui): pulse active subagent indicator

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { StatusRule } from '../components/appChrome.js'
+import { StatusRule, subagentPulseColor } from '../components/appChrome.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 type ReactNodeLike = React.ReactNode
@@ -105,6 +105,12 @@ const baseProps = {
 }
 
 describe('StatusRule background-subagent indicator', () => {
+  it('alternates the pulse between muted and accent colors', () => {
+    expect(subagentPulseColor(0, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.muted)
+    expect(subagentPulseColor(1, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.accent)
+    expect(subagentPulseColor(2, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.muted)
+  })
+
   it('renders ⛓ N on a wide terminal when subagents are running', () => {
     const element = StatusRule({
       ...baseProps,

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -20,7 +20,10 @@ import type { Msg, Usage } from '../types.js'
 import { scrollbarColors } from './overlayPrimitives.js'
 
 const FACE_TICK_MS = 2500
+const SUBAGENT_PULSE_MS = 700
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
+
+export const subagentPulseColor = (tick: number, t: Theme) => (tick % 2 === 0 ? t.color.muted : t.color.accent)
 
 // Keep verb segment width stable so status-bar content to the right doesn't
 // jitter when the ticker rotates between short/long verbs.
@@ -432,6 +435,18 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   return <Text color={color}>♥</Text>
 }
 
+function SubagentPulse({ children, t }: { children: ReactNode; t: Theme }) {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setTick(n => n + 1), SUBAGENT_PULSE_MS)
+
+    return () => clearInterval(id)
+  }, [])
+
+  return <Text color={subagentPulseColor(tick, t)}>{children}</Text>
+}
+
 export function StatusRule({
   battery,
   focusView,
@@ -692,7 +707,8 @@ export function StatusRule({
         ) : null}
         {showSubagents ? (
           <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}⛓ {subagentCount}
+            {' │ '}
+            <SubagentPulse t={t}>⛓</SubagentPulse> {subagentCount}
           </Text>
         ) : null}
         {showResumeHint ? (


### PR DESCRIPTION
## Summary

Make the existing `⛓ N` subagent indicator feel alive while delegated work is running.

- pulse only the chain glyph between the theme's muted and accent colors every 700 ms
- keep the glyph, count, and display width unchanged so the status bar never jitters
- mount the timer only while the indicator is visible and clean it up on unmount
- add focused coverage for the pulse color sequence

This keeps subagent activity glanceable without adding a persistent panel or more status text.

## Verification

- `npm test -- --run src/__tests__/appChromeStatusRule.test.tsx` — 24 passed
- full `vitest run` — 1,459 passed, 4 skipped
- `npm run typecheck` — passed
- Prettier check for both changed files — passed
- independent Codex review — no actionable issues

## Related

- Builds on the status-bar subagent indicator from #14045 / #5625.
- Deliberately narrower than the persistent async delegation panel proposed in #70899.