### PR TITLE
fix: context-length fallback logging, batch trajectory durability, pool cleanup

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -273,6 +273,11 @@ CONTEXT_PROBE_TIERS = [
 # Default context length when no detection method succeeds.
 DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 
+# (model, base_url) pairs that already emitted the step-9 fallback warning.
+# The fallback result itself is deliberately never cached, so without this
+# the warning would repeat on every resolution for the same unknown model.
+_FALLBACK_WARNED: set = set()
+
 # Minimum context length required to run Hermes Agent.  Models with fewer
 # tokens cannot maintain enough working memory for tool-calling workflows.
 # Sessions, model switches, and cron jobs should reject models below this.
@@ -2773,12 +2778,19 @@ def get_model_context_length(
 
     # 9. Default fallback — log so small-context models (8K, 32K) don't
     #    silently get 256K and cause hard-to-debug API failures.
-    logger.warning(
-        "Could not determine context length for model %r (base_url=%s) "
-        "— falling back to %s tokens. Set model.context_length in "
-        "config.yaml to override.",
-        model, base_url or "default", f"{DEFAULT_FALLBACK_CONTEXT:,}",
-    )
+    #    Warn once per (model, base_url): the fallback result is deliberately
+    #    never cached (a wrong value must not freeze), so without dedup this
+    #    would fire on every resolution — e.g. once per gateway message via
+    #    the session-hygiene path.
+    _warn_key = (model, base_url or "")
+    if _warn_key not in _FALLBACK_WARNED:
+        _FALLBACK_WARNED.add(_warn_key)
+        logger.warning(
+            "Could not determine context length for model %r (base_url=%s) "
+            "— falling back to %s tokens. Set model.context_length in "
+            "config.yaml to override.",
+            model, base_url or "default", f"{DEFAULT_FALLBACK_CONTEXT:,}",
+        )
     return DEFAULT_FALLBACK_CONTEXT
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -273,10 +273,26 @@ CONTEXT_PROBE_TIERS = [
 # Default context length when no detection method succeeds.
 DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 
-# (model, base_url) pairs that already emitted the step-9 fallback warning.
+# (model, base_url) pairs that already emitted the fallback warning.
 # The fallback result itself is deliberately never cached, so without this
 # the warning would repeat on every resolution for the same unknown model.
 _FALLBACK_WARNED: set = set()
+
+
+def _warn_context_length_fallback(model: str, base_url: str) -> None:
+    """Warn (once per model+endpoint) that context detection failed and the
+    hard default is being used, so small-context models (8K, 32K) don't
+    silently get 256K and cause hard-to-debug API failures."""
+    key = (model, base_url or "")
+    if key in _FALLBACK_WARNED:
+        return
+    _FALLBACK_WARNED.add(key)
+    logger.warning(
+        "Could not determine context length for model %r (base_url=%s) "
+        "— falling back to %s tokens. Set model.context_length in "
+        "config.yaml to override.",
+        model, base_url or "default", f"{DEFAULT_FALLBACK_CONTEXT:,}",
+    )
 
 # Minimum context length required to run Hermes Agent.  Models with fewer
 # tokens cannot maintain enough working memory for tool-calling workflows.
@@ -2604,6 +2620,9 @@ def get_model_context_length(
                         f"{length:,}", model, default_model,
                     )
                     return length
+            # Same silent-256K bug class as the step-9 fallback below —
+            # warn here too so custom/local endpoints aren't left invisible.
+            _warn_context_length_fallback(model, base_url)
             return DEFAULT_FALLBACK_CONTEXT
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
@@ -2776,21 +2795,10 @@ def get_model_context_length(
         if default_model in model_lower:
             return length
 
-    # 9. Default fallback — log so small-context models (8K, 32K) don't
-    #    silently get 256K and cause hard-to-debug API failures.
-    #    Warn once per (model, base_url): the fallback result is deliberately
-    #    never cached (a wrong value must not freeze), so without dedup this
-    #    would fire on every resolution — e.g. once per gateway message via
-    #    the session-hygiene path.
-    _warn_key = (model, base_url or "")
-    if _warn_key not in _FALLBACK_WARNED:
-        _FALLBACK_WARNED.add(_warn_key)
-        logger.warning(
-            "Could not determine context length for model %r (base_url=%s) "
-            "— falling back to %s tokens. Set model.context_length in "
-            "config.yaml to override.",
-            model, base_url or "default", f"{DEFAULT_FALLBACK_CONTEXT:,}",
-        )
+    # 9. Default fallback — warn (deduped per model+endpoint) so
+    #    small-context models don't silently get 256K. See
+    #    _warn_context_length_fallback for rationale.
+    _warn_context_length_fallback(model, base_url)
     return DEFAULT_FALLBACK_CONTEXT
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2771,7 +2771,14 @@ def get_model_context_length(
         if default_model in model_lower:
             return length
 
-    # 9. Default fallback — 256K
+    # 9. Default fallback — log so small-context models (8K, 32K) don't
+    #    silently get 256K and cause hard-to-debug API failures.
+    logger.warning(
+        "Could not determine context length for model %r (base_url=%s) "
+        "— falling back to %s tokens. Set model.context_length in "
+        "config.yaml to override.",
+        model, base_url or "default", f"{DEFAULT_FALLBACK_CONTEXT:,}",
+    )
     return DEFAULT_FALLBACK_CONTEXT
 
 

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -485,6 +485,8 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
             # Append to batch output file
             with open(batch_output_file, 'a', encoding='utf-8') as f:
                 f.write(json.dumps(trajectory_entry, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
         
         # Aggregate tool statistics
         for tool_name, stats in result.get("tool_stats", {}).items():
@@ -978,8 +980,15 @@ class BatchRunner:
                         except Exception as ckpt_err:
                             # Don't fail the run if checkpoint write fails
                             print(f"⚠️  Warning: Failed to save incremental checkpoint: {ckpt_err}")
+                except KeyboardInterrupt:
+                    print("\n⚠️  Interrupted — terminating batch workers...")
+                    pool.terminate()
+                    pool.join()
+                    raise
                 except Exception as e:
                     logger.error("Batch worker failed: %s", e, exc_info=True)
+                    pool.terminate()
+                    pool.join()
                     raise
                 finally:
                     root_logger.setLevel(original_level)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1187,19 +1187,40 @@ class TestFallbackWarning:
     """When all 9 detection methods fail, the 10th fallback should log a
     warning so users with small-context models (8K, 32K) don't silently get
     256K and hit hard-to-debug API context-length errors.
+
+    The warning is deduped per (model, base_url) — the fallback result is
+    deliberately never cached, so without dedup it would repeat on every
+    resolution (e.g. once per gateway message via session hygiene).
     """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warned_set(self):
+        from agent import model_metadata as mm
+        mm._FALLBACK_WARNED.clear()
+        yield
+        mm._FALLBACK_WARNED.clear()
+
+    @staticmethod
+    def _patch_all_lookups():
+        from contextlib import ExitStack
+        stack = ExitStack()
+        for target, value in [
+            ("agent.model_metadata.get_cached_context_length", None),
+            ("agent.model_metadata.fetch_model_metadata", {}),
+            ("agent.model_metadata.fetch_endpoint_model_metadata", {}),
+            ("agent.model_metadata._query_ollama_api_show", None),
+            ("agent.model_metadata._query_anthropic_context_length", None),
+            ("agent.model_metadata._endpoint_scoped_context_length", None),
+            ("agent.model_metadata._resolve_endpoint_context_length", None),
+            ("agent.models_dev.lookup_models_dev_context", None),
+        ]:
+            stack.enter_context(patch(target, return_value=value))
+        return stack
 
     def test_warning_emitted_on_fallback(self, caplog):
         import logging
 
-        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
-             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
-             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
-             patch("agent.model_metadata._query_anthropic_context_length", return_value=None), \
-             patch("agent.model_metadata._endpoint_scoped_context_length", return_value=None), \
-             patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None), \
-             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+        with self._patch_all_lookups():
             with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
                 result = get_model_context_length(
                     "totally-unknown-model-xyz",
@@ -1210,6 +1231,21 @@ class TestFallbackWarning:
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("totally-unknown-model-xyz" in r.getMessage() for r in warning_msgs)
         assert any("model.context_length" in r.getMessage() for r in warning_msgs)
+
+    def test_warning_fires_once_per_model(self, caplog):
+        """Repeated resolutions of the same unknown model warn only once."""
+        import logging
+
+        with self._patch_all_lookups():
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                for _ in range(3):
+                    get_model_context_length("totally-unknown-model-xyz")
+
+        fallback_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "falling back" in r.getMessage()
+        ]
+        assert len(fallback_warnings) == 1
 
     def test_no_warning_when_cached(self, caplog):
         """No fallback warning when the context length is found in the cache."""

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1177,3 +1177,57 @@ class TestMoAContextLength:
         assert compressor.context_length == configured_context
         assert compressor.threshold_tokens == configured_context // 2
         endpoint_probe.assert_not_called()
+
+
+# =========================================================================
+# Fallback diagnostic logging
+# =========================================================================
+
+class TestFallbackWarning:
+    """When all 9 detection methods fail, the 10th fallback should log a
+    warning so users with small-context models (8K, 32K) don't silently get
+    256K and hit hard-to-debug API context-length errors.
+    """
+
+    def test_warning_emitted_on_fallback(self, caplog):
+        import logging
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.model_metadata._query_anthropic_context_length", return_value=None), \
+             patch("agent.model_metadata._endpoint_scoped_context_length", return_value=None), \
+             patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                result = get_model_context_length(
+                    "totally-unknown-model-xyz",
+                )
+
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        # The warning must mention the model name and the config override hint.
+        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("totally-unknown-model-xyz" in r.getMessage() for r in warning_msgs)
+        assert any("model.context_length" in r.getMessage() for r in warning_msgs)
+
+    def test_no_warning_when_cached(self, caplog):
+        """No fallback warning when the context length is found in the cache."""
+        import logging
+
+        with patch(
+            "agent.model_metadata.get_cached_context_length",
+            return_value=32_000,
+        ):
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                result = get_model_context_length(
+                    "some-model",
+                    base_url="http://127.0.0.1:1/v1",
+                )
+
+        assert result == 32_000
+        fallback_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "falling back" in r.getMessage()
+        ]
+        assert len(fallback_warnings) == 0

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1247,6 +1247,24 @@ class TestFallbackWarning:
         ]
         assert len(fallback_warnings) == 1
 
+    def test_warning_emitted_on_custom_endpoint_fallback(self, caplog):
+        """The sibling step-3b fallback (custom/local endpoint, probes down,
+        no catalog match) is the same silent-256K bug class and must warn too."""
+        import logging
+
+        with self._patch_all_lookups(), \
+             patch("agent.model_metadata._query_local_context_length", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                result = get_model_context_length(
+                    "totally-unknown-model-xyz",
+                    base_url="http://192.168.1.50:8080/v1",
+                )
+
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("totally-unknown-model-xyz" in r.getMessage() for r in warning_msgs)
+        assert any("model.context_length" in r.getMessage() for r in warning_msgs)
+
     def test_no_warning_when_cached(self, caplog):
         """No fallback warning when the context length is found in the cache."""
         import logging

--- a/tests/test_batch_runner_durability.py
+++ b/tests/test_batch_runner_durability.py
@@ -1,0 +1,187 @@
+"""Tests for batch_runner trajectory durability and pool cleanup.
+
+Verifies:
+  1. Trajectory entries are fsync'd to disk before the checkpoint marks
+     them as completed (crash-between-write-and-sync safety).
+  2. Pool.terminate() + pool.join() are called on KeyboardInterrupt and
+     Exception during batch execution (responsive worker shutdown).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# batch_runner uses relative imports, ensure project root is on path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from batch_runner import BatchRunner, _process_batch_worker
+
+
+# =========================================================================
+# Trajectory write durability (fsync)
+# =========================================================================
+
+class TestTrajectoryWriteDurability:
+    """Verify that trajectory entries are flushed and fsync'd before the
+    checkpoint marks them as completed.
+
+    Without fsync, a crash between the write and the disk sync would leave
+    the checkpoint claiming completion with no trajectory data on disk.
+    """
+
+    def test_trajectory_entry_is_synced_to_disk(self, tmp_path, monkeypatch):
+        """_process_batch_worker should flush+fsync the trajectory file."""
+        prompt_result = {
+            "success": True,
+            "trajectory": [{"role": "assistant", "content": "x"}],
+            "reasoning_stats": {"has_any_reasoning": True},
+            "tool_stats": {},
+            "metadata": {},
+            "completed": True,
+            "api_calls": 1,
+            "toolsets_used": [],
+        }
+
+        monkeypatch.setattr(
+            "batch_runner._process_single_prompt", lambda *a, **kw: prompt_result
+        )
+
+        # Intercept os.fsync to record calls
+        fsync_calls = []
+        original_fsync = os.fsync
+
+        def mock_fsync(fd):
+            fsync_calls.append(fd)
+
+        monkeypatch.setattr("os.fsync", mock_fsync)
+
+        result = _process_batch_worker(
+            (
+                1,
+                [(0, {"prompt": "hi"})],
+                tmp_path,
+                set(),
+                {"verbose": False},
+            )
+        )
+
+        # Verify fsync was called at least once during trajectory write
+        assert len(fsync_calls) >= 1, (
+            "os.fsync was not called — trajectory writes are not durable"
+        )
+
+        # Verify the trajectory file exists and is valid
+        output_files = list(tmp_path.glob("*.jsonl"))
+        assert len(output_files) >= 1
+        for f in output_files:
+            lines = f.read_text().strip().split("\n")
+            for line in lines:
+                if line:
+                    entry = json.loads(line)
+                    assert "conversations" in entry
+                    assert "completed" in entry
+
+
+# =========================================================================
+# Pool cleanup on interruption / exception
+# =========================================================================
+
+class TestPoolCleanupOnInterruption:
+    """Verify that pool.terminate() + pool.join() are called when a
+    KeyboardInterrupt or Exception occurs during batch execution.
+
+    CPython's multiprocessing.pool.Pool.join() does NOT accept a timeout
+    parameter — calling pool.join(timeout=10) raises TypeError.  The fix
+    uses pool.terminate() followed by pool.join() (no timeout), which is
+    the correct shutdown pattern.
+    """
+
+    def test_pool_terminate_called_on_exception(self, tmp_path, monkeypatch):
+        """When pool.imap_unordered raises an exception, pool.terminate()
+        and pool.join() must be called for clean worker shutdown.
+
+        We simulate the relevant slice of run()'s try/except block with a
+        mock pool to verify the cleanup contract.
+        """
+        mock_pool = MagicMock()
+        mock_pool.imap_unordered.side_effect = RuntimeError("worker exploded")
+
+        # Reproduce the exception-handling block from batch_runner.run()
+        with pytest.raises(RuntimeError, match="worker exploded"):
+            try:
+                for result in mock_pool.imap_unordered(None, []):
+                    pass
+            except KeyboardInterrupt:
+                mock_pool.terminate()
+                mock_pool.join()
+                raise
+            except Exception:
+                mock_pool.terminate()
+                mock_pool.join()
+                raise
+
+        mock_pool.terminate.assert_called_once()
+        mock_pool.join.assert_called_once_with()
+
+    def test_pool_terminate_called_on_keyboard_interrupt(self, tmp_path, monkeypatch):
+        """When pool.imap_unordered is interrupted (Ctrl+C), pool.terminate()
+        and pool.join() must be called for responsive shutdown."""
+        mock_pool = MagicMock()
+        mock_pool.imap_unordered.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            try:
+                for result in mock_pool.imap_unordered(None, []):
+                    pass
+            except KeyboardInterrupt:
+                mock_pool.terminate()
+                mock_pool.join()
+                raise
+            except Exception:
+                mock_pool.terminate()
+                mock_pool.join()
+                raise
+
+        mock_pool.terminate.assert_called_once()
+        mock_pool.join.assert_called_once_with()
+
+    def test_pool_join_called_without_timeout(self, tmp_path):
+        """Pool.join() must NOT be called with a timeout argument —
+        CPython's Pool.join signature is (self), so join(timeout=10)
+        would raise TypeError."""
+        mock_pool = MagicMock()
+        mock_pool.imap_unordered.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            try:
+                for result in mock_pool.imap_unordered(None, []):
+                    pass
+            except Exception:
+                mock_pool.terminate()
+                mock_pool.join()
+                raise
+
+        # The join call must have no positional/keyword timeout argument
+        join_call = mock_pool.join.call_args
+        assert join_call == call(), (
+            f"pool.join() called with unexpected args: {join_call}"
+        )
+
+    def test_real_pool_join_accepts_no_timeout(self):
+        """Integration check: a real multiprocessing.Pool's join() must not
+        accept a timeout kwarg.  This guards against re-introducing
+        pool.join(timeout=10), which raises TypeError on CPython.
+        """
+        import inspect
+        import multiprocessing.pool
+
+        sig = inspect.signature(multiprocessing.pool.Pool.join)
+        params = list(sig.parameters.keys())
+        # The only parameter should be 'self' — no 'timeout'
+        assert "timeout" not in params, (
+            f"Pool.join has unexpected parameters: {params}"
+        )

--- a/tests/test_batch_runner_durability.py
+++ b/tests/test_batch_runner_durability.py
@@ -3,21 +3,26 @@
 Verifies:
   1. Trajectory entries are fsync'd to disk before the checkpoint marks
      them as completed (crash-between-write-and-sync safety).
-  2. Pool.terminate() + pool.join() are called on KeyboardInterrupt and
-     Exception during batch execution (responsive worker shutdown).
+  2. BatchRunner.run() calls pool.terminate() + pool.join() on
+     KeyboardInterrupt and Exception during batch execution (responsive
+     worker shutdown).  CPython's Pool.join() takes no timeout parameter —
+     join(timeout=10) raises TypeError — so the tests also assert join()
+     is invoked with no arguments.
 """
 
 import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-# batch_runner uses relative imports, ensure project root is on path
+# batch_runner is a root-level module (not part of an installed package),
+# so make the repo root importable when tests run from elsewhere.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import batch_runner
 from batch_runner import BatchRunner, _process_batch_worker
 
 
@@ -26,10 +31,9 @@ from batch_runner import BatchRunner, _process_batch_worker
 # =========================================================================
 
 class TestTrajectoryWriteDurability:
-    """Verify that trajectory entries are flushed and fsync'd before the
-    checkpoint marks them as completed.
+    """Verify that trajectory entries are flushed and fsync'd to disk.
 
-    Without fsync, a crash between the write and the disk sync would leave
+    Without fsync, a crash between the write and the disk sync could leave
     the checkpoint claiming completion with no trajectory data on disk.
     """
 
@@ -52,14 +56,9 @@ class TestTrajectoryWriteDurability:
 
         # Intercept os.fsync to record calls
         fsync_calls = []
-        original_fsync = os.fsync
+        monkeypatch.setattr("os.fsync", lambda fd: fsync_calls.append(fd))
 
-        def mock_fsync(fd):
-            fsync_calls.append(fd)
-
-        monkeypatch.setattr("os.fsync", mock_fsync)
-
-        result = _process_batch_worker(
+        _process_batch_worker(
             (
                 1,
                 [(0, {"prompt": "hi"})],
@@ -87,101 +86,51 @@ class TestTrajectoryWriteDurability:
 
 
 # =========================================================================
-# Pool cleanup on interruption / exception
+# Pool cleanup on interruption / exception — drives the REAL run()
 # =========================================================================
 
-class TestPoolCleanupOnInterruption:
-    """Verify that pool.terminate() + pool.join() are called when a
-    KeyboardInterrupt or Exception occurs during batch execution.
+def _make_runner(tmp_path, monkeypatch):
+    """Build a minimal real BatchRunner against a 1-line tmp dataset."""
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(json.dumps({"prompt": "hi"}) + "\n", encoding="utf-8")
+    # BatchRunner writes to Path("data")/run_name relative to cwd.
+    monkeypatch.chdir(tmp_path)
+    return BatchRunner(
+        dataset_file=str(dataset),
+        batch_size=1,
+        run_name="pool-cleanup-test",
+        num_workers=1,
+    )
 
-    CPython's multiprocessing.pool.Pool.join() does NOT accept a timeout
-    parameter — calling pool.join(timeout=10) raises TypeError.  The fix
-    uses pool.terminate() followed by pool.join() (no timeout), which is
-    the correct shutdown pattern.
+
+def _make_failing_pool(exc):
+    """Context-manager mock whose pool raises `exc` from imap_unordered."""
+    pool = MagicMock()
+    pool.imap_unordered.side_effect = exc
+    pool_cm = MagicMock()
+    pool_cm.__enter__ = MagicMock(return_value=pool)
+    pool_cm.__exit__ = MagicMock(return_value=False)
+    return pool, pool_cm
+
+
+class TestPoolCleanupOnInterruption:
+    """Drive the real BatchRunner.run() with a patched Pool and verify the
+    cleanup contract: terminate() + join() (join with NO timeout argument —
+    CPython's Pool.join signature is (self), so join(timeout=10) would
+    raise TypeError).
     """
 
-    def test_pool_terminate_called_on_exception(self, tmp_path, monkeypatch):
-        """When pool.imap_unordered raises an exception, pool.terminate()
-        and pool.join() must be called for clean worker shutdown.
+    @pytest.mark.parametrize("exc_type", [KeyboardInterrupt, RuntimeError])
+    def test_run_terminates_and_joins_pool(self, tmp_path, monkeypatch, exc_type):
+        runner = _make_runner(tmp_path, monkeypatch)
+        pool, pool_cm = _make_failing_pool(exc_type("boom"))
 
-        We simulate the relevant slice of run()'s try/except block with a
-        mock pool to verify the cleanup contract.
-        """
-        mock_pool = MagicMock()
-        mock_pool.imap_unordered.side_effect = RuntimeError("worker exploded")
+        with patch.object(batch_runner, "Pool", return_value=pool_cm):
+            with pytest.raises(exc_type):
+                runner.run()
 
-        # Reproduce the exception-handling block from batch_runner.run()
-        with pytest.raises(RuntimeError, match="worker exploded"):
-            try:
-                for result in mock_pool.imap_unordered(None, []):
-                    pass
-            except KeyboardInterrupt:
-                mock_pool.terminate()
-                mock_pool.join()
-                raise
-            except Exception:
-                mock_pool.terminate()
-                mock_pool.join()
-                raise
-
-        mock_pool.terminate.assert_called_once()
-        mock_pool.join.assert_called_once_with()
-
-    def test_pool_terminate_called_on_keyboard_interrupt(self, tmp_path, monkeypatch):
-        """When pool.imap_unordered is interrupted (Ctrl+C), pool.terminate()
-        and pool.join() must be called for responsive shutdown."""
-        mock_pool = MagicMock()
-        mock_pool.imap_unordered.side_effect = KeyboardInterrupt()
-
-        with pytest.raises(KeyboardInterrupt):
-            try:
-                for result in mock_pool.imap_unordered(None, []):
-                    pass
-            except KeyboardInterrupt:
-                mock_pool.terminate()
-                mock_pool.join()
-                raise
-            except Exception:
-                mock_pool.terminate()
-                mock_pool.join()
-                raise
-
-        mock_pool.terminate.assert_called_once()
-        mock_pool.join.assert_called_once_with()
-
-    def test_pool_join_called_without_timeout(self, tmp_path):
-        """Pool.join() must NOT be called with a timeout argument —
-        CPython's Pool.join signature is (self), so join(timeout=10)
-        would raise TypeError."""
-        mock_pool = MagicMock()
-        mock_pool.imap_unordered.side_effect = RuntimeError("boom")
-
-        with pytest.raises(RuntimeError):
-            try:
-                for result in mock_pool.imap_unordered(None, []):
-                    pass
-            except Exception:
-                mock_pool.terminate()
-                mock_pool.join()
-                raise
-
-        # The join call must have no positional/keyword timeout argument
-        join_call = mock_pool.join.call_args
-        assert join_call == call(), (
-            f"pool.join() called with unexpected args: {join_call}"
-        )
-
-    def test_real_pool_join_accepts_no_timeout(self):
-        """Integration check: a real multiprocessing.Pool's join() must not
-        accept a timeout kwarg.  This guards against re-introducing
-        pool.join(timeout=10), which raises TypeError on CPython.
-        """
-        import inspect
-        import multiprocessing.pool
-
-        sig = inspect.signature(multiprocessing.pool.Pool.join)
-        params = list(sig.parameters.keys())
-        # The only parameter should be 'self' — no 'timeout'
-        assert "timeout" not in params, (
-            f"Pool.join has unexpected parameters: {params}"
+        pool.terminate.assert_called_once()
+        # join() must be called with no positional/keyword arguments.
+        assert pool.join.call_args_list == [call()], (
+            f"pool.join() called with unexpected args: {pool.join.call_args_list}"
         )


### PR DESCRIPTION
## Salvage of #6629

Addresses the review feedback on #6629 by @aaronlab. The original PR identified three valid concerns but had issues that prevented merging — this PR reworks the still-relevant parts against current `main`.

### What was wrong with #6629

Per the [sweeper review](https://github.com/NousResearch/hermes-agent/pull/6629#pullrequestreview-4679863797):

1. **Token estimation fix already landed** — ceiling division `(len + 3) // 4` shipped as `5c2ecdec` with additional CJK handling. Removed.
2. **`Pool.join(timeout=10)` is invalid** — CPython's `multiprocessing.pool.Pool.join` signature is `(self)`; no timeout parameter. Both exception paths would raise `TypeError`. Fixed.
3. **Config guidance wrong** — PR said `context_length` but the resolver uses `model.context_length` (`agent/model_metadata.py:2232-2236`). Fixed.
4. **AUDIT_ITERATION_2.md / SUMMARY.txt** — 624 lines of unrelated audit documents. Not included.

### What this PR does (3 changes)

#### 1. Context-length fallback diagnostic (`agent/model_metadata.py`)
`get_model_context_length()` silently returned 256K when all 9 detection methods failed. Users with small-context models (8K, 32K) would silently get 256K, causing hard-to-debug API context-length errors. Added a `logger.warning()` at the step 9 fallback with:
- Model name and base_url (so users know which model triggered it)
- The correct config override hint: `model.context_length` (not `context_length`)

#### 2. Fsync for batch trajectory writes (`batch_runner.py`)
Trajectory entries were written without `flush()`/`fsync()`, but the checkpoint immediately marked them as completed. A crash between write and disk sync would leave the checkpoint claiming completion with no trajectory data on disk. Added `f.flush()` + `os.fsync(f.fileno())`.

#### 3. Pool cleanup on interruption (`batch_runner.py`)
`Ctrl+C` during `pool.imap_unordered()` relied on context manager cleanup which can hang. Added explicit `pool.terminate()` + `pool.join()` for both `KeyboardInterrupt` and `Exception` paths. Uses `pool.join()` **without** a timeout argument (the correct CPython API).

### Tests

| Test | What it verifies |
|------|-----------------|
| `test_warning_emitted_on_fallback` | Warning fires at step 9 with model name + config hint |
| `test_no_warning_when_cached` | No false warning when cache hits |
| `test_trajectory_entry_is_synced_to_disk` | `os.fsync` is called during trajectory writes |
| `test_pool_terminate_called_on_exception` | `terminate()` + `join()` called on `RuntimeError` |
| `test_pool_terminate_called_on_keyboard_interrupt` | `terminate()` + `join()` called on `Ctrl+C` |
| `test_pool_join_called_without_timeout` | `join()` called with no timeout argument |
| `test_real_pool_join_accepts_no_timeout` | Integration check: CPython `Pool.join` has no timeout param |

All 7 new tests pass. 71 existing tests in the same files still pass.

### Does #6622 supersede #6629?

No. They touch completely different files and concerns:
- **#6629**: `agent/model_metadata.py`, `batch_runner.py` (token estimation, context logging, batch durability)
- **#6622**: `agent/auxiliary_client.py`, `hermes_cli/plugins.py`, `plugins/memory/holographic/store.py` (error chaining, WAL checkpoint, hook timeout)

Both PRs share the same unrelated audit documents but their code changes are independent.

### Credits

Original investigation by @aaronlab in #6629. Co-authored-by preserved in commit.

### Review follow-up (commit 2)

Post-review /simplify-code pass (3-reviewer parallel + 4-angle deep review) surfaced and fixed:

1. **Warning dedup** — the step-9 fallback result is deliberately never cached, so the warning fired on **every** resolution — traced to once-per-gateway-message via the session-hygiene path (`gateway/run.py` `_handle_message_with_agent`). Now warns once per `(model, base_url)` via a module-level dedup set (same idiom as `model_tools._WARNED_DISABLED_BUNDLES`).
2. **Pool-cleanup tests now drive the real `run()`** — the original three tests reproduced the try/except block inline against a `MagicMock` and passed even with the production code reverted (verified empirically). Replaced with a parametrized test that patches `batch_runner.Pool` and calls the real `BatchRunner.run()`; asserts `terminate()` + `join()` with no args.
3. **Dropped `test_real_pool_join_accepts_no_timeout`** — a change-detector on the CPython stdlib signature that didn't guard `batch_runner` at all.
4. Added `test_warning_fires_once_per_model`; removed dead imports.

Mutation check: all 5 remaining new tests fail against pre-PR `batch_runner.py`/`model_metadata.py`, pass with the fix.

Note: `with Pool(...)` already calls `terminate()` in `__exit__`; the explicit handlers add `join()` (block until workers are reaped) plus the user-visible interrupt message and terminate-before-`Progress.__exit__` ordering.

### Review follow-up (commit 3)

Reuse-reviewer HIGH from the second /simplify-code pass, verified real: the **step-3b probe-down fallback for custom/local endpoints** (`model_metadata.py` ~2602) returns the same silent 256K default but only logged at INFO — invisible by default, and it's the *more common* path for small local models (the exact users this warning exists for). Extracted `_warn_context_length_fallback()` (deduped per `(model, base_url)`) and wired it into **both** fallback sites, per the fix-the-whole-bug-class rule. New regression test drives the custom-endpoint path; mutation-checked (fails without the widening).
