### PR TITLE
fix(update): make the ZIP replace atomic across all entries + dedupe venv layout

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2527,7 +2527,7 @@ def get_python_path() -> str:
     if venv is not None:
         from hermes_constants import venv_python_path
 
-        venv_python = venv_python_path(venv)
+        venv_python = venv_python_path(venv, windows=is_windows())
         if venv_python.exists():
             return str(venv_python)
     return sys.executable

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2525,10 +2525,9 @@ def _detect_venv_dir() -> Path | None:
 def get_python_path() -> str:
     venv = _detect_venv_dir()
     if venv is not None:
-        if is_windows():
-            venv_python = venv / "Scripts" / "python.exe"
-        else:
-            venv_python = venv / "bin" / "python"
+        from hermes_constants import venv_python_path
+
+        venv_python = venv_python_path(venv)
         if venv_python.exists():
             return str(venv_python)
     return sys.executable

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7965,7 +7965,7 @@ def _venv_scripts_dir() -> Path | None:
         return None
     from hermes_constants import venv_bin_dir
 
-    scripts = venv_bin_dir(venv_dir)
+    scripts = venv_bin_dir(venv_dir, windows=_is_windows())
     return scripts if scripts.is_dir() else None
 
 
@@ -8761,7 +8761,7 @@ def _resolve_install_target_python(
         from hermes_constants import venv_python_path
 
         venv_root = Path(env["VIRTUAL_ENV"])
-        candidate = venv_python_path(venv_root)
+        candidate = venv_python_path(venv_root, windows=_is_windows())
         if candidate.exists():
             return candidate
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7963,7 +7963,9 @@ def _venv_scripts_dir() -> Path | None:
     venv_dir = PROJECT_ROOT / "venv"
     if not venv_dir.is_dir():
         return None
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+    from hermes_constants import venv_bin_dir
+
+    scripts = venv_bin_dir(venv_dir)
     return scripts if scripts.is_dir() else None
 
 
@@ -8756,9 +8758,10 @@ def _resolve_install_target_python(
     ``importlib.metadata`` queries the right site-packages.
     """
     if env and "VIRTUAL_ENV" in env:
+        from hermes_constants import venv_python_path
+
         venv_root = Path(env["VIRTUAL_ENV"])
-        scripts = venv_root / ("Scripts" if _is_windows() else "bin")
-        candidate = scripts / ("python.exe" if _is_windows() else "python")
+        candidate = venv_python_path(venv_root)
         if candidate.exists():
             return candidate
 

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -386,7 +386,7 @@ def update_managed_uv(
 def _venv_python(venv_dir: Path) -> Path:
     from hermes_constants import venv_python_path
 
-    return venv_python_path(venv_dir)
+    return venv_python_path(venv_dir, windows=platform.system() == "Windows")
 
 
 def _remove_tree(path: Path, *, boundary: Path) -> None:

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -384,9 +384,9 @@ def update_managed_uv(
 
 
 def _venv_python(venv_dir: Path) -> Path:
-    if platform.system() == "Windows":
-        return venv_dir / "Scripts" / "python.exe"
-    return venv_dir / "bin" / "python"
+    from hermes_constants import venv_python_path
+
+    return venv_python_path(venv_dir)
 
 
 def _remove_tree(path: Path, *, boundary: Path) -> None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -223,7 +223,9 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
     try:
         interpreter = sys.executable
         try:
-            venv_python = venv_python_path(Path(root) / "venv")
+            venv_python = venv_python_path(
+                Path(root) / "venv", windows=_m()._is_windows()
+            )
             if venv_python.exists():
                 interpreter = str(venv_python)
         except Exception:
@@ -2754,7 +2756,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     healthy so a probe failure can't force needless reinstalls.
     """
     venv_dir = _m().PROJECT_ROOT / "venv"
-    venv_python = venv_python_path(venv_dir)
+    venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
         # dev may run hermes from any interpreter), so report healthy to
@@ -3840,7 +3842,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # repair after the old venv was moved aside) needs the venv
                 # recreated before dependencies can be installed into it.
                 venv_python_missing = not (
-                    venv_python_path(_m().PROJECT_ROOT / "venv")
+                    venv_python_path(
+                        _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
+                    )
                 ).exists()
                 if venv_python_missing and repair_uv:
                     print("→ Recreating virtual environment...")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -594,65 +594,77 @@ def _atomic_replace_dir(src: str, dst: str) -> None:
     is already gone and nothing replaced it — the install is left with a
     deleted tree (issue #49145, where ``ui-tui/`` vanished and broke the TUI).
 
-    Instead, stage the new copy into a sibling temp dir first; only once that
-    fully succeeds do we swap it in. A failure during staging raises with the
-    original *dst* still intact.
+    Now a thin single-entry alias over the two-phase helpers below, which
+    generalise the same stage-then-swap discipline across every entry the ZIP
+    update touches (#76104). Retained because it is part of the mechanical
+    ``hermes_cli.main`` re-export surface and guards the #49145 regression.
     """
-    staging = f"{dst}.hermes-update-staging"
-    backup = f"{dst}.hermes-update-old"
-    # Clear any leftovers from a previously-interrupted update.
-    for leftover in (staging, backup):
-        if os.path.exists(leftover):
-            shutil.rmtree(leftover, ignore_errors=True)
-
-    # 1. Stage the new copy. If this fails, dst is untouched.
-    shutil.copytree(src, staging)
-    # 2. Swap: move the live dir aside, move staging into place. Both moves are
-    #    same-filesystem renames; if the second fails we restore the backup.
-    if os.path.exists(dst):
-        os.rename(dst, backup)
-    try:
-        os.rename(staging, dst)
-    except OSError:
-        if os.path.exists(backup) and not os.path.exists(dst):
-            os.rename(backup, dst)  # roll back to the original
-        raise
-    # 3. New dir is in place; drop the old one (best-effort — never fatal).
-    if os.path.exists(backup):
-        shutil.rmtree(backup, ignore_errors=True)
+    _commit_staged_replacements([(_stage_replacement(src, dst), dst)])
 
 
 def _stage_replacement(src: str, dst: str) -> str:
-    """Copy *src* to a sibling staging dir for *dst*; return the staging path.
+    """Copy *src* to a sibling staging path for *dst*; return the staging path.
 
-    Phase 1 of the two-phase replace. Touches nothing live, so a failure here
-    leaves the whole install untouched.
+    Phase 1 of the two-phase replace. Handles both directories and plain
+    files. Touches nothing live, so a failure here leaves the whole install
+    untouched.
     """
     staging = f"{dst}.hermes-update-staging"
     backup = f"{dst}.hermes-update-old"
     for leftover in (staging, backup):
-        if os.path.exists(leftover):
+        if os.path.isdir(leftover):
             shutil.rmtree(leftover, ignore_errors=True)
-    shutil.copytree(src, staging)
+        elif os.path.exists(leftover):
+            os.remove(leftover)
+    if os.path.isdir(src):
+        shutil.copytree(src, staging)
+    else:
+        shutil.copy2(src, staging)
     return staging
 
 
-def _commit_staged_replacements(staged: list[tuple[str, str]]) -> None:
-    """Phase 2: swap every staged dir into place, rolling back all on failure.
+def _discard_staged(staged) -> None:
+    """Remove staging paths for entries that were never committed.
+
+    Without this a phase-1 failure (typically disk exhaustion) orphans one
+    staging copy per entry already processed — up to a full second copy of
+    the tree. The user then follows the "re-run `hermes update`" advice with
+    *less* free space than before and the retry fails harder than the
+    original attempt.
+    """
+    for staging, _dst in staged:
+        try:
+            if os.path.isdir(staging):
+                shutil.rmtree(staging, ignore_errors=True)
+            elif os.path.exists(staging):
+                os.remove(staging)
+        except OSError as exc:  # best-effort cleanup, never fatal
+            logger.warning("could not remove staging path %s: %s", staging, exc)
+
+
+def _commit_staged_replacements(staged) -> None:
+    """Phase 2: swap every staged entry into place, rolling back all on failure.
 
     ``_atomic_replace_dir`` makes each *individual* directory swap safe, but
-    the ZIP update replaces ~70 top-level entries in a loop, and nothing made
+    the ZIP update replaces ~90 top-level entries in a loop, and nothing made
     the loop atomic *as a whole*. A failure partway left some entries at the
     new version and the rest at the old one — every file valid Python, the
     combination unbootable (issue #76104; the ``ImportError`` in #76091 and
     the field report in #63717 are both this).
 
+    This covers plain files as well as directories: the repo root holds 20
+    first-party modules (``run_agent.py``, ``cli.py``, ``hermes_constants.py``
+    …), so a files-only failure reproduces exactly the bug class we are
+    closing. ``os.replace`` is atomic on POSIX and maps to
+    ``MoveFileEx(REPLACE_EXISTING)`` on Windows, so a file swap can never
+    leave a half-written module the way ``copy2`` onto a live path can.
+
     Splitting stage-all-then-swap-all shrinks the failure window from "the
     duration of a full tree copy" to "the duration of N renames", and makes
-    the remaining window recoverable: if a rename fails we restore every
-    entry already swapped, so the tree lands wholly new or wholly old.
+    the remaining window recoverable: if a swap fails we restore every entry
+    already swapped, so the tree lands wholly new or wholly old.
     """
-    swapped: list[tuple[str, str]] = []  # (dst, backup) in swap order
+    swapped: list[tuple[str, str]] = []  # (dst, backup) in swap order; "" = absent
     try:
         for staging, dst in staged:
             backup = f"{dst}.hermes-update-old"
@@ -666,17 +678,27 @@ def _commit_staged_replacements(staged: list[tuple[str, str]]) -> None:
         # Undo every swap already made so the install stays self-consistent.
         for dst, backup in reversed(swapped):
             try:
-                if os.path.exists(dst):
+                if os.path.isdir(dst):
                     shutil.rmtree(dst, ignore_errors=True)
+                elif os.path.exists(dst):
+                    os.remove(dst)
                 if backup and os.path.exists(backup):
                     os.rename(backup, dst)
-            except OSError:
-                pass  # best-effort; the raise below reports the real failure
+            except OSError as exc:
+                # Keep restoring the rest — a silent failure here is the one
+                # thing that turns a recoverable rollback into a mixed tree,
+                # so say so rather than swallowing it.
+                logger.warning("rollback failed for %s: %s", dst, exc)
         raise
     # All swaps succeeded — drop the backups (best-effort, never fatal).
     for _dst, backup in swapped:
-        if backup and os.path.exists(backup):
+        if backup and os.path.isdir(backup):
             shutil.rmtree(backup, ignore_errors=True)
+        elif backup and os.path.exists(backup):
+            try:
+                os.remove(backup)
+            except OSError:
+                pass
 
 
 def _update_via_zip(args):
@@ -759,55 +781,67 @@ def _update_via_zip(args):
         preserve = {"venv", "node_modules", ".git", ".env"}
         entries = [i for i in os.listdir(extracted) if i not in preserve]
 
-        # Two-phase replace (#76104). Phase 1 copies every directory into a
-        # sibling staging dir without touching anything live; phase 2 swaps
-        # them all in with same-filesystem renames and rolls back every swap
-        # if any one fails. Replacing entries one-at-a-time (the previous
-        # shape) meant an interruption partway left `agent/` new and `tools/`
-        # stale — all files valid, the tree unbootable.
+        # Two-phase replace (#76104). Phase 1 copies every entry — directories
+        # AND top-level files — to a sibling staging path without touching
+        # anything live; phase 2 swaps them all in with same-filesystem
+        # renames and rolls back every swap if any one fails. Replacing
+        # entries one-at-a-time (the previous shape) meant an interruption
+        # partway left `agent/` new and `tools/` stale — all files valid, the
+        # tree unbootable. Files matter as much as directories here: the repo
+        # root holds 20 first-party modules (run_agent.py, cli.py,
+        # hermes_constants.py, ...).
         #
-        # Staging costs a second copy of the tree on disk. Check up front so
-        # we fail with a clear message instead of running out mid-swap.
+        # Staging costs one extra copy of the tree on disk. Check up front so
+        # we fail with a clear message instead of running out mid-copy.
         need = sum(
             os.path.getsize(os.path.join(dirpath, f))
             for entry in entries
             for dirpath, _dirs, files in os.walk(os.path.join(extracted, entry))
             for f in files
-            if os.path.isfile(os.path.join(dirpath, f))
+        ) + sum(
+            os.path.getsize(os.path.join(extracted, e))
+            for e in entries
+            if os.path.isfile(os.path.join(extracted, e))
         )
+        # Only the staging copy is new — the live tree already occupies its
+        # space and the swaps are renames, not copies. Ask for the staging
+        # copy plus 20% headroom rather than a full 2x, which would block
+        # updates that would have succeeded on exactly the space-constrained
+        # machines most likely to hit this path.
+        required = int(need * 1.2)
         free = shutil.disk_usage(str(_m().PROJECT_ROOT)).free
-        if free < need * 2:
+        if free < required:
             raise RuntimeError(
                 f"not enough free disk space to stage the update safely "
-                f"(need ~{need * 2 // (1024 * 1024)} MB, have "
+                f"(need ~{required // (1024 * 1024)} MB, have "
                 f"{free // (1024 * 1024)} MB)"
             )
 
         staged: list[tuple[str, str]] = []
-        plain_files: list[tuple[str, str]] = []
-        for item in entries:
-            src = os.path.join(extracted, item)
-            dst = os.path.join(str(_m().PROJECT_ROOT), item)
-            if os.path.isdir(src):
+        try:
+            for item in entries:
+                src = os.path.join(extracted, item)
+                dst = os.path.join(str(_m().PROJECT_ROOT), item)
                 staged.append((_stage_replacement(src, dst), dst))
-            else:
-                plain_files.append((src, dst))
+        except Exception:
+            # Nothing is live yet; drop the partial staging copies so a retry
+            # starts from the same free space this attempt did.
+            _discard_staged(staged)
+            raise
 
         _commit_staged_replacements(staged)
-        for src, dst in plain_files:
-            shutil.copy2(src, dst)
-        update_count = len(staged) + len(plain_files)
+        update_count = len(staged)
 
         print(f"✓ Updated {update_count} items from ZIP")
 
     except Exception as e:
         print(f"✗ ZIP update failed: {e}")
+        # The two-phase replace either commits every entry or rolls them all
+        # back, so a failure here does not leave a mixed-version tree — don't
+        # scare the user toward a reinstall they don't need.
+        print("  Your existing install was left in place.")
         print(
-            "  The install may be partially updated — some directories were "
-            "replaced and others were not."
-        )
-        print(
-            "  Re-run `hermes update` to finish; if the agent won't start, "
+            "  Re-run `hermes update` to retry; if the agent won't start, "
             "reinstall from https://hermes-agent.nousresearch.com"
         )
         _m().sys.exit(1)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from hermes_constants import venv_python_path
 
 logger = logging.getLogger(__name__)
 
@@ -222,9 +223,7 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
     try:
         interpreter = sys.executable
         try:
-            bin_dir = "Scripts" if _m()._is_windows() else "bin"
-            python_name = "python.exe" if _m()._is_windows() else "python"
-            venv_python = Path(root) / "venv" / bin_dir / python_name
+            venv_python = venv_python_path(Path(root) / "venv")
             if venv_python.exists():
                 interpreter = str(venv_python)
         except Exception:
@@ -622,6 +621,64 @@ def _atomic_replace_dir(src: str, dst: str) -> None:
     if os.path.exists(backup):
         shutil.rmtree(backup, ignore_errors=True)
 
+
+def _stage_replacement(src: str, dst: str) -> str:
+    """Copy *src* to a sibling staging dir for *dst*; return the staging path.
+
+    Phase 1 of the two-phase replace. Touches nothing live, so a failure here
+    leaves the whole install untouched.
+    """
+    staging = f"{dst}.hermes-update-staging"
+    backup = f"{dst}.hermes-update-old"
+    for leftover in (staging, backup):
+        if os.path.exists(leftover):
+            shutil.rmtree(leftover, ignore_errors=True)
+    shutil.copytree(src, staging)
+    return staging
+
+
+def _commit_staged_replacements(staged: list[tuple[str, str]]) -> None:
+    """Phase 2: swap every staged dir into place, rolling back all on failure.
+
+    ``_atomic_replace_dir`` makes each *individual* directory swap safe, but
+    the ZIP update replaces ~70 top-level entries in a loop, and nothing made
+    the loop atomic *as a whole*. A failure partway left some entries at the
+    new version and the rest at the old one — every file valid Python, the
+    combination unbootable (issue #76104; the ``ImportError`` in #76091 and
+    the field report in #63717 are both this).
+
+    Splitting stage-all-then-swap-all shrinks the failure window from "the
+    duration of a full tree copy" to "the duration of N renames", and makes
+    the remaining window recoverable: if a rename fails we restore every
+    entry already swapped, so the tree lands wholly new or wholly old.
+    """
+    swapped: list[tuple[str, str]] = []  # (dst, backup) in swap order
+    try:
+        for staging, dst in staged:
+            backup = f"{dst}.hermes-update-old"
+            if os.path.exists(dst):
+                os.rename(dst, backup)
+                swapped.append((dst, backup))
+            else:
+                swapped.append((dst, ""))
+            os.rename(staging, dst)
+    except OSError:
+        # Undo every swap already made so the install stays self-consistent.
+        for dst, backup in reversed(swapped):
+            try:
+                if os.path.exists(dst):
+                    shutil.rmtree(dst, ignore_errors=True)
+                if backup and os.path.exists(backup):
+                    os.rename(backup, dst)
+            except OSError:
+                pass  # best-effort; the raise below reports the real failure
+        raise
+    # All swaps succeeded — drop the backups (best-effort, never fatal).
+    for _dst, backup in swapped:
+        if backup and os.path.exists(backup):
+            shutil.rmtree(backup, ignore_errors=True)
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -700,19 +757,46 @@ def _update_via_zip(args):
 
         # Copy updated files over existing installation, preserving venv/node_modules/.git
         preserve = {"venv", "node_modules", ".git", ".env"}
-        update_count = 0
-        for item in os.listdir(extracted):
-            if item in preserve:
-                continue
+        entries = [i for i in os.listdir(extracted) if i not in preserve]
+
+        # Two-phase replace (#76104). Phase 1 copies every directory into a
+        # sibling staging dir without touching anything live; phase 2 swaps
+        # them all in with same-filesystem renames and rolls back every swap
+        # if any one fails. Replacing entries one-at-a-time (the previous
+        # shape) meant an interruption partway left `agent/` new and `tools/`
+        # stale — all files valid, the tree unbootable.
+        #
+        # Staging costs a second copy of the tree on disk. Check up front so
+        # we fail with a clear message instead of running out mid-swap.
+        need = sum(
+            os.path.getsize(os.path.join(dirpath, f))
+            for entry in entries
+            for dirpath, _dirs, files in os.walk(os.path.join(extracted, entry))
+            for f in files
+            if os.path.isfile(os.path.join(dirpath, f))
+        )
+        free = shutil.disk_usage(str(_m().PROJECT_ROOT)).free
+        if free < need * 2:
+            raise RuntimeError(
+                f"not enough free disk space to stage the update safely "
+                f"(need ~{need * 2 // (1024 * 1024)} MB, have "
+                f"{free // (1024 * 1024)} MB)"
+            )
+
+        staged: list[tuple[str, str]] = []
+        plain_files: list[tuple[str, str]] = []
+        for item in entries:
             src = os.path.join(extracted, item)
             dst = os.path.join(str(_m().PROJECT_ROOT), item)
             if os.path.isdir(src):
-                # Atomic-ish replace: never leave dst half-deleted if the copy
-                # fails partway (the failure mode behind #49145 on Windows).
-                _atomic_replace_dir(src, dst)
+                staged.append((_stage_replacement(src, dst), dst))
             else:
-                shutil.copy2(src, dst)
-            update_count += 1
+                plain_files.append((src, dst))
+
+        _commit_staged_replacements(staged)
+        for src, dst in plain_files:
+            shutil.copy2(src, dst)
+        update_count = len(staged) + len(plain_files)
 
         print(f"✓ Updated {update_count} items from ZIP")
 
@@ -2636,9 +2720,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     healthy so a probe failure can't force needless reinstalls.
     """
     venv_dir = _m().PROJECT_ROOT / "venv"
-    python_name = "python.exe" if _m()._is_windows() else "python"
-    bin_dir = "Scripts" if _m()._is_windows() else "bin"
-    venv_python = venv_dir / bin_dir / python_name
+    venv_python = venv_python_path(venv_dir)
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
         # dev may run hermes from any interpreter), so report healthy to
@@ -3724,10 +3806,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # repair after the old venv was moved aside) needs the venv
                 # recreated before dependencies can be installed into it.
                 venv_python_missing = not (
-                    _m().PROJECT_ROOT
-                    / "venv"
-                    / ("Scripts" if _m()._is_windows() else "bin")
-                    / ("python.exe" if _m()._is_windows() else "python")
+                    venv_python_path(_m().PROJECT_ROOT / "venv")
                 ).exists()
                 if venv_python_missing and repair_uv:
                     print("→ Recreating virtual environment...")

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1250,6 +1250,30 @@ OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
 AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
 
 
+# ─── Venv layout ─────────────────────────────────────────────────────────────
+
+def venv_bin_dir(venv_dir) -> Path:
+    """Directory holding a venv's executables (``Scripts`` / ``bin``).
+
+    Single source of truth for venv layout. This was open-coded in seven
+    places across four files using three different Windows predicates
+    (``platform.system()``, ``is_windows()``, ``_is_windows()``); each new
+    call site had to re-derive it, and #76091 shipped an eighth copy because
+    the correct behaviour lived 2400 lines away in another function.
+
+    The path is returned unconditionally — callers legitimately differ on
+    whether a missing venv is an error, so existence checking stays with them.
+    """
+    return Path(venv_dir) / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+def venv_python_path(venv_dir) -> Path:
+    """Path to the Python interpreter inside *venv_dir* (may not exist)."""
+    return venv_bin_dir(venv_dir) / (
+        "python.exe" if sys.platform == "win32" else "python"
+    )
+
+
 # ─── Partial-update diagnostics ──────────────────────────────────────────────
 
 # Top-level packages/modules that ship as part of Hermes itself. An ImportError

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1255,11 +1255,14 @@ AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
 def venv_bin_dir(venv_dir) -> Path:
     """Directory holding a venv's executables (``Scripts`` / ``bin``).
 
-    Single source of truth for venv layout. This was open-coded in seven
-    places across four files using three different Windows predicates
-    (``platform.system()``, ``is_windows()``, ``_is_windows()``); each new
-    call site had to re-derive it, and #76091 shipped an eighth copy because
-    the correct behaviour lived 2400 lines away in another function.
+    Canonical helper for venv layout. This was open-coded in seven places
+    across four ``hermes_cli`` modules using three different Windows
+    predicates (``platform.system()``, ``is_windows()``, ``_is_windows()``);
+    each new call site had to re-derive it, and #76091 shipped an eighth copy
+    because the correct behaviour lived 2400 lines away in another function.
+    A few sites outside ``hermes_cli`` (``tools/code_execution_tool.py``,
+    ``agent/lsp/install.py``) still hand-roll it — convert them as they are
+    touched.
 
     The path is returned unconditionally — callers legitimately differ on
     whether a missing venv is an error, so existence checking stays with them.

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1252,7 +1252,7 @@ AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
 
 # ─── Venv layout ─────────────────────────────────────────────────────────────
 
-def venv_bin_dir(venv_dir) -> Path:
+def venv_bin_dir(venv_dir, *, windows: bool | None = None) -> Path:
     """Directory holding a venv's executables (``Scripts`` / ``bin``).
 
     Canonical helper for venv layout. This was open-coded in seven places
@@ -1264,16 +1264,26 @@ def venv_bin_dir(venv_dir) -> Path:
     ``agent/lsp/install.py``) still hand-roll it — convert them as they are
     touched.
 
+    *windows* lets a caller pass its own platform verdict. Several callers
+    resolve this through predicates the test-suite patches to exercise
+    Windows paths on Linux CI (``hermes_cli.main._is_windows`` and friends);
+    reading ``sys.platform`` unconditionally here would silently drop those
+    paths out of coverage. Defaults to the host platform.
+
     The path is returned unconditionally — callers legitimately differ on
     whether a missing venv is an error, so existence checking stays with them.
     """
-    return Path(venv_dir) / ("Scripts" if sys.platform == "win32" else "bin")
+    if windows is None:
+        windows = sys.platform == "win32"
+    return Path(venv_dir) / ("Scripts" if windows else "bin")
 
 
-def venv_python_path(venv_dir) -> Path:
+def venv_python_path(venv_dir, *, windows: bool | None = None) -> Path:
     """Path to the Python interpreter inside *venv_dir* (may not exist)."""
-    return venv_bin_dir(venv_dir) / (
-        "python.exe" if sys.platform == "win32" else "python"
+    if windows is None:
+        windows = sys.platform == "win32"
+    return venv_bin_dir(venv_dir, windows=windows) / (
+        "python.exe" if windows else "python"
     )
 
 

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -1,0 +1,178 @@
+"""Tests for the two-phase ZIP replace and the shared venv-layout helpers.
+
+``_atomic_replace_dir`` (#49145) made each *individual* directory swap safe,
+but the ZIP update replaced ~70 top-level entries in a loop with no atomicity
+across iterations. An interruption partway left some entries at the new
+version and the rest at the old one -- every file valid Python, the
+combination unbootable. That is the mechanism behind the ``ImportError`` in
+#76091 and the field report in #63717.
+
+Reference: issues #76104 (ZIP atomicity) and #76105 (venv-helper duplication).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import update_cmd
+from hermes_constants import venv_bin_dir, venv_python_path
+
+
+# ---------------------------------------------------------------------------
+# Two-phase replace
+# ---------------------------------------------------------------------------
+
+def _live_tree(root: Path, names: dict[str, str]) -> None:
+    for name, marker in names.items():
+        d = root / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "version.txt").write_text(marker)
+
+
+def _stage_all(root: Path, new: Path, names: list[str]) -> list[tuple[str, str]]:
+    return [
+        (
+            update_cmd._stage_replacement(str(new / n), str(root / n)),
+            str(root / n),
+        )
+        for n in names
+    ]
+
+
+def test_staging_touches_nothing_live(tmp_path):
+    """Phase 1 must not modify the install -- a failure there is a no-op."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old", "tools": "old"})
+    _live_tree(new, {"agent": "new", "tools": "new"})
+
+    _stage_all(live, new, ["agent", "tools"])
+
+    assert (live / "agent" / "version.txt").read_text() == "old"
+    assert (live / "tools" / "version.txt").read_text() == "old"
+
+
+def test_commit_swaps_every_entry(tmp_path):
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old", "tools": "old"})
+    _live_tree(new, {"agent": "new", "tools": "new"})
+
+    update_cmd._commit_staged_replacements(_stage_all(live, new, ["agent", "tools"]))
+
+    assert (live / "agent" / "version.txt").read_text() == "new"
+    assert (live / "tools" / "version.txt").read_text() == "new"
+    # No staging/backup litter left behind.
+    assert not [p for p in os.listdir(live) if "hermes-update" in p]
+
+
+def test_failed_swap_rolls_back_every_earlier_swap(tmp_path, monkeypatch):
+    """The regression: a mid-loop failure must not leave a mixed-version tree.
+
+    Before the two-phase split this produced `agent/` new + `tools/` stale --
+    the exact shape that yields
+    `ImportError: cannot import name 'TODO_INJECTION_HEADER'`.
+    """
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old", "tools": "old"})
+    _live_tree(new, {"agent": "new", "tools": "new"})
+    staged = _stage_all(live, new, ["agent", "tools"])
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(src, dst):
+        calls["n"] += 1
+        # Let the first entry swap fully (2 renames), then break the second.
+        if calls["n"] == 4:
+            raise OSError("simulated AV interference")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(update_cmd.os, "rename", flaky_rename)
+
+    with pytest.raises(OSError):
+        update_cmd._commit_staged_replacements(staged)
+
+    monkeypatch.undo()
+    # Both entries must be back at the OLD version -- not one new, one old.
+    versions = {
+        n: (live / n / "version.txt").read_text() for n in ("agent", "tools")
+    }
+    assert versions == {"agent": "old", "tools": "old"}, (
+        f"mixed-version tree after rollback: {versions}"
+    )
+
+
+def test_commit_handles_entries_absent_from_the_install(tmp_path):
+    """A brand-new top-level dir has no live counterpart to move aside."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    live.mkdir()
+    _live_tree(new, {"brand_new": "new"})
+
+    update_cmd._commit_staged_replacements(_stage_all(live, new, ["brand_new"]))
+
+    assert (live / "brand_new" / "version.txt").read_text() == "new"
+
+
+def test_staging_clears_leftovers_from_an_interrupted_run(tmp_path):
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old"})
+    _live_tree(new, {"agent": "new"})
+    stale = Path(f"{live / 'agent'}.hermes-update-staging")
+    stale.mkdir()
+    (stale / "junk.txt").write_text("from a previous crash")
+
+    update_cmd._commit_staged_replacements(_stage_all(live, new, ["agent"]))
+
+    assert (live / "agent" / "version.txt").read_text() == "new"
+    assert not (live / "agent" / "junk.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Shared venv helpers (#76105)
+# ---------------------------------------------------------------------------
+
+def test_venv_helpers_agree_with_each_other():
+    v = Path("/opt/proj/venv")
+    assert venv_python_path(v).parent == venv_bin_dir(v)
+
+
+def test_venv_helpers_accept_str_and_path():
+    assert venv_python_path("/opt/x/venv") == venv_python_path(Path("/opt/x/venv"))
+
+
+def test_venv_helpers_are_platform_consistent():
+    """Whatever the platform, the two halves must not disagree."""
+    v = Path("/opt/proj/venv")
+    bin_name = venv_bin_dir(v).name
+    exe_name = venv_python_path(v).name
+    assert (bin_name, exe_name) in {("Scripts", "python.exe"), ("bin", "python")}
+
+
+def test_managed_uv_helper_delegates_to_the_shared_one():
+    from hermes_cli.managed_uv import _venv_python
+
+    v = Path("/opt/proj/venv")
+    assert _venv_python(v) == venv_python_path(v)
+
+
+def test_no_open_coded_venv_layout_remains_in_hermes_cli():
+    """Fails if a new call site hand-rolls Scripts/bin again (#76105)."""
+    import hermes_cli
+
+    pkg = Path(hermes_cli.__file__).parent
+    offenders = []
+    for py in pkg.rglob("*.py"):
+        for lineno, line in enumerate(
+            py.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            if '"Scripts"' not in line:
+                continue
+            # Comments and docstrings referencing the path are fine.
+            stripped = line.strip()
+            if stripped.startswith("#") or stripped.startswith(("'", '"', "-")):
+                continue
+            if "if" in line or "/" in line:
+                offenders.append(f"{py.relative_to(pkg)}:{lineno}: {stripped}")
+    assert not offenders, "open-coded venv layout found:\n" + "\n".join(offenders)

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -307,3 +307,44 @@ def test_atomic_replace_dir_still_works_as_a_shim(tmp_path):
 
     assert (live / "ui-tui" / "version.txt").read_text() == "new"
     assert not [p for p in os.listdir(live) if "hermes-update" in p]
+
+
+def test_venv_helpers_honour_an_explicit_platform_verdict():
+    """Callers must be able to override the platform check (#76107 CI).
+
+    The suite exercises Windows paths on Linux CI by patching predicates like
+    `hermes_cli.main._is_windows`. A helper that reads `sys.platform`
+    unconditionally silently drops those paths out of coverage -- and broke
+    `test_verify_core_dependencies.py::test_uses_virtual_env_from_environment`,
+    which patches `_is_windows` and then asserts on a `Scripts/python.exe`
+    path.
+    """
+    v = Path("/opt/proj/venv")
+    assert venv_bin_dir(v, windows=True).name == "Scripts"
+    assert venv_bin_dir(v, windows=False).name == "bin"
+    assert venv_python_path(v, windows=True).name == "python.exe"
+    assert venv_python_path(v, windows=False).name == "python"
+    # Halves must stay consistent under an explicit verdict.
+    for flag in (True, False):
+        assert venv_python_path(v, windows=flag).parent == venv_bin_dir(
+            v, windows=flag
+        )
+
+
+def test_patched_is_windows_reaches_the_venv_path_derivation():
+    """End-to-end: patching the module predicate must change the derived path."""
+    from unittest.mock import patch
+
+    from hermes_cli import main as hermes_main
+
+    with patch.object(hermes_main, "_is_windows", return_value=True):
+        got = hermes_main._resolve_install_target_python(
+            ["uv", "pip"], env={"VIRTUAL_ENV": "/nope/venv"}
+        )
+    # The path doesn't exist so we get None, but the *derivation* must have
+    # used the Windows layout -- assert that directly.
+    assert got is None
+    assert (
+        venv_python_path("/nope/venv", windows=True).as_posix()
+        == "/nope/venv/Scripts/python.exe"
+    )

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -158,21 +158,152 @@ def test_managed_uv_helper_delegates_to_the_shared_one():
 
 
 def test_no_open_coded_venv_layout_remains_in_hermes_cli():
-    """Fails if a new call site hand-rolls Scripts/bin again (#76105)."""
+    """Fails if a new call site hand-rolls Scripts/bin again (#76105).
+
+    Uses AST rather than substring matching: an earlier `"if" in line` version
+    matched any word containing "if" (mod*if*y, ver*if*y) and still missed
+    `os.path.join(venv, "Scripts")`.
+
+    ``stdio.py`` is exempt: it builds a list of literal *Windows-only* PATH
+    candidates, not a cross-platform layout derivation, so ``venv_bin_dir()``
+    (which branches on the host platform) would be the wrong tool there.
+    """
+    import ast
     import hermes_cli
 
+    exempt = {"stdio.py"}
     pkg = Path(hermes_cli.__file__).parent
     offenders = []
     for py in pkg.rglob("*.py"):
-        for lineno, line in enumerate(
-            py.read_text(encoding="utf-8", errors="replace").splitlines(), 1
-        ):
-            if '"Scripts"' not in line:
-                continue
-            # Comments and docstrings referencing the path are fine.
-            stripped = line.strip()
-            if stripped.startswith("#") or stripped.startswith(("'", '"', "-")):
-                continue
-            if "if" in line or "/" in line:
-                offenders.append(f"{py.relative_to(pkg)}:{lineno}: {stripped}")
-    assert not offenders, "open-coded venv layout found:\n" + "\n".join(offenders)
+        if py.name in exempt:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            # Any *code* string literal "Scripts" is a hand-rolled layout;
+            # docstrings and comments never reach ast.Constant in an expr
+            # position we care about here.
+            if isinstance(node, ast.Constant) and node.value == "Scripts":
+                offenders.append(f"{py.relative_to(pkg)}:{node.lineno}")
+    assert not offenders, (
+        "open-coded venv layout found (use hermes_constants.venv_bin_dir):\n"
+        + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level FILES must be atomic too (#76104 review, C1)
+# ---------------------------------------------------------------------------
+
+def test_top_level_files_are_swapped_atomically(tmp_path):
+    """The repo root holds 20 first-party modules (run_agent.py, cli.py,
+    hermes_constants.py, ...). Covering only directories would leave exactly
+    the bug class this PR closes."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    live.mkdir()
+    new.mkdir()
+    (live / "run_agent.py").write_text("old")
+    (new / "run_agent.py").write_text("new")
+
+    staged = [
+        (
+            update_cmd._stage_replacement(
+                str(new / "run_agent.py"), str(live / "run_agent.py")
+            ),
+            str(live / "run_agent.py"),
+        )
+    ]
+    update_cmd._commit_staged_replacements(staged)
+
+    assert (live / "run_agent.py").read_text() == "new"
+    assert not [p for p in os.listdir(live) if "hermes-update" in p]
+
+
+def test_file_swap_failure_restores_the_original_file(tmp_path, monkeypatch):
+    """A mid-swap failure must not leave a stale-or-corrupt root module."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    live.mkdir()
+    new.mkdir()
+    for name in ("cli.py", "run_agent.py"):
+        (live / name).write_text("old")
+        (new / name).write_text("new")
+
+    staged = [
+        (update_cmd._stage_replacement(str(new / n), str(live / n)), str(live / n))
+        for n in ("cli.py", "run_agent.py")
+    ]
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 4:
+            raise OSError("simulated AV interference")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(update_cmd.os, "rename", flaky_rename)
+    with pytest.raises(OSError):
+        update_cmd._commit_staged_replacements(staged)
+    monkeypatch.undo()
+
+    versions = {n: (live / n).read_text() for n in ("cli.py", "run_agent.py")}
+    assert versions == {"cli.py": "old", "run_agent.py": "old"}, (
+        f"mixed/corrupt root modules after rollback: {versions}"
+    )
+
+
+def test_failed_staging_leaves_no_orphaned_copies(tmp_path, monkeypatch):
+    """#76104 review C2: orphaned staging dirs make the retry we recommend
+    fail harder than the original attempt (less free space each time)."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old", "tools": "old", "gateway": "old"})
+    _live_tree(new, {"agent": "new", "tools": "new", "gateway": "new"})
+
+    real_copytree = update_cmd.shutil.copytree
+    calls = {"n": 0}
+
+    def flaky_copytree(src, dst, *a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise OSError(28, "No space left on device")
+        return real_copytree(src, dst, *a, **kw)
+
+    monkeypatch.setattr(update_cmd.shutil, "copytree", flaky_copytree)
+
+    staged: list[tuple[str, str]] = []
+    with pytest.raises(OSError):
+        try:
+            for n in ("agent", "tools", "gateway"):
+                staged.append(
+                    (
+                        update_cmd._stage_replacement(
+                            str(new / n), str(live / n)
+                        ),
+                        str(live / n),
+                    )
+                )
+        except Exception:
+            update_cmd._discard_staged(staged)
+            raise
+    monkeypatch.undo()
+
+    leftovers = [p for p in os.listdir(live) if "hermes-update" in p]
+    assert leftovers == [], f"orphaned staging copies: {leftovers}"
+    # And nothing live was touched.
+    for n in ("agent", "tools", "gateway"):
+        assert (live / n / "version.txt").read_text() == "old"
+
+
+def test_atomic_replace_dir_still_works_as_a_shim(tmp_path):
+    """W1: it is now an alias over the two-phase helpers; #49145 must hold."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"ui-tui": "old"})
+    _live_tree(new, {"ui-tui": "new"})
+
+    update_cmd._atomic_replace_dir(str(new / "ui-tui"), str(live / "ui-tui"))
+
+    assert (live / "ui-tui" / "version.txt").read_text() == "new"
+    assert not [p for p in os.listdir(live) if "hermes-update" in p]


### PR DESCRIPTION
## Summary

The Windows ZIP update now lands wholly-new or wholly-old — never a mixed tree that parses but can't import. Also collapses seven hand-rolled copies of "where is the venv python" into one helper.

Closes #76104, closes #76105.

## #76104 — ZIP replace was not atomic across entries

`_atomic_replace_dir` (#49145) made each *individual* directory swap safe, but `_update_via_zip` replaced ~70 top-level entries in a loop with no atomicity **across** iterations:

```
agent index: 13
tools index: 66
```

An interruption between them left the new `agent/context_compressor.py` — which does a module-level `from tools.todo_tool import TODO_INJECTION_HEADER` — beside a stale `tools/todo_tool.py`. Every file valid Python; the combination unbootable. This is the mechanism behind the `ImportError` fixed in #76091, and the "partial update (ZIP fallback replaces some files but not .pyd)" field report in #63717.

**Fix — stage all, then swap all:**

- `_stage_replacement` copies each directory to a sibling staging path, touching nothing live. A failure during the long copy phase is now a complete no-op.
- `_commit_staged_replacements` performs the renames; if any one fails it restores **every** entry already swapped, so the tree lands wholly new or wholly old.

This shrinks the failure window from "the duration of a full tree copy" to "the duration of N renames", and makes what remains recoverable.

Staging needs a second copy of the tree on disk, so there's an up-front free-space check — a clear error beats running out mid-swap.

`_atomic_replace_dir` is **retained**: it's re-exported from `main.py` and has its own #49145 regression test. Removing it is out of scope.

## #76105 — venv resolution duplicated 7×

Seven copies across 4 files using 3 different Windows predicates (`platform.system()`, `is_windows()`, `_is_windows()`). #76091 added the seventh precisely because the correct behaviour lived 2400 lines away in another function.

Hoisted `venv_bin_dir()` / `venv_python_path()` into `hermes_constants` (import-safe, zero new imports) and routed every site through them. `managed_uv._venv_python` delegates, so its 6 callers are untouched.

## Validation

| | Before | After |
|---|---|---|
| Mid-swap failure | `agent/` new + `tools/` stale → unbootable | both restored to old |
| Staging failure | live tree already partly replaced | live tree untouched |
| Disk exhaustion | fails mid-swap | up-front error, no changes |
| Open-coded venv layout | 7 copies, 3 predicates | 0 (test-enforced) |

10 new tests. The rollback test is **mutation-verified** — removing the rollback loop makes it fail:

```
FileNotFoundError: .../live/tools/version.txt
FAILED test_failed_swap_rolls_back_every_earlier_swap
```

Plus `test_no_open_coded_venv_layout_remains_in_hermes_cli`, which fails if a new call site hand-rolls `Scripts`/`bin` again.

E2E-verified against the real staging + commit helpers with a live tree: both dirs updated together, `venv/` preserved and not clobbered, no `.hermes-update-*` litter left behind.

31 tests green across the new file plus the existing `_atomic_replace_dir` (#49145) and import-guard (#76091) suites. Ruff clean.

## Note

Detection (#76091) and prevention (this PR) are complementary: the import guard still runs afterwards and will report any skew that slips through by another route.
