### PR TITLE
fix(auth): make test seat belts immune to HOME patching

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -898,6 +898,44 @@ def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any
     logger.info("oauth_trace %s", json.dumps(payload, sort_keys=True, ensure_ascii=False))
 
 
+# Snapshot the user home before a test fixture can mutate ``HOME``.  On POSIX,
+# the passwd database is the preferred env-independent source; the snapshot is
+# the fallback for platforms and runtimes where that lookup is unavailable.
+try:
+    _XAI_IMPORT_TIME_HOME: Optional[Path] = Path(os.path.expanduser("~"))
+except Exception:  # pragma: no cover - expanduser is effectively total
+    _XAI_IMPORT_TIME_HOME = None
+
+
+def _xai_immutable_user_home() -> Optional[Path]:
+    """Return the real user home without consulting mutable test env state."""
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return _XAI_IMPORT_TIME_HOME
+
+
+def _resolve_auth_path(path: Path) -> Path:
+    """Resolve an auth path without making the test seat belt fragile."""
+    try:
+        return path.resolve(strict=False)
+    except Exception:
+        return path
+
+
+def _protected_auth_file_paths() -> set[Path]:
+    """Auth-store paths that tests must never read from or write to."""
+    homes = (_xai_immutable_user_home(), _XAI_IMPORT_TIME_HOME)
+    candidates = {
+        Path(home) / ".hermes" / "auth.json"
+        for home in homes
+        if home is not None
+    }
+    return {_resolve_auth_path(path) for path in candidates}
+
+
 # =============================================================================
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
@@ -910,12 +948,7 @@ def _auth_file_path() -> Path:
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
-        try:
-            resolved = path.resolve(strict=False)
-        except Exception:
-            resolved = path
-        if resolved == real_home_auth:
+        if _resolve_auth_path(path) in _protected_auth_file_paths():
             raise RuntimeError(
                 f"Refusing to touch real user auth store during test run: {path}. "
                 "Set HERMES_HOME to a tmp_path in your test fixture, or run "
@@ -966,23 +999,17 @@ def _load_global_auth_store() -> Dict[str, Any]:
     path. The hermetic conftest does not redirect ``HOME``, so
     ``get_default_hermes_root()`` for a profile-shaped HERMES_HOME can
     still resolve to the real user's home on a dev machine. That would
-    leak real credentials into tests. This guard uses the unmodified
-    ``HOME`` env var (what ``os.path.expanduser('~')`` would resolve to),
-    not ``Path.home()``, because ``Path.home`` is sometimes monkeypatched
-    by fixtures that want to relocate the global root to a tmp path.
+    leak real credentials into tests. The guard uses an env-immutable home
+    source, so patching HOME cannot relocate the protected path.
     """
     global_path = _global_auth_file_path()
-    if global_path is None or not global_path.exists():
+    if global_path is None:
         return {}
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return {}
-            except Exception:
-                pass
+        if _resolve_auth_path(global_path) in _protected_auth_file_paths():
+            return {}
+    if not global_path.exists():
+        return {}
     try:
         return _load_auth_store(global_path)
     except Exception:
@@ -1349,6 +1376,12 @@ def _persist_provider_state_to_store(
     set_active: bool = False,
 ) -> Path:
     """Merge one provider into a specific auth store under that store's lock."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        if _resolve_auth_path(target_path) in _protected_auth_file_paths():
+            raise RuntimeError(
+                f"Refusing to touch real user auth store during test run: {target_path}. "
+                "Use a temporary auth-store target in your test fixture."
+            )
     with _auth_store_lock(target_path=target_path):
         auth_store = _load_auth_store(target_path)
         _store_provider_state(

--- a/tests/hermes_cli/test_auth_seatbelt_env_immutable.py
+++ b/tests/hermes_cli/test_auth_seatbelt_env_immutable.py
@@ -1,0 +1,186 @@
+"""Regression coverage for env-immutable auth-store test seat belts."""
+
+from contextlib import contextmanager
+import os
+from pathlib import Path
+
+import pytest
+
+pwd = pytest.importorskip(
+    "pwd",
+    reason="dangerous-path derivation requires the POSIX passwd database",
+)
+
+from agent import credential_pool
+from hermes_cli import auth
+
+
+def _real_auth_path() -> Path:
+    """Derive the dangerous path independently of the helpers under test."""
+    home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    return (home / ".hermes" / "auth.json").resolve(strict=False)
+
+
+def _configure_dangerous_profile(monkeypatch, tmp_path) -> Path:
+    """Point a profile process at the independently derived protected store."""
+    dangerous_auth = _real_auth_path()
+    monkeypatch.setenv("HOME", str(tmp_path / "patched-home"))
+    monkeypatch.setenv(
+        "HERMES_HOME",
+        str(dangerous_auth.parent / "profiles" / "seatbelt-test"),
+    )
+    global_path = auth._global_auth_file_path()
+    assert global_path is not None
+    assert global_path.resolve(strict=False) == dangerous_auth
+    return dangerous_auth
+
+
+def _forbid_auth_store_io(monkeypatch):
+    """Instrument every explicit-target persistence boundary."""
+    boundary_hits = []
+
+    @contextmanager
+    def fail_lock(*args, **kwargs):
+        boundary_hits.append(("lock", args, kwargs))
+        raise AssertionError("explicit-target persistence reached the auth-store lock")
+        yield  # pragma: no cover
+
+    def fail_load(*args, **kwargs):
+        boundary_hits.append(("load", args, kwargs))
+        raise AssertionError("explicit-target persistence reached auth-store load")
+
+    def fail_save(*args, **kwargs):
+        boundary_hits.append(("save", args, kwargs))
+        raise AssertionError("explicit-target persistence reached auth-store save")
+
+    monkeypatch.setattr(auth, "_auth_store_lock", fail_lock)
+    monkeypatch.setattr(auth, "_load_auth_store", fail_load)
+    monkeypatch.setattr(auth, "_save_auth_store", fail_save)
+    return boundary_hits
+
+
+def test_auth_file_path_refuses_real_store_after_home_is_patched(
+    monkeypatch,
+    tmp_path,
+):
+    dangerous_auth = _real_auth_path()
+    monkeypatch.setenv("HOME", str(tmp_path / "patched-home"))
+    monkeypatch.setenv("HERMES_HOME", str(dangerous_auth.parent))
+
+    with pytest.raises(RuntimeError, match="HERMES_HOME"):
+        auth._auth_file_path()
+
+
+def test_auth_file_path_keeps_production_resolution_unchanged(
+    monkeypatch,
+    tmp_path,
+):
+    dangerous_auth = _real_auth_path()
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "patched-home"))
+    monkeypatch.setenv("HERMES_HOME", str(dangerous_auth.parent))
+
+    assert auth._auth_file_path().resolve(strict=False) == dangerous_auth
+
+
+def test_global_loader_refuses_real_store_before_file_access(
+    monkeypatch,
+    tmp_path,
+):
+    dangerous_auth = _real_auth_path()
+    monkeypatch.setenv("HOME", str(tmp_path / "patched-home"))
+    monkeypatch.setenv(
+        "HERMES_HOME",
+        str(dangerous_auth.parent / "profiles" / "seatbelt-test"),
+    )
+
+    global_path = auth._global_auth_file_path()
+    assert global_path is not None
+    assert global_path.resolve(strict=False) == dangerous_auth
+
+    original_exists = Path.exists
+
+    def fail_dangerous_exists(path):
+        if path.resolve(strict=False) == dangerous_auth:
+            raise AssertionError("global loader reached exists() before its seat belt")
+        return original_exists(path)
+
+    def fail_load(path):
+        raise AssertionError(f"global loader attempted auth-store access: {path}")
+
+    monkeypatch.setattr(Path, "exists", fail_dangerous_exists)
+    monkeypatch.setattr(auth, "_load_auth_store", fail_load)
+
+    assert auth._load_global_auth_store() == {}
+
+
+def test_explicit_target_writer_refuses_real_store_before_io(monkeypatch, tmp_path):
+    dangerous_auth = _configure_dangerous_profile(monkeypatch, tmp_path)
+    boundary_hits = _forbid_auth_store_io(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="Refusing.*auth store"):
+        auth._persist_provider_state_to_store(
+            "test-provider",
+            {"access_token": "test-sentinel"},
+            dangerous_auth,
+            set_active=False,
+        )
+
+    assert boundary_hits == []
+
+
+def test_explicit_target_writer_keeps_production_behavior(monkeypatch, tmp_path):
+    dangerous_auth = _configure_dangerous_profile(monkeypatch, tmp_path)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    boundary_hits = []
+
+    @contextmanager
+    def tracking_lock(*, target_path):
+        boundary_hits.append(("lock", target_path))
+        yield
+
+    def tracking_load(target_path):
+        boundary_hits.append(("load", target_path))
+        return {"version": 1, "providers": {}}
+
+    def tracking_save(auth_store, *, target_path):
+        boundary_hits.append(("save", target_path))
+        return target_path
+
+    monkeypatch.setattr(auth, "_auth_store_lock", tracking_lock)
+    monkeypatch.setattr(auth, "_load_auth_store", tracking_load)
+    monkeypatch.setattr(auth, "_save_auth_store", tracking_save)
+
+    assert (
+        auth._persist_provider_state_to_store(
+            "test-provider",
+            {"access_token": "test-sentinel"},
+            dangerous_auth,
+            set_active=False,
+        )
+        == dangerous_auth
+    )
+    assert [kind for kind, _path in boundary_hits] == ["lock", "load", "save"]
+
+
+def test_direct_write_through_stops_before_real_store_io(monkeypatch, tmp_path):
+    _configure_dangerous_profile(monkeypatch, tmp_path)
+    boundary_hits = _forbid_auth_store_io(monkeypatch)
+
+    auth._write_through_xai_oauth_to_global_root(
+        {"tokens": {"access_token": "test-sentinel"}}
+    )
+
+    assert boundary_hits == []
+
+
+def test_pool_write_through_stops_before_real_store_io(monkeypatch, tmp_path):
+    _configure_dangerous_profile(monkeypatch, tmp_path)
+    boundary_hits = _forbid_auth_store_io(monkeypatch)
+
+    credential_pool._write_through_provider_state_to_global_root(
+        "nous",
+        {"access_token": "test-sentinel"},
+    )
+
+    assert boundary_hits == []


### PR DESCRIPTION
## Summary

Prevent pytest fixtures that patch `HOME` from relocating auth-store safety guards while `HERMES_HOME` still resolves to the real user's `~/.hermes/auth.json`, including explicit-target write-through paths.

## Bug and reproduction

On current upstream `main`, auth-store test seat belts derive protected paths from mutable home state. A fixture can set `HOME` to a temporary directory while leaving `HERMES_HOME` pointed at the real default root or at a profile under it.

The guards then follow patched `HOME`, while active and profile-root targets can still resolve to the real root. That allows the active writer or global fallback loader to reach the real store. The same mismatch also affects explicit-target persistence used by direct xAI OAuth and pooled-provider write-through.

## Fix

Capture the import-time user home and prefer the POSIX passwd-database home (`pwd.getpwuid(os.getuid()).pw_dir`) as an environment-independent source, with the import-time snapshot as a portable fallback. Build one resolved protected auth-path set from that mechanism and share it across:

- active auth-path resolution;
- global fallback loading; and
- the central explicit-target persistence helper.

The global loader refuses before `exists()` or loading. The explicit-target helper refuses before lock, load, or save, which protects both direct xAI OAuth write-through and pooled-provider write-through without changing `agent/credential_pool.py`.

Every refusal remains gated on `PYTEST_CURRENT_TEST`, so production path resolution and auth-store persistence are unchanged. This upstream patch is self-contained and has no shared-xAI store or shared-auth layout dependency.

## Tests

```text
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_auth_seatbelt_env_immutable.py tests/hermes_cli/test_auth_profile_fallback.py -q
```

Result: 14 passed.

The behavior tests independently derive the dangerous path through `pwd.getpwuid`, patch both `HOME` and a profile-shaped `HERMES_HOME`, and instrument lock/load/save so the protected store is never accessed. They exercise the active writer, global loader, central explicit-target writer, direct write-through, pooled-provider write-through, and production gate-off behavior.

Each of the three guarded paths was additionally confirmed to fail without its
fix and pass with it, and the broader auth suite was run to confirm the new
explicit-target refusal does not affect legitimate targets:

```text
scripts/run_tests.sh tests/hermes_cli/test_auth_*.py tests/hermes_cli/test_xai_oauth_*.py -q
```

Result: 20 files, 139 passed, 0 failed.
