### PR TITLE
fix(kanban): don't promote a dependency-waiting card on an empty parent set (t_4f14b90d)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4038,6 +4038,45 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+def _is_dependency_wait(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return True when ``task_id`` is currently waiting on a task
+    dependency declared via ``kanban_block(kind="dependency")``.
+
+    A dependency block does not enter the human ``blocked`` bucket — it
+    routes the card back to ``todo`` (see :func:`block_task`), stamps
+    ``tasks.block_kind = 'dependency'``, and emits a ``dependency_wait``
+    event.  The card then relies on :func:`recompute_ready` gating it on
+    its parent links until they reach ``done``.  That contract only holds
+    while the card's parent edge is intact.
+
+    :func:`recompute_ready` uses this to tell a card that is *waiting on a
+    dependency* apart from a genuinely standalone ``todo`` card.  It
+    matters because ``all([])`` is vacuously True: a dependency-waiting
+    card whose parent link is transiently or permanently missing would
+    otherwise be promoted on an EMPTY parent set
+    (``satisfied_parent_ids: []``) and thrash on respawn (t_4f14b90d;
+    live repro t_7cf95f5a).
+
+    We look at the most recent event among the lifecycle-transition kinds
+    a dependency wait competes with.  If ``dependency_wait`` is the most
+    recent of those, the card is still waiting on its dependency and must
+    not be promoted on a vacuous parent set.  Any later
+    ``promoted`` / ``claimed`` / ``unblocked`` / terminal event means the
+    card advanced and this guard no longer applies (so it cannot be
+    fooled by a stale ``block_kind`` column left over from an earlier
+    cycle).
+    """
+    row = conn.execute(
+        "SELECT kind FROM task_events "
+        "WHERE task_id = ? "
+        "AND kind IN ('dependency_wait', 'promoted', 'claimed', "
+        "'unblocked', 'done', 'archived') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return bool(row) and row["kind"] == "dependency_wait"
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
@@ -4092,6 +4131,29 @@ def recompute_ready(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            # Vacuous-satisfaction guard (t_4f14b90d). ``all([])`` is True, so a
+            # card with ZERO parent links always passes the gate below. That is
+            # correct for a genuinely standalone task, but WRONG for a card that
+            # only landed in ``todo`` because a worker declared a dependency
+            # wait (``kanban_block(kind="dependency")`` -> routes to ``todo``,
+            # stamps ``block_kind='dependency'``, emits ``dependency_wait``).
+            # Such a card's dependency edge can be transiently absent while a
+            # re-decompose / unlink->recompute sweep churns the links, or when a
+            # link was dropped without being re-added. Promoting on that empty
+            # set flips the card ``todo -> ready`` with ``satisfied_parent_ids:
+            # []``, it gets claimed, the worker re-declares the SAME
+            # ``dependency_wait``, and the card thrashes on a ~5-10 min respawn
+            # cadence burning a worker every cycle with zero forward progress
+            # (Prime-Directive violation; live repro t_7cf95f5a on t_3365a1dd).
+            #
+            # An empty satisfied-parent set is NEVER a satisfied gate for a
+            # dependency-waiting card: a dependency wait with no live (done)
+            # parent is a broken/racing link, not a met dependency. Hold it in
+            # ``todo`` until a real parent link exists AND reaches ``done``.
+            # Standalone tasks are unaffected — they never emit
+            # ``dependency_wait``.
+            if not parents and _is_dependency_wait(conn, task_id):
+                continue
             if all(p["status"] in ("done", "archived") for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -101,6 +101,100 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Vacuous-satisfaction guard (t_4f14b90d)
+#
+# recompute_ready gates a ``todo`` card on ``all(p in {done,archived} for p in
+# parents)``. Python's ``all([])`` is vacuously True, so a card with ZERO
+# parent links passes the gate. That is correct for a standalone task, but a
+# card that only landed in ``todo`` via ``kanban_block(kind="dependency")``
+# relies on its parent link to re-gate it. If that link is transiently dropped
+# (re-decompose / unlink->recompute churn), the dependency-waiting card was
+# promoted ``todo -> ready`` on an EMPTY parent set (``satisfied_parent_ids:
+# []``), got claimed, re-declared the SAME dependency wait, and thrashed on a
+# ~5-10 min respawn cadence — burning a worker every cycle with zero forward
+# progress (live repro t_7cf95f5a on t_3365a1dd).
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_wait_with_missing_parent_stays_todo(kanban_home: Path) -> None:
+    """A dependency-waiting card whose parent link was dropped must NOT be
+    promoted on an empty parent set. It stays in ``todo`` until a real
+    ``done`` parent link exists. This is the core t_4f14b90d regression:
+    it FAILS (card -> ready) without the guard in recompute_ready."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Simulate link churn dropping the child's parent edge (re-decompose /
+        # unlink sweep) while the parent is NOT done — exactly the live repro
+        # state where satisfied_parent_ids came back empty.
+        with kb.write_txn(conn):
+            conn.execute(
+                "DELETE FROM task_links WHERE child_id=?", (child,)
+            )
+        parents = conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id=?", (child,)
+        ).fetchall()
+        assert parents == [], "precondition: child has no parent link"
+
+        promoted = kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo", (
+            "dependency wait with no live done parent must stay todo, "
+            "never promote on a vacuous empty parent set"
+        )
+        # And it must not have emitted a bogus promotion for this card.
+        kinds = [e.kind for e in kb.list_events(conn, child)]
+        assert "promoted" not in kinds, (
+            "no promoted event for a vacuously-satisfied dependency wait"
+        )
+        assert isinstance(promoted, int)
+
+
+def test_dependency_wait_promotes_only_when_parent_done(kanban_home: Path) -> None:
+    """The guard must not over-correct: a dependency wait with an intact
+    parent link still promotes exactly once, and only once the parent is
+    ``done`` — not while the parent is merely blocked/todo."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Parent not done yet -> child must stay todo (real link, undone parent).
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Parent reaches done -> child promotes.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_standalone_todo_still_promotes_on_empty_parents(kanban_home: Path) -> None:
+    """No over-correction: an ordinary standalone card (never a dependency
+    wait) with zero parents must reach ``ready`` — the guard only fires for
+    dependency-waiting cards, never for standalone ones."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="standalone", assignee="worker")
+        # A standalone card with no parents is not gated. Force it back to
+        # ``todo`` and confirm recompute_ready still promotes it (the guard,
+        # which only fires on a dependency_wait, must leave it alone).
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+        assert kb.get_task(conn, tid).status == "todo"
+        assert not kb._is_dependency_wait(conn, tid)
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+# ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`recompute_ready` gates a `todo`/`blocked` card on
`all(p["status"] in ("done","archived") for p in parents)`. Python's `all([])`
is **vacuously True**, so a card with **zero parent links** always passes the
gate. Correct for a standalone task; **wrong** for a card that only landed in
`todo` because a worker declared a dependency wait via
`kanban_block(kind="dependency")` (routes to `todo`, stamps
`block_kind='dependency'`, emits `dependency_wait`, relies on the parent link to
re-gate).

When link churn (re-decompose / unlink→recompute) transiently drops the child's
parent edge, the dependency-waiting child is promoted `todo → ready` with
`satisfied_parent_ids: []`, gets claimed, and its worker immediately re-declares
the **same** dependency wait → the card thrashes on a ~5–10 min respawn cadence,
burning a worker every cycle with zero forward progress (Prime-Directive
violation).

**Live repro:** `t_7cf95f5a` on parent `t_3365a1dd`.

## Fix

In `recompute_ready`, skip promotion when the parent set is empty **and** the
card's most-recent lifecycle event is `dependency_wait` (new helper
`_is_dependency_wait`, event-based so a stale `block_kind` column from an earlier
cycle cannot fool it). A dependency wait with no live `done` parent is a
broken/racing link, not a satisfied gate. Standalone `todo` cards are unaffected
— they never emit `dependency_wait`.

## RCA vs. the filed theory

The card body (t_4f14b90d) attributed the bug to a `blocked` parent satisfying
the gate. That is **not** the mechanism: the gate already requires
`status in ("done","archived")`, so a `blocked` parent never satisfied it. The
true mechanism is the vacuous `all([])` on the **empty** parent set during link
churn — which is exactly why every bad `promoted` event shows
`satisfied_parent_ids: []`.

## Acceptance criteria (t_4f14b90d)

1. Only `done`/`archived` satisfies the gate — already enforced by the status
   check; `blocked`/`timed_out`/`cancelled`/`failed` never satisfy it. ✓
2. `satisfied_parent_ids: []` (empty parent set) never promotes a
   dependency-waiting card. ✓ (this fix)
3. Regression tests added — child with a dropped/absent parent link stays
   `todo`; promotes only when a real parent reaches `done`; standalone cards
   still promote (no over-correction). ✓
4. Live repro verified on an **isolated** DB reconstruction (live board
   untouched): `t_7cf95f5a`-analogue stays `todo`, `recompute_ready` emits no
   `promoted` event for it. ✓

## Test evidence

- `tests/hermes_cli/test_kanban_block_kinds.py`: 5 passed (2 pre-existing + 3
  new). Verified **fail-without-fix / pass-with-fix** (neutralizing the guard
  reproduces `todo → ready`).
- Full `-k kanban` suite: **166 passed** (+3 new), 1 skipped. The 7 failures
  seen only under bulk selection are **pre-existing test-isolation artifacts** —
  reproduced identically on a clean `origin/main` baseline with zero changes,
  and all 7 pass when run in isolation.
- Isolated live-repro script confirms the dependency wait is held in `todo`.

## Deployment impact / rollback

Pure promotion-gate logic in `hermes_cli/kanban_db.py` (+ tests). No schema
change, no migration, no external side effects. Rollback = revert this commit;
behavior returns to the prior (defective) vacuous-promotion path.

Refs: HEL-3218 AC-4 (this class of deadlock cannot silently return).
