### PR TITLE
fix(install): restore cua-driver daemon after macOS upgrades

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -882,6 +882,65 @@ def _cua_install_target_writable() -> bool:
         return True
 
 
+def _cua_driver_subprocess_env() -> dict:
+    """Return a cua-driver environment with Hermes-managed secrets removed."""
+    from tools.environments.local import _sanitize_subprocess_env
+
+    return _sanitize_subprocess_env(_cua_driver_env())
+
+
+def _cua_daemon_is_running(binary: str) -> bool:
+    """Best-effort daemon status probe using the pre-update binary."""
+    try:
+        return subprocess.run(
+            [binary, "status"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=2, env=_cua_driver_subprocess_env(),
+            creationflags=_post_setup_no_window_flags(),
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+def _restore_macos_cua_daemon(binary: str) -> None:
+    """Ask LaunchServices to restore a daemon stopped by an app upgrade."""
+    import time
+
+    # The upstream installer may eventually learn to restart the daemon itself.
+    # Avoid forcing a second app instance if it already did so.
+    if _cua_daemon_is_running(binary):
+        return
+
+    try:
+        launched = subprocess.run(
+            [
+                "/usr/bin/open", "-n", "-g", "-a",
+                "/Applications/CuaDriver.app", "--args", "serve",
+            ],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5, env=_cua_driver_subprocess_env(),
+            creationflags=_post_setup_no_window_flags(),
+        )
+        if launched.returncode != 0:
+            raise RuntimeError(launched.stderr.strip() or "LaunchServices request failed")
+
+        # LaunchServices cold starts can include signature verification and take
+        # several seconds. Poll against a deadline so fast failures do not turn
+        # this into the sub-second window produced by a fixed small attempt count.
+        deadline = time.monotonic() + 10.0
+        while True:
+            if _cua_daemon_is_running(binary):
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(0.5, remaining))
+    except Exception as exc:
+        _print_warning(f"    cua-driver updated, but its daemon could not be restored: {exc}")
+        return
+    _print_warning("    cua-driver updated, but its daemon did not restart in time.")
+
+
 def install_cua_driver(
     upgrade: bool = False,
     require_confirmed_update: bool = False,
@@ -1049,6 +1108,10 @@ def install_cua_driver(
             if _re.fullmatch(r"\d+(\.\d+)*", _latest):
                 confirmed_version = _latest
 
+    daemon_was_running = (
+        system == "Darwin" and bool(binary) and _cua_daemon_is_running(binary)
+    )
+
     if binary:
         # Show before/after version when we have a baseline. Best-effort.
         try:
@@ -1068,6 +1131,8 @@ def install_cua_driver(
         pin_version=confirmed_version,
         show_progress=show_installer_progress,
     )
+    if ok and daemon_was_running and binary:
+        _restore_macos_cua_daemon(binary)
     if ok and before:
         try:
             after = subprocess.run(

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -71,6 +71,170 @@ class TestInstallCuaDriverUpgrade:
             assert tools_config.install_cua_driver(upgrade=True) is True
             runner.assert_called_once()
 
+    def test_successful_macos_upgrade_restores_previously_running_daemon(self):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        binary = "/usr/local/bin/cua-driver"
+        status_results = iter([0, 1, 0])
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == [binary, "status"]:
+                # Running before the installer, stopped after it, then restored.
+                return MagicMock(returncode=next(status_results))
+            if cmd == [binary, "--version"]:
+                return MagicMock(returncode=0, stdout="cua-driver 0.14.2")
+            if cmd[0] == "/usr/bin/open":
+                return MagicMock(returncode=0)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("platform.system", return_value="Darwin"), \
+             patch.object(tools_config, "_resolved_cua_driver_cmd", return_value=binary), \
+             patch.object(tools_config.shutil, "which", return_value="/usr/bin/curl"), \
+             patch("tools.computer_use.cua_backend.cua_driver_update_check",
+                   return_value=None), \
+             patch.object(tools_config, "_run_cua_driver_installer", return_value=True), \
+             patch.object(tools_config.subprocess, "run", side_effect=run), \
+             patch.object(tools_config, "_print_warning"):
+            assert tools_config.install_cua_driver(upgrade=True) is True
+
+        assert [binary, "status"] == calls[0]
+        assert [
+            "/usr/bin/open", "-n", "-g", "-a", "/Applications/CuaDriver.app",
+            "--args", "serve",
+        ] in calls
+        assert calls.count([binary, "status"]) == 3
+
+    def test_macos_upgrade_does_not_duplicate_daemon_if_installer_restores_it(self):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        binary = "/usr/local/bin/cua-driver"
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == [binary, "status"]:
+                return MagicMock(returncode=0)
+            if cmd == [binary, "--version"]:
+                return MagicMock(returncode=0, stdout="cua-driver 0.14.2")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("platform.system", return_value="Darwin"), \
+             patch.object(tools_config, "_resolved_cua_driver_cmd", return_value=binary), \
+             patch.object(tools_config.shutil, "which", return_value="/usr/bin/curl"), \
+             patch("tools.computer_use.cua_backend.cua_driver_update_check",
+                   return_value=None), \
+             patch.object(tools_config, "_run_cua_driver_installer", return_value=True), \
+             patch.object(tools_config.subprocess, "run", side_effect=run):
+            assert tools_config.install_cua_driver(upgrade=True) is True
+
+        assert calls.count([binary, "status"]) == 2
+        assert not any(cmd[0] == "/usr/bin/open" for cmd in calls)
+
+    def test_macos_daemon_restore_scrubs_hermes_secrets_from_children(self):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        binary = "/usr/local/bin/cua-driver"
+        status_results = iter([1, 0])
+        child_envs = []
+
+        def run(cmd, **kwargs):
+            child_envs.append(kwargs["env"])
+            if cmd == [binary, "status"]:
+                return MagicMock(returncode=next(status_results))
+            if cmd[0] == "/usr/bin/open":
+                return MagicMock(returncode=0)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(
+            tools_config,
+            "_cua_driver_env",
+            return_value={"PATH": "/usr/bin", "GITHUB_TOKEN": "not-a-real-token"},
+        ), patch.object(tools_config.subprocess, "run", side_effect=run):
+            tools_config._restore_macos_cua_daemon(binary)
+
+        assert child_envs
+        assert all(env.get("PATH") == "/usr/bin" for env in child_envs)
+        assert all("GITHUB_TOKEN" not in env for env in child_envs)
+
+    @pytest.mark.parametrize(
+        ("system", "status_returncode", "installer_ok"),
+        [
+            ("Darwin", 1, True),
+            ("Darwin", 0, False),
+            ("Linux", 0, True),
+        ],
+    )
+    def test_upgrade_does_not_force_start_without_full_restore_contract(
+        self, system, status_returncode, installer_ok
+    ):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        binary = "/usr/local/bin/cua-driver"
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == [binary, "status"]:
+                return MagicMock(returncode=status_returncode)
+            if cmd == [binary, "--version"]:
+                return MagicMock(returncode=0, stdout="cua-driver 0.14.2")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("platform.system", return_value=system), \
+             patch.object(tools_config, "_resolved_cua_driver_cmd", return_value=binary), \
+             patch.object(tools_config.shutil, "which", return_value="/usr/bin/curl"), \
+             patch("tools.computer_use.cua_backend.cua_driver_update_check",
+                   return_value=None), \
+             patch.object(tools_config, "_run_cua_driver_installer",
+                          return_value=installer_ok), \
+             patch.object(tools_config.subprocess, "run", side_effect=run):
+            assert tools_config.install_cua_driver(upgrade=True) is installer_ok
+
+        assert not any(cmd[0] == "/usr/bin/open" for cmd in calls)
+        if system != "Darwin":
+            assert [binary, "status"] not in calls
+
+    def test_restore_failure_warns_without_failing_successful_upgrade(self):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        binary = "/usr/local/bin/cua-driver"
+
+        status_results = iter([0, 1])
+
+        def run(cmd, **kwargs):
+            if cmd == [binary, "status"]:
+                return MagicMock(returncode=next(status_results))
+            if cmd == [binary, "--version"]:
+                return MagicMock(returncode=0, stdout="cua-driver 0.14.2")
+            if cmd[0] == "/usr/bin/open":
+                return MagicMock(returncode=1, stderr="launch failed")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("platform.system", return_value="Darwin"), \
+             patch.object(tools_config, "_resolved_cua_driver_cmd", return_value=binary), \
+             patch.object(tools_config.shutil, "which", return_value="/usr/bin/curl"), \
+             patch("tools.computer_use.cua_backend.cua_driver_update_check",
+                   return_value=None), \
+             patch.object(tools_config, "_run_cua_driver_installer", return_value=True), \
+             patch.object(tools_config.subprocess, "run", side_effect=run), \
+             patch.object(tools_config, "_print_warning") as warning:
+            assert tools_config.install_cua_driver(upgrade=True) is True
+
+        assert any("could not be restored" in call.args[0]
+                   for call in warning.call_args_list)
+
     def test_quiet_refresh_prints_single_contextual_progress_line(self):
         import subprocess
         from unittest.mock import MagicMock


### PR DESCRIPTION
## What does this PR do?

`install_cua_driver(upgrade=True)` now restores a CuaDriver daemon that was running before a successful macOS upgrade.

The upstream installer stops the old daemon while replacing `CuaDriver.app`. Hermes previously returned after the installer succeeded, leaving the daemon offline until something launched it again. The update path now records the pre-upgrade daemon state and restores that state through LaunchServices.

The restore is deliberately narrow and best-effort:

- macOS upgrades only
- only when an existing daemon was running before the installer
- only after the installer succeeds
- no launch for fresh installs, already-current installs, failed installs, or non-macOS systems
- no duplicate launch if the installer has already restored the daemon
- restore failures warn without turning a successful Hermes update into a failure

LaunchServices opens the signed `/Applications/CuaDriver.app` with `serve`; Hermes-managed secrets are removed from both status and launch subprocess environments. A bounded 10-second status poll verifies cold starts without creating a permanent LaunchAgent or changing permission state.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Probe the daemon before a confirmed macOS upgrade.
- Restore a previously running daemon through LaunchServices after installation succeeds.
- Avoid duplicate launches when the installer has already restored the daemon.
- Poll status against a monotonic deadline and keep restore failures non-fatal.
- Sanitize child-process environments before invoking CuaDriver or LaunchServices.
- Add behavior tests for successful restore, no-op conditions, duplicate prevention, secret scrubbing, and non-fatal launch failures.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/hermes_cli/test_install_cua_driver.py tests/hermes_cli/test_cmd_update.py -q`
2. Confirm the CuaDriver upgrade contract tests cover both the restore and no-launch branches.
3. Confirm `git diff --check origin/main...HEAD` succeeds.

TDD evidence:

- RED: the restore-contract test failed before the production change because the upgrade path queried `--version` without first recording daemon status.
- GREEN: the targeted install and update suites pass with **73 tests passed, 0 failed**.
- A broader local `tests/hermes_cli` run produced failures only in unrelated environment/platform-specific test files; both changed test coverage and the update call-path suite passed.
- Independent post-fix review found no blocking issues.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (automated tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A. The behavior is covered by automated tests; no private machine logs or screenshots are included.
