### PR TITLE
fix(telegram): include text document content in prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2238,6 +2238,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _TEXT_INJECT_EXTENSIONS,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -2591,23 +2592,83 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
-def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
-    """Context note prepended to a user turn when they attach a document.
+_MAX_INLINE_TEXT_DOCUMENT_BYTES = 100 * 1024
 
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
+_TEXT_DOCUMENT_MIME_TYPES = {
+    "application/json",
+    "application/ld+json",
+    "application/javascript",
+    "application/sql",
+    "application/toml",
+    "application/x-toml",
+    "application/xml",
+    "application/yaml",
+    "application/x-yaml",
+}
 
-    Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
-    must tell the agent to *extract* the text itself before answering — earlier
-    wording ("Ask the user what they'd like you to do with it") steered the
-    model into punting back to the user, which is why attached PDFs/DOCX looked
-    "unreadable" to the agent even though it has the tools to read them.
+
+def _is_text_document(path: str, mtype: str) -> bool:
+    """Return whether an attachment is safe to treat as UTF-8 prompt text."""
+    normalized_mtype = (mtype or "").split(";", 1)[0].strip().lower()
+    extension = Path(path).suffix.lower()
+    return (
+        normalized_mtype.startswith("text/")
+        or normalized_mtype in _TEXT_DOCUMENT_MIME_TYPES
+        or extension in _TEXT_INJECT_EXTENSIONS
+    )
+
+
+def _read_text_document_for_prompt(path: str) -> Optional[str]:
+    """Read a small UTF-8 text attachment without ever reading it unbounded."""
+    try:
+        with open(path, "rb") as document_file:
+            raw = document_file.read(_MAX_INLINE_TEXT_DOCUMENT_BYTES + 1)
+    except OSError as exc:
+        logger.warning("Could not read text document for prompt %s: %s", path, exc)
+        return None
+
+    if len(raw) > _MAX_INLINE_TEXT_DOCUMENT_BYTES:
+        logger.info(
+            "Text document exceeds prompt inline limit (%s bytes): %s",
+            _MAX_INLINE_TEXT_DOCUMENT_BYTES,
+            path,
+        )
+        return None
+
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        logger.warning("Could not decode text document as UTF-8 %s: %s", path, exc)
+        return None
+
+
+def _build_document_context_note(
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    *,
+    is_text_document: Optional[bool] = None,
+    content_inlined: bool = True,
+) -> str:
+    """Build a truthful path/content note for an attached document.
+
+    ``content_inlined`` defaults to ``True`` for compatibility with existing
+    callers. The inbound-message path passes the actual result of reading (or
+    detecting adapter-injected content), so it never claims content was included
+    when only a cached path is available.
     """
-    if mtype.startswith("text/"):
+    textual = mtype.startswith("text/") if is_text_document is None else is_text_document
+    if textual:
+        if content_inlined:
+            return (
+                f"[The user sent a text document: '{display_name}'. "
+                f"Its content has been included below. "
+                f"The file is also saved at: {agent_path}]"
+            )
         return (
             f"[The user sent a text document: '{display_name}'. "
-            f"Its content has been included below. "
-            f"The file is also saved at: {agent_path}]"
+            f"Its content was not inlined. The file is saved at: {agent_path}. "
+            f"Read it from that path before answering instead of assuming its contents.]"
         )
     return (
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
@@ -2616,6 +2677,40 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
         f"terminal tool or the ocr-and-documents skill — before answering, instead "
         f"of asking the user to paste the contents.]"
     )
+
+
+def _build_document_prompt_context(
+    *,
+    host_path: str,
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    existing_text: str,
+) -> str:
+    """Build the document note and inline small text files when needed.
+
+    Some adapters already inject text using ``[Content of <name>]:``. Detect
+    that marker to avoid duplicating the same attachment. Otherwise, use the
+    cached host path to inline any allowlisted UTF-8 document up to 100 KiB.
+    """
+    textual = _is_text_document(host_path, mtype)
+    content_marker = f"[Content of {display_name}]:"
+    already_inlined = textual and content_marker in (existing_text or "")
+    inline_content = None
+    if textual and not already_inlined:
+        inline_content = _read_text_document_for_prompt(host_path)
+
+    content_inlined = already_inlined or inline_content is not None
+    note = _build_document_context_note(
+        display_name,
+        agent_path,
+        mtype,
+        is_text_document=textual,
+        content_inlined=content_inlined,
+    )
+    if inline_content is None:
+        return note
+    return f"{note}\n\n{content_marker}\n{inline_content}"
 
 
 def _format_duration(seconds: float) -> str:
@@ -15254,7 +15349,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             import mimetypes as _mimetypes
             from tools.credential_files import to_agent_visible_cache_path
 
-            _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
             for i, path in enumerate(event.media_urls):
                 # Per-attachment document handling. Skip anything already routed
                 # as image / audio / video by the buckets above — only genuine
@@ -15272,7 +15366,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype in {"", "application/octet-stream"}:
                     _ext = os.path.splitext(path)[1].lower()
-                    if _ext in _TEXT_EXTENSIONS:
+                    if _ext in _TEXT_INJECT_EXTENSIONS:
                         mtype = "text/plain"
                     else:
                         guessed, _ = _mimetypes.guess_type(path)
@@ -15294,7 +15388,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                context_note = _build_document_context_note(display_name, agent_path, mtype)
+                context_note = _build_document_prompt_context(
+                    host_path=path,
+                    display_name=display_name,
+                    agent_path=agent_path,
+                    mtype=mtype,
+                    existing_text=event.text or "",
+                )
                 message_text = f"{context_note}\n\n{message_text}"
 
         # Discord: surface the triggering message id per-turn on the user

--- a/tests/gateway/test_text_document_prompt_context.py
+++ b/tests/gateway/test_text_document_prompt_context.py
@@ -1,0 +1,93 @@
+from gateway.run import (
+    _MAX_INLINE_TEXT_DOCUMENT_BYTES,
+    _build_document_prompt_context,
+    _is_text_document,
+)
+
+
+def _context(path, *, name="sample.csv", mime="text/csv", existing_text=""):
+    return _build_document_prompt_context(
+        host_path=str(path),
+        display_name=name,
+        agent_path=f"/root/.hermes/cache/documents/{name}",
+        mtype=mime,
+        existing_text=existing_text,
+    )
+
+
+def test_csv_content_is_inlined_from_cached_file(tmp_path):
+    document = tmp_path / "sample.csv"
+    document.write_text("name,value\nalice,42\n", encoding="utf-8")
+
+    context = _context(document)
+
+    assert "Its content has been included below" in context
+    assert "[Content of sample.csv]:" in context
+    assert "name,value\nalice,42" in context
+
+
+def test_application_json_is_treated_as_text(tmp_path):
+    document = tmp_path / "sample.json"
+    document.write_text('{"ok": true}', encoding="utf-8")
+
+    assert _is_text_document(str(document), "application/json") is True
+    assert '{"ok": true}' in _context(
+        document,
+        name="sample.json",
+        mime="application/json",
+    )
+
+
+def test_utf8_bom_is_removed_before_inlining(tmp_path):
+    document = tmp_path / "sample.csv"
+    document.write_bytes(b"\xef\xbb\xbfcolumn\nvalue\n")
+
+    context = _context(document)
+
+    assert "\ufeff" not in context
+    assert "column\nvalue" in context
+
+
+def test_adapter_injected_content_is_not_duplicated(tmp_path):
+    document = tmp_path / "sample.csv"
+    document.write_text("name,value\nalice,42\n", encoding="utf-8")
+    existing = "[Content of sample.csv]:\nname,value\nalice,42"
+
+    context = _context(document, existing_text=existing)
+
+    assert "Its content has been included below" in context
+    assert "[Content of sample.csv]:" not in context
+    assert "name,value" not in context
+
+
+def test_oversized_text_document_uses_truthful_path_only_note(tmp_path):
+    document = tmp_path / "sample.csv"
+    document.write_bytes(b"x" * (_MAX_INLINE_TEXT_DOCUMENT_BYTES + 1))
+
+    context = _context(document)
+
+    assert "Its content was not inlined" in context
+    assert "Its content has been included below" not in context
+    assert "[Content of sample.csv]:" not in context
+    assert "/root/.hermes/cache/documents/sample.csv" in context
+
+
+def test_non_utf8_text_document_uses_truthful_path_only_note(tmp_path):
+    document = tmp_path / "sample.csv"
+    document.write_bytes(b"\xff\xfe\x00\x01")
+
+    context = _context(document)
+
+    assert "Its content was not inlined" in context
+    assert "Its content has been included below" not in context
+
+
+def test_binary_document_keeps_extraction_guidance(tmp_path):
+    document = tmp_path / "sample.pdf"
+    document.write_bytes(b"%PDF-1.7\n")
+
+    context = _context(document, name="sample.pdf", mime="application/pdf")
+
+    assert "Its text is not inlined here" in context
+    assert "extract the document's text yourself" in context
+    assert "[Content of sample.pdf]:" not in context


### PR DESCRIPTION
## Summary

- inline small allowlisted UTF-8 document attachments from the cached file before the inbound message reaches the model
- reuse the gateway's shared text-extension allowlist and recognize textual `application/*` MIME types such as JSON, XML, YAML, and TOML
- avoid duplicating content that a platform adapter has already injected
- keep the existing 100 KiB safety limit and emit a truthful path-only note when a file is too large, unreadable, or not valid UTF-8
- add regression coverage for CSV, JSON, UTF-8 BOM, pre-injected content, oversized files, decode failures, and binary documents

## Problem

A Telegram text document such as a CSV can be downloaded and cached successfully while the gateway only prepends a note saying its content was included. When the adapter did not actually inject the document body, the model receives no data and can answer as though it had read content that was never present.

This change makes the gateway verify and perform the inlining itself for safe text files. The prompt note now reflects what actually happened.

## Testing

```bash
scripts/run_tests.sh tests/gateway/test_text_document_prompt_context.py
```

The added tests cover:

- cached CSV content reaches the prompt
- textual `application/json` files are recognized
- UTF-8 BOM removal
- no duplicate content when an adapter already injected it
- truthful fallback for files over 100 KiB
- truthful fallback for invalid UTF-8
- unchanged extraction guidance for binary documents

Fixes #76022