### PR TITLE
fix(tools): scrub plural result.samples in flux3 video delivery (#75667)

### DIFF
--- a/tools/flux3_video_tool.py
+++ b/tools/flux3_video_tool.py
@@ -473,6 +473,7 @@ async def _save_if_ready(raw: str, save_to, started: float) -> str:
     # Dropped whether or not the save succeeds. A retry re-polls, which mints a
     # fresh URL, so nothing is lost by not handing this one to the model.
     result.pop("sample", None)
+    result.pop("samples", None)  # plural form also carries the signed URL (#75667)
 
     try:
         target, size = await _download_video(url.strip(), save_to, started)


### PR DESCRIPTION
## Problem

`_save_if_ready()` only scrubs the singular `result.sample` field. The live API also carries a **plural `result.samples` list** with the same signed delivery URL, leaking the credential into model context and persisted transcript.

## Fix

Add `result.pop("samples", None)` after the existing `result.pop("sample", None)`.

One-line change. Same pattern as the existing scrub.

Fixes #75667