### PR TITLE
fix(update): claim the four shipped modules missing from the first-party roster

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1294,19 +1294,31 @@ def venv_python_path(venv_dir, *, windows: bool | None = None) -> Path:
 # third-party problem with different remediation. Single source of truth —
 # `hermes_cli.update_cmd`'s post-update probe consumes this same set so the
 # guard that BLOCKS and the hint that EXPLAINS can never disagree.
+#
+# The roster must cover every top-level module we ship: a shipped module that
+# is missing here reads as third-party, so the probe scores its
+# ModuleNotFoundError as "dependencies aren't installed" instead of "our tree
+# is skewed", and the hint stays silent on the crash it exists to explain.
+# ``tests/hermes_cli/test_update_import_guard.py`` pins the roster against
+# pyproject's declared ``py-modules`` so a newly shipped module cannot drift
+# out of it.
 FIRST_PARTY_MODULE_ROOTS = frozenset(
     {
         "agent",
         "acp_adapter",
+        "batch_runner",
         "cli",
         "cron",
         "gateway",
+        "mcp_serve",
         "model_tools",
         "plugins",
         "providers",
         "tools",
+        "toolset_distributions",
         "toolsets",
         "run_agent",
+        "trajectory_compressor",
         "tui_gateway",
         "utils",
     }

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -235,3 +235,51 @@ def test_probe_and_hint_share_one_first_party_definition():
     # Lookalikes stay out of both.
     for lookalike in ("agents", "agentops", "toolsets_x", "hermesx"):
         assert not is_first_party_module(lookalike)
+
+
+def _declared_top_level_modules() -> list[str]:
+    """Top-level modules the wheel actually ships, per pyproject."""
+    import tomllib
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    modules = (
+        data.get("tool", {})
+        .get("setuptools", {})
+        .get("py-modules", [])
+    )
+    return [str(m) for m in modules]
+
+
+def test_roster_covers_every_shipped_top_level_module():
+    """Consistency between the two consumers is not enough — the roster has to
+    be complete.
+
+    A module we ship but omit here reads as third-party in both directions:
+    the probe scores its ModuleNotFoundError as "dependencies aren't installed"
+    and keeps a skewed tree, and the hint stays silent on the very crash it
+    exists to explain. This asserts the relationship (everything shipped is
+    claimed), not a snapshot of the roster, so adding a module is fine as long
+    as it is claimed too.
+    """
+    from hermes_constants import is_first_party_module
+
+    shipped = _declared_top_level_modules()
+    assert shipped, "sanity: expected pyproject to declare top-level py-modules"
+
+    unclaimed = sorted(m for m in shipped if not is_first_party_module(m))
+    assert not unclaimed, (
+        "shipped top-level modules missing from FIRST_PARTY_MODULE_ROOTS: "
+        f"{unclaimed}"
+    )
+
+
+@pytest.mark.parametrize(
+    "modname",
+    ["batch_runner", "mcp_serve", "toolset_distributions", "trajectory_compressor"],
+)
+def test_hint_fires_for_shipped_root_level_modules(modname):
+    """These ship in the wheel, so an ImportError naming one is our skew."""
+    exc = ImportError("cannot import name 'X'")
+    exc.name = modname
+    assert partial_update_hint(exc), f"expected guidance for {modname}"


### PR DESCRIPTION
## What

15cb86eba hoisted `FIRST_PARTY_MODULE_ROOTS` into `hermes_constants` so the probe that **blocks** a bad update and the hint that **explains** it can never disagree, and completed the roster from the two hand-written copies it replaced.

Four top-level modules the wheel actually ships were in neither copy, so they were not carried over:

```
shipped py-modules (pyproject): 18
NOT recognized as first-party:  ['batch_runner', 'mcp_serve',
                                 'toolset_distributions', 'trajectory_compressor']
```

A shipped module missing from the roster reads as third-party in **both** directions:

- **the probe keeps a broken tree.** `_validate_critical_modules_import` scores a `ModuleNotFoundError` as ours only when the root is in the roster (`missing in %r or missing.startswith('hermes_')`). For these four it scores "dependencies aren't installed yet" instead, does not fail the probe, and the partially-updated tree is kept — the exact case `baecc840e` added the probe to catch.
- **the hint stays silent.** `partial_update_hint()` returns `[]` for them, so the user gets the opaque `ImportError` with no "re-run `hermes update`" guidance. That is the *"third-party blamed on our updater"* row in `15cb86eba`'s own divergence table, still open for these four.

Three of the four are imported by first-party code, so a dropped file surfaces under exactly these names:

```
hermes_cli/mcp_config.py:1078      from mcp_serve import run_mcp_server
batch_runner.py:50                 from toolset_distributions import (...)
scripts/sample_and_compress.py:270 from trajectory_compressor import TrajectoryCompressor
```

## Fix

Add the four to `FIRST_PARTY_MODULE_ROOTS`, and pin the roster against pyproject's declared `py-modules` so a newly shipped module cannot drift out of it again.

The existing `test_probe_and_hint_share_one_first_party_definition` guards **consistency** between the two consumers; **completeness** was unguarded — which is how four shipped modules sat outside it.

## Tests

Added to `tests/hermes_cli/test_update_import_guard.py` (5 new, all failing without the fix):

- `test_roster_covers_every_shipped_top_level_module` — asserts the relationship (everything shipped is claimed), not a snapshot, so adding a module is fine as long as it is claimed too
- `test_hint_fires_for_shipped_root_level_modules` — parametrised over the four, driving `partial_update_hint` directly

```
scripts/run_tests.sh tests/hermes_cli/test_update_import_guard.py
=== Summary: 1 files, 25 tests passed, 0 failed ===

# without the fix
AssertionError: shipped top-level modules missing from FIRST_PARTY_MODULE_ROOTS:
['batch_runner', 'mcp_serve', 'toolset_distributions', 'trajectory_compressor']
=== Summary: 1 files, 20 tests passed, 5 failed ===
```

All 19 `tests/hermes_cli/test_update*.py` files: **130 passed, 7 failed** — the same 7 (`test_update_stale_dashboard`, `test_update_yes_flag`) fail on `main` without this change.

