### PR TITLE
fix: include Authorization header in dashboard health probe (#76051)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1564,6 +1564,7 @@ def _apply_main_model_assignment(
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
+_GATEWAY_HEALTH_API_KEY = os.getenv("API_SERVER_KEY", "")
 _GATEWAY_HEALTH_TIMEOUT_MAX = 1.0
 _GATEWAY_HEALTH_ROUTE_TIMEOUT = 1.0
 try:
@@ -1631,6 +1632,8 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     for path in (f"{base}/health/detailed", f"{base}/health"):
         try:
             req = urllib.request.Request(path, method="GET")
+            if _GATEWAY_HEALTH_API_KEY:
+                req.add_header("Authorization", f"Bearer {_GATEWAY_HEALTH_API_KEY}")
             with urllib.request.urlopen(req, timeout=_GATEWAY_HEALTH_TIMEOUT) as resp:
                 if resp.status == 200:
                     body = json.loads(resp.read())


### PR DESCRIPTION
## Summary

When `API_SERVER_KEY` is configured on the gateway, the dashboard's
`_probe_gateway_health()` sends requests to `/health/detailed` without an
`Authorization` header. Every probe returns 401 and logs:

```
WARNING gateway.platforms.api_server: API server rejected invalid API key:
  remote='127.0.0.1' method='GET' path='/health/detailed'
```

Functionality is unaffected (falls back to unauthenticated `/health`), but
the warning spam fills gateway logs on every status poll.

## Changes

- Read `API_SERVER_KEY` from the environment at module level
  (`_GATEWAY_HEALTH_API_KEY`), following the existing pattern for
  `GATEWAY_HEALTH_URL` and `GATEWAY_HEALTH_TIMEOUT`.
- Include `Authorization: Bearer <key>` in the probe request when the key
  is set. When unset, behaviour is identical to before (no header).

## Test Plan

- [ ] With `API_SERVER_KEY` set on gateway + dashboard: probe to
      `/health/detailed` returns 200 (no 401 warning in gateway logs)
- [ ] Without `API_SERVER_KEY`: probe falls back to `/health` as before
- [ ] Syntax check passes

Fixes #76051