### PR TITLE
fix: broaden llama.cpp grammar error classifier to match newer builds

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -780,7 +780,8 @@ def classify_api_error(
     if (
         status_code == 400
         and (
-            "error parsing grammar" in error_msg
+            "failed to parse grammar" in error_msg
+            or "error parsing grammar" in error_msg
             or "json-schema-to-grammar" in error_msg
             or (
                 "unable to generate parser" in error_msg

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -451,6 +451,25 @@ class TestClassifyApiError:
     # ── Provider-specific: llama.cpp grammar-parse ──
 
 
+    def test_llama_cpp_failed_to_parse_grammar(self):
+        """Newer llama.cpp builds return 'Failed to initialize samplers: failed to parse grammar'."""
+        e = MockAPIError(
+            "Failed to initialize samplers: failed to parse grammar",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_llama_cpp_unable_to_generate_parser(self):
+        """Older llama.cpp builds surface the error as 'unable to generate parser'."""
+        e = MockAPIError(
+            "Unable to generate parser for this template",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
 
 
 


### PR DESCRIPTION
## Problem

The llama.cpp grammar error classifier in `agent/error_classifier.py` only recognizes older error phrasing (`"error parsing grammar"`), but newer llama.cpp builds return `"Failed to initialize samplers: failed to parse grammar"`. When the classifier fails to match, Hermes skips the grammar recovery path (stripping `pattern`/`format` keywords from tool schemas and retrying locally) and falls directly to a cloud fallback provider.

This is especially impactful for users running local inference via custom providers (llama.cpp) with MCP servers whose tool schemas include regex patterns like `"\\d{4}-\\d{2}-\\d{2}"`.

## Reproduction

```bash
# Local llama.cpp server returns HTTP 400:
curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "qwen3-80b-next-q4_k_m",
  "messages": [{"role":"user","content":"test"}],
  "tools": [{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"d":{"type":"string","pattern":"\\d{4}-\\d{2}-\\d{2}"}}}}}],
  "max_tokens": 50
}'
# → {"error":{"message":"Failed to initialize samplers: failed to parse grammar"}}
```

In Hermes, this error passes through the classifier unrecognized, triggering cloud fallback instead of the schema-stripping recovery.

## Fix

Added `"failed to parse grammar"` to the match list in the classifier condition, alongside the existing `"error parsing grammar"` and `"unable to generate parser"` checks.

### Changes
- `agent/error_classifier.py`: Added `"failed to parse grammar" in error_msg` condition
- `tests/agent/test_error_classifier.py`: Added `test_llama_cpp_failed_to_parse_grammar` test case

## Testing
```bash
pytest tests/agent/test_error_classifier.py::TestClassifyApiError::test_llama_cpp_failed_to_parse_grammar
# PASSED
pytest tests/agent/test_error_classifier.py::TestClassifyApiError::test_llama_cpp_grammar_parse_error
# PASSED (existing test still passes)
```