### PR TITLE
fix(caching): honor prompt_caching.cache_ttl=off on MoA and fallback stub paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1857,6 +1857,49 @@ def _direct_native_anthropic_tool_cache_capability(
     )
 
 
+def prompt_cache_disabled_from_config() -> bool:
+    """Return whether config globally disables prompt-cache decoration."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        ttl = (
+            (load_config_readonly().get("prompt_caching", {}) or {})
+            .get("cache_ttl", "5m")
+        )
+        return (
+            ttl is False
+            or ttl is None
+            or str(ttl).lower() in ("off", "false", "disabled", "no", "none")
+        )
+    except Exception:
+        return False
+
+
+def blank_cache_policy_stub(cache_disabled: Optional[bool] = None):
+    """Build the destination-identity-blank stub for ``anthropic_prompt_cache_policy``.
+
+    This is the only sanctioned constructor for that stub. Every caller that
+    resolves cache policy against a destination it identifies out-of-band
+    (not a live ``AIAgent``) must go through here, so ``_cache_disabled`` is
+    never silently missing from a hand-rolled ``SimpleNamespace`` (#76085).
+
+    ``cache_disabled``, when omitted, falls back to the global config so
+    stub-based paths without an agent snapshot still honor an operator
+    disable.
+    """
+    from types import SimpleNamespace
+
+    if cache_disabled is None:
+        cache_disabled = prompt_cache_disabled_from_config()
+    return SimpleNamespace(
+        provider="",
+        base_url="",
+        api_mode="",
+        model="",
+        _cache_disabled=cache_disabled,
+    )
+
+
 def plan_cache_sections_for_destination(
     messages: list,
     tools: Optional[list],
@@ -1865,6 +1908,7 @@ def plan_cache_sections_for_destination(
     base_url: str,
     api_mode: str,
     model: str,
+    cache_disabled: Optional[bool] = None,
 ) -> Tuple[list, list]:
     """Plan request-local cache sections for one resolved destination.
 
@@ -1878,15 +1922,13 @@ def plan_cache_sections_for_destination(
     Never mutates ``messages`` or ``tools`` — both return values are
     request-local copies.
     """
-    from types import SimpleNamespace
-
     from agent.prompt_caching import (
         build_prompt_cache_plan,
         strip_anthropic_cache_control,
         strip_anthropic_tool_cache_control,
     )
 
-    stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+    stub = blank_cache_policy_stub(cache_disabled)
     should_cache, native_layout = anthropic_prompt_cache_policy(
         stub,
         provider=provider,

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -398,15 +398,16 @@ def _maybe_apply_moa_cache_control(
     policy says the route doesn't honor markers.
     """
     try:
-        from types import SimpleNamespace
-
-        from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
+        from agent.agent_runtime_helpers import (
+            anthropic_prompt_cache_policy,
+            blank_cache_policy_stub,
+        )
         from agent.prompt_caching import apply_anthropic_cache_control
 
         # The policy function reads agent.* only as fallbacks for kwargs we
         # don't pass; provide a stub so the slot is judged purely on its own
         # resolved runtime.
-        stub = SimpleNamespace(provider="", base_url="", api_mode="", model="")
+        stub = blank_cache_policy_stub(runtime.get("_cache_disabled"))
         should_cache, native_layout = anthropic_prompt_cache_policy(
             stub,
             provider=runtime.get("provider") or "",
@@ -432,6 +433,7 @@ def _run_reference(
     max_tokens: int | None = None,
     reference_timeout: float | None = None,
     context_length_cache: Any = None,
+    cache_disabled: bool | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, accounting)``.
 
@@ -493,7 +495,10 @@ def _run_reference(
         # caching is opt-in per request. OpenAI-family advisors are untouched
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
-        messages = _maybe_apply_moa_cache_control(messages, runtime)
+        cache_runtime = runtime
+        if cache_disabled is not None:
+            cache_runtime = {**runtime, "_cache_disabled": cache_disabled}
+        messages = _maybe_apply_moa_cache_control(messages, cache_runtime)
         # Per-slot max_tokens takes precedence over the preset-level
         # reference_max_tokens passed in by the caller. This lets each
         # reference model have its own output cap independently.
@@ -797,6 +802,9 @@ def _run_references_parallel(
     # instead of re-probing metadata sources per reference (dict get/set is
     # GIL-atomic; a rare duplicate probe on a first-use race is harmless).
     _ctx_len_cache: dict[tuple[str, str], int | None] = {}
+    cache_disabled = (
+        getattr(agent, "_cache_disabled", None) if agent is not None else None
+    )
     try:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -815,6 +823,7 @@ def _run_references_parallel(
                     max_tokens=max_tokens,
                     reference_timeout=reference_timeout,
                     context_length_cache=_ctx_len_cache,
+                    cache_disabled=cache_disabled,
                 )
             ] = idx
 
@@ -1262,6 +1271,12 @@ def aggregate_moa_context(
 
     agg_label = _slot_label(aggregator)
     agg_runtime = _slot_runtime(aggregator)
+    agg_cache_runtime = agg_runtime
+    if agent is not None:
+        agg_cache_runtime = {
+            **agg_runtime,
+            "_cache_disabled": getattr(agent, "_cache_disabled", False),
+        }
     try:
         # Same cache_control decoration as _run_reference's advisor calls
         # (see _maybe_apply_moa_cache_control) — this synthesis call is a
@@ -1274,7 +1289,7 @@ def aggregate_moa_context(
         # breakpoints, even when the resolved aggregator slot is a
         # cache-honoring route (e.g. Claude on OpenRouter/native Anthropic).
         agg_messages = _maybe_apply_moa_cache_control(
-            [{"role": "user", "content": synth_prompt}], agg_runtime
+            [{"role": "user", "content": synth_prompt}], agg_cache_runtime
         )
         response = call_llm(
             task="moa_aggregator",
@@ -1680,6 +1695,9 @@ class MoAChatCompletions:
                 base_url=agg_runtime.get("base_url") or "",
                 api_mode=agg_runtime.get("api_mode") or "",
                 model=agg_runtime.get("model") or "",
+                cache_disabled=getattr(
+                    getattr(self, "_agent", None), "_cache_disabled", None
+                ),
             )
             if guidance:
                 _attach_reference_guidance(agg_messages, str(guidance))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4124,7 +4124,7 @@ class TestMoaAggregatorStreamingBypass:
 
 class TestSynchronousFallbackCachePlans:
     @staticmethod
-    def _run_configured_fallback(monkeypatch, entry):
+    def _run_configured_fallback(monkeypatch, entry, *, cache_ttl="5m"):
         from agent.auxiliary_client import (
             _call_fallback_candidate_sync,
             _try_configured_fallback_chain,
@@ -4143,6 +4143,10 @@ class TestSynchronousFallbackCachePlans:
         monkeypatch.setattr(
             "agent.auxiliary_client._get_auxiliary_task_config",
             lambda task: {"fallback_chain": [entry]},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"prompt_caching": {"cache_ttl": cache_ttl}},
         )
         fallback_client, fallback_model, label = _try_configured_fallback_chain(
             task="moa_aggregator",
@@ -4213,6 +4217,29 @@ class TestSynchronousFallbackCachePlans:
             for part in (message.get("content") if isinstance(message.get("content"), list) else [])
         )
 
+    def test_cache_ttl_disable_strips_fallback_message_and_tool_markers(self, monkeypatch):
+        client, _resolved_calls, _tools = self._run_configured_fallback(
+            monkeypatch,
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "base_url": "https://api.anthropic.com",
+                "api_mode": "anthropic_messages",
+            },
+            cache_ttl=False,
+        )
+
+        wire = client.chat.completions.create.call_args.kwargs
+        assert all("cache_control" not in tool for tool in wire["tools"])
+        assert all(
+            "cache_control" not in message
+            and not any(
+                isinstance(part, dict) and "cache_control" in part
+                for part in (message.get("content") if isinstance(message.get("content"), list) else [])
+            )
+            for message in wire["messages"]
+        )
+
 
 
 class TestAsynchronousFallbackCachePlans:
@@ -4276,3 +4303,45 @@ class TestAsynchronousFallbackCachePlans:
         wire_tools = client.chat.completions.create.call_args.kwargs["tools"]
         assert "cache_control" in wire_tools[-1]
         assert "cache_control" not in tools[-1]
+
+    @pytest.mark.asyncio
+    async def test_async_fallback_honors_cache_ttl_disable(self, monkeypatch):
+        from agent.auxiliary_client import _call_fallback_candidate_async
+
+        client = MagicMock()
+        client.base_url = "https://api.anthropic.com"
+
+        async def _create(**kwargs):
+            return _DummyResponse()
+
+        client.chat.completions.create = MagicMock(side_effect=_create)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"prompt_caching": {"cache_ttl": None}},
+        )
+        tools = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}]
+
+        await _call_fallback_candidate_async(
+            client,
+            "claude-sonnet-4-6",
+            "anthropic",
+            task="moa_aggregator",
+            messages=[{"role": "system", "content": "stable"}, {"role": "user", "content": "lookup"}],
+            temperature=None,
+            max_tokens=None,
+            tools=tools,
+            effective_timeout=30.0,
+            effective_extra_body={},
+            reasoning_config=None,
+        )
+
+        wire = client.chat.completions.create.call_args.kwargs
+        assert all("cache_control" not in tool for tool in wire["tools"])
+        assert all(
+            "cache_control" not in message
+            and not any(
+                isinstance(part, dict) and "cache_control" in part
+                for part in (message.get("content") if isinstance(message.get("content"), list) else [])
+            )
+            for message in wire["messages"]
+        )

--- a/tests/agent/test_moa_aggregator_cache_control.py
+++ b/tests/agent/test_moa_aggregator_cache_control.py
@@ -151,3 +151,72 @@ def test_prepared_aggregator_plans_tools_without_decorating_prepared_state(monke
     assert "cache_control" in calls[0]["tools"][-1]
     assert "cache_control" not in tools[-1]
     assert prepared == canonical_prepared
+
+
+def test_cache_ttl_disable_blocks_prepared_aggregator_markers(monkeypatch):
+    from agent import moa_loop
+
+    calls = []
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **kwargs: calls.append(kwargs) or _response())
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"prompt_caching": {"cache_ttl": "5m"}},
+    )
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    completions = moa_loop.MoAChatCompletions.__new__(moa_loop.MoAChatCompletions)
+    completions._pending_trace = None
+    completions._agent = SimpleNamespace(_cache_disabled=True)
+    tools = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}]
+
+    completions._call_prepared_aggregator(
+        {
+            "messages": [{"role": "system", "content": "system"}, {"role": "user", "content": "lookup"}],
+            "guidance": None,
+            "aggregator": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            "aggregator_temperature": None,
+        },
+        {"tools": tools},
+    )
+
+    wire = calls[0]
+    assert all("cache_control" not in tool for tool in wire["tools"])
+    assert all(
+        "cache_control" not in message
+        and not any(
+            isinstance(part, dict) and "cache_control" in part
+            for part in (message.get("content") if isinstance(message.get("content"), list) else [])
+        )
+        for message in wire["messages"]
+    )
+
+
+def test_cache_ttl_disable_blocks_advisor_markers(monkeypatch):
+    from agent.moa_loop import _maybe_apply_moa_cache_control
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"prompt_caching": {"cache_ttl": "5m"}},
+    )
+    messages = [{"role": "system", "content": "advisor"}, {"role": "user", "content": "review"}]
+
+    wire = _maybe_apply_moa_cache_control(
+        messages,
+        {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+            "_cache_disabled": True,
+        },
+    )
+
+    assert wire == messages

--- a/tests/agent/test_moa_aggregator_cache_control.py
+++ b/tests/agent/test_moa_aggregator_cache_control.py
@@ -115,6 +115,41 @@ def test_aggregator_synthesis_untouched_on_non_caching_route(
     assert isinstance(synth_message["content"], str), "must stay undecorated (plain string content)"
 
 
+def test_aggregator_synthesis_untouched_when_agent_disables_cache(
+    captured_calls, monkeypatch
+):
+    """``prompt_caching.cache_ttl: off`` on the live agent must block markers
+    on the one-shot synthesis call even though its route (native Anthropic)
+    would otherwise honor cache_control (#76085)."""
+    from agent import moa_loop
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "anthropic",
+            "model": "claude-opus-4.8",
+            "base_url": "",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    moa_loop.aggregate_moa_context(
+        user_prompt="what should I do next?",
+        api_messages=[{"role": "user", "content": "help me plan"}],
+        reference_models=[{"provider": "openrouter", "model": "openai/gpt-5.5"}],
+        aggregator={"provider": "anthropic", "model": "claude-opus-4.8"},
+        agent=SimpleNamespace(_cache_disabled=True),
+    )
+
+    agg_kwargs = _aggregator_kwargs(captured_calls)
+    synth_message = agg_kwargs["messages"][0]
+    assert isinstance(synth_message["content"], str), (
+        "agent._cache_disabled must keep the synthesis message undecorated "
+        "(plain string content) even on a cache-honoring route"
+    )
+
+
 def test_prepared_aggregator_plans_tools_without_decorating_prepared_state(monkeypatch):
     from agent import moa_loop
 


### PR DESCRIPTION
## What does this PR do?

`prompt_caching.cache_ttl: off` (and the other falsy spellings: `false`, `null`, `disabled`, `no`, `none`) correctly sets `_cache_disabled = True` on the real `AIAgent` in `agent_init`, and the main request loop honors that flag. It was silently **not honored** on four request paths that resolve cache policy against a blank destination-identity stub instead of the live agent:

- the MoA acting-aggregator's prepared request (`MoAChatCompletions.create` → `_call_prepared_aggregator`)
- MoA advisor slot calls (`_run_reference` / `_run_references_parallel`)
- the MoA one-shot synthesis aggregator (`aggregate_moa_context`)
- the auxiliary fallback replan, both synchronous and asynchronous (`_call_fallback_candidate_sync` / `_call_fallback_candidate_async`, shared through `plan_cache_sections_for_destination`)

Each of these builds a `SimpleNamespace(provider="", base_url="", api_mode="", model="")` to ask `anthropic_prompt_cache_policy()` "does this resolved destination honor `cache_control`?" — but the stub never carried `_cache_disabled`, so `getattr(stub, "_cache_disabled", False)` always evaluated to `False`. The operator's global disable was ignored and `cache_control` markers kept getting injected on these paths.

## Root cause

State was split across two shapes with no shared contract:

```text
config cache_ttl=off
  → AIAgent._cache_disabled = True
      → main loop:  policy(AIAgent)              → cache OFF   (correct)
      → MoA/fallback: policy(blank SimpleNamespace) → cache ON  (bug — flag never carried over)
```

Fixing the four call sites individually would have left the underlying defect class open: two of them (`plan_cache_sections_for_destination`, `_maybe_apply_moa_cache_control`) were *already* independently constructing the same blank stub, which is exactly how the omission happened twice in the first place. A third future call site could reintroduce it the same way.

## Fix

1. **`prompt_cache_disabled_from_config()`** (`agent/agent_runtime_helpers.py`) — reads `prompt_caching.cache_ttl` from the read-only config loader using the same falsy-value contract as `agent_init`, for paths that have no live `AIAgent` to consult.
2. **`blank_cache_policy_stub(cache_disabled=None)`** (`agent/agent_runtime_helpers.py`) — the single sanctioned constructor for the blank policy stub. Resolves `_cache_disabled` as: explicit snapshot → global config fallback. Both `plan_cache_sections_for_destination` and `_maybe_apply_moa_cache_control` now go through this one factory instead of each hand-rolling their own `SimpleNamespace`, closing the duplication that let the omission happen twice.
3. **Conversation-level state threading** (`agent/moa_loop.py`) — the MoA acting aggregator, advisors, and one-shot synthesis now thread `AIAgent._cache_disabled` explicitly through `_run_reference` / `_run_references_parallel` / `aggregate_moa_context` / `MoAChatCompletions.create`, so the disable stays stable for the whole conversation even if the on-disk config changes mid-session. Paths with no live agent (auxiliary fallback replan) fall back to the read-only config loader.

Caching-enabled routes are unchanged: with `cache_disabled=False` (default `cache_ttl: 5m` / `1h`), native Anthropic and OpenRouter-Claude destinations still receive `cache_control` breakpoints exactly as before.

## Diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Config: cache_ttl off] --> B[AIAgent._cache_disabled = True]
    B --> C[Main Loop Policy]
    C --> C1[Cache OFF - already correct]

    B --> D[blank_cache_policy_stub]
    D -->|explicit snapshot or config fallback| E[plan_cache_sections_for_destination]
    D -->|explicit snapshot or config fallback| F[_maybe_apply_moa_cache_control]

    E --> E1[Fallback Replan Sync]
    E --> E2[Fallback Replan Async]
    F --> F1[MoA Advisors]
    F --> F2[MoA One-Shot Synthesis]
    F --> F3[MoA Prepared Aggregator]

    E1 --> Z[Zero cache_control Markers]
    E2 --> Z
    F1 --> Z
    F2 --> Z
    F3 --> Z
```

## Infographic

![Fix summary for issue #76085](https://github.com/JoaoMarcos44/hermes-agent/releases/download/infographic-fix-76085/issue_76085_victorian_infographic.png)

*(Hosted as a release asset on the fork — not committed to the repo tree, per the `infographics/` `.gitignore` policy.)*

## Related Issue

Fixes #76085

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/agent_runtime_helpers.py` — `prompt_cache_disabled_from_config()`, `blank_cache_policy_stub()`, `plan_cache_sections_for_destination()` now uses the shared factory
- `agent/moa_loop.py` — `_maybe_apply_moa_cache_control()` uses the shared factory; `_run_reference`, `_run_references_parallel`, `aggregate_moa_context`, `MoAChatCompletions.create` thread `AIAgent._cache_disabled` explicitly
- `tests/agent/test_auxiliary_client.py` — regression coverage for sync/async fallback replan honoring the disable
- `tests/agent/test_moa_aggregator_cache_control.py` — regression coverage for the prepared aggregator and advisor decoration honoring the disable

## How to Test

```bash
pytest tests/agent/test_auxiliary_client.py tests/agent/test_moa_aggregator_cache_control.py tests/agent/test_prompt_caching.py tests/agent/test_failover_identity.py -v
```

Manual:

1. Set in config:
   ```yaml
   prompt_caching:
     cache_ttl: false
   ```
2. Run an MoA turn (advisors + aggregator) and a turn that hits the auxiliary fallback replan against a Claude destination.
3. Confirm request payloads no longer carry `cache_control` markers on any of the four paths.

## Validation

- `python -m py_compile` on all changed modules: clean
- `git diff --check`: clean, no whitespace/conflict markers
- Targeted regression suite: 200 passed (`test_auxiliary_client.py`, `test_moa_aggregator_cache_control.py`, `test_prompt_caching.py`, `test_failover_identity.py`)
- Full `tests/agent/` suite: passed, no regressions

## Checklist

### Code

- [x] Conventional Commits (`fix(caching): …`)
- [x] Focused change — only the four affected call sites and their shared stub construction
- [x] Tests added and passing
- [x] No changes to caching-enabled routes' behavior

### Documentation & Housekeeping

- [x] Docs — N/A (restores existing documented disable contract, no new config surface)
- [x] Infographic embedded via hosted release asset, not committed (repo policy)
