### PR TITLE
fix(desktop): only the active terminal tab owns Cmd/Ctrl+L add-selection

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/selection.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/selection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAddSelectionShortcut, isMacPlatform, shouldOwnAddSelectionShortcut } from './selection'
+
+const key = (init: Partial<KeyboardEvent> & { key: string }) =>
+  ({
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    type: 'keydown',
+    ...init,
+  }) as KeyboardEvent
+
+/** Chord that isAddSelectionShortcut accepts on this host. */
+const addSelectionKey = () =>
+  isMacPlatform() ? key({ key: 'l', metaKey: true }) : key({ key: 'l', ctrlKey: true })
+
+describe('shouldOwnAddSelectionShortcut', () => {
+  it('only the active tab claims the add-selection shortcut when text is selected (#76116)', () => {
+    const chord = addSelectionKey()
+
+    expect(shouldOwnAddSelectionShortcut(chord, { active: true, hasSelection: true })).toBe(true)
+
+    // Inactive mounted tabs must not also fire — that was the N-pill bug.
+    expect(shouldOwnAddSelectionShortcut(chord, { active: false, hasSelection: true })).toBe(false)
+  })
+
+  it('never claims the shortcut with no selection so clear-screen still reaches the shell', () => {
+    const chord = addSelectionKey()
+
+    expect(shouldOwnAddSelectionShortcut(chord, { active: true, hasSelection: false })).toBe(false)
+    expect(isAddSelectionShortcut(chord)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/selection.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/selection.ts
@@ -105,6 +105,14 @@ export function isAddSelectionShortcut(event: KeyboardEvent) {
   return mod && !event.shiftKey && event.key.toLowerCase() === 'l'
 }
 
+/** Whether this terminal session should own a global ⌘/Ctrl+L keydown. */
+export function shouldOwnAddSelectionShortcut(
+  event: KeyboardEvent,
+  opts: { active: boolean; hasSelection: boolean }
+) {
+  return opts.active && opts.hasSelection && isAddSelectionShortcut(event)
+}
+
 export function terminalSelectionLabel(term: Terminal, shellName: string, text: string) {
   const pos = term.getSelectionPosition()
 

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -17,7 +17,7 @@ import { makeTerminalReader, registerTerminalReader } from './buffer'
 import { mirrorSelection, terminalClipboardIntent } from './clipboard'
 import { terminalLinkHandler, terminalWebLinksAddon } from './links'
 import {
-  isAddSelectionShortcut,
+  shouldOwnAddSelectionShortcut,
   isMacPlatform,
   resolveSurfaceColor,
   terminalSelectionAnchor,
@@ -463,12 +463,26 @@ export function useTerminalSession({
     triggerHaptic('selection')
   }, [])
 
-  // Always listen — gating on the React selection state misses selections the
-  // TUI redraw races. Only swallow ⌘/Ctrl+L when there's text to send, else it
-  // must reach the shell as clear-screen.
+  // Only the active tab owns the global ⌘/Ctrl+L listener. Every open tab
+  // stays mounted, so registering the capture handler on every session
+  // fired N identical add-selection calls for a single keypress (#76116).
+  // Still do not gate on React selection state — TUI redraw races can
+  // clear that while xterm / window still have live text.
+  // Only swallow ⌘/Ctrl+L when there's text to send; otherwise it must
+  // reach the shell as clear-screen.
   useEffect(() => {
+    if (!active) {
+      return
+    }
+
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!isAddSelectionShortcut(event) || !readSelection().trim()) {
+      const hasSelection = Boolean(readSelection().trim())
+      if (
+        !shouldOwnAddSelectionShortcut(event, {
+          active: true,
+          hasSelection,
+        })
+      ) {
         return
       }
 
@@ -480,7 +494,7 @@ export function useTerminalSession({
     window.addEventListener('keydown', onKeyDown, { capture: true })
 
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [addSelectionToChat, readSelection])
+  }, [active, addSelectionToChat, readSelection])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

With two or more terminal tabs open in Desktop, pressing Cmd/Ctrl+L once inserted one `>_ selection` pill **per mounted tab**. Every `TerminalInstance` stays mounted when inactive, and each `useTerminalSession` registered its own window-level capture keydown for the add-selection shortcut without checking `active`. `readSelection()` falls back to `window.getSelection()`, so a selection anywhere (chat, preview, or the active terminal) fired every listener.

## Fix

- Register the global Cmd/Ctrl+L listener only while the session is `active`.
- Add `shouldOwnAddSelectionShortcut()` as a pure helper used by the listener path, with unit tests for the active/inactive and empty-selection cases.

Inactive tabs no longer insert duplicate attachments. Clear-screen when there is no selection is unchanged (listener returns without preventDefault when there is no text).

## Related Issue

Fixes #76116

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts` — gate listener on `active`
- `apps/desktop/src/app/right-sidebar/terminal/selection.ts` — `shouldOwnAddSelectionShortcut`
- `apps/desktop/src/app/right-sidebar/terminal/selection.test.ts` — regression coverage

## How to Test

```bash
cd apps/desktop
npx vitest run src/app/right-sidebar/terminal/selection.test.ts
```

Manual:

1. Open Desktop with 2+ terminal tabs.
2. Select text in chat or a terminal.
3. Press Cmd+L (macOS) or Ctrl+L (Windows/Linux) once.
4. Expect exactly one selection pill in the composer.

Docker vitest: **2/2 passed**.

## Checklist

- [x] Conventional Commits
- [x] Focused PR, no open competing fix for #76116
- [x] Tests added
- [x] Linux (Docker Node 22)

## Notes

I chose gating on `active` over hoisting the listener to `TerminalWorkspace` so the change stays local to the session hook. Happy to hoist later if maintainers prefer a single owner for the chat/preview race with `preview-file.tsx`.