### PR TITLE
fix(agent): treat clean OpenCode text streams without finish_reason as stop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3355,6 +3355,33 @@ def cleanup_task_resources(agent, task_id: str) -> None:
             logger.warning("Failed to cleanup browser for task %s: %s", task_id, e)
 
 
+# Gateways that routinely complete a full text-only answer without sending
+# finish_reason on the final SSE event. Real connection drops still raise
+# and keep using the partial-stream stub path (#32086 / #75801).
+_CLEAN_TEXT_NO_FINISH_PROVIDERS = frozenset({
+    "opencode-go",
+    "opencode-zen",
+    "opencode",
+    "go",
+    "zen",
+})
+
+
+def _provider_accepts_clean_text_end_without_finish_reason(agent) -> bool:
+    """Return True when a clean text stream with no finish_reason is complete.
+
+    OpenCode Go (e.g. gpt-5.6-luna) ends some successful text-only turns
+    without a finish_reason chunk. Classifying those as mid-stream drops
+    forces useless length-continuation retries (#75801). Match by provider
+    id first, then by known OpenCode hostnames on base_url.
+    """
+    provider = (getattr(agent, "provider", None) or "").strip().lower()
+    if provider in _CLEAN_TEXT_NO_FINISH_PROVIDERS:
+        return True
+    base = (getattr(agent, "base_url", None) or "").lower()
+    return "opencode.ai" in base
+
+
 def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None,
@@ -4547,21 +4574,38 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # text content but no tool calls.  Without this guard the partial
         # text is silently stamped finish_reason="stop" and the turn ends as
         # if complete — the model's intended next step is lost (#32086).
+        #
+        # Exception: some OpenCode gateways (notably gpt-5.6-luna on
+        # opencode-go) complete a full text answer cleanly and still omit
+        # finish_reason on the final SSE chunk. Treating those as mid-stream
+        # drops burns the length-continuation budget four times and leaves
+        # Desktop showing "Response remained truncated..." while wiping the
+        # already-streamed answer (#75801). Exception-based stalls on the
+        # same providers still hit the exception -> stub path and keep the
+        # #32086 behaviour.
         _text_only_dropped_no_finish = (
             finish_reason is None
             and content_parts
             and not tool_calls_acc
         )
         if _text_only_dropped_no_finish:
-            logger.warning(
-                "Stream ended with no finish_reason after delivering text "
-                "with no tool calls; treating as a mid-stream drop."
-            )
-            return _build_partial_stream_stub(
-                role, full_content,
-                "".join(reasoning_parts) or None,
-                model_name, usage_obj,
-            )
+            if _provider_accepts_clean_text_end_without_finish_reason(agent):
+                logger.info(
+                    "Stream ended with no finish_reason after delivering text "
+                    "with no tool calls on provider %r; treating as clean stop "
+                    "(gateway omits finish_reason on complete text turns).",
+                    getattr(agent, "provider", None),
+                )
+            else:
+                logger.warning(
+                    "Stream ended with no finish_reason after delivering text "
+                    "with no tool calls; treating as a mid-stream drop."
+                )
+                return _build_partial_stream_stub(
+                    role, full_content,
+                    "".join(reasoning_parts) or None,
+                    model_name, usage_obj,
+                )
 
         effective_finish_reason = finish_reason or "stop"
         if has_truncated_tool_args:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3378,8 +3378,9 @@ def _provider_accepts_clean_text_end_without_finish_reason(agent) -> bool:
     provider = (getattr(agent, "provider", None) or "").strip().lower()
     if provider in _CLEAN_TEXT_NO_FINISH_PROVIDERS:
         return True
-    base = (getattr(agent, "base_url", None) or "").lower()
-    return "opencode.ai" in base
+    base = getattr(agent, "base_url", None) or ""
+    # Host match only — reject path/lookalike false positives (utils.base_url_host_matches).
+    return base_url_host_matches(base, "opencode.ai")
 
 
 def _build_partial_stream_stub(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2445,6 +2445,33 @@ def cleanup_task_resources(agent, task_id: str) -> None:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
 
 
+# Gateways that routinely complete a full text-only answer without sending
+# finish_reason on the final SSE event. Real connection drops still raise
+# and keep using the partial-stream stub path (#32086 / #75801).
+_CLEAN_TEXT_NO_FINISH_PROVIDERS = frozenset({
+    "opencode-go",
+    "opencode-zen",
+    "opencode",
+    "go",
+    "zen",
+})
+
+
+def _provider_accepts_clean_text_end_without_finish_reason(agent) -> bool:
+    """Return True when a clean text stream with no finish_reason is complete.
+
+    OpenCode Go (e.g. gpt-5.6-luna) ends some successful text-only turns
+    without a finish_reason chunk. Classifying those as mid-stream drops
+    forces useless length-continuation retries (#75801). Match by provider
+    id first, then by known OpenCode hostnames on base_url.
+    """
+    provider = (getattr(agent, "provider", None) or "").strip().lower()
+    if provider in _CLEAN_TEXT_NO_FINISH_PROVIDERS:
+        return True
+    base = (getattr(agent, "base_url", None) or "").lower()
+    return "opencode.ai" in base
+
+
 def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None,
@@ -3454,21 +3481,38 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # text content but no tool calls.  Without this guard the partial
         # text is silently stamped finish_reason="stop" and the turn ends as
         # if complete — the model's intended next step is lost (#32086).
+        #
+        # Exception: some OpenCode gateways (notably gpt-5.6-luna on
+        # opencode-go) complete a full text answer cleanly and still omit
+        # finish_reason on the final SSE chunk. Treating those as mid-stream
+        # drops burns the length-continuation budget four times and leaves
+        # Desktop showing "Response remained truncated..." while wiping the
+        # already-streamed answer (#75801). Exception-based stalls on the
+        # same providers still hit the exception -> stub path and keep the
+        # #32086 behaviour.
         _text_only_dropped_no_finish = (
             finish_reason is None
             and content_parts
             and not tool_calls_acc
         )
         if _text_only_dropped_no_finish:
-            logger.warning(
-                "Stream ended with no finish_reason after delivering text "
-                "with no tool calls; treating as a mid-stream drop."
-            )
-            return _build_partial_stream_stub(
-                role, full_content,
-                "".join(reasoning_parts) or None,
-                model_name, usage_obj,
-            )
+            if _provider_accepts_clean_text_end_without_finish_reason(agent):
+                logger.info(
+                    "Stream ended with no finish_reason after delivering text "
+                    "with no tool calls on provider %r; treating as clean stop "
+                    "(gateway omits finish_reason on complete text turns).",
+                    getattr(agent, "provider", None),
+                )
+            else:
+                logger.warning(
+                    "Stream ended with no finish_reason after delivering text "
+                    "with no tool calls; treating as a mid-stream drop."
+                )
+                return _build_partial_stream_stub(
+                    role, full_content,
+                    "".join(reasoning_parts) or None,
+                    model_name, usage_obj,
+                )
 
         effective_finish_reason = finish_reason or "stop"
         if has_truncated_tool_args:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2468,8 +2468,9 @@ def _provider_accepts_clean_text_end_without_finish_reason(agent) -> bool:
     provider = (getattr(agent, "provider", None) or "").strip().lower()
     if provider in _CLEAN_TEXT_NO_FINISH_PROVIDERS:
         return True
-    base = (getattr(agent, "base_url", None) or "").lower()
-    return "opencode.ai" in base
+    base = getattr(agent, "base_url", None) or ""
+    # Host match only — reject path/lookalike false positives (utils.base_url_host_matches).
+    return base_url_host_matches(base, "opencode.ai")
 
 
 def _build_partial_stream_stub(

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -94,6 +94,79 @@ class TestPartialStreamStubFinishReason:
 
 # ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
 
+class TestCleanTextEndWithoutFinishReason:
+    """#75801: OpenCode Go (gpt-5.6-luna) completes text-only turns cleanly
+    but omits finish_reason on the final SSE chunk. Generic providers must
+    still treat that shape as a mid-stream drop (#32086). Exception-based
+    stalls on OpenCode still stub.
+    """
+
+    def _run_clean_text_stream(self, agent, mock_create, monkeypatch, text="Hello!"):
+        def _clean_text_stream():
+            yield _make_stream_chunk(content=text)
+            # clean end: no finish_reason chunk, no exception
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_text_stream()
+        )
+        mock_create.return_value = mock_client
+        agent._fire_stream_delta = lambda t: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        return agent._interruptible_streaming_api_call({})
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_generic_provider_still_stubs(self, _mock_close, mock_create, monkeypatch):
+        agent = _make_agent()
+        agent.provider = "openrouter"
+        response = self._run_clean_text_stream(agent, mock_create, monkeypatch)
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_opencode_go_accepts_as_stop(self, _mock_close, mock_create, monkeypatch):
+        agent = _make_agent()
+        agent.provider = "opencode-go"
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.model = "gpt-5.6-luna"
+        response = self._run_clean_text_stream(
+            agent, mock_create, monkeypatch, text="Hello! How can I help?"
+        )
+        assert response.id != PARTIAL_STREAM_STUB_ID, (
+            "OpenCode Go clean text end without finish_reason must not be "
+            "classified as a mid-stream drop (#75801)."
+        )
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "Hello! How can I help?"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_opencode_go_exception_still_stubs(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _stalling_stream():
+            yield _make_stream_chunk(content="partial answer")
+            raise RuntimeError("connection reset")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _stalling_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent.provider = "opencode-go"
+        agent._current_streamed_assistant_text = "partial answer"
+        agent._fire_stream_delta = lambda t: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
+
 class TestCleanStreamEndMidToolCall:
     """The upstream closes the SSE stream cleanly after delivering a tool
     name + the opening '{' of its arguments — NO exception, NO finish_reason,

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -166,6 +166,47 @@ class TestCleanTextEndWithoutFinishReason:
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_opencode_host_fallback_accepts_as_stop(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Provider id may be blank; official opencode.ai host still counts."""
+        agent = _make_agent()
+        agent.provider = ""
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        response = self._run_clean_text_stream(
+            agent, mock_create, monkeypatch, text="from host fallback",
+        )
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_path_containing_opencode_ai_still_stubs(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Path substring must not be treated as OpenCode (#76112 review)."""
+        agent = _make_agent()
+        agent.provider = "openrouter"
+        agent.base_url = "https://evil.com/opencode.ai/v1"
+        response = self._run_clean_text_stream(agent, mock_create, monkeypatch)
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_lookalike_host_still_stubs(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Lookalike hostnames must not match base_url_host_matches."""
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.base_url = "https://opencode.ai.evil/v1"
+        response = self._run_clean_text_stream(agent, mock_create, monkeypatch)
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
 
 class TestCleanStreamEndMidToolCall:
     """The upstream closes the SSE stream cleanly after delivering a tool

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -189,6 +189,55 @@ def test_completed_turn_still_clears_inflight(emits, turn_env):
     assert server._inflight_snapshot(session) is None
 
 
+def test_returned_partial_error_keeps_final_response_text(emits, turn_env):
+    """#75801: returned-error path must set partial=true when final_response
+    holds the stitched answer, matching the exception path so Desktop does
+    not strip already-streamed bubble text.
+    """
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {
+            "final_response": "Hello! How can I help?",
+            "error": "Response remained truncated after 4 continuation attempts",
+            "failed": True,
+            "partial": True,
+        },
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "hello")
+
+    server._run_prompt_submit("rid", "sid", session, "hello")
+
+    completes = _events(emits, "message.complete")
+    assert len(completes) == 1
+    payload = completes[0]
+    assert payload["status"] == "error"
+    assert payload["partial"] is True
+    assert payload["text"] == "Hello! How can I help?"
+    assert "truncated" in payload["error"]
+
+
+def test_returned_error_without_partial_does_not_set_flag(emits, turn_env):
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {
+            "final_response": "",
+            "error": "provider 402: billing wall",
+            "failed": True,
+        },
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "do the thing")
+
+    server._run_prompt_submit("rid", "sid", session, "do the thing")
+
+    payload = _events(emits, "message.complete")[0]
+    assert payload["status"] == "error"
+    assert "partial" not in payload
+
+
 # ── Exception path ─────────────────────────────────────────────────────
 
 

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -249,6 +249,55 @@ def test_completed_turn_still_clears_inflight(emits, turn_env):
     assert server._inflight_snapshot(session) is None
 
 
+def test_returned_partial_error_keeps_final_response_text(emits, turn_env):
+    """#75801: returned-error path must set partial=true when final_response
+    holds the stitched answer, matching the exception path so Desktop does
+    not strip already-streamed bubble text.
+    """
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {
+            "final_response": "Hello! How can I help?",
+            "error": "Response remained truncated after 4 continuation attempts",
+            "failed": True,
+            "partial": True,
+        },
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "hello")
+
+    server._run_prompt_submit("rid", "sid", session, "hello")
+
+    completes = _events(emits, "message.complete")
+    assert len(completes) == 1
+    payload = completes[0]
+    assert payload["status"] == "error"
+    assert payload["partial"] is True
+    assert payload["text"] == "Hello! How can I help?"
+    assert "truncated" in payload["error"]
+
+
+def test_returned_error_without_partial_does_not_set_flag(emits, turn_env):
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {
+            "final_response": "",
+            "error": "provider 402: billing wall",
+            "failed": True,
+        },
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "do the thing")
+
+    server._run_prompt_submit("rid", "sid", session, "do the thing")
+
+    payload = _events(emits, "message.complete")[0]
+    assert payload["status"] == "error"
+    assert "partial" not in payload
+
+
 # ── Exception path ─────────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13183,6 +13183,21 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
                 if _error_surface:
                     payload["error_surface"] = _error_surface
+                # Match the exception path (_emit_terminal_turn_error): when the
+                # agent finished partial=True with a non-empty final_response
+                # that is not just the error string, keep that text under the
+                # red banner. Desktop only retains bubble text when
+                # failure.partial is set (#75801).
+                if isinstance(result, dict):
+                    final_text = result.get("final_response")
+                    err_text = str(result.get("error") or "")
+                    if (
+                        result.get("partial")
+                        and isinstance(final_text, str)
+                        and final_text.strip()
+                        and final_text.strip() != err_text.strip()
+                    ):
+                        payload["partial"] = True
             if terminal_callback is not None:
                 terminal_receipt_attempted = True
                 terminal_callback(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9613,6 +9613,21 @@ def _run_prompt_submit(
                     (result.get("error") if isinstance(result, dict) else "") or raw
                 )
                 payload["recoverable"] = True
+                # Match the exception path (_emit_terminal_turn_error): when the
+                # agent finished partial=True with a non-empty final_response
+                # that is not just the error string, keep that text under the
+                # red banner. Desktop only retains bubble text when
+                # failure.partial is set (#75801).
+                if isinstance(result, dict):
+                    final_text = result.get("final_response")
+                    err_text = str(result.get("error") or "")
+                    if (
+                        result.get("partial")
+                        and isinstance(final_text, str)
+                        and final_text.strip()
+                        and final_text.strip() != err_text.strip()
+                    ):
+                        payload["partial"] = True
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 


### PR DESCRIPTION
## What does this PR do?

Two related failures show up with Hermes Desktop + OpenCode Go `gpt-5.6-luna`:

1. **False mid-stream classification.** Luna streams a complete text answer, then the SSE ends cleanly with no `finish_reason` and no exception. `interruptible_streaming_api_call` treated every text-only stream without `finish_reason` as a mid-stream drop (`PARTIAL_STREAM_STUB_ID` + `finish_reason=length`, from #32086 / #30963). The loop then injected the "network error mid-stream" continuation up to four times and finally reported "Response remained truncated after 4 continuation attempts".

2. **Desktop wipes the streamed answer.** On the returned-error path, `tui_gateway/server.py` emitted `message.complete` with `status: "error"` but did not set `partial: true` even when `result["partial"]` was true and `final_response` held the stitched answer. The exception path already sets `partial: true` via `_emit_terminal_turn_error`. Desktop only keeps bubble text when `failure.partial && finalText`, so the streamed answer disappeared under the red banner.

This PR:

- Accepts a **clean** text-only end without `finish_reason` as `finish_reason=stop` when the provider is OpenCode (`opencode-go` / `opencode-zen` / `opencode`, including common aliases and `opencode.ai` base URLs).
- Keeps the partial-stream stub for **exception-based** stalls on those same providers, and for clean no-finish text ends on every other provider (preserves #32086).
- Sets `partial: true` on returned-error `message.complete` when `result.partial` is set and `final_response` is non-empty and distinct from the error string.

## Related Issue

Fixes #75801

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Provider gate for OpenCode clean text ends without finish_reason
  - Logging at info when accepting as stop; warning + stub for other providers
- `tui_gateway/server.py`
  - Returned-error path now mirrors exception path for `partial`
- `tests/run_agent/test_partial_stream_finish_reason.py`
  - Generic provider still stubs clean text end
  - OpenCode Go accepts as stop
  - OpenCode Go + exception still stubs
- `tests/tui_gateway/test_failed_turn_retention.py`
  - Partial returned-error keeps final_response text and sets partial
  - Non-partial returned-error still omits the flag

## How to Test

```bash
pytest tests/run_agent/test_partial_stream_finish_reason.py::TestCleanTextEndWithoutFinishReason \
       tests/run_agent/test_partial_stream_finish_reason.py::TestPartialStreamStubFinishReason \
       tests/tui_gateway/test_failed_turn_retention.py::test_returned_partial_error_keeps_final_response_text \
       tests/tui_gateway/test_failed_turn_retention.py::test_returned_error_without_partial_does_not_set_flag \
       -v
```

Docker (`ghcr.io/astral-sh/uv:python3.12-bookworm-slim` + `uv pip install -e ".[dev]"`): **6/6 passed**.

Manual (if you have OpenCode Go + Desktop):

1. Provider `opencode-go`, model `gpt-5.6-luna`
2. Send a short prompt (`hello`)
3. Answer should complete once without four "network error mid-stream" continuations
4. If a turn still fails partial with text, the bubble text should remain under the error banner

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(agent): …`)
- [x] Searched for existing PRs — none open for #75801
- [x] PR is focused on this fix only
- [x] Added / updated tests; they pass
- [x] Tested on Linux via Docker

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] Config example — N/A
- [x] Cross-platform — N/A (streaming classification + WS payload shape)
- [x] Tool schemas — N/A

## Notes

I gated the clean-end exception on OpenCode only rather than accepting no-finish as stop globally. Widening that would re-open the #32086 class of silent incomplete answers on providers that truly drop mid-text without an exception. If maintainers prefer a config flag or a broader allowlist later, happy to adjust.