### PR TITLE
fix(gateway): restore macOS planned restart online notices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11637,13 +11637,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # paths). Chat-originated /restart already has a precise reply target
         # in .restart_notify.json, so keep that lifecycle in the originating
         # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
-            try:
-                await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
-                )
-            finally:
-                _clear_planned_restart_notification()
+        await self._send_planned_restart_startup_notification(
+            pending=planned_restart_notification_pending,
+        )
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -21861,6 +21857,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         return delivered
+
+    async def _send_planned_restart_startup_notification(
+        self,
+        *,
+        pending: Optional[bool] = None,
+    ) -> bool:
+        """Consume one planned-restart marker and notify home channels once."""
+        if pending is None:
+            pending = _planned_restart_notification_pending()
+        if not pending:
+            return False
+        try:
+            await self._send_home_channel_startup_notifications(skip_targets=None)
+        finally:
+            _clear_planned_restart_notification()
+        return True
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -252,6 +252,27 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
+def _signal_gateway_sigusr1_restart(pid: int) -> bool:
+    """Signal a *known* gateway PID to perform its graceful SIGUSR1 restart.
+
+    Unlike :func:`_request_gateway_self_restart`, this does not require the
+    gateway to be an ancestor of the caller. ``launchd_restart()`` already
+    holds a verified gateway PID from :func:`get_running_pid`, so it is safe
+    to signal it directly. Delivering SIGUSR1 triggers the gateway's internal
+    ``restart_signal_handler`` -> ``request_restart(via_service=True)``: the
+    gateway drains in-flight runs, writes the ``.restart_pending.json`` marker
+    (so the next boot broadcasts "♻️ Gateway online"), then exits for launchd's
+    KeepAlive to respawn it. Returns True if the signal was delivered.
+    """
+    if not hasattr(signal, "SIGUSR1"):
+        return False
+    try:
+        os.kill(pid, signal.SIGUSR1)  # windows-footgun: ok — POSIX signal, guarded above
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
+
+
 def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
@@ -4617,6 +4638,18 @@ def launchd_restart():
     try:
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
+            print("✓ Service restart requested")
+            _clear_launchd_unsupported_marker()
+            return
+        if pid is not None and _signal_gateway_sigusr1_restart(pid):
+            # Graceful drain-and-restart requested via SIGUSR1 (the gateway's
+            # own restart handler). launchd's KeepAlive respawns the gateway on
+            # exit, and the gateway writes .restart_pending.json so the next
+            # boot emits the "♻️ Gateway online" home-channel notice — matching
+            # the Linux systemd SIGUSR1 path. On macOS `hermes update` is not a
+            # child of the gateway, so the ancestor-guarded self-restart above
+            # is skipped and we previously fell through to SIGTERM, which never
+            # writes that marker (hence no "Gateway online" message).
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4663,6 +4663,9 @@ def launchd_restart():
                     "⚠ launchd did not publish a replacement gateway PID — "
                     "falling back to kickstart"
                 )
+                # The old gateway has already exited. Do not signal its numeric
+                # PID again after the replacement wait; it may have been reused.
+                pid = None
             else:
                 print(
                     f"⚠ Gateway did not exit after the {drain_timeout:.0f}s drain — "

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -252,27 +252,6 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
-def _signal_gateway_sigusr1_restart(pid: int) -> bool:
-    """Signal a *known* gateway PID to perform its graceful SIGUSR1 restart.
-
-    Unlike :func:`_request_gateway_self_restart`, this does not require the
-    gateway to be an ancestor of the caller. ``launchd_restart()`` already
-    holds a verified gateway PID from :func:`get_running_pid`, so it is safe
-    to signal it directly. Delivering SIGUSR1 triggers the gateway's internal
-    ``restart_signal_handler`` -> ``request_restart(via_service=True)``: the
-    gateway drains in-flight runs, writes the ``.restart_pending.json`` marker
-    (so the next boot broadcasts "♻️ Gateway online"), then exits for launchd's
-    KeepAlive to respawn it. Returns True if the signal was delivered.
-    """
-    if not hasattr(signal, "SIGUSR1"):
-        return False
-    try:
-        os.kill(pid, signal.SIGUSR1)  # windows-footgun: ok — POSIX signal, guarded above
-    except (ProcessLookupError, PermissionError, OSError):
-        return False
-    return True
-
-
 def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
@@ -4629,6 +4608,21 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _wait_for_launchd_service_restart(
+    *,
+    previous_pid: int,
+    timeout: float = 30.0,
+) -> bool:
+    """Wait until launchd owns a replacement PID for the current profile."""
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while time.monotonic() < deadline:
+        managed_pids = _get_service_pids()
+        if any(pid > 0 and pid != previous_pid for pid in managed_pids):
+            return True
+        time.sleep(0.25)
+    return False
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -4641,18 +4635,39 @@ def launchd_restart():
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return
-        if pid is not None and _signal_gateway_sigusr1_restart(pid):
-            # Graceful drain-and-restart requested via SIGUSR1 (the gateway's
-            # own restart handler). launchd's KeepAlive respawns the gateway on
-            # exit, and the gateway writes .restart_pending.json so the next
-            # boot emits the "♻️ Gateway online" home-channel notice — matching
-            # the Linux systemd SIGUSR1 path. On macOS `hermes update` is not a
-            # child of the gateway, so the ancestor-guarded self-restart above
-            # is skipped and we previously fell through to SIGTERM, which never
-            # writes that marker (hence no "Gateway online" message).
-            print("✓ Service restart requested")
-            _clear_launchd_unsupported_marker()
-            return
+        if pid is not None and pid in _get_service_pids():
+            # External callers (notably the desktop updater) are outside the
+            # gateway process tree, so the asynchronous ancestor path above is
+            # unavailable. Only signal a PID that launchd proves it owns, wait
+            # for the old process to drain and exit, then require a replacement
+            # launchd PID before reporting success. A detached gateway must use
+            # the hard recovery path below or SIGUSR1 would stop it permanently.
+            print(
+                f"→ Restarting gateway (PID {pid}) — draining in-flight runs "
+                f"(up to {drain_timeout:.0f}s)..."
+            )
+            graceful_exit = _graceful_restart_via_sigusr1(
+                pid,
+                drain_timeout + 5.0,
+            )
+            if graceful_exit:
+                replaced = _wait_for_launchd_service_restart(
+                    previous_pid=pid,
+                    timeout=30.0,
+                )
+                if replaced:
+                    print("✓ Service restarted")
+                    _clear_launchd_unsupported_marker()
+                    return
+                print(
+                    "⚠ launchd did not publish a replacement gateway PID — "
+                    "falling back to kickstart"
+                )
+            else:
+                print(
+                    f"⚠ Gateway did not exit after the {drain_timeout:.0f}s drain — "
+                    "falling back to launchd restart"
+                )
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,6 +30,62 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     gateway_run._clear_planned_restart_notification()
 
     assert gateway_run._planned_restart_notification_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_service_restart_writes_planned_startup_marker(tmp_path, monkeypatch):
+    """SIGUSR1's service restart path must create the next-boot notice marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    marker = tmp_path / ".restart_pending.json"
+
+    runner, _adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    runner.adapters = {}
+
+    with (
+        patch.object(
+            gateway_run.GatewayRunner,
+            "_drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], False),
+        ),
+        patch.object(gateway_run.GatewayRunner, "_finalize_shutdown_agents"),
+        patch.object(gateway_run.GatewayRunner, "_update_runtime_status"),
+        patch("gateway.status.remove_pid_file"),
+        patch("tools.process_registry.process_registry") as process_registry,
+        patch("tools.terminal_tool.cleanup_all_environments"),
+        patch("tools.browser_tool.cleanup_all_browsers"),
+    ):
+        process_registry.kill_all = MagicMock()
+        assert runner.request_restart(via_service=True) is True
+        restart_task = runner._restart_task
+        assert restart_task is not None
+        await restart_task
+
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["via_service"] is True
+    assert gateway_run._planned_restart_notification_pending() is True
+
+
+@pytest.mark.asyncio
+async def test_planned_startup_marker_is_consumed_exactly_once(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    marker = tmp_path / ".restart_pending.json"
+    marker.write_text("{}", encoding="utf-8")
+
+    runner, _adapter = make_restart_runner()
+    send_mock = AsyncMock(return_value=set())
+    monkeypatch.setattr(runner, "_send_home_channel_startup_notifications", send_mock)
+    send_planned_notification = getattr(
+        runner,
+        "_send_planned_restart_startup_notification",
+    )
+
+    assert await send_planned_notification() is True
+    assert await send_planned_notification() is False
+
+    send_mock.assert_awaited_once_with(skip_targets=None)
+    assert marker.exists() is False
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -397,7 +397,7 @@ class TestLaunchdServiceRecovery:
         assert calls[-1] == ("clear",)
 
     def test_external_restart_falls_back_when_launchd_does_not_replace_pid(self, monkeypatch):
-        """Old-PID exit without a managed replacement must trigger kickstart."""
+        """Old-PID exit without a replacement must kickstart without re-signaling."""
         calls = []
         self._patch_external_restart(monkeypatch, calls)
         monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {4242})
@@ -421,8 +421,12 @@ class TestLaunchdServiceRecovery:
             ("graceful", 4242, 17.0),
             ("wait-for-replacement", 4242, 30.0),
         ]
-        assert ("terminate", 4242, False) in calls
-        assert any(call[0] == "run" for call in calls)
+        assert not any(call[0] in {"terminate", "wait-for-exit"} for call in calls)
+        assert (
+            "run",
+            ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"],
+            {"check": True, "timeout": 90},
+        ) in calls
         assert calls[-1] == ("clear",)
 
     def test_ancestor_restart_keeps_async_fast_path(self, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -283,7 +283,186 @@ class TestLaunchdServiceRecovery:
     def test_wait_for_pid_exit_ignores_nonpositive_pid(self):
         assert gateway_cli._wait_for_pid_exit(0, timeout=30) is True
 
+    @staticmethod
+    def _patch_external_restart(monkeypatch, calls):
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("terminate", pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(
+                ("wait-for-exit", timeout, force_after)
+            )
+            or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(("run", cmd, kwargs))
+            or SimpleNamespace(returncode=0),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_clear_launchd_unsupported_marker",
+            lambda: calls.append(("clear",)),
+        )
 
+    def test_external_restart_waits_for_managed_gateway_replacement(self, monkeypatch):
+        """A managed gateway must exit and be replaced before reporting success."""
+        calls = []
+        self._patch_external_restart(monkeypatch, calls)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {4242})
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid, timeout=30.0: calls.append(
+                ("wait-for-replacement", previous_pid, timeout)
+            )
+            or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda *args, **kwargs: pytest.fail("must not fall back to SIGTERM"),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("must not kickstart a verified replacement"),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("graceful", 4242, 17.0),
+            ("wait-for-replacement", 4242, 30.0),
+            ("clear",),
+        ]
+
+    def test_external_restart_skips_sigusr1_for_detached_gateway(self, monkeypatch):
+        """A PID not owned by launchd must retain the hard recovery path."""
+        calls = []
+        self._patch_external_restart(monkeypatch, calls)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda *args, **kwargs: pytest.fail("must not signal a detached gateway"),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert ("terminate", 4242, False) in calls
+        assert (
+            "run",
+            ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"],
+            {"check": True, "timeout": 90},
+        ) in calls
+        assert calls[-1] == ("clear",)
+
+    def test_external_restart_falls_back_when_gateway_does_not_exit(self, monkeypatch):
+        """Signal delivery without old-PID exit must not be reported as success."""
+        calls = []
+        self._patch_external_restart(monkeypatch, calls)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {4242})
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda *args, **kwargs: pytest.fail("must not wait for replacement before old PID exits"),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls[0] == ("graceful", 4242, 17.0)
+        assert ("terminate", 4242, False) in calls
+        assert any(call[0] == "run" for call in calls)
+        assert calls[-1] == ("clear",)
+
+    def test_external_restart_falls_back_when_launchd_does_not_replace_pid(self, monkeypatch):
+        """Old-PID exit without a managed replacement must trigger kickstart."""
+        calls = []
+        self._patch_external_restart(monkeypatch, calls)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {4242})
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid, timeout=30.0: calls.append(
+                ("wait-for-replacement", previous_pid, timeout)
+            )
+            or False,
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls[:2] == [
+            ("graceful", 4242, 17.0),
+            ("wait-for-replacement", 4242, 30.0),
+        ]
+        assert ("terminate", 4242, False) in calls
+        assert any(call[0] == "run" for call in calls)
+        assert calls[-1] == ("clear",)
+
+    def test_ancestor_restart_keeps_async_fast_path(self, monkeypatch):
+        """A gateway child must not wait for its parent gateway to exit."""
+        calls = []
+        self._patch_external_restart(monkeypatch, calls)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_service_pids",
+            lambda: pytest.fail("ancestor path must return before launchd ownership checks"),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [("clear",)]
+
+    def test_wait_for_launchd_restart_requires_a_new_managed_pid(self, monkeypatch):
+        service_pids = iter(({4242}, {5252}))
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: next(service_pids))
+        monkeypatch.setattr(gateway_cli.time, "monotonic", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda _: None)
+
+        wait_for_restart = getattr(gateway_cli, "_wait_for_launchd_service_restart")
+        assert wait_for_restart(
+            previous_pid=4242,
+            timeout=1.0,
+        ) is True
+
+    def test_wait_for_launchd_restart_times_out_on_old_pid(self, monkeypatch):
+        monotonic = iter((0.0, 0.0, 2.0))
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {4242})
+        monkeypatch.setattr(gateway_cli.time, "monotonic", lambda: next(monotonic))
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda _: None)
+
+        wait_for_restart = getattr(gateway_cli, "_wait_for_launchd_service_restart")
+        assert wait_for_restart(
+            previous_pid=4242,
+            timeout=1.0,
+        ) is False
 
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
         """#43842: when the refresh runs inside the gateway's own process tree,


### PR DESCRIPTION
## What does this PR do?

A macOS restart invoked by the desktop updater or a terminal is not a child of the running gateway. That makes the ancestor-only `_request_gateway_self_restart()` path return `False`, after which `launchd_restart()` sends SIGTERM and kickstarts the job. The gateway reconnects, but SIGTERM does not set `.restart_pending.json`, so the configured home channel never receives the next `Gateway online` notice.

For an external restart, this change uses the existing SIGUSR1 graceful-restart contract only after proving that launchd owns the current gateway PID. It waits for that PID to drain and exit, then requires launchd to publish a different managed PID before reporting success. The gateway's existing SIGUSR1 handler records the planned-restart marker, and the replacement gateway consumes it to send the home-channel startup notice exactly once.

Detached gateways are never sent this service-restart signal. Signal/drain failure falls through to the existing SIGTERM + `launchctl kickstart` recovery path. If the old PID exits but launchd does not publish a replacement, recovery goes directly to `kickstart -k` without re-signaling the exited (and potentially reused) numeric PID.

This salvages the valid first commit from #61143 with @dagryph's original authorship preserved, excludes that PR's malformed follow-up commit, and adds the missing safety and lifecycle coverage. Unlike #43199, it does not duplicate the restart-marker schema in the CLI or risk leaving a CLI-written stale marker.

## Related Issue

Addresses the macOS updater/restart path described in #52567.

Related: #61143, #43199

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - keep the ancestor-only asynchronous restart fast path unchanged;
  - for external callers, send SIGUSR1 only when launchd owns the validated gateway PID;
  - wait for the old PID to exit and a different launchd-managed PID to appear;
  - preserve the existing SIGTERM/kickstart fallback for detached gateways and signal/drain failures;
  - after a confirmed old-PID exit, recover a replacement timeout with direct kickstart so a reused PID is never signaled.
- `gateway/run.py`: extract the existing planned-startup notification consumption into a testable one-shot helper without changing its startup ordering or `finally` cleanup behavior.
- Tests cover launchd ownership, detached gateways, drain timeout, replacement timeout, ancestor behavior, planned-marker creation, and exactly-once startup consumption.

## How to Test

1. Reproduce on current `main`: call `launchd_restart()` from a process outside the gateway tree; it goes directly to SIGTERM and no planned-restart marker is produced.
2. Run the focused launchd regression tests:
   ```bash
   ./scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py \
     -k 'external_restart or ancestor_restart or wait_for_launchd_restart' -q
   ```
   TDD result: **5 failed / 2 passed before the safety patch; 7 passed after it**.
3. Run the related lifecycle/update suite:
   ```bash
   ./scripts/run_tests.sh \
     tests/hermes_cli/test_gateway_service.py \
     tests/hermes_cli/test_update_fleet_restart_timeout.py \
     tests/hermes_cli/test_gateway_restart_loop.py \
     tests/gateway/test_restart_notification.py \
     tests/gateway/test_startup_restart_race.py \
     tests/gateway/test_restart_service_detection.py \
     tests/gateway/test_restart_resume_pending.py \
     tests/gateway/test_restart_redelivery_dedup.py \
     tests/gateway/test_restart_drain.py \
     tests/gateway/test_gateway_shutdown.py \
     tests/gateway/test_clean_shutdown_marker.py \
     -k 'not test_systemd_restart_gracefully_restarts_running_service_and_waits' -q
   ```
   Result on macOS: **201 passed**. The excluded systemd-only test fails identically on clean `origin/main` because its D-Bus preflight is not mocked on macOS.
4. Run the full suite:
   ```bash
   ./scripts/run_tests.sh tests/ -q
   ```
   On this macOS environment the branch reports 72 failures across 32 files.
   Running those same files from a detached clean `origin/main` worktree with
   the identical interpreter and dependencies reports 69 failures across 31
   files. The apparent extra file, `test_update_eol_churn.py`, is an existing
   environment-sensitive baseline: isolated runs report the same **5 failed / 4
   passed** on both branch and clean main. The remaining failures are existing
   optional-SDK and Linux/WSL-on-macOS issues.
5. Manual macOS signal check: a disposable process installed a SIGUSR1 handler, received the real OS signal, wrote its planned marker, and exited with the expected service-restart code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and lifecycle comments cover the contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The related lifecycle suite reports **201 passed**. The full-suite branch/main
comparison reports branch 72 failures in 32 files versus clean main 69 failures
in 31 files; the only file-set difference fails identically when isolated on
both trees. Ruff, bytecode compilation, whitespace validation, and the full
Windows footgun scan (897 files) pass. The disposable macOS signal check reports:

```text
macos_sigusr1_graceful=PASS delivered_and_exited=True exit=75 marker=restart_pending
```
