### PR TITLE
fix(agent): classify "media exceeds size limit" as image_too_large

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -241,6 +241,16 @@ _IMAGE_TOO_LARGE_PATTERNS = [
     "image dimensions exceed",  # Anthropic: "image dimensions exceed max allowed size: 8000 pixels"
     "dimensions exceed max allowed size",  # Anthropic dimension-cap (wording variant)
     "max allowed size: 8000",  # Anthropic dimension-cap (explicit pixel ceiling)
+    # Vendors that reject the same oversized image without using the word
+    # "image".  MiniMax's Anthropic-compatible endpoint returns
+    # "media exceeds size limit: max 10485760 bytes (2013)" for a native
+    # image part above its 10 MB ceiling (#76039).  Matched on the "media"
+    # fragment to mirror "image exceeds" above and catch reworded variants.
+    # A non-image media rejection (audio/video) that lands here is safe: the
+    # shrink pass finds no image parts, returns False, and the caller
+    # surfaces the original error unchanged.
+    "media exceeds",
+    "media too large",
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
 ]

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -53,8 +53,39 @@ class TestImageTooLargeClassification:
         assert result.reason == FailoverReason.image_too_large
         assert result.retryable is True
 
+    def test_minimax_400_media_exceeds_message(self):
+        """A vendor that rejects an oversized image without the word "image".
 
+        MiniMax's Anthropic-compatible endpoint returns this for a native
+        image part over its 10 MB ceiling.  It used to fall through to
+        _REQUEST_VALIDATION_PATTERNS and classify as format_error /
+        non-retryable, which skipped shrink recovery and left the oversized
+        part baked into replayed history — every later turn re-sent the same
+        bytes and failed identically (#76039).
+        """
+        err = _FakeApiError(
+            status_code=400,
+            message="media exceeds size limit: max 10485760 bytes (2013)",
+            body={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "media exceeds size limit: max 10485760 bytes (2013)",
+                },
+            },
+        )
+        result = classify_api_error(err, provider="minimax", model="MiniMax-M3")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
 
+    def test_unrelated_400_still_not_image_too_large(self):
+        """The new "media" patterns must not widen into ordinary 400s."""
+        err = _FakeApiError(
+            status_code=400,
+            message="messages: unexpected role \"tool\" at index 3",
+        )
+        result = classify_api_error(err, provider="minimax", model="MiniMax-M3")
+        assert result.reason != FailoverReason.image_too_large
 
 
 


### PR DESCRIPTION
## What does this PR do?

Vendors that reject an oversized image *without using the word "image"* were classified as non-retryable format errors, which skipped image-shrink recovery and left the session permanently dead.

MiniMax's Anthropic-compatible endpoint (`api.minimax.io/anthropic`, 10 MB per-image ceiling) returns:

```
media exceeds size limit: max 10485760 bytes (2013)
```

None of `_IMAGE_TOO_LARGE_PATTERNS` matched it — every entry contains the literal substring `image`. The 400 fell through to `_REQUEST_VALIDATION_PATTERNS` (the body is `type: invalid_request_error`) and classified as `format_error` / `retryable=False`.

Reproduced on this branch's parent, no API key required:

```python
classify_api_error(err_400("media exceeds size limit: max 10485760 bytes (2013)"),
                   provider="minimax", model="MiniMax-M3")
# before -> reason=format_error     retryable=False
# after  -> reason=image_too_large  retryable=True

classify_api_error(err_400("image exceeds 5 MB maximum"), ...)
# unchanged -> reason=image_too_large retryable=True
```

Why that bricks the session rather than just failing one turn: the oversized part is already baked into history as a `tool_result` image block, and the context compressor rewrites text but not image data. So the same bytes are replayed on every subsequent turn and fail identically — the reporter saw 5 consecutive turns die over 4 minutes with the same error. Recovery required forking the session.

## Related Issue

Fixes #76039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — added `"media exceeds"` and `"media too large"` to `_IMAGE_TOO_LARGE_PATTERNS`, with a comment recording MiniMax's wording and the reasoning below.
- `tests/run_agent/test_image_shrink_recovery.py` — added `test_minimax_400_media_exceeds_message` (the reported wording) and `test_unrelated_400_still_not_image_too_large` (guard against the new patterns widening into ordinary 400s), alongside the existing Anthropic case.

Matched on the `media` fragment rather than the full sentence, mirroring the existing `"image exceeds"` entry, so reworded vendor variants are caught too. A non-image media rejection (audio/video) routed here is safe by construction: `try_shrink_image_parts_in_messages` finds no image parts, returns `False`, and `conversation_loop` logs and surfaces the original error unchanged — that `else` branch already exists.

## User Impact

A session that hits an oversized native-vision screenshot on MiniMax (or any vendor with similar wording) now recovers by shrinking and retrying, instead of dying permanently and forcing the user to start a new session.

## Evidence

Verified against `main` @ `9fc12bf`.

- New MiniMax test **fails on parent, passes here**: `AssertionError: assert <FailoverReason.format_error> == <FailoverReason.image_too_large>`.
- The guard test passes both ways by design — it exists to catch future widening, not to demonstrate the bug.
- Full classifier regression surface (every one of the 17 test files referencing `classify_api_error` / `FailoverReason` / `_IMAGE_TOO_LARGE`): **408 passed, 12 failed**.
- Those 12 are all in `tests/run_agent/test_image_shrink_recovery.py`'s neighbour `test_run_agent.py` and are **pre-existing in my environment**, not caused by this change. Run in isolation, that file gives an identical `6 failed, 223 passed` both with and without the diff — the delta from 6 to 12 is cross-file pollution when the 17 files share one process, also present on the parent. The failures are `TestConcurrentToolExecution`, `test_aiagent_uses_copilot_acp_client`, `TestAnthropicInterruptHandler`, `TestMemoryNudgeCounterPersistence` — none touch error classification.
- `agent/test_error_classifier.py` (the direct surface) passes in full.
- `uvx ruff@0.15.10 check` — clean on both changed files.

I could not run the whole suite locally: a large number of modules fail collection here on missing optional extras (`prompt_toolkit`, `rich` in some paths, provider SDKs), and `tests/agent/` has many environment-dependent failures unrelated to this area. CI is the real check for the rest.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note above; ran the complete classifier regression surface instead
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, kernel 7.1.1), Python 3.14

### Documentation & Housekeeping

- [x] N/A — no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure string matching, no platform-dependent behavior
- [x] N/A — no tool behavior change

## Notes for reviewers

**On scope.** #76039 identifies three interacting bugs. This PR fixes only Bug 1 (the classifier), deliberately:

- **Bug 3** (shrink recovery gated on `image_too_large`) needs no separate change — the gate is correct, it was simply never reached. Fixing classification reaches it.
- **Bug 2** (native-vision fast path in `tools/browser_tool.py:4284-4315` embeds the full-resolution screenshot with no pre-resize) is **not fixed here**. It is a real gap and worth its own change: this PR makes the failure recoverable, but the request still goes out oversized and pays a rejected round-trip plus a re-encode on every turn, because the oversized bytes stay in history. Proactively capping the screenshot at embed time would avoid the round-trip entirely. I left it out to keep this reviewable and because it is a behavior change to the vision path rather than a classification fix.

**Relationship to #69104.** That open PR also edits `error_classifier.py` for image-shaped 400s, but for a different failure class — it adds `_IMAGE_CORRUPT_PATTERNS` and a new `FailoverReason.image_corrupt` for undecodable bytes (xAI's "Invalid PNG image."), which need strip-and-retry rather than shrink-and-retry. It does not touch `_IMAGE_TOO_LARGE_PATTERNS`, so the two are semantically independent. They add adjacent blocks in the same region of the file, so whichever lands second may need a trivial merge — happy to rebase behind it.

**Open question.** `"media too large"` is included on symmetry with `"image too large"` but is not a wording I have observed in the wild; only `"media exceeds"` is evidenced by the report. Say the word if you would rather ship only the observed pattern.
