### PR TITLE
fix(buzz): exact addressing and dynamic channel membership

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1009,7 +1009,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
         # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        if not is_dm and self.require_mention and not self._is_mentioned(content, event):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1090,17 +1090,10 @@ class BuzzAdapter(BasePlatformAdapter):
         tags = event.get("tags")
         if not isinstance(tags, list):
             return False
-        p_tagged_to_self = any(
-            isinstance(tag, (list, tuple))
-            and len(tag) > 1
-            and tag[0] == "p"
-            and str(tag[1]).lower() == self._self_pubkey
-            for tag in tags
-        )
-        if not p_tagged_to_self:
+        if not self._is_p_tagged_to_self(event):
             return False
         content = event.get("content")
-        return isinstance(content, str) and not self._is_mentioned(content)
+        return isinstance(content, str) and not self._is_textually_mentioned(content)
 
     def _maybe_latch_dm(self, channel_id: str, state: dict, event: dict) -> None:
         """Latch a group conversation to chat_type="dm" once any direct
@@ -1112,15 +1105,41 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
-    def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+    def _p_tag_targets(self, event: Optional[dict]) -> set:
+        """Return usable p-tag targets normalized to hex pubkeys."""
+        if not isinstance(event, dict):
+            return set()
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return set()
+        targets = set()
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) <= 1 or tag[0] != "p":
+                continue
+            normalized = _normalize_user_ref(str(tag[1]))
+            if normalized:
+                targets.add(normalized)
+        return targets
+
+    def _is_p_tagged_to_self(self, event: dict) -> bool:
+        return bool(self._self_pubkey and self._self_pubkey in self._p_tag_targets(event))
+
+    def _is_mentioned(self, content: str, event: Optional[dict] = None) -> bool:
+        """True when the message addresses this agent (p-tag, npub, hex, or name)."""
+        p_targets = self._p_tag_targets(event)
+        if p_targets:
+            return bool(self._self_pubkey and self._self_pubkey in p_targets)
+        return self._is_textually_mentioned(content)
+
+    def _is_textually_mentioned(self, content: str) -> bool:
+        """Fallback mention matching for legacy events without usable p-tags."""
         lowered = content.lower()
         if self._self_pubkey and self._self_pubkey in lowered:
             return True
         if self._self_npub and self._self_npub in lowered:
             return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?![\w-])"
             if re.search(pattern, lowered):
                 return True
         return False
@@ -1139,16 +1158,16 @@ class BuzzAdapter(BasePlatformAdapter):
         text = content.strip()
         candidates = []
         if self._display_name:
-            candidates.append(re.escape(self._display_name))
+            candidates.append(rf"@{re.escape(self._display_name)}")
         if self._self_npub:
-            candidates.append(re.escape(self._self_npub))
+            candidates.append(rf"@?{re.escape(self._self_npub)}")
         if self._self_pubkey:
-            candidates.append(re.escape(self._self_pubkey))
+            candidates.append(rf"@?{re.escape(self._self_pubkey)}")
         if not candidates:
             return text
-        # Optional leading '@', one of the identity forms, optional trailing
-        # ':' or ',' and surrounding whitespace.
-        pattern = rf"^@?(?:{'|'.join(candidates)})[\s:,]*"
+        # Display names require an explicit '@'. Raw pubkey/npub identity forms
+        # retain the optional prefix for backwards compatibility.
+        pattern = rf"^(?:{'|'.join(candidates)})(?![\w-])[\s:,]*"
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -77,10 +77,13 @@ _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
-# kind 44100 is Buzz's channel-membership event — used for live DM discovery.
+# kinds 44100/44101 are Buzz's channel-membership add/remove events — used
+# for live joined-channel and DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
-_WS_MEMBERSHIP_KIND = 44100
+_WS_MEMBERSHIP_ADD_KIND = 44100
+_WS_MEMBERSHIP_REMOVE_KIND = 44101
+_WS_MEMBERSHIP_KINDS = [_WS_MEMBERSHIP_ADD_KIND, _WS_MEMBERSHIP_REMOVE_KIND]
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
@@ -403,9 +406,11 @@ class BuzzAdapter(BasePlatformAdapter):
         self._ws_ready: Optional[asyncio.Event] = None
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
+        self._ws_channel_sub_seq = 0
         self._lock_key: Optional[str] = None
         # channel_id -> {"chat_type", "last_ts", "seen": OrderedDict[event_id, None]}
         self._channel_state: Dict[str, dict] = {}
+        self._auto_joined_channel_ids: set = set()
         self._channel_names: Dict[str, str] = {}
         # channel_id -> raw ``channels list`` entry; drives DM-vs-channel
         # classification (see _may_reclassify_as_dm).
@@ -486,23 +491,32 @@ class BuzzAdapter(BasePlatformAdapter):
         except ImportError:
             self._lock_key = None  # status module not available (e.g. tests)
 
-        # Map channel ids to names and pick the watch set.
-        code, out, err = await self._run_cli(["channels", "list"])
-        if code != 0:
-            message = _cli_error_message(err, code)
-            logger.error("Buzz: failed to list channels — %s", message)
-            self._set_fatal_error("connect_failed", message, retryable=code == 2)
-            return False
-        listed = _parse_json_list(out)
-        self._channel_names = {
-            str(ch.get("channel_id")): str(ch.get("name") or ch.get("channel_id"))
-            for ch in listed
-            if ch.get("channel_id")
-        }
-        for ch in listed:
-            if ch.get("channel_id"):
-                self._channel_meta[str(ch["channel_id"])] = ch
-        watch = self.channels or list(self._channel_names)
+        # Map channel ids to names and pick the watch set.  Automatic mode
+        # means "all joined", and the Buzz CLI requires --member for that.
+        if self.channels:
+            code, out, err = await self._run_cli(["channels", "list"])
+            if code != 0:
+                message = _cli_error_message(err, code)
+                logger.error("Buzz: failed to list channels — %s", message)
+                self._set_fatal_error("connect_failed", message, retryable=code == 2)
+                return False
+            listed = _parse_json_list(out)
+            self._remember_channel_listing(listed)
+            watch = self.channels
+        else:
+            listed = await self._list_joined_channels()
+            if listed is None:
+                message = "buzz channels list --member failed"
+                logger.error("Buzz: failed to list joined channels")
+                self._set_fatal_error("connect_failed", message, retryable=True)
+                return False
+            self._remember_channel_listing(listed)
+            watch = [
+                str(ch.get("channel_id"))
+                for ch in listed
+                if ch.get("channel_id")
+            ]
+            self._auto_joined_channel_ids = set(watch)
         if not watch:
             logger.error("Buzz: no channels to watch (configure BUZZ_CHANNELS or join a channel)")
             self._set_fatal_error("config_missing", "no Buzz channels to watch", retryable=False)
@@ -571,6 +585,8 @@ class BuzzAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
         self._channel_state = {}
+        self._auto_joined_channel_ids = set()
+        self._ws_channel_sub_seq = 0
         self._poll_count = 0
 
     # ── Sending ───────────────────────────────────────────────────────────
@@ -776,12 +792,20 @@ class BuzzAdapter(BasePlatformAdapter):
         ]
         await websocket.send(json.dumps(request, separators=(",", ":")))
 
+    def _next_channel_subscription_id(self, subscriptions: Dict[str, Optional[str]]) -> str:
+        while True:
+            subscription_id = f"hermes-buzz-{self._ws_channel_sub_seq}"
+            self._ws_channel_sub_seq += 1
+            if subscription_id not in subscriptions:
+                return subscription_id
+
     async def _subscribe_websocket(self, websocket) -> Dict[str, Optional[str]]:
         """Subscribe to every watched conversation plus membership events
         (kind 44100 p-tagged to us) for live DM discovery."""
         subscriptions: Dict[str, Optional[str]] = {}
-        for index, channel_id in enumerate(list(self._channel_state)):
-            subscription_id = f"hermes-buzz-{index}"
+        self._ws_channel_sub_seq = 0
+        for channel_id in list(self._channel_state):
+            subscription_id = self._next_channel_subscription_id(subscriptions)
             subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
         if self._self_pubkey:
@@ -789,7 +813,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "REQ",
                 _WS_MEMBERSHIP_SUB_ID,
                 {
-                    "kinds": [_WS_MEMBERSHIP_KIND],
+                    "kinds": _WS_MEMBERSHIP_KINDS,
                     "#p": [self._self_pubkey],
                     "since": max(self._membership_since - 1, 0),
                 },
@@ -798,19 +822,99 @@ class BuzzAdapter(BasePlatformAdapter):
             subscriptions[_WS_MEMBERSHIP_SUB_ID] = None
         return subscriptions
 
-    async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
-        before = set(self._channel_state)
-        await self._discover_dms(seed=False)
-        for channel_id in self._channel_state:
-            if channel_id in before:
+    def _h_tag_channel(self, event: dict) -> str:
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return ""
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) <= 1 or tag[0] != "h":
                 continue
-            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
+            channel_id = str(tag[1] or "").strip()
+            if channel_id:
+                return channel_id
+        return ""
+
+    async def _close_channel_subscriptions(
+        self,
+        websocket,
+        subscriptions: Dict[str, Optional[str]],
+        channel_id: str,
+    ) -> None:
+        for subscription_id, subscribed_channel in list(subscriptions.items()):
+            if subscribed_channel != channel_id:
+                continue
+            await websocket.send(json.dumps(["CLOSE", subscription_id], separators=(",", ":")))
+            subscriptions.pop(subscription_id, None)
+
+    async def _remove_channel_watch(
+        self,
+        websocket,
+        subscriptions: Dict[str, Optional[str]],
+        channel_id: str,
+    ) -> None:
+        self._channel_state.pop(channel_id, None)
+        self._auto_joined_channel_ids.discard(channel_id)
+        self._channel_names.pop(channel_id, None)
+        self._channel_meta.pop(channel_id, None)
+        await self._close_channel_subscriptions(websocket, subscriptions, channel_id)
+
+    async def _subscribe_new_websocket_channels(
+        self,
+        websocket,
+        subscriptions: Dict[str, Optional[str]],
+        before: set,
+    ) -> None:
+        for channel_id in self._channel_state:
+            if channel_id in before or channel_id in subscriptions.values():
+                continue
+            subscription_id = self._next_channel_subscription_id(subscriptions)
             subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
             logger.info("Buzz: subscribed to new conversation %s", channel_id)
+
+    async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
+        """Handle membership events p-tagged to us.
+
+        Adds rediscover DMs and seed/subscribe the h-tagged joined channel in
+        automatic mode.  Removes stop watching the h-tagged channel locally.
+        """
+        # Buzz relay-signs 44100/44101 membership events and rejects client
+        # submissions for those kinds.  The adapter contract still fail-closes
+        # unless the event structurally targets us with a p-tag and a channel
+        # h-tag.
+        if not self._is_p_tagged_to_self(event):
+            return
+        kind = int(event.get("kind") or 0)
+        channel_id = self._h_tag_channel(event)
+        if not channel_id:
+            return
+        if kind not in _WS_MEMBERSHIP_KINDS:
+            return
+        try:
+            membership_created_at = int(event.get("created_at") or 0)
+        except (TypeError, ValueError):
+            return
+        if membership_created_at <= 0:
+            return
+        self._membership_since = max(self._membership_since, membership_created_at)
+        if kind == _WS_MEMBERSHIP_REMOVE_KIND:
+            # Relay membership is authoritative at runtime: explicit config
+            # records desired policy, but it cannot keep watching after removal.
+            await self._remove_channel_watch(websocket, subscriptions, channel_id)
+            return
+        before = set(self._channel_state)
+        if not self.channels:
+            if channel_id not in self._channel_state:
+                await self._seed_channel(
+                    channel_id,
+                    chat_type="group",
+                    membership_cutoff=membership_created_at,
+                )
+                self._auto_joined_channel_ids.add(channel_id)
+        await self._discover_dms(seed=False)
+        if not self.channels:
+            await self._reconcile_joined_channels(preserve_absent={channel_id})
+        await self._subscribe_new_websocket_channels(websocket, subscriptions, before)
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -876,6 +980,75 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Inbound polling ───────────────────────────────────────────────────
 
+    async def _list_joined_channels(self) -> Optional[List[dict]]:
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
+        if code != 0:
+            logger.warning(
+                "Buzz: could not list joined channels — %s", _cli_error_message(err, code)
+            )
+            return None
+        return _parse_json_list(out)
+
+    def _remember_channel_listing(self, listed: List[dict]) -> None:
+        for ch in listed:
+            ch_id = str(ch.get("channel_id") or "")
+            if not ch_id:
+                continue
+            self._channel_meta[ch_id] = ch
+            self._channel_names[ch_id] = str(ch.get("name") or ch_id)
+
+    async def _reconcile_joined_channels(self, *, preserve_absent: Optional[set] = None) -> List[str]:
+        """Refresh automatic-mode watches from joined channels only.
+
+        Newly joined channels are seeded, never replayed.  Explicit channel
+        configuration is a fixed watch policy, so reconciliation is a no-op.
+        """
+        if self.channels:
+            return []
+        listed = await self._list_joined_channels()
+        if listed is None:
+            return []
+        self._remember_channel_listing(listed)
+        joined_ids = {
+            str(ch.get("channel_id"))
+            for ch in listed
+            if ch.get("channel_id")
+        }
+        preserve_absent = preserve_absent or set()
+        for channel_id in list(self._auto_joined_channel_ids - joined_ids):
+            if channel_id in preserve_absent:
+                continue
+            state = self._channel_state.get(channel_id)
+            if state is not None and state.get("chat_type") == "dm":
+                self._auto_joined_channel_ids.discard(channel_id)
+                continue
+            self._channel_state.pop(channel_id, None)
+            self._channel_names.pop(channel_id, None)
+            self._channel_meta.pop(channel_id, None)
+            self._auto_joined_channel_ids.discard(channel_id)
+        added: List[str] = []
+        for ch in listed:
+            channel_id = str(ch.get("channel_id") or "")
+            if not channel_id:
+                continue
+            state = self._channel_state.get(channel_id)
+            if state is not None:
+                if state.get("chat_type") != "dm":
+                    self._auto_joined_channel_ids.add(channel_id)
+                continue
+            await self._seed_channel(channel_id, chat_type="group")
+            self._auto_joined_channel_ids.add(channel_id)
+            added.append(channel_id)
+        return added
+
+    async def _poll_sweep(self) -> None:
+        if not self.channels:
+            await self._reconcile_joined_channels()
+        if self._poll_count % _DM_DISCOVERY_EVERY == 0:
+            await self._discover_dms(seed=False)
+        for channel_id in list(self._channel_state):
+            await self._poll_channel(channel_id)
+
     async def _poll_loop(self) -> None:
         """Poll every watched channel for new events until cancelled."""
         try:
@@ -883,10 +1056,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 await asyncio.sleep(self.poll_interval)
                 self._poll_count += 1
                 try:
-                    if self._poll_count % _DM_DISCOVERY_EVERY == 0:
-                        await self._discover_dms(seed=False)
-                    for channel_id in list(self._channel_state):
-                        await self._poll_channel(channel_id)
+                    await self._poll_sweep()
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -894,9 +1064,18 @@ class BuzzAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
 
-    async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
+    async def _seed_channel(
+        self,
+        channel_id: str,
+        chat_type: str,
+        membership_cutoff: Optional[int] = None,
+    ) -> None:
         """Initialize a channel's high-water mark from its newest events."""
-        state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict()}
+        state = {
+            "chat_type": chat_type,
+            "last_ts": int(membership_cutoff or 0),
+            "seen": OrderedDict(),
+        }
         self._channel_state[channel_id] = state
         code, out, err = await self._run_cli(
             ["messages", "get", "--channel", channel_id, "--limit", str(_FETCH_LIMIT)]
@@ -912,6 +1091,8 @@ class BuzzAdapter(BasePlatformAdapter):
         for event in _parse_json_list(out):
             event_id = event.get("id")
             created_at = int(event.get("created_at") or 0)
+            if membership_cutoff is not None and created_at >= membership_cutoff:
+                continue
             if event_id:
                 state["seen"][str(event_id)] = None
             state["last_ts"] = max(state["last_ts"], created_at)
@@ -928,11 +1109,11 @@ class BuzzAdapter(BasePlatformAdapter):
 
         ``dms list`` is only a best-effort source: on some hosted relays it
         returns ``[]`` even when DM conversations exist (#68871).  Those DMs
-        DO surface in ``channels list`` as entries named "DM" with an empty
-        description, so that listing is scanned as a fallback.  Fallback
-        finds are watched as ``group`` and latch to ``dm`` via p-tag
-        detection (_is_direct_message_event) rather than trusting the name
-        alone to unlock the mention-free DM path.
+        DO surface in ``channels list --member`` as entries named "DM" with
+        an empty description, so that member-only listing is scanned as a
+        fallback.  Fallback finds are watched as ``group`` and latch to ``dm``
+        via p-tag detection (_is_direct_message_event) rather than trusting
+        the name alone to unlock the mention-free DM path.
         """
         code, out, _err = await self._run_cli(["dms", "list"])
         if code == 0:
@@ -946,7 +1127,7 @@ class BuzzAdapter(BasePlatformAdapter):
                     self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
                 self._channel_names.setdefault(dm_id, "DM")
 
-        code, out, _err = await self._run_cli(["channels", "list"])
+        code, out, _err = await self._run_cli(["channels", "list", "--member"])
         if code != 0:
             return
         for ch in _parse_json_list(out):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from collections import OrderedDict
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -30,6 +31,7 @@ SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
 SELF_NPUB = "npub1nl2u0wnd8mezfknc74q7pl9ec58h9nrrakce4tnk434qgaxl4psqe5twr6"
 OTHER_PUBKEY = "a" * 64
 CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+NEW_CHANNEL = "11111111-2222-3333-4444-555555555555"
 # Real DM conversation as materialized by a hosted relay: `dms list` returns
 # [] for it (#68871) while `channels list` shows it as name "DM", empty
 # description, indistinguishable from a channel except via message p-tags.
@@ -325,6 +327,26 @@ def _tagged_event(event_id, channel, *, content, pubkey=OTHER_PUBKEY,
     }
 
 
+def _membership_event(kind, channel=NEW_CHANNEL, *, p=SELF_PUBKEY, content=""):
+    tags = [["p", p], ["h", channel]]
+    return {
+        "id": f"membership-{kind}",
+        "pubkey": OTHER_PUBKEY,
+        "content": content,
+        "created_at": 2000,
+        "kind": kind,
+        "tags": tags,
+    }
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message):
+        self.sent.append(json.loads(message))
+
+
 class TestDmClassification:
 
     @pytest.fixture
@@ -427,6 +449,7 @@ class TestDmClassification:
         assert a._may_reclassify_as_dm(DM_CHANNEL) is True
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
+        assert ["channels", "list", "--member"] in [args for args, _stdin in cli.calls]
 
 
 # ── Sending ───────────────────────────────────────────────────────────────
@@ -475,6 +498,315 @@ class TestBuzzAdapterSend:
 
 class TestBuzzAdapterLifecycle:
 
+
+    @pytest.mark.asyncio
+    async def test_connect_auto_mode_lists_only_joined_channels(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: True
+        )
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        adapter.transport = "poll"
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        cli = _ScriptedCli()
+        cli.script(
+            "users", "get",
+            [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}],
+        )
+        cli.script(
+            "channels", "list",
+            [{"channel_id": CHANNEL, "name": "general", "description": "General"}],
+        )
+        cli.script("dms", "list", [])
+        cli.script("messages", "get", [])
+        adapter._run_cli = cli
+
+        assert await adapter.connect() is True
+        await adapter.disconnect()
+
+        assert ["channels", "list", "--member"] in [args for args, _stdin in cli.calls]
+
+    @pytest.mark.asyncio
+    async def test_reconcile_joined_channels_adds_and_seeds_named_channel(self):
+        adapter = _make_adapter()
+        adapter.channels = []
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        cli = _ScriptedCli()
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+        cli.script(
+            "messages", "get",
+            [_tagged_event("old", NEW_CHANNEL, content="@Chip old", created_at=123)],
+        )
+        adapter._run_cli = cli
+
+        added = await adapter._reconcile_joined_channels()
+
+        assert added == [NEW_CHANNEL]
+        assert adapter._channel_names[NEW_CHANNEL] == "ops"
+        assert adapter._channel_meta[NEW_CHANNEL]["description"] == "Operations"
+        assert adapter._channel_state[NEW_CHANNEL]["last_ts"] == 123
+        assert list(adapter._channel_state[NEW_CHANNEL]["seen"]) == ["old"]
+        assert adapter._dispatched == []
+        assert ["channels", "list", "--member"] in [args for args, _stdin in cli.calls]
+
+    @pytest.mark.asyncio
+    async def test_reconcile_joined_channels_does_not_expand_explicit_mode(self):
+        adapter = _make_adapter({"channels": [CHANNEL]})
+        cli = _ScriptedCli()
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+        adapter._run_cli = cli
+
+        assert await adapter._reconcile_joined_channels() == []
+        assert NEW_CHANNEL not in adapter._channel_state
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_reconcile_prunes_removed_joined_channel_but_keeps_dm_watch(self):
+        adapter = _make_adapter()
+        adapter.channels = []
+        cli = _ScriptedCli()
+        cli.script(
+            "channels", "list",
+            [
+                {"channel_id": CHANNEL, "name": "general", "description": "General"},
+                {"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"},
+            ],
+        )
+        cli.script("messages", "get", [])
+        adapter._run_cli = cli
+
+        await adapter._reconcile_joined_channels()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
+
+        cli.responses.clear()
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+
+        await adapter._reconcile_joined_channels()
+
+        assert CHANNEL not in adapter._channel_state
+        assert NEW_CHANNEL in adapter._channel_state
+        assert DM_CHANNEL in adapter._channel_state
+
+    @pytest.mark.asyncio
+    async def test_websocket_membership_subscription_listens_for_adds_and_removes(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+        websocket = _FakeWebSocket()
+
+        await adapter._subscribe_websocket(websocket)
+
+        membership_req = next(frame for frame in websocket.sent if frame[1] == "hermes-buzz-membership")
+        assert membership_req[2]["kinds"] == [44100, 44101]
+
+    @pytest.mark.asyncio
+    async def test_websocket_new_channel_subscription_does_not_overwrite_sparse_map(self):
+        adapter = _make_adapter()
+        adapter._ws_channel_sub_seq = 2
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+        adapter._channel_state[NEW_CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+        websocket = _FakeWebSocket()
+        subscriptions = {
+            "hermes-buzz-membership": None,
+            "hermes-buzz-2": CHANNEL,
+        }
+
+        await adapter._subscribe_new_websocket_channels(websocket, subscriptions, {CHANNEL})
+
+        assert subscriptions["hermes-buzz-2"] == CHANNEL
+        new_ids = [
+            subscription_id
+            for subscription_id, channel_id in subscriptions.items()
+            if channel_id == NEW_CHANNEL
+        ]
+        assert len(new_ids) == 1
+        assert new_ids[0] != "hermes-buzz-2"
+
+    @pytest.mark.asyncio
+    async def test_membership_add_seeds_and_subscribes_h_tagged_channel(self):
+        adapter = _make_adapter()
+        adapter.channels = []
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [])
+        cli.script(
+            "messages", "get",
+            [_tagged_event("old", NEW_CHANNEL, content="@Chip old", created_at=321)],
+        )
+        adapter._run_cli = cli
+        websocket = _FakeWebSocket()
+        subscriptions = {"hermes-buzz-membership": None}
+
+        await adapter._handle_membership_event(websocket, subscriptions, _membership_event(44100))
+
+        assert NEW_CHANNEL in adapter._channel_state
+        assert adapter._channel_state[NEW_CHANNEL]["last_ts"] >= 2000
+        assert "old" in adapter._channel_state[NEW_CHANNEL]["seen"]
+        assert adapter._dispatched == []
+        assert any(
+            frame[0] == "REQ" and frame[2].get("#h") == [NEW_CHANNEL]
+            for frame in websocket.sent
+        )
+
+    @pytest.mark.asyncio
+    async def test_membership_add_does_not_mark_boundary_message_seen(self):
+        adapter = _make_adapter()
+        adapter.channels = []
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        old_event = _tagged_event(
+            "old-before-membership",
+            NEW_CHANNEL,
+            content="@Chip old history",
+            p=SELF_PUBKEY,
+            created_at=1999,
+        )
+        immediate_event = _tagged_event(
+            "immediate-after-membership",
+            NEW_CHANNEL,
+            content="please handle this probe",
+            p=SELF_PUBKEY,
+            created_at=2000,
+        )
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+        cli.script("messages", "get", [old_event, immediate_event])
+        adapter._run_cli = cli
+        websocket = _FakeWebSocket()
+        subscriptions = {"hermes-buzz-membership": None}
+
+        await adapter._handle_membership_event(websocket, subscriptions, _membership_event(44100))
+
+        state = adapter._channel_state[NEW_CHANNEL]
+        assert "old-before-membership" in state["seen"]
+        assert "immediate-after-membership" not in state["seen"]
+        assert state["last_ts"] >= 2000
+
+        await adapter._handle_event(NEW_CHANNEL, state, immediate_event)
+        await adapter._handle_event(NEW_CHANNEL, state, immediate_event)
+
+        assert [d["message_id"] for d in adapter._dispatched] == ["immediate-after-membership"]
+
+    @pytest.mark.asyncio
+    async def test_membership_add_does_not_expand_explicit_mode(self):
+        adapter = _make_adapter({"channels": [CHANNEL]})
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+        adapter._run_cli = cli
+        websocket = _FakeWebSocket()
+        subscriptions = {"hermes-buzz-membership": None}
+
+        await adapter._handle_membership_event(websocket, subscriptions, _membership_event(44100))
+
+        assert NEW_CHANNEL not in adapter._channel_state
+        assert all(channel_id != NEW_CHANNEL for channel_id in subscriptions.values())
+
+    @pytest.mark.asyncio
+    async def test_invalid_membership_events_fail_closed(self):
+        events = [
+            _membership_event(44100, p=OTHER_PUBKEY),
+            {**_membership_event(44100), "tags": [["p", SELF_PUBKEY]]},
+            _membership_event(44999),
+            {**_membership_event(44100), "created_at": 0},
+            {**_membership_event(44100), "created_at": "not-a-timestamp"},
+        ]
+        for event in events:
+            adapter = _make_adapter()
+            adapter.channels = []
+            cli = _ScriptedCli()
+            cli.script("dms", "list", [])
+            cli.script(
+                "channels", "list",
+                [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+            )
+            cli.script("messages", "get", [])
+            adapter._run_cli = cli
+            websocket = _FakeWebSocket()
+            subscriptions = {"hermes-buzz-membership": None}
+
+            await adapter._handle_membership_event(websocket, subscriptions, event)
+
+            assert adapter._channel_state == {}
+            assert adapter._membership_since == 0
+            assert subscriptions == {"hermes-buzz-membership": None}
+            assert websocket.sent == []
+
+    @pytest.mark.asyncio
+    async def test_membership_remove_stops_and_closes_channel_subscription(self):
+        adapter = _make_adapter({"channels": [NEW_CHANNEL]})
+        adapter._channel_state[NEW_CHANNEL] = {"chat_type": "group", "last_ts": 50, "seen": OrderedDict()}
+        adapter._channel_names[NEW_CHANNEL] = "ops"
+        adapter._channel_meta[NEW_CHANNEL] = {"channel_id": NEW_CHANNEL, "name": "ops"}
+        websocket = _FakeWebSocket()
+        subscriptions = {
+            "hermes-buzz-membership": None,
+            "hermes-buzz-ops": NEW_CHANNEL,
+            "hermes-buzz-general": CHANNEL,
+        }
+
+        await adapter._handle_membership_event(websocket, subscriptions, _membership_event(44101))
+
+        assert NEW_CHANNEL not in adapter._channel_state
+        assert NEW_CHANNEL not in adapter._channel_names
+        assert NEW_CHANNEL not in adapter._channel_meta
+        assert "hermes-buzz-ops" not in subscriptions
+        assert ["CLOSE", "hermes-buzz-ops"] in websocket.sent
+
+    @pytest.mark.asyncio
+    async def test_poll_sweep_reconciles_joined_channels_before_polling(self):
+        adapter = _make_adapter()
+        adapter.channels = []
+        adapter._poll_count = _buzz_mod._DM_DISCOVERY_EVERY
+        cli = _ScriptedCli()
+        cli.script(
+            "channels", "list",
+            [{"channel_id": NEW_CHANNEL, "name": "ops", "description": "Operations"}],
+        )
+        cli.script("messages", "get", [])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+
+        await adapter._poll_sweep()
+
+        assert NEW_CHANNEL in adapter._channel_state
+        called_args = [args for args, _stdin in cli.calls]
+        assert called_args.index(["channels", "list", "--member"]) < next(
+            i for i, args in enumerate(called_args) if args[:2] == ["messages", "get"]
+        )
+        assert ["dms", "list"] in called_args
 
     @pytest.mark.asyncio
     async def test_disconnect_releases_scoped_lock(self, monkeypatch):
@@ -584,4 +916,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,53 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_exact_self_ptag_dispatches_group_message(self, adapter):
+        adapter._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL,
+            "name": "general",
+            "description": "General conversation and community updates.",
+        }
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, content="please take this", p=SELF_PUBKEY, created_at=10),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._dispatched[0]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_exact_control_text_fallback_without_ptags_dispatches(self, adapter):
+        adapter._display_name = "Control"
+        await self._poll_with(adapter, _event("e1", content="hey @Control can you help?", created_at=10))
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_bare_display_name_without_ptags_does_not_dispatch(self, adapter):
+        adapter._display_name = "Control"
+        await self._poll_with(adapter, _event("e1", content="Control is currently unhealthy", created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_ptagged_other_hyphenated_name_does_not_dispatch(self, adapter):
+        adapter._display_name = "Control"
+        control_deepseek_pubkey = "b" * 64
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "e1",
+                CHANNEL,
+                content="@Control-Deepseek please take this",
+                p=control_deepseek_pubkey,
+                created_at=10,
+            ),
+        )
+        assert adapter._dispatched == []
+
+    def test_leading_hyphenated_longer_name_not_stripped(self, adapter):
+        adapter._display_name = "Control"
+        assert adapter._strip_mention("@Control /whoami") == "/whoami"
+        assert adapter._strip_mention("Control /whoami") == "Control /whoami"
+        assert adapter._strip_mention("@Control-Deepseek /whoami") == "@Control-Deepseek /whoami"
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):
@@ -346,9 +393,10 @@ class TestDmClassification:
 
 
     @pytest.mark.asyncio
-    async def test_channel_like_metadata_blocks_latch_even_without_mention(self, adapter):
+    async def test_channel_like_metadata_blocks_latch_but_self_ptag_dispatches(self, adapter):
         """Second guard on its own: even a p-tagged, un-mentioned message
-        cannot reclassify a conversation whose metadata says real channel."""
+        cannot reclassify a conversation whose metadata says real channel.
+        The exact p-tag still addresses this gateway as a group message."""
         adapter._channel_meta[CHANNEL]["description"] = ""
         adapter._channel_meta[CHANNEL]["name"] = "announcements"
         await self._poll_with(
@@ -356,7 +404,7 @@ class TestDmClassification:
             _tagged_event("e1", CHANNEL, content="fyi everyone", p=SELF_PUBKEY),
         )
         assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
-        assert adapter._dispatched == []
+        assert [d["chat_type"] for d in adapter._dispatched] == ["group"]
 
 
     @pytest.mark.asyncio
@@ -536,5 +584,4 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -72,8 +72,7 @@ gateway:
       enabled: true
       extra:
         relay_url: https://mycommunity.communities.buzz.xyz
-        channels:                         # channel UUIDs to watch (empty = all joined)
-          - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
+        channels: []                      # recommended: dynamically watch every joined channel
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         poll_interval: 4                  # seconds between inbound poll sweeps (default 4 — balances latency vs. relay load)
         cli_path: ""                      # buzz binary (default: PATH, then ~/bin/buzz)
@@ -97,7 +96,8 @@ gateway:
 
 ## Mentions, channels, and DMs
 
-- In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
+- Leave `channels` empty to watch every channel the Buzz identity has joined. Relay membership additions and removals update the running gateway automatically; no YAML duplication or restart is required.
+- In shared channels the agent only responds when **addressed**. Structured relay recipient (`p`) tags are authoritative. For legacy events without recipient tags, fallback requires an exact explicit `@DisplayName`; bare names, substrings, and prefix matches are ignored.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 
@@ -117,7 +117,7 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
-- **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
+- Inbound uses a NIP-42-authenticated WebSocket subscription by default. In `auto` mode, the adapter falls back to CLI polling if WebSocket authentication cannot be established; `poll_interval` controls that fallback cadence.
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
-- New DM conversations are discovered automatically (every few poll sweeps).
+- New joined channels and DM conversations are discovered automatically. Poll fallback reconciles joined-channel membership before reading messages.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## Summary

Fix two Buzz shared-channel delivery failures:

1. Make structured Nostr `p` recipients authoritative and require an exact explicit `@DisplayName` only as a fallback when no usable recipient tags exist.
2. Make empty `channels` truly mean **all joined channels**, including membership additions/removals while the gateway is already running.

## Root causes

- Prefix/text matching allowed `@Control-Deepseek` to address `Control`, and incidental bare names in prose could dispatch unrelated agents.
- `channels list` returns visible channels, not joined channels; the adapter did not use `--member`.
- The running WebSocket membership handler only rediscovered DMs, so named channels added after startup were never subscribed.
- A first message sent immediately after adding an agent could be swallowed when reconciliation seeded it as historical before subscribing.

## Behavior after this change

- Exact structured `p` recipients take precedence over message prose.
- Legacy fallback requires exact `@DisplayName`; prefixes, substrings, and bare names do not dispatch.
- Automatic mode discovers only `channels list --member` results.
- Relay membership kinds 44100/44101 add/remove runtime watches without config edits or restart.
- Poll fallback reconciles joined memberships and prunes departed channels without deleting DM state.
- Dynamic WebSocket subscription IDs cannot collide after remove/add cycles.
- Membership-boundary seeding suppresses pre-join history while leaving same-second and later messages deliverable.
- Malformed membership events fail closed.
- Explicit channel configuration never expands from a membership-add event.

## Verification

```text
pytest -q tests/gateway/test_buzz_adapter.py
40 passed in 0.40s

python -m py_compile plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py
PASS

git diff --check
PASS
```

Strict TDD captured the live first-message race before the fix:

```text
AssertionError: 'immediate-after-membership' was already in seen
1 failed
```

After the fix, a live ephemeral-channel probe performed the full sequence **without a YAML edit or gateway restart**:

1. Create a new private Buzz channel.
2. Add the already-running PRIME identity as a bot member.
3. Immediately send a correctly `p`-tagged nonce.
4. Observe dynamic subscription and exactly one exact PRIME response.
5. Observe a subsequent unaddressed shared-channel probe for 35 seconds.

```text
member_count=2
prime_response_count=1
prime_response_exact=true
non_target_response_count=0
ambient_prime_response_count=0
```

No Buzz audio, provider, authentication, or routing errors occurred in the acceptance window.

## Safety notes

- Shared channels remain mention-gated.
- Sender allowlists are unchanged.
- Relay membership remains authoritative.
- Channel history is not replayed on startup or ordinary reconciliation.
- Same-second membership-boundary events intentionally favor delivery; normal exact-addressing and allowlist gates still apply.
