### PR TITLE
feat(desktop): make new-session project editable

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -75,6 +75,7 @@ import { isRedoShortcut, isUndoShortcut } from './undo-history'
 import { UrlDialog } from './url-dialog'
 import { chipTypedUrlOnSpace, linkifyUrls } from './url-refs'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
+import { WorkspaceTargetPicker } from './workspace-target-picker'
 
 export function ChatBar({
   busy,
@@ -1210,6 +1211,11 @@ export function ChatBar({
                     additions beside the "+" menu and before the controls.
                     All four render nothing until something contributes. */}
                   <ContribSlot area={COMPOSER_AREAS.top} />
+                  <WorkspaceTargetPicker
+                    cwd={cwd ?? ''}
+                    hasMessages={scope.$messages.get().length > 0}
+                    sessionId={sessionId}
+                  />
                   <VoiceActivity state={voiceActivityState} />
                   <VoicePlaybackActivity />
                   {queueEdit && editingQueuedPrompt && (

--- a/apps/desktop/src/app/chat/composer/workspace-target-picker.test.tsx
+++ b/apps/desktop/src/app/chat/composer/workspace-target-picker.test.tsx
@@ -1,0 +1,109 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $projectTree } from '@/store/projects'
+import {
+  $currentBranch,
+  $currentCwd,
+  $newChatWorkspaceTarget,
+  setCurrentBranch,
+  setCurrentCwdTransient,
+  setNewChatWorkspaceTarget
+} from '@/store/session'
+
+import { WorkspaceTargetPicker } from './workspace-target-picker'
+
+const projects = [
+  {
+    id: 'p_app',
+    label: 'App',
+    path: '/repo/app',
+    repos: [{ groups: [], id: '/repo/app', label: 'app', path: '/repo/app', sessionCount: 0 }],
+    sessionCount: 0
+  },
+  {
+    id: 'p_docs',
+    label: 'Docs',
+    path: '/repo/docs',
+    repos: [{ groups: [], id: '/repo/docs', label: 'docs', path: '/repo/docs', sessionCount: 0 }],
+    sessionCount: 0
+  }
+]
+
+function ReactivePicker(props: Omit<React.ComponentProps<typeof WorkspaceTargetPicker>, 'cwd'>) {
+  const cwd = useStore($currentCwd)
+
+  return <WorkspaceTargetPicker cwd={cwd} {...props} />
+}
+
+function renderPicker(props: Omit<React.ComponentProps<typeof WorkspaceTargetPicker>, 'cwd'> = {}) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ReactivePicker {...props} />
+    </I18nProvider>
+  )
+}
+
+describe('WorkspaceTargetPicker', () => {
+  beforeEach(() => {
+    $projectTree.set(projects)
+    setCurrentCwdTransient('/repo/app')
+    setCurrentBranch('main')
+    setNewChatWorkspaceTarget(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $projectTree.set([])
+    setCurrentCwdTransient('')
+    setCurrentBranch('')
+    setNewChatWorkspaceTarget(undefined)
+  })
+
+  it('displays the project inherited by a blank new session without making it explicit', () => {
+    renderPicker()
+
+    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('App')
+    expect($newChatWorkspaceTarget.get()).toBeUndefined()
+  })
+
+  it('switches the one-shot target and current cwd to another visible project', () => {
+    renderPicker()
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects' }), { button: 0, ctrlKey: false })
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Docs' }))
+
+    expect($newChatWorkspaceTarget.get()).toBe('/repo/docs')
+    expect($currentCwd.get()).toBe('/repo/docs')
+    expect($currentBranch.get()).toBe('')
+    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('Docs')
+  })
+
+  it('clears the one-shot target and current cwd when Home is selected', () => {
+    renderPicker()
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects' }), { button: 0, ctrlKey: false })
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Home' }))
+
+    expect($newChatWorkspaceTarget.get()).toBeNull()
+    expect($currentCwd.get()).toBe('')
+    expect($currentBranch.get()).toBe('')
+    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('Home')
+  })
+
+  it('does not render once a session exists or the draft already contains messages', () => {
+    const { rerender } = renderPicker({ sessionId: 'runtime-1' })
+
+    expect(screen.queryByRole('button', { name: 'Projects' })).toBeNull()
+
+    rerender(
+      <I18nProvider configClient={null} initialLocale="en">
+        <WorkspaceTargetPicker cwd="/repo/app" hasMessages />
+      </I18nProvider>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Projects' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/workspace-target-picker.test.tsx
+++ b/apps/desktop/src/app/chat/composer/workspace-target-picker.test.tsx
@@ -65,38 +65,38 @@ describe('WorkspaceTargetPicker', () => {
   it('displays the project inherited by a blank new session without making it explicit', () => {
     renderPicker()
 
-    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('App')
+    expect(screen.getByRole('button', { name: 'Projects: App' }).textContent).toContain('App')
     expect($newChatWorkspaceTarget.get()).toBeUndefined()
   })
 
   it('switches the one-shot target and current cwd to another visible project', () => {
     renderPicker()
 
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects' }), { button: 0, ctrlKey: false })
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects: App' }), { button: 0, ctrlKey: false })
     fireEvent.click(screen.getByRole('menuitemradio', { name: 'Docs' }))
 
     expect($newChatWorkspaceTarget.get()).toBe('/repo/docs')
     expect($currentCwd.get()).toBe('/repo/docs')
     expect($currentBranch.get()).toBe('')
-    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('Docs')
+    expect(screen.getByRole('button', { name: 'Projects: Docs' }).textContent).toContain('Docs')
   })
 
   it('clears the one-shot target and current cwd when Home is selected', () => {
     renderPicker()
 
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects' }), { button: 0, ctrlKey: false })
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Projects: App' }), { button: 0, ctrlKey: false })
     fireEvent.click(screen.getByRole('menuitemradio', { name: 'Home' }))
 
     expect($newChatWorkspaceTarget.get()).toBeNull()
     expect($currentCwd.get()).toBe('')
     expect($currentBranch.get()).toBe('')
-    expect(screen.getByRole('button', { name: 'Projects' }).textContent).toContain('Home')
+    expect(screen.getByRole('button', { name: 'Projects: Home' }).textContent).toContain('Home')
   })
 
   it('does not render once a session exists or the draft already contains messages', () => {
     const { rerender } = renderPicker({ sessionId: 'runtime-1' })
 
-    expect(screen.queryByRole('button', { name: 'Projects' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Projects:/ })).toBeNull()
 
     rerender(
       <I18nProvider configClient={null} initialLocale="en">
@@ -104,6 +104,6 @@ describe('WorkspaceTargetPicker', () => {
       </I18nProvider>
     )
 
-    expect(screen.queryByRole('button', { name: 'Projects' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Projects:/ })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/composer/workspace-target-picker.tsx
+++ b/apps/desktop/src/app/chat/composer/workspace-target-picker.tsx
@@ -1,0 +1,96 @@
+import { useStore } from '@nanostores/react'
+
+import { baseName, NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { useI18n } from '@/i18n'
+import { $projectTree, projectIdForCwd } from '@/store/projects'
+import { setCurrentBranch, setCurrentCwd, setCurrentCwdTransient, setNewChatWorkspaceTarget } from '@/store/session'
+
+interface WorkspaceTargetPickerProps {
+  cwd: string
+  hasMessages?: boolean
+  sessionId?: null | string
+}
+
+const projectRootCwd = (project: SidebarProjectTree): string =>
+  (project.path || project.repos.find(repo => repo.path)?.path || '').trim()
+
+export function WorkspaceTargetPicker({ cwd, hasMessages = false, sessionId = null }: WorkspaceTargetPickerProps) {
+  const { t } = useI18n()
+  const projects = useStore($projectTree)
+
+  // This is a one-shot draft control, never a live-session cwd picker. Besides
+  // avoiding surprise retargets, the message guard covers the short interval in
+  // which first-submit UI can exist before the runtime id is published.
+  if (sessionId || hasMessages) {
+    return null
+  }
+
+  const target = cwd.trim()
+  const selectedProjectId = target ? projectIdForCwd(target) : NO_PROJECT_ID
+  const selectedProject = projects.find(project => project.id === selectedProjectId)
+  const label = selectedProject?.label || (target ? baseName(target) || target : t.sidebar.projects.home)
+  const choices = projects.filter(project => !project.archived && !project.isNoProject && projectRootCwd(project))
+
+  const selectTarget = (next: null | string) => {
+    setCurrentBranch('')
+
+    if (next === null) {
+      // Home is deliberately transient: detaching this draft must not erase the
+      // remembered remote/default cwd used by later resolution fallbacks.
+      setCurrentCwdTransient('')
+      setNewChatWorkspaceTarget(null)
+
+      return
+    }
+
+    setCurrentCwd(next)
+    setNewChatWorkspaceTarget(next)
+  }
+
+  return (
+    <div
+      className="flex min-w-0 items-center text-[0.6875rem] text-(--ui-text-tertiary)"
+      data-slot="workspace-target-picker"
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={t.sidebar.projects.sectionLabel}
+            className="flex min-w-0 items-center gap-1 bg-transparent text-left transition-colors hover:text-foreground"
+            type="button"
+          >
+            <Codicon name={selectedProject?.icon || (target ? 'folder-library' : 'home')} size="0.75rem" />
+            <span className="max-w-48 truncate">{label}</span>
+            <Codicon className="text-(--ui-text-quaternary)" name="chevron-down" size="0.75rem" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-48">
+          <DropdownMenuRadioGroup value={selectedProjectId || target}>
+            <DropdownMenuRadioItem onSelect={() => selectTarget(null)} value={NO_PROJECT_ID}>
+              <Codicon name="home" size="0.75rem" />
+              <span className="min-w-0 flex-1 truncate">{t.sidebar.projects.home}</span>
+            </DropdownMenuRadioItem>
+            {choices.map(project => {
+              const path = projectRootCwd(project)
+
+              return (
+                <DropdownMenuRadioItem key={project.id} onSelect={() => selectTarget(path)} value={project.id}>
+                  <Codicon name={project.icon || 'folder-library'} size="0.75rem" />
+                  <span className="min-w-0 flex-1 truncate">{project.label}</span>
+                </DropdownMenuRadioItem>
+              )
+            })}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/workspace-target-picker.tsx
+++ b/apps/desktop/src/app/chat/composer/workspace-target-picker.tsx
@@ -63,7 +63,7 @@ export function WorkspaceTargetPicker({ cwd, hasMessages = false, sessionId = nu
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            aria-label={t.sidebar.projects.sectionLabel}
+            aria-label={`${t.sidebar.projects.sectionLabel}: ${label}`}
             className="flex min-w-0 items-center gap-1 bg-transparent text-left transition-colors hover:text-foreground"
             type="button"
           >

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -4,12 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
-import {
-  $currentCwd,
-  $selectedStoredSessionId,
-  $sessions,
-  applyConfiguredDefaultProjectDir
-} from '@/store/session'
+import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
   $activeProjectId,
@@ -27,6 +22,7 @@ import {
   exitProjectScope,
   openProjectCreate,
   pickProjectFolder,
+  projectIdForCwd,
   projectNameForCwd,
   refreshProjects,
   refreshProjectTree,
@@ -243,6 +239,13 @@ describe('projectNameForCwd', () => {
 
     // A linked worktree lives OUTSIDE the project root but still belongs to it.
     expect(projectNameForCwd('/elsewhere/mono-feature/src')).toBe('Monorepo')
+  })
+
+  it('matches nested Windows paths across separator and case differences', () => {
+    $projectTree.set([treeNode({ id: 'p_win', label: 'Windows app', path: 'C:\\Repos\\App' })])
+
+    expect(projectIdForCwd('c:/repos/app/src')).toBe('p_win')
+    expect(projectNameForCwd('c:/repos/app/src')).toBe('Windows app')
   })
 
   it('ignores auto-projects and the No-project bucket (no named identity)', () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -281,8 +281,26 @@ function focusedSessionWorkspaceCwd(): string {
   return $currentCwd.get().trim()
 }
 
-const underPath = (parent: string, child: string): boolean =>
-  child === parent || child.startsWith(parent.endsWith('/') ? parent : `${parent}/`)
+// Comparison-only path spelling: accept either separator everywhere, trim a
+// trailing separator, and fold case for Windows drive/UNC paths. The backend
+// uses the same host-aware identity rule when assigning sessions to projects.
+const comparisonPath = (path: string): string => {
+  const raw = path.trim()
+  const windows = /^[A-Za-z]:[/\\]/.test(raw) || raw.startsWith('\\') || raw.startsWith('//')
+  const normalized = raw.replace(/\\/g, '/').replace(/\/+$/, '')
+
+  return windows ? normalized.toLowerCase() : normalized
+}
+
+const underPath = (parent: string, child: string): boolean => {
+  const normalizedParent = comparisonPath(parent)
+  const normalizedChild = comparisonPath(child)
+
+  return (
+    normalizedChild === normalizedParent ||
+    normalizedChild.startsWith(normalizedParent.endsWith('/') ? normalizedParent : `${normalizedParent}/`)
+  )
+}
 
 // The project (explicit or auto) that owns `cwd`, by longest path match across
 // the live tree. Null when no project covers it (it'll surface as a fresh


### PR DESCRIPTION
## Summary

- add a compact project selector to blank Desktop sessions
- keep the active project as the initial default, while allowing another project or Home / No project before first submit
- make project ownership matching separator- and case-aware for Windows paths

## Motivation

A new Desktop session currently inherits the project being viewed, but that destination cannot be changed without navigating away and starting again. The inherited default is useful; it just needs to be editable before the conversation starts.

Addresses #75537.

## Changes

- show the inherited workspace target above the blank composer
- list visible, non-archived projects using their primary project/repository path
- selecting a project updates the draft's one-shot workspace target and current CWD
- selecting Home explicitly clears the one-shot target so first submit omits `cwd`
- hide the control once a runtime session or messages exist, avoiding mid-session workspace changes
- normalise Windows separators and case when resolving which project owns a nested CWD

## Test Plan

- [x] Desktop UI suite: 3,236 tests passed
- [x] Renderer, Electron and E2E TypeScript checks passed
- [x] ESLint passed for all changed files
- [x] Prettier check passed for all changed files
- [x] Production Desktop build passed
- [x] `git diff --check` passed

## Screenshots / Examples

The blank composer now displays its inherited project as a dropdown. Choosing another project changes the pending workspace; choosing **Home** creates a detached global session.

## Notes for Reviewers

This is intentionally a draft because #75537 is still labelled `needs-decision`. The change preserves project inheritance rather than changing the global New Session default. It only makes that default explicit and editable before the first message.
