### PR TITLE
feat(whatsapp-bridge): add quick WhatsApp QR pairing scripts

### DIFF
--- a/scripts/whatsapp-bridge/whatsapp-quick.cjs
+++ b/scripts/whatsapp-bridge/whatsapp-quick.cjs
@@ -1,0 +1,52 @@
+// Quick WhatsApp QR - starts bridge, immediately generates QR image
+const path = require('path');
+const fs = require('fs');
+const { makeWASocket, useMultiFileAuthState, fetchLatestBaileysVersion, DisconnectReason } = require('@whiskeysockets/baileys');
+const QRCode = require('qrcode');
+const { Boom } = require('@hapi/boom');
+
+const SESSION_DIR = path.join(process.env.HOME || process.env.USERPROFILE, '.hermes', 'whatsapp', 'session');
+const QR_OUTPUT = path.join(process.env.HOME || process.env.USERPROFILE, 'whatsapp-qr.png');
+const logger = { info() {}, warn() {}, error() {} };
+
+async function start() {
+  const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
+  const { version } = await fetchLatestBaileysVersion();
+  const sock = makeWASocket({
+    version, auth: state, logger,
+    printQRInTerminal: false,
+    browser: ['Hermes Agent', 'Chrome', '120.0'],
+    syncFullHistory: false,
+    markOnlineOnConnect: false,
+    getMessage: async () => ({ conversation: '' }),
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('connection.update', async (update) => {
+    const { connection, lastDisconnect, qr } = update;
+    if (qr) {
+      console.log('QR_RECEIVED');
+      try {
+        await QRCode.toFile(QR_OUTPUT, qr, { type: 'png', width: 500, margin: 2 });
+        console.log('QR_SAVED:' + QR_OUTPUT);
+      } catch(e) {
+        console.log('QR_ERROR:' + e.message);
+      }
+    }
+    if (connection === 'close') {
+      const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
+      if (reason === DisconnectReason.loggedOut) {
+        console.log('LOGGED_OUT');
+        process.exit(1);
+      } else {
+        console.log('RECONNECT');
+        setTimeout(start, reason === 515 ? 1000 : 3000);
+      }
+    } else if (connection === 'open') {
+      console.log('CONNECTED');
+    }
+  });
+}
+
+start();

--- a/scripts/whatsapp-bridge/whatsapp-quick.js
+++ b/scripts/whatsapp-bridge/whatsapp-quick.js
@@ -1,0 +1,54 @@
+// Quick WhatsApp QR - ESM version with proper pino logger
+import path from 'path';
+import fs from 'fs';
+import { makeWASocket, useMultiFileAuthState, fetchLatestBaileysVersion, DisconnectReason } from '@whiskeysockets/baileys';
+import QRCode from 'qrcode';
+import { Boom } from '@hapi/boom';
+import pino from 'pino';
+
+const logger = pino({ level: 'warn' });
+const SESSION_DIR = path.join(process.env.HOME || process.env.USERPROFILE, '.hermes', 'whatsapp', 'session');
+const QR_OUTPUT = path.join(process.env.HOME || process.env.USERPROFILE, 'whatsapp-qr.png');
+
+async function start() {
+  const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
+  const { version } = await fetchLatestBaileysVersion();
+  const sock = makeWASocket({
+    version, auth: state, logger,
+    printQRInTerminal: false,
+    browser: ['Hermes Agent', 'Chrome', '120.0'],
+    syncFullHistory: false,
+    markOnlineOnConnect: false,
+    getMessage: async () => ({ conversation: '' }),
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('connection.update', async (update) => {
+    const { connection, lastDisconnect, qr } = update;
+    if (qr) {
+      console.log('QR_RECEIVED');
+      try {
+        await QRCode.toFile(QR_OUTPUT, qr, { type: 'png', width: 500, margin: 2 });
+        console.log('QR_SAVED:' + QR_OUTPUT);
+        console.log('QR_DATA:' + qr);
+      } catch(e) {
+        console.log('QR_ERROR:' + e.message);
+      }
+    }
+    if (connection === 'close') {
+      const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
+      if (reason === DisconnectReason.loggedOut) {
+        console.log('LOGGED_OUT');
+        process.exit(1);
+      } else {
+        console.log('RECONNECT');
+        setTimeout(start, reason === 515 ? 1000 : 3000);
+      }
+    } else if (connection === 'open') {
+      console.log('CONNECTED');
+    }
+  });
+}
+
+start();


### PR DESCRIPTION
## Summary
Adds two helper scripts for quick WhatsApp QR pairing during setup:

- `whatsapp-quick.js` - ESM version with proper pino logger
- `whatsapp-quick.cjs` - CommonJS version for quick QR generation

Both scripts use Baileys to pair a WhatsApp session, save credentials to `~/.hermes/whatsapp/session`, and render the pairing QR to a PNG file for manual scanning.

## Why
These are convenience scripts for bootstrapping the WhatsApp gateway without watching terminal output.

## Test Plan
- [ ] Scripts run and emit a QR PNG on first pairing
- [ ] Session saved to `~/.hermes/whatsapp/session`
- [ ] Reconnect works after temporary disconnect