### PR TITLE
[codex] add per-instance API retry override

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -530,9 +530,10 @@ def init_agent(
         api_mode (str): API mode override: "chat_completions" or "codex_responses"
         model (str): Model name to use (default: "anthropic/claude-opus-4.6")
         max_iterations (int): Maximum number of tool calling iterations (default: 90)
-        api_max_retries (int | None): Per-instance total provider-attempt
-            ceiling. None uses agent.api_max_retries from config or the legacy
-            default of 3.
+        api_max_retries (int | None): A positive explicit value is a strict
+            per-instance total provider-attempt ceiling. None uses
+            agent.api_max_retries from config or the legacy default of 3,
+            including existing provider-specific retry policies.
         enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
         disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
         save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
@@ -1814,7 +1815,8 @@ def init_agent(
     # App-level API attempt count (wraps each model API call). An explicit
     # constructor value is instance-local and takes precedence without
     # mutating shared config. None preserves the existing config/default path.
-    if api_max_retries is not None:
+    agent._api_max_retries_is_explicit = api_max_retries is not None
+    if agent._api_max_retries_is_explicit:
         agent._api_max_retries = api_max_retries
     else:
         try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -517,6 +517,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    api_max_retries: int | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -529,6 +530,9 @@ def init_agent(
         api_mode (str): API mode override: "chat_completions" or "codex_responses"
         model (str): Model name to use (default: "anthropic/claude-opus-4.6")
         max_iterations (int): Maximum number of tool calling iterations (default: 90)
+        api_max_retries (int | None): Per-instance total provider-attempt
+            ceiling. None uses agent.api_max_retries from config or the legacy
+            default of 3.
         enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
         disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
         save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
@@ -567,6 +571,12 @@ def init_agent(
             identity even when skip_context_files=True. Project context files from the cwd
             remain skipped.
     """
+    if api_max_retries is not None:
+        if isinstance(api_max_retries, bool) or not isinstance(api_max_retries, int):
+            raise TypeError("api_max_retries must be a positive integer or None")
+        if api_max_retries <= 0:
+            raise ValueError("api_max_retries must be a positive integer")
+
     _install_safe_stdio()
 
     agent.model = model
@@ -1801,15 +1811,19 @@ def init_agent(
         _platform_hints_cfg = {}
     agent._platform_hint_overrides = _platform_hints_cfg
 
-    # App-level API retry count (wraps each model API call).  Default 3,
-    # overridable via agent.api_max_retries in config.yaml.  See #11616.
-    try:
-        _raw_api_retries = _agent_section.get("api_max_retries", 3)
-        _api_retries = int(_raw_api_retries)
-        _api_retries = max(_api_retries, 1)  # 1 = no retry (single attempt)
-    except (TypeError, ValueError):
-        _api_retries = 3
-    agent._api_max_retries = _api_retries
+    # App-level API attempt count (wraps each model API call). An explicit
+    # constructor value is instance-local and takes precedence without
+    # mutating shared config. None preserves the existing config/default path.
+    if api_max_retries is not None:
+        agent._api_max_retries = api_max_retries
+    else:
+        try:
+            _raw_api_retries = _agent_section.get("api_max_retries", 3)
+            _api_retries = int(_raw_api_retries)
+            _api_retries = max(_api_retries, 1)  # 1 = no retry (single attempt)
+        except (TypeError, ValueError):
+            _api_retries = 3
+        agent._api_max_retries = _api_retries
 
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4335,13 +4335,18 @@ def run_conversation(
                 # `overloaded` (to spare the credential pool), but `overloaded`
                 # is excluded from `is_rate_limited` — the gate for the adaptive
                 # Z.AI backoff below. Detect the overload directly so its
-                # long-backoff schedule runs, and raise the retry ceiling so the
-                # long tier (30/60/90/120s) is reachable. See
-                # zai_coding_overload_retry_ceiling() for the ceiling rationale.
+                # long-backoff schedule runs. Configuration/default instances
+                # retain the legacy ceiling extension that makes the long tier
+                # (30/60/90/120s) reachable, but a positive constructor override
+                # is a strict per-instance total-attempt ceiling. See
+                # zai_coding_overload_retry_ceiling() for the extension rationale.
                 _is_zai_coding_overload = is_zai_coding_overload_error(
                     base_url=str(_base), model=_model, error=api_error
                 )
-                if _is_zai_coding_overload:
+                if (
+                    _is_zai_coding_overload
+                    and not getattr(agent, "_api_max_retries_is_explicit", False)
+                ):
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
                 _should_fallback = (
                     is_rate_limited

--- a/run_agent.py
+++ b/run_agent.py
@@ -503,6 +503,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        api_max_retries: int | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -586,6 +587,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            api_max_retries=api_max_retries,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/run_agent/test_api_max_retries_config.py
+++ b/tests/run_agent/test_api_max_retries_config.py
@@ -1,20 +1,29 @@
-"""Tests for agent.api_max_retries config surface.
+"""Tests for the AIAgent and config api_max_retries surfaces.
 
 Closes #11616 — make the hardcoded ``max_retries = 3`` in the agent's API
 retry loop user-configurable so fallback-provider setups can fail over
 faster on flaky primaries instead of burning ~3x180s on the same stall.
 """
-from unittest.mock import patch
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from run_agent import AIAgent
 
 
-def _make_agent(api_max_retries=None):
-    """Build an AIAgent with a mocked config.load_config that returns a
-    config tree containing the given agent.api_max_retries (or default)."""
-    cfg = {"agent": {}}
-    if api_max_retries is not None:
-        cfg["agent"]["api_max_retries"] = api_max_retries
+_UNSET = object()
+
+
+def _make_agent(*, config_api_max_retries=_UNSET, api_max_retries=_UNSET, cfg=None):
+    """Build an isolated AIAgent without provider or filesystem access."""
+    cfg = cfg if cfg is not None else {"agent": {}}
+    if config_api_max_retries is not _UNSET:
+        cfg["agent"]["api_max_retries"] = config_api_max_retries
+
+    kwargs = {}
+    if api_max_retries is not _UNSET:
+        kwargs["api_max_retries"] = api_max_retries
 
     with patch("run_agent.OpenAI"), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
@@ -26,7 +35,30 @@ def _make_agent(api_max_retries=None):
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
+            **kwargs,
         )
+
+
+def _run_retryable_failure(api_max_retries):
+    agent = _make_agent(api_max_retries=api_max_retries)
+    agent.client = MagicMock()
+    error = Exception("upstream unavailable")
+    error.status_code = 500
+    agent.client.chat.completions.create.side_effect = error
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+
+    with patch.object(agent, "_persist_session"), \
+         patch.object(agent, "_save_trajectory"), \
+         patch.object(agent, "_cleanup_task_resources"), \
+         patch.object(agent, "_try_recover_primary_transport", return_value=False), \
+         patch("agent.conversation_loop.jittered_backoff", return_value=0.0):
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    return agent.client.chat.completions.create.call_count
 
 
 def test_default_api_max_retries_is_three():
@@ -37,12 +69,93 @@ def test_default_api_max_retries_is_three():
 
 def test_api_max_retries_honors_config_override():
     """Setting agent.api_max_retries in config propagates to the agent."""
-    agent = _make_agent(api_max_retries=1)
+    agent = _make_agent(config_api_max_retries=1)
     assert agent._api_max_retries == 1
 
-    agent2 = _make_agent(api_max_retries=5)
+    agent2 = _make_agent(config_api_max_retries=5)
     assert agent2._api_max_retries == 5
 
 
+def test_explicit_none_preserves_config_override():
+    agent = _make_agent(config_api_max_retries=4, api_max_retries=None)
+    assert agent._api_max_retries == 4
+
+
+def test_explicit_api_max_retries_overrides_config_without_mutation():
+    cfg = {"agent": {"api_max_retries": 5}}
+    original = deepcopy(cfg)
+
+    agent = _make_agent(api_max_retries=2, cfg=cfg)
+
+    assert agent._api_max_retries == 2
+    assert cfg == original
+
+
+def test_public_constructor_forwards_api_max_retries_unchanged():
+    with patch("agent.agent_init.init_agent") as init_agent:
+        AIAgent(api_max_retries=2)
+
+    assert init_agent.call_args.kwargs["api_max_retries"] == 2
+
+
+@pytest.mark.parametrize(
+    ("value", "error_type"),
+    [
+        (True, TypeError),
+        (False, TypeError),
+        (1.5, TypeError),
+        ("2", TypeError),
+        (0, ValueError),
+        (-1, ValueError),
+    ],
+)
+def test_invalid_explicit_api_max_retries_fails_before_provider_construction(
+    value, error_type
+):
+    with patch("run_agent.OpenAI") as openai:
+        with pytest.raises(error_type, match="api_max_retries"):
+            AIAgent(api_max_retries=value)
+
+    openai.assert_not_called()
+
+
+def test_explicit_one_is_one_total_provider_attempt():
+    assert _run_retryable_failure(1) == 1
+
+
+def test_explicit_two_is_two_total_provider_attempts():
+    assert _run_retryable_failure(2) == 2
+
+
+def test_non_retryable_failure_remains_single_attempt():
+    agent = _make_agent(api_max_retries=2)
+    agent.client = MagicMock()
+    error = Exception("invalid request")
+    error.status_code = 400
+    agent.client.chat.completions.create.side_effect = error
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+
+    with patch.object(agent, "_persist_session"), \
+         patch.object(agent, "_save_trajectory"), \
+         patch.object(agent, "_cleanup_task_resources"):
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_retry_override_is_isolated_between_instances_and_non_persistent():
+    cfg = {"agent": {"api_max_retries": 7}}
+    original = deepcopy(cfg)
+
+    agent_one = _make_agent(api_max_retries=1, cfg=cfg)
+    agent_two = _make_agent(api_max_retries=2, cfg=cfg)
+
+    assert agent_one._api_max_retries == 1
+    assert agent_two._api_max_retries == 2
+    assert cfg == original
 
 

--- a/tests/run_agent/test_api_max_retries_config.py
+++ b/tests/run_agent/test_api_max_retries_config.py
@@ -61,8 +61,52 @@ def _run_retryable_failure(api_max_retries):
     return agent.client.chat.completions.create.call_count
 
 
+def _zai_overload_error():
+    error = Exception(
+        "The service may be temporarily overloaded, please try again later"
+    )
+    error.status_code = 429
+    error.body = {
+        "error": {
+            "code": "1305",
+            "message": "The service may be temporarily overloaded, please try again later",
+        }
+    }
+    return error
+
+
+def _run_zai_overload_failure(
+    *, api_max_retries=_UNSET, config_api_max_retries=_UNSET
+):
+    agent = _make_agent(
+        api_max_retries=api_max_retries,
+        config_api_max_retries=config_api_max_retries,
+    )
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent.model = "glm-5.2"
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = _zai_overload_error()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+
+    with patch.object(agent, "_persist_session"), \
+         patch.object(agent, "_save_trajectory"), \
+         patch.object(agent, "_cleanup_task_resources"), \
+         patch.object(agent, "_try_recover_primary_transport", return_value=False), \
+         patch(
+             "agent.conversation_loop.adaptive_rate_limit_backoff",
+             return_value=(0.0, "zai_coding_overload_short"),
+         ) as adaptive_backoff:
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    return agent.client.chat.completions.create.call_count, adaptive_backoff.call_count
+
+
 def test_default_api_max_retries_is_three():
-    """No config override → legacy default of 3 retries preserved."""
+    """No config override → legacy base of three total attempts preserved."""
     agent = _make_agent()
     assert agent._api_max_retries == 3
 
@@ -127,6 +171,35 @@ def test_explicit_two_is_two_total_provider_attempts():
     assert _run_retryable_failure(2) == 2
 
 
+@pytest.mark.parametrize(("api_max_retries", "expected_calls"), [(1, 1), (2, 2)])
+def test_explicit_api_max_retries_is_strict_for_zai_overload(
+    api_max_retries, expected_calls
+):
+    provider_calls, backoff_calls = _run_zai_overload_failure(
+        api_max_retries=api_max_retries
+    )
+
+    assert provider_calls == expected_calls
+    assert backoff_calls == expected_calls - 1
+
+
+@pytest.mark.parametrize(
+    "api_max_retries",
+    [pytest.param(_UNSET, id="omitted"), pytest.param(None, id="none")],
+)
+def test_config_path_preserves_zai_overload_ceiling_extension(api_max_retries):
+    from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+    provider_calls, backoff_calls = _run_zai_overload_failure(
+        api_max_retries=api_max_retries,
+        config_api_max_retries=1,
+    )
+    expected_ceiling = zai_coding_overload_retry_ceiling()
+
+    assert provider_calls == expected_ceiling
+    assert backoff_calls == expected_ceiling - 1
+
+
 def test_non_retryable_failure_remains_single_attempt():
     agent = _make_agent(api_max_retries=2)
     agent.client = MagicMock()
@@ -157,5 +230,3 @@ def test_retry_override_is_isolated_between_instances_and_non_persistent():
     assert agent_one._api_max_retries == 1
     assert agent_two._api_max_retries == 2
     assert cfg == original
-
-

--- a/website/docs/guides/python-library.md
+++ b/website/docs/guides/python-library.md
@@ -315,15 +315,19 @@ print(review)
 | `api_key` | `str` | `None` | API key (falls back to env vars) |
 | `base_url` | `str` | `None` | Custom API endpoint URL |
 | `platform` | `str` | `None` | Platform hint (`"discord"`, `"telegram"`, etc.) |
-| `api_max_retries` | `int \| None` | `None` | Per-instance total provider-attempt ceiling |
+| `api_max_retries` | `int \| None` | `None` | Strict total provider-attempt ceiling when explicitly set |
 
 `api_max_retries=None` (or omitting the parameter) preserves the existing
-`agent.api_max_retries` configuration behavior and legacy default. An explicit
-positive integer takes precedence for that `AIAgent` instance: `1` means one
-total provider attempt with no same-provider retry. The override is
-instance-local and is not written to configuration or environment state.
-Booleans, non-integers, zero, and negative values are rejected during
-initialization before a provider client is constructed.
+`agent.api_max_retries` configuration behavior, legacy default, and existing
+provider-specific retry policies. This includes the narrow Z.AI Coding Plan
+GLM-5.2 overload policy, which may extend the configuration/default attempt
+budget. An explicit positive integer behaves differently: it is a strict
+total provider-attempt ceiling for that `AIAgent` instance, and
+provider-specific policies cannot raise it. Explicit `1` means exactly one
+provider attempt. The override is instance-local and is not written to
+configuration or environment state. Booleans, non-integers, zero, and negative
+values are rejected during initialization before a provider client is
+constructed.
 
 ---
 

--- a/website/docs/guides/python-library.md
+++ b/website/docs/guides/python-library.md
@@ -315,6 +315,15 @@ print(review)
 | `api_key` | `str` | `None` | API key (falls back to env vars) |
 | `base_url` | `str` | `None` | Custom API endpoint URL |
 | `platform` | `str` | `None` | Platform hint (`"discord"`, `"telegram"`, etc.) |
+| `api_max_retries` | `int \| None` | `None` | Per-instance total provider-attempt ceiling |
+
+`api_max_retries=None` (or omitting the parameter) preserves the existing
+`agent.api_max_retries` configuration behavior and legacy default. An explicit
+positive integer takes precedence for that `AIAgent` instance: `1` means one
+total provider attempt with no same-provider retry. The override is
+instance-local and is not written to configuration or environment state.
+Booleans, non-integers, zero, and negative values are rejected during
+initialization before a provider client is constructed.
 
 ---
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -901,12 +901,14 @@ Instead, when the budget is actually exhausted (500/500), Hermes injects one mes
 ```yaml
 agent:
   max_turns: 500               # Max iterations per conversation turn (default: 500)
-  api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+  api_max_retries: 3           # Base provider attempts before fallback (default: 3; minimum: 1)
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (500/500) — response may be incomplete`.
 
-`agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+`agent.api_max_retries` is the app-level base total provider-attempt count for calls that enter the transient retry path (for example, connection drops and 5xx responses) before exhaustion handling. On the normal path, the default `3` means up to three app-level provider attempts, not four. The effective minimum is `1`: configuration values below `1`, including `0`, are floored to `1`, so `0` does not cause immediate failover before a provider attempt.
+
+The narrow Z.AI Coding Plan GLM-5.2 overload policy (HTTP 429 with code 1305 or the matching temporary-overload message) may extend this attempt budget when Hermes is using the configuration/default path so its adaptive backoff schedule remains reachable. A positive `AIAgent(api_max_retries=N)` constructor value is different: it is a strict per-instance total provider-attempt ceiling that provider-specific retry policies cannot raise. Existing fallback behavior after the applicable attempt budget is exhausted remains unchanged.
 
 ## Verify-on-Stop (coding verification)
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -688,12 +688,14 @@ context:
 ```yaml
 agent:
   max_turns: 500               # 每次对话轮次的最大迭代次数（默认：500）
-  api_max_retries: 3           # 回退启动前每个 provider 的重试次数（默认：3）
+  api_max_retries: 3           # 回退前的 provider 基础尝试次数（默认：3；最小：1）
 ```
 
 当迭代预算完全耗尽时，CLI 向用户显示通知：`⚠ Iteration budget reached (500/500) — response may be incomplete`。
 
-`agent.api_max_retries` 控制 Hermes 在回退 provider 切换启动**之前**对瞬时错误（速率限制、连接断开、5xx）重试 provider API 调用的次数。默认为 `3` —— 总共四次尝试。如果您配置了[回退 providers](/user-guide/features/fallback-providers) 并希望更快地故障转移，请将其降至 `0`，这样主 provider 上的第一个瞬时错误会立即切换到回退，而不是对不稳定的端点进行重试。
+`agent.api_max_retries` 是进入瞬时错误重试路径（例如连接断开和 5xx 响应）的 API 调用在耗尽处理前的应用层 provider 基础总尝试次数。在普通路径中，默认值 `3` 表示最多进行三次应用层 provider 尝试，而不是四次。有效最小值为 `1`：低于 `1` 的配置值（包括 `0`）会被提高到 `1`，因此 `0` 不会在进行一次 provider 尝试之前立即触发回退。
+
+仅对 Z.AI Coding Plan GLM-5.2 过载策略（HTTP 429 且错误码为 1305，或匹配的临时过载消息），当 Hermes 使用配置/默认路径时，可能扩展该尝试预算，以保证其自适应退避调度可达。显式传入的正整数 `AIAgent(api_max_retries=N)` 构造参数不同：它是该实例严格的 provider 总尝试上限，provider 特定的重试策略不能提高此上限。在适用的尝试预算耗尽后，现有回退行为保持不变。
 
 ### API 超时
 


### PR DESCRIPTION
## Summary

Expose `api_max_retries: int | None = None` on the public `AIAgent` constructor while preserving the distinction between an explicit instance override and the existing configuration/default path.

A positive explicit constructor value is a strict per-instance total provider-attempt ceiling. Explicit `1` means exactly one provider attempt; explicit `2` permits at most two. Provider-specific policies, including the narrow Z.AI Coding Plan GLM-5.2 overload policy, cannot raise that explicit ceiling.

Omitted or `None` retains existing configuration resolution, the legacy default, and provider-specific retry extensions. No configuration or environment state is mutated. Existing failure classification, fallback, credential-pool behavior, and backoff matching remain unchanged.

## Review correction lineage

### Prior failed candidate

- Commit: `7191bab895177b43569f3ed91ee02eb266be92e6`
- Tree: `83d190b27d1d09c304d0a07cb2a43550c741e68f`
- Sole parent: `536754919d433f1da96990642d40f6d3395e9db6`
- Tier 2 result: failed on Major M1 because public configuration documentation contradicted runtime attempt-count semantics.
- Linked acceptance defect: the Z.AI overload path could raise an explicit constructor ceiling.

### Corrected exact candidate

- Commit: `3ef9e740f5e7d9f259ba50c824c1d60414b305a5`
- Tree: `12389400e8b493e46548bbb6d15e063d4c4304fa`
- Sole parent: `7191bab895177b43569f3ed91ee02eb266be92e6`
- Branch: `alphathetacoding:fix/public-api-max-retries-override`
- Current upstream observed during correction: `15cb86eba3fec5541ac57b7073d9a7e1b55ad3d2` (tree `201c5022d856ef0d8ab3609e296d49624a374be1`)

The 12 upstream commits after the working base do not touch the public constructor, agent initialization, retry-loop ceiling logic, Z.AI retry policy, affected tests, or `api_max_retries` public documentation. The correction was therefore applied without rebasing.

## Correction summary

- Preserve explicit-constructor intent in one instance-local boolean.
- Prevent the Z.AI overload policy from raising an explicit constructor ceiling.
- Preserve the existing Z.AI ceiling extension for omitted/`None` configuration-driven instances.
- Add mocked provider-call proofs for explicit `1`, explicit `2`, omitted, and `None` Z.AI paths.
- Correct the Python-library guide plus English and Chinese configuration documentation.
- Correct the changed test wording from “3 retries” to three total app-level attempts.

## Exact changed paths

- `agent/agent_init.py`
- `agent/conversation_loop.py`
- `run_agent.py`
- `tests/run_agent/test_api_max_retries_config.py`
- `website/docs/guides/python-library.md`
- `website/docs/user-guide/configuration.md`
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md`

## Targeted validation

All Python tests ran through `scripts/run_tests.sh` using the isolated task venv. Provider calls and backoff waits were mocked.

- `scripts/run_tests.sh tests/run_agent/test_api_max_retries_config.py -q` — 19 passed
- `scripts/run_tests.sh tests/test_retry_utils.py -q` — 11 passed
- `scripts/run_tests.sh tests/run_agent/test_32646_fallback_429_after_timeout.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_init_fallback_on_exhausted_pool.py tests/run_agent/test_63425_credential_pool_auto_detect.py -q` — 22 passed
- `scripts/run_tests.sh tests/run_agent/test_notice_spine.py -k test_agent_init_exposes_notice_callback -q` — 1 passed
- `scripts/run_tests.sh tests/run_agent/test_callable_api_key.py -k 'test_callable_api_key_passed_to_openai_constructor or test_callable_api_key_survives_normalization or test_string_api_key_still_works' -q` — 3 passed
- Total targeted tests — 56 passed, 0 failed
- Isolated `py_compile` for `agent/agent_init.py`, `agent/conversation_loop.py`, `run_agent.py`, and `tests/run_agent/test_api_max_retries_config.py` — passed
- `ruff check` on those changed Python files — passed
- `git diff --check` — passed
- Exact changed-path inspection — passed (7 authorized paths)
- Public documentation searches found no remaining claim that default 3 means four attempts total or that setting/dropping `api_max_retries` to 0 causes immediate failover
- Docusaurus build not run because `website/node_modules` is absent

No live provider or credential access occurred.

## Bounded interface audit

- `fallback_model=None` remains an authoritative instance opt-out: initialization creates an empty fallback chain and no later initialization path repopulates it.
- `credential_pool=None` is not an authoritative opt-out: initialization can still resolve credentials through pool-backed provider helpers, and `agent/chat_completion_helpers.py` can attach a provider pool during fallback activation. This correction intentionally does not implement a credential-pool opt-out and does not change that behavior.

## Remaining non-blocking findings

- No remaining non-blocking correctness finding was introduced by the correction.
- The optional Docusaurus build remains unrun because website dependencies are unavailable in the clean task checkout.
- The pre-existing `credential_pool=None` audit conclusion above remains out of scope and unchanged.

## Review state

Author self-review found zero Blockers and zero Majors against the original P8-RR-05A1 contract, Major M1, the strict explicit-instance ceiling, legacy Z.AI configuration/default behavior, documentation consistency, backward compatibility, and forbidden effects.

This PR intentionally remains draft. The corrected exact candidate is ready for same-reviewer focused confirmation; it has not been marked ready and must not be merged from this correction task.
