### PR TITLE
fix(discord): leave voice channels before cancelling the bot task

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1677,6 +1677,19 @@ class DiscordAdapter(BasePlatformAdapter):
         # Cancel the liveness probe first so it can't fire a spurious fatal
         # error / reconnect while we're intentionally tearing the adapter down.
         await self._cancel_liveness_task()
+        # Clean up all active voice connections *before* cancelling the bot task.
+        # leave_voice_channel() ends in `await vc.disconnect()`, and discord.py's
+        # VoiceClient.disconnect() sends a voice state update over the main
+        # gateway websocket and then waits for the voice socket to close.  The
+        # bot task is the loop running that gateway connection, so cancelling it
+        # first leaves the handshake with no transport: it can never complete and
+        # blocks until the caller's shutdown timeout fires.
+        for guild_id in list(self._voice_clients.keys()):
+            try:
+                await self.leave_voice_channel(guild_id)
+            except Exception as e:  # pragma: no cover - defensive logging
+                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
+
         # Cancel the bot task before closing the client.  If connect() timed out
         # and returned False, the background client.start() task may still be
         # running; calling client.close() alone is not enough to stop it because
@@ -1684,12 +1697,6 @@ class DiscordAdapter(BasePlatformAdapter):
         # WebSocket handshake is in flight.  Explicitly cancelling the task here
         # ensures the zombie client cannot receive or dispatch any further events.
         await self._cancel_bot_task()
-        # Clean up all active voice connections before closing the client
-        for guild_id in list(self._voice_clients.keys()):
-            try:
-                await self.leave_voice_channel(guild_id)
-            except Exception as e:  # pragma: no cover - defensive logging
-                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
 
         if self._client:
             try:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -768,6 +768,49 @@ class TestDiscordVoiceChannelMethods:
 
 
     @pytest.mark.asyncio
+    async def test_disconnect_leaves_voice_before_cancelling_bot_task(self):
+        """Voice must be torn down while the gateway websocket is still alive.
+
+        VoiceClient.disconnect() sends a voice state update over the main gateway
+        connection and waits for the voice socket to close.  The bot task is the
+        loop running that connection, so cancelling it first strands the
+        handshake and the disconnect blocks until the caller's shutdown timeout.
+        """
+        adapter = self._make_adapter()
+        events = []
+
+        async def cancel_liveness_task():
+            events.append("cancel_liveness_task")
+
+        async def cancel_bot_task():
+            events.append("cancel_bot_task")
+
+        async def leave_voice_channel(guild_id):
+            events.append(f"leave_voice_channel:{guild_id}")
+
+        async def close():
+            events.append("close_client")
+
+        adapter._cancel_liveness_task = cancel_liveness_task
+        adapter._cancel_bot_task = cancel_bot_task
+        adapter.leave_voice_channel = leave_voice_channel
+        adapter._client.close = close
+        adapter._voice_clients[111] = MagicMock()
+        adapter._ready_event = MagicMock()
+        adapter._post_connect_task = None
+        adapter._missed_message_backfill_task = None
+
+        await adapter.disconnect()
+
+        assert events == [
+            "cancel_liveness_task",
+            "leave_voice_channel:111",
+            "cancel_bot_task",
+            "close_client",
+        ]
+
+
+    @pytest.mark.asyncio
     async def test_get_user_voice_channel_success(self):
         adapter = self._make_adapter()
         mock_vc = MagicMock()


### PR DESCRIPTION
Fixes #76044.

## The bug

`DiscordAdapter.disconnect()` cancels the bot task *before* cleaning up voice clients:

```python
await self._cancel_bot_task()
# Clean up all active voice connections before closing the client
for guild_id in list(self._voice_clients.keys()):
    try:
        await self.leave_voice_channel(guild_id)
```

`leave_voice_channel()` ends in `await vc.disconnect()`. In discord.py that sends a voice state update over the **main gateway websocket**, then waits for the voice websocket to close. The bot task is the loop running that gateway connection (`client.start()`), so cancelling it first leaves the handshake with no transport — it can never complete, and blocks until the caller's 5s shutdown timeout fires.

Every shutdown with a voice connection open pays a fixed ~5s penalty and ends with the voice disconnect abandoned rather than completed:

```
WARNING gateway.run: ✗ discord disconnect timed out after 5.0s - forcing continue
INFO    gateway.run: Shutdown phase: all adapters disconnected at +5.29s
```

A bot that never joins voice tears down instantly, which is presumably why this has gone unnoticed.

## The fix

Move the voice-cleanup loop above `await self._cancel_bot_task()`, so voice disconnects while the gateway websocket is still alive.

This preserves the zombie-client protection the existing comment describes — that a timed-out `connect()` can leave a `client.start()` task dispatching events, and `client.close()` alone won't stop it. The bot task is still cancelled before `client.close()`; it just happens after voice teardown rather than before. Voice teardown is the one step in `disconnect()` that still requires a live gateway.

## Measured

On a live gateway, with a voice connection open in both cases:

| | before | after |
|---|---|---|
| Discord disconnect | `✗ timed out after 5.0s` | `✓ disconnected (0.12s)` |
| All adapters disconnected | +5.29s | +0.46s |
| Wall-clock `systemctl stop` | ~5.4s | 0.76s |

## Tests

Adds `test_disconnect_leaves_voice_before_cancelling_bot_task`, following the events-list style of the existing `test_leave_voice_channel_processes_pending_audio_before_disconnect` in the same class.

It is a real regression test — on the previous ordering it fails at index 1:

```
At index 1 diff: 'cancel_bot_task' != 'leave_voice_channel:111'
```

- `tests/gateway/test_voice_command.py`: 68 passed, 7 skipped
- `tests/gateway/`: 4462 passed, 30 skipped, 5 failed

The 5 failures are pre-existing and unrelated (`test_discord_send.py` ×3, `test_send_multiple_images.py`, `test_session_store_prune.py`). They reproduce identically on unmodified `origin/main` in a full-suite run — 4461 passed with the same 5 failures — and pass in isolation on both, so they look order-dependent. This branch's only delta is the +1 test it adds.

`ruff check` passes on both files. I deliberately did not run `ruff format`: both files already differ from it on `origin/main`, so formatting them would bury a 3-line fix in unrelated churn.
