### PR TITLE
fix(skills): research-paper-writing was hidden by a toolset typo

### DIFF
--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]
     category: research
     related_skills: [arxiv, subagent-driven-development, plan]
-    requires_toolsets: [terminal, files]
+    requires_toolsets: [terminal, file]
 
 ---
 

--- a/tests/agent/test_skill_toolset_names.py
+++ b/tests/agent/test_skill_toolset_names.py
@@ -1,0 +1,112 @@
+"""Guard: skill frontmatter must reference real toolset names.
+
+`requires_toolsets` / `fallback_for_toolsets` are matched by exact string against
+the toolsets a tool registered with (`registry.register(..., toolset="file")`).
+A typo does not raise and is not reported anywhere — `_skill_should_show()` simply
+finds the name absent from the available set and hides the skill *unconditionally*,
+on every platform, for every user. The skill silently stops existing.
+
+That is what happened to `research-paper-writing`, which declared
+`requires_toolsets: [terminal, files]`. The registered toolset is `file`
+(singular, `tools/file_tools.py`), so the skill could never appear:
+
+    >>> _skill_should_show({"requires_toolsets": ["terminal", "file"]},  set(), {"terminal", "file", "web"})
+    True
+    >>> _skill_should_show({"requires_toolsets": ["terminal", "files"]}, set(), {"terminal", "file", "web"})
+    False
+
+This is a behaviour contract, not a snapshot: valid names are DISCOVERED from the
+`registry.register(...)` calls rather than frozen in a literal, so adding or
+renaming a toolset cannot make this test stale, and it fails only on a name that
+no tool actually registers.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_DIR = REPO_ROOT / "tools"
+SKILLS_DIR = REPO_ROOT / "skills"
+
+TOOLSET_KEYS = ("requires_toolsets", "fallback_for_toolsets")
+
+# registry.register(name="read_file", toolset="file", ...) — the call is often
+# spread over multiple lines, hence DOTALL and the non-greedy prefix.
+_REGISTER_TOOLSET = re.compile(
+    r"registry\.register\([^)]*?toolset\s*=\s*[\"\']([a-z_][a-z0-9_]*)[\"\']",
+    re.DOTALL,
+)
+
+
+def _registered_toolsets() -> set[str]:
+    """Toolset names some tool actually registers under.
+
+    Scanned statically rather than by importing every tool module: several carry
+    optional third-party dependencies, and a test that silently skips when an
+    import fails would stop guarding anything.
+    """
+    names: set[str] = set()
+    for py in sorted(TOOLS_DIR.glob("*.py")):
+        names.update(_REGISTER_TOOLSET.findall(py.read_text(encoding="utf-8")))
+    return names
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8-sig")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    try:
+        data = yaml.safe_load(text[3:end])
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _declared_toolsets(path: Path) -> list[tuple[str, str]]:
+    """[(frontmatter_key, toolset_name)] declared by one SKILL.md."""
+    fm = _frontmatter(path)
+    hermes = ((fm.get("metadata") or {}).get("hermes") or {}) if isinstance(fm, dict) else {}
+    out: list[tuple[str, str]] = []
+    for source in (fm, hermes):
+        if not isinstance(source, dict):
+            continue
+        for key in TOOLSET_KEYS:
+            value = source.get(key)
+            if isinstance(value, str):
+                value = [v.strip() for v in value.split(",") if v.strip()]
+            if isinstance(value, list):
+                out.extend((key, str(v)) for v in value)
+    return out
+
+
+def test_toolset_scan_finds_the_known_toolsets():
+    """The scan itself must work, or the guard below passes vacuously."""
+    registered = _registered_toolsets()
+    assert "file" in registered, f"static scan failed to find the file toolset: {sorted(registered)}"
+    assert "web" in registered
+    assert len(registered) > 5, f"suspiciously few toolsets discovered: {sorted(registered)}"
+    # The specific typo this test exists to catch is not a real toolset.
+    assert "files" not in registered
+
+
+@pytest.mark.parametrize(
+    "skill_file",
+    sorted(SKILLS_DIR.rglob("SKILL.md")),
+    ids=lambda p: str(p.relative_to(SKILLS_DIR).parent) if isinstance(p, Path) else str(p),
+)
+def test_bundled_skill_toolsets_are_real(skill_file: Path):
+    registered = _registered_toolsets()
+    for key, name in _declared_toolsets(skill_file):
+        assert name in registered, (
+            f"{skill_file.relative_to(REPO_ROOT)}: {key} references unknown toolset "
+            f"{name!r}. A name no tool registers hides the skill unconditionally "
+            f"(see _skill_should_show). Registered: {sorted(registered)}"
+        )


### PR DESCRIPTION
`research-paper-writing` declared `requires_toolsets: [terminal, files]`. The registered toolset is `file` (singular) — `tools/file_tools.py` calls `registry.register(..., toolset="file")`. There is no `files` toolset, so `_skill_should_show()` found the name absent from the available set and hid the skill unconditionally, on every platform, for every user:

    _skill_should_show({"requires_toolsets": ["terminal", "file"]},
                       set(), {"terminal", "file", "web"})   -> True
    _skill_should_show({"requires_toolsets": ["terminal", "files"]},
                       set(), {"terminal", "file", "web"})   -> False

The skill has been in the bundle but unreachable. Nothing surfaced it: a typo here does not raise, is not logged, and is not validated anywhere, so the only symptom is a skill that silently does not exist.

Also add a guard so the whole class cannot recur. Valid toolset names are DISCOVERED from the `registry.register(..., toolset=...)` call sites rather than frozen in a literal, so the test asserts a behaviour contract instead of a snapshot: adding or renaming a toolset cannot make it stale, and it fails only on a name no tool actually registers. It covers both `requires_toolsets` and `fallback_for_toolsets`, at the top level and under `metadata.hermes`.

The scan is static rather than importing every tool module: several carry optional third-party dependencies, and a guard that silently skips on an ImportError would stop guarding anything. A companion test asserts the scan itself found the known toolsets, so it cannot pass vacuously.

Verification: 71 skills pass. Negative controls — restoring the typo fails exactly `[research/research-paper-writing]` with a message naming the file and listing valid toolsets; breaking the scan fails the sanity test plus the two skills that declare toolsets, rather than passing green.

Note the guard also covers `productivity/maps` (declares `[terminal]`), which is correct today and stays passing.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

