### PR TITLE
fix(whatsapp): preserve stanza-only quote context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15331,6 +15331,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             else:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+        elif (
+            getattr(event, "reply_to_message_id", None)
+            and source is not None
+            and getattr(source, "platform", None) == Platform.WHATSAPP
+        ):
+            # Baileys can retain the native stanza id while omitting the quoted
+            # payload. Keep the relation explicit rather than presenting a
+            # contextless approval such as "send it" to the agent.
+            reply_id = " ".join(str(event.reply_to_message_id).split())[:128]
+            message_text = (
+                f"[Replying to WhatsApp message {json.dumps(reply_id)}; "
+                f"quoted text unavailable]\n\n{message_text}"
+            )
 
         if "@" in message_text:
             try:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1503,8 +1503,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             reply_to_message_id = None
             reply_to_author_id = None
             reply_to_is_own_message = False
-            if data.get("hasQuotedMessage"):
-                raw_reply_id = data.get("quotedMessageId")
+            raw_reply_id = data.get("quotedMessageId")
+            if data.get("hasQuotedMessage") or raw_reply_id is not None:
                 if raw_reply_id is not None:
                     reply_to_message_id = str(raw_reply_id)
                 quoted_participant = self._normalize_whatsapp_id(data.get("quotedParticipant"))

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -721,6 +721,7 @@ async function startSocket() {
         senderNumber,
         botIds,
         isGroup,
+        messageStore,
         downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
         cacheDirs: {
           image: IMAGE_CACHE_DIR,

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -130,6 +130,66 @@ import {
 }
 
 {
+  const store = createBoundedMessageStore(2);
+  store.remember({
+    key: { id: 'outbound-stanza-only' },
+    message: { conversation: 'send the approved draft?' },
+  });
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-stanza-only',
+        remoteJid: '15551234567@s.whatsapp.net',
+        fromMe: false,
+      },
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: '/queue send it',
+          contextInfo: { stanzaId: 'outbound-stanza-only' },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    messageStore: store,
+  });
+
+  assert.equal(event.quotedMessageId, 'outbound-stanza-only');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, 'send the approved draft?');
+  console.log('  ✓ stanza-only replies recover quoted text from the message store');
+}
+
+{
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-unresolved-quote',
+        remoteJid: '15551234567@s.whatsapp.net',
+        fromMe: false,
+      },
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: '/queue send it',
+          contextInfo: { stanzaId: 'evicted-message' },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+  });
+
+  assert.equal(event.quotedMessageId, 'evicted-message');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, '');
+  console.log('  ✓ unresolved stanza-only replies retain their quote relation');
+}
+
+{
   const event = await extractBridgeEvent({
     msg: {
       key: { id: 'doc-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -305,6 +305,7 @@ export async function extractBridgeEvent({
   isGroup = false,
   downloadMedia,
   writeMediaFile,
+  messageStore,
   cacheDirs = {},
 }) {
   const messageContent = getMessageContent(msg);
@@ -313,8 +314,16 @@ export async function extractBridgeEvent({
   const quotedMessageId = contextInfo?.stanzaId || null;
   const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
   const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
-  const hasQuotedMessage = !!contextInfo?.quotedMessage;
-  const quotedText = textFromQuotedMessage(contextInfo?.quotedMessage);
+  const storedQuotedMessage = quotedMessageId && !contextInfo?.quotedMessage
+    ? messageStore?.get(quotedMessageId)
+    : null;
+  const quotedMessage = contextInfo?.quotedMessage
+    || (storedQuotedMessage ? getMessageContent(storedQuotedMessage) : null);
+  // Baileys may omit the inline quoted payload while retaining stanzaId.
+  // The identifier alone still proves this is a reply and must survive the
+  // bridge even when the bounded store can no longer recover its text.
+  const hasQuotedMessage = !!(quotedMessageId || quotedMessage);
+  const quotedText = textFromQuotedMessage(quotedMessage);
 
   let body = '';
   let hasMedia = false;

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -36,6 +36,16 @@ def _source() -> SessionSource:
     )
 
 
+def _whatsapp_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="15551234567@s.whatsapp.net",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+
+
 @pytest.mark.asyncio
 async def test_reply_prefix_injected_when_text_absent_from_history():
     runner = _make_runner()
@@ -98,4 +108,26 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.startswith(f'[Replying to: "{quoted}"]')
     assert result.endswith("What's the best time to go?")
 
+
+@pytest.mark.asyncio
+async def test_whatsapp_reply_id_is_explicit_when_quote_text_is_unavailable():
+    runner = _make_runner()
+    source = _whatsapp_source()
+    event = MessageEvent(
+        text="send it",
+        source=source,
+        reply_to_message_id="outbound-42",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[{"role": "assistant", "content": "two possible drafts"}],
+    )
+
+    assert result is not None
+    assert result.startswith(
+        '[Replying to WhatsApp message "outbound-42"; quoted text unavailable]'
+    )
+    assert result.endswith("send it")
 

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -216,6 +216,26 @@ class TestBridgeEventMetadata:
         assert event.raw_message["quotedRemoteJid"] == "15551234567@s.whatsapp.net"
         assert event.raw_message["hasQuotedMessage"] is True
 
+    @pytest.mark.asyncio
+    async def test_stanza_id_preserves_reply_when_inline_quote_is_absent(self):
+        adapter = _make_adapter()
+        data = {
+            "messageId": "incoming-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "body": "/queue send it",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "quotedMessageId": "outbound-msg",
+            "hasQuotedMessage": False,
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert event.reply_to_message_id == "outbound-msg"
+        assert event.reply_to_text is None
+
 
 # ---------------------------------------------------------------------------
 # display_config tier classification
@@ -228,4 +248,3 @@ class TestWhatsAppTier:
         from gateway.display_config import resolve_display_setting
         # TIER_MEDIUM has streaming: None (follow global), not False
         assert resolve_display_setting({}, "whatsapp", "streaming") is None
-


### PR DESCRIPTION
Closes #74380

## Summary
- treat a Baileys `stanzaId` as authoritative reply metadata even when the inline `quotedMessage` payload is absent
- recover quoted text from the bridge's bounded message store when available and retain the reply ID through the Python adapter when it is not
- render an explicit WhatsApp message-ID pointer when the quoted payload has been evicted, so queued instructions do not become contextless

## Scope
PR #73399 owns durable `platform_metadata` persistence. This PR deliberately does not duplicate that schema work; it fixes the earlier live bridge -> adapter -> queued-turn rendering path.

## Verification
- `node --check` for both changed bridge modules
- `node scripts/whatsapp-bridge/bridge.native.test.mjs`
- `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py tests/gateway/test_reply_to_injection.py tests/gateway/test_queue_command.py tests/gateway/test_whatsapp_native_delivery.py -q` (`18 passed`)
- Ruff on changed Python files
- contribution publish gate and gitleaks