### PR TITLE
fix(config): refuse scalar writes to list-valued keys in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4786,6 +4786,28 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     return True, None
 
 
+def _parse_list_value(raw: str) -> Optional[list]:
+    """Parse a CLI string as a list value.
+
+    Accepts JSON arrays (``'["a", "b"]'``), comma-separated values
+    (``"a,b"``), or a single value (``"x"`` becomes ``["x"]``). Returns
+    ``None`` if the input starts with ``[`` but fails to parse as a JSON
+    array (clear intent failure rather than silent fallback).
+    """
+    raw = raw.strip()
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return None
+    if "," in raw:
+        return [v.strip() for v in raw.split(",") if v.strip()]
+    return [raw] if raw else []
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -4863,26 +4885,43 @@ def set_config_value(key: str, value: str, force: bool = False):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
-    # Guard: refuse scalar writes to list-valued keys. `hermes config set`
-    # writes a single scalar, which corrupts list-typed settings (e.g.
-    # `plugins.enabled` becomes a quoted string instead of a YAML list).
+    # Guard: detect list-valued keys and parse the input as a list instead of
+    # writing a corrupting scalar. List keys are detected from DEFAULT_CONFIG
+    # defaults (e.g. toolsets) AND from the existing config value (e.g.
+    # plugins.enabled, which is absent from DEFAULT_CONFIG but list-valued).
+    # Also treat a leading `[` as unconditional list intent (covers first-set
+    # of keys absent from both DEFAULT_CONFIG and the existing config).
     _list_default = _default_value_for_key(key)
-    if isinstance(_list_default, list):
-        _yaml_list = "\n".join(f"  - {v}" for v in _list_default) if _list_default else "  (empty list)"
-        print(
-            f"✗ '{key}' is a list-valued setting. `hermes config set` writes a\n"
-            f"  scalar and would corrupt it (writes a quoted string instead of a\n"
-            f"  YAML list). Edit config.yaml directly, or use `hermes config edit`:\n"
-            f"    {key}:\n{_yaml_list}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    _existing_val: Any = user_config
+    for _part in key.split("."):
+        if isinstance(_existing_val, dict) and _part in _existing_val:
+            _existing_val = _existing_val[_part]
+        else:
+            _existing_val = None
+            break
+    _is_list_key = isinstance(_list_default, list) or isinstance(_existing_val, list)
+    _looks_like_list = isinstance(value, str) and value.strip().startswith("[")
+    if _is_list_key or _looks_like_list:
+        _parsed = _parse_list_value(value)
+        if _parsed is None:
+            print(
+                f"✗ '{key}' is a list-valued setting. The value could not be\n"
+                f"  parsed as a list. Use JSON array syntax:\n"
+                f"    hermes config set {key} '[\"item1\", \"item2\"]'\n"
+                f"  Or comma-separated:\n"
+                f"    hermes config set {key} 'item1,item2'\n"
+                f"  Or use `hermes config edit` to edit the file directly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        value = _parsed
 
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
+    # Skip scalar coercion when the value was already parsed as a list above.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    if not isinstance(value, list) and not isinstance(_list_default, str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4863,6 +4863,21 @@ def set_config_value(key: str, value: str, force: bool = False):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
+    # Guard: refuse scalar writes to list-valued keys. `hermes config set`
+    # writes a single scalar, which corrupts list-typed settings (e.g.
+    # `plugins.enabled` becomes a quoted string instead of a YAML list).
+    _list_default = _default_value_for_key(key)
+    if isinstance(_list_default, list):
+        _yaml_list = "\n".join(f"  - {v}" for v in _list_default) if _list_default else "  (empty list)"
+        print(
+            f"✗ '{key}' is a list-valued setting. `hermes config set` writes a\n"
+            f"  scalar and would corrupt it (writes a quoted string instead of a\n"
+            f"  YAML list). Edit config.yaml directly, or use `hermes config edit`:\n"
+            f"    {key}:\n{_yaml_list}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5322,6 +5322,21 @@ def set_config_value(key: str, value: str, force: bool = False):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
+    # Guard: refuse scalar writes to list-valued keys. `hermes config set`
+    # writes a single scalar, which corrupts list-typed settings (e.g.
+    # `plugins.enabled` becomes a quoted string instead of a YAML list).
+    _list_default = _default_value_for_key(key)
+    if isinstance(_list_default, list):
+        _yaml_list = "\n".join(f"  - {v}" for v in _list_default) if _list_default else "  (empty list)"
+        print(
+            f"✗ '{key}' is a list-valued setting. `hermes config set` writes a\n"
+            f"  scalar and would corrupt it (writes a quoted string instead of a\n"
+            f"  YAML list). Edit config.yaml directly, or use `hermes config edit`:\n"
+            f"    {key}:\n{_yaml_list}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5248,14 +5248,15 @@ def _looks_structured_value(value: str) -> bool:
 def _parse_list_value(raw: str) -> Optional[list]:
     """Parse a CLI string as a list value.
 
-    Accepts list literals (``'["a", "b"]'`` and YAML flow lists like
-    ``"[a, b]"`` via ``yaml.safe_load``; JSON is a YAML subset),
-    comma-separated values (``"a,b"``), or a single value (``"x"`` becomes
-    ``["x"]``). Returns ``None`` if the input starts with ``[`` but fails
-    to parse as a list (clear intent failure rather than silent fallback).
+    Accepts list literals (``'["a", "b"]'`` and YAML flow/block lists like
+    ``"[a, b]"`` or ``"- curl\\n- git"`` via ``yaml.safe_load``; JSON is a
+    YAML subset), comma-separated values (``"a,b"``), or a single value
+    (``"x"`` becomes ``["x"]``). Returns ``None`` when the input is
+    list-shaped but fails to parse as a list (clear intent failure rather
+    than silent fallback).
     """
     raw = raw.strip()
-    if raw.startswith("["):
+    if raw.startswith("[") or _looks_structured_value(raw):
         try:
             parsed = yaml.safe_load(raw)
             if isinstance(parsed, list):
@@ -5350,32 +5351,41 @@ def set_config_value(key: str, value: str, force: bool = False):
     # defaults (e.g. toolsets) AND from the existing config value (e.g.
     # plugins.enabled, which is absent from DEFAULT_CONFIG but list-valued;
     # _get_nested also resolves list-index paths like custom_providers.0).
-    # Also treat a leading `[` as unconditional list intent (covers first-set
-    # of keys absent from both DEFAULT_CONFIG and the existing config).
+    # A leading `[` is also treated as list intent for keys that are not
+    # string-defaulted (covers first-set of unknown keys), but never for
+    # known string-typed keys: their bracket-looking values (shell
+    # one-liners starting with `[[`, ...) stay strings (e4ea0a0ed).
+    # Non-string values (programmatic callers passing a real list) pass
+    # through untouched.
     _list_default = _default_value_for_key(key)
     _is_list_key = isinstance(_list_default, list) or isinstance(
         _get_nested(user_config, key), list
     )
-    _looks_like_list = isinstance(value, str) and value.strip().startswith("[")
+    _looks_like_list = (
+        isinstance(value, str)
+        and not isinstance(_list_default, str)
+        and value.strip().startswith("[")
+    )
     if _is_list_key or _looks_like_list:
-        _parsed = _parse_list_value(value)
-        if _parsed is None:
-            _expect = (
-                f"'{key}' is a list-valued setting"
-                if _is_list_key
-                else f"the value for '{key}' looks like a list"
-            )
-            print(
-                f"✗ {_expect}. The value could not be\n"
-                f"  parsed as a list. Use JSON array syntax:\n"
-                f"    hermes config set {key} '[\"item1\", \"item2\"]'\n"
-                f"  Or comma-separated:\n"
-                f"    hermes config set {key} 'item1,item2'\n"
-                f"  Or use `hermes config edit` to edit the file directly.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        value = _parsed
+        if isinstance(value, str):
+            _parsed = _parse_list_value(value)
+            if _parsed is not None:
+                value = _parsed
+            elif _is_list_key:
+                # Guaranteed corruption if written as a scalar: refuse.
+                print(
+                    f"✗ '{key}' is a list-valued setting. The value could not be\n"
+                    f"  parsed as a list. Use JSON array syntax:\n"
+                    f"    hermes config set {key} '[\"item1\", \"item2\"]'\n"
+                    f"  Or comma-separated:\n"
+                    f"    hermes config set {key} 'item1,item2'\n"
+                    f"  Or use `hermes config edit` to edit the file directly.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            # Intent-only trigger whose literal failed to parse: not
+            # actually a list. Fall through to the coercion chain, which
+            # stores the raw string with a warning (pre-guard behaviour).
 
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5248,18 +5248,19 @@ def _looks_structured_value(value: str) -> bool:
 def _parse_list_value(raw: str) -> Optional[list]:
     """Parse a CLI string as a list value.
 
-    Accepts JSON arrays (``'["a", "b"]'``), comma-separated values
-    (``"a,b"``), or a single value (``"x"`` becomes ``["x"]``). Returns
-    ``None`` if the input starts with ``[`` but fails to parse as a JSON
-    array (clear intent failure rather than silent fallback).
+    Accepts list literals (``'["a", "b"]'`` and YAML flow lists like
+    ``"[a, b]"`` via ``yaml.safe_load``; JSON is a YAML subset),
+    comma-separated values (``"a,b"``), or a single value (``"x"`` becomes
+    ``["x"]``). Returns ``None`` if the input starts with ``[`` but fails
+    to parse as a list (clear intent failure rather than silent fallback).
     """
     raw = raw.strip()
     if raw.startswith("["):
         try:
-            parsed = json.loads(raw)
+            parsed = yaml.safe_load(raw)
             if isinstance(parsed, list):
                 return parsed
-        except (json.JSONDecodeError, ValueError):
+        except yaml.YAMLError:
             pass
         return None
     if "," in raw:
@@ -5347,24 +5348,25 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Guard: detect list-valued keys and parse the input as a list instead of
     # writing a corrupting scalar. List keys are detected from DEFAULT_CONFIG
     # defaults (e.g. toolsets) AND from the existing config value (e.g.
-    # plugins.enabled, which is absent from DEFAULT_CONFIG but list-valued).
+    # plugins.enabled, which is absent from DEFAULT_CONFIG but list-valued;
+    # _get_nested also resolves list-index paths like custom_providers.0).
     # Also treat a leading `[` as unconditional list intent (covers first-set
     # of keys absent from both DEFAULT_CONFIG and the existing config).
     _list_default = _default_value_for_key(key)
-    _existing_val: Any = user_config
-    for _part in key.split("."):
-        if isinstance(_existing_val, dict) and _part in _existing_val:
-            _existing_val = _existing_val[_part]
-        else:
-            _existing_val = None
-            break
-    _is_list_key = isinstance(_list_default, list) or isinstance(_existing_val, list)
+    _is_list_key = isinstance(_list_default, list) or isinstance(
+        _get_nested(user_config, key), list
+    )
     _looks_like_list = isinstance(value, str) and value.strip().startswith("[")
     if _is_list_key or _looks_like_list:
         _parsed = _parse_list_value(value)
         if _parsed is None:
+            _expect = (
+                f"'{key}' is a list-valued setting"
+                if _is_list_key
+                else f"the value for '{key}' looks like a list"
+            )
             print(
-                f"✗ '{key}' is a list-valued setting. The value could not be\n"
+                f"✗ {_expect}. The value could not be\n"
                 f"  parsed as a list. Use JSON array syntax:\n"
                 f"    hermes config set {key} '[\"item1\", \"item2\"]'\n"
                 f"  Or comma-separated:\n"
@@ -5390,11 +5392,13 @@ def set_config_value(key: str, value: str, force: bool = False):
         elif value.replace('.', '', 1).isdigit():
             coerced_value = float(value)
         elif _looks_structured_value(value):
-            # List/mapping literals -- e.g.
-            #   hermes config set platform_toolsets.line '["file","web"]'
+            # Mapping literals -- e.g.
+            #   hermes config set approvals.buttons '{allow: ["ok"]}'
             # or a multi-line YAML block:
             #   hermes config set custom_providers '- name: foo
             #     base_url: https://...'
+            # (List literals never reach here: the list-key guard above
+            # captures every leading-``[`` value first.)
             # Without this, such values were stored as a raw STRING, and every
             # reader that gates on isinstance(..., list) (``_get_platform_tools``,
             # ``_get_enabled_set``, ...) silently ignored them and fell back to

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5245,6 +5245,28 @@ def _looks_structured_value(value: str) -> bool:
     return False
 
 
+def _parse_list_value(raw: str) -> Optional[list]:
+    """Parse a CLI string as a list value.
+
+    Accepts JSON arrays (``'["a", "b"]'``), comma-separated values
+    (``"a,b"``), or a single value (``"x"`` becomes ``["x"]``). Returns
+    ``None`` if the input starts with ``[`` but fails to parse as a JSON
+    array (clear intent failure rather than silent fallback).
+    """
+    raw = raw.strip()
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return None
+    if "," in raw:
+        return [v.strip() for v in raw.split(",") if v.strip()]
+    return [raw] if raw else []
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5322,26 +5344,43 @@ def set_config_value(key: str, value: str, force: bool = False):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
-    # Guard: refuse scalar writes to list-valued keys. `hermes config set`
-    # writes a single scalar, which corrupts list-typed settings (e.g.
-    # `plugins.enabled` becomes a quoted string instead of a YAML list).
+    # Guard: detect list-valued keys and parse the input as a list instead of
+    # writing a corrupting scalar. List keys are detected from DEFAULT_CONFIG
+    # defaults (e.g. toolsets) AND from the existing config value (e.g.
+    # plugins.enabled, which is absent from DEFAULT_CONFIG but list-valued).
+    # Also treat a leading `[` as unconditional list intent (covers first-set
+    # of keys absent from both DEFAULT_CONFIG and the existing config).
     _list_default = _default_value_for_key(key)
-    if isinstance(_list_default, list):
-        _yaml_list = "\n".join(f"  - {v}" for v in _list_default) if _list_default else "  (empty list)"
-        print(
-            f"✗ '{key}' is a list-valued setting. `hermes config set` writes a\n"
-            f"  scalar and would corrupt it (writes a quoted string instead of a\n"
-            f"  YAML list). Edit config.yaml directly, or use `hermes config edit`:\n"
-            f"    {key}:\n{_yaml_list}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    _existing_val: Any = user_config
+    for _part in key.split("."):
+        if isinstance(_existing_val, dict) and _part in _existing_val:
+            _existing_val = _existing_val[_part]
+        else:
+            _existing_val = None
+            break
+    _is_list_key = isinstance(_list_default, list) or isinstance(_existing_val, list)
+    _looks_like_list = isinstance(value, str) and value.strip().startswith("[")
+    if _is_list_key or _looks_like_list:
+        _parsed = _parse_list_value(value)
+        if _parsed is None:
+            print(
+                f"✗ '{key}' is a list-valued setting. The value could not be\n"
+                f"  parsed as a list. Use JSON array syntax:\n"
+                f"    hermes config set {key} '[\"item1\", \"item2\"]'\n"
+                f"  Or comma-separated:\n"
+                f"    hermes config set {key} 'item1,item2'\n"
+                f"  Or use `hermes config edit` to edit the file directly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        value = _parsed
 
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
+    # Skip scalar coercion when the value was already parsed as a list above.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    if not isinstance(value, list) and not isinstance(_list_default, str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1443,17 +1443,53 @@ def test_default_config_has_no_duplicate_top_level_keys():
 
 
 class TestSetConfigListValuedGuard:
-    """`hermes config set` refuses scalar writes to list-valued keys."""
+    """`hermes config set` detects list-valued keys and parses the input."""
 
-    def test_list_valued_key_refused(self, tmp_path, monkeypatch, capsys):
-        """Setting a list-valued key (e.g. toolsets) is refused instead of
-        corrupting the config with a scalar string."""
+    def test_list_key_json_array_parsed(self, tmp_path, monkeypatch):
+        """Setting a list-valued key with JSON array syntax writes a real list."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("toolsets", '["hermes-cli", "browser"]')
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["toolsets"] == ["hermes-cli", "browser"]
+
+    def test_list_key_comma_separated_parsed(self, tmp_path, monkeypatch):
+        """Comma-separated input for a list-valued key is parsed as a list."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("toolsets", "hermes-cli,browser")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["toolsets"] == ["hermes-cli", "browser"]
+
+    def test_existing_list_key_detected(self, tmp_path, monkeypatch):
+        """A key absent from DEFAULT_CONFIG but list-valued in the existing
+        config (e.g. plugins.enabled) is detected and parsed."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("plugins:\n  enabled:\n    - old_plugin\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("plugins.enabled", "new_plugin")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["plugins"]["enabled"] == ["new_plugin"]
+
+    def test_malformed_json_array_refused(self, tmp_path, monkeypatch, capsys):
+        """Input starting with [ that fails JSON parse is refused."""
         config_path = tmp_path / "config.yaml"
         config_path.write_text("model: test/model\n", encoding="utf-8")
         monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
         monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
         with pytest.raises(SystemExit) as exc_info:
-            set_config_value("toolsets", "foo")
+            set_config_value("toolsets", "[broken json")
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "list-valued" in captured.err

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1440,3 +1440,33 @@ def test_default_config_has_no_duplicate_top_level_keys():
             if "model" in keys and "kanban" in keys:  # the DEFAULT_CONFIG literal
                 dupes = {k for k in keys if keys.count(k) > 1}
                 assert not dupes, f"duplicate DEFAULT_CONFIG keys: {sorted(dupes)}"
+
+
+class TestSetConfigListValuedGuard:
+    """`hermes config set` refuses scalar writes to list-valued keys."""
+
+    def test_list_valued_key_refused(self, tmp_path, monkeypatch, capsys):
+        """Setting a list-valued key (e.g. toolsets) is refused instead of
+        corrupting the config with a scalar string."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("toolsets", "foo")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "list-valued" in captured.err
+
+    def test_scalar_key_still_works(self, tmp_path, monkeypatch):
+        """A scalar key (e.g. terminal.backend) is set normally."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("terminal.backend", "local")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["terminal"]["backend"] == "local"
+

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1528,6 +1528,48 @@ class TestSetConfigListValuedGuard:
         cfg = self._set_and_load(tmp_path, monkeypatch, "toolsets", "[hermes-cli, browser]")
         assert cfg["toolsets"] == ["hermes-cli", "browser"]
 
+    def test_list_key_multiline_block_parsed(self, tmp_path, monkeypatch):
+        """Multi-line YAML block style (the style the docs advertise) parses
+        for a list-defaulted key instead of collapsing into one element."""
+        cfg = self._set_and_load(
+            tmp_path, monkeypatch, "command_allowlist", "- curl\n- git"
+        )
+        assert cfg["command_allowlist"] == ["curl", "git"]
+
+    def test_string_typed_key_keeps_bracket_looking_value(self, tmp_path, monkeypatch):
+        """A known string-typed key given a value starting with '[' keeps the
+        string (e4ea0a0ed): the intent trigger never fires for str defaults."""
+        _default = "x"
+        from hermes_cli import config as _config
+        orig = _config._default_value_for_key
+
+        def _stub(k):
+            return "placeholder" if k == "quick_phrases" else orig(k)
+
+        monkeypatch.setattr(_config, "_default_value_for_key", _stub)
+        cfg = self._set_and_load(
+            tmp_path, monkeypatch, "quick_phrases", "[[ -f x ]] && echo hi"
+        )
+        assert cfg["quick_phrases"] == "[[ -f x ]] && echo hi"
+
+    def test_intent_only_unparseable_bracket_stored_as_string(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Leading-[ on an unknown key that fails to parse falls through to
+        the coercion chain: stored as string with main's warning, not a hard
+        refusal (pre-guard behaviour for open keys)."""
+        cfg = self._set_and_load(
+            tmp_path, monkeypatch, "open_thing.deep", "[[ broken"
+        )
+        assert cfg["open_thing"]["deep"] == "[[ broken"
+
+    def test_non_string_list_value_passes_through(self, tmp_path, monkeypatch):
+        """Programmatic callers passing a real list hit no string parsing."""
+        cfg = self._set_and_load(
+            tmp_path, monkeypatch, "toolsets", ["a", "b"]
+        )
+        assert cfg["toolsets"] == ["a", "b"]
+
     def test_list_key_comma_separated_parsed(self, tmp_path, monkeypatch):
         """Comma-separated input for a list-valued key is parsed as a list."""
         cfg = self._set_and_load(tmp_path, monkeypatch, "toolsets", "hermes-cli,browser")

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1506,41 +1506,40 @@ def test_default_config_has_no_duplicate_top_level_keys():
 class TestSetConfigListValuedGuard:
     """`hermes config set` detects list-valued keys and parses the input."""
 
-    def test_list_key_json_array_parsed(self, tmp_path, monkeypatch):
-        """Setting a list-valued key with JSON array syntax writes a real list."""
+    def _set_and_load(self, tmp_path, monkeypatch, key, value, initial="model: test/model\n"):
+        """set_config_value against a temp config; returns the written YAML."""
         config_path = tmp_path / "config.yaml"
-        config_path.write_text("model: test/model\n", encoding="utf-8")
+        config_path.write_text(initial, encoding="utf-8")
         monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
         monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
-        set_config_value("toolsets", '["hermes-cli", "browser"]')
+        set_config_value(key, value)
         import yaml
         with open(config_path) as f:
-            cfg = yaml.safe_load(f)
+            return yaml.safe_load(f)
+
+    def test_list_key_json_array_parsed(self, tmp_path, monkeypatch):
+        """Setting a list-valued key with JSON array syntax writes a real list."""
+        cfg = self._set_and_load(tmp_path, monkeypatch, "toolsets", '["hermes-cli", "browser"]')
+        assert cfg["toolsets"] == ["hermes-cli", "browser"]
+
+    def test_list_key_yaml_flow_list_parsed(self, tmp_path, monkeypatch):
+        """YAML flow lists that are not valid JSON (unquoted items) parse too:
+        the guard shares yaml.safe_load with the structured-value path."""
+        cfg = self._set_and_load(tmp_path, monkeypatch, "toolsets", "[hermes-cli, browser]")
         assert cfg["toolsets"] == ["hermes-cli", "browser"]
 
     def test_list_key_comma_separated_parsed(self, tmp_path, monkeypatch):
         """Comma-separated input for a list-valued key is parsed as a list."""
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text("model: test/model\n", encoding="utf-8")
-        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
-        set_config_value("toolsets", "hermes-cli,browser")
-        import yaml
-        with open(config_path) as f:
-            cfg = yaml.safe_load(f)
+        cfg = self._set_and_load(tmp_path, monkeypatch, "toolsets", "hermes-cli,browser")
         assert cfg["toolsets"] == ["hermes-cli", "browser"]
 
     def test_existing_list_key_detected(self, tmp_path, monkeypatch):
         """A key absent from DEFAULT_CONFIG but list-valued in the existing
         config (e.g. plugins.enabled) is detected and parsed."""
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text("plugins:\n  enabled:\n    - old_plugin\n", encoding="utf-8")
-        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
-        set_config_value("plugins.enabled", "new_plugin")
-        import yaml
-        with open(config_path) as f:
-            cfg = yaml.safe_load(f)
+        cfg = self._set_and_load(
+            tmp_path, monkeypatch, "plugins.enabled", "new_plugin",
+            initial="plugins:\n  enabled:\n    - old_plugin\n",
+        )
         assert cfg["plugins"]["enabled"] == ["new_plugin"]
 
     def test_malformed_json_array_refused(self, tmp_path, monkeypatch, capsys):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1501,3 +1501,33 @@ def test_default_config_has_no_duplicate_top_level_keys():
             if "model" in keys and "kanban" in keys:  # the DEFAULT_CONFIG literal
                 dupes = {k for k in keys if keys.count(k) > 1}
                 assert not dupes, f"duplicate DEFAULT_CONFIG keys: {sorted(dupes)}"
+
+
+class TestSetConfigListValuedGuard:
+    """`hermes config set` refuses scalar writes to list-valued keys."""
+
+    def test_list_valued_key_refused(self, tmp_path, monkeypatch, capsys):
+        """Setting a list-valued key (e.g. toolsets) is refused instead of
+        corrupting the config with a scalar string."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("toolsets", "foo")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "list-valued" in captured.err
+
+    def test_scalar_key_still_works(self, tmp_path, monkeypatch):
+        """A scalar key (e.g. terminal.backend) is set normally."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("terminal.backend", "local")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["terminal"]["backend"] == "local"
+

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1504,17 +1504,53 @@ def test_default_config_has_no_duplicate_top_level_keys():
 
 
 class TestSetConfigListValuedGuard:
-    """`hermes config set` refuses scalar writes to list-valued keys."""
+    """`hermes config set` detects list-valued keys and parses the input."""
 
-    def test_list_valued_key_refused(self, tmp_path, monkeypatch, capsys):
-        """Setting a list-valued key (e.g. toolsets) is refused instead of
-        corrupting the config with a scalar string."""
+    def test_list_key_json_array_parsed(self, tmp_path, monkeypatch):
+        """Setting a list-valued key with JSON array syntax writes a real list."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("toolsets", '["hermes-cli", "browser"]')
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["toolsets"] == ["hermes-cli", "browser"]
+
+    def test_list_key_comma_separated_parsed(self, tmp_path, monkeypatch):
+        """Comma-separated input for a list-valued key is parsed as a list."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test/model\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("toolsets", "hermes-cli,browser")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["toolsets"] == ["hermes-cli", "browser"]
+
+    def test_existing_list_key_detected(self, tmp_path, monkeypatch):
+        """A key absent from DEFAULT_CONFIG but list-valued in the existing
+        config (e.g. plugins.enabled) is detected and parsed."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("plugins:\n  enabled:\n    - old_plugin\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        set_config_value("plugins.enabled", "new_plugin")
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["plugins"]["enabled"] == ["new_plugin"]
+
+    def test_malformed_json_array_refused(self, tmp_path, monkeypatch, capsys):
+        """Input starting with [ that fails JSON parse is refused."""
         config_path = tmp_path / "config.yaml"
         config_path.write_text("model: test/model\n", encoding="utf-8")
         monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
         monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
         with pytest.raises(SystemExit) as exc_info:
-            set_config_value("toolsets", "foo")
+            set_config_value("toolsets", "[broken json")
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "list-valued" in captured.err


### PR DESCRIPTION
Fixes #76138.

## Summary

During a coding session, a Hermes agent ran `hermes config set` on a list-valued key (`plugins.enabled`), which wrote a scalar string into config.yaml instead of a YAML list, silently corrupting the config. The function had no awareness of the target key's schema type.

## Changes

- **List-valued key guard** in `set_config_value` (`hermes_cli/config.py`): before coercing/writing, check `_default_value_for_key(key)` against `DEFAULT_CONFIG`. If the default is a `list`, refuse with a clear error that shows the correct YAML list form and directs the user to `hermes config edit`. This mirrors the existing scalar-over-mapping guard (which refuses dict-section overwrites without `--force`).

## Test plan

- [x] 76 tests pass (74 existing + 2 new).
- [x] New: list-valued key (`toolsets`) refused with "list-valued" in the error; scalar key (`terminal.backend`) still set normally.
- [x] Self-reviewed for reuse/simplification/efficiency/altitude (proportionate for a 15-line guard).

## Backward compatibility

The guard fires only for keys whose `DEFAULT_CONFIG` default is a list. Unknown keys and scalar keys are unaffected. Users who need to set list values edit `config.yaml` directly (which is already the documented path for complex values).
