### PR TITLE
fix(tui): preserve npm engine diagnostics

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2033,7 +2033,6 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             # npm `omit=dev` config would silently skip them and the TUI
             # build would fail. See _run_npm_install_deterministic.
             "--include=dev",
-            "--silent",
             "--no-fund",
             "--no-audit",
             "--progress=false",

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -176,3 +176,51 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_make_tui_argv_preserves_engine_failure_for_recovery(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """The startup install must retain npm's EBADENGINE diagnostic.
+
+    npm's ``--silent`` mode exits non-zero with empty stdout/stderr for this
+    failure, which prevents the recovery path from either upgrading a managed
+    npm or printing the manual command for an unmanaged one.
+    """
+    from hermes_cli import npm_engine
+
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    engine_error = (
+        "npm error code EBADENGINE\n"
+        'npm error notsup Required: {"node":">=20.0.0","npm":">=12.0.0"}\n'
+        'npm error notsup Actual: {"node":"v24.0.0","npm":"11.13.0"}\n'
+    )
+
+    def fake_run(cmd, **kwargs):
+        stderr = "" if "--silent" in cmd else engine_error
+        return types.SimpleNamespace(returncode=1, stdout="", stderr=stderr)
+
+    seen = {}
+
+    def fake_repair(npm, output):
+        seen["npm"] = npm
+        seen["output"] = output
+        return False
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(npm_engine, "maybe_repair_npm_engine", fake_repair)
+
+    with pytest.raises(SystemExit):
+        main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert seen["npm"] == "/bin/npm"
+    assert "EBADENGINE" in seen["output"]


### PR DESCRIPTION
## What does this PR do?

Preserves npm engine diagnostics during automatic TUI dependency installation.

The TUI startup installer currently passes `--silent` to npm. When `engine-strict=true` rejects an incompatible npm version, npm can exit non-zero with empty captured output under `--silent`. That prevents `maybe_repair_npm_engine` from parsing the required npm range, so Hermes neither repairs a managed npm nor prints the manual upgrade command for an unmanaged npm; startup ends with only `npm install failed.`

This removes `--silent` from the captured install command. Successful installs remain quiet because the subprocess output is captured, while failed installs retain the diagnostic needed by the existing recovery path.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Remove `--silent` from the TUI startup npm install command in `hermes_cli/main.py`.
- Add a regression test proving EBADENGINE output reaches `maybe_repair_npm_engine`.

## How to Test

1. Use an npm version excluded by the repository's `engines.npm` range with `engine-strict=true`.
2. Trigger a TUI dependency install with `hermes --tui`.
3. Confirm Hermes reports the incompatible npm version and either repairs a managed npm or prints the manual upgrade command instead of only `npm install failed.`

Focused automated verification:

```text
python -m pytest tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_npm_engine.py -q -o 'addopts='
21 passed
```

Manual verification on Ubuntu 24.04 / Linux:

- Reproduced the original opaque failure with npm 11.13.0.
- Confirmed the recovery path reported the required range and manual upgrade command after this change.
- Upgraded to npm 12.0.2 and confirmed `hermes --tui` rendered successfully.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (focused tests pass; full suite left to CI)
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: removal of npm's output-suppression flag is platform-neutral
- [x] Tool descriptions/schemas update: N/A
