### PR TITLE
fix(discord): honor retry_after in auto-thread creation instead of dropping messages on 429

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -55,6 +55,13 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+# Auto-thread creation honors Discord's 429 retry_after up to this bound.
+# discord.py raises RateLimited only when the server-requested delay exceeds
+# its internal cap, so a fixed-backoff retry can never clear the bucket.
+# Delays within this bound are waited out and retried; longer delays mean the
+# rate limit will not clear for minutes, so we surface a retry hint to the
+# user instead of blocking the message handler on a doomed wait.
+_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS = 30.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -6561,6 +6568,16 @@ class DiscordAdapter(BasePlatformAdapter):
         retried once after a short backoff so transient connect errors
         (e.g. ``Cannot connect to host discord.com:443``) don't immediately
         burn through to the caller's failure path (#20243).
+
+        Discord 429 rate limits are handled specially. discord.py raises
+        ``RateLimited`` only when the server-requested ``retry_after``
+        exceeds its internal ``max_ratelimit_timeout``, so the fixed 0.75s
+        backoff can never clear the bucket — retrying on it just re-429s.
+        We wait out ``retry_after`` when it is within
+        ``_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS``, and give up
+        immediately (recording the delay on ``self._last_auto_thread_rate_limit``)
+        when it is longer so the caller can surface a rate-limit-aware
+        notice instead of a generic "please retry".
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
@@ -6568,6 +6585,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
         last_direct_error: Exception | None = None
         last_fallback_error: Exception | None = None
+        # Reset per-call rate-limit state; set on failure so the caller can
+        # tailor the user-facing notice (#...).
+        self._last_auto_thread_rate_limit = None
 
         for attempt in range(2):
             try:
@@ -6579,6 +6599,34 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+                if self._is_discord_rate_limit(direct_error):
+                    retry_after = self._extract_discord_retry_after(direct_error)
+                    if retry_after is not None:
+                        self._last_auto_thread_rate_limit = retry_after
+                    if (
+                        retry_after is not None
+                        and retry_after <= _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS
+                        and attempt == 0
+                    ):
+                        # Short rate limit — wait out the bucket, then retry
+                        # the direct path. The seed-message fallback would hit
+                        # the same bucket, so skip it this round.
+                        logger.warning(
+                            "[%s] Auto-thread creation rate-limited; retrying in %.1fs",
+                            self.name,
+                            retry_after,
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                    # Long rate limit (or second attempt) — do not block for
+                    # minutes; the caller turns the recorded retry_after into
+                    # a "try again in ~Ns" notice.
+                    logger.warning(
+                        "[%s] Auto-thread creation rate-limited (retry_after=%s); giving up",
+                        self.name,
+                        retry_after,
+                    )
+                    break
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -6595,6 +6643,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     return thread
                 except Exception as fallback_error:
                     last_fallback_error = fallback_error
+                    if self._is_discord_rate_limit(fallback_error):
+                        retry_after = self._extract_discord_retry_after(fallback_error)
+                        if retry_after is not None:
+                            self._last_auto_thread_rate_limit = retry_after
+                        logger.warning(
+                            "[%s] Auto-thread creation fallback rate-limited (retry_after=%s); giving up",
+                            self.name,
+                            retry_after,
+                        )
+                        break
                     if attempt == 0:
                         # Brief backoff before the second attempt — most failures
                         # in this path are transient connect errors that recover
@@ -7531,10 +7589,21 @@ class DiscordAdapter(BasePlatformAdapter):
                     # user can retry once Discord recovers, and skip agent
                     # invocation for this message.
                     try:
-                        await message.channel.send(
-                            "⚠️ Hermes could not create a Discord thread for "
-                            "this message, so the request was not processed. Please retry."
+                        rate_limit_after = getattr(
+                            self, "_last_auto_thread_rate_limit", None
                         )
+                        if rate_limit_after is not None:
+                            await message.channel.send(
+                                f"⚠️ Discord is rate-limiting requests "
+                                f"(retry in ~{rate_limit_after:.0f}s). "
+                                "Your message was not processed — "
+                                "please try again shortly."
+                            )
+                        else:
+                            await message.channel.send(
+                                "⚠️ Hermes could not create a Discord thread for "
+                                "this message, so the request was not processed. Please retry."
+                            )
                     except Exception as notify_error:
                         logger.warning(
                             "[%s] Failed to notify user of auto-thread failure: %s",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -62,6 +62,24 @@ _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 # rate limit will not clear for minutes, so we surface a retry hint to the
 # user instead of blocking the message handler on a doomed wait.
 _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS = 30.0
+
+
+class _AutoThreadRateLimited:
+    """Sentinel returned by ``_auto_create_thread`` on a 429 that exceeds the
+    wait bound.
+
+    Carries the server-requested ``retry_after`` so the caller can surface a
+    rate-limit-aware notice without any shared adapter state. Deliberately
+    truthy-but-distinct: the caller must check ``isinstance`` before the
+    generic ``if result:`` success test, and must NOT mutate adapter state
+    (``_auto_create_thread`` yields during retry waits, so another message
+    could observe stale state mid-flight).
+    """
+
+    __slots__ = ("retry_after",)
+
+    def __init__(self, retry_after: float) -> None:
+        self.retry_after = float(retry_after)
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -6575,9 +6593,9 @@ class DiscordAdapter(BasePlatformAdapter):
         backoff can never clear the bucket — retrying on it just re-429s.
         We wait out ``retry_after`` when it is within
         ``_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS``, and give up
-        immediately (recording the delay on ``self._last_auto_thread_rate_limit``)
-        when it is longer so the caller can surface a rate-limit-aware
-        notice instead of a generic "please retry".
+        immediately (returning :class:`_AutoThreadRateLimited` carrying the
+        delay) when it is longer so the caller can surface a
+        rate-limit-aware notice instead of a generic "please retry".
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
@@ -6585,9 +6603,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         last_direct_error: Exception | None = None
         last_fallback_error: Exception | None = None
-        # Reset per-call rate-limit state; set on failure so the caller can
-        # tailor the user-facing notice (#...).
-        self._last_auto_thread_rate_limit = None
+        # Rate-limit outcome travels in the return value, NOT adapter state:
+        # this method awaits (retry sleeps) and another message's
+        # _auto_create_thread could interleave, so a shared attribute would
+        # race. The caller consumes the per-call sentinel locally.
 
         for attempt in range(2):
             try:
@@ -6601,8 +6620,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 last_direct_error = direct_error
                 if self._is_discord_rate_limit(direct_error):
                     retry_after = self._extract_discord_retry_after(direct_error)
-                    if retry_after is not None:
-                        self._last_auto_thread_rate_limit = retry_after
                     if (
                         retry_after is not None
                         and retry_after <= _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS
@@ -6619,14 +6636,14 @@ class DiscordAdapter(BasePlatformAdapter):
                         await asyncio.sleep(retry_after)
                         continue
                     # Long rate limit (or second attempt) — do not block for
-                    # minutes; the caller turns the recorded retry_after into
-                    # a "try again in ~Ns" notice.
+                    # minutes; hand the retry_after back to the caller so it
+                    # can say "try again in ~Ns".
                     logger.warning(
                         "[%s] Auto-thread creation rate-limited (retry_after=%s); giving up",
                         self.name,
                         retry_after,
                     )
-                    break
+                    return _AutoThreadRateLimited(retry_after or 0.0)
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -6645,14 +6662,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     last_fallback_error = fallback_error
                     if self._is_discord_rate_limit(fallback_error):
                         retry_after = self._extract_discord_retry_after(fallback_error)
-                        if retry_after is not None:
-                            self._last_auto_thread_rate_limit = retry_after
                         logger.warning(
                             "[%s] Auto-thread creation fallback rate-limited (retry_after=%s); giving up",
                             self.name,
                             retry_after,
                         )
-                        break
+                        return _AutoThreadRateLimited(retry_after or 0.0)
                     if attempt == 0:
                         # Brief backoff before the second attempt — most failures
                         # in this path are transient connect errors that recover
@@ -7564,6 +7579,25 @@ class DiscordAdapter(BasePlatformAdapter):
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)
+                if isinstance(thread, _AutoThreadRateLimited):
+                    # Discord 429 beyond the wait bound: the caller hands back
+                    # the server-requested retry_after so we can tell the user
+                    # WHEN to retry. The sentinel is per-call — never read
+                    # adapter state here (it would race across messages).
+                    try:
+                        await message.channel.send(
+                            f"⚠️ Discord is rate-limiting requests "
+                            f"(retry in ~{thread.retry_after:.0f}s). "
+                            "Your message was not processed — "
+                            "please try again shortly."
+                        )
+                    except Exception as notify_error:
+                        logger.warning(
+                            "[%s] Failed to notify user of auto-thread failure: %s",
+                            self.name,
+                            notify_error,
+                        )
+                    return False
                 if thread:
                     parent_channel_id = str(message.channel.id)
                     is_thread = True
@@ -7589,21 +7623,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     # user can retry once Discord recovers, and skip agent
                     # invocation for this message.
                     try:
-                        rate_limit_after = getattr(
-                            self, "_last_auto_thread_rate_limit", None
+                        await message.channel.send(
+                            "⚠️ Hermes could not create a Discord thread for "
+                            "this message, so the request was not processed. Please retry."
                         )
-                        if rate_limit_after is not None:
-                            await message.channel.send(
-                                f"⚠️ Discord is rate-limiting requests "
-                                f"(retry in ~{rate_limit_after:.0f}s). "
-                                "Your message was not processed — "
-                                "please try again shortly."
-                            )
-                        else:
-                            await message.channel.send(
-                                "⚠️ Hermes could not create a Discord thread for "
-                                "this message, so the request was not processed. Please retry."
-                            )
                     except Exception as notify_error:
                         logger.warning(
                             "[%s] Failed to notify user of auto-thread failure: %s",

--- a/tests/gateway/test_discord_auto_thread_rate_limit.py
+++ b/tests/gateway/test_discord_auto_thread_rate_limit.py
@@ -1,0 +1,294 @@
+"""Tests for rate-limit-aware auto-thread creation.
+
+When Discord rate-limits thread creation (HTTP 429), discord.py raises
+``RateLimited`` only when the server-requested ``retry_after`` exceeds its
+internal ``max_ratelimit_timeout``. The old retry loop slept a fixed 0.75s
+and retried — guaranteed to fail against a long Retry-After (e.g. 260s),
+so the user's message was dropped with a generic "please retry" notice.
+
+The fix:
+  1. Honors ``retry_after`` within ``_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS``
+     by waiting out the bucket before retrying the direct path.
+  2. Gives up immediately for longer rate limits and records the delay on
+     ``_last_auto_thread_rate_limit`` so the caller surfaces a
+     rate-limit-aware notice ("retry in ~Ns") instead of the generic one.
+"""
+
+from types import SimpleNamespace
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+# tests/gateway/conftest.py installs a comprehensive discord mock at
+# collection time, so ``discord`` here is that mock (no __file__). We define
+# a real RateLimited stand-in and monkeypatch it onto the adapter's discord
+# reference per-test so ``raise RateLimited(n)`` behaves like the real one.
+
+
+class _RateLimited(Exception):
+    """Stand-in for discord.RateLimited with the same retry_after contract."""
+
+    def __init__(self, retry_after: float):
+        self.retry_after = float(retry_after)
+        super().__init__(f"Too many requests. Retry in {retry_after:.2f} seconds.")
+
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS,
+)
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(name=guild_name)
+        self.topic = None
+        self.send = AsyncMock()
+
+
+class FakeThread:
+    def __init__(self, channel_id: int = 1, name: str = "thread", parent=None, guild_name: str = "Hermes Server"):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    # Make the adapter's discord.RateLimited a real exception class so the
+    # production ``_is_discord_rate_limit`` isinstance check works.
+    monkeypatch.setattr(discord_platform.discord, "RateLimited", _RateLimited, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = DiscordAdapter(config)
+    a._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    a._text_batch_delay_seconds = 0  # disable batching for tests
+    a.handle_message = AsyncMock()
+    return a
+
+
+def make_message(*, channel, content: str = "hello"):
+    author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser", bot=False)
+    return SimpleNamespace(
+        id=123,
+        content=content,
+        mentions=[],
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+    )
+
+
+def _patch_sleep(monkeypatch, sleeps):
+    """Record asyncio.sleep calls without actually waiting."""
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", _fake_sleep)
+
+
+# ── direct: short rate limit is waited out, then retried ─────────────
+
+
+@pytest.mark.asyncio
+async def test_short_rate_limit_waits_retry_after_then_succeeds(adapter, monkeypatch):
+    """A 429 with retry_after within the bound is waited out and retried.
+
+    The direct ``create_thread`` raises ``RateLimited(3.0)`` once, then
+    succeeds. The adapter must sleep ``retry_after`` (not the fixed 0.75s
+    backoff) before retrying, and the retried call must return the thread.
+    """
+    sleeps = []
+    _patch_sleep(monkeypatch, sleeps)
+
+    channel = FakeTextChannel(channel_id=100)
+    message = make_message(channel=channel)
+    fake_thread = FakeThread(channel_id=100)
+    calls = {"n": 0}
+
+    async def flaky_create_thread(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimited(3.0)
+        return fake_thread
+
+    message.create_thread = flaky_create_thread
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is fake_thread
+    assert calls["n"] == 2, "direct path should be retried once after the wait"
+    assert sleeps == [3.0], "should sleep the server-requested retry_after, not 0.75s"
+    # Seed-message fallback must not have run — the retry succeeded directly.
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_direct_connect_error_uses_seed_fallback(adapter, monkeypatch):
+    """Non-rate-limit direct error falls through to the seed-message fallback.
+
+    The original #20243 behavior is preserved: transient connect errors on
+    ``message.create_thread`` still try the seed-message fallback, which
+    creates the thread from a posted message. No rate-limit state is set.
+    """
+    sleeps = []
+    _patch_sleep(monkeypatch, sleeps)
+
+    channel = FakeTextChannel(channel_id=100)
+    message = make_message(channel=channel)
+    fake_thread = FakeThread(channel_id=100)
+
+    async def always_connect_error(**kwargs):
+        raise RuntimeError("Cannot connect to host discord.com:443")
+
+    async def seed_create_thread(**kwargs):
+        return fake_thread
+
+    message.create_thread = always_connect_error
+    # channel.send returns the seed message whose create_thread succeeds.
+    channel.send.return_value = SimpleNamespace(create_thread=seed_create_thread)
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is fake_thread
+    assert sleeps == [], "fallback succeeded on the first attempt — no backoff needed"
+    channel.send.assert_awaited_once()
+    assert adapter._last_auto_thread_rate_limit is None
+
+
+@pytest.mark.asyncio
+async def test_two_short_rate_limits_give_up_skipping_fallback(adapter, monkeypatch):
+    """Two short direct rate limits → give up; seed fallback is NOT attempted.
+
+    The seed-message fallback would hit the same channel bucket and only
+    spam a stray message into the channel, so it is skipped once the direct
+    path has been rate-limited on both attempts.
+    """
+    sleeps = []
+    _patch_sleep(monkeypatch, sleeps)
+
+    channel = FakeTextChannel(channel_id=100)
+    message = make_message(channel=channel)
+
+    async def always_rate_limited(**kwargs):
+        raise _RateLimited(2.0)
+
+    message.create_thread = always_rate_limited
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    assert sleeps == [2.0], "attempt 0 waits out the short limit; attempt 1 gives up"
+    channel.send.assert_not_awaited(), "seed fallback must not spam a 429'd channel"
+    assert adapter._last_auto_thread_rate_limit == 2.0
+
+
+# ── direct: long rate limit gives up fast with recorded retry_after ──
+
+
+@pytest.mark.asyncio
+async def test_long_rate_limit_gives_up_and_records_retry_after(adapter, monkeypatch):
+    """A 429 with retry_after beyond the bound gives up immediately.
+
+    The adapter must NOT block for minutes. It returns None and records the
+    delay so the caller can tell the user when to retry. The seed-message
+    fallback is skipped too — it would hit the same bucket.
+    """
+    sleeps = []
+    _patch_sleep(monkeypatch, sleeps)
+
+    long_wait = _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS + 60  # e.g. 90s
+    channel = FakeTextChannel(channel_id=100)
+    message = make_message(channel=channel)
+
+    async def always_rate_limited(**kwargs):
+        raise _RateLimited(long_wait)
+
+    message.create_thread = always_rate_limited
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    assert adapter._last_auto_thread_rate_limit == long_wait
+    assert sleeps == [], "long rate limit must not block the handler"
+    channel.send.assert_not_awaited(), "fallback would also 429 — skip it"
+
+
+# ── handle_message integration: rate-limit-aware user notice ─────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_failure_notifies_user_with_retry_hint(adapter, monkeypatch):
+    """Rate-limit failure surfaces a 'retry in ~Ns' notice, not the generic one."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    channel = FakeTextChannel(channel_id=800)
+    message = make_message(channel=channel, content="hello")
+
+    async def rate_limited_create_thread(**kwargs):
+        raise _RateLimited(120.0)
+
+    message.create_thread = rate_limited_create_thread
+
+    # Silence sleeps — 120s > bound, so none happen anyway, but keep it fast.
+    _patch_sleep(monkeypatch, [])
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    channel.send.assert_awaited_once()
+    sent_text = channel.send.await_args.args[0]
+    assert "rate-limiting" in sent_text.lower()
+    assert "120" in sent_text  # tells the user roughly when to retry
+
+
+@pytest.mark.asyncio
+async def test_non_rate_limit_failure_keeps_generic_notice(adapter, monkeypatch):
+    """A non-429 failure keeps the original generic 'could not create' notice."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    channel = FakeTextChannel(channel_id=800)
+    message = make_message(channel=channel, content="hello")
+
+    async def failing_create_thread(**kwargs):
+        raise RuntimeError("Cannot connect to host discord.com:443")
+
+    message.create_thread = failing_create_thread
+
+    # The seed-message fallback also fails (same connect error), but the
+    # user-facing notice must still go through.
+    async def failing_seed_create_thread(**kwargs):
+        raise RuntimeError("Cannot connect to host discord.com:443")
+
+    channel.send.return_value = SimpleNamespace(create_thread=failing_seed_create_thread)
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    # Last channel.send is the user-facing notice (after 2 fallback seed
+    # attempts). Verify it kept the original generic wording.
+    channel.send.assert_awaited()
+    sent_text = channel.send.await_args.args[0]
+    assert "could not create" in sent_text.lower()
+    assert "thread" in sent_text.lower()
+    assert "rate-limiting" not in sent_text.lower()

--- a/tests/gateway/test_discord_auto_thread_rate_limit.py
+++ b/tests/gateway/test_discord_auto_thread_rate_limit.py
@@ -9,9 +9,10 @@ so the user's message was dropped with a generic "please retry" notice.
 The fix:
   1. Honors ``retry_after`` within ``_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS``
      by waiting out the bucket before retrying the direct path.
-  2. Gives up immediately for longer rate limits and records the delay on
-     ``_last_auto_thread_rate_limit`` so the caller surfaces a
-     rate-limit-aware notice ("retry in ~Ns") instead of the generic one.
+  2. Gives up immediately for longer rate limits and returns a per-call
+     ``_AutoThreadRateLimited`` sentinel carrying the delay, so the caller
+     surfaces a rate-limit-aware notice ("retry in ~Ns") instead of the
+     generic one — without any shared adapter state.
 """
 
 from types import SimpleNamespace
@@ -41,6 +42,7 @@ import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
 from plugins.platforms.discord.adapter import (  # noqa: E402
     DiscordAdapter,
     _AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS,
+    _AutoThreadRateLimited,
 )
 
 
@@ -165,7 +167,7 @@ async def test_direct_connect_error_uses_seed_fallback(adapter, monkeypatch):
     assert result is fake_thread
     assert sleeps == [], "fallback succeeded on the first attempt — no backoff needed"
     channel.send.assert_awaited_once()
-    assert adapter._last_auto_thread_rate_limit is None
+    assert not isinstance(result, _AutoThreadRateLimited)
 
 
 @pytest.mark.asyncio
@@ -189,10 +191,10 @@ async def test_two_short_rate_limits_give_up_skipping_fallback(adapter, monkeypa
 
     result = await adapter._auto_create_thread(message)
 
-    assert result is None
+    assert isinstance(result, _AutoThreadRateLimited)
+    assert result.retry_after == 2.0
     assert sleeps == [2.0], "attempt 0 waits out the short limit; attempt 1 gives up"
     channel.send.assert_not_awaited(), "seed fallback must not spam a 429'd channel"
-    assert adapter._last_auto_thread_rate_limit == 2.0
 
 
 # ── direct: long rate limit gives up fast with recorded retry_after ──
@@ -220,8 +222,8 @@ async def test_long_rate_limit_gives_up_and_records_retry_after(adapter, monkeyp
 
     result = await adapter._auto_create_thread(message)
 
-    assert result is None
-    assert adapter._last_auto_thread_rate_limit == long_wait
+    assert isinstance(result, _AutoThreadRateLimited)
+    assert result.retry_after == long_wait
     assert sleeps == [], "long rate limit must not block the handler"
     channel.send.assert_not_awaited(), "fallback would also 429 — skip it"
 
@@ -292,3 +294,56 @@ async def test_non_rate_limit_failure_keeps_generic_notice(adapter, monkeypatch)
     assert "could not create" in sent_text.lower()
     assert "thread" in sent_text.lower()
     assert "rate-limiting" not in sent_text.lower()
+
+
+# ── interleaving regression: per-message notice isolation (#review) ────
+
+
+@pytest.mark.asyncio
+async def test_interleaved_rate_limit_failures_get_own_notices(adapter, monkeypatch):
+    """Concurrent auto-thread failures each surface their own retry hint.
+
+    Regression for shared-state hazard: retry-after metadata travels in the
+    per-call ``_AutoThreadRateLimited`` return value, never on adapter state,
+    so two messages racing through ``_auto_create_thread`` (which awaits
+    during retry sleeps) cannot overwrite each other's rate-limit notice.
+    """
+    import asyncio
+
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    sleeps = []
+    _patch_sleep(monkeypatch, sleeps)
+
+    channel_a = FakeTextChannel(channel_id=810)
+    channel_b = FakeTextChannel(channel_id=811)
+    msg_a = make_message(channel=channel_a, content="hello a")
+    msg_b = make_message(channel=channel_b, content="hello b")
+
+    async def rate_limited_a(**kwargs):
+        raise _RateLimited(45.0)
+
+    async def rate_limited_b(**kwargs):
+        raise _RateLimited(90.0)
+
+    msg_a.create_thread = rate_limited_a
+    msg_b.create_thread = rate_limited_b
+
+    await asyncio.gather(
+        adapter._handle_message(msg_a),
+        adapter._handle_message(msg_b),
+    )
+
+    # Each message got its OWN rate-limit notice with its own retry_after —
+    # 45s for channel A, 90s for channel B. If the metadata lived on shared
+    # adapter state, both could show the same (last-written) value.
+    adapter.handle_message.assert_not_awaited()
+    text_a = channel_a.send.await_args.args[0]
+    text_b = channel_b.send.await_args.args[0]
+    assert "45" in text_a and "rate-limiting" in text_a.lower()
+    assert "90" in text_b and "rate-limiting" in text_b.lower()
+    assert "45" not in text_b, "channel B must not inherit channel A's retry_after"
+    assert "90" not in text_a, "channel A must not inherit channel B's retry_after"


### PR DESCRIPTION
## What does this PR do?

Fixes auto-thread creation silently dropping user messages when Discord rate-limits thread creation (HTTP 429).

**Root cause:** When Discord returns 429 on `message.create_thread()`, discord.py raises `RateLimited` only when the server-requested `retry_after` exceeds its internal `max_ratelimit_timeout`. The old retry loop in `_auto_create_thread` slept a fixed **0.75s** and retried — guaranteed to fail against a long Retry-After (observed in production logs: 260s) — then dropped the message with a generic "⚠️ could not create a Discord thread … please retry" notice.

**Fix (in `plugins/platforms/discord/adapter.py`):**
- **Short rate limit** (`retry_after ≤ 30s`, new `_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS`): wait out the bucket, then retry the direct `create_thread` path. The retry now actually succeeds instead of re-429ing.
- **Long rate limit** (> 30s): give up immediately — never block the message handler for minutes — skip the seed-message fallback (it would hit the same bucket and spam a stray `🧵 Thread created by Hermes` message into the channel), and return a `_AutoThreadRateLimited` sentinel carrying the delay.
- The failure notice in `_handle_message` is now rate-limit-aware: "⚠️ Discord is rate-limiting requests (retry in ~260s)" instead of the generic message, so the user knows *when* to retry.
- Reuses the adapter's existing `_is_discord_rate_limit` / `_extract_discord_retry_after` helpers (already used for slash-command sync).

## Related Issue

No issue filed; discovered live in production logs (auto-thread creation 429'd with `Retry in 260.56 seconds` while the retry loop only slept 0.75s). Related work that motivated the direction:
- #52423 deletes the orphaned fallback seed message on fallback failure (complementary — we skip the fallback entirely on 429, they clean up the non-429 case)
- #44488 retries 429s in the standalone send path honoring `retry_after` (same pattern, different call path)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Add `_AUTO_THREAD_MAX_RATE_LIMIT_WAIT_SECONDS = 30.0` module constant
  - Add `_AutoThreadRateLimited` sentinel class (carries `retry_after` per call)
  - Rework `_auto_create_thread` to honor Discord's `retry_after` (short: wait + retry; long: give up fast + return sentinel; fallback skipped on 429 to avoid channel spam)
  - `_handle_message` consumes the sentinel locally for a rate-limit-aware user notice (no shared adapter state — race-free across concurrent messages)
- `tests/gateway/test_discord_auto_thread_rate_limit.py` (new, 7 tests)
  - Short rate limit waited out then retried
  - Non-rate-limit connect error still uses the seed-message fallback (#20243 behavior preserved)
  - Two short rate limits → give up, fallback NOT attempted (no channel spam)
  - Long rate limit → immediate give-up, sentinel carries `retry_after`
  - Integration: rate-limit failure surfaces "retry in ~Ns" notice
  - Integration: non-rate-limit failure keeps the original generic notice
  - **Interleaving regression**: two concurrent rate-limited messages each get their own notice (45s/90s, no cross-talk)

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_discord_auto_thread_rate_limit.py` → **7 passed**
2. Regression: `scripts/run_tests.sh tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_double_dispatch.py tests/gateway/test_discord_sync_limit.py` → **12 passed**
3. Full suite: `scripts/run_tests.sh -j 4` (CI parity) — see note below
4. `ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_auto_thread_rate_limit.py` → clean

Manual reproduction (needs a Discord server with `discord.auto_thread: true`): send a burst of @mention messages to exhaust the thread-creation bucket; the bot should either create the thread after the short wait or show "Discord is rate-limiting requests (retry in ~Ns)" instead of silently dropping the request.

## Checklist

- [x] Branch named per CONTRIBUTING (`fix/description`)
- [x] Tests run via `scripts/run_tests.sh` (CI parity)
- [x] Manual test of the changed code path (Discord auto-thread creation)
- [x] No cross-platform impact (network-only change; no file I/O, process, or terminal handling)
- [x] PR is one logical change (429 handling in auto-thread creation)
- [x] Conventional Commits (`fix(discord): ...`)
- [x] Tested on: **macOS** (Apple Silicon, Python 3.11)

## Platforms Tested

- **macOS** (Apple Silicon, Python 3.11.15) — full test suite + ruff

## Note on full-suite failures (pre-existing, unrelated)

`scripts/run_tests.sh -j 4` reports 46 failures across 18 files — **none touch the Discord plugin or this change**. Verified pre-existing: the same failures reproduce on clean `origin/main` (stash of this branch) — e.g. `test_daytona_environment` (needs Daytona), `test_voice_mode` / `test_wake_word` / `test_transcription_tools` (needs audio/OS APIs), `test_systemd_notify` / `test_gateway_service` / `test_service_manager` (Linux/systemd-only, run on macOS), `test_web_tools_config` (network), and `test_update_eol_churn` (line-ending churn). All Discord gateway tests pass.
