### PR TITLE
fix(agent): synthesize results after terminal loop caps

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -25,7 +25,7 @@ import threading
 import time
 import uuid
 from types import SimpleNamespace
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
@@ -2068,14 +2068,47 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
-def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
-    """Request a summary when max iterations are reached. Returns the final response text."""
-    print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
+class FinalSummaryResult(NamedTuple):
+    """Outcome metadata for a tool-free final-response request."""
 
-    summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
+    text: str
+    api_attempts: int
+    already_streamed: bool
+
+
+def _request_final_summary(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    summary_request: str | None = None,
+    failure_response: str | None = None,
+    call_role: str = "iteration_summary",
+    request_id_prefix: str = "iteration-summary",
+    client_reason: str = "iteration_limit_summary",
+    status_message: str | None = None,
+    retry_empty: bool = True,
+    persist_summary_request: bool = True,
+) -> FinalSummaryResult:
+    """Request one tool-free final response after a terminal loop condition."""
+    print(
+        status_message
+        or f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
+    )
+
+    custom_failure_response = failure_response is not None
+    failure_response = failure_response or (
+        "I reached the iteration limit and couldn't generate a summary."
+    )
+
+    summary_api_request_id = f"{request_id_prefix}:{uuid.uuid4()}"
     summary_call_outcome = "failed"
+    summary_api_attempts = 0
+    summary_already_streamed = False
 
     def _managed_summary_call(request, callback, *, retry_count: int):
+        nonlocal summary_api_attempts
+        summary_api_attempts += 1
         from agent import relay_llm
 
         return relay_llm.execute_current(
@@ -2088,25 +2121,30 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     getattr(agent, "api_mode", "") or "chat_completions"
                 ),
                 "api_request_id": summary_api_request_id,
-                "call_role": "iteration_summary",
+                "call_role": call_role,
                 "retry_count": retry_count,
             },
             defer_logical_completion=True,
         )
 
-    summary_request = (
+    summary_request = summary_request or (
         "You've reached the maximum number of tool-calling iterations allowed. "
         "Please provide a final response summarizing what you've found and accomplished so far, "
         "without calling any more tools."
     )
-    messages.append({"role": "user", "content": summary_request})
+    summary_prompt_message = {"role": "user", "content": summary_request}
+    if persist_summary_request:
+        messages.append(summary_prompt_message)
+        summary_messages = messages
+    else:
+        summary_messages = [*messages, summary_prompt_message]
 
     try:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
+        for msg in summary_messages:
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
@@ -2208,9 +2246,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
-            codex_kwargs = agent._build_api_kwargs(api_messages)
-            codex_kwargs.pop("tools", None)
-            summary_response = agent._run_codex_stream(codex_kwargs)
+            codex_kwargs = agent._build_api_kwargs(api_messages, tools_for_api=[])
+            summary_response = _managed_summary_call(
+                codex_kwargs,
+                agent._run_codex_stream,
+                retry_count=0,
+            )
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
             final_response = (_cnr_sum.content or "").strip()
@@ -2277,7 +2318,25 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if summary_extra_body:
                 summary_kwargs["extra_body"] = summary_extra_body
 
-            if agent.api_mode == "anthropic_messages":
+            if agent.api_mode == "bedrock_converse":
+                _bedrock_kwargs = agent._build_api_kwargs(
+                    api_messages,
+                    tools_for_api=[],
+                )
+                summary_response = _managed_summary_call(
+                    _bedrock_kwargs,
+                    lambda request: _dispatch_nonstreaming_api_request(
+                        agent,
+                        request,
+                        make_client=lambda *_args, **_kwargs: None,
+                    ),
+                    retry_count=0,
+                )
+                _bedrock_result = agent._get_transport().normalize_response(
+                    summary_response
+                )
+                final_response = (_bedrock_result.content or "").strip()
+            elif agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
                 _ant_kw = _tsum.build_kwargs(
                     model=agent.model,
@@ -2298,9 +2357,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
-                summary_client = agent._ensure_primary_openai_client(
-                    reason="iteration_limit_summary"
-                )
+                summary_client = agent._ensure_primary_openai_client(reason=client_reason)
                 summary_response = _managed_summary_call(
                     summary_kwargs,
                     lambda request: summary_client.chat.completions.create(**request),
@@ -2316,16 +2373,40 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_call_outcome = "success"
                 messages.append({"role": "assistant", "content": final_response})
             else:
-                final_response = "I reached the iteration limit and couldn't generate a summary."
-        else:
+                final_response = failure_response
+        elif retry_empty:
             # Retry summary generation
             if agent.api_mode == "codex_responses":
-                codex_kwargs = agent._build_api_kwargs(api_messages)
-                codex_kwargs.pop("tools", None)
-                retry_response = agent._run_codex_stream(codex_kwargs)
+                codex_kwargs = agent._build_api_kwargs(
+                    api_messages,
+                    tools_for_api=[],
+                )
+                retry_response = _managed_summary_call(
+                    codex_kwargs,
+                    agent._run_codex_stream,
+                    retry_count=1,
+                )
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
                 final_response = (_cnr_retry.content or "").strip()
+            elif agent.api_mode == "bedrock_converse":
+                _bedrock_kwargs = agent._build_api_kwargs(
+                    api_messages,
+                    tools_for_api=[],
+                )
+                retry_response = _managed_summary_call(
+                    _bedrock_kwargs,
+                    lambda request: _dispatch_nonstreaming_api_request(
+                        agent,
+                        request,
+                        make_client=lambda *_args, **_kwargs: None,
+                    ),
+                    retry_count=1,
+                )
+                _bedrock_result = agent._get_transport().normalize_response(
+                    retry_response
+                )
+                final_response = (_bedrock_result.content or "").strip()
             elif agent.api_mode == "anthropic_messages":
                 _tretry = agent._get_transport()
                 _ant_kw2 = _tretry.build_kwargs(
@@ -2361,7 +2442,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_kwargs["extra_body"] = summary_extra_body
 
                 summary_client = agent._ensure_primary_openai_client(
-                    reason="iteration_limit_summary_retry"
+                    reason=f"{client_reason}_retry"
                 )
                 summary_response = _managed_summary_call(
                     summary_kwargs,
@@ -2378,13 +2459,22 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_call_outcome = "success"
                     messages.append({"role": "assistant", "content": final_response})
                 else:
-                    final_response = "I reached the iteration limit and couldn't generate a summary."
+                    final_response = failure_response
             else:
-                final_response = "I reached the iteration limit and couldn't generate a summary."
+                final_response = failure_response
+        else:
+            final_response = failure_response
 
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        final_response = (
+            failure_response
+            if custom_failure_response
+            else (
+                f"I reached the maximum iterations ({agent.max_iterations}) "
+                f"but couldn't summarize. Error: {str(e)}"
+            )
+        )
     finally:
         from agent import relay_llm
 
@@ -2393,8 +2483,46 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             outcome=summary_call_outcome,
         )
 
-    return final_response
+    summary_already_streamed = bool(
+        summary_call_outcome == "success"
+        and agent.api_mode == "codex_responses"
+        and agent.stream_delta_callback is not None
+    )
+    return FinalSummaryResult(
+        final_response,
+        summary_api_attempts,
+        summary_already_streamed,
+    )
 
+
+def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
+    """Request a tool-free summary after the normal iteration budget is spent."""
+    return _request_final_summary(agent, messages, api_call_count).text
+
+
+def handle_terminal_cap_summary(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    summary_request: str,
+    failure_response: str,
+    status_message: str,
+) -> FinalSummaryResult:
+    """Request one tool-free final response after a terminal tool-loop cap."""
+    return _request_final_summary(
+        agent,
+        messages,
+        api_call_count,
+        summary_request=summary_request,
+        failure_response=failure_response,
+        call_role="guardrail_summary",
+        request_id_prefix="guardrail-summary",
+        client_reason="tool_guardrail_summary",
+        status_message=status_message,
+        retry_empty=False,
+        persist_summary_request=False,
+    )
 
 
 def cleanup_task_resources(agent, task_id: str) -> None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6216,11 +6216,22 @@ def run_conversation(
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"
-                    final_response = agent._toolguard_controlled_halt_response(decision)
+                    _guardrail_final = agent._toolguard_final_response(
+                        messages,
+                        decision,
+                        api_call_count,
+                    )
+                    final_response = _guardrail_final.text
+                    api_call_count += _guardrail_final.api_attempts
                     agent._emit_status(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
                     )
-                    messages.append({"role": "assistant", "content": final_response})
+                    if not (
+                        messages
+                        and messages[-1].get("role") == "assistant"
+                        and messages[-1].get("content") == final_response
+                    ):
+                        messages.append({"role": "assistant", "content": final_response})
                     # Emit the halt message to the client so it's not
                     # indistinguishable from a crash.  The stream display
                     # was flushed (callback(None)) before tool execution,
@@ -6229,8 +6240,17 @@ def run_conversation(
                     if final_response:
                         agent._safe_print(f"\n{final_response}\n")
                         if agent.stream_delta_callback:
+                            if _guardrail_final.already_streamed:
+                                agent._response_was_previewed = True
+                            else:
+                                try:
+                                    agent.stream_delta_callback(final_response)
+                                except Exception:
+                                    logger.debug(
+                                        "stream_delta_callback failed for guardrail halt",
+                                        exc_info=True,
+                                    )
                             try:
-                                agent.stream_delta_callback(final_response)
                                 agent.stream_delta_callback(None)
                             except Exception:
                                 pass

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -40,6 +40,7 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
+from agent.tool_guardrails import TERMINAL_LOOP_CAP_CODES
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -212,6 +213,30 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _append_terminal_cap_skips(agent, tool_calls, messages: list) -> bool:
+    """Close unstarted tool calls after a terminal cap without side effects."""
+    for skipped_tc in tool_calls:
+        skipped_name = skipped_tc.function.name
+        messages.append(
+            make_tool_result_message(
+                skipped_name,
+                (
+                    f"[Tool execution skipped — {skipped_name} was not started "
+                    "because a terminal tool-loop cap was reached]"
+                ),
+                skipped_tc.id,
+                effect_disposition="none",
+            )
+        )
+        if not _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"terminal-cap skipped tool result {skipped_name}",
+        ):
+            return False
+    return True
 
 
 def _emit_cancelled_terminal_post_tool_call(
@@ -1951,6 +1976,20 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 response_preview = _fr_str[:agent.log_prefix_chars] + "..." if len(_fr_str) > agent.log_prefix_chars else _fr_str
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
 
+        _halt = getattr(agent, "_tool_guardrail_halt_decision", None)
+        if (
+            _halt is not None
+            and _halt.code in TERMINAL_LOOP_CAP_CODES
+            and i < len(assistant_message.tool_calls)
+        ):
+            if not _append_terminal_cap_skips(
+                agent,
+                assistant_message.tool_calls[i:],
+                messages,
+            ):
+                return
+            break
+
         if agent._interrupt_requested and i < len(assistant_message.tool_calls):
             remaining = len(assistant_message.tool_calls) - i
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
@@ -2016,6 +2055,19 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _active_env = get_active_env(effective_task_id)
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
+
+    _guardrails = getattr(agent, "_tool_guardrails", None)
+    _batch_cap_check = getattr(_guardrails, "batch_would_hit_loop_cap", None)
+    if (
+        callable(_batch_cap_check)
+        and _batch_cap_check(
+            [call.function.name for call in assistant_message.tool_calls]
+        )
+    ):
+        # Reserve cap checks in emission order. A concurrent batch could let a
+        # later mutating call start before an earlier capped search/delegation
+        # call records the terminal halt.
+        segments = [("sequential", list(assistant_message.tool_calls))]
 
     for kind, calls in segments:
         if getattr(agent, "_incremental_persistence_failed", False):

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -134,6 +134,9 @@ class ToolCallGuardrailConfig:
 # pathological, so the defaults are deliberately low.
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
+TERMINAL_LOOP_CAP_CODES = frozenset(
+    {"loop_web_search_cap", "loop_subagent_cap"}
+)
 
 
 @dataclass(frozen=True)
@@ -291,6 +294,17 @@ class ToolCallGuardrailController:
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
+
+    def batch_would_hit_loop_cap(self, tool_names: list[str]) -> bool:
+        """Return whether this batch can cross a terminal per-turn loop cap."""
+        web_searches = sum(name == "web_search" for name in tool_names)
+        subagents = sum(name == "delegate_task" for name in tool_names)
+        web_cap = self.config.loop_caps.max_web_searches
+        subagent_cap = self.config.loop_caps.max_subagents
+        return bool(
+            (web_cap and self._turn_web_search_count + web_searches > web_cap)
+            or (subagent_cap and self._turn_subagent_count + subagents > subagent_cap)
+        )
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))

--- a/run_agent.py
+++ b/run_agent.py
@@ -192,6 +192,7 @@ from agent.codex_responses_adapter import (
     _summarize_user_message_for_log,  # also used by _sync_external_memory_for_turn (memory boundary)
 )
 from agent.tool_guardrails import (
+    TERMINAL_LOOP_CAP_CODES,
     ToolGuardrailDecision,
     append_toolguard_guidance,
     toolguard_synthetic_result,
@@ -6960,6 +6961,40 @@ class AIAgent:
             "to change strategy instead of repeating the same call."
         )
 
+    def _toolguard_final_response(
+        self,
+        messages: list,
+        decision: ToolGuardrailDecision,
+        api_call_count: int,
+    ):
+        """Return a useful final answer for terminal research/delegation caps."""
+        from agent.chat_completion_helpers import (
+            FinalSummaryResult,
+            handle_terminal_cap_summary,
+        )
+
+        fallback = self._toolguard_controlled_halt_response(decision)
+        if decision.code not in TERMINAL_LOOP_CAP_CODES:
+            return FinalSummaryResult(fallback, 0, False)
+
+        return handle_terminal_cap_summary(
+            self,
+            messages,
+            api_call_count,
+            summary_request=(
+                "The tool-call guardrail stopped further research because this turn "
+                f"reached {decision.code}. Do not call any more tools. Answer the "
+                "user's original request now using the evidence already present in "
+                "the conversation. Clearly state any important limitations caused "
+                "by the cap instead of returning only a guardrail error."
+            ),
+            failure_response=fallback,
+            status_message=(
+                f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}. "
+                "Requesting a final answer from existing results..."
+            ),
+        )
+
     def _append_guardrail_observation(
         self,
         tool_name: str,
@@ -7003,6 +7038,21 @@ class AIAgent:
             if len(tool_calls) <= 1:
                 return self._execute_tool_calls_sequential(
                     assistant_message, messages, effective_task_id, api_call_count
+                )
+
+            _batch_cap_check = getattr(
+                self._tool_guardrails,
+                "batch_would_hit_loop_cap",
+                None,
+            )
+            if callable(_batch_cap_check) and _batch_cap_check(
+                [call.function.name for call in tool_calls]
+            ):
+                return self._execute_tool_calls_sequential(
+                    assistant_message,
+                    messages,
+                    effective_task_id,
+                    api_call_count,
                 )
 
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
@@ -7116,7 +7166,11 @@ class AIAgent:
         from agent.tool_executor import execute_tool_calls_sequential
         return execute_tool_calls_sequential(self, assistant_message, messages, effective_task_id, api_call_count)
 
-    def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
+    def _handle_max_iterations(
+        self,
+        messages: list,
+        api_call_count: int,
+    ) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations
         return handle_max_iterations(self, messages, api_call_count)

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,8 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.chat_completion_helpers import FinalSummaryResult
+from agent.tool_guardrails import ToolGuardrailDecision
 from run_agent import AIAgent
 
 
@@ -84,6 +86,16 @@ def _hard_stop_config(**overrides) -> dict:
     }
     cfg["tool_loop_guardrails"].update(overrides)
     return cfg
+
+
+def _loop_cap_config(cap_key: str) -> dict:
+    return {
+        "tool_loop_guardrails": {
+            "loop_caps": {
+                cap_key: 1,
+            }
+        }
+    }
 
 
 def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_execution():
@@ -412,6 +424,7 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert result["turn_exit_reason"] == "guardrail_halt"
     halt_text = result["final_response"]
     assert "stopped retrying" in halt_text
+    assert agent.client.chat.completions.create.call_count == 3
 
     # The halt message must have been pushed through the callback at least
     # once.  Empty-queue SSE writers were the bug — clients saw no content
@@ -420,3 +433,365 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_web_search_cap_synthesizes_existing_results_without_more_tools():
+    """A terminal research cap should preserve evidence in a final answer.
+
+    The cap still blocks the extra search, but the model receives one tool-free
+    call so users get a useful partial report instead of only guardrail text.
+    """
+    agent = _make_agent(
+        "web_search",
+        "write_file",
+        max_iterations=10,
+        config=_loop_cap_config("max_web_searches"),
+    )
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "web_search",
+                    json.dumps({"query": "first query"}),
+                    "c-first",
+                )
+            ],
+        ),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "web_search",
+                    json.dumps({"query": "second query"}),
+                    "c-capped",
+                ),
+                _mock_tool_call(
+                    "write_file",
+                    json.dumps({"path": "/tmp/must-not-run", "content": "unsafe"}),
+                    "c-skipped-write",
+                ),
+            ],
+        ),
+        _mock_response(
+            content="Useful partial report from the available evidence.",
+            finish_reason="stop",
+            tool_calls=None,
+        ),
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+    agent._disable_streaming = True
+    deltas: list = []
+    agent.stream_delta_callback = lambda delta: deltas.append(delta)
+
+    existing_result = json.dumps(
+        {"data": {"web": [{"title": "Useful source", "url": "https://example.com"}]}}
+    )
+    with (
+        patch("run_agent.handle_function_call", return_value=existing_result) as dispatch,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("research this topic thoroughly")
+
+    assert dispatch.call_count == 1
+    assert not any(
+        call.args and call.args[0] == "write_file"
+        for call in dispatch.call_args_list
+    )
+    assert agent.client.chat.completions.create.call_count == 3
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["guardrail"]["code"] == "loop_web_search_cap"
+    assert result["api_calls"] == 3
+    assert result["final_response"] == "Useful partial report from the available evidence."
+    assert [
+        message
+        for message in result["messages"]
+        if message.get("role") == "assistant"
+        and message.get("content") == result["final_response"]
+    ] == [{"role": "assistant", "content": result["final_response"]}]
+    assert not any(
+        message.get("role") == "user"
+        and "tool-call guardrail stopped further research" in message.get("content", "")
+        for message in result["messages"]
+    )
+    skipped_write = next(
+        message
+        for message in result["messages"]
+        if message.get("tool_call_id") == "c-skipped-write"
+    )
+    assert "terminal tool-loop cap" in skipped_write["content"]
+
+    summary_request = agent.client.chat.completions.create.call_args_list[-1].kwargs
+    assert "tools" not in summary_request
+    assert "tool_choice" not in summary_request
+    assert any(
+        message.get("role") == "tool" and "Useful source" in message.get("content", "")
+        for message in summary_request["messages"]
+    )
+    assert summary_request["messages"][-1]["role"] == "user"
+    assert "Do not call any more tools" in summary_request["messages"][-1]["content"]
+
+    text_deltas = [delta for delta in deltas if isinstance(delta, str)]
+    assert result["final_response"] in text_deltas
+
+
+def test_subagent_cap_also_requests_tool_free_final_response():
+    agent = _make_agent("delegate_task")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Partial report from completed subagents.",
+        finish_reason="stop",
+        tool_calls=None,
+    )
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_subagent_cap",
+        message="cap reached",
+        tool_name="delegate_task",
+        count=50,
+    )
+
+    response = agent._toolguard_final_response(
+        [{"role": "user", "content": "research this"}],
+        decision,
+        api_call_count=2,
+    )
+
+    assert response.text == "Partial report from completed subagents."
+    assert response.api_attempts == 1
+    assert response.already_streamed is False
+    summary_request = agent.client.chat.completions.create.call_args.kwargs
+    assert "tools" not in summary_request
+    assert "tool_choice" not in summary_request
+
+
+def test_terminal_loop_cap_summary_failure_uses_controlled_halt_fallback():
+    agent = _make_agent("web_search")
+    agent.client.chat.completions.create.side_effect = RuntimeError("provider unavailable")
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_web_search_cap",
+        message="cap reached",
+        tool_name="web_search",
+        count=50,
+    )
+    messages = [
+        {"role": "user", "content": "research this"},
+        {"role": "tool", "content": "useful existing result"},
+    ]
+
+    response = agent._toolguard_final_response(messages, decision, api_call_count=2)
+
+    assert "stopped retrying web_search" in response.text
+    assert "loop_web_search_cap" in response.text
+    assert response.api_attempts == 1
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_terminal_loop_cap_empty_summary_is_not_retried():
+    agent = _make_agent("web_search")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="",
+        finish_reason="stop",
+        tool_calls=None,
+    )
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_web_search_cap",
+        message="cap reached",
+        tool_name="web_search",
+        count=50,
+    )
+
+    response = agent._toolguard_final_response(
+        [{"role": "user", "content": "research this"}],
+        decision,
+        api_call_count=2,
+    )
+
+    assert "loop_web_search_cap" in response.text
+    assert response.api_attempts == 1
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_terminal_loop_cap_codex_summary_is_tool_free_and_marked_streamed():
+    agent = _make_agent("web_search")
+    agent.api_mode = "codex_responses"
+    deltas = []
+    agent.stream_delta_callback = deltas.append
+    build_calls = []
+
+    def build_kwargs(api_messages, tools_for_api=None):
+        build_calls.append((api_messages, tools_for_api))
+        return {"model": "codex-test", "input": api_messages}
+
+    def run_codex_stream(_request):
+        agent.stream_delta_callback("Codex cap summary")
+        return object()
+
+    transport = SimpleNamespace(
+        normalize_response=lambda _response: SimpleNamespace(
+            content="Codex cap summary"
+        )
+    )
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_web_search_cap",
+        message="cap reached",
+        tool_name="web_search",
+        count=50,
+    )
+
+    with (
+        patch.object(agent, "_build_api_kwargs", side_effect=build_kwargs),
+        patch.object(agent, "_run_codex_stream", side_effect=run_codex_stream),
+        patch.object(agent, "_get_transport", return_value=transport),
+    ):
+        response = agent._toolguard_final_response(
+            [{"role": "user", "content": "research this"}],
+            decision,
+            api_call_count=2,
+        )
+
+    assert response == FinalSummaryResult("Codex cap summary", 1, True)
+    assert len(build_calls) == 1
+    assert build_calls[0][1] == []
+    assert deltas == ["Codex cap summary"]
+
+
+def test_terminal_loop_cap_bedrock_summary_uses_converse_transport_without_tools():
+    agent = _make_agent("web_search")
+    agent.api_mode = "bedrock_converse"
+    build_calls = []
+
+    def build_kwargs(api_messages, tools_for_api=None):
+        build_calls.append((api_messages, tools_for_api))
+        return {
+            "__bedrock_converse__": True,
+            "model": "bedrock-test",
+            "messages": api_messages,
+        }
+
+    transport = SimpleNamespace(
+        normalize_response=lambda _response: SimpleNamespace(
+            content="Bedrock cap summary"
+        )
+    )
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_web_search_cap",
+        message="cap reached",
+        tool_name="web_search",
+        count=50,
+    )
+
+    with (
+        patch.object(agent, "_build_api_kwargs", side_effect=build_kwargs),
+        patch.object(agent, "_get_transport", return_value=transport),
+        patch(
+            "agent.chat_completion_helpers._dispatch_nonstreaming_api_request",
+            return_value=object(),
+        ) as dispatch,
+    ):
+        response = agent._toolguard_final_response(
+            [{"role": "user", "content": "research this"}],
+            decision,
+            api_call_count=2,
+        )
+
+    assert response == FinalSummaryResult("Bedrock cap summary", 1, False)
+    assert len(build_calls) == 1
+    assert build_calls[0][1] == []
+    dispatch.assert_called_once()
+
+
+def test_terminal_loop_cap_anthropic_summary_is_tool_free():
+    agent = _make_agent("web_search")
+    agent.api_mode = "anthropic_messages"
+    build_calls = []
+
+    def build_kwargs(**kwargs):
+        build_calls.append(kwargs)
+        return {"model": kwargs["model"], "messages": kwargs["messages"]}
+
+    transport = SimpleNamespace(
+        build_kwargs=build_kwargs,
+        normalize_response=lambda _response, **_kwargs: SimpleNamespace(
+            content="Anthropic cap summary"
+        ),
+    )
+    decision = ToolGuardrailDecision(
+        action="block",
+        code="loop_web_search_cap",
+        message="cap reached",
+        tool_name="web_search",
+        count=50,
+    )
+
+    with (
+        patch.object(agent, "_get_transport", return_value=transport),
+        patch.object(agent, "_anthropic_messages_create", return_value=object()),
+    ):
+        response = agent._toolguard_final_response(
+            [{"role": "user", "content": "research this"}],
+            decision,
+            api_call_count=2,
+        )
+
+    assert response == FinalSummaryResult("Anthropic cap summary", 1, False)
+    assert len(build_calls) == 1
+    assert build_calls[0]["tools"] is None
+
+
+def test_already_streamed_cap_summary_is_not_replayed_to_client():
+    agent = _make_agent(
+        "web_search",
+        config=_loop_cap_config("max_web_searches"),
+    )
+    deltas = []
+    agent.stream_delta_callback = deltas.append
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "web_search",
+                    json.dumps({"query": "first query"}),
+                    call_id="call-first",
+                )
+            ],
+        ),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "web_search",
+                    json.dumps({"query": "second query"}),
+                    call_id="call-second",
+                )
+            ],
+        ),
+    ]
+
+    def already_streamed(*_args, **_kwargs):
+        agent.stream_delta_callback("Already streamed cap summary")
+        return FinalSummaryResult("Already streamed cap summary", 1, True)
+
+    with (
+        patch("run_agent.handle_function_call", return_value="source evidence"),
+        patch.object(
+            agent,
+            "_toolguard_final_response",
+            side_effect=already_streamed,
+        ),
+    ):
+        result = agent.run_conversation("research this")
+
+    text_deltas = [delta for delta in deltas if isinstance(delta, str)]
+    assert text_deltas.count("Already streamed cap summary") == 1
+    assert result["api_calls"] == 3


### PR DESCRIPTION
## What does this PR do?

Terminal `loop_web_search_cap` and `loop_subagent_cap` guardrails currently replace all collected work with a canned stop message. This PR preserves the cap while asking the current model for one tool-free final response from the evidence already in the turn.

It also makes terminal-cap handling fail-closed within a mixed tool batch: when the next emitted batch would cross one of these caps, calls are reserved in order and every call after the capped search/delegation is closed with a synthetic skipped result instead of being allowed to start concurrently.

The summary path:

- performs exactly one provider attempt (no empty-response retry)
- sends no tool definitions for Chat Completions, Anthropic Messages, Codex Responses, or Bedrock Converse
- uses an ephemeral instruction rather than persisting a synthetic user message
- records the extra attempt in `result["api_calls"]`
- avoids replaying Codex output that was already streamed
- falls back to the existing controlled-halt text if the provider fails or returns empty content

Other hard-stop guardrails retain their current behavior. This is intentionally narrower than a general “one rebound” implementation.

## Related Issue(s)

Related to #64322.

Complements, but does not supersede, the broader recovery proposal in #64363. This PR handles only the terminal per-turn caps added in #66600; it does not give other hard-stop guardrails another tool-enabled model round.

## Testing

- `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_tool_guardrails.py tests/run_agent/test_agent_guardrails.py tests/run_agent/test_run_agent.py tests/run_agent/test_tool_batch_segmentation.py tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_concurrent_interrupt.py tests/run_agent/test_tool_executor_contextvar_propagation.py -q`
  - 314 passed on Arch Linux
- The focused ARM64 guardrail/segmentation set:
  - 70 passed on Raspberry Pi OS / Debian 13
- Full local suite:
  - 23,661 passed, 1 unrelated failure
- `.venv/bin/ruff check .`
- `.venv/bin/python scripts/check-windows-footguns.py --all`
- `python -m py_compile` for all changed Python files
- `git diff --check`

The lone full-suite failure was `tests/agent/test_compression_concurrent_fork.py::test_fence_cancelled_compression_leaves_lock_reacquirable`; this timing-sensitive compression file also fails in a clean `upstream/main` worktree with the same environment. Required GitHub CI remains authoritative for the complete matrix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Checklist

- [x] I tested this locally
- [x] I added/updated tests for my changes
- [ ] All tests pass locally with `./scripts/run_tests.sh`
- [x] Code is formatted and follows project conventions
- [x] I performed a self-review
- [x] No secrets, credentials, or personal data included
- [x] I updated documentation (if applicable)

The full-suite checkbox is intentionally left unchecked only because the clean-base failure documented above reproduces unchanged on `upstream/main`; the focused 314-test regression set is green.

## Platform

- OS: Arch Linux (Aorus) and Debian GNU/Linux 13 ARM64 (Raspberry Pi 5 focused tests)
- Python: 3.11
- Install method: local editable checkout / existing Hermes development venv

## Screenshots / Logs

Not applicable — agent runtime/control-flow change.

## Additional Notes

Brave Search PR #75333 is unrelated: it changes setup-time capability detection only. The exact cap code is produced by #66600, while #31448 made controlled halt text visible to clients. This PR keeps both protections and changes only the terminal-cap recovery path.