### PR TITLE
fix(desktop): snooze the update toast when the overlay is declined

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -33,6 +33,7 @@ import {
   applyUpdates,
   checkBackendUpdates,
   checkUpdates,
+  dismissUpdateOverlay,
   resetUpdateApplyState,
   setUpdateOverlayOpen,
   type UpdateApplyState
@@ -85,12 +86,18 @@ export function UpdatesOverlay() {
       return
     }
 
-    setUpdateOverlayOpen(next)
+    if (next) {
+      setUpdateOverlayOpen(true)
 
-    if (
-      !next &&
-      (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'guiSkew')
-    ) {
+      return
+    }
+
+    // Closing the idle view is a decline ("Maybe later"), so it snoozes the
+    // toast the same way dismissing the toast itself does. The other phases are
+    // outcomes of an apply the user already started, not a decline.
+    dismissUpdateOverlay({ snooze: phase === 'idle' })
+
+    if (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'guiSkew') {
       resetUpdateApplyState()
     }
   }

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -52,6 +52,7 @@ const {
   $updateApply,
   $updateOverlayOpen,
   $updateOverlayTarget,
+  dismissUpdateOverlay,
   requestActiveUpdate,
   resetUpdateApplyState,
   startUpdatePoller,
@@ -104,6 +105,26 @@ describe('maybeNotifyUpdateAvailable', () => {
     // A different commit lands while still within the cooldown window.
     maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }))
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet after the overlay is declined, not just the toast', () => {
+    // "Maybe later" in the overlay is the same intent as closing the toast, so
+    // it starts the same cooldown. Without this the toast returns on the next
+    // check — minutes away in this repo.
+    dismissUpdateOverlay({ snooze: true })
+    expect($updateOverlayOpen.get()).toBe(false)
+
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }))
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps reminding when the overlay closes on a finished apply', () => {
+    // Closing a restart/error/manual view is not a decline, so it must not
+    // silence the reminder for a genuinely new update.
+    dismissUpdateOverlay({ snooze: false })
+
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }))
+    expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 
   it('re-shows once the cooldown elapses', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -58,6 +58,25 @@ export const $updateOverlayTarget = atom<UpdateTarget>('client')
 
 export const setUpdateOverlayOpen = (open: boolean) => $updateOverlayOpen.set(open)
 
+/**
+ * Close the updates overlay. Declining an offered update ("Maybe later", or the
+ * close button on the idle view) is the same "remind me later" intent as
+ * dismissing the toast, so it must (re)start that same cooldown — pass
+ * `snooze: true` for those. Without it the toast returns on the very next
+ * check, which in this repo is minutes away, and the user who just said "later"
+ * is nagged again immediately.
+ *
+ * Closing while an apply is finishing, errored or needs manual steps is not a
+ * decline, so those callers pass `snooze: false`.
+ */
+export const dismissUpdateOverlay = ({ snooze }: { snooze: boolean }) => {
+  $updateOverlayOpen.set(false)
+
+  if (snooze) {
+    snoozeUpdateToast()
+  }
+}
+
 export const openUpdateOverlayFor = (target: UpdateTarget) => {
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)


### PR DESCRIPTION
## Problem

Dismissing the update toast starts the 24h cooldown, but declining the same update in the overlay — "Maybe later", or its close button — does not. `handleClose` only closed the dialog.

Because this repo lands ~100 commits a day (the cooldown's own comment says as much), the next check is minutes away. So a user who opens the toast, reads the changelog and picks "Maybe later" gets the toast straight back. From the outside the reminder looks impossible to clear, and clicking through to "Update now" does not help either: the pull succeeds, but new commits have landed by the time the app restarts.

## Change

Add `dismissUpdateOverlay({ snooze })` to the store and call it from the overlay:

- closing the **idle** view is a decline, so it starts the same cooldown as dismissing the toast
- closing on **restart / error / manual / guiSkew** is the outcome of an apply the user already started, not a decline, so the reminder stays live

Keeping the branch in the store rather than the component matches where the rest of the update logic lives and makes it testable with the existing suite.

## Tests

Two cases added to `src/store/updates.test.ts` (32 pass, was 30). Both were mutation-checked: making `dismissUpdateOverlay` never snooze fails the first, always snooze fails the second.

`typecheck` and `eslint` are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UvEYhWxDgXJZHJ1HyNN19