### PR TITLE
fix(qqbot): accept dm chat_type in approval authorization

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1101,7 +1101,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## Problem

QQ Bot DM (C2C) sessions build their gateway session key with `chat_type="dm"` (see `build_session_key` in `gateway/session.py`, which uses `chat_type="dm"` for DMs). But `_is_authorized_interaction_for_session` in the qqbot adapter only accepted `c2c` / `group` / `guild`.

Result: every approval-button click in a QQ private chat falls through to `return False` and is logged as:

```
Rejected unauthorized approval click for session agent:main:qqbot:dm:<openid> (operator=<same openid>)
```

Command approval via inline keyboard is completely unusable in QQ DMs. Group/guild approvals are unaffected.

## Fix

Treat `dm` like `c2c` — both are 1:1 user chats where the operator's openid must equal the chat id. Group/guild logic unchanged.

## Verification

- `dm` + owner → authorized (was rejected before)
- `dm` + attacker → still rejected (no permission loosened)
- `c2c` + owner → authorized (regression pass)
- `group` + other user → still rejected (regression pass)
- Live-tested on QQ: with the fix, the approval button resolves the pending command; before it, every click was rejected.