### PR TITLE
fix(logging): log a digest of user message text instead of the text

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -491,9 +491,18 @@ def build_turn_context(
     agent.iteration_budget = IterationBudget(agent.max_iterations)
 
     # Log conversation turn start for debugging/observability.
+    # Log a length and a checksum prefix instead of the message body, for
+    # the same reason as the gateway side: what a user writes must not
+    # accumulate in log files.
     _preview_text = summarize_user_message_for_log(user_message)
-    _msg_preview = (_preview_text[:80] + "...") if len(_preview_text) > 80 else _preview_text
-    _msg_preview = _msg_preview.replace("\n", " ")
+    if _preview_text:
+        import hashlib as _hashlib
+        _msg_preview = "<%d chars sha256:%s>" % (
+            len(_preview_text),
+            _hashlib.sha256(_preview_text.encode("utf-8")).hexdigest()[:12],
+        )
+    else:
+        _msg_preview = "<empty>"
     logger.info(
         "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
         agent.session_id or "none", agent.model, agent.provider or "unknown",

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -493,7 +493,9 @@ def build_turn_context(
     # Log conversation turn start for debugging/observability.
     # Log a length and a checksum prefix instead of the message body, for
     # the same reason as the gateway side: what a user writes must not
-    # accumulate in log files.
+    # accumulate in log files.  The digest is taken over the value this layer
+    # actually sees, which the gateway may have enriched, so the two logs are
+    # not expected to agree — each identifies its own input.
     _preview_text = summarize_user_message_for_log(user_message)
     if _preview_text:
         import hashlib as _hashlib

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15532,9 +15532,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        _msg_preview = (event.text or "")[:80].replace("\n", " ")
+        # Log a length and a checksum prefix instead of the message body.
+        # A raw preview means everything a user writes accumulates in the log
+        # file for good.  The digest still lets you correlate the same message
+        # across log lines.  It is taken over the whole platform message, so it
+        # will not match a checksum computed over any extracted part of it.
+        def _redact(v):
+            v = v or ""
+            if not v:
+                return "<empty>"
+            import hashlib as _h
+            return "<%d chars sha256:%s>" % (len(v), _h.sha256(v.encode("utf-8")).hexdigest()[:12])
+        _msg_preview = _redact(event.text)
         _reply_id = getattr(event, "reply_to_message_id", None)
-        _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
+        _reply_txt = _redact(getattr(event, "reply_to_text", None))
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
             _platform_name, source.user_name or source.user_id or "unknown",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5429,6 +5429,24 @@ class TurnRunner:
 
 
 
+def _redact_message_text(value) -> str:
+    """Return a length and checksum prefix instead of the message body.
+
+    A raw preview means everything a user writes accumulates in the log file
+    for good. The digest still shows that a message arrived and how long it
+    was, without keeping what it said.
+    """
+    value = value or ""
+    if not value:
+        return "<empty>"
+    import hashlib as _hashlib
+
+    return "<%d chars sha256:%s>" % (
+        len(value),
+        _hashlib.sha256(value.encode("utf-8")).hexdigest()[:12],
+    )
+
+
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -15537,15 +15555,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # file for good.  The digest still lets you correlate the same message
         # across log lines.  It is taken over the whole platform message, so it
         # will not match a checksum computed over any extracted part of it.
-        def _redact(v):
-            v = v or ""
-            if not v:
-                return "<empty>"
-            import hashlib as _h
-            return "<%d chars sha256:%s>" % (len(v), _h.sha256(v.encode("utf-8")).hexdigest()[:12])
-        _msg_preview = _redact(event.text)
+        _msg_preview = _redact_message_text(event.text)
         _reply_id = getattr(event, "reply_to_message_id", None)
-        _reply_txt = _redact(getattr(event, "reply_to_text", None))
+        _reply_txt = _redact_message_text(getattr(event, "reply_to_text", None))
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
             _platform_name, source.user_name or source.user_id or "unknown",
@@ -24343,7 +24355,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         pending = _pending_text or _build_media_placeholder(pending_event)
                     if pending:
-                        logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
+                        logger.debug("Processing queued message after agent completion: %s", _redact_message_text(pending))
 
             # Leftover /steer: if a steer arrived after the last tool batch
             # (e.g. during the final API call), the agent couldn't inject it
@@ -24353,7 +24365,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _leftover_steer = result.get("pending_steer")
                 if _leftover_steer:
                     pending = _leftover_steer
-                    logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+                    logger.debug("Delivering leftover /steer as next turn: %s", _redact_message_text(pending))
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent
@@ -24387,7 +24399,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pending = None
 
             if pending_event or pending:
-                logger.debug("Processing pending message: '%s...'", pending[:40])
+                logger.debug("Processing pending message: %s", _redact_message_text(pending))
 
                 # Clear the adapter's interrupt event so the next _run_agent call
                 # doesn't immediately re-trigger the interrupt before the new agent


### PR DESCRIPTION
`gateway/run.py` and `agent/turn_context.py` write the first ~100 characters of every inbound message to `agent.log`. Anything a user types accumulates there indefinitely — including content the surrounding application deliberately keeps out of its own storage.

**Change:** log the length and a sha256 prefix instead of the text.

```
inbound message: platform=slack user=… msg=<147 chars sha256:a729477c281d>
```

That still shows a message arrived and how long it was, without keeping what it said. `reply_to_text` is redacted the same way; empty values render as `<empty>`.

**Scope:** the queued-message and leftover `/steer` diagnostics are redacted too, so DEBUG logging does not reintroduce raw text.

**On correlation:** an earlier version of this description claimed the digests let you follow one message across both log points. That was wrong — the gateway hashes the raw event text while the turn layer may see an enriched value, so the two are not expected to agree. Each digest identifies its own input, and the comments say so rather than implying a guarantee that does not hold.

This is a policy change rather than a bug fix, so I understand if you would rather have it behind a config flag — happy to rework it that way. Opened separately from #76025 so that one is not held up by this discussion.