### PR TITLE
fix: guard rmtree in skills install against wiping category directories (#75983)

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1157,6 +1157,53 @@ class TestInstallPathSafety:
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
 
+    def test_install_from_quarantine_refuses_to_rmtree_category_dir(self, tmp_path):
+        """Installing a skill whose name matches an existing category directory
+        must not rmtree the category (issue #75983)."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        # Create an existing category directory with two skills inside.
+        cat_dir = skills_dir / "devops"
+        for name in ("docker", "kubernetes"):
+            skill = cat_dir / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        # Prepare a quarantine bundle whose name collides with the category.
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: devops\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="devops",
+            files={"SKILL.md": "---\nname: devops\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="devops",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="category directory"):
+                hub.install_from_quarantine(
+                    q_dir, "devops", "", bundle, scan_result,
+                )
+
+        # Category directory and its children must be untouched.
+        assert (cat_dir / "docker" / "SKILL.md").is_file()
+        assert (cat_dir / "kubernetes" / "SKILL.md").is_file()
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3707,6 +3707,22 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
+        # Guard against wiping an entire category directory.
+        # If ``install_dir`` is an existing category (has subdirectories that
+        # contain SKILL.md files but no SKILL.md of its own), refusing to
+        # rmtree prevents silent data loss — e.g. ``hermes skills install devops``
+        # when ``skills/devops/`` already holds multiple skills.
+        _child_skills = [
+            p for p in install_dir.iterdir()
+            if p.is_dir() and (p / "SKILL.md").is_file()
+        ]
+        if _child_skills and not (install_dir / "SKILL.md").is_file():
+            raise ValueError(
+                f"Refusing to install: '{install_dir.name}' is an existing "
+                f"category directory containing {len(_child_skills)} skill(s) "
+                f"({', '.join(p.name for p in _child_skills[:3])}{'...' if len(_child_skills) > 3 else ''}). "
+                f"Choose a different skill name or specify a category to install into."
+            )
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large


### PR DESCRIPTION
## Problem

When running `hermes skills install <name>` and the skill name matches an existing category directory (e.g. `devops`), the unconditional `shutil.rmtree(install_dir)` at the top of `install_from_quarantine()` silently deletes the entire category directory and every skill inside it. This is a P1 data-loss bug (issue #75983).

## Root Cause

In `tools/skills_hub.py` `install_from_quarantine()`:

```python
if install_dir.exists():
    shutil.rmtree(install_dir)
```

When `category` is empty and `safe_skill_name` equals a category directory name, `install_dir` resolves to the category directory itself (e.g. `skills/devops/`), and `rmtree` wipes it unconditionally.

## Fix

Before calling `rmtree`, check whether the existing directory is a category (contains child directories with SKILL.md files but has no SKILL.md of its own). If it is, raise a `ValueError` with an actionable message instead of proceeding with the deletion. The caller in `hermes_cli/skills_hub.py` already catches `ValueError` and displays it to the user.

**Files changed:**
- `tools/skills_hub.py` — add category-directory guard before `rmtree`
- `tests/tools/test_skills_hub.py` — regression test confirming category directories are preserved

## Testing

```bash
pytest tests/tools/test_skills_hub.py::TestInstallFromQuarantine::test_install_from_quarantine_refuses_to_rmtree_category_dir -v
```

Fixes #75983