### PR TITLE
fix(whatsapp): hide Windows console flashes on bridge helper spawns

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,7 +27,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs, windows_hide_flags
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -225,6 +225,9 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 timeout=10,
+                # Windowless pythonw parent: without CREATE_NO_WINDOW each
+                # taskkill allocates a visible console flash (#75628).
+                creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
             )
         except FileNotFoundError:
             if force:
@@ -350,7 +353,9 @@ def check_whatsapp_requirements() -> bool:
             [_node, "--version"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
-            timeout=5
+            timeout=5,
+            # Probe fires on every bridge start/reconnect (#75628).
+            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
         return result.returncode == 0
     except Exception:
@@ -558,6 +563,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         text=True, encoding='utf-8', errors='replace',
                         timeout=npm_install_timeout,
                         env=with_hermes_node_path(),
+                        # npm is a console-subsystem process; hide the flash
+                        # when deps reinstall during reconnect (#75628).
+                        creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")

--- a/tests/gateway/test_whatsapp_windows_hide_flags.py
+++ b/tests/gateway/test_whatsapp_windows_hide_flags.py
@@ -1,0 +1,70 @@
+"""WhatsApp bridge subprocesses must hide Windows console flashes (#75628).
+
+``node --version``, ``taskkill``, and ``npm install`` are console-subsystem
+children. From a windowless ``pythonw`` gateway parent they allocate a
+visible console unless ``creationflags=windows_hide_flags()`` is set.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import plugins.platforms.whatsapp.adapter as wa
+
+
+def test_check_whatsapp_requirements_passes_hide_flags_on_windows():
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="v22.0.0\n", stderr="")
+
+    with (
+        patch.object(wa, "_IS_WINDOWS", True),
+        patch.object(wa, "windows_hide_flags", return_value=0x08000000),
+        patch.object(wa, "find_node_executable", return_value="node.exe"),
+        patch.object(wa.subprocess, "run", side_effect=fake_run),
+    ):
+        assert wa.check_whatsapp_requirements() is True
+
+    assert captured.get("creationflags") == 0x08000000
+
+
+def test_check_whatsapp_requirements_no_flags_on_posix():
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="v22.0.0\n", stderr="")
+
+    with (
+        patch.object(wa, "_IS_WINDOWS", False),
+        patch.object(wa, "find_node_executable", return_value="/usr/bin/node"),
+        patch.object(wa.subprocess, "run", side_effect=fake_run),
+    ):
+        assert wa.check_whatsapp_requirements() is True
+
+    assert captured.get("creationflags") == 0
+
+
+def test_terminate_bridge_process_passes_hide_flags_on_windows():
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    proc = SimpleNamespace(pid=4242)
+
+    with (
+        patch.object(wa, "_IS_WINDOWS", True),
+        patch.object(wa, "windows_hide_flags", return_value=0x08000000),
+        patch.object(wa.subprocess, "run", side_effect=fake_run),
+    ):
+        wa._terminate_bridge_process(proc, force=True)
+
+    assert captured.get("creationflags") == 0x08000000
+    # First positional argv is the taskkill command list.
+    # subprocess.run(cmd, ...) — cmd is args[0]
+    # We only assert creationflags; command shape is covered elsewhere.


### PR DESCRIPTION
## What does this PR do?

On Windows the WhatsApp gateway runs under windowless `pythonw.exe`. Three helper spawns still used the default console creation flags, so each reconnect flashed a visible Windows Terminal window for ~100–150 ms:

1. `node --version` in `check_whatsapp_requirements()` (every bridge start)
2. `taskkill` in `_terminate_bridge_process()` (every terminate/reconnect)
3. `npm install --silent` when bridge deps reinstall

The bridge process itself already uses `windows_detach_popen_kwargs()`, and `_kill_port_process()` already passes `windows_hide_flags()`. These three sites were simply missed.

## Fix

Pass `creationflags=windows_hide_flags() if _IS_WINDOWS else 0` on those three `subprocess.run` calls. `windows_hide_flags()` is a documented no-op on POSIX.

## Related Issue

Fixes #75628

## Type of Change

- [x] Bug fix
- [x] Cross-platform / Windows
- [x] Tests

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — hide flags on the three call sites
- `tests/gateway/test_whatsapp_windows_hide_flags.py` — assert creationflags on Windows paths and 0 on POSIX

## How to Test

```bash
pytest tests/gateway/test_whatsapp_windows_hide_flags.py -v
```

Docker (`uv` + Python 3.12): **3/3 passed**.

On a real Windows host with WhatsApp gateway + Windows Terminal as default console host, restart the gateway and confirm no console flash during reconnect (the issue reports a WinEvent hook as verification).

## Checklist

- [x] Conventional Commits
- [x] No open competing PR for #75628
- [x] Focused change
- [x] Tests added
- [x] Cross-platform considered (flag is no-op off Windows)

## Notes

I left `hermes_cli/clipboard.py` alone even though the issue body sketched similar hide flags there — that is a separate surface and this PR stays scoped to the WhatsApp reconnect flashes.