### PR TITLE
fix(tui_gateway): tolerate a deleted working directory across session, completion and exec paths (supersedes #40153)

### DIFF
--- a/tests/tui_gateway/test_safe_getcwd.py
+++ b/tests/tui_gateway/test_safe_getcwd.py
@@ -1,0 +1,183 @@
+"""Regression tests: tui_gateway must tolerate a deleted working directory.
+
+``os.getcwd()`` raises ``FileNotFoundError`` once the process's working
+directory is removed out from under it (the folder Hermes was launched in gets
+deleted, rebuilt, or ``git worktree remove``'d mid-session). ``tui_gateway``
+called it unguarded on seven fallback paths.
+
+Severity is process death, not degradation: ``session.create`` and
+``session.resume`` are NOT in ``server._LONG_HANDLERS``, so they run inline on
+the reader thread, and ``tui_gateway/entry.py`` calls ``dispatch(req)`` with no
+``try``/``except`` — an escaping FileNotFoundError exits the stdio gateway.
+
+``server._safe_getcwd`` mirrors the already-merged ``tools/terminal_tool.py``
+helper (#39491). These tests pin every substituted site so the crash class
+cannot silently regress, and pin the ``_SlashWorker`` subprocess contract that
+the substitution must not disturb.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tui_gateway.server as server
+
+
+def _getcwd_raises() -> MagicMock:
+    """A stand-in for os.getcwd() under a deleted CWD."""
+    return MagicMock(side_effect=FileNotFoundError(2, "No such file or directory"))
+
+
+@pytest.fixture
+def deleted_dir(tmp_path):
+    """A real path that existed and no longer does."""
+    d = tmp_path / "workspace"
+    d.mkdir()
+    path = str(d)
+    d.rmdir()
+    assert not os.path.isdir(path)
+    return path
+
+
+# ── the helper itself ────────────────────────────────────────────────────
+
+def test_safe_getcwd_returns_real_cwd_when_available():
+    assert server._safe_getcwd() == os.getcwd()
+
+
+def test_safe_getcwd_prefers_terminal_cwd_when_getcwd_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    with patch("os.getcwd", _getcwd_raises()):
+        assert server._safe_getcwd() == str(tmp_path)
+
+
+def test_safe_getcwd_falls_back_to_home_when_getcwd_raises(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    expected = os.path.expanduser("~")
+    with patch("os.getcwd", _getcwd_raises()):
+        assert server._safe_getcwd() == expected
+
+
+def test_safe_getcwd_does_not_swallow_unrelated_oserrors(monkeypatch):
+    """Parity with tools/terminal_tool.py: only FileNotFoundError is tolerated,
+    so a genuine PermissionError still surfaces instead of being masked."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    with patch("os.getcwd", MagicMock(side_effect=PermissionError(13, "denied"))):
+        with pytest.raises(PermissionError):
+            server._safe_getcwd()
+
+
+# ── _default_session_cwd — the gap the sweeper named on #40153 ───────────
+
+def test_default_session_cwd_survives_deleted_cwd(monkeypatch):
+    """session.create / session.resume resolve through here and run INLINE, so
+    an unguarded getcwd on this path kills the gateway process."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    expected = os.path.expanduser("~")
+    with patch.object(server, "_launch_configured_cwd", return_value=None):
+        with patch("os.getcwd", _getcwd_raises()):
+            assert server._default_session_cwd() == expected
+
+
+# ── _completion_cwd — both substituted sites ─────────────────────────────
+
+def test_completion_cwd_or_chain_survives_deleted_cwd(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    expected = os.path.expanduser("~")
+    with patch.object(server, "_profile_configured_cwd", return_value=None):
+        with patch.object(server, "_launch_configured_cwd", return_value=None):
+            with patch("os.getcwd", _getcwd_raises()):
+                assert server._completion_cwd({}) == expected
+
+
+def test_completion_cwd_survives_deleted_cwd_supplied_by_client(deleted_dir, monkeypatch):
+    """The isdir-failed tail. In the real scenario the client's last-known cwd
+    IS the deleted directory, so ``os.path.isdir`` returns False and the tail
+    fires even though a cwd was supplied — the ``except Exception: pass`` above
+    it does not cover that ``return``."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    expected = os.path.expanduser("~")
+    with patch("os.getcwd", _getcwd_raises()):
+        assert server._completion_cwd({"cwd": deleted_dir}) == expected
+
+
+# ── _SlashWorker: guarded cwd + untouched subprocess contract ────────────
+
+def test_slash_worker_spawns_with_fallback_cwd_and_preserves_contract(monkeypatch, tmp_path):
+    """The cwd substitution must not disturb the profile-home env scoping
+    (#40677), UTF-8 lossy decode (#53137), windows_hide_flags() or
+    start_new_session=True that this block has accumulated."""
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value=str(tmp_path))
+        ),
+    }):
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value.stdout = MagicMock()
+            mock_popen.return_value.stderr = MagicMock()
+            with patch("os.getcwd", _getcwd_raises()):
+                server._SlashWorker(session_key="k", model="m")
+
+    assert mock_popen.called, "Popen was not invoked"
+    kwargs = mock_popen.call_args[1]
+    assert kwargs["cwd"] == str(tmp_path)
+    # preservation guarantee, asserted rather than promised
+    assert kwargs["env"] is not None
+    assert kwargs["start_new_session"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+    assert "creationflags" in kwargs
+
+
+# ── methods_tools.py handlers ────────────────────────────────────────────
+
+@pytest.mark.parametrize("method_name", ["cli.exec", "config.show", "shell.exec"])
+def test_methods_tools_handlers_resolve_safe_getcwd(method_name):
+    """HandlerRegistry.install() rebuilds each handler with server.py's
+    globals, so methods_tools.py calls the bare name with no import. Pin that
+    the name really is resolvable, or these sites ship a latent NameError."""
+    handler = server._methods[method_name]
+    assert "_safe_getcwd" in handler.__globals__
+
+
+def test_cli_exec_runs_with_fallback_cwd(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    completed = MagicMock(stdout="", stderr="", returncode=0)
+    with patch("subprocess.run", return_value=completed) as mock_run:
+        with patch("os.getcwd", _getcwd_raises()):
+            resp = server._methods["cli.exec"]("1", {"argv": ["--version"]})
+
+    assert "error" not in resp, resp
+    assert mock_run.called
+    assert mock_run.call_args[1]["cwd"] == str(tmp_path)
+
+
+def test_shell_exec_runs_with_fallback_cwd(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    completed = MagicMock(stdout="", stderr="", returncode=0)
+    with patch("subprocess.run", return_value=completed) as mock_run:
+        with patch("os.getcwd", _getcwd_raises()):
+            resp = server._methods["shell.exec"]("2", {"command": "echo hi"})
+
+    assert "error" not in resp, resp
+    assert mock_run.called
+    assert mock_run.call_args[1]["cwd"] == str(tmp_path)
+
+
+def test_config_show_reports_fallback_working_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    with patch("os.getcwd", _getcwd_raises()):
+        resp = server._methods["config.show"]("3", {})
+
+    assert "error" not in resp, resp
+    rows = [
+        row
+        for section in resp["result"]["sections"]
+        for row in section["rows"]
+        if row[0] == "Working Dir"
+    ]
+    assert rows == [["Working Dir", str(tmp_path)]]

--- a/tests/tui_gateway/test_safe_getcwd.py
+++ b/tests/tui_gateway/test_safe_getcwd.py
@@ -111,6 +111,10 @@ def test_slash_worker_spawns_with_fallback_cwd_and_preserves_contract(monkeypatc
     (#40677), UTF-8 lossy decode (#53137), windows_hide_flags() or
     start_new_session=True that this block has accumulated."""
     monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    # Deliberately NOT tmp_path: that is the expected fallback cwd, so reusing
+    # it would let the HERMES_HOME assertion pass without the override firing.
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
     with patch.dict("sys.modules", {
         "hermes_constants": MagicMock(
             get_hermes_home=MagicMock(return_value=str(tmp_path))
@@ -120,13 +124,15 @@ def test_slash_worker_spawns_with_fallback_cwd_and_preserves_contract(monkeypatc
             mock_popen.return_value.stdout = MagicMock()
             mock_popen.return_value.stderr = MagicMock()
             with patch("os.getcwd", _getcwd_raises()):
-                server._SlashWorker(session_key="k", model="m")
+                server._SlashWorker(
+                    session_key="k", model="m", profile_home=str(profile_home)
+                )
 
     assert mock_popen.called, "Popen was not invoked"
     kwargs = mock_popen.call_args[1]
     assert kwargs["cwd"] == str(tmp_path)
     # preservation guarantee, asserted rather than promised
-    assert kwargs["env"] is not None
+    assert kwargs["env"]["HERMES_HOME"] == str(profile_home)
     assert kwargs["start_new_session"] is True
     assert kwargs["encoding"] == "utf-8"
     assert kwargs["errors"] == "replace"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -391,7 +391,7 @@ def _(rid, params: dict) -> dict:
             encoding="utf-8",
             errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
-            cwd=os.getcwd(),
+            cwd=_safe_getcwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
@@ -1408,7 +1408,7 @@ def _(rid, params: dict) -> dict:
             {
                 "title": "Environment",
                 "rows": [
-                    ["Working Dir", os.getcwd()],
+                    ["Working Dir", _safe_getcwd()],
                     ["Config File", str(_hermes_home / "config.yaml")],
                 ],
             },
@@ -1886,7 +1886,7 @@ def _(rid, params: dict) -> dict:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=_safe_getcwd(),
             # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
             # the gateway thread on locale-mismatched Windows (#53137).
             encoding="utf-8", errors="replace",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1366,15 +1366,24 @@ def _safe_getcwd() -> str:
     ``os.getcwd()`` raises FileNotFoundError when the process's working
     directory has been removed out from under it (e.g. the folder Hermes was
     launched in was deleted, rebuilt, or ``git worktree remove``'d mid-session).
-    Every ``os.getcwd()`` in this package is a *fallback* on a path that has
-    already exhausted its explicit sources, so a raise here is never recoverable
-    locally — ``session.create``/``session.resume`` run inline (they are not in
-    ``_LONG_HANDLERS``) and ``tui_gateway/entry.py`` does not guard
-    ``dispatch()``, so the stdio gateway process exits.
+    This guards the seven *fallback* sites that resolve a cwd only after their
+    explicit sources are exhausted — ``_SlashWorker``, ``_default_session_cwd``
+    and both ``_completion_cwd`` returns here, plus ``cli.exec``,
+    ``config.show`` and ``shell.exec`` in ``methods_tools.py`` — where a raise
+    is never recoverable locally: ``session.create``/``session.resume`` run
+    inline (they are not in ``_LONG_HANDLERS``) and ``tui_gateway/entry.py``
+    does not guard ``dispatch()``, so the stdio gateway process exits.
 
-    Mirrors :func:`tools.terminal_tool._safe_getcwd` (added in #39491) exactly,
-    including the TERMINAL_CWD -> home fallback chain, so the two surfaces
-    cannot drift.
+    ``compute_host.py`` (:520, :752) still calls ``os.getcwd()`` directly, by
+    design: ``host_supervisor.py`` starts that child with ``cwd=str(self.cwd)``
+    (:328), which defaults to ``_repo_root()`` (:150), so the compute host
+    cannot observe the deleted launch directory — ``Popen`` would fail first if
+    it could.
+
+    The body is identical to :func:`tools.terminal_tool._safe_getcwd` (added in
+    #39491), including the TERMINAL_CWD -> home fallback chain, but they are
+    two independent copies with nothing enforcing the mirror — change both
+    together.
     """
     try:
         return os.getcwd()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -378,7 +378,7 @@ class _SlashWorker:
             encoding="utf-8",
             errors="replace",
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=_safe_getcwd(),
             env=env,
             creationflags=windows_hide_flags(),
             start_new_session=True,
@@ -1360,6 +1360,28 @@ def _launch_configured_cwd() -> str | None:
         return None
 
 
+def _safe_getcwd() -> str:
+    """Return the current working directory, tolerating a deleted CWD.
+
+    ``os.getcwd()`` raises FileNotFoundError when the process's working
+    directory has been removed out from under it (e.g. the folder Hermes was
+    launched in was deleted, rebuilt, or ``git worktree remove``'d mid-session).
+    Every ``os.getcwd()`` in this package is a *fallback* on a path that has
+    already exhausted its explicit sources, so a raise here is never recoverable
+    locally — ``session.create``/``session.resume`` run inline (they are not in
+    ``_LONG_HANDLERS``) and ``tui_gateway/entry.py`` does not guard
+    ``dispatch()``, so the stdio gateway process exits.
+
+    Mirrors :func:`tools.terminal_tool._safe_getcwd` (added in #39491) exactly,
+    including the TERMINAL_CWD -> home fallback chain, so the two surfaces
+    cannot drift.
+    """
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+
+
 def _default_session_cwd() -> str:
     """Fallback cwd for a session with no explicit / stored / profile cwd.
 
@@ -1368,7 +1390,7 @@ def _default_session_cwd() -> str:
     than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
     ``TERMINAL_CWD``.
     """
-    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
+    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or _safe_getcwd()
 
 
 def write_json(obj: dict) -> bool:
@@ -2176,7 +2198,7 @@ def _completion_cwd(params: dict | None = None) -> str:
         # configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
         or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
+        or _safe_getcwd()
     )
     try:
         resolved = os.path.abspath(os.path.expanduser(str(raw)))
@@ -2184,7 +2206,10 @@ def _completion_cwd(params: dict | None = None) -> str:
             return resolved
     except Exception:
         pass
-    return os.getcwd()
+    # Reached whenever ``raw`` is not a live directory — which is exactly the
+    # deleted-CWD case, since the client's last-known cwd IS the deleted dir.
+    # The ``except`` above does not cover this return.
+    return _safe_getcwd()
 
 
 def _terminal_task_cwd(session: dict | None) -> str:


### PR DESCRIPTION
## What does this PR do?

**The guard for this exact bug is already enforced in `tools/` and entirely absent in `tui_gateway/`.** `tools/terminal_tool.py::_safe_getcwd` (`:1314`) landed as merged **`ad69d3edc` / #39491** *"fix(terminal): guard os.getcwd() against a deleted CWD"*; **#19928** *"fix(local): recover when persistent_shell cwd is deleted (#17558)"* and **#19933** merged the same idea on the local-shell surface. `git grep _safe_getcwd -- tui_gateway/` on main returns **nothing** — the TUI gateway never got it. This PR closes that asymmetry.

In user terms: *"I deleted (or `git worktree remove`'d, or rebuilt) the folder I launched Hermes in, and now the TUI can't open a new chat, can't resume a session, and slash commands are dead — the gateway just falls over."*

`os.getcwd()` raises `FileNotFoundError` once the process's working directory is removed out from under it. `tui_gateway/` calls it unguarded on **seven** fallback paths.

**This is process death, not degradation.** `session.create` and `session.resume` are **not** in `server._LONG_HANDLERS`, so `dispatch()` runs them inline via `return handle_request(req)` with no `except`, and `tui_gateway/entry.py:480` calls `resp = dispatch(req)` with no `try`/`except` and none in `main()` — an escaping `FileNotFoundError` **exits the stdio gateway process**. Only the Desktop/WS path degrades, because `tui_gateway/ws.py:383` catches around its own dispatch call and returns `-32603`.

Reachability chains, verified on main:

| RPC | resolves through | inline? | outcome today |
|---|---|---|---|
| `session.create` | `methods_session.py:34` → `_completion_cwd` | inline | **gateway process exits** |
| `session.resume` | `methods_session.py:423`/`:512` → `_default_session_cwd` | inline | **gateway process exits** |
| `shell.exec` | `methods_tools.py:1889` | inline | `-32000` / `5003`, command never runs |
| `config.show` | `methods_tools.py:1411` | inline | `5030`, settings panel fails to render |
| `cli.exec` | `methods_tools.py:394` | pool | `-32000 handler error` |

`_completion_cwd`'s isdir-failed tail is reachable **even when the client supplies a `cwd`** — in this scenario the client's last-known cwd *is* the deleted directory, so `os.path.isdir()` returns False and the fallback fires. The `except Exception: pass` above it does not cover that `return`.

## Related Issue

No issue exists for this surface, so there is no `Fixes:` line. The nearest filed report, **#62169** (*"Terminal sandbox: deleted CWD permanently breaks all subsequent commands (exit 126)"*), is the terminal-sandbox surface and is already fixed there — cited as corroborating evidence that users hit this class in the wild, not as the issue this closes.

**Supersedes #40153** (@Dusk1e). See below.

## Supersedes #40153 — deficiency shown mechanically, not argued

#40153 identified a real bug and its helper is sound. It has been **`CONFLICTING` / `DIRTY` since 2026-06-05** (last commit `2026-06-05T22:26:10Z`; its only force-push predates the 07-14 review by five weeks) and is **incomplete against current main**. Two mechanical facts, not opinions:

1. `grep -c '_default_session_cwd'` over its entire diff returns **0**. It never touches the site the review explicitly named.
2. Its hunk anchors are `208 / 234 / 793 / 801`; main's real call sites are `381 / 1371 / 2179 / 2187` — roughly 1400 lines of drift. That drift is *why* it reads `DIRTY`, and the `_SlashWorker` block it patches has since gained profile-home env scoping (#40677), UTF-8 lossy decode (#53137), `windows_hide_flags()` and `start_new_session=True`. Its diff still shows the old `env=os.environ.copy()` form with no `encoding=`/`creationflags=`/`start_new_session=`.

The 2026-07-14 automated review on #40153 (`keep_open salvageability=high`) states both points:

> **### Problems**
> - Current main also has a later-added unguarded fallback in `_default_session_cwd()` (`tui_gateway/server.py:1116`). A deleted launch CWD can still fail that default/resume route after this PR's three substitutions.
>
> **### Suggested changes**
> - During salvage, apply the safe resolver to `_default_session_cwd()` and add coverage for that path alongside the slash-worker and completion cases.
> - Preserve the current `_SlashWorker` subprocess setup at `tui_gateway/server.py:295-324`, including profile-home environment scoping and platform process flags.

Both are satisfied here: `_default_session_cwd` is substituted **and** covered by a dedicated test, and the `_SlashWorker` block is preserved byte-for-byte apart from the `cwd=` argument — with `env`, `creationflags`, `start_new_session=True`, `encoding="utf-8"` and `errors="replace"` **asserted in a test** rather than merely promised.

Credit for identifying the failure path belongs to @Dusk1e; this is the complete, rebased version against current main.

### Three-way red-before proof

Run against the new test file, which is identical in all three legs. This is the artifact that distinguishes a genuine improvement from a re-file:

| leg | `tui_gateway` state | result |
|---|---|---|
| 1 | clean `origin/main`, no fix | **14 failed, 0 passed** — all red |
| 2 | cut back to **#40153's exact 3-site shape** (helper + `_SlashWorker` + both `_completion_cwd` sites) | **4 failed, 10 passed** — `_default_session_cwd` and all three `methods_tools` cases **still red** |
| 3 | this PR | **14 passed** |

Leg 2's four survivors are exactly `test_default_session_cwd_survives_deleted_cwd`, `test_cli_exec_runs_with_fallback_cwd`, `test_shell_exec_runs_with_fallback_cwd`, `test_config_show_reports_fallback_working_dir`.

## Changes Made

- **`tui_gateway/server.py`** — added `_safe_getcwd()` immediately above `_default_session_cwd`, mirroring `tools/terminal_tool.py:1314` exactly (same `TERMINAL_CWD` → `expanduser("~")` chain) so the two surfaces cannot drift. Substituted at four sites: `_SlashWorker` spawn (`:381`), `_default_session_cwd` (`:1371`), `_completion_cwd` or-chain (`:2179`), `_completion_cwd` isdir-failed tail (`:2187`).
- **`tui_gateway/methods_tools.py`** — substituted at three more sites sharing the identical root cause: `cli.exec` (`:394`), `config.show` (`:1411`), `shell.exec` (`:1889`).
- **`tests/tui_gateway/test_safe_getcwd.py`** — new file, 14 tests.

**Exception type — `FileNotFoundError`, not `OSError`.** Chosen for exact parity with the merged `tools/terminal_tool.py` idiom, so a reader diffing the two helpers sees them as identical. A genuine `PermissionError` therefore still surfaces instead of being silently masked, and a test pins that. #67308 is separately *proposing* to widen the `tools/` helper to cover the macOS-TCC `PermissionError` case; if that merges, widening this copy to match is a one-line follow-up. Diverging pre-emptively would create exactly the drift this PR exists to remove.

**No import added to `methods_tools.py` — this is deliberate.** `tui_gateway/method_ctx.py::HandlerRegistry.install()` rebuilds every handler with `types.FunctionType(fn.__code__, vars(server), ...)`, so names in a `methods_*.py` handler body resolve against **`server.py`'s** namespace — which is why `methods_complete.py` calls bare `_completion_cwd` while importing only `HandlerRegistry`. All three sites were individually confirmed to sit inside `@method` bodies (`cli.exec` `:371`, `config.show` `:1383`, `shell.exec` `:1866`), and a parametrized test asserts `_safe_getcwd` is present in each rebound handler's `__globals__` so these sites cannot ship a latent `NameError`.

### Sites deliberately excluded

`tui_gateway/compute_host.py:520` (`str(frame.get("cwd") or os.getcwd())`) and `:752` (the `hello` handshake) are **not** substituted. Both rest on one verifiable fact rather than two separate arguments: `tui_gateway/host_supervisor.py:326` spawns that child with an **explicit `cwd=str(self.cwd)`**, and `self.cwd` defaults to `_repo_root()` (`:150`), never the user's launch directory. The compute-host process therefore always runs with a live, installation-owned cwd, so `os.getcwd()` there cannot observe the deleted launch dir — and if that directory were itself missing, `Popen` would fail at spawn time and the child would never reach either line. Substituting there would add unreachable code.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tui_gateway/test_safe_getcwd.py -v
```

To reproduce the original failure by hand:

1. `mkdir /tmp/scratch && cd /tmp/scratch`, launch the TUI from there.
2. From another shell, `rmdir /tmp/scratch`.
3. In the TUI, start a new chat (`session.create`) or resume one (`session.resume`). On `main` the stdio gateway process exits; with this PR the session opens in `TERMINAL_CWD`, falling back to the user's home directory.

Per-file results (CI uses per-file subprocess isolation, so these were verified per file, not via a flat `pytest tests/` run):

| file | result |
|---|---|
| `tests/tui_gateway/test_safe_getcwd.py` | 14 passed |
| `tests/tui_gateway/test_protocol.py` | 37 passed |
| `tests/tui_gateway/test_session_cwd_follow.py` | 7 passed |
| `tests/tui_gateway/test_subprocess_encoding.py` | 4 passed |
| `tests/tui_gateway/test_slash_worker_profile_home.py` | 1 passed |
| `tests/tui_gateway/test_slash_worker_sys_path.py` | 3 passed |
| `tests/tui_gateway/test_slash_worker_ansi.py` | 1 passed |
| `tests/tui_gateway/test_slash_worker_mcp_discovery.py` | 1 passed |
| `tests/gateway/test_complete_path_at_filter.py` | 9 passed |
| `tests/gateway/test_completion_delivery.py` | 7 passed |
| `tests/gateway/test_config_cwd_bridge.py` | 12 passed |
| `tests/gateway/test_cwd_placeholder.py` | 2 passed |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected files individually instead (table above); a flat `pytest tests/` run is not reproducible in this repo, and CI isolates per file
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helper and the `_completion_cwd` tail; no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — the helper is platform-neutral (`os.getenv` + `expanduser`); no `os.name` branching was introduced, and the Windows-specific `creationflags`/`windows_hide_flags()` on both subprocess blocks are preserved and asserted. Executed on macOS only.
- [x] N/A — no tool descriptions or schemas changed
