### PR TITLE
fix(profiles): clean interrupted profile clones

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -22,6 +22,7 @@ Usage::
 import json
 import os
 import re
+import secrets
 import shlex
 import shutil
 import stat
@@ -988,75 +989,50 @@ def profiles_to_serve(multiplex: bool) -> List[Tuple[str, Path]]:
     return serve
 
 
-def create_profile(
-    name: str,
-    clone_from: Optional[str] = None,
-    clone_all: bool = False,
-    clone_config: bool = False,
-    no_alias: bool = False,
-    no_skills: bool = False,
-    description: Optional[str] = None,
-) -> Path:
-    """Create a new profile directory.
+def _new_profile_staging_root(profiles_root: Path, canon: str) -> Path:
+    """Create a private, uniquely owned staging root below ``profiles_root``."""
+    profiles_root.mkdir(parents=True, exist_ok=True)
+    prefix = f".{canon}.creating-"
+    for _ in range(10):
+        staging_root = profiles_root / f"{prefix}{secrets.token_hex(8)}"
+        try:
+            staging_root.mkdir(mode=0o700)
+        except FileExistsError:
+            continue
+        return staging_root
+    raise FileExistsError(f"Could not allocate a staging directory for profile '{canon}'")
 
-    Parameters
-    ----------
-    name:
-        Profile identifier (lowercase, alphanumeric, hyphens, underscores).
-    clone_from:
-        Source profile to clone from. If ``None`` and clone_config/clone_all
-        is True, defaults to the currently active profile.
-    clone_all:
-        If True, do a full copytree of the source (all state).
-    clone_config:
-        If True, copy config files (config.yaml, .env, SOUL.md), installed
-        skills, and selected profile identity files from the source profile.
-    no_alias:
-        If True, skip wrapper script creation.
-    no_skills:
-        If True, create an empty profile with no bundled skills, and write
-        a marker file so ``hermes update`` skips re-seeding this profile's
-        skills. Mutually exclusive with ``clone_config``/``clone_all`` (those
-        explicitly copy skills from the source).
 
-    Returns
-    -------
-    Path
-        The newly created profile directory.
-    """
-    if no_skills and (clone_from is not None or clone_config or clone_all):
-        raise ValueError(
-            "--no-skills is mutually exclusive with --clone / --clone-from / --clone-all "
-            "(cloning explicitly copies skills from the source profile)."
-        )
-    canon = normalize_profile_name(name)
-    validate_profile_name(canon)
+def _discard_profile_staging_root(
+    staging_root: Path, profiles_root: Path, canon: str
+) -> None:
+    """Remove only the staging root allocated for this profile creation."""
+    prefix = f".{canon}.creating-"
+    suffix = staging_root.name.removeprefix(prefix)
+    if (
+        staging_root.parent != profiles_root
+        or not staging_root.name.startswith(prefix)
+        or re.fullmatch(r"[0-9a-f]{16}", suffix) is None
+    ):
+        raise RuntimeError(f"Refusing to remove unbounded profile staging path: {staging_root}")
 
-    if canon == "default":
-        raise ValueError(
-            "Cannot create a profile named 'default' — it is the built-in profile (~/.hermes)."
-        )
+    if not os.path.lexists(staging_root):
+        return
+    if staging_root.is_symlink():
+        staging_root.unlink()
+        return
+    _rmtree_with_retry(staging_root, _make_rmtree_path_writable)
 
-    profile_dir = get_profile_dir(canon)
-    if profile_dir.exists():
-        raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
 
-    # Resolve clone source
-    source_dir = None
-    if clone_from is not None or clone_all or clone_config:
-        if clone_from is None:
-            # Default: clone from active profile
-            from hermes_constants import get_hermes_home
-            source_dir = get_hermes_home()
-        else:
-            clone_from = normalize_profile_name(clone_from)
-            validate_profile_name(clone_from)
-            source_dir = get_profile_dir(clone_from)
-        if not source_dir.is_dir():
-            raise FileNotFoundError(
-                f"Source profile '{clone_from or 'active'}' does not exist at {source_dir}"
-            )
-
+def _populate_profile_directory(
+    profile_dir: Path,
+    source_dir: Optional[Path],
+    *,
+    clone_all: bool,
+    no_skills: bool,
+    description: Optional[str],
+) -> None:
+    """Build a complete profile inside an unpublished staging directory."""
     if clone_all and source_dir:
         # Full copy of source profile (exclude sibling ~/.hermes/profiles/)
         shutil.copytree(
@@ -1097,7 +1073,12 @@ def create_profile(
             # same agent capabilities as the source profile.
             source_skills = source_dir / "skills"
             if source_skills.is_dir():
-                shutil.copytree(source_skills, profile_dir / "skills", symlinks=True, dirs_exist_ok=True)
+                shutil.copytree(
+                    source_skills,
+                    profile_dir / "skills",
+                    symlinks=True,
+                    dirs_exist_ok=True,
+                )
 
             # Clone memory and other subdirectory files
             for relpath in _CLONE_SUBDIR_FILES:
@@ -1169,6 +1150,103 @@ def create_profile(
             )
         except Exception:
             pass  # non-fatal — user can describe later with `hermes profile describe`
+
+
+def create_profile(
+    name: str,
+    clone_from: Optional[str] = None,
+    clone_all: bool = False,
+    clone_config: bool = False,
+    no_alias: bool = False,
+    no_skills: bool = False,
+    description: Optional[str] = None,
+) -> Path:
+    """Create a new profile directory.
+
+    Parameters
+    ----------
+    name:
+        Profile identifier (lowercase, alphanumeric, hyphens, underscores).
+    clone_from:
+        Source profile to clone from. If ``None`` and clone_config/clone_all
+        is True, defaults to the currently active profile.
+    clone_all:
+        If True, do a full copytree of the source (all state).
+    clone_config:
+        If True, copy config files (config.yaml, .env, SOUL.md), installed
+        skills, and selected profile identity files from the source profile.
+    no_alias:
+        If True, skip wrapper script creation.
+    no_skills:
+        If True, create an empty profile with no bundled skills, and write
+        a marker file so ``hermes update`` skips re-seeding this profile's
+        skills. Mutually exclusive with ``clone_config``/``clone_all`` (those
+        explicitly copy skills from the source).
+
+    Returns
+    -------
+    Path
+        The newly created profile directory.
+    """
+    if no_skills and (clone_from is not None or clone_config or clone_all):
+        raise ValueError(
+            "--no-skills is mutually exclusive with --clone / --clone-from / --clone-all "
+            "(cloning explicitly copies skills from the source profile)."
+        )
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+
+    if canon == "default":
+        raise ValueError(
+            "Cannot create a profile named 'default' — it is the built-in profile (~/.hermes)."
+        )
+
+    profile_dir = get_profile_dir(canon)
+    if os.path.lexists(profile_dir):
+        raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
+
+    # Resolve clone source
+    source_dir = None
+    if clone_from is not None or clone_all or clone_config:
+        if clone_from is None:
+            # Default: clone from active profile
+            from hermes_constants import get_hermes_home
+            source_dir = get_hermes_home()
+        else:
+            clone_from = normalize_profile_name(clone_from)
+            validate_profile_name(clone_from)
+            source_dir = get_profile_dir(clone_from)
+        if not source_dir.is_dir():
+            raise FileNotFoundError(
+                f"Source profile '{clone_from or 'active'}' does not exist at {source_dir}"
+            )
+
+    profiles_root = _get_profiles_root()
+    staging_root = _new_profile_staging_root(profiles_root, canon)
+    candidate_dir = staging_root / "profile"
+
+    try:
+        _populate_profile_directory(
+            candidate_dir,
+            source_dir,
+            clone_all=clone_all,
+            no_skills=no_skills,
+            description=description,
+        )
+
+        # Re-check immediately before publication to catch a destination that
+        # appeared while staging. A dangling symlink also counts as occupied.
+        if os.path.lexists(profile_dir):
+            raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
+        candidate_dir.rename(profile_dir)
+    except BaseException as exc:
+        try:
+            _discard_profile_staging_root(staging_root, profiles_root, canon)
+        except Exception as cleanup_error:
+            exc.add_note(f"Could not remove profile staging directory: {cleanup_error}")
+        raise
+    else:
+        _discard_profile_staging_root(staging_root, profiles_root, canon)
 
     # Phase 4: when running inside a container under s6, register the
     # new profile's gateway as a runtime s6 service so
@@ -1431,6 +1509,28 @@ def _stop_profile_backends(canon: str, profile_dir: Path) -> None:
     print(f"✓ Stopped {len(pids)} profile backend process(es)")
 
 
+def _make_rmtree_path_writable(func, path, exc) -> None:
+    """Retry an rmtree operation after making its path and parent writable."""
+    if isinstance(exc, tuple):
+        exc = exc[1]
+
+    if not isinstance(exc, PermissionError):
+        raise exc
+
+    try:
+        os.chmod(path, os.stat(path).st_mode | stat.S_IWUSR)
+    except OSError:
+        pass
+
+    parent = os.path.dirname(path)
+    if parent:
+        try:
+            os.chmod(parent, os.stat(parent).st_mode | stat.S_IWUSR)
+        except OSError:
+            pass
+    func(path)
+
+
 def _rmtree_with_retry(profile_dir: Path, onexc_handler) -> None:
     """``shutil.rmtree`` with a short retry loop for transient races.
 
@@ -1553,44 +1653,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # 4. Remove profile directory
     remove_error: Exception | None = None
     try:
-        def _make_writable(func, path, exc):
-            """onexc/onerror handler: add +w on PermissionError so rmtree can proceed.
-
-            Handles two cases on NixOS (and other systems with read-only
-            copies from immutable stores):
-            1. The path itself isn't writable (e.g. a file with mode 0444)
-            2. The *parent* directory isn't writable (e.g. mode 0555)
-
-            Compatible with both the ``onexc`` API (3.12+, receives an
-            exception instance) and the ``onerror`` API (3.11-, receives
-            ``sys.exc_info()`` tuple).
-            """
-            import stat as _stat
-
-            # Normalise the two callback signatures:
-            #   onexc(func, path, exc_instance)   — 3.12+
-            #   onerror(func, path, exc_info_tuple) — 3.11
-            if isinstance(exc, tuple):
-                exc = exc[1]  # exc_info → actual exception object
-
-            if isinstance(exc, PermissionError):
-                # Make the path writable
-                try:
-                    os.chmod(path, os.stat(path).st_mode | _stat.S_IWUSR)
-                except OSError:
-                    pass
-                # Also make the parent writable (needed for unlink/rmdir)
-                parent = os.path.dirname(path)
-                if parent:
-                    try:
-                        os.chmod(parent, os.stat(parent).st_mode | _stat.S_IWUSR)
-                    except OSError:
-                        pass
-                func(path)
-            else:
-                raise
-
-        _rmtree_with_retry(profile_dir, _make_writable)
+        _rmtree_with_retry(profile_dir, _make_rmtree_path_writable)
         print(f"✓ Removed {profile_dir}")
     except Exception as e:
         print(f"⚠ Could not remove {profile_dir}: {e}")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -114,6 +114,71 @@ class TestGetProfileDir:
 class TestCreateProfile:
     """Tests for create_profile()."""
 
+    def test_interrupted_clone_all_cleans_partial_tree_and_can_retry(
+        self, profile_env, monkeypatch
+    ):
+        default_home = profile_env / ".hermes"
+        (default_home / "payload.txt").write_text("complete", encoding="utf-8")
+        target = get_profile_dir("coder")
+        profiles_root = _get_profiles_root()
+        real_copytree = shutil.copytree
+        copy_destinations = []
+
+        def interrupting_copytree(source, destination, *args, **kwargs):
+            destination = Path(destination)
+            copy_destinations.append(destination)
+            destination.mkdir(parents=True, exist_ok=True)
+            (destination / "partial.txt").write_text("partial", encoding="utf-8")
+            raise KeyboardInterrupt
+
+        register_service = MagicMock()
+        monkeypatch.setattr(profiles, "_maybe_register_gateway_service", register_service)
+        monkeypatch.setattr(profiles.shutil, "copytree", interrupting_copytree)
+
+        with pytest.raises(KeyboardInterrupt):
+            create_profile("coder", clone_all=True, no_alias=True)
+
+        assert copy_destinations
+        assert copy_destinations[0] != target
+        assert not target.exists()
+        assert list(profiles_root.glob(".coder.creating-*")) == []
+        register_service.assert_not_called()
+
+        monkeypatch.setattr(profiles.shutil, "copytree", real_copytree)
+        created = create_profile("coder", clone_all=True, no_alias=True)
+
+        assert created == target
+        assert (created / "payload.txt").read_text(encoding="utf-8") == "complete"
+        assert list(profiles_root.glob(".coder.creating-*")) == []
+        register_service.assert_called_once_with("coder")
+
+        monkeypatch.setattr(profiles, "_check_gateway_running", lambda _path: False)
+        monkeypatch.setattr(profiles, "_cleanup_gateway_service", lambda *_args: None)
+        monkeypatch.setattr(
+            profiles, "_maybe_unregister_gateway_service", lambda *_args: None
+        )
+        monkeypatch.setattr(profiles, "_stop_profile_backends", lambda *_args: None)
+
+        assert delete_profile("coder", yes=True) == target
+        assert not target.exists()
+
+    def test_profile_staging_cleanup_rejects_unbounded_path(
+        self, profile_env
+    ):
+        profiles_root = _get_profiles_root()
+        profiles_root.mkdir(parents=True)
+        unrelated = profile_env / "unrelated"
+        unrelated.mkdir()
+        sentinel = unrelated / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="unbounded profile staging path"):
+            profiles._discard_profile_staging_root(
+                unrelated, profiles_root, "coder"
+            )
+
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+
 
     def test_seeds_placeholder_env_file(self, profile_env):
         """Fresh profiles get their own .env (owner-only) so channel/env
@@ -814,6 +879,4 @@ class TestProfilesToServe:
         assert set(serve) == {"default", "coder", "writer"}
         assert serve["default"] == _get_default_hermes_home()
         assert serve["coder"] == get_profile_dir("coder")
-
-
 


### PR DESCRIPTION
## What does this PR do?

Makes profile creation cancellation-safe. Profiles are now built in a private,
uniquely owned sibling staging directory and published to the requested profile
name only after population completes.

Previously, `create_profile(..., clone_all=True)` passed the final named profile
path directly to `shutil.copytree`. A `KeyboardInterrupt` during that copy left a
partial profile visible at the final path, and retrying the same profile name then
failed with `FileExistsError`.

The new flow:

- creates a mode-0700 hidden staging root under the same `profiles/` filesystem;
- builds the complete candidate there and strips clone-only runtime state before
  publication;
- catches `BaseException` so cancellation removes the bounded, owned staging tree;
- validates the exact parent/name pattern before any staging cleanup;
- treats dangling destination symlinks as occupied and rechecks immediately before
  the same-filesystem rename;
- publishes the completed directory with one rename, then performs the existing
  gateway registration step;
- reuses the deployed-Python-compatible retrying `rmtree` callback for staging and
  normal profile deletion.

User impact: an interrupted clone leaves neither a partial named profile nor a
staging tree, and the same name can be retried immediately.

**Risk classification: HIGH — this changes profile filesystem write/delete
behavior. Codex/manual review is required before merge.** In particular, please
review the bounded cleanup guard and POSIX/Windows directory rename behavior.

No active profile, gateway, service, configuration, dependency, or runtime was
modified while developing or validating this change.

## Related Issue

N/A — local regression discovered while closing interrupted-profile cleanup work.
Duplicate searches for interrupted/partial/cancelled profile clones found no open
issue or PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py`: stage profile contents privately, clean interrupted
  candidates with an exact-path guard, publish completed profiles by rename, and
  share Python 3.11/3.12-compatible `rmtree` retry handling.
- `tests/hermes_cli/test_profiles.py`: reproduce `KeyboardInterrupt` after a
  partial clone write, prove zero final/staging trees and no registration side
  effect, retry successfully, exercise real deletion on Python 3.11, and prove an
  unrelated path is rejected by the cleanup guard.

## How to Test

1. Run the focused profile suites:
   `scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profiles_s6_hooks.py tests/hermes_cli/test_profile_distribution.py -q`
2. Confirm all 98 tests pass, including
   `test_interrupted_clone_all_cleans_partial_tree_and_can_retry` and
   `test_profile_staging_cleanup_rejects_unbounded_path`.
3. Run `ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`,
   `python3 -m py_compile ...`, the Windows-footgun checker, and Gitleaks over
   `origin/main...HEAD`.

Validation performed after rebasing onto current `origin/main`:

- Focused profile suites: **98 passed, 0 failed**.
- Ruff: passed for both changed files.
- Python bytecode compilation: passed on Python 3.11.15.
- `git diff --check`: passed.
- Windows-footgun scan: production file passed; every newly added text write in
  the test uses explicit UTF-8. A whole-file scan of the pre-existing test module
  still reports unrelated baseline encoding findings.
- Gitleaks 8.30.1 over the exact two-file diff: no findings.
- Broader `scripts/run_tests.sh -q`: intentionally stopped after the changed and
  related profile suites passed. At termination it had reached 66.4% and reported
  15,684 passes / 58 failures. None were in either changed file or the related
  profile suites. Observed failures were baseline/environmental: `/tmp` is mounted
  `noexec` on this host (breaking executable-temp-script tests), optional Anthropic
  and Hindsight dependencies are absent/disabled, and unrelated credential,
  timing, and host-assumption tests failed. Authoritative full-suite CI remains
  required; this PR does **not** claim a clean full-suite run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see partial full-suite disclosure above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (aarch64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and safety contract are documented in code/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

N/A — CLI filesystem behavior is covered by regression tests.
