### PR TITLE
fix(api_server): don't send the advertised virtual model to the provider

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3389,6 +3389,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
             stored_model = session.get("model") if isinstance(session, dict) else None
+            # `_handle_create_session` stores `body.get("model") or
+            # self._model_name`, so a session created without an explicit model
+            # persists the *advertised* model name — a virtual id, not something
+            # any provider can serve. Treat it as "no session model", mirroring
+            # the `model != self._model_name` guard that already exists on the
+            # per-request path. Without this the virtual id reaches the provider
+            # as a real model and every turn on such a session fails.
+            if stored_model == self._model_name:
+                stored_model = None
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None
@@ -3499,6 +3508,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
             stored_model = session.get("model") if isinstance(session, dict) else None
+            # `_handle_create_session` stores `body.get("model") or
+            # self._model_name`, so a session created without an explicit model
+            # persists the *advertised* model name — a virtual id, not something
+            # any provider can serve. Treat it as "no session model", mirroring
+            # the `model != self._model_name` guard that already exists on the
+            # per-request path. Without this the virtual id reaches the provider
+            # as a real model and every turn on such a session fails.
+            if stored_model == self._model_name:
+                stored_model = None
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None


### PR DESCRIPTION
### The bug

`_handle_create_session` persists `body.get("model") or self._model_name`, so a session created **without** an explicit model stores the API server's *advertised* model name. That name is a virtual id — `hermes-agent` by default, or the active profile name — not something any provider can serve.

Both session chat handlers then read that value back as `session_model` and pass it down as a real model. Every turn on such a session fails. On an `openai-codex` / ChatGPT account it surfaces as:

```
HTTP 400 {"detail": "The 'hermes-agent' model is not supported when using Codex with a ChatGPT account."}
```

This hits any client following the documented flow — `POST /api/sessions` without a `model`, then `POST /api/sessions/{id}/chat/stream`.

### Why this shape of fix

The per-request path already guards against exactly this, in `_session_runtime_request_from_body`:

```python
if not route and model and model != self._model_name:
```

The session-persisted path introduced with the model-lock work was missing the same guard. This adds it to both `_handle_session_chat` and `_handle_session_chat_stream`: a stored model equal to the advertised name means *no session model*, so resolution falls through to the configured default, as it did before.

Guarding at the read site rather than the write site is deliberate — it also repairs sessions already persisted with the virtual id, which a create-side-only fix would leave broken.

### Verification

Against 0.19.1, provider `openai-codex`, `model.default: gpt-5.6-terra`, no `model_routes` configured. Model taken from the agent log's `API call #1: model=…`, not from the session record:

| create | chat | model that ran |
|---|---|---|
| `{}` | `{}` | `gpt-5.6-terra` |
| `{"model":"gpt-5.6-luna"}` | `{"model":"gpt-5.6-luna"}` | `gpt-5.6-luna` |
| `{"model":"gpt-5.6-sol"}` | `{"model":"gpt-5.6-sol"}` | `gpt-5.6-sol` |

The first row returned HTTP 400 before this change. The other two are unchanged, confirming per-session model selection still works.

### Workaround for anyone hitting this

Point the advertised name at a real model, which makes the leak harmless:

```yaml
platforms:
  api_server:
    extra:
      model_name: gpt-5.6-terra
```
