### PR TITLE
fix(desktop): keep demo plugins opt-in

### DIFF
--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -3,8 +3,8 @@
  *
  *  - BUNDLED: every `src/plugins/<name>/plugin.{ts,tsx}` default-exporting a
  *    `HermesPlugin` registers automatically (vite glob — drop a folder in).
- *    None ship in-tree today; reference/demo plugins live in the companion
- *    `hermes-example-plugins` repo.
+ *    Reference/demo plugins that ship in-tree must set `defaultEnabled: false`
+ *    so production boots stay uncluttered unless the user opts in.
  *  - RUNTIME: the on-disk door (`<hermes home>/desktop-plugins/<name>/plugin.js`)
  *    — the agent's/user's door, watched + hot-reloaded by the runtime loader.
  */

--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -3,8 +3,10 @@
  *
  *  - BUNDLED: every `src/plugins/<name>/plugin.{ts,tsx}` default-exporting a
  *    `HermesPlugin` registers automatically (vite glob — drop a folder in).
- *    Reference/demo plugins that ship in-tree must set `defaultEnabled: false`
- *    so production boots stay uncluttered unless the user opts in.
+ *    Bundled reference/demo modules that ship in-tree must set
+ *    `defaultEnabled: false` so production boots stay uncluttered unless the
+ *    user opts in. (Runtime-loader examples like `hello-runtime` are not
+ *    bundled modules and are exempt.)
  *  - RUNTIME: the on-disk door (`<hermes home>/desktop-plugins/<name>/plugin.js`)
  *    — the agent's/user's door, watched + hot-reloaded by the runtime loader.
  */

--- a/apps/desktop/src/plugins/README.md
+++ b/apps/desktop/src/plugins/README.md
@@ -4,10 +4,10 @@ Drop a `<name>/plugin.{ts,tsx}` here that default-exports a `HermesPlugin` and
 it registers automatically at boot (vite glob in `../contrib/plugins.ts`), with
 the same inventory + live enable/disable contract as runtime plugins.
 
-None ship in-tree today — reference/demo plugins (the counter example, the
-gateway-pill 1:1 rebuild, the runtime-loader hello world) live in the companion
-[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
-repo so the shipped app stays uncluttered.
+Reference/demo plugins that ship in-tree (the counter example, the gateway-pill
+1:1 rebuild, the runtime-loader hello world) must opt out of default activation
+with `defaultEnabled: false` so the shipped app stays uncluttered while Settings
+can still inventory them for SDK dogfooding.
 
 User- and agent-authored plugins load at runtime from
 `$HERMES_HOME/desktop-plugins/<name>/plugin.js` (the disk door) — see the

--- a/apps/desktop/src/plugins/README.md
+++ b/apps/desktop/src/plugins/README.md
@@ -4,10 +4,12 @@ Drop a `<name>/plugin.{ts,tsx}` here that default-exports a `HermesPlugin` and
 it registers automatically at boot (vite glob in `../contrib/plugins.ts`), with
 the same inventory + live enable/disable contract as runtime plugins.
 
-Reference/demo plugins that ship in-tree (the counter example, the gateway-pill
-1:1 rebuild, the runtime-loader hello world) must opt out of default activation
-with `defaultEnabled: false` so the shipped app stays uncluttered while Settings
-can still inventory them for SDK dogfooding.
+Reference/demo plugins that ship in-tree as bundled modules (the counter
+example, the gateway-pill 1:1 rebuild) must opt out of default activation
+with `defaultEnabled: false` so the shipped app stays uncluttered while
+Settings can still inventory them for SDK dogfooding. The runtime-loader
+`hello-runtime` example is not a bundled module — it ships as raw text and
+goes through the runtime pipeline, so the opt-in rule does not apply to it.
 
 User- and agent-authored plugins load at runtime from
 `$HERMES_HOME/desktop-plugins/<name>/plugin.js` (the disk door) — see the

--- a/apps/desktop/src/plugins/bundled-defaults.test.ts
+++ b/apps/desktop/src/plugins/bundled-defaults.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import examplePlugin from './example/plugin'
+import gatewayPillPlugin from './gateway-pill/plugin'
+
+describe('bundled demo plugin defaults', () => {
+  it('keeps dogfood/demo plugins inventoried but opt-in by default', () => {
+    expect(examplePlugin.id).toBe('example')
+    expect(examplePlugin.defaultEnabled).toBe(false)
+    expect(gatewayPillPlugin.id).toBe('gateway-pill')
+    expect(gatewayPillPlugin.defaultEnabled).toBe(false)
+  })
+})

--- a/apps/desktop/src/plugins/example/plugin.tsx
+++ b/apps/desktop/src/plugins/example/plugin.tsx
@@ -70,6 +70,7 @@ function ClickCounter() {
 }
 
 const plugin: HermesPlugin = {
+  defaultEnabled: false,
   id: 'example',
   name: 'Example Plugin',
   defaultEnabled: false,

--- a/apps/desktop/src/plugins/gateway-pill/plugin.tsx
+++ b/apps/desktop/src/plugins/gateway-pill/plugin.tsx
@@ -348,6 +348,7 @@ function PillLabel() {
 // ---------------------------------------------------------------------------
 
 const plugin: HermesPlugin = {
+  defaultEnabled: false,
   id: 'gateway-pill',
   name: 'Gateway Pill',
   register(ctx) {


### PR DESCRIPTION
Fixes #76064

## Summary
- mark the bundled `example` click-counter plugin as opt-in (`defaultEnabled: false`)
- mark the bundled `gateway-pill` dogfood plugin as opt-in so it no longer duplicates the built-in gateway status by default
- update bundled-plugin docs/comments to require demo plugins to stay inventoried but disabled until a user enables them

## Validation
- `npm run test:ui -- src/plugins/bundled-defaults.test.ts`
- `npm run typecheck`
- `npm exec eslint src/contrib/plugins.ts src/plugins/example/plugin.tsx src/plugins/gateway-pill/plugin.tsx src/plugins/bundled-defaults.test.ts`
- `git diff --check`
