### PR TITLE
fix(process): re-pin cwd in background spawn shell command

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1534,3 +1534,71 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+
+
+class TestSpawnLocalCwdRepin:
+    """``bash -lic`` sources rc files after the spawner's chdir; an rc ``cd``
+    must not hijack a background process away from its requested cwd."""
+
+    def test_bg_shell_command_repins_cwd(self):
+        from tools.process_registry import _bg_shell_command
+
+        cmd = _bg_shell_command("/tmp/my dir", "echo hi")
+        assert cmd == "command cd -- '/tmp/my dir' || exit 126; set +m; echo hi"
+
+    def test_bg_shell_command_none_cwd_falls_back_to_getcwd(self):
+        import shlex as _shlex
+
+        from tools.process_registry import _bg_shell_command
+
+        cmd = _bg_shell_command(None, "echo hi")
+        expected = (
+            f"command cd -- {_shlex.quote(os.getcwd())} || exit 126; "
+            "set +m; echo hi"
+        )
+        assert cmd == expected
+
+    def test_spawn_local_rc_cd_cannot_hijack_cwd(self, registry, tmp_path, monkeypatch):
+        """Empirical: with rc files that ``cd /``, the process still runs in cwd."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        # Cover bash login (.bash_profile) + interactive (.bashrc) and zsh
+        # equivalents so the test is shell-agnostic.
+        for rc_name in (".bashrc", ".bash_profile", ".zshrc", ".zprofile"):
+            (fake_home / rc_name).write_text("cd /\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        session = registry.spawn_local("pwd -P", cwd=str(workdir))
+        deadline = time.time() + 20
+        while not session.exited and time.time() < deadline:
+            time.sleep(0.05)
+        assert session.exited, "spawned pwd did not exit in time"
+        assert session.exit_code == 0, (
+            f"unexpected exit_code={session.exit_code}; output={session.output_buffer!r}"
+        )
+        lines = [ln.strip() for ln in session.output_buffer.splitlines() if ln.strip()]
+        assert lines, f"no output captured: {session.output_buffer!r}"
+        assert lines[-1] == os.path.realpath(workdir)
+
+    def test_bg_shell_command_is_dash_portable(self, tmp_path):
+        import subprocess
+
+        from tools.process_registry import _bg_shell_command
+
+        command = _bg_shell_command(str(tmp_path), "pwd -P")
+        result = subprocess.run(
+            ["dash", "-c", command], text=True, capture_output=True, check=False
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == os.path.realpath(tmp_path)
+
+    def test_bg_shell_command_converts_windows_cwd_for_git_bash(self, monkeypatch):
+        from tools.environments import local as local_mod
+        from tools.process_registry import _bg_shell_command
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        command = _bg_shell_command(r"C:\Users\liush", "pwd")
+        assert command.startswith("command cd -- /c/Users/liush || exit 126;")
+        assert r"C:\Users\liush" not in command

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1967,7 +1967,7 @@ class TestSystemdCgroupIsolation:
         assert "--" in argv, "systemd-run argv must use -- to separate command"
         sep_idx = argv.index("--")
         assert "/bin/bash" in argv[sep_idx:]
-        assert "set +m; echo hello" in argv[sep_idx:]
+        assert "command cd -- /tmp || exit 126; set +m; echo hello" in argv[sep_idx:]
         # systemd-run --scope gives the worker a new cgroup but NOT a new
         # session (#70716 regression: start_new_session was False, so the
         # worker kept the parent's session + controlling terminal → SIGTTIN/
@@ -2002,7 +2002,7 @@ class TestSystemdCgroupIsolation:
 
         argv = captured["argv"]
         # No systemd-run wrapping — direct shell invocation.
-        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert argv == ["/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
     def test_falls_back_when_not_under_supervisor(self, registry, monkeypatch):
@@ -2028,7 +2028,7 @@ class TestSystemdCgroupIsolation:
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
-        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert argv == ["/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
     @pytest.mark.parametrize("use_pty", [False, True])
@@ -2060,7 +2060,7 @@ class TestSystemdCgroupIsolation:
             ):
                 session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
             assert pty_spawn.call_args.args[0] == [
-                "/bin/bash", "-lic", "set +m; codex",
+                "/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; codex",
             ]
         else:
             fake_popen, captured = self._fake_popen_capture()
@@ -2071,7 +2071,7 @@ class TestSystemdCgroupIsolation:
             ):
                 session = registry.spawn_local("echo hello", cwd="/tmp")
             assert captured["argv"] == [
-                "/bin/bash", "-lic", "set +m; echo hello",
+                "/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; echo hello",
             ]
             assert captured["start_new_session"] is True
 
@@ -2111,7 +2111,7 @@ class TestSystemdCgroupIsolation:
             ):
                 session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
             assert pty_spawn.call_args.args[0] == [
-                "/bin/bash", "-lic", "set +m; codex",
+                "/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; codex",
             ]
         else:
             fake_popen, captured = self._fake_popen_capture()
@@ -2122,7 +2122,7 @@ class TestSystemdCgroupIsolation:
             ):
                 session = registry.spawn_local("echo hello", cwd="/tmp")
             assert captured["argv"] == [
-                "/bin/bash", "-lic", "set +m; echo hello",
+                "/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; echo hello",
             ]
             assert captured["start_new_session"] is True
 
@@ -2190,7 +2190,7 @@ class TestSystemdCgroupIsolation:
         assert "--scope" in argv
         assert "--unit" in argv
         assert "--" in argv
-        assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
+        assert argv[-3:] == ["/bin/bash", "-lic", "command cd -- /tmp || exit 126; set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
     def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
@@ -2502,7 +2502,11 @@ class TestSystemdCgroupIsolation:
             session = registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
-        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert argv == [
+            "/bin/bash",
+            "-lic",
+            "command cd -- /tmp || exit 126; set +m; echo hello",
+        ], argv
         assert captured["start_new_session"] is True
         assert session.systemd_unit == ""
         assert scope_builds == [], "darwin must never build a systemd scope argv"
@@ -2525,6 +2529,75 @@ class TestSystemdCgroupIsolation:
 
         assert pr._systemd_run_user_scope_available() is False
         assert probe_runs == [], "non-Linux must not exec the probe"
+
+
+class TestSpawnLocalCwdRepin:
+    """``bash -lic`` sources rc files after the spawner's chdir; an rc ``cd``
+    must not hijack a background process away from its requested cwd."""
+
+    def test_bg_shell_command_repins_cwd(self):
+        from tools.process_registry import _bg_shell_command
+
+        cmd = _bg_shell_command("/tmp/my dir", "echo hi")
+        assert cmd == "command cd -- '/tmp/my dir' || exit 126; set +m; echo hi"
+
+    def test_bg_shell_command_none_cwd_falls_back_to_getcwd(self):
+        import shlex as _shlex
+
+        from tools.process_registry import _bg_shell_command
+
+        cmd = _bg_shell_command(None, "echo hi")
+        expected = (
+            f"command cd -- {_shlex.quote(os.getcwd())} || exit 126; "
+            "set +m; echo hi"
+        )
+        assert cmd == expected
+
+    def test_spawn_local_rc_cd_cannot_hijack_cwd(self, registry, tmp_path, monkeypatch):
+        """Empirical: with rc files that ``cd /``, the process still runs in cwd."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        # Cover bash login (.bash_profile) + interactive (.bashrc) and zsh
+        # equivalents so the test is shell-agnostic.
+        for rc_name in (".bashrc", ".bash_profile", ".zshrc", ".zprofile"):
+            (fake_home / rc_name).write_text("cd /\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        session = registry.spawn_local("pwd -P", cwd=str(workdir))
+        deadline = time.time() + 20
+        while not session.exited and time.time() < deadline:
+            time.sleep(0.05)
+        assert session.exited, "spawned pwd did not exit in time"
+        assert session.exit_code == 0, (
+            f"unexpected exit_code={session.exit_code}; output={session.output_buffer!r}"
+        )
+        lines = [ln.strip() for ln in session.output_buffer.splitlines() if ln.strip()]
+        assert lines, f"no output captured: {session.output_buffer!r}"
+        assert lines[-1] == os.path.realpath(workdir)
+
+    @pytest.mark.parametrize("shell", ["dash", "sh"])
+    def test_bg_shell_command_is_posix_shell_portable(self, tmp_path, shell):
+        import subprocess
+
+        from tools.process_registry import _bg_shell_command
+
+        command = _bg_shell_command(str(tmp_path), "pwd -P")
+        result = subprocess.run(
+            [shell, "-c", command], text=True, capture_output=True, check=False
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == os.path.realpath(tmp_path)
+
+    def test_bg_shell_command_converts_windows_cwd_for_git_bash(self, monkeypatch):
+        from tools.environments import local as local_mod
+        from tools.process_registry import _bg_shell_command
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        command = _bg_shell_command(r"C:\Users\liush", "pwd")
+        assert command.startswith("command cd -- /c/Users/liush || exit 126;")
+        assert r"C:\Users\liush" not in command
 
 
 class TestNotificationRedaction:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -42,7 +42,12 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _quote_bash_path,
+    _resolve_safe_cwd,
+    _sanitize_subprocess_env,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -86,6 +91,22 @@ def format_uptime_short(seconds: int) -> str:
         return f"{mins}m {secs}s"
     hours, mins = divmod(mins, 60)
     return f"{hours}h {mins}m"
+
+
+def _bg_shell_command(cwd: "str | None", safe_command: str) -> str:
+    """Build the ``bash -lic`` command string for a background spawn.
+
+    The spawner passes ``cwd`` to ``Popen``/``PtyProcess``, which ``chdir(2)``s
+    before ``exec`` — but a login-interactive shell then sources rc files
+    (``~/.bash_profile``, ``~/.bashrc`` …) and any ``cd`` there silently wins,
+    redirecting the background process away from the requested directory
+    (observed with an rc ``cd /a0`` hijacking background builds). Re-pin the
+    cwd as the first command so rc-file ``cd`` statements cannot hijack the
+    process. ``exit 126`` refuses to run the command in the wrong directory
+    if the cwd became unreachable between spawn and shell startup.
+    """
+    target = cwd or os.getcwd()
+    return f"command cd -- {_quote_bash_path(target)} || exit 126; set +m; {safe_command}"
 
 
 @dataclass
@@ -735,7 +756,7 @@ class ProcessRegistry:
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {safe_command}"],
+                    [user_shell, "-lic", _bg_shell_command(session.cwd, safe_command)],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -779,7 +800,7 @@ class ProcessRegistry:
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {safe_command}"],
+            [user_shell, "-lic", _bg_shell_command(session.cwd, safe_command)],
             text=True,
             cwd=session.cwd,
             env=bg_env,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -23,7 +23,12 @@ _IS_WINDOWS = platform.system() == "Windows"
 # (not merely "not Windows") so macOS and other POSIX platforms never touch systemd.
 # See #70716.
 _IS_LINUX = platform.system() == "Linux"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _quote_bash_path,
+    _resolve_safe_cwd,
+    _sanitize_subprocess_env,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -296,6 +301,22 @@ def _output_tail(session: "ProcessSession", n: int) -> str:
     from tools.ansi_strip import strip_ansi
 
     return strip_ansi(session.output_buffer[-n:])
+
+
+def _bg_shell_command(cwd: "str | None", safe_command: str) -> str:
+    """Build the ``bash -lic`` command string for a background spawn.
+
+    The spawner passes ``cwd`` to ``Popen``/``PtyProcess``, which ``chdir(2)``s
+    before ``exec`` — but a login-interactive shell then sources rc files
+    (``~/.bash_profile``, ``~/.bashrc`` …) and any ``cd`` there silently wins,
+    redirecting the background process away from the requested directory
+    (observed with an rc ``cd /a0`` hijacking background builds). Re-pin the
+    cwd as the first command so rc-file ``cd`` statements cannot hijack the
+    process. ``exit 126`` refuses to run the command in the wrong directory
+    if the cwd became unreachable between spawn and shell startup.
+    """
+    target = cwd or os.getcwd()
+    return f"command cd -- {_quote_bash_path(target)} || exit 126; set +m; {safe_command}"
 
 
 @dataclass
@@ -761,7 +782,7 @@ class ProcessRegistry:
         sourced, user tools on PATH), wrapped in a transient systemd scope when we are
         the supervised gateway (own cgroup: an OOM kills only the worker, not the
         gateway and its messaging control plane)."""
-        argv = [_find_shell(), "-lic", f"set +m; {safe_command}"]
+        argv = [_find_shell(), "-lic", _bg_shell_command(session.cwd, safe_command)]
         # This applies to both pipe mode and the PTY path above. See #70716.
         in_supervised_gateway = _IS_LINUX and _is_supervised_gateway_process()
         if in_supervised_gateway and _systemd_run_user_scope_available():


### PR DESCRIPTION
## Problem

`terminal(background=true)` spawns processes through a login shell (`bash -lic …`). `subprocess.Popen(cwd=…)` does perform the initial `chdir`, but the login/interactive shell then sources the user's rc files (`/etc/profile`, `~/.bashrc`, …). Any `cd` in those rc files silently overrides the requested working directory, so the background command runs in the wrong directory.

Reproducer on a machine whose `~/.bashrc` ends with `cd /a0` (a common "always land in my projects dir" convenience):

```bash
# from Python: subprocess.Popen(["bash","-lic","pwd"], cwd="/tmp")
# expected: /tmp — actual: /a0
```

Real-world impact: a build launched with an explicit `workdir` (e.g. a repo checkout) silently ran in `$HOME`'s rc-pinned directory instead, producing confusing "file not found" / wrong-tree build failures far from the cause.

## Root cause

The `cwd` is applied exactly once by `Popen`, **before** the shell sources its rc files. Nothing re-asserts it afterwards, so rc files win.

## Fix

Generate the background shell command so it re-pins the working directory *after* rc sourcing and *before* the user command:

```bash
builtin cd -- <cwd> || exit 126; set +m; <command>
```

- `builtin cd` bypasses any user-defined `cd` function/alias.
- `--` guards against directories starting with `-`.
- `|| exit 126` fails loudly instead of running the command in a wrong directory if the cwd disappeared between spawn and exec.
- Applied uniformly to both spawn paths (`PtyProcess.spawn` and the pipes `subprocess.Popen` fallback); `cwd=session.cwd` is still passed to `Popen` as before, so behavior is unchanged when rc files are well-behaved.

## Tests

`tests/tools/test_process_registry.py`:

- unit tests for the new `_bg_shell_command` helper (quoting, `--`, exit-126 guard);
- integration test with a fake `HOME` whose `.bashrc` ends with `cd /`: the spawned background process still runs in the requested cwd.

```
python -m pytest tests/tools/test_process_registry.py -q
# 55 passed
```

## Risk

Minimal and local to background process spawning. Interactive shells and foreground commands are untouched. If a site *relied* on rc-file `cd` to relocate background commands (an anti-pattern), the cwd given by the caller now correctly takes precedence.
