### PR TITLE
fix(cli): verify node_modules existence before skipping npm install

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1739,6 +1739,11 @@ def _npm_lockfile_changed(hermes_root: Path) -> bool:
     # node_modules means the cache was recorded by another checkout.
     if not (_m().PROJECT_ROOT / "node_modules").is_dir():
         return True
+    # An interrupted or corrupted npm install may leave node_modules/ present
+    # but missing npm's hidden lockfile (.package-lock.json).  Treat that as
+    # "changed" so we force a reinstall instead of silently breaking the TUI.
+    if not (_m().PROJECT_ROOT / "node_modules" / ".package-lock.json").is_file():
+        return True
     # A matching lockfile hash over a tree whose web build toolchain never
     # landed must NOT skip the reinstall — otherwise every later `hermes
     # update` keeps rebuilding against a half-installed tree and serving a


### PR DESCRIPTION
Fixes #75670

## Problem

In `hermes_cli/update_cmd.py`, `_npm_lockfile_changed()` compares the `package-lock.json` hash against a cached value. When they match, `npm install` is **skipped entirely**. It already checks whether `node_modules/` exists as a directory, but does **not** verify that npm's hidden lockfile (`node_modules/.package-lock.json`) is present.

If a previous `npm install` was interrupted, or `node_modules/` was corrupted/deleted and recreated incompletely, the directory could exist while `.package-lock.json` was missing. The hash match meant the update path skipped the install, leaving the TUI in a broken state after `hermes update`.

## Fix

Add a fast sentinel check in `_npm_lockfile_changed()`: if `node_modules/.package-lock.json` is missing, treat the lockfile as **changed** and force a reinstall. This mirrors the existing check in `_tui_need_npm_install()` (in `main.py`), which already uses `.package-lock.json` as a completeness sentinel for the TUI launch path.

### Changed file
- `hermes_cli/update_cmd.py`: 5 lines added in `_npm_lockfile_changed()`
