### PR TITLE
fix(tools): truncate exception text in tool error log handlers (#75927)

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1019,8 +1019,10 @@ def image_generate_tool(
 
     except Exception as e:
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
-        error_msg = f"Error generating image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        _detail = str(e)
+        error_msg = f"Error generating image: {_detail}"
+        logger.error("Error generating image: %s",
+                     _detail[:2000] if len(_detail) > 2000 else _detail)
 
         response_data = {
             "success": False,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3146,13 +3146,17 @@ def text_to_speech_tool(
         return tool_error(error_msg, success=False)
     except FileNotFoundError as e:
         # Missing dependencies or files
-        error_msg = f"TTS dependency missing ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
+        _detail = str(e)
+        error_msg = f"TTS dependency missing ({provider}): {_detail}"
+        logger.error("TTS dependency missing (%s): %s", provider,
+                     _detail[:2000] if len(_detail) > 2000 else _detail)
         return tool_error(error_msg, success=False)
     except Exception as e:
         # Unexpected errors
-        error_msg = f"TTS generation failed ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
+        _detail = str(e)
+        error_msg = f"TTS generation failed ({provider}): {_detail}"
+        logger.error("TTS generation failed (%s): %s", provider,
+                     _detail[:2000] if len(_detail) > 2000 else _detail)
         return tool_error(error_msg, success=False)
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1322,8 +1322,10 @@ async def vision_analyze_tool(
         return json.dumps(result, indent=2, ensure_ascii=False)
         
     except Exception as e:
-        error_msg = f"Error analyzing image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        _detail = str(e)
+        error_msg = f"Error analyzing image: {_detail}"
+        logger.error("Error analyzing image: %s",
+                     _detail[:2000] if len(_detail) > 2000 else _detail)
         
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
@@ -1805,8 +1807,10 @@ async def video_analyze_tool(
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     except Exception as e:
-        error_msg = f"Error analyzing video: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        _detail = str(e)
+        error_msg = f"Error analyzing video: {_detail}"
+        logger.error("Error analyzing video: %s",
+                     _detail[:2000] if len(_detail) > 2000 else _detail)
 
         err_str = str(e).lower()
         if any(hint in err_str for hint in (


### PR DESCRIPTION
## Problem

Five tool error handlers interpolate an unbounded `str(e)` into the log message **and** pass `exc_info=True`. When the underlying HTTP error carries a large response body (e.g. an HTML challenge page from Cloudflare), the entire body is written to the log **twice per failure**.

The reporter measured **90.6 MB of gateway.error.log** from 54 failed `vision_analyze` calls.

## Fix

Truncate exception text to 2000 chars in the log message at all five sites. Drop `exc_info=True` to eliminate the second unbounded write.

Full exception text preserved in `error_msg` returned to the agent.

## Sites changed

| File | Line | Message |
|---|---|---|
| `tools/vision_tools.py` | 1325 | `Error analyzing image` |
| `tools/vision_tools.py` | 1808 | `Error analyzing video` |
| `tools/image_generation_tool.py` | 1022 | `Error generating image` |
| `tools/tts_tool.py` | 3149 | `TTS dependency missing` |
| `tools/tts_tool.py` | 3154 | `TTS generation failed` |

Follows existing convention in `agent/tool_executor.py:1179`.

Fixes #75927