### PR TITLE
fix(setup): explain Matrix availability on Windows

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6394,6 +6394,23 @@ def _configure_platform(platform: dict) -> None:
         print_info(f"  {platform['install_hint']}")
 
 
+def _is_setup_progress(status: str) -> bool:
+    """Whether a platform status means the user made meaningful progress.
+
+    Used by the post-setup gateway install/restart offer so that rows which
+    exist only to explain why a platform cannot be configured (e.g. Matrix's
+    ``unavailable on this OS`` placeholder on native Windows) are never
+    treated as setup progress.
+    """
+    s = status.lower()
+    return not (
+        s == "not configured"
+        or s.startswith("partially")
+        or s.startswith("plugin disabled")
+        or s.startswith("unavailable")
+    )
+
+
 def gateway_setup():
     """Interactive setup for messaging platforms + gateway service."""
     if is_managed():
@@ -6501,16 +6518,10 @@ def gateway_setup():
     # Consider any platform (built-in or plugin) where the user has made
     # meaningful progress.  ``_platform_status`` already handles plugin
     # entries via their check_fn and per-platform dual-states like
-    # WhatsApp's "enabled, not paired".
-    def _is_progress(status: str) -> bool:
-        s = status.lower()
-        return not (
-            s == "not configured"
-            or s.startswith("partially")
-            or s.startswith("plugin disabled")
-        )
-
-    any_configured = any(_is_progress(_platform_status(p)) for p in _all_platforms())
+    # WhatsApp's "enabled, not paired". Rows that merely explain why a
+    # platform cannot be configured (Matrix's ``unavailable on this OS``
+    # placeholder on native Windows) never count as progress.
+    any_configured = any(_is_setup_progress(_platform_status(p)) for p in _all_platforms())
 
     if any_configured:
         print()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5363,6 +5363,25 @@ _PLATFORMS = [
 ]
 
 
+_WINDOWS_MATRIX_UNAVAILABLE_REASON = (
+    "Matrix setup is unavailable on native Windows because the encrypted Matrix "
+    "client dependency (python-olm) has no Windows wheel. Run Hermes in WSL to "
+    "configure Matrix."
+)
+
+
+def _windows_matrix_placeholder(entry=None) -> dict:
+    """Return the disabled Matrix setup row shown on native Windows."""
+    return {
+        "key": "matrix",
+        "label": getattr(entry, "label", "Matrix"),
+        "emoji": getattr(entry, "emoji", "🔐"),
+        "token_var": "MATRIX_ACCESS_TOKEN",
+        "unavailable_reason": _WINDOWS_MATRIX_UNAVAILABLE_REASON,
+        "_registry_entry": entry,
+    }
+
+
 def _all_platforms() -> list[dict]:
     """Return the full list of platforms for setup menus.
 
@@ -5375,12 +5394,11 @@ def _all_platforms() -> list[dict]:
 
     Platform-specific gating: some platforms can't be configured on
     every host. Currently:
-      - Matrix is hidden on Windows. The [matrix] extra pulls
+      - Matrix is visible but disabled on Windows. The [matrix] extra pulls
         ``mautrix[encryption]`` -> ``python-olm``, which has no Windows
         wheel and needs ``make`` + libolm to build from sdist. There's
-        no native Windows path that works, so we don't offer it in the
-        picker. Users who want Matrix on Windows can run hermes under
-        WSL.
+        no native Windows path that works, so the picker explains that users
+        who want Matrix on Windows can run hermes under WSL.
     """
     # Populate the registry so plugin platforms are visible. Idempotent.
     # Bundled platform plugins (``kind: platform``) auto-load unconditionally,
@@ -5396,9 +5414,11 @@ def _all_platforms() -> list[dict]:
 
     platforms = [dict(p) for p in _PLATFORMS]
 
-    # Drop platforms that can't function on this host. See docstring.
-    if sys.platform == "win32":
-        platforms = [p for p in platforms if p.get("key") != "matrix"]
+    # Keep platforms that can't function on this host visible when the absence
+    # would be confusing, but mark them unavailable so selecting the row gives
+    # an actionable explanation instead of attempting setup. See docstring.
+    if sys.platform == "win32" and not any(p.get("key") == "matrix" for p in platforms):
+        platforms.append(_windows_matrix_placeholder())
 
     by_key = {p["key"]: p for p in platforms}
 
@@ -5410,10 +5430,12 @@ def _all_platforms() -> list[dict]:
     for entry in platform_registry.all_entries():
         if entry.name in by_key:
             continue  # built-in already covers it
-        # Drop platforms that can't function on this host. Matrix is hidden on
-        # Windows (python-olm has no Windows wheel) — applies whether matrix is
-        # a built-in or, post-#41112, a registry-discovered plugin.
+        # Matrix cannot function on native Windows (python-olm has no Windows
+        # wheel), but keep it visible with an unavailable status so users know
+        # why the setup target exists in docs yet cannot be configured here.
         if sys.platform == "win32" and entry.name == "matrix":
+            by_key[entry.name] = _windows_matrix_placeholder(entry)
+            platforms = [by_key[p["key"]] if p.get("key") == entry.name else p for p in platforms]
             continue
         platforms.append(
             {
@@ -5434,6 +5456,9 @@ def _platform_status(platform: dict) -> str:
     Returns uncolored text so it can safely be embedded in
     curses menu items (ANSI codes break width calculation).
     """
+    if platform.get("unavailable_reason"):
+        return "unavailable on this OS"
+
     entry = platform.get("_registry_entry")
     if entry is not None:
         configured = False
@@ -6327,6 +6352,17 @@ def _configure_platform(platform: dict) -> None:
     is needed here. User-installed platform plugins under ~/.hermes/plugins/
     must already be in ``plugins.enabled`` before they appear in this menu.
     """
+    if platform.get("unavailable_reason"):
+        print()
+        print(
+            color(
+                f"  ─── {platform.get('emoji', '🔌')} {platform.get('label', platform['key'])} Setup ───",
+                Colors.CYAN,
+            )
+        )
+        print_warning(f"  {platform['unavailable_reason']}")
+        return
+
     entry = platform.get("_registry_entry")
 
     if entry is not None and entry.setup_fn is not None:

--- a/tests/hermes_cli/test_gateway_platform_gating.py
+++ b/tests/hermes_cli/test_gateway_platform_gating.py
@@ -2,18 +2,19 @@
 
 Some messaging platforms can't function on every host. The gate lives
 in one place — ``_all_platforms()`` — so the setup wizard, the curses
-gateway-config menu, and any future picker all see the same filtered
-list.
+gateway-config menu, and any future picker all see the same list.
 
 Currently:
-- Matrix is hidden on Windows. The ``[matrix]`` extra pulls
-  ``mautrix[encryption]`` -> ``python-olm``, which has no Windows wheel
-  and needs ``make`` + libolm to build from sdist. There's no native
-  Windows path that works.
+- Matrix is visible but marked ``unavailable on this OS`` on native
+  Windows. The ``[matrix]`` extra pulls ``mautrix[encryption]`` ->
+  ``python-olm``, which has no Windows wheel and needs ``make`` +
+  libolm to build from sdist. There's no native Windows path that
+  works, so the picker keeps the row with an actionable explanation
+  (pointing at WSL) instead of silently dropping it.
 """
 
 
-class TestMatrixHiddenOnWindows:
+class TestMatrixGatedOnWindows:
     def test_matrix_present_on_linux(self, monkeypatch):
         """Sanity: matrix is still in the picker on Linux/macOS."""
         import hermes_cli.gateway as gateway_mod
@@ -23,9 +24,8 @@ class TestMatrixHiddenOnWindows:
         keys = {p["key"] for p in platforms}
         assert "matrix" in keys, "matrix must be available on Linux"
 
-
     def test_other_platforms_unaffected_on_windows(self, monkeypatch):
-        """Gating must only drop matrix, not collateral damage."""
+        """Gating must only gate matrix, not collateral damage."""
         import hermes_cli.gateway as gateway_mod
 
         monkeypatch.setattr(gateway_mod.sys, "platform", "win32")
@@ -38,3 +38,62 @@ class TestMatrixHiddenOnWindows:
                 f"{must_have} disappeared from Windows picker — gate is "
                 "over-filtering"
             )
+
+
+class TestUnavailableRowsAreNotSetupProgress:
+    """The post-setup gateway offer must ignore explainer-only rows.
+
+    A row that exists purely to explain why a platform can't be
+    configured on this host (``unavailable on this OS``) must never
+    make ``any_configured`` true, otherwise the wizard offers gateway
+    installation/restart although nothing was configured.
+    """
+
+    def test_unavailable_status_is_not_progress(self):
+        import hermes_cli.gateway as gateway_mod
+
+        assert gateway_mod._is_setup_progress("unavailable on this OS") is False
+        assert gateway_mod._is_setup_progress("unavailable") is False
+
+    def test_configured_statuses_still_count_as_progress(self):
+        import hermes_cli.gateway as gateway_mod
+
+        assert gateway_mod._is_setup_progress("configured") is True
+        assert gateway_mod._is_setup_progress("enabled, not paired") is True
+
+    def test_wizard_offers_nothing_when_only_placeholder_is_present(
+        self, monkeypatch, capsys
+    ):
+        """Wizard-level: a lone unavailable placeholder must not trigger the
+        install/restart offer."""
+        import hermes_cli.gateway as gateway_mod
+
+        placeholder = gateway_mod._windows_matrix_placeholder()
+        monkeypatch.setattr(
+            gateway_mod, "_all_platforms", lambda: [placeholder]
+        )
+        monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+        monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+        # First select the Matrix row (index 0), then "Done" (index 1).
+        choices = iter([0, 1])
+        monkeypatch.setattr(gateway_mod, "prompt_choice", lambda *a, **k: next(choices))
+        # Any invocation of the install/start offer prompts is a failure:
+        # with only an unavailable row, the wizard must not offer anything.
+        offered = []
+
+        def _fail_if_offered(prompt, default=True):
+            offered.append(prompt)
+            return False
+
+        monkeypatch.setattr(gateway_mod, "prompt_yes_no", _fail_if_offered)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_mod, "is_linux", lambda: True)
+
+        gateway_mod.gateway_setup()
+
+        out = capsys.readouterr().out
+        # The unavailable row is shown with its reason…
+        assert "Matrix" in out
+        assert "native Windows" in out
+        # …but no install/start offer prompt is ever raised.
+        assert offered == [], f"wizard offered setup for unavailable-only rows: {offered}"

--- a/tests/hermes_cli/test_gateway_setup_windows_matrix.py
+++ b/tests/hermes_cli/test_gateway_setup_windows_matrix.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from hermes_cli import gateway as gateway_mod
+
+
+def test_matrix_stays_visible_but_unavailable_on_native_windows(monkeypatch):
+    monkeypatch.setattr(gateway_mod.sys, "platform", "win32")
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+
+    matrix_entry = SimpleNamespace(
+        name="matrix",
+        label="Matrix",
+        emoji="🟩",
+        required_env=["MATRIX_ACCESS_TOKEN"],
+        install_hint="",
+    )
+    monkeypatch.setattr(
+        "gateway.platform_registry.platform_registry.all_entries",
+        lambda: [matrix_entry],
+    )
+
+    matrix = next(p for p in gateway_mod._all_platforms() if p["key"] == "matrix")
+
+    assert matrix["label"] == "Matrix"
+    assert matrix["token_var"] == "MATRIX_ACCESS_TOKEN"
+    assert "python-olm" in matrix["unavailable_reason"]
+    assert gateway_mod._platform_status(matrix) == "unavailable on this OS"
+
+
+def test_selecting_windows_matrix_row_explains_wsl_path(capsys):
+    platform = gateway_mod._windows_matrix_placeholder()
+
+    gateway_mod._configure_platform(platform)
+
+    out = capsys.readouterr().out
+    assert "Matrix" in out
+    assert "native Windows" in out
+    assert "WSL" in out


### PR DESCRIPTION
Fixes #76092

## Summary
- keep Matrix visible in `hermes gateway setup` on native Windows instead of silently omitting it
- mark the Matrix row as unavailable on this OS because `python-olm` has no native Windows wheel
- show an actionable setup explanation that directs Windows users to run Hermes under WSL for Matrix

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_setup_windows_matrix.py`
- `scripts/run_tests.sh tests/hermes_cli/test_setup_matrix_e2ee.py tests/gateway/test_matrix_plugin_setup.py tests/hermes_cli/test_gateway_setup_windows_matrix.py`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_setup_windows_matrix.py`
- `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_setup_windows_matrix.py`
- `git diff --check`
