### PR TITLE
fix(dashboard): enable touch scrollback in chat

### DIFF
--- a/web/src/lib/terminal-touch-scroll.test.ts
+++ b/web/src/lib/terminal-touch-scroll.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { installTerminalTouchScroll } from "./terminal-touch-scroll";
+
+function touchEvent(type: string, y: number): TouchEvent {
+  const ev = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const touch = { clientY: y } as Touch;
+
+  Object.defineProperty(ev, "touches", { value: type === "touchend" ? [] : [touch] });
+  Object.defineProperty(ev, "changedTouches", { value: [touch] });
+
+  return ev;
+}
+
+function term(viewportY: number, baseY: number) {
+  const terminal = {
+    buffer: { active: { baseY, viewportY } },
+    scrollLines: vi.fn((amount: number) => {
+      const active = terminal.buffer.active;
+      active.viewportY = Math.max(0, Math.min(active.baseY, active.viewportY + amount));
+    }),
+  };
+
+  return terminal;
+}
+
+describe("installTerminalTouchScroll", () => {
+  it("converts one-finger vertical drags into xterm scrollback lines", () => {
+    const host = new EventTarget() as HTMLElement;
+    const terminal = term(20, 100);
+    const cleanup = installTerminalTouchScroll(host, terminal);
+
+    host.dispatchEvent(touchEvent("touchstart", 200));
+    const move = touchEvent("touchmove", 164);
+    host.dispatchEvent(move);
+
+    expect(terminal.scrollLines).toHaveBeenCalledWith(2);
+    expect(move.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it("lets the outer page handle touch drags at the terminal boundary", () => {
+    const host = new EventTarget() as HTMLElement;
+    const terminal = term(0, 100);
+    const cleanup = installTerminalTouchScroll(host, terminal);
+
+    host.dispatchEvent(touchEvent("touchstart", 100));
+    const move = touchEvent("touchmove", 136);
+    host.dispatchEvent(move);
+
+    expect(terminal.scrollLines).not.toHaveBeenCalled();
+    expect(move.defaultPrevented).toBe(false);
+
+    cleanup();
+  });
+
+  it("removes listeners on cleanup", () => {
+    const host = new EventTarget() as HTMLElement;
+    const terminal = term(20, 100);
+    const cleanup = installTerminalTouchScroll(host, terminal);
+
+    cleanup();
+
+    host.dispatchEvent(touchEvent("touchstart", 200));
+    host.dispatchEvent(touchEvent("touchmove", 164));
+
+    expect(terminal.scrollLines).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/terminal-touch-scroll.ts
+++ b/web/src/lib/terminal-touch-scroll.ts
@@ -1,0 +1,114 @@
+interface ScrollableTerminal {
+  buffer: {
+    active: {
+      baseY: number;
+      viewportY: number;
+    };
+  };
+  scrollLines: (amount: number) => void;
+}
+
+const TOUCH_SCROLL_PX_PER_LINE = 18;
+const TOUCH_SCROLL_MIN_PX = 2;
+const CAPTURE = { capture: true } as const;
+const PASSIVE_CAPTURE = { capture: true, passive: true } as const;
+const ACTIVE_CAPTURE = { capture: true, passive: false } as const;
+
+function firstTouchY(ev: TouchEvent): number | null {
+  const touch = ev.touches[0] ?? ev.changedTouches[0];
+
+  return touch ? touch.clientY : null;
+}
+
+function canScrollTerminal(term: ScrollableTerminal, amount: number): boolean {
+  const { baseY, viewportY } = term.buffer.active;
+
+  if (amount < 0) {
+    return viewportY > 0;
+  }
+
+  if (amount > 0) {
+    return viewportY < baseY;
+  }
+
+  return false;
+}
+
+/**
+ * Add touch-drag scrollback support for dashboard xterm panes.
+ *
+ * xterm.js handles wheel/trackpad scrollback for the embedded TUI, but iPadOS
+ * WebKit does not translate a finger drag inside the terminal into wheel events
+ * or native scrollbar dragging. Mirror the wheel path by converting vertical
+ * touch movement into `scrollLines()` while there is xterm scrollback available;
+ * at the top/bottom boundary we leave the event alone so the outer dashboard
+ * page can still move above the software keyboard.
+ */
+export function installTerminalTouchScroll(host: HTMLElement, term: ScrollableTerminal): () => void {
+  let lastY: number | null = null;
+  let residualPx = 0;
+
+  const reset = () => {
+    lastY = null;
+    residualPx = 0;
+  };
+
+  const onTouchStart = (ev: TouchEvent) => {
+    if (ev.touches.length !== 1) {
+      reset();
+      return;
+    }
+
+    lastY = firstTouchY(ev);
+    residualPx = 0;
+  };
+
+  const onTouchMove = (ev: TouchEvent) => {
+    if (ev.touches.length !== 1 || lastY === null) {
+      reset();
+      return;
+    }
+
+    const nextY = firstTouchY(ev);
+    if (nextY === null) {
+      reset();
+      return;
+    }
+
+    const deltaPx = lastY - nextY;
+    lastY = nextY;
+
+    if (Math.abs(deltaPx) < TOUCH_SCROLL_MIN_PX) {
+      return;
+    }
+
+    residualPx += deltaPx;
+    const lines = residualPx / TOUCH_SCROLL_PX_PER_LINE;
+    const wholeLines = lines < 0 ? Math.ceil(lines) : Math.floor(lines);
+
+    if (wholeLines === 0) {
+      return;
+    }
+
+    if (!canScrollTerminal(term, wholeLines)) {
+      return;
+    }
+
+    residualPx -= wholeLines * TOUCH_SCROLL_PX_PER_LINE;
+    term.scrollLines(wholeLines);
+    ev.preventDefault();
+    ev.stopPropagation();
+  };
+
+  host.addEventListener("touchstart", onTouchStart, PASSIVE_CAPTURE);
+  host.addEventListener("touchmove", onTouchMove, ACTIVE_CAPTURE);
+  host.addEventListener("touchcancel", reset, CAPTURE);
+  host.addEventListener("touchend", reset, CAPTURE);
+
+  return () => {
+    host.removeEventListener("touchstart", onTouchStart, PASSIVE_CAPTURE);
+    host.removeEventListener("touchmove", onTouchMove, ACTIVE_CAPTURE);
+    host.removeEventListener("touchcancel", reset, CAPTURE);
+    host.removeEventListener("touchend", reset, CAPTURE);
+  };
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -70,6 +70,7 @@ import {
   isViewportPinnedToBottom,
   shouldFollowPtyOutput,
 } from "@/lib/pty-scroll";
+import { installTerminalTouchScroll } from "@/lib/terminal-touch-scroll";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -806,6 +807,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ev.stopPropagation();
       return false;
     });
+    const cleanupTouchScroll = installTerminalTouchScroll(host, term);
 
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
@@ -1475,6 +1477,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onScrollDisposable?.dispose();
       mobileInputCleanup?.();
       compositionForwarder.dispose();
+      cleanupTouchScroll();
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -58,6 +58,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { installTerminalTouchScroll } from "@/lib/terminal-touch-scroll";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -732,6 +733,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ev.stopPropagation();
       return false;
     });
+    const cleanupTouchScroll = installTerminalTouchScroll(host, term);
 
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
@@ -1235,6 +1237,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       mobileInputCleanup?.();
+      cleanupTouchScroll();
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);


### PR DESCRIPTION
Fixes #76002

## Summary
- add a dashboard xterm touch-drag scroll helper that converts one-finger vertical swipes into `scrollLines()` calls
- keep the outer Dashboard page scrollable at the terminal scrollback boundaries so users can still move the input above the iPad keyboard
- wire the helper into `ChatPage` next to the existing wheel/trackpad scrollback handler

## Validation
- `npm run test -- src/lib/terminal-touch-scroll.test.ts`
- `npm run test`
- `npm run typecheck`
- `npm exec eslint src/pages/ChatPage.tsx src/lib/terminal-touch-scroll.ts src/lib/terminal-touch-scroll.test.ts` (warnings only from pre-existing `ChatPage` hook rules)
- `npm run build`
- `git diff --check`
