### PR TITLE
chore: map tron@chriswykel.com -> Wpnx330 (PR #68334 salvage)

### DIFF
--- a/contributors/emails/tron@chriswykel.com
+++ b/contributors/emails/tron@chriswykel.com
@@ -1,0 +1,3 @@
+Wpnx330
+# PR #68334 salvage (compression: pre-LLM feasibility check, from #60451).
+# TRON <tron@chriswykel.com> is @Wpnx330's coding-agent commit identity.


### PR DESCRIPTION
Maps `tron@chriswykel.com` (TRON — @Wpnx330's coding-agent commit identity on PR #68334 / #60451) to `Wpnx330` via the contributors/emails directory, so the upcoming salvage of PR #68334 passes the contributor-attribution audit with the original author's commit preserved.

One mapping file, no code changes.
