### PR TITLE
fix(runtime): preserve project uv config during managed repair

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -750,6 +750,16 @@ def _stage_candidate_venv(
         logger.warning("candidate dependency sync refused: uv.lock is missing")
         _remove_tree(candidate, boundary=runtime_root)
         return None
+    # ``uv.lock`` records resolver settings from ``[tool.uv]`` (notably
+    # ``exclude-newer``).  Keep the interpreter/bootstrap steps isolated from
+    # ambient uv config, but let the locked project sync read its own
+    # pyproject.toml. Otherwise UV_NO_CONFIG/--no-config removes those settings,
+    # while an ambient UV_CONFIG_FILE can redirect discovery away from the
+    # checkout; either case makes uv reject the current lockfile as stale before
+    # a replacement venv can be built.
+    sync_env = dict(env)
+    for key in ("UV_NO_CONFIG", "UV_CONFIG_FILE"):
+        sync_env.pop(key, None)
     synced = subprocess.run(
         [
             uv_bin,
@@ -759,10 +769,9 @@ def _stage_candidate_venv(
             "--locked",
             "--python",
             str(_venv_python(candidate)),
-            "--no-config",
         ],
         cwd=project_root,
-        env=env,
+        env=sync_env,
         check=False,
     )
     if synced.returncode != 0:

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -366,6 +366,57 @@ class TestManagedPythonStore:
         assert base_env["PYTHONHOME"] == "/poison/home"
 
 
+class TestCandidateVenvStaging:
+    def test_sync_loads_project_uv_config_while_venv_creation_stays_isolated(
+        self, tmp_path, monkeypatch
+    ):
+        """The locked sync must read [tool.uv] from pyproject.toml.
+
+        In particular, ``exclude-newer`` is recorded in uv.lock. Running sync
+        with UV_NO_CONFIG/--no-config makes uv ignore the project setting and
+        reject the otherwise-current lockfile.
+        """
+        from hermes_cli.managed_uv import _stage_candidate_venv
+
+        # An explicit ambient config file must not override the checkout's
+        # pyproject.toml when the replacement environment is resolved.
+        monkeypatch.setenv("UV_CONFIG_FILE", "/poison/uv.toml")
+
+        root = tmp_path / "checkout"
+        root.mkdir()
+        (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        generation = root / ".hermes-runtime" / "python" / "generation-test"
+        python = generation / "bin" / "python"
+        python.parent.mkdir(parents=True)
+        python.write_text("candidate", encoding="utf-8")
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, dict(kwargs["env"])))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "hermes_cli.managed_uv.subprocess.run", side_effect=fake_run
+        ), patch(
+            "hermes_cli.managed_uv._smoke_candidate_venv",
+            return_value=(True, "", None),
+        ):
+            candidate = _stage_candidate_venv(
+                "uv", project_root=root, generation=generation, python=python
+            )
+
+        assert candidate is not None
+        assert len(calls) == 2
+        venv_cmd, venv_env = calls[0]
+        sync_cmd, sync_env = calls[1]
+        assert "--no-config" in venv_cmd
+        assert venv_env["UV_NO_CONFIG"] == "1"
+        assert "--no-config" not in sync_cmd
+        assert "UV_NO_CONFIG" not in sync_env
+        assert "UV_CONFIG_FILE" not in sync_env
+
+
 class TestRuntimeRepair:
     def test_safe_runtime_is_a_noop(self, tmp_path):
         from hermes_cli.managed_uv import repair_vulnerable_runtime

--- a/tests/hermes_cli/test_managed_uv_project_config.py
+++ b/tests/hermes_cli/test_managed_uv_project_config.py
@@ -1,0 +1,110 @@
+"""Real-uv regression for managed runtime project-config discovery."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_candidate_sync_uses_checkout_tool_uv_config(tmp_path, monkeypatch):
+    """Locked sync must discover checkout-local ``[tool.uv]`` settings.
+
+    ``exclude-newer`` is recorded in ``uv.lock``. Ignoring the project's
+    configuration, or inheriting an explicit ambient config file, makes a real
+    ``uv sync --locked`` reject that otherwise-current lockfile.
+    """
+    uv_bin = shutil.which("uv")
+    if uv_bin is None:
+        pytest.skip("real uv binary is required for config-discovery regression")
+
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        """\
+[project]
+name = "managed-uv-config-fixture"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+all = []
+
+[tool.uv]
+exclude-newer = "2020-01-01T00:00:00Z"
+""",
+        encoding="utf-8",
+    )
+
+    real_run = subprocess.run
+    lock_env = dict(os.environ)
+    lock_env.pop("UV_CONFIG_FILE", None)
+    lock_env.pop("UV_NO_CONFIG", None)
+    locked = real_run(
+        [uv_bin, "lock"],
+        cwd=root,
+        env=lock_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert locked.returncode == 0, locked.stderr
+
+    poison = tmp_path / "ambient-uv.toml"
+    poison.write_text(
+        'exclude-newer = "2019-01-01T00:00:00Z"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("UV_CONFIG_FILE", str(poison))
+    monkeypatch.setenv("UV_NO_CONFIG", "1")
+
+    generation = root / ".hermes-runtime" / "python" / "generation-test"
+    generation.mkdir(parents=True)
+
+    def run_with_real_sync(cmd, **kwargs):
+        if len(cmd) > 1 and cmd[1] == "venv":
+            # The config-discovery contract belongs to the locked sync. Build
+            # its candidate with the test interpreter so CI does not need a
+            # separately downloaded managed Python generation.
+            candidate = Path(cmd[2])
+            return real_run(
+                [
+                    uv_bin,
+                    "venv",
+                    str(candidate),
+                    "--python",
+                    sys.executable,
+                    "--no-python-downloads",
+                    "--no-config",
+                ],
+                cwd=kwargs["cwd"],
+                env=kwargs["env"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        return real_run(cmd, **kwargs)
+
+    from hermes_cli.managed_uv import _stage_candidate_venv
+
+    with patch(
+        "hermes_cli.managed_uv.subprocess.run", side_effect=run_with_real_sync
+    ), patch(
+        "hermes_cli.managed_uv._smoke_candidate_venv",
+        return_value=(True, "", None),
+    ):
+        candidate = _stage_candidate_venv(
+            uv_bin,
+            project_root=root,
+            generation=generation,
+            python=Path(sys.executable),
+        )
+
+    assert candidate is not None
+    assert (candidate / "pyvenv.cfg").is_file()


### PR DESCRIPTION
## What does this PR do?

Fixes managed-runtime repair when the repository lockfile depends on checkout-local `[tool.uv]` resolver settings such as `exclude-newer`.

Runtime bootstrap still uses `uv venv --no-config` so a user's ambient uv configuration cannot affect interpreter creation. The subsequent locked project sync now reads the checkout's own uv configuration and removes inherited `UV_NO_CONFIG` / `UV_CONFIG_FILE` values that could suppress or redirect project config discovery.

Without this separation, `repair_vulnerable_runtime()` can reject a valid checked-in lockfile as needing an update even though the lock is current for the repository's declared resolver settings.

## Related Issue

No linked issue; reproduced during an in-place managed-runtime repair on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/managed_uv.py`
  - Keep candidate interpreter bootstrap isolated with `uv venv --no-config`.
  - Run `uv sync --locked` without `--no-config` so checkout-local `[tool.uv]` settings are honored.
  - Remove inherited `UV_NO_CONFIG` and `UV_CONFIG_FILE` from the sync subprocess environment.
- `tests/hermes_cli/test_managed_uv.py`
  - Assert bootstrap remains isolated.
  - Assert locked sync does not carry `--no-config`, `UV_NO_CONFIG`, or an ambient `UV_CONFIG_FILE`.
  - Use pytest-managed environment cleanup so poisoned uv variables do not leak between tests.
- `tests/hermes_cli/test_managed_uv_project_config.py`
  - Exercise the real `uv` binary against a temporary checkout with
    `[tool.uv] exclude-newer` and a matching generated lockfile.
  - Prove poisoned ambient `UV_NO_CONFIG` / `UV_CONFIG_FILE` values do not
    suppress or redirect checkout-local config discovery.

## How to Test

1. Set ambient `UV_NO_CONFIG=1` and point `UV_CONFIG_FILE` at an unrelated config.
2. Run the managed-runtime repair path for a checkout whose lockfile uses repository-local `[tool.uv]` resolver settings.
3. Confirm interpreter bootstrap remains config-isolated and locked sync discovers only the checkout-local project configuration.
4. Run `python -m pytest -q tests/hermes_cli/test_managed_uv_project_config.py tests/hermes_cli/test_managed_uv.py` — **37 passed**.
5. Run `git diff --check origin/main...HEAD` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and found no duplicate of this project-config discovery fix
- [x] My PR contains only changes related to this bug
- [x] I've added regression tests
- [x] I've tested on Linux (Python 3.11, managed uv runtime)

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public configuration surface changed
- [x] `cli-config.yaml.example` update — N/A; no Hermes config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: subprocess environment handling uses a copied `os.environ`; candidate path handling remains unchanged
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

The real-`uv` regression fails against `origin/main` with `uv.lock needs to be
updated`, then passes with this fix. Focused regression suite: `37 passed in
1.05s`.
