### PR TITLE
refactor(prompt-caching): consolidate #76032 cache-plan internals, guard empty suffix, async fallback parity

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1857,6 +1857,62 @@ def _direct_native_anthropic_tool_cache_capability(
     )
 
 
+def plan_cache_sections_for_destination(
+    messages: list,
+    tools: Optional[list],
+    *,
+    provider: str,
+    base_url: str,
+    api_mode: str,
+    model: str,
+) -> Tuple[list, list]:
+    """Plan request-local cache sections for one resolved destination.
+
+    Shared core of the synchronous acting-aggregator (MoA) and auxiliary
+    fallback senders: resolve the cache policy for the destination's real
+    provider/base_url/api_mode/model, then either return stripped canonical
+    copies (non-caching route) or a :func:`build_prompt_cache_plan` layout
+    (caching route, with the direct-native tool marker when the destination
+    is api.anthropic.com on the Messages wire).
+
+    Never mutates ``messages`` or ``tools`` — both return values are
+    request-local copies.
+    """
+    from types import SimpleNamespace
+
+    from agent.prompt_caching import (
+        build_prompt_cache_plan,
+        strip_anthropic_cache_control,
+        strip_anthropic_tool_cache_control,
+    )
+
+    stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+    should_cache, native_layout = anthropic_prompt_cache_policy(
+        stub,
+        provider=provider,
+        base_url=base_url,
+        api_mode=api_mode,
+        model=model,
+    )
+    if not should_cache:
+        canonical_messages = copy.deepcopy(messages or [])
+        strip_anthropic_cache_control(canonical_messages)
+        return canonical_messages, strip_anthropic_tool_cache_control(tools)
+    plan = build_prompt_cache_plan(
+        messages,
+        tools,
+        native_anthropic=native_layout,
+        direct_native_tool_cache=_direct_native_anthropic_tool_cache_capability(
+            stub,
+            provider=provider,
+            base_url=base_url,
+            api_mode=api_mode,
+            model=model,
+        ),
+    )
+    return plan.messages, plan.tools
+
+
 def anthropic_prompt_cache_policy(
     agent,
     *,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4468,43 +4468,71 @@ async def _call_fallback_candidate_async(
             task or "call", fb_label, fb_timeout, effective_timeout,
         )
         effective_timeout = fb_timeout
-    fb_base = str(getattr(fb_client, "base_url", "") or "")
+    destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
+        messages,
+        tools,
+        destination=destination,
+    )
     fb_kwargs = _build_call_kwargs(
-        fb_label, fb_model, messages,
+        destination.provider, destination.model, fallback_messages,
         temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout,
+        tools=fallback_tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=fb_base, task=task)
+        base_url=destination.base_url, task=task)
     try:
         return _validate_llm_response(
             await _relay_async_completion(
                 fb_client,
                 fb_kwargs,
-                provider=fb_label,
+                provider=destination.provider,
+                api_mode=destination.api_mode,
             ),
             task,
         )
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
-        fb_provider = _auth_refresh_provider_for_route(fb_label, fb_base)
+        fb_provider = _auth_refresh_provider_for_route(
+            destination.provider, destination.base_url
+        )
         if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
             retry_client, retry_model = _get_cached_client(
-                fb_provider, fb_model, async_mode=True)
+                fb_provider,
+                destination.model,
+                async_mode=True,
+                base_url=destination.base_url or None,
+                api_mode=destination.api_mode,
+            )
             if retry_client is not None:
+                retry_destination = _FallbackDestination(
+                    fb_provider,
+                    destination.base_url
+                    or str(getattr(retry_client, "base_url", "") or ""),
+                    destination.api_mode,
+                    retry_model or destination.model,
+                )
+                retry_messages, retry_tools = _replan_synchronous_cache_sections(
+                    messages,
+                    tools,
+                    destination=retry_destination,
+                )
                 retry_kwargs = _build_call_kwargs(
-                    fb_provider, retry_model or fb_model, messages,
+                    retry_destination.provider,
+                    retry_destination.model,
+                    retry_messages,
                     temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
+                    tools=retry_tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
-                    base_url=str(getattr(retry_client, "base_url", "") or fb_base), task=task)
+                    base_url=retry_destination.base_url, task=task)
                 try:
                     return _validate_llm_response(
                         await _relay_async_completion(
                             retry_client,
                             retry_kwargs,
-                            provider=fb_provider,
+                            provider=retry_destination.provider,
+                            api_mode=retry_destination.api_mode,
                         ),
                         task,
                     )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4181,6 +4181,27 @@ def _auth_refresh_provider_for_route(
     return normalized
 
 
+def _fallback_chain_entry(task: Optional[str], fb_label: str) -> Optional[Dict[str, Any]]:
+    """Resolve the configured ``fallback_chain`` entry a label points at.
+
+    Labels minted by :func:`_try_configured_fallback_chain` carry the entry
+    index in our own stable format (``fallback_chain[<i>](<provider>)``).
+    Returns ``None`` when the label is not a configured-chain candidate or
+    the index no longer resolves to a dict entry.
+    """
+    if not task or not fb_label:
+        return None
+    m = re.match(r"fallback_chain\[(\d+)\]", fb_label)
+    if not m:
+        return None
+    try:
+        chain = _get_auxiliary_task_config(task).get("fallback_chain")
+        entry = chain[int(m.group(1))] if isinstance(chain, list) else None
+    except Exception:
+        return None
+    return entry if isinstance(entry, dict) else None
+
+
 def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[float]:
     """Resolve a per-entry ``timeout`` for a configured fallback candidate.
 
@@ -4192,24 +4213,13 @@ def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[floa
     primary's 30s deadline every turn (#62452).
 
     Entries in ``auxiliary.<task>.fallback_chain`` may declare their own
-    ``timeout`` (seconds). This helper reads it by parsing the entry index
-    out of the label minted by :func:`_try_configured_fallback_chain`
-    (``fallback_chain[<i>](<provider>)`` — our own stable format). Returns
-    ``None`` when the label is not a configured-chain candidate, the entry
-    has no ``timeout``, or the value is invalid — callers then keep the
-    task-level timeout, preserving existing behavior.
+    ``timeout`` (seconds). Returns ``None`` when the label is not a
+    configured-chain candidate, the entry has no ``timeout``, or the value
+    is invalid — callers then keep the task-level timeout, preserving
+    existing behavior.
     """
-    if not task or not fb_label:
-        return None
-    m = re.match(r"fallback_chain\[(\d+)\]", fb_label)
-    if not m:
-        return None
-    try:
-        chain = _get_auxiliary_task_config(task).get("fallback_chain")
-        entry = chain[int(m.group(1))] if isinstance(chain, list) else None
-        raw = entry.get("timeout") if isinstance(entry, dict) else None
-    except Exception:
-        return None
+    entry = _fallback_chain_entry(task, fb_label)
+    raw = entry.get("timeout") if entry else None
     if isinstance(raw, (int, float)) and not isinstance(raw, bool) and raw > 0:
         return float(raw)
     return None
@@ -4284,15 +4294,9 @@ def _fallback_destination(
     api_mode = None
     model = fb_model
 
-    match = re.match(r"fallback_chain\[(\d+)\]", fb_label or "")
-    if match and task:
-        try:
-            chain = _get_auxiliary_task_config(task).get("fallback_chain")
-            entry = chain[int(match.group(1))] if isinstance(chain, list) else None
-        except Exception:
-            entry = None
-        if isinstance(entry, dict):
-            return _fallback_destination_from_entry(entry, fb_client, fb_model)
+    entry = _fallback_chain_entry(task, fb_label)
+    if entry is not None:
+        return _fallback_destination_from_entry(entry, fb_client, fb_model)
 
     return _complete_fallback_destination(provider, base_url, api_mode, model)
 
@@ -4304,42 +4308,16 @@ def _replan_synchronous_cache_sections(
     destination: _FallbackDestination,
 ) -> tuple[list, list]:
     """Strip source decoration and plan one synchronous destination locally."""
-    from agent.agent_runtime_helpers import (
-        _direct_native_anthropic_tool_cache_capability,
-        anthropic_prompt_cache_policy,
-    )
-    from agent.prompt_caching import (
-        build_prompt_cache_plan,
-        strip_anthropic_cache_control,
-        strip_anthropic_tool_cache_control,
-    )
+    from agent.agent_runtime_helpers import plan_cache_sections_for_destination
 
-    canonical_messages = copy.deepcopy(messages or [])
-    strip_anthropic_cache_control(canonical_messages)
-    canonical_tools = strip_anthropic_tool_cache_control(tools)
-    stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
-    should_cache, native_layout = anthropic_prompt_cache_policy(
-        stub,
+    return plan_cache_sections_for_destination(
+        messages,
+        tools,
         provider=destination.provider,
         base_url=destination.base_url,
         api_mode=destination.api_mode or "",
         model=destination.model or "",
     )
-    if not should_cache:
-        return canonical_messages, canonical_tools
-    plan = build_prompt_cache_plan(
-        canonical_messages,
-        canonical_tools,
-        native_anthropic=native_layout,
-        direct_native_tool_cache=_direct_native_anthropic_tool_cache_capability(
-            stub,
-            provider=destination.provider,
-            base_url=destination.base_url,
-            api_mode=destination.api_mode or "",
-            model=destination.model or "",
-        ),
-    )
-    return plan.messages, plan.tools
 
 
 def _call_fallback_candidate_sync(

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -8,7 +8,6 @@ iteration.
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import logging
 import re
@@ -1660,57 +1659,39 @@ class MoAChatCompletions:
         extra_body: Any = agg_kwargs.get("extra_body")
         agg_runtime = _slot_runtime(aggregator)
         try:
-            from types import SimpleNamespace
-
             from agent.agent_runtime_helpers import (
-                _direct_native_anthropic_tool_cache_capability,
-                anthropic_prompt_cache_policy,
-            )
-            from agent.prompt_caching import (
-                build_prompt_cache_plan,
-                strip_anthropic_cache_control,
-                strip_anthropic_tool_cache_control,
+                plan_cache_sections_for_destination,
             )
 
             guidance = prepared.get("guidance")
-            canonical_messages = copy.deepcopy(agg_messages)
+            planning_messages = agg_messages
             if guidance:
-                canonical_messages = peel_reference_guidance(
-                    canonical_messages,
+                planning_messages = peel_reference_guidance(
+                    agg_messages,
                     str(guidance),
                 )
-            strip_anthropic_cache_control(canonical_messages)
-            canonical_tools = strip_anthropic_tool_cache_control(tools)
-            cache_stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
-            should_cache, native_layout = anthropic_prompt_cache_policy(
-                cache_stub,
+            # plan_cache_sections_for_destination never mutates its inputs
+            # and always returns request-local copies, so the prepared
+            # state stays canonical.
+            agg_messages, tools = plan_cache_sections_for_destination(
+                planning_messages,
+                tools,
                 provider=agg_runtime.get("provider") or "",
                 base_url=agg_runtime.get("base_url") or "",
                 api_mode=agg_runtime.get("api_mode") or "",
                 model=agg_runtime.get("model") or "",
             )
-            if should_cache:
-                plan = build_prompt_cache_plan(
-                    canonical_messages,
-                    canonical_tools,
-                    native_anthropic=native_layout,
-                    direct_native_tool_cache=_direct_native_anthropic_tool_cache_capability(
-                        cache_stub,
-                        provider=agg_runtime.get("provider") or "",
-                        base_url=agg_runtime.get("base_url") or "",
-                        api_mode=agg_runtime.get("api_mode") or "",
-                        model=agg_runtime.get("model") or "",
-                    ),
-                )
-                agg_messages = plan.messages
-                tools = plan.tools
-            else:
-                agg_messages = canonical_messages
-                tools = canonical_tools
             if guidance:
                 _attach_reference_guidance(agg_messages, str(guidance))
         except Exception as exc:  # pragma: no cover - cache planning must not block MoA
-            logger.debug("MoA aggregator cache plan skipped: %s", exc)
+            # Warning, not debug: since the call-block site skips MoA, this
+            # block is the aggregator's ONLY decoration path — a silent
+            # failure here ships an undecorated request and regresses the
+            # exact 0%-cache MoA failure the planning exists to prevent.
+            logger.warning(
+                "MoA aggregator cache plan failed — sending undecorated "
+                "request (cache misses expected): %s", exc,
+            )
         # Record the exact aggregator INPUT (incl. the injected reference
         # context) into the pending trace so a trace captures what the
         # aggregator actually saw, not a reconstruction. Traces are a

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -21,7 +21,15 @@ class PromptCachePlan:
 
     messages: List[Dict[str, Any]]
     tools: List[Dict[str, Any]]
-    marker_count: int
+
+    @property
+    def marker_count(self) -> int:
+        """Wire-visible cache markers in this plan (computed on demand).
+
+        Only tests consume this; keeping it lazy avoids walking every
+        message part and tool schema on the per-request hot path.
+        """
+        return _count_cache_markers(self.messages, self.tools)
 
 
 def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = False) -> None:
@@ -309,11 +317,7 @@ def build_prompt_cache_plan(
             native_anthropic=native_anthropic,
             static_system_prefix=static_system_prefix,
         )
-        return PromptCachePlan(
-            messages=planned_messages,
-            tools=planned_tools,
-            marker_count=_count_cache_markers(planned_messages, planned_tools),
-        )
+        return PromptCachePlan(messages=planned_messages, tools=planned_tools)
 
     marker = _build_marker(cache_ttl)
     if (
@@ -338,11 +342,7 @@ def build_prompt_cache_plan(
     )[-2:]:
         _apply_cache_marker(messages[endpoint], marker, native_anthropic=True)
 
-    return PromptCachePlan(
-        messages=messages,
-        tools=planned_tools,
-        marker_count=_count_cache_markers(messages, planned_tools),
-    )
+    return PromptCachePlan(messages=messages, tools=planned_tools)
 
 
 def apply_anthropic_cache_control(

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -99,12 +99,28 @@ def _apply_system_cache_markers(
     static_system_prefix: str | None,
     *,
     native_anthropic: bool,
+    mark_suffix: bool = True,
+    fallback_to_whole: bool = True,
 ) -> int:
-    """Mark the static system prefix and full prompt when they can be split.
+    """Mark the static system prefix (and optionally the full prompt).
 
     The system prompt remains one stored string. Splitting it only in the
     outgoing request keeps session persistence and non-Anthropic transports
     unchanged while making the stable prefix independently cacheable.
+
+    ``mark_suffix=False`` is the tool-cache-plan layout: only the static
+    prefix carries a marker, the volatile suffix rides unmarked (its
+    breakpoint budget is spent on the tools array instead).
+
+    ``fallback_to_whole=False`` skips marking entirely when the prefix
+    split is not possible (no prefix, mismatched prefix, non-string
+    content) instead of marking the whole message.
+
+    When the prompt IS exactly the static prefix (empty suffix), the whole
+    message is marked as a single block — never a two-part split with an
+    empty text block, which Anthropic rejects.
+
+    Returns the number of markers applied (0, 1, or 2).
     """
     content = message.get("content")
     if (
@@ -115,16 +131,26 @@ def _apply_system_cache_markers(
     ):
         suffix = content[len(static_system_prefix):]
         if suffix:
+            suffix_part: dict = {"type": "text", "text": suffix}
+            if mark_suffix:
+                suffix_part["cache_control"] = cache_marker
             message["content"] = [
                 {
                     "type": "text",
                     "text": static_system_prefix,
                     "cache_control": cache_marker,
                 },
-                {"type": "text", "text": suffix, "cache_control": cache_marker},
+                suffix_part,
             ]
-            return 2
+            return 2 if mark_suffix else 1
+        # Empty suffix: the stored prompt IS the static prefix. Mark it as
+        # one whole block — a [marked-prefix, ""] split would put an empty
+        # text block on the wire (HTTP 400 on native Anthropic).
+        _apply_cache_marker(message, cache_marker, native_anthropic=native_anthropic)
+        return 1
 
+    if not fallback_to_whole:
+        return 0
     _apply_cache_marker(message, cache_marker, native_anthropic=native_anthropic)
     return 1
 
@@ -262,29 +288,6 @@ def _completed_transaction_endpoint_indexes(
     return endpoints
 
 
-def _apply_static_prefix_marker(
-    messages: List[Dict[str, Any]],
-    cache_marker: Dict[str, str],
-    static_system_prefix: str | None,
-) -> None:
-    """Mark only the reusable static system prefix for a tool-cache plan."""
-    if not messages or not isinstance(static_system_prefix, str) or not static_system_prefix:
-        return
-    system = messages[0]
-    if not isinstance(system, dict):
-        return
-    content = system.get("content")
-    if system.get("role") != "system" or not isinstance(content, str):
-        return
-    if not content.startswith(static_system_prefix):
-        return
-    suffix = content[len(static_system_prefix):]
-    system["content"] = [
-        {"type": "text", "text": static_system_prefix, "cache_control": cache_marker},
-        {"type": "text", "text": suffix},
-    ]
-
-
 def build_prompt_cache_plan(
     api_messages: List[Dict[str, Any]],
     tools: List[Dict[str, Any]] | None,
@@ -313,7 +316,21 @@ def build_prompt_cache_plan(
         )
 
     marker = _build_marker(cache_ttl)
-    _apply_static_prefix_marker(messages, marker, static_system_prefix)
+    if (
+        messages
+        and isinstance(messages[0], dict)
+        and messages[0].get("role") == "system"
+    ):
+        # Tool-cache layout: only the static prefix carries a system-side
+        # marker; the volatile suffix's budget is spent on the tools array.
+        _apply_system_cache_markers(
+            messages[0],
+            marker,
+            static_system_prefix,
+            native_anthropic=True,
+            mark_suffix=False,
+            fallback_to_whole=False,
+        )
     planned_tools[-1]["cache_control"] = dict(marker)
     for endpoint in _completed_transaction_endpoint_indexes(
         messages,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4213,3 +4213,66 @@ class TestSynchronousFallbackCachePlans:
             for part in (message.get("content") if isinstance(message.get("content"), list) else [])
         )
 
+
+
+class TestAsynchronousFallbackCachePlans:
+    @pytest.mark.asyncio
+    async def test_async_fallback_replans_cache_sections_like_sync(self, monkeypatch):
+        """Async mirror parity: per-destination cache replan, not verbatim pass-through."""
+        from agent.auxiliary_client import (
+            _call_fallback_candidate_async,
+            _try_configured_fallback_chain,
+        )
+
+        entry = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        }
+        client = MagicMock()
+        client.base_url = entry["base_url"]
+
+        async def _create(**kwargs):
+            return _DummyResponse()
+
+        client.chat.completions.create = MagicMock(side_effect=_create)
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            lambda provider, model=None, **kwargs: (client, model),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": [entry]},
+        )
+        fallback_client, fallback_model, label = _try_configured_fallback_chain(
+            task="moa_aggregator",
+            failed_provider="primary",
+        )
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+        await _call_fallback_candidate_async(
+            fallback_client,
+            fallback_model,
+            label,
+            task="moa_aggregator",
+            messages=[
+                {"role": "system", "content": "stable prefix"},
+                {"role": "user", "content": "lookup"},
+            ],
+            temperature=None,
+            max_tokens=None,
+            tools=tools,
+            effective_timeout=30.0,
+            effective_extra_body={},
+            reasoning_config=None,
+        )
+
+        wire_tools = client.chat.completions.create.call_args.kwargs["tools"]
+        assert "cache_control" in wire_tools[-1]
+        assert "cache_control" not in tools[-1]

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -129,6 +129,33 @@ class TestPromptCachePlan:
         assert plan.marker_count == 2
         assert "cache_control" not in plan.messages[-1]
 
+    def test_static_prefix_equal_to_whole_prompt_emits_no_empty_block(self):
+        """Empty volatile suffix must not produce an empty text block.
+
+        Anthropic rejects text blocks whose ``text`` is empty; when the
+        stored system prompt IS the static prefix (no volatile tier), the
+        plan must mark it as one whole block instead of a two-part split
+        with a trailing ``{"type": "text", "text": ""}``.
+        """
+        messages = [
+            {"role": "system", "content": "stable prefix"},
+            {"role": "user", "content": "lookup"},
+        ]
+        plan = build_prompt_cache_plan(
+            messages,
+            _tool_heavy_native_tools(),
+            native_anthropic=True,
+            static_system_prefix="stable prefix",
+            direct_native_tool_cache=True,
+        )
+
+        system_content = plan.messages[0]["content"]
+        assert isinstance(system_content, list)
+        for part in system_content:
+            assert part.get("text"), "no empty text blocks on the wire"
+        assert any("cache_control" in part for part in system_content)
+        assert plan.tools[-1]["cache_control"] == MARKER
+
     def test_tool_strip_is_request_local(self):
         tools = _tool_heavy_native_tools()
         tools[-1]["cache_control"] = MARKER


### PR DESCRIPTION
## Summary

Post-merge follow-up to #76032 (tool-schema caching, #20880): fixes a latent empty-text-block 400, collapses the ~120 lines of logic the salvage landed in triplicate, replans cache sections on the async fallback path (parity with the sync mirror), and takes marker counting off the request hot path.

## Changes

- `agent/prompt_caching.py`: fold the tool-cache static-prefix split into the existing `_apply_system_cache_markers` via `mark_suffix`/`fallback_to_whole` flags; delete `_apply_static_prefix_marker`. Inherits the `if suffix:` guard — a system prompt exactly equal to the static prefix now marks one whole block instead of emitting `{"type":"text","text":""}` (rejected by native Anthropic). `PromptCachePlan.marker_count` becomes a lazy property (only tests read it).
- `agent/agent_runtime_helpers.py`: new shared `plan_cache_sections_for_destination()` — the stub → policy → strip → plan core that MoA's `_call_prepared_aggregator` and `_replan_synchronous_cache_sections` each implemented inline. Also removes one redundant full-transcript deepcopy+strip per request.
- `agent/moa_loop.py`: route the aggregator plan through the shared helper; promote the cache-plan failure log debug → warning (the call-block site skips MoA, so this is the aggregator's only decoration path — silent failure means undecorated requests and 0% cache).
- `agent/auxiliary_client.py`: extract `_fallback_chain_entry()` (label-regex + chain lookup previously duplicated in `_fallback_entry_timeout` and `_fallback_destination`); `_call_fallback_candidate_async` now resolves the destination and replans both cache sections like its sync mirror, instead of shipping the primary's markers verbatim, and threads provider/api_mode to the relay.
- Tests: empty-suffix regression guard; async fallback replan parity test (mutation-checked — fails on the verbatim pass-through shape).

## Validation

| | Result |
|---|---|
| Targeted suites (6 files) | 453 passed |
| Behavior parity vs merged main (`build_prompt_cache_plan`, 30 combos: layouts × prefixes × history lengths) | byte-identical messages+tools |
| Empty-suffix case | `[marked-static, ""]` → `[marked-static]` (single block) |
| Mutation checks | empty-suffix test fails on merged-main planner; async parity test fails on pass-through shape |
| ruff (agent/) | clean |

Addresses the review findings from the post-merge audit of #76032.
