### PR TITLE
feat(security): add governed DPS MCP approvals

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -931,6 +931,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             : undefined,
           command,
           description,
+          requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -33,7 +33,7 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: { choices?: string[]; requestId?: string; smartDenied?: boolean } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -86,6 +86,22 @@ describe('PendingToolApproval', () => {
       expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('includes request_id when responding to an identity-bound approval', async () => {
+    const request = mockGateway()
+    setRequest('rm -rf /tmp/x', undefined, { requestId: 'req-sensitive' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', {
+        choice: 'once',
+        request_id: 'req-sensitive',
+        session_id: 'sess-1'
+      })
+    })
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -142,10 +142,14 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+        const params: { choice: ApprovalChoice; request_id?: string; session_id?: string } = {
           choice,
           session_id: request.sessionId ?? undefined
-        })
+        }
+        if (request.requestId) {
+          params.request_id = request.requestId
+        }
+        await gateway.request<{ resolved?: boolean }>('approval.respond', params)
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId)
       } catch (error) {
@@ -153,7 +157,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -67,6 +67,17 @@ describe('approval prompt store', () => {
 
     expect($approvalRequest.get()?.allowPermanent).toBe(false)
   })
+
+  it('carries requestId for identity-bound approvals', () => {
+    setApprovalRequest({
+      command: 'x',
+      description: 'sensitive',
+      requestId: 'req-sensitive',
+      sessionId: 's1'
+    })
+
+    expect($approvalRequest.get()?.requestId).toBe('req-sensitive')
+  })
 })
 
 describe('sudo prompt store', () => {

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -76,6 +76,7 @@ export interface ApprovalRequest extends KeyedPrompt {
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
 }
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1115,6 +1115,53 @@ platform_toolsets:
 #       allowed_models: []      # model whitelist (empty = all)
 #       max_tool_rounds: 5      # tool loop limit (0 = disable)
 #       log_level: "info"       # audit verbosity
+#
+# Optional MCP prepare/execute permission rail. Disabled by default.
+# Configure by exact MCP server name; tool entries are fnmatch-style patterns
+# over that server's raw MCP tool names, not Hermes' mcp__server__tool names.
+# A protected execute requires a matching unexpired prepare result with a
+# proposal_token and preview, plus one-shot approval from the same Telegram
+# user/chat/thread/session context. Reads/status/prepare calls remain allowed.
+#
+# mcp_permission_rails:
+#   servers:
+#     dps-work:
+#       enabled: false
+#       ttl_seconds: 120
+#       tools:
+#         read: ["dps_get_*", "dps_list_*"]
+#         status: ["dps_status_*"]
+#         prepare: ["dps_prepare_*"]
+#         execute: ["dps_execute_*"]
+#       prepare_prefix: "dps_prepare_"
+#       execute_prefix: "dps_execute_"
+#       # Optional exact bindings may coexist with the prefix transform.
+#       bindings: []
+#       result_paths:
+#         proposal_token: ["data.proposal_token"]
+#         preview: ["data.action.preview"]
+#         expires_at: ["data.expires_at"]
+#         confirmation_code: ["data.confirmation_code"]
+#       execute_token_paths: ["proposal_token"]
+#       execute_confirmation_code_paths: ["confirmation_code"]
+#       # Optional client attestation for backend-verified prepare/execute
+#       # bindings. Disabled by default. These entries name environment
+#       # variables only; never put kid, HMAC key material, OAuth client id, or
+#       # operator subject plaintext in config.yaml. Backend B independently
+#       # verifies the OAuth client and operator subject against the request.
+#       attestation:
+#         enabled: false
+#         kid_env: DPS_WORK_HERMES_ATTESTATION_KID
+#         key_env: DPS_WORK_HERMES_ATTESTATION_KEY
+#         oauth_client_id_env: DPS_WORK_HERMES_OAUTH_CLIENT_ID
+#         operator_subject_env: DPS_WORK_HERMES_OPERATOR_SUBJECT
+#         ttl_seconds: 300
+#         # Nonempty thread sentinel signed for direct Telegram chats with no
+#         # thread/topic id.
+#         direct_thread_sentinel: "__hermes_direct_no_thread__"
+#       deny_execute_tools:
+#         # Keep denylisted until the backend import bug is fixed.
+#         - "dps_execute_project_document_import"
 
 # =============================================================================
 # Text-to-Speech

--- a/docs/security/sensitive-approval-contract.md
+++ b/docs/security/sensitive-approval-contract.md
@@ -1,0 +1,26 @@
+# Sensitive Approval Contract
+
+`tools.approval` provides a narrow primitive for high-risk approval flows. It
+binds a pending request to a minted `request_id`, a non-empty authenticated
+platform `user_id`, and immutable routing context such as platform, chat,
+thread, and session.
+
+This primitive is not a complete business-write authorization rail. The MCP
+prepare/execute permission rail adds the higher-level binding for configured
+MCP servers: proposal token digest, prepare/execute tool relation, preview and
+canonical-result digests, short TTL, and exact Telegram user/chat/thread/session
+context. Initial protected MCP executes are Telegram-only, because local
+TUI/Desktop JSON-RPC has no authenticated human `user_id` and must fail closed
+for sensitive approvals.
+
+Logs must not include raw `request_id`, command payloads, proposal payloads, or
+context identifiers. Use a short SHA-256 digest or another opaque correlation
+value when correlation is needed.
+
+Residual same-UID risk: an OS process with permission to inspect the gateway
+process memory, environment, or `/proc` entries may steal the HMAC signer key.
+The subprocess env scrubber removes configured attestation `key_env` values
+from child process environments, but that is not a same-UID memory isolation
+boundary. Production deployments that need to defend against this threat should
+run the signer in an isolated process, account, container, or external service
+with a narrower access boundary than the gateway worker.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -492,6 +492,7 @@ def _format_exec_approval_fallback(
     *,
     allow_permanent: bool = True,
     allow_session: bool = True,
+    request_id: str | None = None,
     smart_denied: bool = False,
 ) -> str:
     """Render the text fallback from approval capabilities, not platform names."""
@@ -500,14 +501,20 @@ def _format_exec_approval_fallback(
     if smart_denied:
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
-    choices = [f"Reply `{command_prefix}approve` to execute this one operation"]
+    approve_command = f"{command_prefix}approve"
+    deny_command = f"{command_prefix}deny"
+    if request_id:
+        approve_command = f"{approve_command} {request_id}"
+        deny_command = f"{deny_command} {request_id}"
+
+    choices = [f"Reply `{approve_command}` to execute this one operation"]
     if not smart_denied and allow_session:
         choices.append(
             f"`{command_prefix}approve session` to approve this pattern for the session"
         )
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
-    choices.append(f"`{command_prefix}deny` to cancel")
+    choices.append(f"`{deny_command}` to cancel")
     return (
         f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
@@ -4853,17 +4860,27 @@ class TurnRunner:
             # false positives from MagicMock auto-attribute creation in tests.
             if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
                 try:
+                    _approval_kwargs = {
+                        "chat_id": ctx._status_chat_id,
+                        "command": cmd,
+                        "session_key": _approval_session_key,
+                        "description": desc,
+                        "metadata": ctx._status_thread_metadata,
+                        "allow_permanent": approval_data.get("allow_permanent", True),
+                        "allow_session": approval_data.get("allow_session", True),
+                        "smart_denied": approval_data.get("smart_denied", False),
+                    }
+                    if approval_data.get("request_id"):
+                        try:
+                            _sig = inspect.signature(type(ctx._status_adapter).send_exec_approval)
+                            if "request_id" in _sig.parameters:
+                                _approval_kwargs["request_id"] = approval_data.get("request_id")
+                            if "expected_context" in _sig.parameters:
+                                _approval_kwargs["expected_context"] = approval_data.get("expected_context")
+                        except Exception:
+                            pass
                     _approval_fut = safe_schedule_threadsafe(
-                        ctx._status_adapter.send_exec_approval(
-                            chat_id=ctx._status_chat_id,
-                            command=cmd,
-                            session_key=_approval_session_key,
-                            description=desc,
-                            metadata=ctx._status_thread_metadata,
-                            allow_permanent=approval_data.get("allow_permanent", True),
-                            allow_session=approval_data.get("allow_session", True),
-                            smart_denied=approval_data.get("smart_denied", False),
-                        ),
+                        ctx._status_adapter.send_exec_approval(**_approval_kwargs),
                         ctx._loop_for_step,
                         logger=logger,
                         log_message="send_exec_approval scheduling error",
@@ -4893,6 +4910,7 @@ class TurnRunner:
                 _p,
                 allow_permanent=approval_data.get("allow_permanent", True),
                 allow_session=approval_data.get("allow_session", True),
+                request_id=approval_data.get("request_id"),
                 smart_denied=approval_data.get("smart_denied", False),
             )
             try:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -424,6 +424,22 @@ def session_is_messaging_surface() -> bool:
     return False
 
 
+def get_trusted_session_env(name: str, default: str = "") -> str:
+    """Read only ContextVar-bound session identity, never ``os.environ``.
+
+    Sensitive rails use this during protected calls so model-controlled process
+    env changes cannot spoof gateway provenance. Empty strings remain explicit
+    empty values; unset context variables return *default*.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return default
+    value = var.get()
+    if value is _UNSET:
+        return default
+    return value
+
+
 def declare_stateless_channel() -> None:
     """Declare that this session cannot receive an async background completion.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -69,6 +69,42 @@ def _int_value(value: Any) -> int:
         return 0
 
 
+def _current_session_id_for_key(session_store: Any, session_key: str) -> str:
+    """Return the gateway-owned session_id currently bound to a session key."""
+    if not session_key or session_store is None:
+        return ""
+    peek = getattr(session_store, "peek_session_id", None)
+    if not callable(peek):
+        return ""
+    try:
+        value = peek(session_key)
+    except Exception:
+        return ""
+    return str(value or "")
+
+
+def _observed_sensitive_approval_context(
+    source: SessionSource,
+    *,
+    session_key: str,
+    session_id: str,
+) -> Optional[dict]:
+    if not session_id:
+        return None
+    try:
+        from tools.hermes_attestation import normalize_thread_id
+    except Exception:
+        normalize_thread_id = lambda value: value  # type: ignore[assignment]
+    return {
+        "platform": getattr(source.platform, "value", str(source.platform)),
+        "chat_id": source.chat_id,
+        "user_id": source.user_id,
+        "thread_id": normalize_thread_id(getattr(source, "thread_id", None)),
+        "session_id": session_id,
+        "session_key": session_key,
+    }
+
+
 def _model_switch_skew_guard() -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
 
@@ -5209,6 +5245,7 @@ class GatewaySlashCommandsMixin:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            has_sensitive_gateway_approval,
         )
 
         if not has_blocking_approval(session_key):
@@ -5218,18 +5255,44 @@ class GatewaySlashCommandsMixin:
             return t("gateway.approve.no_pending")
 
         # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
-        resolve_all = "all" in args
-        remaining = [a for a in args if a != "all"]
+        args = event.get_command_args().strip().split()
+        args_lower = [a.lower() for a in args]
+        resolve_all = "all" in args_lower
+        remaining = [(raw, lower) for raw, lower in zip(args, args_lower) if lower != "all"]
+        request_id = next(
+            (
+                raw for raw, lower in remaining
+                if lower not in {"always", "permanent", "permanently", "session", "ses"}
+            ),
+            None,
+        )
+        if request_id and not has_sensitive_gateway_approval(session_key, request_id):
+            request_id = None
 
-        if any(a in {"always", "permanent", "permanently"} for a in remaining):
+        remaining_lower = [lower for _, lower in remaining]
+        if any(a in {"always", "permanent", "permanently"} for a in remaining_lower):
             choice = "always"
-        elif any(a in {"session", "ses"} for a in remaining):
+        elif any(a in {"session", "ses"} for a in remaining_lower):
             choice = "session"
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        observed_context = None
+        if request_id:
+            observed_context = _observed_sensitive_approval_context(
+                source,
+                session_key=session_key,
+                session_id=_current_session_id_for_key(
+                    getattr(self, "session_store", None), session_key
+                ),
+            )
+        count = resolve_gateway_approval(
+            session_key,
+            choice,
+            resolve_all=False if request_id else resolve_all,
+            request_id=request_id,
+            observed_context=observed_context,
+        )
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -5258,6 +5321,7 @@ class GatewaySlashCommandsMixin:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            has_sensitive_gateway_approval,
         )
 
         if not has_blocking_approval(session_key):
@@ -5272,17 +5336,32 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip()
         tokens = raw_args.split()
         resolve_all = bool(tokens) and tokens[0].lower() == "all"
+        request_id = None
         if resolve_all:
             reason = raw_args[len(tokens[0]):].strip()
         else:
-            reason = raw_args
+            if tokens and has_sensitive_gateway_approval(session_key, tokens[0]):
+                request_id = tokens[0]
+                reason = raw_args[len(tokens[0]):].strip()
+            else:
+                reason = raw_args
         # Cap to a sane one-liner; the agent only needs a short hint.
         if reason:
             reason = reason[:280].strip()
 
+        observed_context = None
+        if request_id:
+            observed_context = _observed_sensitive_approval_context(
+                source,
+                session_key=session_key,
+                session_id=_current_session_id_for_key(
+                    getattr(self, "session_store", None), session_key
+                ),
+            )
         count = resolve_gateway_approval(
-            session_key, "deny", resolve_all=resolve_all,
-            reason=reason or None,
+            session_key, "deny", resolve_all=False if request_id else resolve_all,
+            reason=reason or None, request_id=request_id,
+            observed_context=observed_context,
         )
         if not count:
             return t("gateway.deny.no_pending")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,9 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "mcp_permission_rails": {
+        "servers": {},
+    },
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -835,7 +835,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        self._approval_state: Dict[int, Any] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -5398,6 +5398,8 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         allow_permanent: bool = True,
         allow_session: bool = True,
+        request_id: Optional[str] = None,
+        expected_context: Optional[Dict[str, Any]] = None,
         smart_denied: bool = False,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
@@ -5461,7 +5463,15 @@ class TelegramAdapter(BasePlatformAdapter):
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
             # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            if request_id:
+                expected_ctx = dict(expected_context or {}) if isinstance(expected_context, dict) else {}
+                self._approval_state[approval_id] = {
+                    "request_id": request_id,
+                    "session_key": session_key,
+                    "expected_context": expected_ctx,
+                }
+            else:
+                self._approval_state[approval_id] = session_key
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -6324,7 +6334,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                approval_state = self._approval_state.pop(approval_id, None)
+                request_id = None
+                if isinstance(approval_state, dict):
+                    session_key = approval_state.get("session_key")
+                    request_id = approval_state.get("request_id")
+                    expected_context = approval_state.get("expected_context")
+                else:
+                    session_key = approval_state
+                    expected_context = None
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
@@ -6338,15 +6356,63 @@ class TelegramAdapter(BasePlatformAdapter):
                 # the command was already denied and will not run (#63501
                 # regression follow-up: 60s waits made stale taps common).
                 try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
+                    from tools.approval import (
+                        resolve_gateway_approval,
+                        resolve_sensitive_gateway_approval,
                     )
+                    observed_context = None
+                    resolution_status = ""
+                    if request_id:
+                        if not isinstance(expected_context, dict):
+                            await query.answer(text="This approval cannot prove its expected context.")
+                            return
+                        expected_session_id = str(expected_context.get("session_id") or "")
+                        expected_thread_id = str(expected_context.get("thread_id") or "")
+                        if not expected_session_id or not expected_thread_id:
+                            await query.answer(text="This approval cannot prove its expected context.")
+                            return
+                        observed_thread_id = (
+                            str(query_thread_id)
+                            if query_thread_id is not None
+                            else expected_thread_id
+                        )
+                        observed_context = {
+                            "platform": "telegram",
+                            "chat_id": str(query_chat_id) if query_chat_id is not None else None,
+                            "user_id": caller_id,
+                            "thread_id": observed_thread_id,
+                            "session_id": expected_session_id,
+                            "session_key": session_key,
+                        }
+                        resolution = resolve_sensitive_gateway_approval(
+                            session_key,
+                            choice,
+                            request_id=request_id,
+                            observed_context=observed_context,
+                        )
+                        resolution_status = str(resolution.get("status") or "")
+                        count = 1 if resolution.get("resolved") else 0
+                    else:
+                        count = resolve_gateway_approval(session_key, choice)
+                    if request_id:
+                        logger.info(
+                            "Telegram button resolved sensitive approval "
+                            "(resolved=%s, status=%s, choice=%s)",
+                            bool(count), resolution_status or "", choice,
+                        )
+                    else:
+                        logger.info(
+                            "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                            count, session_key, choice, user_display,
+                        )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
                     count = 0
+
+                if request_id and count == 0 and resolution_status == "context_mismatch":
+                    self._approval_state[approval_id] = approval_state
+                    await query.answer(text="This approval belongs to a different chat, thread, or user.")
+                    return
 
                 if count:
                     # Map choice to human-readable label

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -204,6 +204,69 @@ class TestApproveCommand:
         assert e1.result == "session"
         assert e2.result == "session"
 
+    @pytest.mark.asyncio
+    async def test_sensitive_approve_requires_case_preserved_request_id_and_source_identity(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner.session_store.peek_session_id.return_value = "sid-approve-1"
+        entry = _ApprovalEntry({
+            "command": "sensitive",
+            "description": "sensitive",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": source.chat_id,
+                "user_id": source.user_id,
+                "session_id": "sid-approve-1",
+                "session_key": session_key,
+            },
+            "request_id": "ReqCaseSensitive123",
+            "sensitive": True,
+        })
+        _gateway_queues[session_key] = [entry]
+
+        no_id = await runner._handle_approve_command(_make_event("/approve"))
+        assert not entry.event.is_set()
+        assert "no pending" in no_id.lower()
+
+        result = await runner._handle_approve_command(_make_event("/approve ReqCaseSensitive123"))
+        assert entry.event.is_set()
+        assert entry.result == "once"
+        assert "approved" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_sensitive_approve_fails_closed_without_trusted_session_id(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner.session_store.peek_session_id.return_value = None
+        entry = _ApprovalEntry({
+            "command": "sensitive",
+            "description": "sensitive",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": source.chat_id,
+                "user_id": source.user_id,
+                "session_id": "sid-approve-1",
+                "session_key": session_key,
+            },
+            "request_id": "ReqCaseSensitive123",
+            "sensitive": True,
+        })
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_approve_command(
+            _make_event("/approve ReqCaseSensitive123")
+        )
+
+        assert not entry.event.is_set()
+        assert _gateway_queues[session_key] == [entry]
+        assert "no pending" in result.lower()
+
 
 # ------------------------------------------------------------------
 # /deny command
@@ -234,6 +297,38 @@ class TestDenyCommand:
         assert entry.result == "deny"
         assert entry.reason == "that path is still in use"
         assert "that path is still in use" in result
+
+    @pytest.mark.asyncio
+    async def test_sensitive_deny_uses_trusted_session_id_in_observed_context(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner.session_store.peek_session_id.return_value = "sid-deny-1"
+        entry = _ApprovalEntry({
+            "command": "sensitive",
+            "description": "sensitive",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": source.chat_id,
+                "user_id": source.user_id,
+                "session_id": "sid-deny-1",
+                "session_key": session_key,
+            },
+            "request_id": "ReqCaseSensitiveDeny123",
+            "sensitive": True,
+        })
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_deny_command(
+            _make_event("/deny ReqCaseSensitiveDeny123 not safe")
+        )
+
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+        assert entry.reason == "not safe"
+        assert "not safe" in result
 
     @pytest.mark.asyncio
     async def test_deny_all_with_reason(self):

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -105,6 +105,40 @@ class TestTelegramExecApproval:
         assert "dangerous deletion" in kwargs["text"]
         assert kwargs["reply_markup"] is not None  # InlineKeyboardMarkup
 
+    @pytest.mark.asyncio
+    async def test_sensitive_button_state_carries_expected_session_id(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="protected write",
+            session_key="agent:main:telegram:group:12345:99",
+            request_id="req-sensitive",
+            expected_context={
+                "platform": "telegram",
+                "chat_id": "12345",
+                "user_id": "u123",
+                "thread_id": "99",
+                "session_id": "sess-durable-1",
+                "session_key": "agent:main:telegram:group:12345:99",
+            },
+        )
+
+        assert result.success is True
+        assert adapter._approval_state[1] == {
+            "request_id": "req-sensitive",
+            "session_key": "agent:main:telegram:group:12345:99",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": "12345",
+                "user_id": "u123",
+                "thread_id": "99",
+                "session_id": "sess-durable-1",
+                "session_key": "agent:main:telegram:group:12345:99",
+            },
+        }
+
 
     @pytest.mark.asyncio
     async def test_non_smart_allow_permanent_false_keeps_session(self, monkeypatch):
@@ -268,6 +302,144 @@ class TestTelegramApprovalCallback:
         assert "Alice\\_Bob" in edit_kwargs["text"]
         assert "Approved once" in edit_kwargs["text"]
 
+    @pytest.mark.asyncio
+    async def test_approval_callback_passes_request_id_and_observed_identity(self):
+        adapter = _make_adapter()
+        adapter._approval_state[7] = {
+            "request_id": "req-sensitive",
+            "session_key": "agent:main:telegram:group:12345:99",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": "12345",
+                "user_id": "u123",
+                "thread_id": "99",
+                "session_id": "sess-durable-1",
+                "session_key": "agent:main:telegram:group:12345:99",
+            },
+        }
+
+        query = AsyncMock()
+        query.data = "ea:once:7"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = 99
+        query.message.chat = SimpleNamespace(type="supergroup")
+        query.from_user = MagicMock()
+        query.from_user.id = "u123"
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch(
+                "tools.approval.resolve_sensitive_gateway_approval",
+                return_value={"resolved": True, "status": "approved"},
+            ) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once()
+        _, choice = mock_resolve.call_args.args
+        kwargs = mock_resolve.call_args.kwargs
+        assert choice == "once"
+        assert kwargs["request_id"] == "req-sensitive"
+        assert kwargs["observed_context"] == {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "user_id": "u123",
+            "thread_id": "99",
+            "session_id": "sess-durable-1",
+            "session_key": "agent:main:telegram:group:12345:99",
+        }
+
+    @pytest.mark.asyncio
+    async def test_sensitive_approval_callback_without_session_id_fails_closed(self):
+        adapter = _make_adapter()
+        adapter._approval_state[9] = {
+            "request_id": "req-sensitive",
+            "session_key": "agent:main:telegram:group:12345:99",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": "12345",
+                "user_id": "u123",
+                "thread_id": "99",
+                "session_key": "agent:main:telegram:group:12345:99",
+            },
+        }
+
+        query = AsyncMock()
+        query.data = "ea:once:9"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = 99
+        query.message.chat = SimpleNamespace(type="supergroup")
+        query.from_user = MagicMock()
+        query.from_user.id = "u123"
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch(
+                "tools.approval.resolve_sensitive_gateway_approval",
+                return_value={"resolved": True, "status": "approved"},
+            ) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        query.edit_message_text.assert_not_called()
+        assert "context" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_sensitive_approval_context_mismatch_keeps_button_live(self):
+        adapter = _make_adapter()
+        adapter._approval_state[8] = {
+            "request_id": "req-sensitive",
+            "session_key": "agent:main:telegram:group:12345:99",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": "12345",
+                "user_id": "u123",
+                "thread_id": "99",
+                "session_id": "sess-durable-1",
+                "session_key": "agent:main:telegram:group:12345:99",
+            },
+        }
+
+        query = AsyncMock()
+        query.data = "ea:once:8"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = 99
+        query.message.chat = SimpleNamespace(type="supergroup")
+        query.from_user = MagicMock()
+        query.from_user.id = "mallory"
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch(
+                "tools.approval.resolve_sensitive_gateway_approval",
+                return_value={"resolved": False, "status": "context_mismatch"},
+            ):
+                await adapter._handle_callback_query(update, context)
+
+        assert adapter._approval_state[8]["request_id"] == "req-sensitive"
+        query.edit_message_text.assert_not_called()
+        assert "different" in query.answer.call_args.kwargs["text"].lower()
+
 
     @pytest.mark.asyncio
     async def test_update_prompt_callback_not_affected(self, tmp_path):
@@ -359,4 +531,3 @@ class TestTelegramApprovalCallback:
         assert runner.last_source is not None
         assert runner.last_source.platform == Platform.TELEGRAM
         assert runner.last_source.user_id == "222"
-

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -8,8 +8,10 @@ user message. If either anchor is unavailable or rejected, the adapter must
 avoid retrying with a partial topic route that can render outside the lane.
 """
 
+import asyncio
 import sys
 import socket
+import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -133,8 +135,94 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._typing_paused = set()
     adapter.platform = Platform.TELEGRAM
     return adapter
+
+
+def _approval_update(*, data: str, thread_id=None, answers=None):
+    answers = answers if answers is not None else []
+    edits = []
+
+    class Query:
+        def __init__(self):
+            self.data = data
+            self.from_user = SimpleNamespace(id="user-1", first_name="Alice")
+            self.message = SimpleNamespace(
+                chat_id="chat-1",
+                chat=SimpleNamespace(type="private"),
+                message_thread_id=thread_id,
+                text="approval prompt",
+            )
+
+        async def answer(self, text=None, **_kwargs):
+            answers.append(text)
+
+        async def edit_message_text(self, **kwargs):
+            edits.append(kwargs)
+
+    return SimpleNamespace(callback_query=Query()), answers, edits
+
+
+def _start_sensitive_approval(adapter):
+    from tools.approval import register_gateway_notify, request_sensitive_human_approval
+    from tools.hermes_attestation import DIRECT_THREAD_SENTINEL
+
+    notified = []
+    notify_seen = threading.Event()
+    result = {}
+
+    async def send_message(**_kwargs):
+        return SimpleNamespace(message_id=7001)
+
+    adapter._bot = SimpleNamespace(send_message=send_message)
+    adapter._approval_state = {}
+    adapter._is_callback_user_authorized = lambda *_args, **_kwargs: True
+
+    def notify(data):
+        notified.append(dict(data))
+        send_result = asyncio.run(
+            adapter.send_exec_approval(
+                chat_id="chat-1",
+                command=data["command"],
+                session_key="sess-1",
+                description=data["description"],
+                metadata={},
+                allow_permanent=data.get("allow_permanent", False),
+                allow_session=data.get("allow_session", False),
+                request_id=data["request_id"],
+                expected_context=data["expected_context"],
+            )
+        )
+        assert send_result.success
+        notify_seen.set()
+
+    def wait_for_decision():
+        register_gateway_notify("sess-1", notify)
+        result.update(
+            request_sensitive_human_approval(
+                session_key="sess-1",
+                command="Protected MCP execute",
+                description="Protected MCP execute requires Telegram approval.",
+                expected_context={
+                    "platform": "telegram",
+                    "chat_id": "chat-1",
+                    "user_id": "user-1",
+                    "thread_id": DIRECT_THREAD_SENTINEL,
+                    "session_id": "sid-1",
+                    "session_key": "sess-1",
+                },
+                ttl_seconds=10.0,
+                pattern_key="mcp_permission_rail:dps:execute",
+            )
+        )
+
+    worker = threading.Thread(target=wait_for_decision, daemon=True)
+    worker.start()
+    assert notify_seen.wait(2)
+    assert notified
+    approval_id = next(iter(adapter._approval_state))
+    return notified, result, worker, approval_id
 
 
 def test_non_forum_group_reply_thread_id_does_not_fork_session_key():
@@ -199,6 +287,46 @@ def test_forum_group_topic_message_preserves_thread_session_key():
     assert event.source.chat_type == "group"
     assert event.source.thread_id == "17585"
     assert build_session_key(event.source) == "agent:main:telegram:group:-100123:17585"
+
+
+@pytest.mark.asyncio
+async def test_sensitive_approval_button_direct_no_thread_resolves_once():
+    adapter = _make_adapter()
+    _notified, result, worker, approval_id = _start_sensitive_approval(adapter)
+
+    update, answers, _edits = _approval_update(data=f"ea:once:{approval_id}", thread_id=None)
+    await adapter._handle_callback_query(update, SimpleNamespace())
+    worker.join(2)
+
+    assert worker.is_alive() is False
+    assert result["resolved"] is True
+    assert result["choice"] == "once"
+    assert any(answer and "Approved once" in answer for answer in answers)
+
+
+@pytest.mark.asyncio
+async def test_sensitive_approval_button_wrong_thread_fails_closed_then_direct_resolves():
+    adapter = _make_adapter()
+    _notified, result, worker, approval_id = _start_sensitive_approval(adapter)
+
+    wrong_update, wrong_answers, _wrong_edits = _approval_update(
+        data=f"ea:once:{approval_id}",
+        thread_id="thread-2",
+    )
+    await adapter._handle_callback_query(wrong_update, SimpleNamespace())
+
+    assert result == {}
+    assert worker.is_alive() is True
+    assert adapter._approval_state.get(approval_id)
+    assert any(answer and "different chat, thread, or user" in answer for answer in wrong_answers)
+
+    direct_update, _answers, _edits = _approval_update(data=f"ea:once:{approval_id}", thread_id=None)
+    await adapter._handle_callback_query(direct_update, SimpleNamespace())
+    worker.join(2)
+
+    assert worker.is_alive() is False
+    assert result["resolved"] is True
+    assert result["choice"] == "once"
 
 
 def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
@@ -722,5 +850,3 @@ async def test_thread_fallback_only_fires_once():
     # Second chunk: should use thread_id=None directly (effective_thread_id
     # was cleared per-chunk but the metadata doesn't change between chunks)
     # The key point: the message was delivered despite the invalid thread
-
-

--- a/tests/tools/test_hermes_attestation.py
+++ b/tests/tools/test_hermes_attestation.py
@@ -1,0 +1,140 @@
+"""A2 Hermes attestation fixed vectors.
+
+The expected canonical strings mirror Backend B's dps-hermes-attestation.ts:
+code-point key sorting, JSON-compatible finite values only, and HMAC over the
+canonical payload bytes.
+"""
+
+from decimal import Decimal
+import hashlib
+import hmac
+
+import pytest
+
+
+def test_canonical_hermes_json_cross_language_vectors():
+    from tools.hermes_attestation import canonical_hermes_json
+
+    assert canonical_hermes_json({
+        "\U0001f600": 1,
+        "\uffff": 2,
+        "a": [{"z": -0.0, "A": Decimal("1.25")}],
+    }) == '{"a":[{"A":1.25,"z":0}],"\uffff":2,"\U0001f600":1}'
+
+    assert canonical_hermes_json({
+        "null": None,
+        "bools": [True, False],
+        "ints": [0, -7, 42],
+        "decimals": [Decimal("12.50"), Decimal("0.125")],
+    }) == '{"bools":[true,false],"decimals":[12.5,0.125],"ints":[0,-7,42],"null":null}'
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), object()])
+def test_canonical_hermes_json_rejects_non_finite_and_unsupported(value):
+    from tools.hermes_attestation import HermesAttestationError, canonical_hermes_json
+
+    with pytest.raises(HermesAttestationError):
+        canonical_hermes_json({"bad": value})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        2**53 - 1,
+        -(2**53 - 1),
+        {"nested": [2**53 - 1, {"proposal": -(2**53 - 1)}]},
+    ],
+)
+def test_canonical_hermes_json_accepts_js_safe_integer_boundaries(value):
+    from tools.hermes_attestation import canonical_hermes_json
+
+    assert canonical_hermes_json(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        2**53,
+        -(2**53),
+        {"args": {"amount": 2**53}},
+        {"proposal": [{"target_version": -(2**53)}]},
+    ],
+)
+def test_canonical_hermes_json_rejects_ints_outside_js_safe_range(value):
+    from tools.hermes_attestation import HermesAttestationError, canonical_hermes_json
+
+    with pytest.raises(HermesAttestationError, match="safe integer"):
+        canonical_hermes_json(value)
+
+
+def test_attestation_policy_requires_scrubbable_key_env_name():
+    from tools.hermes_attestation import HermesAttestationError, HermesAttestationPolicy
+
+    with pytest.raises(HermesAttestationError, match="must end with _KEY"):
+        HermesAttestationPolicy.from_mapping({
+            "enabled": True,
+            "kid_env": "A2_KID",
+            "key_env": "A2_SECRET",
+            "oauth_client_id_env": "A2_CLIENT",
+            "operator_subject_env": "A2_SUBJECT",
+        })
+
+
+def test_hmac_attestation_token_fixed_vector(monkeypatch):
+    from tools.hermes_attestation import HermesAttestationPolicy, canonical_hermes_json, sign_attestation
+
+    monkeypatch.setenv("A2_KID", "h1")
+    monkeypatch.setenv("A2_KEY", "h" * 64)
+    monkeypatch.setenv("A2_CLIENT", "hermes-client")
+    monkeypatch.setenv("A2_SUBJECT", "auth0|marcial")
+    monkeypatch.setattr("tools.hermes_attestation.secrets.token_urlsafe", lambda _n: "nonce-fixed")
+
+    policy = HermesAttestationPolicy.from_mapping({
+        "enabled": True,
+        "kid_env": "A2_KID",
+        "key_env": "A2_KEY",
+        "oauth_client_id_env": "A2_CLIENT",
+        "operator_subject_env": "A2_SUBJECT",
+    })
+    ctx = {
+        "platform": "telegram",
+        "user_id": "u_123",
+        "chat_id": "chat_123",
+        "thread_id": "thread_123",
+        "session_id": "session_123",
+        "session_key": "key_123",
+        "message_id": "msg_123",
+    }
+    token = sign_attestation(
+        policy=policy,
+        phase="prepare",
+        tool_name="dps_prepare_project_note",
+        args={"b": 1, "a": Decimal("2.5")},
+        ctx=ctx,
+        now_seconds=1000,
+    )
+    payload = {
+        "v": 1,
+        "kid": "h1",
+        "phase": "prepare",
+        "tool_name": "dps_prepare_project_note",
+        "oauth_client_id": "hermes-client",
+        "operator_subject": "auth0|marcial",
+        "platform": "telegram",
+        "platform_user_id": "u_123",
+        "chat_id": "chat_123",
+        "thread_id": "thread_123",
+        "session_id": "session_123",
+        "originating_user_message_id": "msg_123",
+        "iat": 1000,
+        "exp": 1300,
+        "nonce": "nonce-fixed",
+        "tool_args_digest": hashlib.sha256(b'{"a":2.5,"b":1}').hexdigest(),
+    }
+    canonical = canonical_hermes_json(payload)
+    signature = hmac.new(b"h" * 64, canonical.encode("utf-8"), hashlib.sha256).digest()
+    import base64
+
+    encoded = base64.urlsafe_b64encode(canonical.encode("utf-8")).decode("ascii").rstrip("=")
+    sig = base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
+    assert token == f"hmac-sha256-v1.{encoded}.{sig}"

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from tools.environments.local import (
     hermes_subprocess_env,
+    _sanitize_subprocess_env,
     _ALWAYS_STRIP_KEYS,
     _HERMES_PROVIDER_ENV_FORCE_PREFIX,
 )
@@ -212,3 +213,34 @@ class TestInternalDynamicSecrets:
         assert {
             "GATEWAY_RELAY_ID", "GATEWAY_RELAY_SECRET", "GATEWAY_RELAY_DELIVERY_KEY",
         } <= _ALWAYS_STRIP_KEYS
+
+
+def test_sanitize_subprocess_env_strips_configured_attestation_key_env():
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={
+            "mcp_permission_rails": {
+                "servers": {
+                    "dps": {
+                        "enabled": True,
+                        "attestation": {
+                            "enabled": True,
+                            "key_env": "LOCAL_HERMES_ATTESTATION_KEY",
+                        },
+                    }
+                }
+            }
+        },
+    ):
+        result = _sanitize_subprocess_env(
+            {
+                "PATH": "/usr/bin",
+                "LOCAL_HERMES_ATTESTATION_KEY": "attestation-key-material",
+                "DPS_HERMES_ATTESTATION_KID": "kid-1",
+                "DPS_HERMES_OAUTH_CLIENT_ID": "client-1",
+            }
+        )
+
+    assert "LOCAL_HERMES_ATTESTATION_KEY" not in result
+    assert result["DPS_HERMES_ATTESTATION_KID"] == "kid-1"
+    assert result["DPS_HERMES_OAUTH_CLIENT_ID"] == "client-1"

--- a/tests/tools/test_mcp_permission_rail.py
+++ b/tests/tools/test_mcp_permission_rail.py
@@ -1,0 +1,1283 @@
+"""Config-driven MCP prepare/execute permission rail.
+
+All tests use mocked MCP sessions. No real MCP servers, network calls, OAuth,
+or live config are touched.
+"""
+
+import asyncio
+import base64
+import contextvars
+import hashlib
+import hmac
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _future_expiry(seconds=30):
+    return time.time() + seconds
+
+
+def _call_result(payload, *, is_error=False, structured=None):
+    if isinstance(payload, dict) and "proposal_token" in payload and "preview" in payload:
+        payload = {
+            "ok": True,
+            "data": {
+                "proposal_token": payload["proposal_token"],
+                "expires_at": payload.get("expires_at", _future_expiry()),
+                "action": {"preview": payload["preview"]},
+                **(
+                    {"confirmation_code": payload["confirmation_code"]}
+                    if "confirmation_code" in payload
+                    else {}
+                ),
+            },
+        }
+    if isinstance(payload, str):
+        text = payload
+    else:
+        text = json.dumps(payload, sort_keys=True)
+    return SimpleNamespace(
+        content=[SimpleNamespace(text=text)],
+        isError=is_error,
+        structuredContent=structured,
+    )
+
+
+def _server(name, session):
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask(name)
+    server.session = session
+    server._tools = []
+    return server
+
+
+def _run_mcp_loop(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    return asyncio.run(coro)
+
+
+def _policy(*, ttl=60.0, deny_execute_tools=None):
+    return {
+        "mcp_permission_rails": {
+            "servers": {
+                "dps": {
+                    "enabled": True,
+                    "ttl_seconds": ttl,
+                    "tools": {
+                        "prepare": ["proposal.prepare", "alt.prepare"],
+                        "execute": ["proposal.execute", "alt.execute"],
+                        "status": ["proposal.status"],
+                        "read": ["proposal.read"],
+                    },
+                    "bindings": [
+                        {
+                            "prepare": "proposal.prepare",
+                            "execute": "proposal.execute",
+                        },
+                        {
+                            "prepare": "alt.prepare",
+                            "execute": "alt.execute",
+                        },
+                    ],
+                    "deny_execute_tools": list(deny_execute_tools or []),
+                    "result_paths": {
+                        "proposal_token": ["data.proposal_token"],
+                        "preview": ["data.action.preview"],
+                        "expires_at": ["data.expires_at"],
+                        "confirmation_code": ["data.confirmation_code"],
+                    },
+                    "execute_token_paths": ["proposal_token"],
+                    "execute_confirmation_code_paths": ["confirmation_code"],
+                },
+                "other": {
+                    "enabled": True,
+                    "ttl_seconds": ttl,
+                    "tools": {
+                        "prepare": ["proposal.prepare"],
+                        "execute": ["proposal.execute"],
+                    },
+                    "bindings": [
+                        {
+                            "prepare": "proposal.prepare",
+                            "execute": "proposal.execute",
+                        }
+                    ],
+                    "result_paths": {
+                        "proposal_token": ["data.proposal_token"],
+                        "preview": ["data.action.preview"],
+                        "expires_at": ["data.expires_at"],
+                    },
+                    "execute_token_paths": ["proposal_token"],
+                },
+            }
+        }
+    }
+
+
+def _dps_policy(**overrides):
+    cfg = _policy(**{k: v for k, v in overrides.items() if k in {"ttl", "deny_execute_tools"}})
+    server = cfg["mcp_permission_rails"]["servers"]["dps"]
+    server["tools"] = {
+        "prepare": ["dps_prepare_*"],
+        "execute": ["dps_execute_*"],
+        "status": ["dps_status_*"],
+        "read": ["dps_get_*", "dps_list_*"],
+    }
+    server.pop("bindings", None)
+    server["prepare_prefix"] = "dps_prepare_"
+    server["execute_prefix"] = "dps_execute_"
+    server["result_paths"] = {
+        "proposal_token": ["data.proposal_token"],
+        "preview": ["data.action.preview"],
+        "expires_at": ["data.expires_at"],
+        "confirmation_code": ["data.confirmation_code"],
+    }
+    server["execute_token_paths"] = ["proposal_token"]
+    server["execute_confirmation_code_paths"] = ["confirmation_code"]
+    for key, value in overrides.items():
+        if key not in {"ttl", "deny_execute_tools"}:
+            server[key] = value
+    return cfg
+
+
+def _bind_context(
+    *,
+    platform="telegram",
+    chat_id="chat-1",
+    user_id="user-1",
+    thread_id="thread-1",
+    session_key="sess-1",
+    session_id="sid-1",
+    message_id="msg-1",
+):
+    from gateway.session_context import set_session_vars
+    from tools.approval import set_current_session_key
+
+    tokens = set_session_vars(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        thread_id=thread_id,
+        session_key=session_key,
+        session_id=session_id,
+        message_id=message_id,
+    )
+    approval_token = set_current_session_key(session_key)
+    return tokens, approval_token
+
+
+def _clear_context(tokens, approval_token):
+    from gateway.session_context import clear_session_vars
+    from tools.approval import reset_current_session_key
+
+    reset_current_session_key(approval_token)
+    clear_session_vars(tokens)
+
+
+def _observed_context(
+    *,
+    platform="telegram",
+    chat_id="chat-1",
+    user_id="user-1",
+    thread_id="thread-1",
+    session_key="sess-1",
+    session_id="sid-1",
+    message_id="msg-1",
+):
+    return {
+        "platform": platform,
+        "chat_id": chat_id,
+        "user_id": user_id,
+        "thread_id": thread_id,
+        "session_key": session_key,
+        "session_id": session_id,
+        "message_id": message_id,
+    }
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _proposal_token(payload_hash=None, binding=None):
+    payload_hash = payload_hash or ("a" * 64)
+    proposal = {
+        "v": 1,
+        "iss": "dps-backend",
+        "iat": 1000,
+        "exp": 1300,
+        "jti": "jti-1",
+        "oauth_issuer": "https://tenant.example/",
+        "subject": "auth0|marcial",
+        "operator_id": "11111111-1111-4111-8111-111111111111",
+        "actor_role": "marcial",
+        "tool_name": "project.document.import",
+        "tool_version": 1,
+        "target_type": "project",
+        "target_id": "123",
+        "target_version": None,
+        "payload": {"amount": 12.5},
+        "payload_hash": payload_hash,
+        "confirmation_code": "dale",
+        "hermes_binding": binding or {
+            "v": 1,
+            "prepare_attestation_digest": "b" * 64,
+            "prepare_mcp_tool_name": "dps_prepare_project_document_import",
+            "base_context_digest": "c" * 64,
+            "oauth_client_id": "hermes-client",
+            "operator_subject_digest": "d" * 64,
+            "originating_user_message_id_digest": "e" * 64,
+            "prepare_nonce_digest": "f" * 64,
+            "prepare_tool_args_digest": "1" * 64,
+            "kid": "h1",
+            "iat": 1000,
+            "exp": 1300,
+        },
+    }
+    encoded = _b64url(json.dumps(proposal, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signature = _b64url(hmac.new(b"p" * 64, encoded.encode("ascii"), hashlib.sha256).digest())
+    return f"{encoded}.{signature}", proposal
+
+
+def _attested_dps_policy(**overrides):
+    cfg = _dps_policy(**overrides)
+    cfg["mcp_permission_rails"]["servers"]["dps"]["attestation"] = {
+        "enabled": True,
+        "kid_env": "DPS_HERMES_ATTESTATION_KID",
+        "key_env": "DPS_HERMES_ATTESTATION_KEY",
+        "oauth_client_id_env": "DPS_HERMES_OAUTH_CLIENT_ID",
+        "operator_subject_env": "DPS_HERMES_OPERATOR_SUBJECT",
+    }
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    from tools import approval
+    import tools.mcp_tool as mcp_tool
+
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        mcp_tool._servers.clear()
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    approval._session_approved.clear()
+    approval._permanent_approved.clear()
+    approval._pending.clear()
+    try:
+        from tools import mcp_permission_rail
+
+        mcp_permission_rail.clear_pending_proposals()
+        mcp_permission_rail._known_protected_servers.clear()
+    except Exception:
+        pass
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    yield
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    try:
+        from tools import mcp_permission_rail
+
+        mcp_permission_rail.clear_pending_proposals()
+        mcp_permission_rail._known_protected_servers.clear()
+    except Exception:
+        pass
+    with mcp_tool._lock:
+        mcp_tool._servers.clear()
+        mcp_tool._servers.update(saved_servers)
+
+
+def _handler(server_name, tool_name, session, *, config=None):
+    import tools.mcp_tool as mcp_tool
+
+    mcp_tool._servers[server_name] = _server(server_name, session)
+    return mcp_tool._make_tool_handler(server_name, tool_name, 120)
+
+
+def _handler_with_annotations(server_name, tool_name, session, annotations):
+    import tools.mcp_tool as mcp_tool
+
+    mcp_tool._servers[server_name] = _server(server_name, session)
+    return mcp_tool._make_tool_handler(server_name, tool_name, 120, annotations)
+
+
+def _prepare(handler, token="tok-1", preview="Safe exact preview"):
+    return json.loads(
+        handler({"draft": "not logged"})
+    )
+
+
+def test_unconfigured_mcp_execute_passthrough_regression():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("executed"))
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", return_value={}
+    ):
+        result = json.loads(_handler("dps", "proposal.execute", session)({"x": 1}))
+
+    assert result["result"] == "executed"
+    session.call_tool.assert_called_once_with("proposal.execute", arguments={"x": 1})
+
+
+def test_protected_execute_without_prepare_denies_before_mcp_call():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("should not run"))
+
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            result = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    assert "BLOCKED" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_prepare_registers_pending_but_auto_chain_same_turn_waits_for_human():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": "tok-1", "preview": "Import 3 rows"}),
+            _call_result("should not execute"),
+        ]
+    )
+
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy(ttl=0.01)
+        ):
+            prepare_result = json.loads(
+                _handler("dps", "proposal.prepare", session)({"draft": "x"})
+            )
+            execute_result = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "Import 3 rows" in prepare_result["result"]
+    assert "error" in execute_result
+    assert session.call_tool.call_count == 1
+
+
+def test_approved_path_calls_execute_once_and_returns_result():
+    from tools.approval import register_gateway_notify, resolve_sensitive_gateway_approval
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": "tok-1", "preview": "Create record"}),
+            _call_result("executed once"),
+        ]
+    )
+    notified = []
+
+    def notify(data):
+        notified.append(dict(data))
+        threading.Thread(
+            target=lambda: resolve_sensitive_gateway_approval(
+                "sess-1",
+                "once",
+                request_id=data["request_id"],
+                observed_context=_observed_context(),
+            ),
+            daemon=True,
+        ).start()
+
+    register_gateway_notify("sess-1", notify)
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            json.loads(_handler("dps", "proposal.prepare", session)({"draft": "x"}))
+            result = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert result["result"] == "executed once"
+    assert "Create record" in notified[0]["command"]
+    assert notified[0]["expected_context"]["session_id"] == "sid-1"
+    assert session.call_tool.call_count == 2
+    session.call_tool.assert_called_with(
+        "proposal.execute", arguments={"proposal_token": "tok-1"}
+    )
+
+
+def test_denial_consumes_pending_and_execute_never_runs():
+    from tools.approval import register_gateway_notify, resolve_sensitive_gateway_approval
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": "tok-1", "preview": "Create record"}),
+            _call_result("should not execute"),
+        ]
+    )
+
+    def notify(data):
+        threading.Thread(
+            target=lambda: resolve_sensitive_gateway_approval(
+                "sess-1",
+                "deny",
+                request_id=data["request_id"],
+                observed_context=_observed_context(),
+            ),
+            daemon=True,
+        ).start()
+
+    register_gateway_notify("sess-1", notify)
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            json.loads(_handler("dps", "proposal.prepare", session)({"draft": "x"}))
+            denied = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+            replay = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in denied
+    assert "denied" in denied["error"].lower()
+    assert "error" in replay
+    assert session.call_tool.call_count == 1
+
+
+def test_wrong_token_tool_server_user_chat_thread_session_all_deny_without_execute():
+    cases = [
+        ("token", {"proposal_token": "wrong"}, {}, "proposal.execute", "dps"),
+        ("tool", {"proposal_token": "tok-1"}, {}, "alt.execute", "dps"),
+        ("server", {"proposal_token": "tok-1"}, {}, "proposal.execute", "other"),
+        ("user", {"proposal_token": "tok-1"}, {"user_id": "user-2"}, "proposal.execute", "dps"),
+        ("chat", {"proposal_token": "tok-1"}, {"chat_id": "chat-2"}, "proposal.execute", "dps"),
+        ("thread", {"proposal_token": "tok-1"}, {"thread_id": "thread-2"}, "proposal.execute", "dps"),
+        ("session_key", {"proposal_token": "tok-1"}, {"session_key": "sess-2"}, "proposal.execute", "dps"),
+        ("session_id", {"proposal_token": "tok-1"}, {"session_id": "sid-2"}, "proposal.execute", "dps"),
+    ]
+
+    for _name, execute_args, context_override, execute_tool, execute_server in cases:
+        tokens, approval_token = _bind_context()
+        session = MagicMock()
+        session.call_tool = AsyncMock(
+            return_value=_call_result({"proposal_token": "tok-1", "preview": "Preview"})
+        )
+        try:
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+                "hermes_cli.config.load_config", return_value=_policy()
+            ):
+                json.loads(_handler("dps", "proposal.prepare", session)({"draft": "x"}))
+        finally:
+            _clear_context(tokens, approval_token)
+
+        new_context = {
+            "platform": "telegram",
+            "chat_id": "chat-1",
+            "user_id": "user-1",
+            "thread_id": "thread-1",
+            "session_key": "sess-1",
+            "session_id": "sid-1",
+            **context_override,
+        }
+        tokens, approval_token = _bind_context(**new_context)
+        try:
+            execute_session = MagicMock()
+            execute_session.call_tool = AsyncMock(return_value=_call_result("bad"))
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+                "hermes_cli.config.load_config", return_value=_policy()
+            ):
+                result = json.loads(
+                    _handler(execute_server, execute_tool, execute_session)(execute_args)
+                )
+        finally:
+            _clear_context(tokens, approval_token)
+
+        assert "error" in result, _name
+        execute_session.call_tool.assert_not_called()
+
+
+def test_expired_pending_proposal_denies_and_audits_expired(caplog):
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": "tok-1", "preview": "Preview"})
+    )
+    try:
+        with caplog.at_level("INFO", logger="tools.mcp_permission_rail"), patch(
+            "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop
+        ), patch("hermes_cli.config.load_config", return_value=_policy(ttl=0.01)):
+            json.loads(_handler("dps", "proposal.prepare", session)({"draft": "x"}))
+            time.sleep(0.02)
+            execute_session = MagicMock()
+            execute_session.call_tool = AsyncMock(return_value=_call_result("bad"))
+            result = json.loads(
+                _handler("dps", "proposal.execute", execute_session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    execute_session.call_tool.assert_not_called()
+    assert "event=expired" in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_prepare_parse_failure_fails_closed_and_registers_no_pending():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result({"preview": "No token"}))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            prepare = json.loads(_handler("dps", "proposal.prepare", session)({}))
+            execute_session = MagicMock()
+            execute_session.call_tool = AsyncMock(return_value=_call_result("bad"))
+            execute = json.loads(
+                _handler("dps", "proposal.execute", execute_session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in prepare
+    assert "proposal_token" in prepare["error"] or "ok is not true" in prepare["error"]
+    assert "error" in execute
+    execute_session.call_tool.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform,user_id,env",
+    [
+        ("telegram", "user-1", {"HERMES_CRON_SESSION": "1"}),
+        ("telegram", "user-1", {"HERMES_DELEGATED_CHILD_CONTEXT": "1"}),
+        ("telegram", "user-1", {"HERMES_KANBAN_TASK": "t_1"}),
+        ("desktop", "", {}),
+        ("tui", "", {}),
+    ],
+)
+def test_non_human_contexts_fail_closed_for_execute(monkeypatch, platform, user_id, env):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    tokens, approval_token = _bind_context(platform=platform, user_id=user_id)
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": "tok-1", "preview": "Preview"})
+    )
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            json.loads(_handler("dps", "proposal.prepare", session)({}))
+            execute_session = MagicMock()
+            execute_session.call_tool = AsyncMock(return_value=_call_result("bad"))
+            execute = json.loads(
+                _handler("dps", "proposal.execute", execute_session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in execute
+    assert "Telegram" in execute["error"] or "human" in execute["error"]
+    execute_session.call_tool.assert_not_called()
+
+
+def test_read_status_and_unknown_tools_passthrough_under_policy():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("ok"))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            for tool in ("proposal.read", "proposal.status"):
+                result = json.loads(_handler("dps", tool, session)({"x": tool}))
+                assert result["result"] == "ok"
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert session.call_tool.call_count == 2
+
+
+def test_config_denylisted_execute_blocks_without_hardcoded_tool_name():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config",
+            return_value=_policy(deny_execute_tools=["proposal.execute"]),
+        ):
+            result = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    assert "disabled by configuration" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_concurrent_execute_consumes_pending_once():
+    from tools.approval import register_gateway_notify, resolve_sensitive_gateway_approval
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": "tok-1", "preview": "Preview"}),
+            _call_result("executed"),
+        ]
+    )
+
+    def notify(data):
+        time.sleep(0.05)
+        resolve_sensitive_gateway_approval(
+            "sess-1",
+            "once",
+            request_id=data["request_id"],
+            observed_context=_observed_context(),
+        )
+
+    register_gateway_notify("sess-1", notify)
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            json.loads(_handler("dps", "proposal.prepare", session)({}))
+            handler = _handler("dps", "proposal.execute", session)
+            barrier = threading.Barrier(3)
+            results = []
+
+            def run_execute():
+                barrier.wait()
+                results.append(json.loads(handler({"proposal_token": "tok-1"})))
+
+            thread_contexts = [contextvars.copy_context(), contextvars.copy_context()]
+            threads = [
+                threading.Thread(target=ctx.run, args=(run_execute,))
+                for ctx in thread_contexts
+            ]
+            for thread in threads:
+                thread.start()
+            barrier.wait()
+            for thread in threads:
+                thread.join(timeout=5)
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert len(results) == 2
+    assert sum(1 for result in results if result.get("result") == "executed") == 1
+    assert sum(1 for result in results if "error" in result) == 1
+    assert session.call_tool.call_count == 2
+
+
+def test_deny_execute_patterns_apply_before_execute_patterns_and_categories():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+    cfg = _dps_policy(
+        deny_execute_tools=["dps_execute_project_document_import", "dps_get_blocked"]
+    )
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", return_value=cfg
+    ):
+        execute = json.loads(
+            _handler("dps", "dps_execute_project_document_import", session)(
+                {"proposal_token": "tok-1"}
+            )
+        )
+        read_overlap = json.loads(
+            _handler("dps", "dps_get_blocked", session)({})
+        )
+
+    assert "disabled by configuration" in execute["error"]
+    assert "disabled by configuration" in read_overlap["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_overlap_uses_safe_precedence_execute_before_read():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+    cfg = _policy()
+    cfg["mcp_permission_rails"]["servers"]["dps"]["tools"]["read"].append("proposal.execute")
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=cfg
+        ):
+            result = json.loads(
+                _handler("dps", "proposal.execute", session)(
+                    {"proposal_token": "tok-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    assert "no matching unexpired prepare" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "annotations",
+    [
+        None,
+        {},
+        {"readOnlyHint": False},
+        {"readOnlyHint": "true"},
+    ],
+)
+def test_mutation_annotation_not_covered_fails_closed_before_mcp_call(annotations):
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", return_value=_policy()
+    ):
+        result = json.loads(
+            _handler_with_annotations("dps", "catalog_like_create", session, annotations)({})
+        )
+
+    assert "mutation-capable" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_readonly_annotation_allows_unknown_tool_passthrough():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("ok"))
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", return_value=_policy()
+    ):
+        result = json.loads(
+            _handler_with_annotations("dps", "catalog_like_status", session, {"readOnlyHint": True})({})
+        )
+
+    assert result["result"] == "ok"
+    session.call_tool.assert_called_once()
+
+
+def test_config_exception_for_known_protected_server_fails_closed():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+
+    with patch("hermes_cli.config.load_config", return_value=_policy()):
+        from tools.mcp_permission_rail import before_tool_call
+
+        assert before_tool_call("dps", "proposal.read", {}).policy is not None
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", side_effect=OSError("cannot read")
+    ):
+        result = json.loads(
+            _handler("dps", "proposal.read", session)({})
+        )
+
+    assert "failed closed" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_config_exception_never_yields_passthrough_even_without_known_cache():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", side_effect=OSError("cannot read")
+    ):
+        result = json.loads(_handler("unknown", "whatever", session)({}))
+
+    assert "failed closed" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_invalid_enabled_config_empty_execute_pattern_fails_closed():
+    cfg = _policy()
+    cfg["mcp_permission_rails"]["servers"]["dps"]["tools"]["execute"] = []
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+
+    with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+        "hermes_cli.config.load_config", return_value=cfg
+    ):
+        result = json.loads(_handler("dps", "proposal.read", session)({}))
+
+    assert "configuration is invalid" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_real_dps_structured_shape_object_preview_text_mirror_and_hook_redaction():
+    from tools.approval import register_gateway_notify, resolve_sensitive_gateway_approval
+
+    tokens, approval_token = _bind_context()
+    structured = {
+        "ok": True,
+        "data": {
+            "proposal_token": "tok-secret",
+            "confirmation_code": "code-secret",
+            "expires_at": _future_expiry(30),
+            "action": {
+                "preview": {
+                    "project_id": 123,
+                    "customer": "private name",
+                    "changes": ["import document"],
+                }
+            },
+        },
+    }
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"ok": False, "data": "text mirror should be ignored"}, structured=structured),
+            _call_result("executed"),
+        ]
+    )
+    hooks = []
+    notified = []
+
+    def notify(data):
+        notified.append(dict(data))
+        threading.Thread(
+            target=lambda: resolve_sensitive_gateway_approval(
+                "sess-1",
+                "once",
+                request_id=data["request_id"],
+                observed_context=_observed_context(),
+            ),
+            daemon=True,
+        ).start()
+
+    register_gateway_notify("sess-1", notify)
+    try:
+        with patch("tools.approval._fire_approval_hook", side_effect=lambda name, **kw: hooks.append((name, kw))), patch(
+            "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop
+        ), patch("hermes_cli.config.load_config", return_value=_dps_policy()):
+            prepare = json.loads(
+                _handler("dps", "dps_prepare_project_document_import", session)({"draft": "x"})
+            )
+            result = json.loads(
+                _handler("dps", "dps_execute_project_document_import", session)(
+                    {
+                        "proposal_token": "tok-secret",
+                        "confirmation_code": "code-secret",
+                    }
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert prepare["structuredContent"] == structured
+    assert result["result"] == "executed"
+    assert "private name" in notified[0]["command"]
+    hook_commands = [kw["command"] for _name, kw in hooks]
+    assert hook_commands
+    assert all("private name" not in command for command in hook_commands)
+    assert all("tok-secret" not in command for command in hook_commands)
+    assert all("proposal_digest=" in command for command in hook_commands)
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        ({"ok": False, "data": {}}, "ok is not true"),
+        (
+            {
+                "ok": True,
+                "data": {
+                    "proposal_token": "tok-1",
+                    "expires_at": time.time() - 10,
+                    "action": {"preview": {"x": 1}},
+                },
+            },
+            "past expires_at",
+        ),
+        (
+            {
+                "ok": True,
+                "data": {
+                    "proposal_token": "tok-1",
+                    "expires_at": time.time() + 90000,
+                    "action": {"preview": {"x": 1}},
+                },
+            },
+            "overlong expires_at",
+        ),
+    ],
+)
+def test_prepare_structured_contract_rejects_bad_backend_results(payload, error):
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("mirror", structured=payload))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_dps_policy()
+        ):
+            result = json.loads(_handler("dps", "dps_prepare_alpha", session)({}))
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    assert error in result["error"]
+
+
+def test_confirmation_code_mismatch_denies_after_consuming_pending():
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result(
+            {"proposal_token": "tok-1", "preview": {"x": 1}, "confirmation_code": "code-1"}
+        )
+    )
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_policy()
+        ):
+            json.loads(_handler("dps", "proposal.prepare", session)({}))
+            execute_session = MagicMock()
+            execute_session.call_tool = AsyncMock(return_value=_call_result("bad"))
+            result = json.loads(
+                _handler("dps", "proposal.execute", execute_session)(
+                    {"proposal_token": "tok-1", "confirmation_code": "wrong"}
+                )
+            )
+            replay = json.loads(
+                _handler("dps", "proposal.execute", execute_session)(
+                    {"proposal_token": "tok-1", "confirmation_code": "code-1"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "confirmation_code" in result["error"]
+    assert "no matching unexpired prepare" in replay["error"]
+    execute_session.call_tool.assert_not_called()
+
+
+def test_pending_caps_replace_duplicates_and_cleanup_session():
+    from tools import mcp_permission_rail
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": "tok-1", "preview": {"n": 1}}),
+            _call_result({"proposal_token": "tok-1", "preview": {"n": 2}}),
+            _call_result({"proposal_token": "tok-2", "preview": {"n": 3}}),
+        ]
+    )
+    cfg = _policy()
+    cfg["mcp_permission_rails"]["servers"]["dps"]["max_pending_per_session"] = 1
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=cfg
+        ):
+            handler = _handler("dps", "proposal.prepare", session)
+            json.loads(handler({}))
+            json.loads(handler({}))
+            assert len(mcp_permission_rail._pending) == 1
+            assert '"n":2' in mcp_permission_rail._pending[0].preview
+            json.loads(handler({}))
+            assert len(mcp_permission_rail._pending) == 1
+            mcp_permission_rail.clear_session_pending_proposals("sess-1")
+            assert mcp_permission_rail._pending == []
+    finally:
+        _clear_context(tokens, approval_token)
+
+
+def _decode_attestation_from_meta(meta):
+    encoded = meta["dps.hermes.attestation"].split(".")[1]
+    padded = encoded + ("=" * (-len(encoded) % 4))
+    return json.loads(base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8"))
+
+
+def _attestation_env(monkeypatch, *, key="k" * 64, kid="h1", client="hermes-client", subject="auth0|marcial"):
+    monkeypatch.setenv("DPS_HERMES_ATTESTATION_KID", kid)
+    monkeypatch.setenv("DPS_HERMES_ATTESTATION_KEY", key)
+    monkeypatch.setenv("DPS_HERMES_OAUTH_CLIENT_ID", client)
+    monkeypatch.setenv("DPS_HERMES_OPERATOR_SUBJECT", subject)
+
+
+def test_a2_prepare_attestation_is_meta_only_and_strips_model_spoof(monkeypatch):
+    from tools.hermes_attestation import canonical_hermes_tool_args_digest
+
+    _attestation_env(monkeypatch)
+    token, _proposal = _proposal_token()
+    tokens, approval_token = _bind_context(message_id="telegram-msg-9")
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": token, "preview": {"x": 1}})
+    )
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_attested_dps_policy()
+        ):
+            result = json.loads(
+                _handler("dps", "dps_prepare_project_document_import", session)(
+                    {
+                        "draft": "x",
+                        "hermes_attestation": "model-spoof",
+                        "__dps_hermes_attestation": "model-spoof-2",
+                    }
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" not in result
+    session.call_tool.assert_called_once()
+    _name, _args, kwargs = session.call_tool.mock_calls[0]
+    assert kwargs["arguments"] == {"draft": "x"}
+    assert set(kwargs["meta"]) == {"dps.hermes.attestation"}
+    payload = _decode_attestation_from_meta(kwargs["meta"])
+    assert payload["phase"] == "prepare"
+    assert payload["kid"] == "h1"
+    assert payload["oauth_client_id"] == "hermes-client"
+    assert payload["operator_subject"] == "auth0|marcial"
+    assert payload["platform"] == "telegram"
+    assert payload["originating_user_message_id"] == "telegram-msg-9"
+    assert payload["tool_args_digest"] == canonical_hermes_tool_args_digest({"draft": "x"})
+    assert payload["exp"] - payload["iat"] <= 300
+
+
+@pytest.mark.parametrize(
+    "env_patch,error_fragment",
+    [
+        ({"DPS_HERMES_ATTESTATION_KEY": ""}, "key env is missing"),
+        ({"DPS_HERMES_ATTESTATION_KEY": "short"}, "key is weak"),
+        ({"DPS_HERMES_ATTESTATION_KID": "bad kid"}, "kid is invalid"),
+        ({"DPS_HERMES_OAUTH_CLIENT_ID": ""}, "oauth_client_id env is missing"),
+        ({"DPS_HERMES_OPERATOR_SUBJECT": ""}, "operator_subject env is missing"),
+    ],
+)
+def test_a2_attestation_missing_or_weak_env_fails_before_mcp(monkeypatch, env_patch, error_fragment):
+    _attestation_env(monkeypatch)
+    for key, value in env_patch.items():
+        if value:
+            monkeypatch.setenv(key, value)
+        else:
+            monkeypatch.delenv(key, raising=False)
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_attested_dps_policy()
+        ):
+            result = json.loads(_handler("dps", "dps_prepare_project_document_import", session)({}))
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert error_fragment in result["error"]
+    session.call_tool.assert_not_called()
+
+
+def test_a2_attestation_requires_trusted_originating_message_id(monkeypatch):
+    _attestation_env(monkeypatch)
+    tokens, approval_token = _bind_context(message_id="")
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_call_result("bad"))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_attested_dps_policy()
+        ):
+            result = json.loads(
+                _handler("dps", "dps_prepare_project_document_import", session)(
+                    {"HERMES_SESSION_MESSAGE_ID": "model-spoof"}
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "originating message_id" in result["error"]
+    session.call_tool.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "token_case,error",
+    [
+        ("malformed", "malformed"),
+        ("oversized", "oversized"),
+        ("missing_binding", "hermes binding"),
+    ],
+    ids=["malformed", "oversized", "missing_binding"],
+)
+def test_a2_prepare_rejects_malformed_proposal_metadata(monkeypatch, token_case, error):
+    if token_case == "malformed":
+        token = "not-base64.sig"
+    elif token_case == "oversized":
+        token = "x" * 48_001
+    else:
+        token = _proposal_token(binding=None)[0].split(".")[0] + ".sig"
+        raw = json.loads(base64.urlsafe_b64decode((token.split(".")[0] + "=" * (-len(token.split(".")[0]) % 4)).encode("ascii")).decode("utf-8"))
+        raw.pop("hermes_binding", None)
+        token = _b64url(json.dumps(raw, separators=(",", ":")).encode("utf-8")) + ".sig"
+    _attestation_env(monkeypatch)
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": token, "preview": {"x": 1}})
+    )
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_attested_dps_policy()
+        ):
+            result = json.loads(_handler("dps", "dps_prepare_project_document_import", session)({}))
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert error in result["error"]
+
+
+def test_a2_execute_attestation_contains_approval_and_proposal_digests(monkeypatch):
+    from tools.approval import register_gateway_notify, resolve_sensitive_gateway_approval
+    from tools.hermes_attestation import canonical_hermes_tool_args_digest, canonical_proposal_digest
+
+    _attestation_env(monkeypatch)
+    token, proposal = _proposal_token(payload_hash="f" * 64)
+    tokens, approval_token = _bind_context(message_id="msg-execute")
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _call_result({"proposal_token": token, "preview": {"x": 1}}),
+            _call_result({"ok": True}),
+        ]
+    )
+    notified = []
+
+    def notify(data):
+        notified.append(dict(data))
+        threading.Thread(
+            target=lambda: resolve_sensitive_gateway_approval(
+                "sess-1",
+                "once",
+                request_id=data["request_id"],
+                observed_context=_observed_context(message_id="msg-execute"),
+            ),
+            daemon=True,
+        ).start()
+
+    register_gateway_notify("sess-1", notify)
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=_attested_dps_policy()
+        ):
+            json.loads(_handler("dps", "dps_prepare_project_document_import", session)({"draft": "x"}))
+            result = json.loads(
+                _handler("dps", "dps_execute_project_document_import", session)(
+                    {
+                        "proposal_token": token,
+                        "confirmation_code": "dale",
+                        "dps_hermes_attestation": "model-spoof",
+                    }
+                )
+            )
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" not in result
+    assert notified[0]["allow_session"] is False
+    assert notified[0]["allow_permanent"] is False
+    _name, _args, kwargs = session.call_tool.mock_calls[-1]
+    assert kwargs["arguments"] == {"proposal_token": token, "confirmation_code": "dale"}
+    payload = _decode_attestation_from_meta(kwargs["meta"])
+    assert payload["phase"] == "execute"
+    assert payload["approval_request_id"] == notified[0]["request_id"]
+    assert payload["approval_event_id"].startswith("ape_")
+    assert payload["approved_at"].endswith("Z")
+    assert payload["proposal_token_digest"] == canonical_hermes_tool_args_digest(token)
+    assert payload["proposal_digest"] == canonical_proposal_digest(proposal)
+    assert payload["proposal_payload_digest"] == "f" * 64
+    assert payload["tool_args_digest"] == canonical_hermes_tool_args_digest(
+        {"proposal_token": token, "confirmation_code": "dale"}
+    )
+
+
+def test_prepare_preview_exact_max_registers_pending():
+    from tools import mcp_permission_rail
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": "tok-1", "preview": "x" * 12})
+    )
+    cfg = _policy()
+    cfg["mcp_permission_rails"]["servers"]["dps"]["max_preview_chars"] = 14
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=cfg
+        ):
+            result = json.loads(_handler("dps", "proposal.prepare", session)({}))
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" not in result
+    assert len(mcp_permission_rail._pending) == 1
+    assert mcp_permission_rail._pending[0].preview == '"xxxxxxxxxxxx"'
+
+
+def test_prepare_preview_max_plus_one_blocks_without_pending_or_approval():
+    from tools import mcp_permission_rail
+    from tools.approval import register_gateway_notify
+
+    tokens, approval_token = _bind_context()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_call_result({"proposal_token": "tok-1", "preview": "x" * 13})
+    )
+    cfg = _policy()
+    cfg["mcp_permission_rails"]["servers"]["dps"]["max_preview_chars"] = 14
+    notified = []
+    register_gateway_notify("sess-1", lambda data: notified.append(dict(data)))
+    try:
+        with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_loop), patch(
+            "hermes_cli.config.load_config", return_value=cfg
+        ):
+            result = json.loads(_handler("dps", "proposal.prepare", session)({}))
+    finally:
+        _clear_context(tokens, approval_token)
+
+    assert "error" in result
+    assert "BLOCKED" in result["error"]
+    assert "narrow" in result["error"]
+    assert "DPS Work" in result["error"]
+    assert mcp_permission_rail._pending == []
+    assert notified == []

--- a/tests/tools/test_sensitive_approval_identity.py
+++ b/tests/tools/test_sensitive_approval_identity.py
@@ -1,0 +1,357 @@
+"""Sensitive approval identity binding.
+
+These tests pin the generic primitive used by future high-risk rails: a
+sensitive approval must resolve by request id plus exact observed approver
+context, never by FIFO session key alone.
+"""
+
+import threading
+import time
+
+
+def _clear_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+
+
+def _ctx(session_key="sess-sensitive", user_id="u1", session_id="sid-sensitive"):
+    return {
+        "platform": "telegram",
+        "chat_id": "chat-1",
+        "user_id": user_id,
+        "thread_id": "thread-1",
+        "session_id": session_id,
+        "session_key": session_key,
+    }
+
+
+def _entry(session_key="sess-sensitive", **data):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    payload = {
+        "command": "redacted display only",
+        "description": "sensitive operation",
+        "sensitive": True,
+        "expected_context": _ctx(session_key),
+        **data,
+    }
+    entry = _ApprovalEntry(payload)
+    _gateway_queues[session_key] = [entry]
+    return entry
+
+
+def setup_function():
+    _clear_state()
+
+
+def teardown_function():
+    _clear_state()
+
+
+def test_sensitive_entry_mints_request_id_and_freezes_expected_context():
+    entry = _entry()
+    request_id = entry.data["request_id"]
+    assert isinstance(request_id, str)
+    assert len(request_id) >= 32
+
+    entry.data["expected_context"]["user_id"] = "mallory"
+    result = entry.resolve_sensitive("once", request_id=request_id, observed_context=_ctx())
+
+    assert result["resolved"] is True
+    assert entry.result == "once"
+
+
+def test_sensitive_requires_non_empty_expected_user_id():
+    from tools.approval import _ApprovalEntry
+
+    for expected_context in (
+        {"platform": "telegram", "session_key": "sess-only"},
+        {"platform": "telegram", "chat_id": "chat-only"},
+        {"platform": "telegram", "thread_id": "thread-only"},
+        {"platform": "telegram", "user_id": ""},
+    ):
+        try:
+            _ApprovalEntry(
+                {
+                    "command": "redacted display only",
+                    "description": "sensitive operation",
+                    "sensitive": True,
+                    "expected_context": expected_context,
+                }
+            )
+        except ValueError as exc:
+            assert "expected user_id" in str(exc)
+        else:
+            raise AssertionError(f"accepted weak context: {expected_context!r}")
+
+
+def test_sensitive_cannot_resolve_by_fifo_or_resolve_all():
+    from tools.approval import resolve_gateway_approval, _gateway_queues
+
+    entry = _entry()
+    session_key = "sess-sensitive"
+
+    assert resolve_gateway_approval(session_key, "once") == 0
+    assert resolve_gateway_approval(session_key, "once", resolve_all=True) == 0
+    assert _gateway_queues[session_key] == [entry]
+    assert not entry.event.is_set()
+
+
+def test_sensitive_cannot_resolve_without_request_id():
+    from tools.approval import resolve_gateway_approval, _gateway_queues
+
+    session_key = "sess-sensitive"
+    entry = _entry(session_key=session_key)
+
+    assert (
+        resolve_gateway_approval(
+            session_key,
+            "once",
+            observed_context=_ctx(session_key),
+        )
+        == 0
+    )
+    assert _gateway_queues[session_key] == [entry]
+    assert not entry.event.is_set()
+
+
+def test_sensitive_exact_context_required_for_every_non_null_field():
+    from tools.approval import resolve_sensitive_gateway_approval, _gateway_queues
+
+    session_key = "sess-sensitive"
+    entry = _entry(session_key=session_key)
+
+    for field, value in {
+        "platform": "slack",
+        "chat_id": "chat-2",
+        "user_id": "u2",
+        "thread_id": "thread-2",
+        "session_id": "sid-2",
+        "session_key": "other-session",
+    }.items():
+        observed = _ctx(session_key)
+        observed[field] = value
+        result = resolve_sensitive_gateway_approval(
+            session_key,
+            "once",
+            request_id=entry.data["request_id"],
+            observed_context=observed,
+        )
+        assert result["resolved"] is False
+        assert result["status"] == "context_mismatch"
+        assert _gateway_queues[session_key] == [entry]
+        assert not entry.event.is_set()
+
+
+def test_sensitive_exact_request_resolves_once_and_replay_fails():
+    from tools.approval import resolve_sensitive_gateway_approval
+
+    session_key = "sess-sensitive"
+    entry = _entry(session_key=session_key)
+
+    first = resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=entry.data["request_id"],
+        observed_context=_ctx(session_key),
+    )
+    replay = resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=entry.data["request_id"],
+        observed_context=_ctx(session_key),
+    )
+
+    assert first["resolved"] is True
+    assert first["status"] == "approved"
+    assert first["approval_event_id"].startswith("ape_")
+    assert first["approved_at"].endswith("Z")
+    assert entry.event.is_set()
+    assert entry.result == "once"
+    assert replay["resolved"] is False
+    assert replay["status"] == "not_found"
+
+
+def test_sensitive_unsupported_adapter_identity_fails_closed():
+    from tools.approval import resolve_sensitive_gateway_approval, _gateway_queues
+
+    session_key = "sess-sensitive"
+    entry = _entry(session_key=session_key)
+
+    result = resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=entry.data["request_id"],
+        observed_context={
+            "platform": "unsupported-local",
+            "session_id": "local-session",
+            "session_key": session_key,
+        },
+    )
+
+    assert result["resolved"] is False
+    assert result["status"] == "context_mismatch"
+    assert "user_id" in result["mismatched_fields"]
+    assert _gateway_queues[session_key] == [entry]
+    assert not entry.event.is_set()
+
+
+def test_sensitive_session_and_always_choices_fail_closed():
+    from tools.approval import resolve_sensitive_gateway_approval, _gateway_queues
+
+    for choice in ("session", "always"):
+        session_key = f"sess-{choice}"
+        entry = _entry(session_key=session_key)
+
+        result = resolve_sensitive_gateway_approval(
+            session_key,
+            choice,
+            request_id=entry.data["request_id"],
+            observed_context=_ctx(session_key),
+        )
+
+        assert result["resolved"] is False
+        assert result["status"] == "invalid_choice"
+        assert "approval_event_id" not in result
+        assert "approved_at" not in result
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+        assert session_key not in _gateway_queues
+
+
+def test_sensitive_ttl_caps_gateway_wait(monkeypatch):
+    from tools import approval as mod
+
+    session_key = "sess-wait-ttl"
+    monkeypatch.setattr(mod, "_get_approval_config", lambda: {"timeout": 300})
+
+    notified = []
+    start = time.monotonic()
+    result = mod._await_gateway_decision(
+        session_key,
+        lambda data: notified.append(data["request_id"]),
+        {
+            "command": "redacted display only",
+            "description": "sensitive operation",
+            "sensitive": True,
+            "expected_context": _ctx(session_key),
+            "ttl_seconds": 0.01,
+        },
+    )
+    elapsed = time.monotonic() - start
+
+    assert notified
+    assert result["resolved"] is False
+    assert result["choice"] is None
+    assert result["reason"] is None
+    assert result["approval_request_id"] == notified[0]
+    assert "approval_event_id" not in result
+    assert "approved_at" not in result
+    assert elapsed < 1
+    assert not mod.has_blocking_approval(session_key)
+
+
+def test_sensitive_expired_request_fails_closed():
+    from tools.approval import resolve_sensitive_gateway_approval, _gateway_queues
+
+    session_key = "sess-expired"
+    entry = _entry(session_key=session_key, ttl_seconds=-0.01)
+    time.sleep(0.02)
+
+    result = resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=entry.data["request_id"],
+        observed_context=_ctx(session_key),
+    )
+
+    assert result["resolved"] is False
+    assert result["status"] == "expired"
+    assert entry.event.is_set()
+    assert entry.result == "deny"
+    assert session_key not in _gateway_queues
+
+
+def test_sensitive_double_response_is_atomic_one_shot():
+    from tools.approval import resolve_sensitive_gateway_approval
+
+    session_key = "sess-race"
+    entry = _entry(session_key=session_key)
+    request_id = entry.data["request_id"]
+    barrier = threading.Barrier(3)
+    results = []
+
+    def respond():
+        barrier.wait()
+        results.append(
+            resolve_sensitive_gateway_approval(
+                session_key,
+                "once",
+                request_id=request_id,
+                observed_context=_ctx(session_key),
+            )
+        )
+
+    threads = [threading.Thread(target=respond), threading.Thread(target=respond)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(results) == 2
+    assert sum(1 for result in results if result["resolved"]) == 1
+    assert sum(1 for result in results if result["status"] == "not_found") == 1
+    assert entry.event.is_set()
+    assert entry.result == "once"
+
+
+def test_sensitive_result_logs_digest_not_raw_request_id(caplog):
+    import logging
+    from tools.approval import resolve_sensitive_gateway_approval
+
+    caplog.set_level(logging.INFO, logger="tools.approval")
+    session_key = "sess-logs"
+    raw_request_id = "raw-sensitive-request-id-123456789"
+    _entry(session_key=session_key, request_id=raw_request_id)
+
+    resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=raw_request_id,
+        observed_context=_ctx(session_key),
+    )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert raw_request_id not in messages
+    assert "request_digest=" in messages
+
+
+def test_sensitive_mismatch_and_denial_do_not_create_approval_event():
+    from tools.approval import resolve_sensitive_gateway_approval
+
+    session_key = "sess-no-event"
+    entry = _entry(session_key=session_key)
+    mismatch = resolve_sensitive_gateway_approval(
+        session_key,
+        "once",
+        request_id=entry.data["request_id"],
+        observed_context={**_ctx(session_key), "chat_id": "other"},
+    )
+    denied = resolve_sensitive_gateway_approval(
+        session_key,
+        "deny",
+        request_id=entry.data["request_id"],
+        observed_context=_ctx(session_key),
+    )
+
+    assert mismatch["status"] == "context_mismatch"
+    assert "approval_event_id" not in mismatch
+    assert denied["status"] == "denied"
+    assert "approval_event_id" not in denied
+    assert "approved_at" not in denied

--- a/tests/tui_gateway/test_sensitive_approval_response.py
+++ b/tests/tui_gateway/test_sensitive_approval_response.py
@@ -1,0 +1,133 @@
+"""TUI/Desktop approval response binding for sensitive requests."""
+
+
+def _clear_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+
+
+def setup_function():
+    _clear_state()
+
+
+def teardown_function():
+    _clear_state()
+
+
+def test_approval_respond_with_request_id_preserves_local_plumbing(monkeypatch):
+    from tui_gateway import server
+
+    sid = "ui-session-1"
+    server._sessions.clear()
+    server._sessions[sid] = {"session_key": "stored-session-1"}
+
+    captured = {}
+
+    def fake_resolve(session_key, choice, *, request_id, observed_context, reason=None):
+        captured.update(
+            {
+                "choice": choice,
+                "observed_context": observed_context,
+                "reason": reason,
+                "request_id": request_id,
+                "session_key": session_key,
+            }
+        )
+        return {"resolved": True, "status": "approved", "request_id": request_id}
+
+    monkeypatch.setattr(
+        "tools.approval.resolve_sensitive_gateway_approval",
+        fake_resolve,
+    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args, **_kwargs: None)
+
+    response = server._methods["approval.respond"](
+        1,
+        {"choice": "once", "request_id": "req-local", "session_id": sid},
+    )
+
+    assert response["result"]["resolved"] is True
+    assert captured == {
+        "choice": "once",
+        "observed_context": {
+            "platform": "tui",
+            "session_id": sid,
+            "session_key": "stored-session-1",
+        },
+        "reason": None,
+        "request_id": "req-local",
+        "session_key": "stored-session-1",
+    }
+
+
+def test_local_json_rpc_cannot_resolve_sensitive_user_bound_approval(monkeypatch):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+    from tui_gateway import server
+
+    sid = "ui-session-1"
+    session_key = "stored-session-1"
+    request_id = "req-sensitive-local"
+    server._sessions.clear()
+    server._sessions[sid] = {"session_key": session_key}
+
+    entry = _ApprovalEntry(
+        {
+            "command": "redacted display only",
+            "description": "DPS-class write",
+            "expected_context": {
+                "platform": "telegram",
+                "chat_id": "chat-1",
+                "user_id": "telegram-user-1",
+                "thread_id": "thread-1",
+                "session_key": session_key,
+            },
+            "request_id": request_id,
+            "sensitive": True,
+        }
+    )
+    _gateway_queues[session_key] = [entry]
+
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args, **_kwargs: None)
+
+    response = server._methods["approval.respond"](
+        1,
+        {"choice": "once", "request_id": request_id, "session_id": sid},
+    )
+
+    result = response["result"]
+    assert result["resolved"] is False
+    assert result["status"] == "context_mismatch"
+    assert "user_id" in result["mismatched_fields"]
+    assert not entry.event.is_set()
+    assert _gateway_queues[session_key] == [entry]
+
+
+def test_local_json_rpc_preserves_ordinary_non_sensitive_approvals(monkeypatch):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+    from tui_gateway import server
+
+    sid = "ui-session-ordinary"
+    session_key = "stored-session-ordinary"
+    server._sessions.clear()
+    server._sessions[sid] = {"session_key": session_key}
+    entry = _ApprovalEntry({"command": "ordinary dangerous command"})
+    _gateway_queues[session_key] = [entry]
+
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args, **_kwargs: None)
+
+    response = server._methods["approval.respond"](
+        1,
+        {"choice": "once", "session_id": sid},
+    )
+
+    assert response["result"] == {"resolved": 1}
+    assert entry.event.is_set()
+    assert entry.result == "once"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,12 +9,15 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import fnmatch
 import functools
 import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
@@ -2152,9 +2155,117 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # resolves every pending approval in the session.
 
 
+_SENSITIVE_APPROVAL_CONTEXT_FIELDS = (
+    "platform",
+    "chat_id",
+    "user_id",
+    "thread_id",
+    "session_id",
+    "session_key",
+)
+_SENSITIVE_APPROVAL_DEFAULT_TTL_SECONDS = 120.0
+
+
+def _approval_event_id() -> str:
+    return "ape_" + secrets.token_urlsafe(32)
+
+
+def _approval_utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class SensitiveApprovalContext:
+    """Immutable identity context required to resolve a sensitive approval.
+
+    Contract: this primitive binds only the authenticated platform user id plus
+    immutable session/chat/thread context.  A sensitive approval MUST include a
+    non-empty expected ``user_id`` from a real adapter; session_key,
+    session_id, chat_id, or thread_id alone are routing hints, not human
+    identity.  Future DPS rail writes must add their own binding above this
+    primitive: proposal token digest, tool name, payload/preview digest, and a
+    short TTL.  Initial DPS writes are Telegram-only.
+    """
+
+    platform: Optional[str] = None
+    chat_id: Optional[str] = None
+    user_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    session_id: Optional[str] = None
+    session_key: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, value: Optional[dict]) -> "SensitiveApprovalContext":
+        data = value if isinstance(value, dict) else {}
+        normalized = {
+            field: (None if data.get(field) in (None, "") else str(data.get(field)))
+            for field in _SENSITIVE_APPROVAL_CONTEXT_FIELDS
+        }
+        return cls(**normalized)
+
+    def has_user_binding(self) -> bool:
+        return self.user_id is not None
+
+    def mismatches(self, observed: Optional[dict]) -> list[str]:
+        observed_ctx = self.from_mapping(observed)
+        fields = []
+        for field in _SENSITIVE_APPROVAL_CONTEXT_FIELDS:
+            expected = getattr(self, field)
+            if expected is not None and getattr(observed_ctx, field) != expected:
+                fields.append(field)
+        return fields
+
+
+def _sensitive_approval_result(
+    *,
+    request_id: Optional[str],
+    resolved: bool,
+    status: str,
+    mismatched_fields: Optional[list[str]] = None,
+    approval_event_id: Optional[str] = None,
+    approved_at: Optional[str] = None,
+) -> dict:
+    request_digest = _approval_request_digest(request_id)
+    result = {
+        "request_id": request_id,
+        "resolved": resolved,
+        "sensitive": True,
+        "status": status,
+    }
+    if mismatched_fields:
+        result["mismatched_fields"] = list(mismatched_fields)
+    if approval_event_id:
+        result["approval_event_id"] = approval_event_id
+    if approved_at:
+        result["approved_at"] = approved_at
+    logger.info(
+        "Sensitive approval resolution status=%s resolved=%s request_digest=%s",
+        status,
+        resolved,
+        request_digest,
+    )
+    return result
+
+
+def _approval_request_digest(request_id: Optional[str]) -> str:
+    if not request_id:
+        return ""
+    return hashlib.sha256(str(request_id).encode("utf-8")).hexdigest()[:12]
+
+
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = (
+        "data",
+        "event",
+        "expires_at",
+        "reason",
+        "request_id",
+        "result",
+        "sensitive_context",
+        "approval_event_id",
+        "approved_at",
+    )
 
     def __init__(self, data: dict):
         self.event = threading.Event()
@@ -2164,6 +2275,93 @@ class _ApprovalEntry:
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
         self.reason: Optional[str] = None
+        self.request_id: Optional[str] = None
+        self.sensitive_context: Optional[SensitiveApprovalContext] = None
+        self.expires_at: Optional[float] = None
+        self.approval_event_id: Optional[str] = None
+        self.approved_at: Optional[str] = None
+
+        if data.get("sensitive") is True:
+            context = SensitiveApprovalContext.from_mapping(data.get("expected_context"))
+            if not context.has_user_binding():
+                raise ValueError("sensitive approvals require a non-empty expected user_id")
+            self.sensitive_context = context
+            self.request_id = str(data.get("request_id") or secrets.token_urlsafe(32))
+            try:
+                ttl_seconds = float(
+                    data.get("ttl_seconds", _SENSITIVE_APPROVAL_DEFAULT_TTL_SECONDS)
+                )
+            except (TypeError, ValueError):
+                ttl_seconds = _SENSITIVE_APPROVAL_DEFAULT_TTL_SECONDS
+            self.expires_at = time.monotonic() + ttl_seconds
+            data["request_id"] = self.request_id
+            data["allow_permanent"] = False
+            data["allow_session"] = False
+            data["choices"] = ["once", "deny"]
+
+    @property
+    def sensitive(self) -> bool:
+        return self.sensitive_context is not None
+
+    def resolve_sensitive(
+        self,
+        choice: str,
+        *,
+        request_id: Optional[str],
+        observed_context: Optional[dict],
+    ) -> dict:
+        if not self.sensitive:
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="not_sensitive",
+            )
+        if not request_id or request_id != self.request_id:
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="request_id_mismatch",
+            )
+        if self.expires_at is not None and time.monotonic() > self.expires_at:
+            self.result = "deny"
+            self.event.set()
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="expired",
+            )
+
+        mismatches = self.sensitive_context.mismatches(observed_context)
+        if mismatches:
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="context_mismatch",
+                mismatched_fields=mismatches,
+            )
+
+        normalized_choice = str(choice or "deny").strip().lower()
+        if normalized_choice not in {"once", "deny"}:
+            self.result = "deny"
+            self.event.set()
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="invalid_choice",
+            )
+
+        self.result = normalized_choice
+        if normalized_choice == "once":
+            self.approval_event_id = _approval_event_id()
+            self.approved_at = _approval_utc_now()
+        self.event.set()
+        return _sensitive_approval_result(
+            request_id=request_id,
+            resolved=True,
+            status="denied" if normalized_choice == "deny" else "approved",
+            approval_event_id=self.approval_event_id,
+            approved_at=self.approved_at,
+        )
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
@@ -2195,9 +2393,59 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+def resolve_sensitive_gateway_approval(
+    session_key: str,
+    choice: str,
+    *,
+    request_id: str,
+    observed_context: Optional[dict],
+    reason: Optional[str] = None,
+) -> dict:
+    """Resolve one sensitive approval by request id and observed identity."""
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="not_found",
+            )
+
+        entry = next(
+            (
+                candidate
+                for candidate in queue
+                if getattr(candidate, "sensitive", False)
+                and candidate.request_id == request_id
+            ),
+            None,
+        )
+        if entry is None:
+            return _sensitive_approval_result(
+                request_id=request_id,
+                resolved=False,
+                status="not_found",
+            )
+
+        result = entry.resolve_sensitive(
+            choice,
+            request_id=request_id,
+            observed_context=observed_context,
+        )
+        if reason:
+            entry.reason = reason
+        if entry.event.is_set():
+            queue.remove(entry)
+            if not queue:
+                _gateway_queues.pop(session_key, None)
+        return result
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             request_id: Optional[str] = None,
+                             observed_context: Optional[dict] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
@@ -2211,15 +2459,33 @@ def resolve_gateway_approval(session_key: str, choice: str,
 
     Returns the number of approvals resolved (0 means nothing was pending).
     """
+    if request_id:
+        result = resolve_sensitive_gateway_approval(
+            session_key,
+            choice,
+            request_id=request_id,
+            observed_context=observed_context,
+            reason=reason,
+        )
+        return 1 if result.get("resolved") else 0
+
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
         if resolve_all:
-            targets = list(queue)
-            queue.clear()
+            targets = [entry for entry in queue if not getattr(entry, "sensitive", False)]
+            for entry in targets:
+                queue.remove(entry)
         else:
-            targets = [queue.pop(0)]
+            target = next(
+                (entry for entry in queue if not getattr(entry, "sensitive", False)),
+                None,
+            )
+            if target is None:
+                return 0
+            queue.remove(target)
+            targets = [target]
         if not queue:
             _gateway_queues.pop(session_key, None)
 
@@ -2231,10 +2497,66 @@ def resolve_gateway_approval(session_key: str, choice: str,
     return len(targets)
 
 
+def request_sensitive_human_approval(
+    *,
+    session_key: str,
+    command: str,
+    hook_command: str | None = None,
+    description: str,
+    expected_context: dict,
+    ttl_seconds: float,
+    pattern_key: str,
+) -> dict:
+    """Request a one-shot sensitive approval bound to exact human context.
+
+    Higher-level rails use this after binding their own proposal token and
+    preview digest. This helper deliberately exposes only the sensitive gateway
+    path: no YOLO, permanent allowlist, session approval, or FIFO approval can
+    authorize the action.
+    """
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        return {"resolved": False, "choice": None, "notify_failed": True}
+
+    return _await_gateway_decision(
+        session_key,
+        notify_cb,
+        {
+            "command": command,
+            "hook_command": hook_command if isinstance(hook_command, str) and hook_command else command,
+            "description": description,
+            "pattern_key": pattern_key,
+            "pattern_keys": [pattern_key],
+            "sensitive": True,
+            "expected_context": dict(expected_context or {}),
+            "ttl_seconds": ttl_seconds,
+            "allow_permanent": False,
+            "allow_session": False,
+            "choices": ["once", "deny"],
+        },
+        surface="gateway",
+    )
+
+
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
         return bool(_gateway_queues.get(session_key))
+
+
+def has_sensitive_gateway_approval(
+    session_key: str,
+    request_id: Optional[str] = None,
+) -> bool:
+    """Return whether a sensitive approval is pending for this session."""
+    with _lock:
+        queue = _gateway_queues.get(session_key) or []
+        return any(
+            getattr(entry, "sensitive", False)
+            and (request_id is None or entry.request_id == request_id)
+            for entry in queue
+        )
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -3263,6 +3585,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     the final tool-facing result dict remain the caller's responsibility.
     """
     command = approval_data.get("command", "")
+    hook_command = approval_data.get("hook_command", command)
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
@@ -3283,7 +3606,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # gateway notify callback so observers get the event in real time.
     _fire_approval_hook(
         "pre_approval_request",
-        command=command,
+        command=hook_command,
         description=description,
         pattern_key=primary_key,
         pattern_keys=list(all_keys),
@@ -3313,6 +3636,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     _now = time.monotonic()
     _deadline = _now + max(timeout, 0)
+    if entry.expires_at is not None:
+        _deadline = min(_deadline, entry.expires_at)
     _activity_state = {"last_touch": _now, "start": _now}
     resolved = False
     while True:
@@ -3351,7 +3676,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     _outcome = "timeout" if not resolved else (choice if choice else "timeout")
     _fire_approval_hook(
         "post_approval_response",
-        command=command,
+        command=hook_command,
         description=description,
         pattern_key=primary_key,
         pattern_keys=list(all_keys),
@@ -3359,7 +3684,18 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         surface=surface,
         choice=_outcome,
     )
-    return {"resolved": resolved, "choice": choice, "reason": entry.reason}
+    result = {
+        "resolved": resolved,
+        "choice": choice,
+        "reason": entry.reason,
+    }
+    if getattr(entry, "sensitive", False):
+        result["approval_request_id"] = entry.request_id
+        if entry.approval_event_id:
+            result["approval_event_id"] = entry.approval_event_id
+        if entry.approved_at:
+            result["approved_at"] = entry.approved_at
+    return result
 
 
 def check_all_command_guards(command: str, env_type: str,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -349,7 +349,34 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
 
 
-def _is_hermes_internal_secret(key: str) -> bool:
+def _configured_attestation_key_envs() -> frozenset[str]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+    except Exception:
+        return frozenset()
+    root = cfg.get("mcp_permission_rails") if isinstance(cfg, dict) else None
+    servers = root.get("servers") if isinstance(root, dict) else None
+    if not isinstance(servers, dict):
+        return frozenset()
+    names: set[str] = set()
+    for raw in servers.values():
+        if not isinstance(raw, dict):
+            continue
+        attestation = raw.get("attestation")
+        if not isinstance(attestation, dict) or attestation.get("enabled") is not True:
+            continue
+        key_env = str(attestation.get("key_env") or "").strip()
+        if key_env and key_env.upper().endswith("_KEY"):
+            names.add(key_env.upper())
+    return frozenset(names)
+
+
+def _is_hermes_internal_secret(
+    key: str,
+    attestation_key_envs: frozenset[str] | None = None,
+) -> bool:
     """Return True for Hermes-internal secrets injected under *dynamic* names.
 
     ``_HERMES_PROVIDER_ENV_BLOCKLIST`` is name-based and derived from the
@@ -383,6 +410,8 @@ def _is_hermes_internal_secret(key: str) -> bool:
     a model-driving CLI legitimately needs matches these patterns.
     """
     upper = key.upper()
+    if attestation_key_envs is not None and upper in attestation_key_envs:
+        return True
     if upper.startswith("AUXILIARY_") and (
         upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
     ):
@@ -461,11 +490,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         _is_passthrough = lambda _: False  # noqa: E731
 
     sanitized: dict[str, str] = {}
+    attestation_key_envs = _configured_attestation_key_envs()
 
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
-        if _is_hermes_internal_secret(key):
+        if _is_hermes_internal_secret(key, attestation_key_envs):
             continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
@@ -473,10 +503,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (extra_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            if _is_hermes_internal_secret(real_key):
+            if _is_hermes_internal_secret(real_key, attestation_key_envs):
                 continue
             sanitized[real_key] = value
-        elif _is_hermes_internal_secret(key):
+        elif _is_hermes_internal_secret(key, attestation_key_envs):
             continue
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
@@ -591,6 +621,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     ``os.environ`` into the returned dict.
     """
     env = os.environ.copy()
+    attestation_key_envs = _configured_attestation_key_envs()
 
     # Tier 1 — always strip.
     for key in _ALWAYS_STRIP_KEYS:
@@ -603,7 +634,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     for key in list(env):
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             env.pop(key, None)
-        elif _is_hermes_internal_secret(key):
+        elif _is_hermes_internal_secret(key, attestation_key_envs):
             env.pop(key, None)
 
     if not inherit_credentials:
@@ -1225,13 +1256,14 @@ def _make_run_env(env: dict) -> dict:
 
     merged = dict(os.environ | env)
     run_env = {}
+    attestation_key_envs = _configured_attestation_key_envs()
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            if _is_hermes_internal_secret(real_key):
+            if _is_hermes_internal_secret(real_key, attestation_key_envs):
                 continue
             run_env[real_key] = v
-        elif _is_hermes_internal_secret(k):
+        elif _is_hermes_internal_secret(k, attestation_key_envs):
             continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v

--- a/tools/hermes_attestation.py
+++ b/tools/hermes_attestation.py
@@ -1,0 +1,315 @@
+"""Hermes client attestations for protected MCP prepare/execute rails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+import base64
+import hashlib
+import hmac
+import json
+import math
+import os
+import re
+import secrets
+import time
+from typing import Any, Mapping
+
+
+DIRECT_THREAD_SENTINEL = "__hermes_direct_no_thread__"
+ATTESTATION_META_KEY = "dps.hermes.attestation"
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_KID_RE = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_PROPOSAL_TOKEN_BYTES = 48_000
+_MAX_PROPOSAL_PAYLOAD_BYTES = 48_000
+_JS_SAFE_INTEGER_MAX = 2**53 - 1
+_INTERNAL_ARG_FIELDS = {
+    "_meta",
+    "__dps_hermes_attestation",
+    "dps_hermes_attestation",
+    "hermes_attestation",
+}
+
+
+class HermesAttestationError(ValueError):
+    """Fail-closed attestation/config/proposal error with a non-secret reason."""
+
+
+@dataclass(frozen=True)
+class HermesAttestationPolicy:
+    enabled: bool
+    kid_env: str = ""
+    key_env: str = ""
+    oauth_client_id_env: str = ""
+    operator_subject_env: str = ""
+    ttl_seconds: int = 300
+    direct_thread_sentinel: str = DIRECT_THREAD_SENTINEL
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "HermesAttestationPolicy":
+        if not isinstance(value, Mapping) or value.get("enabled") is not True:
+            return cls(enabled=False)
+        ttl = value.get("ttl_seconds", 300)
+        try:
+            ttl_int = int(ttl)
+        except (TypeError, ValueError):
+            ttl_int = 300
+        ttl_int = min(max(ttl_int, 1), 300)
+        sentinel = str(value.get("direct_thread_sentinel") or DIRECT_THREAD_SENTINEL).strip()
+        key_env = _env_ref(value.get("key_env"), "key_env")
+        if not key_env.upper().endswith("_KEY"):
+            raise HermesAttestationError("attestation key_env must end with _KEY")
+        return cls(
+            enabled=True,
+            kid_env=_env_ref(value.get("kid_env"), "kid_env"),
+            key_env=key_env,
+            oauth_client_id_env=_env_ref(value.get("oauth_client_id_env"), "oauth_client_id_env"),
+            operator_subject_env=_env_ref(value.get("operator_subject_env"), "operator_subject_env"),
+            ttl_seconds=ttl_int,
+            direct_thread_sentinel=sentinel or DIRECT_THREAD_SENTINEL,
+        )
+
+    def resolve(self) -> tuple[str, str, str, str]:
+        if not self.enabled:
+            raise HermesAttestationError("attestation disabled")
+        kid = _env_value(self.kid_env, "kid")
+        key = _env_value(self.key_env, "key")
+        oauth_client_id = _env_value(self.oauth_client_id_env, "oauth_client_id")
+        operator_subject = _env_value(self.operator_subject_env, "operator_subject")
+        if not _KID_RE.match(kid):
+            raise HermesAttestationError("attestation kid is invalid")
+        if len(key.encode("utf-8")) < 32:
+            raise HermesAttestationError("attestation key is weak")
+        return kid, key, oauth_client_id, operator_subject
+
+
+def _env_ref(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if text.startswith("${") and text.endswith("}"):
+        text = text[2:-1].strip()
+        if text.startswith("env:"):
+            text = text[4:].strip()
+    if not text or not _ENV_NAME_RE.match(text):
+        raise HermesAttestationError(f"attestation {label} must name an env var")
+    return text
+
+
+def _env_value(name: str, label: str) -> str:
+    value = os.environ.get(name, "")
+    if not isinstance(value, str) or not value.strip():
+        raise HermesAttestationError(f"attestation {label} env is missing")
+    return value.strip()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    text = str(value or "")
+    padding = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode((text + padding).encode("ascii"))
+
+
+def sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def strip_internal_hermes_fields(value: Any) -> Any:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, Mapping):
+        return value
+    return {key: item for key, item in value.items() if key not in _INTERNAL_ARG_FIELDS}
+
+
+def canonical_hermes_tool_args_digest(value: Any) -> str:
+    if isinstance(value, str):
+        return sha256_hex(value)
+    return sha256_hex(canonical_hermes_json(strip_internal_hermes_fields(value)))
+
+
+def canonical_proposal_digest(proposal: Mapping[str, Any]) -> str:
+    return sha256_hex(canonical_hermes_json(proposal))
+
+
+def canonical_hermes_json(value: Any) -> str:
+    return _render_json(value)
+
+
+def _render_json(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value < -_JS_SAFE_INTEGER_MAX or value > _JS_SAFE_INTEGER_MAX:
+            raise HermesAttestationError("hermes_json safe integer unsupported")
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise HermesAttestationError("hermes_json_number_unsupported")
+        if value == 0:
+            return "0"
+        return _render_float(value)
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise HermesAttestationError("hermes_json_number_unsupported")
+        if value == 0:
+            return "0"
+        return format(value.normalize(), "f").rstrip("0").rstrip(".")
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_render_json(item) for item in value) + "]"
+    if isinstance(value, Mapping):
+        parts = []
+        for key in sorted(value.keys(), key=lambda item: str(item)):
+            if not isinstance(key, str) or not key:
+                raise HermesAttestationError("hermes_json_key_unsupported")
+            parts.append(f"{_render_json(key)}:{_render_json(value[key])}")
+        return "{" + ",".join(parts) + "}"
+    raise HermesAttestationError("hermes_json_value_unsupported")
+
+
+def _render_float(value: float) -> str:
+    text = repr(value)
+    if "e" not in text and "E" not in text:
+        return text
+    mantissa, exponent_text = re.split("[eE]", text)
+    exponent = int(exponent_text)
+    if -6 <= exponent < 21:
+        fixed = format(value, f".{max(0, 18)}f").rstrip("0").rstrip(".")
+        return fixed or "0"
+    mantissa = mantissa.rstrip("0").rstrip(".")
+    sign = "+" if exponent >= 0 else "-"
+    return f"{mantissa}e{sign}{abs(exponent)}"
+
+
+def normalize_thread_id(thread_id: str, sentinel: str = DIRECT_THREAD_SENTINEL) -> str:
+    value = str(thread_id or "").strip()
+    return value or sentinel
+
+
+def require_attestable_context(
+    ctx: Mapping[str, str],
+    policy: HermesAttestationPolicy,
+) -> dict[str, str]:
+    platform = str(ctx.get("platform") or "").strip()
+    user_id = str(ctx.get("user_id") or "").strip()
+    chat_id = str(ctx.get("chat_id") or "").strip()
+    thread_id = normalize_thread_id(str(ctx.get("thread_id") or ""), policy.direct_thread_sentinel)
+    session_id = str(ctx.get("session_id") or "").strip()
+    session_key = str(ctx.get("session_key") or "").strip()
+    message_id = str(ctx.get("message_id") or "").strip()
+    if not all((platform, user_id, chat_id, thread_id, session_id, session_key, message_id)):
+        raise HermesAttestationError("attestation context is incomplete")
+    if platform != "telegram":
+        raise HermesAttestationError("attestation requires Telegram context")
+    return {
+        "platform": platform,
+        "platform_user_id": user_id,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+        "session_id": session_id,
+        "session_key": session_key,
+        "originating_user_message_id": message_id,
+    }
+
+
+def sign_attestation(
+    *,
+    policy: HermesAttestationPolicy,
+    phase: str,
+    tool_name: str,
+    args: Mapping[str, Any],
+    ctx: Mapping[str, str],
+    approval: Mapping[str, str] | None = None,
+    proposal: Mapping[str, str] | None = None,
+    now_seconds: int | None = None,
+) -> str:
+    kid, key, oauth_client_id, operator_subject = policy.resolve()
+    trusted = require_attestable_context(ctx, policy)
+    iat = int(now_seconds if now_seconds is not None else time.time())
+    payload: dict[str, Any] = {
+        "v": 1,
+        "kid": kid,
+        "phase": phase,
+        "tool_name": tool_name,
+        "oauth_client_id": oauth_client_id,
+        "operator_subject": operator_subject,
+        "platform": trusted["platform"],
+        "platform_user_id": trusted["platform_user_id"],
+        "chat_id": trusted["chat_id"],
+        "thread_id": trusted["thread_id"],
+        "session_id": trusted["session_id"],
+        "originating_user_message_id": trusted["originating_user_message_id"],
+        "iat": iat,
+        "exp": iat + policy.ttl_seconds,
+        "nonce": secrets.token_urlsafe(24),
+        "tool_args_digest": canonical_hermes_tool_args_digest(args),
+    }
+    if approval:
+        payload.update({
+            "approval_request_id": _required(approval, "approval_request_id"),
+            "approval_event_id": _required(approval, "approval_event_id"),
+            "approved_at": _required(approval, "approved_at"),
+        })
+    if proposal:
+        payload.update({
+            "proposal_token_digest": _required(proposal, "proposal_token_digest"),
+            "proposal_digest": _required(proposal, "proposal_digest"),
+            "proposal_payload_digest": _required(proposal, "proposal_payload_digest"),
+        })
+    canonical = canonical_hermes_json(payload)
+    signature = hmac.new(key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).digest()
+    return f"hmac-sha256-v1.{_b64url(canonical.encode('utf-8'))}.{_b64url(signature)}"
+
+
+def _required(value: Mapping[str, str], key: str) -> str:
+    item = str(value.get(key) or "").strip()
+    if not item:
+        raise HermesAttestationError(f"attestation {key} missing")
+    return item
+
+
+def attestation_meta(token: str) -> dict[str, str]:
+    if not token:
+        raise HermesAttestationError("attestation token missing")
+    return {ATTESTATION_META_KEY: token}
+
+
+def decode_proposal_token_metadata(token: str) -> dict[str, str]:
+    token_text = str(token or "")
+    if not token_text or len(token_text.encode("utf-8")) > _MAX_PROPOSAL_TOKEN_BYTES:
+        raise HermesAttestationError("proposal token missing or oversized")
+    first_segment = token_text.split(".", 1)[0]
+    try:
+        decoded = _b64url_decode(first_segment)
+    except Exception as exc:
+        raise HermesAttestationError("proposal token payload is malformed") from exc
+    if len(decoded) > _MAX_PROPOSAL_PAYLOAD_BYTES:
+        raise HermesAttestationError("proposal token payload is oversized")
+    try:
+        proposal = json.loads(decoded.decode("utf-8"))
+    except Exception as exc:
+        raise HermesAttestationError("proposal token payload is malformed") from exc
+    if not isinstance(proposal, dict) or proposal.get("v") != 1:
+        raise HermesAttestationError("proposal token version is invalid")
+    binding = proposal.get("hermes_binding")
+    if not isinstance(binding, dict) or binding.get("v") != 1:
+        raise HermesAttestationError("proposal token hermes binding is missing")
+    payload_hash = proposal.get("payload_hash")
+    if not isinstance(payload_hash, str) or not _HEX64_RE.match(payload_hash):
+        raise HermesAttestationError("proposal token payload_hash is invalid")
+    return {
+        "proposal_token_digest": canonical_hermes_tool_args_digest(token_text),
+        "proposal_digest": canonical_proposal_digest(proposal),
+        "proposal_payload_digest": payload_hash,
+    }
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/tools/mcp_permission_rail.py
+++ b/tools/mcp_permission_rail.py
@@ -1,0 +1,1015 @@
+"""Config-driven MCP prepare/execute permission rail.
+
+The rail is generic: config names exact MCP server/tool patterns and result
+paths. Unconfigured servers/tools keep normal MCP behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fnmatch
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_PREVIEW_CHARS = 3000
+_HARD_MAX_PREVIEW_CHARS = 3000
+
+
+@dataclass(frozen=True)
+class MCPRailPolicy:
+    server_name: str
+    ttl_seconds: float
+    max_backend_expiry_seconds: float
+    max_pending_global: int
+    max_pending_per_session: int
+    max_preview_chars: int
+    prepare_patterns: tuple[str, ...]
+    execute_patterns: tuple[str, ...]
+    status_patterns: tuple[str, ...]
+    read_patterns: tuple[str, ...]
+    bindings: tuple[tuple[str, str], ...]
+    prepare_prefix: str
+    execute_prefix: str
+    deny_execute_patterns: tuple[str, ...]
+    token_result_paths: tuple[str, ...]
+    preview_result_paths: tuple[str, ...]
+    expires_at_result_paths: tuple[str, ...]
+    confirmation_code_result_paths: tuple[str, ...]
+    execute_token_paths: tuple[str, ...]
+    execute_confirmation_code_paths: tuple[str, ...]
+    attestation: Any = None
+    invalid_reason: str = ""
+
+
+@dataclass(frozen=True)
+class MCPRailDecision:
+    policy: Optional[MCPRailPolicy]
+    kind: str = "unprotected"
+    prepare_tool: str = ""
+    prepare_execute_tool: str = ""
+    approved: bool = False
+    denied_message: str = ""
+    pending: Optional["PendingProposal"] = None
+    call_args: Optional[Mapping[str, Any]] = None
+    mcp_meta: Optional[Mapping[str, Any]] = None
+
+    @property
+    def protected_execute(self) -> bool:
+        return self.kind == "execute" and self.policy is not None
+
+
+@dataclass(frozen=True)
+class PendingProposal:
+    server_name: str
+    prepare_tool: str
+    execute_tool: str
+    proposal_token_digest: str
+    confirmation_code_digest: str
+    preview_digest: str
+    canonical_result_digest: str
+    proposal_digest: str
+    proposal_payload_digest: str
+    preview: str
+    expires_at: float
+    context: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class _ExtractedProposal:
+    proposal_token_digest: str
+    confirmation_code_digest: str
+    preview_digest: str
+    canonical_result_digest: str
+    proposal_digest: str
+    proposal_payload_digest: str
+    preview: str
+    backend_expires_at_wall: float
+
+
+_pending_lock = threading.Lock()
+_pending: list[PendingProposal] = []
+_known_protected_servers: set[str] = set()
+
+
+def clear_pending_proposals() -> None:
+    """Clear in-memory proposals. Intended for tests and session-bound cleanup."""
+    with _pending_lock:
+        _pending.clear()
+
+
+def clear_session_pending_proposals(session_key: str) -> None:
+    """Drop pending proposals for a finished session."""
+    if not session_key:
+        return
+    with _pending_lock:
+        _pending[:] = [
+            proposal
+            for proposal in _pending
+            if proposal.context.get("session_key") != session_key
+        ]
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _audit(
+    event: str,
+    *,
+    server_name: str,
+    tool_name: str,
+    proposal_digest: str = "",
+    preview_digest: str = "",
+    result_digest: str = "",
+    reason: str = "",
+) -> None:
+    logger.info(
+        "mcp_permission_rail event=%s server=%s tool=%s proposal_digest=%s "
+        "preview_digest=%s result_digest=%s reason=%s",
+        event,
+        server_name,
+        tool_name,
+        proposal_digest[:12] if proposal_digest else "",
+        preview_digest[:12] if preview_digest else "",
+        result_digest[:12] if result_digest else "",
+        reason,
+    )
+
+
+def _as_str_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return (stripped,) if stripped else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+    return ()
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_preview_limit(value: Any) -> int:
+    parsed = _as_positive_int(value, _DEFAULT_MAX_PREVIEW_CHARS)
+    return min(parsed, _HARD_MAX_PREVIEW_CHARS)
+
+
+def _invalid_policy(server_name: str, reason: str) -> MCPRailPolicy:
+    return MCPRailPolicy(
+        server_name=server_name,
+        ttl_seconds=120.0,
+        max_backend_expiry_seconds=86400.0,
+        max_pending_global=256,
+        max_pending_per_session=8,
+        max_preview_chars=_DEFAULT_MAX_PREVIEW_CHARS,
+        prepare_patterns=(),
+        execute_patterns=(),
+        status_patterns=(),
+        read_patterns=(),
+        bindings=(),
+        prepare_prefix="",
+        execute_prefix="",
+        deny_execute_patterns=(),
+        token_result_paths=(),
+        preview_result_paths=(),
+        expires_at_result_paths=(),
+        confirmation_code_result_paths=(),
+        execute_token_paths=(),
+        execute_confirmation_code_paths=(),
+        attestation=None,
+        invalid_reason=reason,
+    )
+
+
+def _load_policy(server_name: str) -> Optional[MCPRailPolicy]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        return _invalid_policy(server_name, f"config load failed: {exc}")
+
+    root = cfg.get("mcp_permission_rails") if isinstance(cfg, dict) else None
+    if not isinstance(root, dict):
+        return None
+    servers = root.get("servers")
+    if not isinstance(servers, dict):
+        return None
+    raw = servers.get(server_name)
+    if not isinstance(raw, dict) or raw.get("enabled") is not True:
+        return None
+    _known_protected_servers.add(server_name)
+
+    tools = raw.get("tools") if isinstance(raw.get("tools"), dict) else {}
+    result_paths = raw.get("result_paths") if isinstance(raw.get("result_paths"), dict) else {}
+    bindings = []
+    bindings_raw = raw.get("bindings") or ()
+    if isinstance(bindings_raw, list):
+        for item in bindings_raw:
+            if not isinstance(item, dict):
+                continue
+            prepare = str(item.get("prepare") or "").strip()
+            execute = str(item.get("execute") or "").strip()
+            if prepare and execute:
+                bindings.append((prepare, execute))
+
+    prepare_patterns = _as_str_tuple(tools.get("prepare"))
+    execute_patterns = _as_str_tuple(tools.get("execute"))
+    prepare_prefix = str(raw.get("prepare_prefix") or "").strip()
+    execute_prefix = str(raw.get("execute_prefix") or "").strip()
+    if not execute_patterns:
+        return _invalid_policy(server_name, "enabled protected server has no execute patterns")
+    if prepare_patterns and not bindings and not (prepare_prefix and execute_prefix):
+        return _invalid_policy(
+            server_name,
+            "enabled protected server has prepare patterns but no deterministic bindings",
+        )
+
+    try:
+        from tools.hermes_attestation import HermesAttestationPolicy
+
+        attestation = HermesAttestationPolicy.from_mapping(raw.get("attestation"))
+    except Exception as exc:
+        return _invalid_policy(server_name, f"attestation config invalid: {exc}")
+
+    return MCPRailPolicy(
+        server_name=server_name,
+        ttl_seconds=_as_float(raw.get("ttl_seconds"), 120.0),
+        max_backend_expiry_seconds=_as_float(raw.get("max_backend_expiry_seconds"), 86400.0),
+        max_pending_global=_as_positive_int(raw.get("max_pending_global"), 256),
+        max_pending_per_session=_as_positive_int(raw.get("max_pending_per_session"), 8),
+        max_preview_chars=_as_preview_limit(raw.get("max_preview_chars")),
+        prepare_patterns=prepare_patterns,
+        execute_patterns=execute_patterns,
+        status_patterns=_as_str_tuple(tools.get("status")),
+        read_patterns=_as_str_tuple(tools.get("read")),
+        bindings=tuple(bindings),
+        prepare_prefix=prepare_prefix,
+        execute_prefix=execute_prefix,
+        deny_execute_patterns=_as_str_tuple(raw.get("deny_execute_tools")),
+        token_result_paths=_as_str_tuple(result_paths.get("proposal_token") or ("proposal_token",)),
+        preview_result_paths=_as_str_tuple(result_paths.get("preview") or ("preview",)),
+        expires_at_result_paths=_as_str_tuple(result_paths.get("expires_at") or ("expires_at",)),
+        confirmation_code_result_paths=_as_str_tuple(result_paths.get("confirmation_code") or ()),
+        execute_token_paths=_as_str_tuple(raw.get("execute_token_paths") or ("proposal_token",)),
+        execute_confirmation_code_paths=_as_str_tuple(
+            raw.get("execute_confirmation_code_paths") or ("confirmation_code",)
+        ),
+        attestation=attestation,
+    )
+
+
+def _matches(tool_name: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(tool_name, pattern) for pattern in patterns)
+
+
+def _execute_for_prepare(policy: MCPRailPolicy, prepare_tool: str) -> str:
+    matches = [
+        execute
+        for prepare, execute in policy.bindings
+        if fnmatch.fnmatchcase(prepare_tool, prepare)
+        and not any(char in execute for char in "*?[")
+    ]
+    if len(set(matches)) == 1:
+        return matches[0]
+    if policy.prepare_prefix and policy.execute_prefix and prepare_tool.startswith(policy.prepare_prefix):
+        execute_tool = policy.execute_prefix + prepare_tool[len(policy.prepare_prefix) :]
+        if _matches(execute_tool, policy.execute_patterns) and not _matches(
+            execute_tool, policy.deny_execute_patterns
+        ):
+            return execute_tool
+    return ""
+
+
+def _current_context() -> dict[str, str]:
+    try:
+        from gateway.session_context import get_trusted_session_env
+    except Exception:
+        get_trusted_session_env = None
+
+    def get(name: str) -> str:
+        if get_trusted_session_env is None:
+            return ""
+        return get_trusted_session_env(name, "") or ""
+
+    try:
+        from tools.hermes_attestation import normalize_thread_id
+    except Exception:
+        normalize_thread_id = lambda value: value  # type: ignore[assignment]
+
+    return {
+        "platform": get("HERMES_SESSION_PLATFORM"),
+        "source": get("HERMES_SESSION_SOURCE"),
+        "chat_id": get("HERMES_SESSION_CHAT_ID"),
+        "user_id": get("HERMES_SESSION_USER_ID"),
+        "thread_id": normalize_thread_id(get("HERMES_SESSION_THREAD_ID")),
+        "session_id": get("HERMES_SESSION_ID"),
+        "session_key": get("HERMES_SESSION_KEY"),
+        "message_id": get("HERMES_SESSION_MESSAGE_ID"),
+    }
+
+
+def _is_blocked_non_human_context(ctx: Mapping[str, str]) -> bool:
+    source = str(ctx.get("source") or "").strip().lower()
+    platform = str(ctx.get("platform") or "").strip().lower()
+    if os.environ.get("HERMES_CRON_SESSION") or source == "cron" or platform == "cron":
+        return True
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    try:
+        from agent.delegation_context import is_delegated_child_process_context
+
+        if is_delegated_child_process_context():
+            return True
+    except Exception:
+        if os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"):
+            return True
+    return not (
+        ctx.get("platform") == "telegram"
+        and bool(ctx.get("chat_id"))
+        and bool(ctx.get("user_id"))
+        and bool(ctx.get("session_id"))
+        and bool(ctx.get("session_key"))
+        and bool(ctx.get("message_id"))
+    )
+
+
+def _context_matches(expected: Mapping[str, str], observed: Mapping[str, str]) -> bool:
+    for key, expected_value in expected.items():
+        if expected_value and str(observed.get(key) or "") != str(expected_value):
+            return False
+    return True
+
+
+def _values_at_path(data: Any, path: str) -> list[Any]:
+    node = data
+    for part in path.split("."):
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+            continue
+        return []
+    if node in (None, ""):
+        return []
+    return [node]
+
+
+def _single_string_value(data: Any, paths: tuple[str, ...], label: str) -> str:
+    values: list[str] = []
+    for path in paths:
+        for value in _values_at_path(data, path):
+            if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+                text = str(value).strip()
+                if text:
+                    values.append(text)
+    unique = sorted(set(values))
+    if len(unique) != 1:
+        raise ValueError(f"ambiguous or missing {label}")
+    return unique[0]
+
+
+def _optional_string_value(data: Any, paths: tuple[str, ...], label: str) -> str:
+    if not paths:
+        return ""
+    try:
+        return _single_string_value(data, paths, label)
+    except ValueError:
+        return ""
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+
+
+def _canonical_digest(data: Any) -> str:
+    return _hash(_canonical_json(data))
+
+
+def _single_json_value(data: Any, paths: tuple[str, ...], label: str) -> Any:
+    values: list[Any] = []
+    for path in paths:
+        values.extend(_values_at_path(data, path))
+    unique = sorted({_canonical_json(value) for value in values})
+    if len(unique) != 1:
+        raise ValueError(f"ambiguous or missing {label}")
+    for value in values:
+        if _canonical_json(value) == unique[0]:
+            return value
+    raise ValueError(f"ambiguous or missing {label}")
+
+
+def _json_candidates_from_result(result: Any) -> list[dict[str, Any]]:
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return [structured]
+    if structured is not None:
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if not isinstance(text, str) or not text.strip():
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            candidates.append(parsed)
+    return candidates
+
+
+def _displayable_preview(preview: Any, *, max_chars: int) -> str:
+    escaped = _canonical_json(preview).encode("unicode_escape", "backslashreplace").decode("ascii")
+    if len(escaped) > max_chars:
+        raise ValueError(
+            "preview exceeds max_preview_chars; BLOCKED because the full "
+            "canonical preview cannot be displayed. narrow the request or use "
+            "DPS Work for this operation."
+        )
+    return escaped
+
+
+def _parse_backend_expiry(value: Any, *, now_wall: float, max_seconds: float) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        parsed = float(value)
+    elif isinstance(value, str) and value.strip():
+        raw = value.strip()
+        try:
+            parsed = float(raw)
+        except ValueError:
+            iso = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+            try:
+                dt = datetime.fromisoformat(iso)
+            except ValueError as exc:
+                raise ValueError("invalid expires_at") from exc
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            parsed = dt.timestamp()
+    else:
+        raise ValueError("invalid expires_at")
+    if parsed <= now_wall:
+        raise ValueError("past expires_at")
+    if parsed - now_wall > max_seconds:
+        raise ValueError("overlong expires_at")
+    return parsed
+
+
+def _extract_prepare_proposal(policy: MCPRailPolicy, result: Any) -> _ExtractedProposal:
+    proposals: list[_ExtractedProposal] = []
+    for candidate in _json_candidates_from_result(result):
+        if candidate.get("ok") is not True:
+            raise ValueError("prepare result ok is not true")
+        token = _single_string_value(candidate, policy.token_result_paths, "proposal_token")
+        preview = _single_json_value(candidate, policy.preview_result_paths, "preview")
+        expires_raw = _single_json_value(candidate, policy.expires_at_result_paths, "expires_at")
+        confirmation_code = _optional_string_value(
+            candidate,
+            policy.confirmation_code_result_paths,
+            "confirmation_code",
+        )
+        proposal_meta = {"proposal_digest": "", "proposal_payload_digest": ""}
+        if getattr(getattr(policy, "attestation", None), "enabled", False):
+            try:
+                from tools.hermes_attestation import decode_proposal_token_metadata
+
+                proposal_meta = decode_proposal_token_metadata(token)
+            except Exception as exc:
+                raise ValueError(f"proposal_token metadata invalid: {exc}") from exc
+        proposals.append(
+            _ExtractedProposal(
+                proposal_token_digest=_hash(token),
+                confirmation_code_digest=_hash(confirmation_code) if confirmation_code else "",
+                preview_digest=_canonical_digest(preview),
+                canonical_result_digest=_canonical_digest(candidate),
+                proposal_digest=proposal_meta["proposal_digest"],
+                proposal_payload_digest=proposal_meta["proposal_payload_digest"],
+                preview=_displayable_preview(preview, max_chars=policy.max_preview_chars),
+                backend_expires_at_wall=_parse_backend_expiry(
+                    expires_raw,
+                    now_wall=time.time(),
+                    max_seconds=policy.max_backend_expiry_seconds,
+                ),
+            )
+        )
+
+    unique = {
+        (
+            item.proposal_token_digest,
+            item.confirmation_code_digest,
+            item.preview_digest,
+            item.canonical_result_digest,
+            item.proposal_digest,
+            item.proposal_payload_digest,
+            item.preview,
+            item.backend_expires_at_wall,
+        )
+        for item in proposals
+    }
+    if len(unique) != 1:
+        raise ValueError("ambiguous or missing proposal_token/preview/expires_at")
+    return proposals[0]
+
+
+def _extract_execute_token_digest(policy: MCPRailPolicy, args: Mapping[str, Any]) -> str:
+    token = _single_string_value(args, policy.execute_token_paths, "proposal_token")
+    return _hash(token)
+
+
+def _protected_call_args(args: Mapping[str, Any]) -> Mapping[str, Any]:
+    try:
+        from tools.hermes_attestation import strip_internal_hermes_fields
+
+        stripped = strip_internal_hermes_fields(args or {})
+        return stripped if isinstance(stripped, Mapping) else (args or {})
+    except Exception:
+        return args or {}
+
+
+def _prepare_attestation_meta(
+    policy: MCPRailPolicy,
+    tool_name: str,
+    args: Mapping[str, Any],
+    ctx: Mapping[str, str],
+) -> Mapping[str, Any] | str:
+    attestation = getattr(policy, "attestation", None)
+    if not getattr(attestation, "enabled", False):
+        return {}
+    try:
+        from tools.hermes_attestation import attestation_meta, sign_attestation
+
+        token = sign_attestation(
+            policy=attestation,
+            phase="prepare",
+            tool_name=tool_name,
+            args=args,
+            ctx=ctx,
+        )
+        return attestation_meta(token)
+    except Exception as exc:
+        _audit("denied", server_name=policy.server_name, tool_name=tool_name, reason="attestation_prepare")
+        return f"BLOCKED: Protected MCP prepare attestation failed closed ({exc})."
+
+
+def _execute_attestation_meta(
+    policy: MCPRailPolicy,
+    tool_name: str,
+    args: Mapping[str, Any],
+    ctx: Mapping[str, str],
+    pending: PendingProposal,
+    approval: Mapping[str, Any],
+) -> Mapping[str, Any] | str:
+    attestation = getattr(policy, "attestation", None)
+    if not getattr(attestation, "enabled", False):
+        return {}
+    proposal = {
+        "proposal_token_digest": pending.proposal_token_digest,
+        "proposal_digest": pending.proposal_digest,
+        "proposal_payload_digest": pending.proposal_payload_digest,
+    }
+    approval_meta = {
+        "approval_request_id": str(approval.get("approval_request_id") or ""),
+        "approval_event_id": str(approval.get("approval_event_id") or ""),
+        "approved_at": str(approval.get("approved_at") or ""),
+    }
+    try:
+        from tools.hermes_attestation import attestation_meta, sign_attestation
+
+        token = sign_attestation(
+            policy=attestation,
+            phase="execute",
+            tool_name=tool_name,
+            args=args,
+            ctx=ctx,
+            approval=approval_meta,
+            proposal=proposal,
+        )
+        return attestation_meta(token)
+    except Exception as exc:
+        _audit("denied", server_name=policy.server_name, tool_name=tool_name, reason="attestation_execute")
+        return f"BLOCKED: Protected MCP execute attestation failed closed ({exc})."
+
+
+def _execute_confirmation_digest(
+    policy: MCPRailPolicy,
+    args: Mapping[str, Any],
+    expected_digest: str,
+) -> str:
+    if not expected_digest:
+        return ""
+    code = _single_string_value(args, policy.execute_confirmation_code_paths, "confirmation_code")
+    return _hash(code)
+
+
+def _is_read_only_annotation(tool_annotations: Any) -> bool:
+    if isinstance(tool_annotations, Mapping):
+        return tool_annotations.get("readOnlyHint") is True
+    return getattr(tool_annotations, "readOnlyHint", None) is True
+
+
+def before_tool_call(
+    server_name: str,
+    tool_name: str,
+    args: Mapping[str, Any],
+    tool_annotations: Any = None,
+) -> MCPRailDecision:
+    policy = _load_policy(server_name)
+    if policy is None:
+        return MCPRailDecision(policy=None)
+    if policy.invalid_reason:
+        _audit("denied", server_name=server_name, tool_name=tool_name, reason="invalid_config")
+        return MCPRailDecision(
+            policy=policy,
+            kind="config",
+            denied_message=(
+                "BLOCKED: MCP permission rail failed closed because protected "
+                f"server configuration is invalid ({policy.invalid_reason})."
+            ),
+        )
+
+    _purge_expired()
+
+    # Safe precedence: deny > execute > prepare > status > read.
+    if _matches(tool_name, policy.deny_execute_patterns):
+        _audit("denied", server_name=server_name, tool_name=tool_name, reason="config_deny")
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message="BLOCKED: Protected MCP execute tool is disabled by configuration.",
+        )
+    if _matches(tool_name, policy.execute_patterns):
+        kind = "execute"
+    elif _matches(tool_name, policy.prepare_patterns):
+        kind = "prepare"
+    elif _matches(tool_name, policy.status_patterns):
+        return MCPRailDecision(policy=policy, kind="status")
+    elif _matches(tool_name, policy.read_patterns):
+        return MCPRailDecision(policy=policy, kind="read")
+    elif not _is_read_only_annotation(tool_annotations):
+        _audit(
+            "denied",
+            server_name=server_name,
+            tool_name=tool_name,
+            reason="mutation_annotation_not_covered",
+        )
+        return MCPRailDecision(
+            policy=policy,
+            kind="unknown_mutation",
+            denied_message=(
+                "BLOCKED: MCP tool on protected server is mutation-capable "
+                "but does not match a protected execute or deny pattern."
+            ),
+        )
+    else:
+        return MCPRailDecision(policy=policy)
+
+    if kind == "prepare":
+        execute_tool = _execute_for_prepare(policy, tool_name)
+        if not execute_tool:
+            return MCPRailDecision(
+                policy=policy,
+                kind="prepare",
+                denied_message=(
+                    "BLOCKED: MCP prepare tool is protected but its execute "
+                    "relation is ambiguous or missing in config."
+                ),
+            )
+        ctx = _current_context()
+        call_args = _protected_call_args(args or {})
+        if getattr(getattr(policy, "attestation", None), "enabled", False) and _is_blocked_non_human_context(ctx):
+            _audit("context_blocked", server_name=server_name, tool_name=tool_name, reason="non_human_context")
+            return MCPRailDecision(
+                policy=policy,
+                kind="prepare",
+                denied_message=(
+                    "BLOCKED: Protected MCP prepare attestation requires a live "
+                    "Telegram human context with an originating message_id."
+                ),
+                call_args=call_args,
+            )
+        meta = _prepare_attestation_meta(policy, tool_name, call_args, ctx)
+        if isinstance(meta, str):
+            return MCPRailDecision(
+                policy=policy,
+                kind="prepare",
+                denied_message=meta,
+                call_args=call_args,
+            )
+        return MCPRailDecision(
+            policy=policy,
+            kind="prepare",
+            prepare_tool=tool_name,
+            prepare_execute_tool=execute_tool,
+            call_args=call_args,
+            mcp_meta=meta,
+        )
+
+    ctx = _current_context()
+    if _is_blocked_non_human_context(ctx):
+        _audit("context_blocked", server_name=server_name, tool_name=tool_name, reason="non_human_context")
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message=(
+                "BLOCKED: Protected MCP execute requires a live Telegram human "
+                "context with an authenticated user_id and durable session_id."
+            ),
+        )
+
+    try:
+        call_args = _protected_call_args(args or {})
+        token_digest = _extract_execute_token_digest(policy, call_args)
+    except ValueError as exc:
+        _audit("denied", server_name=server_name, tool_name=tool_name, reason="missing_token")
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message=f"BLOCKED: Protected MCP execute has {exc}.",
+        )
+
+    pending = _consume_pending(policy, tool_name, token_digest, ctx)
+    if isinstance(pending, str):
+        return MCPRailDecision(policy=policy, kind="execute", denied_message=pending)
+    try:
+        confirmation_digest = _execute_confirmation_digest(
+            policy,
+            call_args,
+            pending.confirmation_code_digest,
+        )
+    except ValueError as exc:
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message=f"BLOCKED: Protected MCP execute has {exc}.",
+        )
+    if pending.confirmation_code_digest and confirmation_digest != pending.confirmation_code_digest:
+        _audit(
+            "denied",
+            server_name=server_name,
+            tool_name=tool_name,
+            proposal_digest=pending.proposal_token_digest,
+            reason="confirmation_mismatch",
+        )
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message=(
+                "BLOCKED: Protected MCP execute confirmation_code does not "
+                "match the prepare proposal."
+            ),
+        )
+
+    _audit(
+        "requested",
+        server_name=server_name,
+        tool_name=tool_name,
+        proposal_digest=pending.proposal_token_digest,
+        preview_digest=pending.preview_digest,
+        result_digest=pending.canonical_result_digest,
+    )
+    approved, message, approval = _request_approval(pending)
+    if not approved:
+        _audit(
+            "denied",
+            server_name=server_name,
+            tool_name=tool_name,
+            proposal_digest=pending.proposal_token_digest,
+            preview_digest=pending.preview_digest,
+            result_digest=pending.canonical_result_digest,
+            reason="human_denied_or_unavailable",
+        )
+        return MCPRailDecision(policy=policy, kind="execute", denied_message=message)
+
+    _audit(
+        "approved",
+        server_name=server_name,
+        tool_name=tool_name,
+        proposal_digest=pending.proposal_token_digest,
+        preview_digest=pending.preview_digest,
+        result_digest=pending.canonical_result_digest,
+    )
+    meta = _execute_attestation_meta(policy, tool_name, call_args, ctx, pending, approval)
+    if isinstance(meta, str):
+        return MCPRailDecision(
+            policy=policy,
+            kind="execute",
+            denied_message=meta,
+            call_args=call_args,
+        )
+    return MCPRailDecision(
+        policy=policy,
+        kind="execute",
+        approved=True,
+        pending=pending,
+        call_args=call_args,
+        mcp_meta=meta,
+    )
+
+
+def _consume_pending(
+    policy: MCPRailPolicy,
+    execute_tool: str,
+    token_digest: str,
+    ctx: Mapping[str, str],
+) -> PendingProposal | str:
+    with _pending_lock:
+        _purge_expired_locked(time.monotonic())
+        matches = [
+            proposal
+            for proposal in _pending
+            if proposal.server_name == policy.server_name
+            and proposal.execute_tool == execute_tool
+            and proposal.proposal_token_digest == token_digest
+        ]
+        if not matches:
+            _audit(
+                "denied",
+                server_name=policy.server_name,
+                tool_name=execute_tool,
+                proposal_digest=token_digest,
+                reason="no_matching_prepare",
+            )
+            return (
+                "BLOCKED: Protected MCP execute has no matching unexpired "
+                "prepare proposal for this session/tool/token."
+            )
+
+        context_matches = [proposal for proposal in matches if _context_matches(proposal.context, ctx)]
+        if not context_matches:
+            _audit(
+                "context_blocked",
+                server_name=policy.server_name,
+                tool_name=execute_tool,
+                proposal_digest=token_digest,
+                reason="context_mismatch",
+            )
+            return "BLOCKED: Protected MCP execute context does not match the pending prepare proposal."
+        if len(context_matches) != 1:
+            _audit(
+                "denied",
+                server_name=policy.server_name,
+                tool_name=execute_tool,
+                proposal_digest=token_digest,
+                reason="ambiguous_pending",
+            )
+            return "BLOCKED: Protected MCP execute matched ambiguous proposals."
+
+        proposal = context_matches[0]
+        _pending.remove(proposal)
+        return proposal
+
+
+def _request_approval(pending: PendingProposal) -> tuple[bool, str, Mapping[str, Any]]:
+    try:
+        from tools.approval import request_sensitive_human_approval
+    except Exception:
+        return False, "BLOCKED: Sensitive approval system is unavailable.", {}
+
+    remaining = max(0.01, pending.expires_at - time.monotonic())
+    decision = request_sensitive_human_approval(
+        session_key=pending.context.get("session_key", ""),
+        command=(
+            f"Protected MCP execute: {pending.server_name}/{pending.execute_tool}\n"
+            f"Proposal digest: {pending.proposal_token_digest[:12]}\n"
+            f"Preview digest: {pending.preview_digest[:12]}\n"
+            f"Result digest: {pending.canonical_result_digest[:12]}\n"
+            "Escaped preview:\n"
+            "-----BEGIN MCP PREVIEW-----\n"
+            f"{pending.preview}\n"
+            "-----END MCP PREVIEW-----"
+        ),
+        hook_command=(
+            f"protected_mcp_execute server={pending.server_name} "
+            f"tool={pending.execute_tool} "
+            f"proposal_digest={pending.proposal_token_digest[:12]} "
+            f"preview_digest={pending.preview_digest[:12]} "
+            f"result_digest={pending.canonical_result_digest[:12]}"
+        ),
+        description="Protected MCP execute requires Telegram approval.",
+        expected_context=dict(pending.context),
+        ttl_seconds=remaining,
+        pattern_key=f"mcp_permission_rail:{pending.server_name}:{pending.execute_tool}",
+    )
+    if decision.get("notify_failed"):
+        return False, "BLOCKED: Failed to send protected MCP approval request.", decision
+    if decision.get("resolved") is True and decision.get("choice") == "once":
+        return True, "", decision
+    if decision.get("resolved") is True and decision.get("choice") == "deny":
+        return False, "BLOCKED: Protected MCP execute was denied by the user.", decision
+    return False, "BLOCKED: Protected MCP execute was not approved by the Telegram user.", decision
+
+
+def after_tool_result(decision: MCPRailDecision, result: Any) -> str:
+    if decision.policy is None or decision.kind != "prepare":
+        return ""
+    if decision.denied_message:
+        return decision.denied_message
+    try:
+        proposal = _extract_prepare_proposal(decision.policy, result)
+    except ValueError as exc:
+        _audit(
+            "denied",
+            server_name=decision.policy.server_name,
+            tool_name=decision.prepare_execute_tool or "",
+            reason="prepare_parse_failure",
+        )
+        return f"BLOCKED: Protected MCP prepare result has {exc}."
+
+    ctx = _current_context()
+    if _is_blocked_non_human_context(ctx):
+        return ""
+    now_wall = time.time()
+    expires_wall = min(proposal.backend_expires_at_wall, now_wall + decision.policy.ttl_seconds)
+    if expires_wall <= now_wall:
+        return "BLOCKED: Protected MCP prepare result has expired expires_at."
+    pending = PendingProposal(
+        server_name=decision.policy.server_name,
+        prepare_tool=decision.prepare_tool,
+        execute_tool=decision.prepare_execute_tool,
+        proposal_token_digest=proposal.proposal_token_digest,
+        confirmation_code_digest=proposal.confirmation_code_digest,
+        preview_digest=proposal.preview_digest,
+        canonical_result_digest=proposal.canonical_result_digest,
+        proposal_digest=proposal.proposal_digest,
+        proposal_payload_digest=proposal.proposal_payload_digest,
+        preview=proposal.preview,
+        expires_at=time.monotonic() + (expires_wall - now_wall),
+        context=ctx,
+    )
+    with _pending_lock:
+        _purge_expired_locked(time.monotonic())
+        _pending[:] = [
+            existing
+            for existing in _pending
+            if not (
+                existing.server_name == pending.server_name
+                and existing.execute_tool == pending.execute_tool
+                and existing.proposal_token_digest == pending.proposal_token_digest
+                and _context_matches(existing.context, pending.context)
+            )
+        ]
+        _pending.append(pending)
+        _enforce_caps_locked(decision.policy)
+    return ""
+
+
+def _purge_expired() -> None:
+    with _pending_lock:
+        _purge_expired_locked(time.monotonic())
+
+
+def _purge_expired_locked(now: float) -> None:
+    kept: list[PendingProposal] = []
+    expired: list[PendingProposal] = []
+    for proposal in _pending:
+        if proposal.expires_at <= now:
+            expired.append(proposal)
+        else:
+            kept.append(proposal)
+    if expired:
+        _pending[:] = kept
+    for proposal in expired:
+        _audit(
+            "expired",
+            server_name=proposal.server_name,
+            tool_name=proposal.execute_tool,
+            proposal_digest=proposal.proposal_token_digest,
+            preview_digest=proposal.preview_digest,
+            result_digest=proposal.canonical_result_digest,
+        )
+
+
+def _enforce_caps_locked(policy: MCPRailPolicy) -> None:
+    if policy.max_pending_per_session > 0:
+        by_session: dict[str, list[PendingProposal]] = {}
+        for proposal in _pending:
+            by_session.setdefault(proposal.context.get("session_key", ""), []).append(proposal)
+        to_remove: set[int] = set()
+        for proposals in by_session.values():
+            overflow = len(proposals) - policy.max_pending_per_session
+            if overflow > 0:
+                for proposal in proposals[:overflow]:
+                    to_remove.add(id(proposal))
+        if to_remove:
+            _pending[:] = [proposal for proposal in _pending if id(proposal) not in to_remove]
+    if policy.max_pending_global > 0 and len(_pending) > policy.max_pending_global:
+        del _pending[: len(_pending) - policy.max_pending_global]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4776,7 +4776,12 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+def _make_tool_handler(
+    server_name: str,
+    tool_name: str,
+    tool_timeout: float,
+    tool_annotations: Any = None,
+):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
@@ -4843,8 +4848,40 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        rail_call_state = {"protected_execute": False, "rail_blocked": False}
+
         async def _call():
             _mark_server_call_started(server)
+            try:
+                from tools.mcp_permission_rail import before_tool_call
+
+                rail_decision = before_tool_call(
+                    server_name,
+                    tool_name,
+                    args or {},
+                    tool_annotations=tool_annotations,
+                )
+            except Exception as rail_exc:
+                logger.error(
+                    "MCP permission rail failed closed for %s/%s: %s",
+                    server_name,
+                    tool_name,
+                    rail_exc,
+                )
+                return tool_error(
+                    "BLOCKED: MCP permission rail failed closed before tool call."
+                )
+            if rail_decision.denied_message:
+                rail_call_state["rail_blocked"] = True
+                return tool_error(rail_decision.denied_message)
+            rail_call_state["protected_execute"] = bool(
+                getattr(rail_decision, "protected_execute", False)
+            )
+            call_args = getattr(rail_decision, "call_args", None)
+            if call_args is None:
+                call_args = args
+            mcp_meta = getattr(rail_decision, "mcp_meta", None) or {}
+
             async with server._rpc_lock:
                 # Snapshot the agent's context so an elicitation callback
                 # triggered during this call (fired on the MCP recv loop
@@ -4852,7 +4889,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    if mcp_meta:
+                        result = await server.session.call_tool(
+                            tool_name,
+                            arguments=call_args,
+                            meta=mcp_meta,
+                        )
+                    else:
+                        result = await server.session.call_tool(tool_name, arguments=call_args)
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -4877,6 +4921,24 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return tool_error(_sanitize_error(
                     error_text or "MCP tool returned an error"
                 ))
+
+            try:
+                from tools.mcp_permission_rail import after_tool_result
+
+                rail_result_error = after_tool_result(rail_decision, result)
+            except Exception as rail_exc:
+                logger.error(
+                    "MCP permission rail failed closed after %s/%s: %s",
+                    server_name,
+                    tool_name,
+                    rail_exc,
+                )
+                return tool_error(
+                    "BLOCKED: MCP permission rail failed closed after tool call."
+                )
+            if rail_result_error:
+                rail_call_state["rail_blocked"] = True
+                return tool_error(rail_result_error)
 
             # Collect text from content blocks. MCP tool results can also
             # include ImageContent blocks (screenshot / Blockbench / Playwright
@@ -4950,7 +5012,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    if not rail_call_state.get("rail_blocked"):
+                        _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):
@@ -4959,6 +5022,16 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            if rail_call_state.get("protected_execute"):
+                _bump_server_error(server_name)
+                logger.error(
+                    "Protected MCP execute %s/%s call failed without retry: %s",
+                    server_name, tool_name, exc,
+                )
+                return tool_error(_sanitize_error(
+                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+                ))
+
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.
@@ -5759,7 +5832,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name,
+                    mcp_tool.name,
+                    server.tool_timeout,
+                    getattr(mcp_tool, "annotations", None) or {},
                 ),
                 "check_fn": check_fn,
             }

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -889,7 +889,30 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     try:
-        from tools.approval import resolve_gateway_approval
+        from tools.approval import (
+            resolve_gateway_approval,
+            resolve_sensitive_gateway_approval,
+        )
+
+        request_id = params.get("request_id")
+        if request_id:
+            # TUI and Desktop talk to the locally spawned gateway over the
+            # trusted local JSON-RPC channel. There is no authenticated human
+            # account on that boundary, so sensitive approvals bind to the
+            # originating local runtime session instead of inventing user_id.
+            return _ok(
+                rid,
+                resolve_sensitive_gateway_approval(
+                    session["session_key"],
+                    params.get("choice", "deny"),
+                    request_id=request_id,
+                    observed_context={
+                        "platform": "tui",
+                        "session_id": params.get("session_id"),
+                        "session_key": session["session_key"],
+                    },
+                ),
+            )
 
         return _ok(
             rid,

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1187,6 +1187,21 @@ describe('createGatewayEventHandler', () => {
     expect(getOverlayState().approval).toMatchObject({ choices: ['once', 'deny'], smartDenied: true })
   })
 
+  it('preserves approval request_id on the overlay', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: {
+        command: 'rm -rf /tmp/x',
+        description: 'sensitive',
+        request_id: 'req-sensitive'
+      },
+      type: 'approval.request'
+    } as any)
+
+    expect(getOverlayState().approval).toMatchObject({ requestId: 'req-sensitive' })
+  })
+
   it('still surfaces terminal turn failures as errors', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1177,6 +1177,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             choices: ev.payload.choices,
             command: String(ev.payload.command ?? ''),
             description,
+            requestId: typeof ev.payload.request_id === 'string' ? ev.payload.request_id : undefined,
             smartDenied: ev.payload.smart_denied === true
           }
         })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -178,8 +178,12 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.approval) {
+      const params: Record<string, unknown> = { choice: 'deny', session_id: getUiState().sid }
+      if (overlay.approval.requestId) {
+        params.request_id = overlay.approval.requestId
+      }
       return gateway
-        .rpc<ApprovalRespondResponse>('approval.respond', { choice: 'deny', session_id: getUiState().sid })
+        .rpc<ApprovalRespondResponse>('approval.respond', params)
         .then(r => r && (patchOverlayState({ approval: null }), patchTurnState({ outcome: 'denied' })))
     }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -924,13 +924,18 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const answerApproval = useCallback(
-    (choice: string) =>
-      respondWith('approval.respond', { choice, session_id: ui.sid }, () => {
+    (choice: string) => {
+      const params: Record<string, unknown> = { choice, session_id: ui.sid }
+      if (overlay.approval?.requestId) {
+        params.request_id = overlay.approval.requestId
+      }
+      return respondWith('approval.respond', params, () => {
         patchOverlayState({ approval: null })
         patchTurnState({ outcome: choice === 'deny' ? 'denied' : `approved (${choice})` })
         patchUiState({ status: 'running…' })
-      }),
-    [respondWith, ui.sid]
+      })
+    },
+    [overlay.approval?.requestId, respondWith, ui.sid]
   )
 
   const answerSudo = useCallback(

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -703,6 +703,7 @@ export type GatewayEvent =
         choices?: string[]
         command: string
         description: string
+        request_id?: string
         smart_denied?: boolean
       }
       session_id?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -95,6 +95,7 @@ export interface ApprovalReq {
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
 }
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -125,6 +125,74 @@ Result:
 - `create_issue` is still allowed
 - `delete_issue` is ignored because `include` takes precedence
 
+## Prepare/Execute permission rail
+
+`mcp_permission_rails` is empty by default. When configured for an exact MCP
+server name, it protects server-native execute tools by requiring:
+
+- a matching protected prepare tool result in the same session context
+- an unexpired `proposal_token` digest and configured prepare/execute binding
+- one-shot approval from the same authenticated Telegram user/chat/thread/session
+
+Reads, status tools, and prepare tools remain callable. Desktop/TUI/local,
+cron, delegated subagents, detached/background, and other non-human contexts
+fail closed for protected execute.
+
+```yaml
+mcp_permission_rails:
+  servers:
+    dps-work:
+      enabled: false
+      ttl_seconds: 120
+      max_preview_chars: 3000
+      tools:
+        read: ["dps_get_*", "dps_list_*"]
+        status: ["dps_status_*"]
+        prepare: ["dps_prepare_*"]
+        execute: ["dps_execute_*"]
+      prepare_prefix: "dps_prepare_"
+      execute_prefix: "dps_execute_"
+      # Optional exact bindings may coexist with the prefix transform.
+      bindings: []
+      result_paths:
+        proposal_token: ["data.proposal_token"]
+        preview: ["data.action.preview"]
+        expires_at: ["data.expires_at"]
+        confirmation_code: ["data.confirmation_code"]
+      execute_token_paths: ["proposal_token"]
+      execute_confirmation_code_paths: ["confirmation_code"]
+      deny_execute_tools:
+        # Keep denylisted until the backend import bug is fixed.
+        - "dps_execute_project_document_import"
+```
+
+The example is deliberately disabled. Tool categories use server-native MCP
+tool patterns, not Hermes `mcp__server__tool` names. The rail classifies with
+deny > execute > prepare > status > read precedence. `prepare_prefix` and
+`execute_prefix` define a deterministic transform, so `dps_prepare_foo` binds
+to `dps_execute_foo`; exact `bindings` can be added for exceptions.
+
+For protected servers, Hermes also passes MCP tool annotations into the rail.
+Any tool whose `readOnlyHint` is not exactly `true` is treated as
+mutation-capable and must match a protected `execute` pattern or a
+`deny_execute_tools` pattern before the MCP call is made.
+
+Prepare results should prefer structured MCP output. The expected DPS shape is
+`structuredContent: {ok: true, data: {proposal_token, confirmation_code?,
+expires_at, action: {preview}}}`. `expires_at` must be valid and future; the
+pending approval expires at the earlier of the backend timestamp and the local
+`ttl_seconds`.
+
+The approval prompt must display the full canonical escaped preview. Hermes
+does not approve truncated previews for protected prepares; if the canonical
+preview exceeds `max_preview_chars` (default and hard cap: `3000`), prepare
+fails closed and asks the operator to narrow the request or use DPS Work. The
+stored preview digest is still computed from the full preview.
+
+If a session ends, hosts may call
+`tools.mcp_permission_rail.clear_session_pending_proposals(session_key)` to
+drop any remaining in-memory proposals for that session.
+
 ## Utility-tool policy
 
 Hermes may register these utility wrappers per MCP server:


### PR DESCRIPTION
## Summary

Adds a generic sensitive-approval primitive and a default-off DPS Work MCP permission rail so Hermes can support governed `prepare → later owner approval → execute` flows without trusting prompts or model-provided authorization fields.

- Binds approvals to trusted platform/user/chat/thread/session/message context and server-generated request/event IDs.
- Adds one-shot approval handling across Telegram, gateway, TUI, and desktop; broad/permanent approvals cannot satisfy protected DPS execute tools.
- Classifies DPS MCP tools fail-closed: valid read-only allowlist, protected prepares, protected executes, and explicit deny (`project.document.import`).
- Generates HMAC attestations from env-only key references and injects them through MCP `_meta`, never model-visible args.
- Scrubs configured attestation key variables from child process environments.
- Refuses approval when the full canonical preview cannot be displayed; no approval is created for truncated previews.
- Blocks cron, subagents, detached tools, and non-human session surfaces from producing owner approvals.

## Dependency

Companion DPS server verification PR: https://github.com/paintdepotmiami-cell/dps-system/pull/205

This PR remains safe/default-off without the DPS PR, but governed execute must not be enabled until the server-side verifier is deployed and configured.

## Security contract

Protected DPS execute requires all of the following:

1. A successful protected prepare with canonical proposal metadata.
2. A later, explicit owner approval; the originating request message cannot self-approve.
3. Exact match on platform user, chat, thread sentinel/topic, session, originating message, tool, proposal ID, action ID, payload digest, and proposal-token digest.
4. A server-generated one-use approval event.
5. A signed attestation consumed by the DPS backend verifier.

Missing MCP annotations, missing `readOnlyHint`, invalid context provenance, replay, mismatch, timeout, denial, unsafe integer canonicalization, overlong preview, or absent attestation policy fails closed.

## Configuration / activation

Everything is default-off in the example/default config. This PR does **not**:

- register an MCP server;
- perform OAuth login or grant scopes;
- create or install HMAC keys;
- modify active Hermes configuration;
- enable DPS writes;
- deploy or mutate provider data.

## Verification

Post-rebase against current `origin/main`:

- Python approval/rail/attestation/gateway selection: **145/145**.
- TUI: **97/97** + TypeScript typecheck.
- Desktop: **52/52** + TypeScript typecheck.
- Python `compileall`: passed.
- `git diff --check`: clean.
- Cross-language Python A2 → TypeScript DPS B prepare/execute round-trips passed with test-only keys; context mismatch failed closed.
- Claude full pre-rebase security review: APPROVE.
- Claude current-head post-rebase security review with a 30-turn limit: **APPROVE**. It confirmed that the conflict resolution preserves current-main `session_is_messaging_surface()` behavior and adds `get_trusted_session_env()` without an `os.environ` fallback.
- Non-blocking review observations: P2 availability blast radius when global config loading fails; P3 fallback scrubbing if config cannot reveal a custom key env name; P3 repeated config-load overhead/dead internal state.

This PR remains **draft / IN REVIEW** because it is a high-risk authorization change, depends on DPS PR #205, and has not been authorized for merge or production activation.

## Rollback

1. Leave `mcp.permission_rails.dps.enabled: false` (default) or set it false.
2. Remove/disable the MCP registration if later configured.
3. Revert this commit to remove the approval primitive, permission rail, and attestation generation.

No database rollback or provider compensation is required.

## Residual / follow-up

- Same-UID process memory access is not an isolation boundary; deployments that include that threat should isolate the signer.
- Production rollout requires a dedicated OAuth client, env-only rotating HMAC key, paired DPS deployment, and a separate owner-approved activation gate.
- `project.document.import` remains denied until its DPS executor classification defect is repaired and tested.
