### PR TITLE
fix(slack): honour rich_text_list offset when rendering ordered lists

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -447,8 +447,18 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
                 _walk_elements(elem.get("elements", []), quote_depth=quote_depth + 1)
             elif elem_type == "rich_text_list":
                 list_style = elem.get("style")
+                # Slack splits one visible list into several blocks when the
+                # user puts anything between the items, and reports where the
+                # continuation resumes in "offset" (omitted when it is zero).
+                # Numbering every block from 1 renames the user's items: a list
+                # they see as 4. and 5. reaches the agent as 1. and 2.
+                try:
+                    list_offset = int(elem.get("offset") or 0)
+                except (TypeError, ValueError):
+                    list_offset = 0
                 for idx, item in enumerate(elem.get("elements", [])):
-                    item_bullet = "• " if list_style == "bullet" else f"{idx + 1}. "
+                    number = list_offset + idx + 1
+                    item_bullet = "• " if list_style == "bullet" else f"{number}. "
                     _walk_elements([item], quote_depth=quote_depth, bullet=item_bullet)
             elif elem_type == "rich_text_preformatted":
                 code_lines: list[str] = []

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1739,6 +1739,160 @@ class TestIncomingDocumentHandling:
         assert "• First bullet" in msg_event.text
         assert "• Second bullet" in msg_event.text
 
+    @pytest.mark.asyncio
+    async def test_ordered_list_continuation_keeps_its_numbering(self, adapter):
+        """A list split by prose must keep the numbers the user sees.
+
+        Slack sends the continuation as a separate ``rich_text_list`` block and
+        reports where it resumes in ``offset``. Numbering every block from 1
+        renames the user's items, which changes the message when the numbering
+        is the content.
+        """
+        event = self._make_event(
+            text="Here is the plan",
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_list",
+                            "style": "ordered",
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Intake"}],
+                                },
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Analysis"}],
+                                },
+                            ],
+                        },
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "text", "text": "That covers stage one."}
+                            ],
+                        },
+                        {
+                            "type": "rich_text_list",
+                            "style": "ordered",
+                            "offset": 2,
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Decision"}],
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        text = adapter.handle_message.call_args[0][0].text
+        assert "1. Intake" in text
+        assert "2. Analysis" in text
+        assert "That covers stage one." in text
+        assert "3. Decision" in text
+        assert "1. Decision" not in text
+
+    @pytest.mark.asyncio
+    async def test_ordered_list_without_offset_starts_at_one(self, adapter):
+        """The common single-block case must be unchanged."""
+        event = self._make_event(
+            text="Plain list",
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_list",
+                            "style": "ordered",
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "First"}],
+                                },
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Second"}],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        text = adapter.handle_message.call_args[0][0].text
+        assert "1. First" in text
+        assert "2. Second" in text
+
+    @pytest.mark.asyncio
+    async def test_unusable_list_offset_falls_back_to_one(self, adapter):
+        """A malformed offset must not raise or drop the items."""
+        event = self._make_event(
+            text="Odd payload",
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_list",
+                            "style": "ordered",
+                            "offset": "not-a-number",
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Only item"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        assert "1. Only item" in adapter.handle_message.call_args[0][0].text
+
+    @pytest.mark.asyncio
+    async def test_bullet_list_ignores_offset(self, adapter):
+        """Bullets carry no numbering, so an offset must not reach them."""
+        event = self._make_event(
+            text="Bullets",
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_list",
+                            "style": "bullet",
+                            "offset": 4,
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "Alpha"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        text = adapter.handle_message.call_args[0][0].text
+        assert "• Alpha" in text
+        assert "5." not in text
+
 
 # ---------------------------------------------------------------------------
 # TestIncomingAudioHandling — Slack voice messages (regression)


### PR DESCRIPTION
Slack splits one visible ordered list into several `rich_text_list` blocks when the user puts anything between the items, and reports where the continuation resumes in `offset` (the field is omitted when it is zero).

`_extract_text_from_slack_blocks` numbers every block from 1, so a message the user sees as

```
1. a
2. b
(a line of prose)
3. c
```

reaches the agent as 1. 2. … 1. — the continuation restarts. Where the numbering carries the meaning (a ranked list, an ordered procedure), that is a changed message rather than a formatting difference, and the agent has no way to notice.

**Change:** add the block offset to the item index.

**Behaviour:** unchanged when `offset` is absent or zero (the common single-block case); bullet lists untouched; non-integer values fall back to 0.

**Checked** against the extractor with offset absent / 0 / 3 / null / a non-integer string, and a bullet list — the first two, null and the string render 1., 2., …; offset 3 renders 4., 5.; the bullet list is unaffected.