### PR TITLE
fix(update): restore mid-swap backup before clearing leftovers in staging

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -840,7 +840,20 @@ def _update_via_zip(args):
             _discard_staged(staged)
             raise
 
-        _commit_staged_replacements(staged)
+        try:
+            _commit_staged_replacements(staged)
+        except Exception:
+            # The rollback already restored every swapped entry, but staging
+            # copies for the not-yet-swapped entries (potentially most of a
+            # full tree) are still on disk. Drop them, or the retry's
+            # up-front free-space check — which runs BEFORE the lazy
+            # per-entry leftover cleanup — fails on litter this attempt
+            # left behind: the exact "retry fails harder" failure mode
+            # _discard_staged exists to prevent. Safe post-rollback: swapped
+            # entries' staging paths were renamed away, and _discard_staged
+            # skips paths that no longer exist.
+            _discard_staged(staged)
+            raise
         update_count = len(staged)
 
         print(f"✓ Updated {update_count} items from ZIP")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -665,9 +665,10 @@ def _commit_staged_replacements(staged) -> None:
     This covers plain files as well as directories: the repo root holds 20
     first-party modules (``run_agent.py``, ``cli.py``, ``hermes_constants.py``
     …), so a files-only failure reproduces exactly the bug class we are
-    closing. ``os.replace`` is atomic on POSIX and maps to
-    ``MoveFileEx(REPLACE_EXISTING)`` on Windows, so a file swap can never
-    leave a half-written module the way ``copy2`` onto a live path can.
+    closing. Every swap is an ``os.rename`` onto a path that was just moved
+    aside — a same-filesystem rename is atomic on POSIX and NTFS alike, so a
+    file swap can never leave a half-written module the way ``copy2`` onto a
+    live path can.
 
     Splitting stage-all-then-swap-all shrinks the failure window from "the
     duration of a full tree copy" to "the duration of N renames", and makes

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -613,6 +613,14 @@ def _stage_replacement(src: str, dst: str) -> str:
     """
     staging = f"{dst}.hermes-update-staging"
     backup = f"{dst}.hermes-update-old"
+    # A previous run may have died between "move dst aside" and "move staging
+    # in" — leaving dst missing and the backup as the ONLY copy of that entry.
+    # Restore it before clearing leftovers: deleting the backup first and then
+    # failing to stage (disk exhaustion is likely right after writing a full
+    # staging copy) would leave a hole in the install with nothing to roll
+    # back to. The restore is a same-filesystem rename — instant and safe.
+    if not os.path.exists(dst) and os.path.exists(backup):
+        os.rename(backup, dst)
     for leftover in (staging, backup):
         if os.path.isdir(leftover):
             shutil.rmtree(leftover, ignore_errors=True)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1261,8 +1261,8 @@ def venv_bin_dir(venv_dir, *, windows: bool | None = None) -> Path:
     each new call site had to re-derive it, and #76091 shipped an eighth copy
     because the correct behaviour lived 2400 lines away in another function.
     A few sites outside ``hermes_cli`` (``tools/code_execution_tool.py``,
-    ``agent/lsp/install.py``) still hand-roll it — convert them as they are
-    touched.
+    ``agent/lsp/install.py``, ``agent/lsp/servers.py``) still hand-roll it —
+    convert them as they are touched.
 
     *windows* lets a caller pass its own platform verdict. Several callers
     resolve this through predicates the test-suite patches to exercise

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -348,3 +348,41 @@ def test_patched_is_windows_reaches_the_venv_path_derivation():
         venv_python_path("/nope/venv", windows=True).as_posix()
         == "/nope/venv/Scripts/python.exe"
     )
+
+
+# ---------------------------------------------------------------------------
+# Crash between "move dst aside" and "move staging in" (Phase 2 review HIGH)
+# ---------------------------------------------------------------------------
+
+def test_staging_restores_backup_when_dst_is_missing(tmp_path, monkeypatch):
+    """A previous run that died mid-swap leaves dst missing and the backup as
+    the ONLY copy of that entry. On retry, _stage_replacement must restore
+    the backup to dst BEFORE clearing leftovers — otherwise a staging failure
+    right after (disk exhaustion is likeliest exactly then) leaves a hole in
+    the install with nothing to roll back to."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    live.mkdir()
+    _live_tree(new, {"agent": "new"})
+    # Simulate the crashed state: dst gone, backup holds the old tree.
+    backup = live / "agent.hermes-update-old"
+    backup.mkdir()
+    (backup / "version.txt").write_text("old")
+
+    # Staging fails (disk full) on the fresh copy.
+    def boom(src, dst, *a, **kw):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(update_cmd.shutil, "copytree", boom)
+    with pytest.raises(OSError):
+        update_cmd._stage_replacement(str(new / "agent"), str(live / "agent"))
+    monkeypatch.undo()
+
+    # The old tree must have been restored to dst before the failure.
+    assert (live / "agent" / "version.txt").read_text() == "old"
+    assert not backup.exists()
+
+    # And a clean retry completes the update normally.
+    staged = _stage_all(live, new, ["agent"])
+    update_cmd._commit_staged_replacements(staged)
+    assert (live / "agent" / "version.txt").read_text() == "new"
+    assert not [p for p in os.listdir(live) if "hermes-update" in p]

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -386,3 +386,85 @@ def test_staging_restores_backup_when_dst_is_missing(tmp_path, monkeypatch):
     update_cmd._commit_staged_replacements(staged)
     assert (live / "agent" / "version.txt").read_text() == "new"
     assert not [p for p in os.listdir(live) if "hermes-update" in p]
+
+
+def test_commit_failure_plus_discard_leaves_no_staging_litter(tmp_path, monkeypatch):
+    """Phase-2 failure must not orphan staging copies for unswapped entries.
+
+    _update_via_zip calls _discard_staged when _commit_staged_replacements
+    raises. The rollback restores every swapped entry, but staging copies for
+    the not-yet-swapped entries (potentially most of a full tree) would
+    otherwise survive — and the retry's up-front free-space check runs BEFORE
+    the lazy per-entry leftover cleanup, so the litter makes the retry fail
+    harder than the original attempt. This pins the combination: rollback +
+    discard leaves the old tree intact and ZERO update litter."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"agent": "old", "tools": "old", "gateway": "old"})
+    _live_tree(new, {"agent": "new", "tools": "new", "gateway": "new"})
+    staged = _stage_all(live, new, ["agent", "tools", "gateway"])
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 4:  # first entry fully swapped, second breaks
+            raise OSError("simulated AV interference")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(update_cmd.os, "rename", flaky_rename)
+    with pytest.raises(OSError):
+        try:
+            update_cmd._commit_staged_replacements(staged)
+        except OSError:
+            # Mirrors the _update_via_zip wiring.
+            update_cmd._discard_staged(staged)
+            raise
+    monkeypatch.undo()
+
+    # Old tree intact...
+    for n in ("agent", "tools", "gateway"):
+        assert (live / n / "version.txt").read_text() == "old"
+    # ...and zero litter of any kind (staging OR backup).
+    litter = [p for p in os.listdir(live) if "hermes-update" in p]
+    assert litter == [], f"orphaned update litter: {litter}"
+
+
+def test_update_via_zip_wires_discard_into_the_commit_failure_path():
+    """AST wiring contract: _update_via_zip must call _discard_staged from an
+    exception handler around _commit_staged_replacements. The behavioral test
+    above mirrors that wiring; this pins the production function itself so a
+    refactor can't silently drop the cleanup."""
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(update_cmd._update_via_zip))
+    tree = ast.parse(src)
+
+    def _calls(node, name):
+        return any(
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == name
+            for n in ast.walk(node)
+        )
+
+    wired = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        body_commits = any(
+            _calls(stmt, "_commit_staged_replacements") for stmt in node.body
+        )
+        handler_discards = any(
+            _calls(handler, "_discard_staged") for handler in node.handlers
+        )
+        if body_commits and handler_discards:
+            wired = True
+            break
+    assert wired, (
+        "_update_via_zip no longer discards staging copies when "
+        "_commit_staged_replacements fails — commit-phase litter will make "
+        "the retry's free-space check fail harder than the first attempt"
+    )


### PR DESCRIPTION
## Summary

An interrupted `hermes update` can no longer destroy the only remaining copy of an entry, and a failed update can no longer leave staging litter that makes the retry fail harder than the first attempt.

Follow-up to #76107, from its Phase 2 review (findings surfaced after merge).

## Hole 1 — retry after a mid-swap crash could lose an entry entirely

`_commit_staged_replacements` swaps each entry as `rename(dst, backup)` then `rename(staging, dst)`. A hard kill between those two renames leaves `dst` **missing** and `<dst>.hermes-update-old` as the **only copy** of that entry.

On retry, `_stage_replacement` treated that backup as a stale leftover and deleted it **before** staging the fresh copy. If staging then failed — disk exhaustion is likeliest exactly after writing a full staging copy — the install was left with a hole and nothing to roll back to. Empirically reproduced against the merged helpers:

```
dst exists after failed retry: False
backup still exists:           False
```

Fix: when `dst` is missing and the backup exists, restore it first (same-filesystem rename, instant), then proceed with normal cleanup and staging.

## Hole 2 — commit-phase failure orphaned staging copies (converged finding: two reviewers independently)

`_discard_staged` only ran when *phase-1 staging* failed. A *phase-2 commit* failure rolled the live tree back correctly but orphaned staging copies for every not-yet-swapped entry — up to most of a full tree. The retry's up-front free-space check runs **before** the lazy per-entry leftover cleanup, so the litter makes the retry fail "not enough free disk space" on exactly the space-constrained machines the 1.2× threshold was chosen for — the same "retry fails harder" failure mode `_discard_staged`'s own docstring says it exists to prevent.

Fix: `_update_via_zip` now discards staging copies when the commit phase raises (safe post-rollback: swapped entries' staging paths were already renamed away).

## Also

Two docstring corrections from the same review: `_commit_staged_replacements` cited `os.replace` while the code uses `os.rename` (the atomicity claim holds — same-filesystem rename is atomic on POSIX and NTFS — but named the wrong function), and `venv_bin_dir`'s remaining hand-rolled-site list missed `agent/lsp/servers.py:270`.

## Validation

| | Before | After |
|---|---|---|
| Retry after mid-swap crash, staging fails | entry lost (no dst, no backup) | old tree restored, install intact |
| Retry after mid-swap crash, staging succeeds | new version lands | unchanged — new version lands |
| Commit fails mid-swap | rollback OK, ~1 tree of staging litter | rollback OK, zero litter |
| Retry free-space check after failed commit | can fail on prior run's litter | starts from the same free space |

Three new tests, all **mutation-verified** (removing the backup-restore fails `test_staging_restores_backup_when_dst_is_missing`; removing the try/except around the commit fails the AST wiring contract). 118 tests green across the update/zip/venv suites; ruff clean.
