### PR TITLE
fix(photon): hydrate outbound reply targets

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -480,15 +480,11 @@ async function normalizeBinaryContent(content) {
   return meta;
 }
 
-// Best-effort text preview of a reaction's resolved target Message, so the
-// Python adapter can populate the gateway's `reply_to_text` (context: WHAT was
-// tapped back). The SDK only emits a reaction once it has resolved the full
-// target Message (toReactionMessages bails otherwise), so `target.content` is
-// hydrated here — no extra round trip. Handles plain text and our patched mixed
-// text+attachment groups (first text child); null for attachment/voice-only
-// targets. Capped so one long bubble can't balloon the NDJSON line.
+// Best-effort text preview of a resolved target message. Capped so one long
+// bubble cannot balloon the NDJSON line. Handles plain text and mixed
+// text+attachment groups; returns null for attachment/voice-only targets.
 const REACTION_TARGET_TEXT_CAP = 2000;
-function reactionTargetText(target) {
+function messageTextPreview(target) {
   const c = target && typeof target === "object" ? target.content : null;
   if (!c || typeof c !== "object") return null;
   let text = null;
@@ -557,7 +553,7 @@ async function normalizeContent(content) {
       targetDirection: target?.direction ?? null,
       // Text of the reacted-to message, so Python can correlate the tapback to
       // the gateway's reply_to_text. Null for attachment/voice-only targets.
-      targetText: reactionTargetText(target),
+      targetText: messageTextPreview(target),
     };
   }
   // A user tapping a poll choice arrives as `poll_option` carrying the chosen
@@ -590,8 +586,31 @@ async function normalizeEvent(space, message) {
   try {
     const msgSpace = message.space || {};
     const ts = message.timestamp;
+    const replyTargetId =
+      message.replyTargetGuid ?? message.reply_to_guid ??
+      message.threadOriginatorGuid ?? message.threadRootMessageId ?? null;
+    // Reply targets are often Hermes' outbound messages, so they are not in
+    // knownMessages (which is populated from inbound events only). Hydrate a
+    // cache miss through Spectrum so the adapter can preserve quoted context.
+    let replyTarget = replyTargetId
+      ? knownMessages.get(replyTargetId)
+      : null;
+    if (replyTargetId && !replyTarget && typeof space.getMessage === "function") {
+      try {
+        replyTarget = await space.getMessage(replyTargetId);
+        if (replyTarget) rememberKnownMessage(replyTarget);
+      } catch (e) {
+        console.error(
+          `photon-sidecar: failed to hydrate reply target ${replyTargetId}: ` +
+            (e && e.message ? e.message : String(e))
+        );
+      }
+    }
     return {
       messageId: message.id ?? null,
+      replyToMessageId: replyTargetId,
+      replyToText: messageTextPreview(replyTarget),
+      replyToIsOwnMessage: replyTarget?.isFromMe === true,
       platform: message.platform || space.__platform || "iMessage",
       space: {
         id: space.id ?? msgSpace.id ?? null,


### PR DESCRIPTION
## Summary

- hydrate Photon/iMessage reply targets when the local inbound-message cache misses
- preserve the target ID, quoted text, and outbound-target flag for Hermes reply context
- reuse the bounded target-text preview helper for normal replies and reactions

## Problem

Photon/Spectrum supplied the reply target ID, but Hermes' sidecar only looked up targets in `knownMessages`, which is populated from inbound events. Replies to Hermes' outbound messages therefore arrived with a valid target ID but empty target text, so short replies were ambiguous to the agent.

## Fix

On a reply-target cache miss, call `space.getMessage(replyTargetId)` and derive the quoted text from the hydrated message. Failures remain best-effort and do not break the inbound stream.

## Validation

- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `git diff --check`
- `python3 -m compileall -q plugins/platforms/photon`
- Live Photon/iMessage validation on a real reply: before the fix, `reply_to_id` was populated but `reply_to_text` was empty; after the fix, the target text was populated and Hermes received `[Replying to your previous message: ...]`.

No private message content, phone numbers, credentials, or message IDs are included here.