### PR TITLE
fix(tui): preserve interleaved thinking and tool order

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1055,6 +1055,9 @@ DEFAULT_CONFIG = {
         # seconds, and with this off the user stares at a spinner the whole
         # time even though tokens are streaming. Set false for quiet output.
         "show_reasoning": True,
+        # Keep the compact thinking/tools panels by default. Set true in the
+        # TUI to retain each reasoning block beside the tool it led to.
+        "interleave_thinking": False,
         # When reasoning display is on, the post-response "Reasoning" recap box
         # collapses long thinking to the first 10 lines. Set true to print the
         # complete thinking text uncollapsed (live streaming is always full).

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -330,6 +330,96 @@ describe('createGatewayEventHandler', () => {
     expect(toolTrails[0]?.tools?.[1]).toContain('Read File')
   })
 
+  it('keeps a completed tool with the reasoning segment that preceded it', () => {
+    turnController.recordReasoningDelta('inspect the repository')
+    turnController.recordToolStart('tool-1', 'search_files', 'alpha')
+    turnController.recordToolComplete('tool-1', 'search_files')
+    turnController.recordReasoningDelta('read the matching file')
+    turnController.recordToolStart('tool-2', 'read_file', 'beta')
+    turnController.recordToolComplete('tool-2', 'read_file')
+
+    expect(getTurnState().streamSegments).toMatchObject([
+      { kind: 'trail', thinking: 'inspect the repository', tools: [expect.stringContaining('Search Files')] },
+      { kind: 'trail', thinking: 'read the matching file', tools: [expect.stringContaining('Read File')] }
+    ])
+  })
+
+  it('only preserves chronological segments in the completed transcript when configured', () => {
+    const recordTimeline = () => {
+      turnController.recordReasoningDelta('inspect the repository')
+      turnController.recordToolStart('tool-1', 'search_files', 'alpha')
+      turnController.recordToolComplete('tool-1', 'search_files')
+      turnController.recordReasoningDelta('read the matching file')
+      turnController.recordToolStart('tool-2', 'read_file', 'beta')
+      turnController.recordToolComplete('tool-2', 'read_file')
+
+      return turnController
+        .recordMessageComplete({ text: '' })
+        .finalMessages.filter(msg => Boolean(msg.thinking?.trim() || msg.tools?.length))
+    }
+
+    const compact = recordTimeline()
+    expect(compact).toMatchObject([
+      {
+        thinking: 'inspect the repository',
+        tools: [expect.stringContaining('Search Files'), expect.stringContaining('Read File')]
+      },
+      { thinking: 'read the matching file' }
+    ])
+
+    turnController.fullReset()
+    patchUiState({ interleaveThinking: true })
+
+    expect(recordTimeline()).toMatchObject([
+      { thinking: 'inspect the repository', tools: [expect.stringContaining('Search Files')] },
+      { thinking: 'read the matching file', tools: [expect.stringContaining('Read File')] }
+    ])
+  })
+
+  it('uses the selected timeline layout when the turn is interrupted', () => {
+    vi.useFakeTimers()
+
+    try {
+      const interruptTimeline = () => {
+        const appended: Msg[] = []
+
+        turnController.recordReasoningDelta('inspect the repository')
+        turnController.recordToolStart('tool-1', 'search_files', 'alpha')
+        turnController.recordToolComplete('tool-1', 'search_files')
+        turnController.recordReasoningDelta('read the matching file')
+        turnController.recordToolStart('tool-2', 'read_file', 'beta')
+        turnController.recordToolComplete('tool-2', 'read_file')
+        turnController.interruptTurn({
+          appendMessage: msg => appended.push(msg),
+          gw: { request: vi.fn(async () => ({ status: 'interrupted' })) },
+          sid: 'sess-1',
+          sys: vi.fn()
+        })
+
+        return appended
+      }
+
+      expect(interruptTimeline()).toMatchObject([
+        {
+          thinking: 'inspect the repository',
+          tools: [expect.stringContaining('Search Files'), expect.stringContaining('Read File')]
+        },
+        { thinking: 'read the matching file' }
+      ])
+
+      turnController.fullReset()
+      patchUiState({ interleaveThinking: true })
+
+      expect(interruptTimeline()).toMatchObject([
+        { thinking: 'inspect the repository', tools: [expect.stringContaining('Search Files')] },
+        { thinking: 'read the matching file', tools: [expect.stringContaining('Read File')] }
+      ])
+    } finally {
+      vi.runAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps tool tokens across handler recreation mid-turn', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -26,6 +26,7 @@ describe('applyDisplay', () => {
           display: {
             bell_on_complete: true,
             details_mode: 'expanded',
+            interleave_thinking: true,
             inline_diffs: false,
             show_reasoning: true,
             streaming: false,
@@ -42,6 +43,7 @@ describe('applyDisplay', () => {
     expect(s.compact).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
+    expect(s.interleaveThinking).toBe(true)
     expect(s.showReasoning).toBe(true)
     expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(false)
@@ -65,6 +67,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
     expect(s.inlineDiffs).toBe(true)
+    expect(s.interleaveThinking).toBe(false)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -330,6 +330,7 @@ export interface UiState {
   info: null | SessionInfo
   liveSessionCount: number
   inlineDiffs: boolean
+  interleaveThinking: boolean
   mouseTracking: MouseTrackingMode
   notice: Notice | null
   pasteCollapseLines: number

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -6,7 +6,12 @@ import {
   STREAM_TYPING_BATCH_MS
 } from '../config/timing.js'
 import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayTypes.js'
-import { appendToolShelfMessage, isToolShelfMessage } from '../lib/liveProgress.js'
+import {
+  canHoldToolShelf,
+  compactToolTimeline,
+  isToolShelfMessage,
+  mergeToolShelfInto
+} from '../lib/liveProgress.js'
 import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
 import {
   boundedLiveRenderText,
@@ -300,7 +305,9 @@ class TurnController {
 
     this.closeReasoningSegment()
 
-    const segments = this.segmentMessages
+    const segments = getUiState().interleaveThinking
+      ? this.segmentMessages
+      : compactToolTimeline(this.segmentMessages)
     const partial = this.bufRef.trimStart()
     const tools = this.pendingSegmentTools
 
@@ -392,7 +399,7 @@ class TurnController {
   }
 
   private pushSegment(msg: Msg) {
-    this.segmentMessages = appendToolShelfMessage(this.segmentMessages, msg)
+    this.segmentMessages = [...this.segmentMessages, msg]
   }
 
   flushStreamingSegment() {
@@ -456,18 +463,23 @@ class TurnController {
       return false
     }
 
-    const next = appendToolShelfMessage(this.segmentMessages, {
+    const pending: Msg = {
       kind: 'trail',
       role: 'system',
       text: '',
       tools: this.pendingSegmentTools
-    })
+    }
+    const lastIndex = this.segmentMessages.length - 1
+    const last = this.segmentMessages[lastIndex]
 
-    if (next.length === this.segmentMessages.length + 1) {
+    if (!canHoldToolShelf(last)) {
       return false
     }
 
-    this.segmentMessages = next
+    this.segmentMessages = [
+      ...this.segmentMessages.slice(0, -1),
+      mergeToolShelfInto(last!, pending)
+    ]
     this.pendingSegmentTools = []
     patchTurnState({ streamPendingTools: [], streamSegments: this.segmentMessages })
 
@@ -625,9 +637,12 @@ class TurnController {
 
     // Archive prepended so the trail msg anchors under the user prompt,
     // not between thinking/tools and final assistant text.
+    const displaySegments = getUiState().interleaveThinking
+      ? segments
+      : compactToolTimeline(segments)
     const finalMessages: Msg[] = [
       ...archiveDoneTodos(),
-      ...segments,
+      ...displaySegments,
       ...(hasDetails(finalDetails) ? [finalDetails] : [])
     ]
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -19,6 +19,7 @@ const buildUiState = (): UiState => ({
   focusView: false,
   indicatorStyle: DEFAULT_INDICATOR_STYLE,
   info: null,
+  interleaveThinking: false,
   liveSessionCount: 0,
   inlineDiffs: true,
   mouseTracking: MOUSE_TRACKING,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -277,6 +277,7 @@ export const applyDisplay = (
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
+    interleaveThinking: d.interleave_thinking === true,
     inlineDiffs: d.inline_diffs !== false,
     mouseTracking: normalizeMouseTracking(d),
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -5,14 +5,11 @@ import type { AppLayoutProgressProps } from '../app/interfaces.js'
 import { toggleTodoCollapsed, useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { blockRenders } from '../domain/blockLayout.js'
-import { appendToolShelfMessage } from '../lib/liveProgress.js'
+import { compactToolTimeline } from '../lib/liveProgress.js'
 import type { ActiveTool, DetailsMode, Msg, SectionVisibility } from '../types.js'
 
 import { MessageLine } from './messageLine.js'
 import { TodoPanel } from './todoPanel.js'
-
-const groupedSegments = (segments: Msg[]): Msg[] =>
-  segments.reduce<Msg[]>((acc, msg) => appendToolShelfMessage(acc, msg), [])
 
 interface LiveBlock {
   isStreaming?: boolean
@@ -46,7 +43,8 @@ export const StreamingAssistant = memo(function StreamingAssistant({
   // back into settled history (prevMsg). Tracking the predecessor rather than
   // the live text is what keeps the streaming block from jumping when it
   // flushes into a settled segment.
-  const blocks: LiveBlock[] = groupedSegments(streamSegments).map((msg, i) => ({ key: `seg:${i}`, msg }))
+  const timeline = ui.interleaveThinking ? streamSegments : compactToolTimeline(streamSegments)
+  const blocks: LiveBlock[] = timeline.map((msg, i) => ({ key: `seg:${i}`, msg }))
 
   if (activeTools.length) {
     blocks.push({ key: 'active-tools', msg: { kind: 'trail', role: 'system', text: '' }, tools: activeTools })

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -83,6 +83,7 @@ export interface ConfigDisplayConfig {
   details_mode?: string
   /** Focus view (/focus) — display-only reduced-output mode. */
   focus_view?: boolean
+  interleave_thinking?: boolean
   inline_diffs?: boolean
   mouse_tracking?: boolean | null | number | string
   sections?: Record<string, string>

--- a/ui-tui/src/lib/liveProgress.test.ts
+++ b/ui-tui/src/lib/liveProgress.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import type { Msg } from '../types.js'
 
-import { appendToolShelfMessage, canHoldToolShelf, isTodoDone, mergeToolShelfInto } from './liveProgress.js'
+import {
+  appendToolShelfMessage,
+  canHoldToolShelf,
+  compactToolTimeline,
+  isTodoDone,
+  mergeToolShelfInto
+} from './liveProgress.js'
 
 describe('isTodoDone', () => {
   it('only treats non-empty all-completed/cancelled lists as done', () => {
@@ -112,5 +118,21 @@ describe('appendToolShelfMessage', () => {
     )
 
     expect(merged).toHaveLength(3)
+  })
+})
+
+describe('compactToolTimeline', () => {
+  it('restores the compact tool shelf without mutating chronological source segments', () => {
+    const chronological: Msg[] = [
+      { kind: 'trail', role: 'system', text: '', thinking: 'plan', tools: ['one ✓'] },
+      { kind: 'trail', role: 'system', text: '', thinking: 'inspect result', tools: ['two ✓'] }
+    ]
+
+    expect(compactToolTimeline(chronological)).toEqual([
+      { kind: 'trail', role: 'system', text: '', thinking: 'plan', tools: ['one ✓', 'two ✓'] },
+      { kind: 'trail', role: 'system', text: '', thinking: 'inspect result' }
+    ])
+    expect(chronological[0]?.tools).toEqual(['one ✓'])
+    expect(chronological[1]?.tools).toEqual(['two ✓'])
   })
 })

--- a/ui-tui/src/lib/liveProgress.ts
+++ b/ui-tui/src/lib/liveProgress.ts
@@ -77,3 +77,37 @@ export const appendToolShelfMessage = (prev: readonly Msg[], msg: Msg): Msg[] =>
 
   return [...prev, msg]
 }
+
+// The controller keeps its source segments in event order. The compact view
+// deliberately coalesces completed tool shelves into the first contextual
+// reasoning block, preserving the pre-timeline layout for users who have not
+// opted into chronological thinking.
+export const compactToolTimeline = (segments: readonly Msg[]): Msg[] =>
+  segments
+    .flatMap(msg => {
+      if (
+        !(
+          msg.kind === 'trail' &&
+          msg.role === 'system' &&
+          !msg.text &&
+          msg.thinking?.trim() &&
+          msg.tools?.length
+        )
+      ) {
+        return [msg]
+      }
+
+      const { toolTokens, tools, ...thinking } = msg
+
+      return [
+        thinking,
+        {
+          kind: 'trail' as const,
+          role: 'system' as const,
+          text: '',
+          tools,
+          ...(toolTokens !== undefined && { toolTokens })
+        }
+      ]
+    })
+    .reduce<Msg[]>((timeline, msg) => appendToolShelfMessage(timeline, msg), [])

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1587,6 +1587,7 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
+  interleave_thinking: false # TUI: retain chronological reasoning → tool-call order
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -224,6 +224,7 @@ display:
   skin: default              # any built-in or custom skin
   personality: helpful
   details_mode: collapsed    # hidden | collapsed | expanded — global accordion default
+  interleave_thinking: false # show thinking and completed tools in chronological order
   sections:                  # optional: per-section overrides (any subset)
     thinking: expanded       # always open
     tools: expanded          # always open


### PR DESCRIPTION
Fixes #18241

## What changed and why

The TUI now retains reasoning and completed-tool segments in their original event order. Setting `display.interleave_thinking: true` renders each reasoning block beside the tool call it led to; the default `false` continues to use the compact grouped layout. Completed and interrupted turns use the same selected layout, so the view no longer changes after a turn settles.

## How to test

1. Add `display.interleave_thinking: true` to `~/.hermes/config.yaml`.
2. Run `hermes --tui` with a reasoning model that makes multiple tool calls.
3. Verify the transcript reads reasoning → tool → reasoning → tool during the live turn and after completion.
4. Remove the setting or set it to `false` and verify the compact grouped tool shelf remains.

Automated: `pytest tests/cli/test_reasoning_command.py -q -x --timeout=60` (33 passed). The repository test command also exited successfully. UI Vitest/typecheck could not run because this checkout has no installed UI dependencies and the required workspace package was unavailable from the offline npm cache.

## What platforms tested on

- macOS worker: Python regression tests and config-default validation.
- Interactive TUI validation pending; UI dependencies were unavailable in the worker checkout.

<!-- autocontrib:worker-id=issue-followup-1e435561 kind=pr-open -->