### PR TITLE
fix(cli): redact secrets in interrupt_debug.log writes (#75461)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13991,7 +13991,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             try:
                                 _dbg = _hermes_home / "interrupt_debug.log"
                                 with open(_dbg, "a", encoding="utf-8") as _f:
-                                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={str(interrupt_msg)[:60]!r}, "
+                                    from agent.redact import redact_sensitive_text
+                                    _redacted_msg = redact_sensitive_text(str(interrupt_msg))[:60]
+                                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={_redacted_msg!r}, "
                                              f"children={len(self.agent._active_children)}, "
                                              f"parent._interrupt={self.agent._interrupt_requested}\n")
                                     for _ci, _ch in enumerate(self.agent._active_children):
@@ -15319,7 +15321,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             try:
                                 _dbg = _hermes_home / "interrupt_debug.log"
                                 with open(_dbg, "a", encoding="utf-8") as _f:
-                                    _f.write(f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={str(payload)[:60]!r}, "
+                                    from agent.redact import redact_sensitive_text
+                                    _redacted_msg = redact_sensitive_text(str(payload))[:60]
+                                    _f.write(f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={_redacted_msg!r}, "
                                              f"agent_running={self._agent_running}\n")
                             except Exception:
                                 pass


### PR DESCRIPTION
## Problem

Two `open().write()` sites in `interrupt_debug.log` bypass `RedactingFormatter`. When a user pastes a bot token during platform setup, the value is written in plaintext and stays indefinitely.

Evidence from the issue:
```
agent.log            ... msg=1234567890:***
interrupt_debug.log  ... msg=1234567890:AAAAAAAAA...
```

## Fix

Apply `redact_sensitive_text()` before the 60-char truncation at both write sites. Uses the same redaction module already covering the main logging pipeline.

## Sites

| Line | Message |
|---|---|
| cli.py:13994 | `interrupt fired: msg=...` |
| cli.py:15322 | `ENTER: queued interrupt msg=...` |

Fixes #75461