### PR TITLE
chore: add contributor email mapping for @rodboev

### DIFF
--- a/contributors/emails/rod.boev@gmail.com
+++ b/contributors/emails/rod.boev@gmail.com
@@ -1,0 +1,2 @@
+rodboev
+# PR #37611 salvage (prompt-caching: tool schema markers)


### PR DESCRIPTION
## Summary
Adds the contributor email mapping for @rodboev ahead of the #37611 salvage, so `check-attribution` passes when the cherry-picked commit lands.

- `rod.boev@gmail.com` -> rodboev (verified via the GitHub users search API)

Merge before the salvage PR.
