### PR TITLE
fix(desktop): keep model picker on active remote gateway

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -21,7 +21,7 @@ import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, modelOptionsTransport, requestModelOptions } from '@/lib/model-options'
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
@@ -400,9 +400,12 @@ export const ChatView = memo(function ChatView({
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({
-    queryKey: modelOptionsQueryKey(activeGatewayProfile, activeSessionId),
+    queryKey: modelOptionsQueryKey(activeGatewayProfile, activeSessionId, modelOptionsTransport(gateway)),
     queryFn: () => requestModelOptions({ gateway: gateway || undefined, sessionId: activeSessionId }),
-    enabled: gatewayOpen
+    // Do not seed the remote picker cache with a global REST response during
+    // the brief window where the connection state is open but the gateway
+    // object has not been published yet.
+    enabled: gatewayOpen && gateway !== null
   })
 
   const quickModels = useMemo(

--- a/apps/desktop/src/app/contrib/surfaces.gateway-profile.test.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.gateway-profile.test.tsx
@@ -1,0 +1,89 @@
+import { act, cleanup, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import { $gateway } from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $gatewayState } from '@/store/session'
+
+import type * as RoutesModule from '../routes'
+
+import { ChatRoutesSurface } from './surfaces'
+
+const { modelMenuProps } = vi.hoisted(() => ({
+  modelMenuProps: [] as Array<{ gateway?: unknown; profile?: string }>
+}))
+
+vi.mock('@/contrib/react/use-contributions', () => ({ useContributions: vi.fn() }))
+vi.mock('../chat', () => ({
+  ChatView: ({ modelMenuContent }: { modelMenuContent?: ReactNode }) => <>{modelMenuContent}</>
+}))
+vi.mock('../routes', async importOriginal => {
+  const actual = await importOriginal<typeof RoutesModule>()
+
+  return {
+    ...actual,
+    contributedRoutes: () => [],
+    NEW_CHAT_ROUTE: '/',
+    ROUTES_AREA: 'routes',
+    sessionRoute: (id: string) => `/${id}`
+  }
+})
+vi.mock('../shell/model-menu-panel', () => ({
+  ModelMenuPanel: (props: { gateway?: unknown; profile?: string }) => {
+    modelMenuProps.push(props)
+
+    return <div data-testid="model-menu" />
+  }
+}))
+vi.mock('./latest-actions', () => ({
+  latestChatActions: () => ({}),
+  latestSidebarActions: () => ({})
+}))
+
+beforeEach(() => {
+  modelMenuProps.length = 0
+  $activeGatewayProfile.set('alpha')
+  $gatewayState.set('open')
+})
+
+afterEach(() => {
+  cleanup()
+  $gateway.set(null)
+  $activeGatewayProfile.set('default')
+  $gatewayState.set('closed')
+})
+
+describe('ChatRoutesSurface active-profile gateway', () => {
+  it('replaces the picker transport on an open-to-open profile swap', () => {
+    const alphaGateway = { id: 'alpha' } as unknown as HermesGateway
+    const betaGateway = { id: 'beta' } as unknown as HermesGateway
+
+    $gateway.set(alphaGateway)
+
+    const actions = {
+      getGateway: () => $gateway.get(),
+      requestGateway: vi.fn(),
+      selectModel: vi.fn()
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ChatRoutesSurface actions={actions as never} />
+      </MemoryRouter>
+    )
+
+    expect(modelMenuProps.at(-1)).toMatchObject({ gateway: alphaGateway, profile: 'alpha' })
+
+    act(() => {
+      // A prewarmed profile is already open, so the connection state remains
+      // 'open'; only the gateway identity and active profile change.
+      $gateway.set(betaGateway)
+      $activeGatewayProfile.set('beta')
+    })
+
+    expect(modelMenuProps.at(-1)).toMatchObject({ gateway: betaGateway, profile: 'beta' })
+  })
+})

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -13,6 +13,8 @@ import { Navigate, Route, Routes, useParams } from 'react-router'
 
 import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
+import type { HermesGateway } from '@/hermes'
+import { $gateway } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $freshDraftReady, $gatewayState } from '@/store/session'
 
@@ -114,18 +116,12 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   maxVoiceRecordingSeconds?: number
 }) {
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  // Gateway identity is not implied by connection state: a prewarmed profile
+  // swap can replace one open gateway with another while state remains "open".
+  const gateway = useStore($gateway) as HermesGateway | null
   const gatewayState = useStore($gatewayState)
   useContributions(ROUTES_AREA)
   const routeContributions = contributedRoutes()
-
-  // Recapture the live gateway instance whenever the connection state flips.
-  // getGateway reads a controller ref, so gatewayState is the intentional
-  // re-eval trigger (not a value the computation itself reads).
-  const gateway = useMemo(
-    () => actions.getGateway(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [actions, gatewayState]
-  )
 
   const modelMenuContent = useMemo(
     () =>

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -20,7 +20,7 @@ import { usePointerQuiet } from '@/components/ui/keyboard-first'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, modelOptionsTransport, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
@@ -129,7 +129,7 @@ export function ModelCatalogMenu({
   const visibleModels = useStore($visibleModels)
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, modelOptionsTransport(gateway)),
     // Gateway-first even with no session: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers the local
     // REST fallback can't know about (#53817).

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -7,7 +7,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { DropdownMenuItem, dropdownMenuRow } from '@/components/ui/dropdown-menu'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, modelOptionsTransport, requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
@@ -72,7 +72,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   // back to the catalog's reported current, and a non-reactive read would
   // never repaint that fallback once the catalog resolved.
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, activeSessionId),
+    queryKey: modelOptionsQueryKey(profile, activeSessionId, modelOptionsTransport(gateway)),
     queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId: activeSessionId })
   })
 
@@ -93,7 +93,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
     setRefreshing(true)
 
     try {
-      const queryKey = modelOptionsQueryKey(profile, activeSessionId)
+      const queryKey = modelOptionsQueryKey(profile, activeSessionId, modelOptionsTransport(gateway))
 
       const next = await requestModelOptions({ gateway, refresh: true, sessionId: activeSessionId })
 

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, modelOptionsTransport, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
@@ -58,7 +58,7 @@ export function ModelPickerDialog({
   const [search, setSearch] = useState('')
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, modelOptionsTransport(gw)),
     queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
     enabled: open
   })

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -12,7 +12,7 @@ import { Switch } from '@/components/ui/switch'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Search } from '@/lib/icons'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, modelOptionsTransport, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import {
@@ -51,7 +51,7 @@ export function ModelVisibilityDialog({
   const collapsedProviders = useStore($collapsedProviders)
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, modelOptionsTransport(gw)),
     queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway: gw, sessionId }),
     enabled: open
   })

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -51,13 +51,24 @@ describe('requestModelOptions', () => {
 
 describe('modelOptionsQueryKey', () => {
   it('isolates new-chat catalogs by active gateway profile', () => {
-    expect(modelOptionsQueryKey('default')).toEqual(['model-options', 'default', 'global'])
-    expect(modelOptionsQueryKey('compass')).toEqual(['model-options', 'compass', 'global'])
+    expect(modelOptionsQueryKey('default')).toEqual(['model-options', 'default', 'global', 'gateway'])
+    expect(modelOptionsQueryKey('compass')).toEqual(['model-options', 'compass', 'global', 'gateway'])
     expect(modelOptionsQueryKey('default')).not.toEqual(modelOptionsQueryKey('compass'))
   })
 
   it('keeps session catalogs inside the owning profile namespace', () => {
-    expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual(['model-options', 'compass', 'session-1'])
+    expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual([
+      'model-options',
+      'compass',
+      'session-1',
+      'gateway'
+    ])
+  })
+
+  it('does not reuse a pre-gateway REST catalog for a remote gateway', () => {
+    expect(modelOptionsQueryKey('default', null, 'rest')).not.toEqual(
+      modelOptionsQueryKey('default', null, 'gateway')
+    )
   })
 })
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -44,10 +44,25 @@ interface ModelOptionsRequest {
   sessionId?: null | string
 }
 
-export function modelOptionsQueryKey(profile: null | string | undefined, sessionId?: null | string) {
+export type ModelOptionsTransport = 'gateway' | 'rest'
+
+/**
+ * Return the transport used for a model-options request. REST is still a
+ * valid fallback for onboarding, but its catalog is not interchangeable with
+ * a remote gateway catalog (which may include virtual/session-scoped models).
+ */
+export function modelOptionsTransport(gateway: HermesGateway | null | undefined): ModelOptionsTransport {
+  return gateway ? 'gateway' : 'rest'
+}
+
+export function modelOptionsQueryKey(
+  profile: null | string | undefined,
+  sessionId?: null | string,
+  transport: ModelOptionsTransport = 'gateway'
+) {
   const profileKey = (profile ?? '').trim() || 'default'
 
-  return ['model-options', profileKey, sessionId || 'global'] as const
+  return ['model-options', profileKey, sessionId || 'global', transport] as const
 }
 
 export function requestModelOptions({

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -310,6 +310,7 @@ def build_model_options_payload(
         refresh=refresh,
         probe_custom_providers=refresh,
         probe_current_custom_provider=not refresh,
+        for_picker=True,
     )
 
 

--- a/tests/hermes_cli/test_aux_picker_inventory.py
+++ b/tests/hermes_cli/test_aux_picker_inventory.py
@@ -104,6 +104,22 @@ def test_aux_picker_requests_exhausted_pool_visibility(configured_home):
     assert seen.get("for_picker") is True
 
 
+def test_desktop_model_options_requests_picker_visibility(configured_home):
+    """The Desktop/TUI shared catalog must preserve exhausted providers too."""
+    from hermes_cli import inventory
+
+    seen = {}
+
+    def _capture(**kwargs):
+        seen.update(kwargs)
+        return []
+
+    with patch("hermes_cli.model_switch.list_authenticated_providers", _capture):
+        inventory.build_model_options_payload(inventory.load_picker_context())
+
+    assert seen.get("for_picker") is True
+
+
 # ─── Shared rendering ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Keep the Desktop model picker bound to the current reactive gateway identity across open-to-open profile swaps.
- Prevent a REST catalog fetched during gateway startup from satisfying a later remote-gateway query.
- Make the shared model-options inventory request picker-grade provider visibility with `for_picker=True`.

## Root cause

`ChatRoutesSurface` memoized `actions.getGateway()` using the coarse `$gatewayState` as the refresh trigger. A prewarmed profile switch can replace gateway A with gateway B while both remain `open`, leaving the renderer with `profile=B` and `gateway=A`.

Separately, REST and gateway model catalogs shared the same React Query key, so an early REST response could remain fresh after the remote gateway became available. The public inventory wrapper also omitted `for_picker=True`, allowing temporarily exhausted providers to disappear from interactive model selection.

## Changes

- Subscribe `ChatRoutesSurface` to `$gateway` directly.
- Add `gateway`/`rest` transport identity to model-options query keys.
- Avoid seeding ChatView's remote catalog while the gateway object is not published.
- Preserve REST fallback for onboarding/local surfaces without cache aliasing.
- Pass `for_picker=True` through the shared backend model-options wrapper.
- Add renderer and backend regression coverage.

## Test plan

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/lib/model-options.ts src/lib/model-options.test.ts src/app/contrib/surfaces.tsx src/app/contrib/surfaces.gateway-profile.test.tsx src/app/chat/index.tsx src/app/shell/model-menu-panel.tsx src/components/model-picker.tsx src/components/model-visibility-dialog.tsx`
- `cd apps/desktop && npx vitest run src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx src/app/contrib/surfaces.gateway-profile.test.tsx --reporter=dot`
- `scripts/run_tests.sh tests/hermes_cli/test_aux_picker_inventory.py -q`

All checks pass: 33 frontend tests and 4 backend tests.

## Deployment note

This change has two deployment surfaces: the renderer changes require a new Hermes Desktop macOS build, while the inventory change requires updating and restarting the remote dashboard/gateway backend. Version skew is expected during rollout; the existing REST fallback remains available for surfaces that do not yet have a gateway object.
