### PR TITLE
fix(desktop): refresh project tree after completed turns

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -44,7 +44,7 @@ import {
   normalizeProfileKey,
   refreshActiveProfile
 } from '@/store/profile'
-import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
+import { $startWorkSessionRequest, followActiveSessionCwd, refreshProjectTree } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -400,6 +400,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     hydrateFromStoredSession,
     queryClient,
     refreshHermesConfig,
+    refreshProjectTree,
     refreshSessions,
     sessionStateByRuntimeIdRef,
     updateSessionState

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -42,6 +42,7 @@ interface MessageStreamOptions {
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
+  refreshProjectTree?: () => Promise<void>
   refreshSessions: () => Promise<void>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
   updateSessionState: (
@@ -69,6 +70,7 @@ export function useMessageStream({
   hydrateFromStoredSession,
   queryClient,
   refreshHermesConfig,
+  refreshProjectTree,
   refreshSessions,
   sessionStateByRuntimeIdRef,
   updateSessionState
@@ -158,6 +160,11 @@ export function useMessageStream({
     const run = () => {
       sessionsRefreshTimerRef.current = null
       void refreshSessions().catch(() => undefined)
+      // The Projects overview renders its disclosure toggle and preview rows
+      // from projects.tree, not from the flat session list. A project-scoped
+      // `+` opens an unlisted tile, so its first completed turn must refresh
+      // both authorities or the persisted chat remains unreachable there.
+      void refreshProjectTree?.().catch(() => undefined)
       // Sync freshly-titled rows to other windows (e.g. main, when the turn
       // ran in the pop-out).
       broadcastSessionsChanged()
@@ -170,7 +177,7 @@ export function useMessageStream({
     }
 
     sessionsRefreshTimerRef.current = window.setTimeout(run, 300)
-  }, [refreshSessions])
+  }, [refreshProjectTree, refreshSessions])
 
   useEffect(
     () => () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -20,6 +20,7 @@ const ACTIVE_SID = 'session-active'
 const ACTIVE_PROFILE = 'compass'
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let refreshHermesConfig: ReturnType<typeof vi.fn<() => Promise<void>>>
+let refreshProjectTree: ReturnType<typeof vi.fn<() => Promise<void>>>
 let refreshSessions: ReturnType<typeof vi.fn<() => Promise<void>>>
 let queryClient: QueryClient
 
@@ -33,6 +34,7 @@ function Harness() {
     hydrateFromStoredSession: vi.fn(async () => undefined),
     queryClient,
     refreshHermesConfig,
+    refreshProjectTree,
     refreshSessions,
     sessionStateByRuntimeIdRef,
     updateSessionState: (sessionId, updater) => {
@@ -62,6 +64,7 @@ const sessionInfo = (sessionId: string, payload: Record<string, unknown>) =>
 beforeEach(() => {
   handleEvent = null
   refreshHermesConfig = vi.fn<() => Promise<void>>(async () => undefined)
+  refreshProjectTree = vi.fn<() => Promise<void>>(async () => undefined)
   refreshSessions = vi.fn<() => Promise<void>>(async () => undefined)
   queryClient = new QueryClient()
   setCurrentModel('')
@@ -140,7 +143,7 @@ describe('session.info model-options invalidation gating', () => {
 })
 
 describe('message.complete sidebar refresh coalescing', () => {
-  it('collapses near-simultaneous completions into one refresh', async () => {
+  it('collapses near-simultaneous completions into one flat-session and project-tree refresh', async () => {
     await mountStream()
     vi.useFakeTimers()
 
@@ -148,11 +151,13 @@ describe('message.complete sidebar refresh coalescing', () => {
     act(() => handleEvent!({ payload: { text: 'b' }, session_id: 's2', type: 'message.complete' }))
 
     expect(refreshSessions).not.toHaveBeenCalled()
+    expect(refreshProjectTree).not.toHaveBeenCalled()
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(400)
     })
 
     expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(refreshProjectTree).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

- refresh `projects.tree` alongside the flat session list after a completed turn
- make project-scoped sessions appear under their project immediately after the first persisted message
- cover the coalesced refresh behavior with a regression test

## Root cause

The Desktop sidebar derives project disclosure toggles and child sessions from `projects.tree`. The message completion path refreshed only `session.list`, so a session created from a project `+` could be persisted with the correct `cwd` while the project still appeared empty until a full reload.

## Verification

- `npm run typecheck --workspace apps/desktop`
- `npm run test:ui --workspace apps/desktop -- src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx`
- `git diff --check`