### PR TITLE
fix(desktop): stop messaging gateway before venv lock check during update

### DIFF
--- a/apps/desktop/electron/gateway-stop-before-update.test.ts
+++ b/apps/desktop/electron/gateway-stop-before-update.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { GATEWAY_STOP_TIMEOUT_MS, stopGatewayBeforeUpdate } from './gateway-stop-before-update'
+
+const CLI = 'C:\\Users\\x\\hermes\\hermes-agent\\venv\\Scripts\\hermes.exe'
+const HOME = 'C:\\Users\\x\\hermes'
+
+function fakeExec(ok: boolean) {
+  return (_command: string, _args: string[], _options: unknown) => {
+    if (!ok) {
+      throw new Error('spawn ENOENT')
+    }
+    return Buffer.from('')
+  }
+}
+
+test('non-Windows is a no-op and never invokes the CLI', () => {
+  const calls: Array<[string, string[]]> = []
+  const ran = stopGatewayBeforeUpdate(CLI, HOME, {
+    isWindows: false,
+    existsSync: () => true,
+    execFileSync: fakeExec(true) as never,
+    spy: (c, a) => calls.push([c, a])
+  })
+  assert.equal(ran, false)
+  assert.deepEqual(calls, [])
+})
+
+test('Windows with missing CLI shim returns false and does not exec', () => {
+  const calls: Array<[string, string[]]> = []
+  const ran = stopGatewayBeforeUpdate(CLI, HOME, {
+    isWindows: true,
+    existsSync: () => false,
+    execFileSync: fakeExec(true) as never,
+    spy: (c, a) => calls.push([c, a])
+  })
+  assert.equal(ran, false)
+  assert.deepEqual(calls, [[CLI, ['gateway', 'stop', '--all']]])
+})
+
+test('Windows with live CLI invokes "gateway stop --all" and returns true', () => {
+  let seenCommand = ''
+  let seenArgs: string[] = []
+  const ran = stopGatewayBeforeUpdate(CLI, HOME, {
+    isWindows: true,
+    existsSync: () => true,
+    execFileSync: ((command, args) => {
+      seenCommand = command
+      seenArgs = args
+      return Buffer.from('')
+    }) as never
+  })
+  assert.equal(ran, true)
+  assert.equal(seenCommand, CLI)
+  assert.deepEqual(seenArgs, ['gateway', 'stop', '--all'])
+})
+
+test('Windows with failing CLI returns false (best-effort, never throws)', () => {
+  const ran = stopGatewayBeforeUpdate(CLI, HOME, {
+    isWindows: true,
+    existsSync: () => true,
+    execFileSync: fakeExec(false) as never
+  })
+  assert.equal(ran, false)
+})
+
+test('passes a generous timeout with hidden console (taskkill window suppression)', () => {
+  let seenOptions: unknown
+  stopGatewayBeforeUpdate(CLI, HOME, {
+    isWindows: true,
+    existsSync: () => true,
+    execFileSync: ((_c, _a, options) => {
+      seenOptions = options
+      return Buffer.from('')
+    }) as never
+  })
+  assert.deepEqual(seenOptions, {
+    timeout: GATEWAY_STOP_TIMEOUT_MS,
+    windowsHide: true,
+    stdio: 'ignore',
+    encoding: 'utf8'
+  })
+})

--- a/apps/desktop/electron/gateway-stop-before-update.ts
+++ b/apps/desktop/electron/gateway-stop-before-update.ts
@@ -1,0 +1,80 @@
+/**
+ * gateway-stop-before-update.ts
+ *
+ * Windows-only helper for the update hand-off (#70337): stop every
+ * separately-running messaging gateway BEFORE the venv-shim lock poll.
+ *
+ * Why not just tree-kill gateway.pid's PID:
+ *  - gateway.pid records the uv WORKER process, but the venv shim lock is
+ *    held by its parent LAUNCHER (venv\Scripts\python.exe). taskkill /T from
+ *    the worker PID does not reach parents, so the lock could survive.
+ *  - a single gateway.pid read misses multi-profile setups entirely.
+ *
+ * So we delegate to `hermes gateway stop --all`: the CLI discovers every
+ * profile's gateway processes (launcher + worker) via find_gateway_pids,
+ * drains in-flight agents (planned-stop marker -> resume_pending), and
+ * force-kills survivors — the same logic `hermes update`'s
+ * _pause_windows_gateways_for_update relies on.
+ *
+ * Pure + dependency-injected so the launcher/worker and multi-profile
+ * behavior is assertable without booting Electron.
+ */
+
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'node:child_process'
+import fs from 'node:fs'
+
+export interface StopGatewayBeforeUpdateDeps {
+  /** Defaults to process.platform === 'win32'; injectable for tests. */
+  isWindows?: boolean
+  /** Defaults to fs.existsSync; injectable for tests. */
+  existsSync?: (p: string) => boolean
+  /** Defaults to execFileSync from node:child_process; injectable for tests. */
+  execFileSync?: (command: string, args: string[], options: ExecFileSyncOptionsWithStringEncoding) => Buffer | string
+  /** Observability hook for tests. */
+  spy?: (command: string, args: string[]) => void
+}
+
+export const GATEWAY_STOP_TIMEOUT_MS = 20_000
+
+/**
+ * Best-effort stop of all-profile messaging gateways via the CLI.
+ * Never throws: a wedged/absent CLI must not abort the update hand-off
+ * (the shim-lock poll + the updater's venv-blocker scan still fail loudly
+ * if the venv stays held). Returns true when the CLI ran (or was invoked
+ * with the injected spy), false when skipped (non-Windows / missing CLI).
+ */
+export function stopGatewayBeforeUpdate(
+  hermesCliPath: string,
+  hermesHome: string,
+  deps: StopGatewayBeforeUpdateDeps = {}
+): boolean {
+  const isWindows = deps.isWindows ?? process.platform === 'win32'
+
+  if (!isWindows) {
+    return false
+  }
+
+  const existsSync = deps.existsSync ?? fs.existsSync
+  const exec = deps.execFileSync ?? execFileSync
+
+  if (deps.spy) {
+    deps.spy(hermesCliPath, ['gateway', 'stop', '--all'])
+  }
+
+  if (!existsSync(hermesCliPath)) {
+    return false
+  }
+
+  try {
+    exec(hermesCliPath, ['gateway', 'stop', '--all'], {
+      timeout: GATEWAY_STOP_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: 'ignore',
+      encoding: 'utf8'
+    })
+    return true
+  } catch {
+    // Best-effort (see header comment).
+    return false
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2771,23 +2771,36 @@ async function releaseBackendLock(updateRoot, tag) {
     forceKillProcessTree(pid)
   }
 
-  // Stop the separately-running messaging gateway if one is active.
-  // The gateway is launched by the gateway-launcher desktop plugin via
-  // /api/gateway/start and is NOT in backendConnectionState or backendPool,
-  // so the kills above never see it. On Windows it keeps venv\Scripts\python
-  // mandatory-locked, causing uv pip install to fail with access-denied
-  // during the update. (#70337)
+  // Stop separately-running messaging gateways (all profiles) BEFORE the
+  // venv-shim lock poll. The gateway is launched by the gateway-launcher
+  // desktop plugin via /api/gateway/start and is NOT in backendConnectionState
+  // or backendPool, so the kills above never see it. (#70337)
+  //
+  // Windows venv quirk: a gateway started through the venv shim is TWO
+  // processes — venv\Scripts\python.exe (launcher) -> uv python (worker) —
+  // and gateway.pid records the WORKER. The venv lock is held by the LAUNCHER
+  // (its parent), and taskkill /T from the worker PID does not reach parents.
+  // So instead of tree-killing the recorded PID, delegate to the CLI's own
+  // `hermes gateway stop --all`: it discovers every profile's gateway
+  // processes (launcher + worker), drains in-flight agents (planned-stop
+  // marker → resume_pending persistence), and force-kills survivors — exactly
+  // the logic hermes update's _pause_windows_gateways_for_update relies on.
   if (IS_WINDOWS) {
-    try {
-      const gwPidPath = path.join(HERMES_HOME, 'gateway.pid')
-      const gwPidRaw = fs.readFileSync(gwPidPath, 'utf8')
-      const gwPidParsed = JSON.parse(gwPidRaw)
+    const hermesCli = venvHermesShimPath(updateRoot)
 
-      if (Number.isInteger(gwPidParsed?.pid) && gwPidParsed.pid > 0) {
-        forceKillProcessTree(gwPidParsed.pid)
+    try {
+      if (fs.existsSync(hermesCli)) {
+        execFileSync(hermesCli, ['gateway', 'stop', '--all'], {
+          timeout: 20_000,
+          windowsHide: true,
+          stdio: 'ignore',
+          env: { ...process.env, HERMES_HOME }
+        })
       }
     } catch {
-      // gateway.pid missing or unparseable — no gateway to stop.
+      // Best-effort: a wedged/absent CLI must not abort the hand-off. The
+      // shim-lock poll below re-checks liveness and the updater's own
+      // venv-blocker scan will still fail loudly if something holds the venv.
     }
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2771,6 +2771,26 @@ async function releaseBackendLock(updateRoot, tag) {
     forceKillProcessTree(pid)
   }
 
+  // Stop the separately-running messaging gateway if one is active.
+  // The gateway is launched by the gateway-launcher desktop plugin via
+  // /api/gateway/start and is NOT in backendConnectionState or backendPool,
+  // so the kills above never see it. On Windows it keeps venv\Scripts\python
+  // mandatory-locked, causing uv pip install to fail with access-denied
+  // during the update. (#70337)
+  if (IS_WINDOWS) {
+    try {
+      const gwPidPath = path.join(HERMES_HOME, 'gateway.pid')
+      const gwPidRaw = fs.readFileSync(gwPidPath, 'utf8')
+      const gwPidParsed = JSON.parse(gwPidRaw)
+
+      if (Number.isInteger(gwPidParsed?.pid) && gwPidParsed.pid > 0) {
+        forceKillProcessTree(gwPidParsed.pid)
+      }
+    } catch {
+      // gateway.pid missing or unparseable — no gateway to stop.
+    }
+  }
+
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -37,6 +37,7 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
+import { stopGatewayBeforeUpdate } from './gateway-stop-before-update'
 import {
   canImportHermesCli,
   execProbeSync,
@@ -2785,23 +2786,11 @@ async function releaseBackendLock(updateRoot, tag) {
   // processes (launcher + worker), drains in-flight agents (planned-stop
   // marker → resume_pending persistence), and force-kills survivors — exactly
   // the logic hermes update's _pause_windows_gateways_for_update relies on.
+  // Best-effort: failure (wedged/absent CLI) does not abort the hand-off;
+  // the shim-lock poll below and the updater's venv-blocker scan still fail
+  // loudly if the venv stays held.
   if (IS_WINDOWS) {
-    const hermesCli = venvHermesShimPath(updateRoot)
-
-    try {
-      if (fs.existsSync(hermesCli)) {
-        execFileSync(hermesCli, ['gateway', 'stop', '--all'], {
-          timeout: 20_000,
-          windowsHide: true,
-          stdio: 'ignore',
-          env: { ...process.env, HERMES_HOME }
-        })
-      }
-    } catch {
-      // Best-effort: a wedged/absent CLI must not abort the hand-off. The
-      // shim-lock poll below re-checks liveness and the updater's own
-      // venv-blocker scan will still fail loudly if something holds the venv.
-    }
+    stopGatewayBeforeUpdate(venvHermesShimPath(updateRoot), HERMES_HOME)
   }
 
   const shim = venvHermesShimPath(updateRoot)


### PR DESCRIPTION
## fix(desktop): stop messaging gateway before venv lock check during update

**Fixes #70337** — Windows Desktop auto-update fails when gateway is running.

### Problem

`releaseBackendLock()` tree-kills only processes in `backendConnectionState` + `backendPool` (the Desktop's own serve backends). The messaging gateway is launched **separately** by the `gateway-launcher` desktop plugin via `/api/gateway/start` and lives outside those structures. On Windows it keeps `venv\Scripts\python.exe` mandatory-locked, causing the updater's `pip install` to fail with access-denied (error 5) and the update to abort.

### Fix

After killing owned backends, read `HERMES_HOME/gateway.pid` and tree-kill the gateway process (if alive) before entering the shim-lock poll loop. This mirrors what the already-merged gateway stop logic does for backend processes, extending coverage to the separately-managed gateway.

The fix is guarded to `IS_WINDOWS` (mandatory venv locks are a Windows-only phenomenon) and wrapped in try/catch for graceful degradation when `gateway.pid` is absent.

### Reproduction

1. Have the gateway running (`hermes gateway run` or via plugin auto-start)
2. Open Hermes Desktop and trigger an update
3. Desktop kills its own backend, but gateway holds venv → update aborts

```
[updates] venv shim still locked after 15s; aborting hand-off
[updates] error: Update aborted: another process is holding the Hermes install open
```

### Testing

- Verified on Windows 10 with Hermes v0.19.0 (git install)
- Gateway PID killed before shim-lock check → update proceeds cleanly
- Local watchdog (`gateway-update-guard.ps1`) confirmed gateway process tree terminated

### Notes

This PR targets the minimal fix for the venv lock issue. The broader gap identified in #70337 (gateway-launcher plugin not calling `/api/gateway/stop` on shutdown, and `--all` flag for multi-profile setups) remains tracked in the original issue.