### PR TITLE
fix(kanban): prevent block-loop triage redecomposition

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -132,6 +132,9 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
+TRIAGE_CONTINUATION_EVENT_KINDS = frozenset(
+    {"block_loop_detected", "decomposed"}
+)
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -3857,6 +3860,25 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
     return out
 
 
+def triage_continuation_event(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[str]:
+    """Return the latest event that makes triage unsafe to auto-specify.
+
+    Loop-breaker roots await an explicit continuation decision; roots with a
+    prior decomposition already materialized a work graph. The append-only
+    event remains authoritative even after child links are cleaned up.
+    """
+    kinds = sorted(TRIAGE_CONTINUATION_EVENT_KINDS)
+    placeholders = ", ".join("?" for _ in kinds)
+    row = conn.execute(
+        f"SELECT kind FROM task_events WHERE task_id = ? AND kind IN ({placeholders}) "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id, *kinds),
+    ).fetchone()
+    return str(row["kind"]) if row is not None else None
+
+
 def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5905,6 +5927,8 @@ def specify_triage_task(
         ).fetchone()
         if existing is None:
             return False
+        if triage_continuation_event(conn, task_id) is not None:
+            return False
         sets: list[str] = ["status = 'todo'"]
         params: list[Any] = []
         changed_fields: list[str] = []
@@ -6061,6 +6085,8 @@ def decompose_triage_task(
         if root_row is None:
             return None
         if root_row["status"] != "triage":
+            return None
+        if triage_continuation_event(conn, task_id) is not None:
             return None
         tenant = root_row["tenant"]
         # Children inherit the root's workspace by default so a fan-out

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -57,6 +57,7 @@ matching profile from the available roster.
 
 You will be given:
   - The original task title and body
+  - Recent task comments, in chronological order
   - The list of available profiles (each with name + description)
   - The fallback "default_assignee" used when no profile fits
 
@@ -77,6 +78,9 @@ Output a single JSON object with this exact shape:
   }
 
 Rules:
+  - Treat comments as later task updates. Later comments override conflicting
+    older body text. Never recreate or replay work or side effects that a later
+    comment says are already complete.
   - "parents" is a list of INDICES (0-based) into this same "tasks" list,
     expressing actual data dependencies. Tasks with no parents run in
     PARALLEL. Tasks with parents wait until every parent completes.
@@ -113,6 +117,9 @@ _USER_TEMPLATE = """Task id: {task_id}
 Title: {title}
 Body:
 {body}
+
+Recent comments (chronological; later comments override conflicting older body):
+{comments}
 
 Available profiles (assignees you may pick from):
 {roster}
@@ -249,6 +256,24 @@ def _format_roster(roster: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _format_recent_comments(comments: list[kb.Comment]) -> str:
+    """Render a bounded chronological tail of task updates."""
+    if not comments:
+        return "  (none)"
+    rendered = []
+    remaining = 4000
+    for comment in comments[-10:]:
+        line = f"  - {comment.author}: {_truncate(comment.body, 1000)}"
+        if len(line) > remaining:
+            line = _truncate(line, remaining)
+        if line:
+            rendered.append(line)
+            remaining -= len(line)
+        if remaining <= 0:
+            break
+    return "\n".join(rendered) or "  (none)"
+
+
 def _normalize_assignee_choice(
     assignee: object,
     *,
@@ -283,11 +308,19 @@ def decompose_task(
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
+        continuation_event = kb.triage_continuation_event(conn, task_id)
+        comments = kb.list_comments(conn, task_id) if task is not None else []
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
     if task.status != "triage":
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
+        )
+    if continuation_event is not None:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            f"explicit continuation required after {continuation_event}",
         )
 
     cfg = _load_config()
@@ -307,6 +340,7 @@ def decompose_task(
         task_id=task.id,
         title=_truncate(task.title or "", 400),
         body=_truncate(task.body or "(no body)", 4000),
+        comments=_format_recent_comments(comments),
         roster=_format_roster(roster),
         default_assignee=default_assignee,
     )
@@ -434,7 +468,7 @@ def decompose_task(
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
-                root_assignee=orchestrator,
+                root_assignee=task.assignee or orchestrator,
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
@@ -457,7 +491,7 @@ def decompose_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+    """Return fresh triage ids, excluding recovery/materialized roots."""
     with kb.connect_closing() as conn:
         rows = kb.list_tasks(
             conn,
@@ -465,4 +499,8 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             limit=1000,
         )
-    return [row.id for row in rows]
+        return [
+            row.id
+            for row in rows
+            if kb.triage_continuation_event(conn, row.id) is None
+        ]

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -72,6 +72,9 @@ heading, in this order:
       obvious; never invent scope creep).
 
 Rules:
+  - Treat comments as later task updates. Later comments override conflicting
+    older body text. Never recreate or replay work or side effects that a later
+    comment says are already complete.
   - Keep the tightened title close in meaning to the original idea — do
     NOT invent a different project.
   - If the original idea is already detailed, preserve its substance and
@@ -86,6 +89,9 @@ _USER_TEMPLATE = """Task id: {task_id}
 Current title: {title}
 Current body:
 {body}
+
+Recent comments (chronological; later comments override conflicting older body):
+{comments}
 """
 
 
@@ -103,6 +109,24 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1] + "…"
+
+
+def _format_recent_comments(comments: list[kb.Comment]) -> str:
+    """Render a bounded chronological tail of task updates."""
+    if not comments:
+        return "  (none)"
+    rendered = []
+    remaining = 4000
+    for comment in comments[-10:]:
+        line = f"  - {comment.author}: {_truncate(comment.body, 1000)}"
+        if len(line) > remaining:
+            line = _truncate(line, remaining)
+        if line:
+            rendered.append(line)
+            remaining -= len(line)
+        if remaining <= 0:
+            break
+    return "\n".join(rendered) or "  (none)"
 
 
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
@@ -154,11 +178,19 @@ def specify_task(
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
+        continuation_event = kb.triage_continuation_event(conn, task_id)
+        comments = kb.list_comments(conn, task_id) if task is not None else []
     if task is None:
         return SpecifyOutcome(task_id, False, "unknown task id")
     if task.status != "triage":
         return SpecifyOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
+        )
+    if continuation_event is not None:
+        return SpecifyOutcome(
+            task_id,
+            False,
+            f"explicit continuation required after {continuation_event}",
         )
 
     try:
@@ -171,6 +203,7 @@ def specify_task(
         task_id=task.id,
         title=_truncate(task.title or "", 400),
         body=_truncate(task.body or "(no body)", 4000),
+        comments=_format_recent_comments(comments),
     )
 
     try:
@@ -261,4 +294,8 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             include_archived=False,
         )
-    return [t.id for t in tasks]
+        return [
+            task.id
+            for task in tasks
+            if kb.triage_continuation_event(conn, task.id) is None
+        ]

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import pytest
 
 from gateway.kanban_watchers import _resolve_auto_decompose_settings
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
 
 
 def test_enabled_by_default_when_key_absent():
@@ -25,5 +27,23 @@ def test_disabled_when_flag_false():
         lambda: {"kanban": {"auto_decompose": False}}
     )
     assert enabled is False
+
+
+def test_runtime_triage_scan_excludes_block_loop_recovery(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    kb.init_db()
+    with kb.connect() as conn:
+        fresh = kb.create_task(conn, title="fresh rough idea", triage=True)
+        recovery = kb.create_task(conn, title="already executed", assignee="mike")
+        assert kb.claim_task(conn, recovery, claimer="mike") is not None
+        assert kb.block_task(conn, recovery, reason="review", kind="needs_input")
+        assert kb.unblock_task(conn, recovery)
+        assert kb.claim_task(conn, recovery, claimer="mike") is not None
+        assert kb.block_task(conn, recovery, reason="review", kind="needs_input")
+
+    assert decomp.list_triage_ids() == [fresh]
 
 

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,111 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def _drive_block_loop_to_triage(tid: str) -> None:
+    with kb.connect() as conn:
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="await review", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="still await review", kind="needs_input")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+
+
+def test_block_loop_triage_requires_explicit_continuation_without_llm_or_children(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="existing development workflow",
+            body="old bootstrap instructions",
+            assignee="mike",
+        )
+    _drive_block_loop_to_triage(tid)
+    with kb.connect() as conn:
+        kb.add_comment(conn, tid, author="karim", body="Approved: bounded continuation only")
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid, author="auto-decomposer")
+
+    assert outcome.ok is False
+    assert "explicit continuation" in outcome.reason
+    call_llm.assert_not_called()
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee == "mike"
+        assert kb.child_ids(conn, tid) == []
+        assert kb.list_comments(conn, tid)[-1].body == "Approved: bounded continuation only"
+
+
+def test_recent_comments_follow_body_and_are_declared_authoritative(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="bounded change",
+            body="Old scope: replay the bootstrap",
+            assignee="mike",
+            triage=True,
+        )
+        kb.add_comment(conn, tid, author="karim", body="New scope: do not replay bootstrap")
+
+    payload = jsonlib.dumps(
+        {
+            "fanout": False,
+            "rationale": "single continuation",
+            "title": "Bounded continuation",
+            "body": "Do not replay bootstrap.",
+            "assignee": "mike",
+        }
+    )
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_fake_aux_response(payload),
+    ) as call_llm:
+        outcome = decomp.decompose_task(tid, author="me")
+
+    assert outcome.ok is True
+    messages = call_llm.call_args.kwargs["messages"]
+    assert "later comments override conflicting" in messages[0]["content"].lower()
+    user_prompt = messages[1]["content"]
+    assert user_prompt.index("Old scope") < user_prompt.index("New scope")
+
+
+def test_fanout_preserves_existing_root_owner(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="development root", assignee="mike", triage=True
+        )
+    payload = jsonlib.dumps(
+        {
+            "fanout": True,
+            "rationale": "parallel units",
+            "tasks": [
+                {"title": "inspect", "assignee": "researcher", "parents": []}
+            ],
+        }
+    )
+    patches = _patch_list_profiles(["default", "mike", "researcher"])
+    for patcher in patches:
+        patcher.start()
+    try:
+        with _patch_aux_client(payload), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"orchestrator_profile": "default"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for patcher in patches:
+            patcher.stop()
+
+    assert outcome.ok is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.assignee == "mike"
+
+

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,54 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_atomic_decompose_rejects_block_loop_recovery_triage(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already executed", assignee="mike")
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="default",
+            children=[{"title": "stale bootstrap", "assignee": "researcher"}],
+            author="auto-decomposer",
+        )
+        assert child_ids is None
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.assignee == "mike"
+        assert kb.child_ids(conn, tid) == []
+
+
+def test_atomic_decompose_does_not_rematerialize_prior_work_graph(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="materialized workflow", triage=True)
+        first = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="mike",
+            children=[{"title": "first child", "assignee": "researcher"}],
+            author="decomposer",
+        )
+        assert first is not None
+        assert kb.triage_continuation_event(conn, tid) == "decomposed"
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'triage' WHERE id = ?", (tid,))
+
+        replay = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="default",
+            children=[{"title": "duplicate child", "assignee": "researcher"}],
+            author="auto-decomposer",
+        )
+        assert replay is None
+        assert kb.parent_ids(conn, tid) == first
+
+
 
 

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -138,3 +138,47 @@ def test_cli_specify_tenant_filter(kanban_home, capsys):
         assert kb.get_task(conn, inside).status in {"todo", "ready"}
 
 
+def test_specifier_refuses_block_loop_recovery_without_calling_llm(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already executed", assignee="mike")
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = spec.specify_task(tid, author="auto-specifier")
+
+    assert outcome.ok is False
+    assert "explicit continuation required" in outcome.reason
+    call_llm.assert_not_called()
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee == "mike"
+
+
+def test_specifier_prompt_uses_recent_comments_as_authoritative(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="bounded task",
+            body="Old scope: replay bootstrap",
+            triage=True,
+        )
+        kb.add_comment(conn, tid, author="karim", body="New scope: do not replay bootstrap")
+
+    content = jsonlib.dumps({"title": "Bounded task", "body": "Do not replay."})
+    patcher, call_llm = _patch_aux_client(content)
+    with patcher:
+        outcome = spec.specify_task(tid)
+
+    assert outcome.ok is True
+    messages = call_llm.call_args.kwargs["messages"]
+    assert "Later comments override conflicting" in messages[0]["content"]
+    user_prompt = messages[1]["content"]
+    assert user_prompt.index("Old scope") < user_prompt.index("New scope")
+
+

--- a/tests/hermes_cli/test_kanban_specify_db.py
+++ b/tests/hermes_cli/test_kanban_specify_db.py
@@ -79,3 +79,26 @@ def test_specify_records_audit_comment_only_when_author_given(kanban_home):
     assert comments2 == []
 
 
+def test_atomic_specify_rejects_block_loop_recovery_triage(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already executed", assignee="mike")
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="mike") is not None
+        assert kb.block_task(conn, tid, reason="review", kind="needs_input")
+
+        assert kb.specify_triage_task(
+            conn,
+            tid,
+            title="stale bootstrap",
+            body="repeat old side effects",
+            assignee="default",
+        ) is False
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.title == "already executed"
+        assert task.assignee == "mike"
+
+


### PR DESCRIPTION
## Summary

Prevent triage recovery roots from being automatically specified/decomposed as if they were fresh rough ideas.

## Root cause

The block-loop breaker correctly routes a repeatedly unblocked/re-blocked task to `triage` and emits `block_loop_detected`. The auto-decompose sweep selected every triage task without consulting append-only task history, so it immediately reinterpreted stale body text, could materialize duplicate children, and fanout replaced an existing root owner with the configured orchestrator.

Specifier/decomposer prompts also omitted task comments, so a recent scope approval could lose to older body text.

## Fix

- Treat `block_loop_detected` and prior `decomposed` events as durable continuation guards.
- Exclude guarded roots from automatic triage scans.
- Enforce the same guard atomically in DB specification/decomposition helpers to close races and direct-call bypasses.
- Return a clean `explicit continuation required` outcome without invoking the LLM.
- Preserve an existing root assignee during legitimate fanout.
- Append a bounded chronological tail of recent comments to both prompts and declare later comments authoritative over conflicting body text.

## Verification

- RED reproducer before fix: focused failures for runtime scan, module guard, atomic DB guard, owner preservation, and comment precedence.
- Rebased candidate/support/runtime + block-loop suite: `23 passed`.
- Ruff on all changed files: passed.
- `git diff origin/main --check`: passed.

## Rollout

1. Merge after independent review and CI.
2. Deploy through the normal Hermes release path; no live config/profile/database migration is required.
3. Observe gateway logs for `explicit continuation required` and verify loop-breaker roots remain in triage with their assignee/comments/children unchanged.
4. Continue a guarded root only through an explicit human edit/promotion; do not auto-reprocess its stale body.

## Rollback

Revert commit `c39c5350a`. No schema migration or data rewrite is introduced, so rollback is code-only. Existing task events/comments remain untouched.

## Safety

No live COO v3.0.4, profile, deployment, credential, or production database was modified.