### PR TITLE
fix(agent): honor prompt_caching.cache_ttl=off on MoA and fallback stub paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1878,6 +1878,30 @@ def prompt_caching_disabled_from_config() -> bool:
     return str(ttl).lower() in ("off", "false", "disabled", "no", "none")
 
 
+def blank_cache_policy_stub(cache_disabled: Optional[bool] = None):
+    """Build the destination-identity-blank stub for ``anthropic_prompt_cache_policy``.
+
+    Single sanctioned constructor for that stub. Callers that resolve cache
+    policy against a destination identified out-of-band (not a live
+    ``AIAgent``) must go through here so ``_cache_disabled`` is never left
+    off a hand-rolled ``SimpleNamespace`` (#76085).
+
+    When ``cache_disabled`` is omitted, falls back to the global config so
+    stub paths without an agent snapshot still honor an operator disable.
+    """
+    from types import SimpleNamespace
+
+    if cache_disabled is None:
+        cache_disabled = prompt_caching_disabled_from_config()
+    return SimpleNamespace(
+        provider="",
+        base_url="",
+        api_mode="",
+        model="",
+        _cache_disabled=bool(cache_disabled),
+    )
+
+
 def plan_cache_sections_for_destination(
     messages: list,
     tools: Optional[list],
@@ -1905,23 +1929,13 @@ def plan_cache_sections_for_destination(
     consulted so MoA/auxiliary paths cannot re-enable markers after the
     user turned caching off (#76085).
     """
-    from types import SimpleNamespace
-
     from agent.prompt_caching import (
         build_prompt_cache_plan,
         strip_anthropic_cache_control,
         strip_anthropic_tool_cache_control,
     )
 
-    if cache_disabled is None:
-        cache_disabled = prompt_caching_disabled_from_config()
-    stub = SimpleNamespace(
-        provider="",
-        base_url="",
-        api_mode="",
-        model="",
-        _cache_disabled=bool(cache_disabled),
-    )
+    stub = blank_cache_policy_stub(cache_disabled)
     should_cache, native_layout = anthropic_prompt_cache_policy(
         stub,
         provider=provider,
@@ -3931,6 +3945,7 @@ __all__ = [
     "extract_reasoning",
     "dump_api_request_debug",
     "prompt_caching_disabled_from_config",
+    "blank_cache_policy_stub",
     "plan_cache_sections_for_destination",
     "anthropic_prompt_cache_policy",
     "create_openai_client",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1857,6 +1857,27 @@ def _direct_native_anthropic_tool_cache_capability(
     )
 
 
+def prompt_caching_disabled_from_config() -> bool:
+    """Return True when ``prompt_caching.cache_ttl`` is configured as off.
+
+    Mirrors the disable detection in ``agent_init`` so stub-based policy
+    paths (MoA slot decoration, auxiliary fallback replan) honor the same
+    config contract without holding a live ``AIAgent`` (#76085 / #33555).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        pc_cfg = load_config_readonly().get("prompt_caching", {}) or {}
+        ttl = pc_cfg.get("cache_ttl", "5m")
+    except Exception:
+        return False
+    if ttl in {"5m", "1h"}:
+        return False
+    if ttl is False or ttl is None:
+        return True
+    return str(ttl).lower() in ("off", "false", "disabled", "no", "none")
+
+
 def plan_cache_sections_for_destination(
     messages: list,
     tools: Optional[list],
@@ -1865,6 +1886,7 @@ def plan_cache_sections_for_destination(
     base_url: str,
     api_mode: str,
     model: str,
+    cache_disabled: Optional[bool] = None,
 ) -> Tuple[list, list]:
     """Plan request-local cache sections for one resolved destination.
 
@@ -1877,6 +1899,11 @@ def plan_cache_sections_for_destination(
 
     Never mutates ``messages`` or ``tools`` — both return values are
     request-local copies.
+
+    ``cache_disabled`` threads the operator's ``prompt_caching.cache_ttl``
+    disable into the blank policy stub. When omitted, the live config is
+    consulted so MoA/auxiliary paths cannot re-enable markers after the
+    user turned caching off (#76085).
     """
     from types import SimpleNamespace
 
@@ -1886,7 +1913,15 @@ def plan_cache_sections_for_destination(
         strip_anthropic_tool_cache_control,
     )
 
-    stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+    if cache_disabled is None:
+        cache_disabled = prompt_caching_disabled_from_config()
+    stub = SimpleNamespace(
+        provider="",
+        base_url="",
+        api_mode="",
+        model="",
+        _cache_disabled=bool(cache_disabled),
+    )
     should_cache, native_layout = anthropic_prompt_cache_policy(
         stub,
         provider=provider,
@@ -3895,6 +3930,8 @@ __all__ = [
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
+    "prompt_caching_disabled_from_config",
+    "plan_cache_sections_for_destination",
     "anthropic_prompt_cache_policy",
     "create_openai_client",
     "switch_model",

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -404,27 +404,21 @@ def _maybe_apply_moa_cache_control(
     blank-agent pattern (#76085).
     """
     try:
-        from types import SimpleNamespace
-
         from agent.agent_runtime_helpers import (
             anthropic_prompt_cache_policy,
-            prompt_caching_disabled_from_config,
+            blank_cache_policy_stub,
         )
         from agent.prompt_caching import apply_anthropic_cache_control
 
-        if cache_disabled is None:
-            cache_disabled = prompt_caching_disabled_from_config()
+        # Prefer an explicit kwarg, then a snapshot on the runtime dict
+        # (threaded from the live agent), else config via the stub factory.
+        if cache_disabled is None and "_cache_disabled" in runtime:
+            cache_disabled = runtime.get("_cache_disabled")
 
         # The policy function reads agent.* only as fallbacks for kwargs we
-        # don't pass; provide a stub so the slot is judged purely on its own
-        # resolved runtime (plus the operator disable flag).
-        stub = SimpleNamespace(
-            provider="",
-            base_url="",
-            api_mode="",
-            model="",
-            _cache_disabled=bool(cache_disabled),
-        )
+        # don't pass; blank_cache_policy_stub is the only sanctioned stub
+        # so _cache_disabled cannot be left off again (#76085).
+        stub = blank_cache_policy_stub(cache_disabled)
         should_cache, native_layout = anthropic_prompt_cache_policy(
             stub,
             provider=runtime.get("provider") or "",
@@ -450,6 +444,7 @@ def _run_reference(
     max_tokens: int | None = None,
     reference_timeout: float | None = None,
     context_length_cache: Any = None,
+    cache_disabled: bool | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, accounting)``.
 
@@ -511,7 +506,12 @@ def _run_reference(
         # caching is opt-in per request. OpenAI-family advisors are untouched
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
-        messages = _maybe_apply_moa_cache_control(messages, runtime)
+        # Pin the live agent disable onto the runtime so advisor decoration
+        # tracks conversation state, not a fresh config re-read (#76085).
+        cache_runtime = runtime
+        if cache_disabled is not None:
+            cache_runtime = {**runtime, "_cache_disabled": cache_disabled}
+        messages = _maybe_apply_moa_cache_control(messages, cache_runtime)
         # Per-slot max_tokens takes precedence over the preset-level
         # reference_max_tokens passed in by the caller. This lets each
         # reference model have its own output cap independently.
@@ -815,6 +815,9 @@ def _run_references_parallel(
     # instead of re-probing metadata sources per reference (dict get/set is
     # GIL-atomic; a rare duplicate probe on a first-use race is harmless).
     _ctx_len_cache: dict[tuple[str, str], int | None] = {}
+    cache_disabled = (
+        getattr(agent, "_cache_disabled", None) if agent is not None else None
+    )
     try:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -833,6 +836,7 @@ def _run_references_parallel(
                     max_tokens=max_tokens,
                     reference_timeout=reference_timeout,
                     context_length_cache=_ctx_len_cache,
+                    cache_disabled=cache_disabled,
                 )
             ] = idx
 
@@ -1280,6 +1284,14 @@ def aggregate_moa_context(
 
     agg_label = _slot_label(aggregator)
     agg_runtime = _slot_runtime(aggregator)
+    # Pin the live agent disable onto synthesis decoration so mid-session
+    # config flips cannot re-enable markers on this path alone (#76085).
+    agg_cache_runtime = agg_runtime
+    if agent is not None:
+        agg_cache_runtime = {
+            **agg_runtime,
+            "_cache_disabled": getattr(agent, "_cache_disabled", None),
+        }
     try:
         # Same cache_control decoration as _run_reference's advisor calls
         # (see _maybe_apply_moa_cache_control) — this synthesis call is a
@@ -1292,7 +1304,7 @@ def aggregate_moa_context(
         # breakpoints, even when the resolved aggregator slot is a
         # cache-honoring route (e.g. Claude on OpenRouter/native Anthropic).
         agg_messages = _maybe_apply_moa_cache_control(
-            [{"role": "user", "content": synth_prompt}], agg_runtime
+            [{"role": "user", "content": synth_prompt}], agg_cache_runtime
         )
         response = call_llm(
             task="moa_aggregator",

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1691,6 +1691,16 @@ class MoAChatCompletions:
             # plan_cache_sections_for_destination never mutates its inputs
             # and always returns request-local copies, so the prepared
             # state stays canonical.
+            # Tri-state: only pass a bool when a live agent snapshot exists.
+            # Prepared-aggregator facades built via __new__ have no _agent;
+            # getattr(self._agent, ...) raises and bool(None-agent) would
+            # force False and suppress the planner's config fallback (#76085).
+            _agent = getattr(self, "_agent", None)
+            _cache_disabled = (
+                getattr(_agent, "_cache_disabled", None)
+                if _agent is not None
+                else None
+            )
             agg_messages, tools = plan_cache_sections_for_destination(
                 planning_messages,
                 tools,
@@ -1698,9 +1708,7 @@ class MoAChatCompletions:
                 base_url=agg_runtime.get("base_url") or "",
                 api_mode=agg_runtime.get("api_mode") or "",
                 model=agg_runtime.get("model") or "",
-                cache_disabled=bool(
-                    getattr(self._agent, "_cache_disabled", False)
-                ),
+                cache_disabled=_cache_disabled,
             )
             if guidance:
                 _attach_reference_guidance(agg_messages, str(guidance))

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -383,6 +383,8 @@ def _merge_slot_extra_body(
 def _maybe_apply_moa_cache_control(
     messages: list[dict[str, Any]],
     runtime: dict[str, Any],
+    *,
+    cache_disabled: bool | None = None,
 ) -> list[dict[str, Any]]:
     """Decorate an advisor or aggregator request with cache_control when its
     route honors it.
@@ -396,17 +398,33 @@ def _maybe_apply_moa_cache_control(
 
     Returns the messages unchanged on any resolution error or when the
     policy says the route doesn't honor markers.
+
+    ``cache_disabled`` (or the live config when omitted) is stamped onto the
+    policy stub so ``prompt_caching.cache_ttl: off`` is not bypassed by the
+    blank-agent pattern (#76085).
     """
     try:
         from types import SimpleNamespace
 
-        from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
+        from agent.agent_runtime_helpers import (
+            anthropic_prompt_cache_policy,
+            prompt_caching_disabled_from_config,
+        )
         from agent.prompt_caching import apply_anthropic_cache_control
+
+        if cache_disabled is None:
+            cache_disabled = prompt_caching_disabled_from_config()
 
         # The policy function reads agent.* only as fallbacks for kwargs we
         # don't pass; provide a stub so the slot is judged purely on its own
-        # resolved runtime.
-        stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+        # resolved runtime (plus the operator disable flag).
+        stub = SimpleNamespace(
+            provider="",
+            base_url="",
+            api_mode="",
+            model="",
+            _cache_disabled=bool(cache_disabled),
+        )
         should_cache, native_layout = anthropic_prompt_cache_policy(
             stub,
             provider=runtime.get("provider") or "",
@@ -1680,6 +1698,9 @@ class MoAChatCompletions:
                 base_url=agg_runtime.get("base_url") or "",
                 api_mode=agg_runtime.get("api_mode") or "",
                 model=agg_runtime.get("model") or "",
+                cache_disabled=bool(
+                    getattr(self._agent, "_cache_disabled", False)
+                ),
             )
             if guidance:
                 _attach_reference_guidance(agg_messages, str(guidance))

--- a/tests/agent/test_cache_disabled_on_stubs.py
+++ b/tests/agent/test_cache_disabled_on_stubs.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
 
 
 def _has_cache_control(obj) -> bool:

--- a/tests/agent/test_cache_disabled_on_stubs.py
+++ b/tests/agent/test_cache_disabled_on_stubs.py
@@ -1,0 +1,172 @@
+"""Regression for #76085: prompt_caching.cache_ttl off on stub policy paths.
+
+Blank SimpleNamespace stubs used by MoA decoration and auxiliary/MoA
+plan_cache_sections_for_destination never carried ``_cache_disabled``, so
+``anthropic_prompt_cache_policy`` re-enabled cache_control markers even when
+the operator set ``prompt_caching.cache_ttl: false``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _has_cache_control(obj) -> bool:
+    if isinstance(obj, dict):
+        if "cache_control" in obj:
+            return True
+        return any(_has_cache_control(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_cache_control(v) for v in obj)
+    return False
+
+
+class TestPromptCachingDisabledFromConfig:
+    def test_off_values(self):
+        from agent.agent_runtime_helpers import prompt_caching_disabled_from_config
+
+        for ttl in (False, None, "off", "false", "disabled", "no", "none", "OFF"):
+            with patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"prompt_caching": {"cache_ttl": ttl}},
+            ):
+                assert prompt_caching_disabled_from_config() is True, ttl
+
+    def test_enabled_values(self):
+        from agent.agent_runtime_helpers import prompt_caching_disabled_from_config
+
+        for ttl in ("5m", "1h"):
+            with patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"prompt_caching": {"cache_ttl": ttl}},
+            ):
+                assert prompt_caching_disabled_from_config() is False, ttl
+
+
+class TestPlanCacheSectionsHonorsDisable:
+    def test_explicit_cache_disabled_strips_markers(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        out_msgs, out_tools = plan_cache_sections_for_destination(
+            messages,
+            tools,
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+            cache_disabled=True,
+        )
+        assert not _has_cache_control(out_msgs)
+        assert not _has_cache_control(out_tools)
+
+    def test_config_off_without_explicit_flag(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": "off"}},
+        ):
+            out_msgs, out_tools = plan_cache_sections_for_destination(
+                messages,
+                None,
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+                api_mode="anthropic_messages",
+                model="claude-opus-4.8",
+            )
+        assert not _has_cache_control(out_msgs)
+        assert out_tools is None or not _has_cache_control(out_tools)
+
+    def test_enabled_still_adds_markers_on_native_anthropic(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "again"},
+        ]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": "5m"}},
+        ):
+            out_msgs, _ = plan_cache_sections_for_destination(
+                messages,
+                None,
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+                api_mode="anthropic_messages",
+                model="claude-opus-4.8",
+                cache_disabled=False,
+            )
+        assert _has_cache_control(out_msgs), (
+            "With caching enabled, native Anthropic destinations must still "
+            "receive cache_control breakpoints."
+        )
+
+
+class TestMoASlotDecorationHonorsDisable:
+    def test_maybe_apply_skips_markers_when_disabled(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        runtime = {
+            "provider": "anthropic",
+            "model": "claude-opus-4.8",
+            "base_url": "",
+            "api_mode": "anthropic_messages",
+        }
+        out = _maybe_apply_moa_cache_control(
+            messages, runtime, cache_disabled=True
+        )
+        assert not _has_cache_control(out)
+        # Inputs must not be mutated.
+        assert not _has_cache_control(messages)
+
+    def test_maybe_apply_config_off(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        runtime = {
+            "provider": "anthropic",
+            "model": "claude-opus-4.8",
+            "base_url": "",
+            "api_mode": "anthropic_messages",
+        }
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": False}},
+        ):
+            out = _maybe_apply_moa_cache_control(messages, runtime)
+        assert not _has_cache_control(out)

--- a/tests/agent/test_cache_disabled_on_stubs.py
+++ b/tests/agent/test_cache_disabled_on_stubs.py
@@ -258,3 +258,112 @@ class TestPreparedAggregatorNoAgentConfigOff:
         )
         assert not _has_cache_control(calls[0].get("messages") or [])
         assert tools == canonical_tools
+
+
+class TestBlankCachePolicyStubFactory:
+    def test_factory_sets_cache_disabled_from_config(self):
+        from agent.agent_runtime_helpers import blank_cache_policy_stub
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": "off"}},
+        ):
+            stub = blank_cache_policy_stub()
+        assert stub._cache_disabled is True
+
+    def test_factory_honors_explicit_false(self):
+        from agent.agent_runtime_helpers import blank_cache_policy_stub
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": "off"}},
+        ):
+            stub = blank_cache_policy_stub(False)
+        assert stub._cache_disabled is False
+
+
+class TestOneShotSynthesisAgentDisable:
+    """aggregate_moa_context must pin agent._cache_disabled onto decoration
+    so the one-shot synthesis path cannot re-enable markers mid-session.
+    """
+
+    def test_synthesis_untouched_when_agent_disables_cache(self):
+        from agent import moa_loop
+
+        calls = []
+        with (
+            patch.object(
+                moa_loop,
+                "call_llm",
+                side_effect=lambda **kwargs: calls.append(kwargs) or SimpleNamespace(
+                    choices=[SimpleNamespace(
+                        message=SimpleNamespace(content="synth", tool_calls=[]),
+                        finish_reason="stop",
+                    )],
+                    usage=None,
+                    model="fake",
+                ),
+            ),
+            patch.object(
+                moa_loop,
+                "_run_references_parallel",
+                return_value=[("advisor-a", "advice from a", None)],
+            ),
+            patch.object(
+                moa_loop,
+                "_slot_runtime",
+                return_value={
+                    "provider": "anthropic",
+                    "model": "claude-opus-4.8",
+                    "base_url": "",
+                    "api_mode": "anthropic_messages",
+                },
+            ),
+            # Config would enable caching; agent snapshot must win.
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"prompt_caching": {"cache_ttl": "5m"}},
+            ),
+        ):
+            moa_loop.aggregate_moa_context(
+                user_prompt="what should I do next?",
+                api_messages=[{"role": "user", "content": "help me plan"}],
+                reference_models=[{"provider": "openrouter", "model": "openai/gpt-5.5"}],
+                aggregator={"provider": "anthropic", "model": "claude-opus-4.8"},
+                agent=SimpleNamespace(_cache_disabled=True),
+            )
+
+        assert calls, "synthesis must still call the LLM"
+        synth_msgs = calls[0].get("messages") or []
+        assert not _has_cache_control(synth_msgs), (
+            "agent._cache_disabled must keep the one-shot synthesis "
+            "message undecorated even on a cache-honoring route"
+        )
+
+
+class TestAdvisorRuntimeDisable:
+    def test_maybe_apply_honors_runtime_cache_disabled_snapshot(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "advisor"},
+            {"role": "user", "content": "review"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "again"},
+        ]
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": "5m"}},
+        ):
+            out = _maybe_apply_moa_cache_control(
+                messages,
+                {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "base_url": "https://api.anthropic.com",
+                    "api_mode": "anthropic_messages",
+                    "_cache_disabled": True,
+                },
+            )
+        assert not _has_cache_control(out)
+        assert out == messages or not _has_cache_control(out)

--- a/tests/agent/test_cache_disabled_on_stubs.py
+++ b/tests/agent/test_cache_disabled_on_stubs.py
@@ -169,3 +169,92 @@ class TestMoASlotDecorationHonorsDisable:
         ):
             out = _maybe_apply_moa_cache_control(messages, runtime)
         assert not _has_cache_control(out)
+
+
+class TestPreparedAggregatorNoAgentConfigOff:
+    """Prepared-aggregator facades from ``MoAChatCompletions.__new__`` have
+    no ``_agent``. The planner must not raise and must honor config-off.
+    """
+
+    def test_prepared_aggregator_without_agent_honors_config_off(self):
+        import copy
+
+        from agent import moa_loop
+
+        calls = []
+        with (
+            patch.object(
+                moa_loop,
+                "call_llm",
+                side_effect=lambda **kwargs: calls.append(kwargs) or SimpleNamespace(
+                    choices=[SimpleNamespace(
+                        message=SimpleNamespace(content="ok", tool_calls=[]),
+                        finish_reason="stop",
+                    )],
+                    usage=None,
+                    model="fake",
+                ),
+            ),
+            patch.object(
+                moa_loop,
+                "_slot_runtime",
+                return_value={
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "base_url": "https://api.anthropic.com",
+                    "api_mode": "anthropic_messages",
+                },
+            ),
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"prompt_caching": {"cache_ttl": "off"}},
+            ),
+        ):
+            completions = moa_loop.MoAChatCompletions.__new__(
+                moa_loop.MoAChatCompletions
+            )
+            # No _agent attribute — the regression surface from review.
+            completions._pending_trace = None
+            prepared = {
+                "messages": [
+                    {"role": "system", "content": "system"},
+                    {"role": "user", "content": "lookup"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "lookup",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "lookup",
+                        "content": "result",
+                    },
+                ],
+                "guidance": None,
+                "aggregator": {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                },
+                "aggregator_temperature": None,
+            }
+            tools = [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }]
+            canonical_tools = copy.deepcopy(tools)
+
+            completions._call_prepared_aggregator(prepared, {"tools": tools})
+
+        assert calls, "prepared aggregator must still call the LLM"
+        assert not _has_cache_control(calls[0].get("tools") or []), (
+            "config cache_ttl=off with no live _agent must not inject "
+            "cache_control (planner config fallback, not forced False)."
+        )
+        assert not _has_cache_control(calls[0].get("messages") or [])
+        assert tools == canonical_tools


### PR DESCRIPTION
## What does this PR do?

`prompt_caching.cache_ttl: off` sets `_cache_disabled` on the real `AIAgent` in `init_agent`. Main-loop requests honor that flag. MoA advisor/aggregator decoration and the shared `plan_cache_sections_for_destination()` helper do not: they resolve policy against a blank `SimpleNamespace` stub, so `getattr(stub, "_cache_disabled", False)` is always false and `cache_control` markers still get injected.

That breaks the documented contract from #33555 that the config disable is global. Operators who turn caching off (providers that mishandle markers, OAuth extra-usage concerns, debugging) still saw markers on:

- MoA aggregator requests
- MoA advisor requests on cache-honoring slots
- Auxiliary / MoA destinations planned through `plan_cache_sections_for_destination`

## Fix

1. Add `prompt_caching_disabled_from_config()` with the same TTL disable detection as `init_agent`.
2. Stamp `_cache_disabled` onto the policy stub in:
   - `plan_cache_sections_for_destination()` (optional `cache_disabled` param; defaults to config)
   - `_maybe_apply_moa_cache_control()` (same)
3. MoA acting-aggregator path passes `getattr(self._agent, "_cache_disabled", False)` so a live agent disable wins when available.

Caching-enabled routes are unchanged: with `cache_disabled=False` / default TTL, native Anthropic destinations still receive breakpoints.

## Related Issue

Fixes #76085

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/agent_runtime_helpers.py` — config helper + stub flag in `plan_cache_sections_for_destination`
- `agent/moa_loop.py` — stub flag in `_maybe_apply_moa_cache_control`; pass agent flag from prepared aggregator
- `tests/agent/test_cache_disabled_on_stubs.py` — config detection, plan-path strip, MoA decoration strip, enabled path still marks

## How to Test

```bash
pytest tests/agent/test_cache_disabled_on_stubs.py -v
```

Docker (`ghcr.io/astral-sh/uv:python3.12-bookworm-slim` + `uv pip install -e ".[dev]"`): **7/7 passed**.

Manual:

1. Set in config:
   ```yaml
   prompt_caching:
     cache_ttl: false
   ```
2. Run an MoA turn or a path that hits auxiliary fallback replan against a Claude destination
3. Confirm request payloads no longer carry `cache_control` markers

## Checklist

### Code

- [x] Contributing Guide
- [x] Conventional Commits (`fix(agent): …`)
- [x] Searched for open PRs on #76085 — none
- [x] Focused change
- [x] Tests added and passing
- [x] Linux / Docker

### Documentation & Housekeeping

- [x] Docs — N/A (restores existing documented disable)
- [x] Config example — N/A
- [x] Cross-platform — N/A
- [x] Tool schemas — N/A

## Notes

I defaulted the stub paths to read config when the caller does not pass an explicit flag so auxiliary fallback does not need a full agent object. When MoA has `self._agent`, the agent flag is still threaded for consistency with runtime state after init.