### PR TITLE
Add custom-provider session affinity

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -15,6 +15,7 @@ This module provides:
 """
 
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -1317,7 +1318,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
+        "discover_models", "extra_body", "extra_headers", "session_affinity",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1378,6 +1379,12 @@ def _normalize_custom_provider_entry(
         "name": name,
         "base_url": base_url,
     }
+    if "session_affinity" in entry:
+        # Provider session affinity is a trust decision: only the literal YAML
+        # boolean ``true`` opts in. Quoted strings and other truthy values fail
+        # closed. Leave an omitted setting absent so existing provider-catalog
+        # data shapes remain backward compatible while lookups still default off.
+        normalized["session_affinity"] = entry.get("session_affinity") is True
 
     provider_key = provider_key.strip()
     if provider_key:
@@ -1491,6 +1498,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "session_affinity",
         "ssl_ca_cert",
         "ssl_verify",
     ):
@@ -1682,6 +1690,72 @@ def get_custom_provider_extra_headers(
         if headers:
             return headers
     return {}
+
+
+def normalize_session_affinity_base_url(base_url: Any) -> str:
+    """Return the stable effective-route identity used by affinity digests."""
+    raw = str(base_url or "").strip()
+    if not raw:
+        return ""
+    return normalize_route_base_url(raw)
+
+
+def build_session_affinity_key(base_url: Any, session_id: Any) -> str:
+    """Build the opaque v1 provider-scoped affinity key for one agent session."""
+    digest_input = "\0".join(
+        (
+            "hermes-affinity-v1",
+            normalize_session_affinity_base_url(base_url),
+            str(session_id or ""),
+        )
+    ).encode("utf-8")
+    return f"v1.{hashlib.sha256(digest_input).hexdigest()}"
+
+
+def custom_provider_session_affinity_enabled(
+    base_url: Any,
+    custom_providers: List[Dict[str, Any]],
+    *,
+    provider_name: str = "custom",
+    model: str = "",
+) -> bool:
+    """Return whether the exact effective custom-provider route opted in.
+
+    A named identity wins over URL-only matching. URL-only matching fails
+    closed when multiple provider entries own the same route, preventing one
+    entry's opt-in from silently enabling another entry.
+    """
+    target_url = normalize_session_affinity_base_url(base_url)
+    if not target_url:
+        return False
+
+    identity = str(provider_name or "").strip().lower()
+    if identity.startswith("custom:"):
+        identity = identity.split(":", 1)[1].strip()
+    elif identity == "custom":
+        identity = ""
+
+    candidates: List[Dict[str, Any]] = []
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        if normalize_session_affinity_base_url(entry.get("base_url")) != target_url:
+            continue
+        if identity:
+            aliases = {
+                str(entry.get("provider_key") or "").strip().lower(),
+                str(entry.get("name") or "").strip().lower(),
+            }
+            aliases.update(alias.replace(" ", "-") for alias in tuple(aliases))
+            if identity not in aliases:
+                continue
+        # ``session_affinity`` is provider-route scoped, not model scoped. Keep
+        # the ``model`` argument for call-site compatibility, but do not let a
+        # configured default model disable affinity after a same-provider model
+        # switch.
+        candidates.append(entry)
+
+    return len(candidates) == 1 and candidates[0].get("session_affinity") is True
 
 
 def apply_custom_provider_extra_headers_to_client_kwargs(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4751,6 +4751,38 @@ class AIAgent:
             return primary_client
         with self._openai_client_lock():
             request_kwargs = dict(self._client_kwargs)
+
+        # Session affinity belongs to the effective primary AIAgent route, not
+        # shared provider/client state. Derive it for each OpenAI-wire chat
+        # request after route resolution and before cache comparison so route,
+        # session, and opt-in changes naturally select a separate wire client.
+        # Native transports and auxiliary clients never pass through this seam.
+        session_affinity_key = None
+        provider = str(getattr(self, "provider", "") or "").strip().lower()
+        session_id = str(getattr(self, "session_id", "") or "")
+        if (
+            getattr(self, "api_mode", None) == "chat_completions"
+            and (provider == "custom" or provider.startswith("custom:"))
+            and session_id
+        ):
+            from hermes_cli.config import (
+                build_session_affinity_key,
+                custom_provider_session_affinity_enabled,
+            )
+
+            effective_base_url = request_kwargs.get("base_url") or self.base_url
+            provider_name = str(
+                getattr(self, "requested_provider", "") or provider
+            )
+            if custom_provider_session_affinity_enabled(
+                effective_base_url,
+                getattr(self, "_custom_providers", []) or [],
+                provider_name=provider_name,
+                model=str(getattr(self, "model", "") or ""),
+            ):
+                session_affinity_key = build_session_affinity_key(
+                    effective_base_url, session_id
+                )
         # Per-request OpenAI-wire clients (used by both the non-streaming
         # chat-completions path and the streaming chat-completions path
         # in `_interruptible_api_call`) should not run the SDK's built-in
@@ -4767,6 +4799,20 @@ class AIAgent:
             and self._api_kwargs_have_image_parts(api_kwargs or {})
         ):
             request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
+        if session_affinity_key is not None:
+            affinity_header = "X-Hermes-Affinity-Key"
+            # Copy the final nested mapping and remove case-insensitive aliases;
+            # the generated route/session value remains authoritative after any
+            # provider-specific request-header construction above.
+            headers = {
+                key: value
+                for key, value in dict(
+                    request_kwargs.get("default_headers") or {}
+                ).items()
+                if str(key).lower() != affinity_header.lower()
+            }
+            headers[affinity_header] = session_affinity_key
+            request_kwargs["default_headers"] = headers
         # Reuse the cached wire client while the effective kwargs are
         # unchanged: constructing openai.OpenAI + its httpx pool costs
         # ~19-35ms per LLM call (fresh TCP+TLS handshake), ~5x per turn.

--- a/tests/hermes_cli/test_custom_provider_session_affinity.py
+++ b/tests/hermes_cli/test_custom_provider_session_affinity.py
@@ -1,0 +1,131 @@
+"""Provider configuration and digest contract for Hermes session affinity."""
+
+import re
+
+from hermes_cli.config import (
+    _normalize_custom_provider_entry,
+    build_session_affinity_key,
+    custom_provider_session_affinity_enabled,
+    normalize_session_affinity_base_url,
+    providers_dict_to_custom_providers,
+)
+
+
+def test_named_provider_normalizes_explicit_boolean_opt_in():
+    enabled = providers_dict_to_custom_providers({
+        "trusted-local": {
+            "api": "https://llm.example/v1",
+            "session_affinity": True,
+        }
+    })
+    disabled = providers_dict_to_custom_providers({
+        "ordinary": {"api": "https://cloud.example/v1"}
+    })
+
+    assert enabled[0]["session_affinity"] is True
+    assert "session_affinity" not in disabled[0]
+
+
+def test_legacy_provider_normalizes_false_and_invalid_values_to_disabled():
+    explicit_false = _normalize_custom_provider_entry({
+        "name": "disabled",
+        "base_url": "https://disabled.example/v1",
+        "session_affinity": False,
+    })
+    quoted_true = _normalize_custom_provider_entry({
+        "name": "not-an-explicit-bool",
+        "base_url": "https://invalid.example/v1",
+        "session_affinity": "true",
+    })
+
+    assert explicit_false is not None
+    assert explicit_false["session_affinity"] is False
+    assert quoted_true is not None
+    assert quoted_true["session_affinity"] is False
+
+
+def test_affinity_opt_in_lookup_is_exact_and_route_scoped():
+    providers = [
+        {
+            "name": "trusted-local",
+            "provider_key": "trusted-local",
+            "base_url": "https://llm.example/v1/",
+            "session_affinity": True,
+        },
+        {
+            "name": "cloud",
+            "provider_key": "cloud",
+            "base_url": "https://cloud.example/v1",
+            "session_affinity": False,
+        },
+    ]
+
+    assert custom_provider_session_affinity_enabled(
+        "https://llm.example/v1", providers, provider_name="custom:trusted-local"
+    )
+    assert not custom_provider_session_affinity_enabled(
+        "https://cloud.example/v1", providers, provider_name="custom:cloud"
+    )
+    assert not custom_provider_session_affinity_enabled(
+        "https://unknown.example/v1", providers, provider_name="custom"
+    )
+
+
+def test_named_provider_opt_in_survives_model_switch_on_the_same_route():
+    providers = [
+        {
+            "name": "trusted-local",
+            "provider_key": "trusted-local",
+            "base_url": "https://llm.example/v1",
+            "model": "initial-model",
+            "session_affinity": True,
+        }
+    ]
+
+    assert custom_provider_session_affinity_enabled(
+        "https://llm.example/v1",
+        providers,
+        provider_name="custom:trusted-local",
+        model="switched-model",
+    )
+
+
+def test_exact_versioned_digest_contract_and_normalized_route_reuse():
+    expected = "v1.50d7bc4b8de379a2d029943e7060e8e3ad3e31d981d84bdf1796a5f17a0c60cc"
+
+    assert normalize_session_affinity_base_url(" https://llm.gucci.dev/v1/ ") == (
+        "https://llm.gucci.dev/v1"
+    )
+    assert (
+        build_session_affinity_key("https://llm.gucci.dev/v1", "parent-session-123")
+        == expected
+    )
+    assert (
+        build_session_affinity_key("https://llm.gucci.dev/v1/", "parent-session-123")
+        == expected
+    )
+    assert re.fullmatch(r"v1\.[0-9a-f]{64}", expected)
+    assert "parent-session-123" not in expected
+
+
+def test_route_normalization_does_not_strip_query_value_slashes():
+    route = "https://llm.example/v1?upstream=https://replica.example/"
+
+    assert normalize_session_affinity_base_url(route) == route
+    assert build_session_affinity_key(route, "session") != build_session_affinity_key(
+        route.rstrip("/"), "session"
+    )
+
+
+def test_different_sessions_and_provider_routes_have_different_keys():
+    parent = build_session_affinity_key(
+        "https://llm.gucci.dev/v1", "parent-session-123"
+    )
+    child = build_session_affinity_key("https://llm.gucci.dev/v1", "child-session-456")
+    other_route = build_session_affinity_key(
+        "https://other.example/v1", "parent-session-123"
+    )
+
+    assert parent != child
+    assert parent != other_route
+    assert child != other_route

--- a/tests/run_agent/test_custom_provider_session_affinity_client.py
+++ b/tests/run_agent/test_custom_provider_session_affinity_client.py
@@ -1,0 +1,240 @@
+"""Request-local OpenAI client headers for custom-provider session affinity."""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.config import build_session_affinity_key
+from run_agent import AIAgent
+
+_ROUTE = "https://llm.internal.example/v1"
+_AFFINITY_HEADER = "X-Hermes-Affinity-Key"
+
+
+class _StubClient:
+    def __init__(self):
+        self.is_closed = False
+
+    def close(self):
+        self.is_closed = True
+
+
+def _make_agent(*, session_id="parent-session", enabled=True):
+    with patch("run_agent.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_ROUTE,
+            provider="custom",
+            requested_provider="custom:trusted-local",
+            model="test-model",
+            session_id=session_id,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = _StubClient()
+    agent._custom_providers = [
+        {
+            "name": "Trusted Local",
+            "provider_key": "trusted-local",
+            "base_url": _ROUTE,
+            "model": "test-model",
+            "session_affinity": enabled,
+        }
+    ]
+    return agent
+
+
+class _Harness:
+    def __init__(self, agent):
+        self.agent = agent
+        self.built = []
+        self.closed = []
+        self.patchers = []
+
+    def __enter__(self):
+        def _fake_create(kwargs, *, reason, shared):
+            if not shared:
+                snapshot = dict(kwargs)
+                if isinstance(snapshot.get("default_headers"), dict):
+                    snapshot["default_headers"] = dict(snapshot["default_headers"])
+                self.built.append((snapshot, reason))
+            return _StubClient()
+
+        def _fake_close(client, *, reason, shared):
+            self.closed.append((client, reason))
+
+        self.patchers = [
+            patch.object(self.agent, "_create_openai_client", side_effect=_fake_create),
+            patch.object(self.agent, "_close_openai_client", side_effect=_fake_close),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+        return self
+
+    def __exit__(self, *_exc):
+        for patcher in self.patchers:
+            patcher.stop()
+
+
+def _built_headers(harness):
+    return harness.built[-1][0].get("default_headers", {})
+
+
+def test_enabled_route_adds_exact_digest_to_request_local_client_only():
+    agent = _make_agent(session_id="parent-session-123")
+    shared_headers = {"X-Static": "configured"}
+    agent._client_kwargs["default_headers"] = shared_headers
+
+    with _Harness(agent) as harness:
+        agent._create_request_openai_client(reason="chat_completion_request")
+
+    assert _built_headers(harness) == {
+        "X-Static": "configured",
+        _AFFINITY_HEADER: build_session_affinity_key(_ROUTE, "parent-session-123"),
+    }
+    assert shared_headers == {"X-Static": "configured"}
+    assert agent._client_kwargs["default_headers"] is shared_headers
+    assert _AFFINITY_HEADER not in agent._client_kwargs["default_headers"]
+
+
+def test_generated_header_wins_case_insensitively_without_mutating_configured_headers():
+    agent = _make_agent(session_id="real-session")
+    configured = {
+        "x-hermes-affinity-key": "configured-spoof",
+        "X-Other": "preserved",
+    }
+    agent._client_kwargs["default_headers"] = configured
+
+    with _Harness(agent) as harness:
+        agent._create_request_openai_client(reason="chat_completion_stream_request")
+
+    headers = _built_headers(harness)
+    assert headers[_AFFINITY_HEADER] == build_session_affinity_key(
+        _ROUTE, "real-session"
+    )
+    assert "x-hermes-affinity-key" not in headers
+    assert headers["X-Other"] == "preserved"
+    assert configured["x-hermes-affinity-key"] == "configured-spoof"
+
+
+def test_copilot_vision_headers_do_not_overwrite_opted_in_affinity():
+    route = "https://api.githubcopilot.com"
+    agent = _make_agent(session_id="vision-session")
+    agent.base_url = route
+    getattr(agent, "_client_kwargs")["base_url"] = route
+    getattr(agent, "_custom_providers")[0]["base_url"] = route
+
+    with (
+        patch.object(
+            agent,
+            "_copilot_headers_for_request",
+            return_value={"X-Copilot-Vision": "true"},
+        ),
+        _Harness(agent) as harness,
+    ):
+        agent._create_request_openai_client(
+            reason="vision",
+            api_kwargs={
+                "messages": [
+                    {"content": [{"type": "image_url", "image_url": {"url": "x"}}]}
+                ]
+            },
+        )
+
+    assert _built_headers(harness)["X-Copilot-Vision"] == "true"
+    assert _built_headers(harness)[_AFFINITY_HEADER] == build_session_affinity_key(
+        route, "vision-session"
+    )
+
+
+def test_disabled_and_native_routes_do_not_receive_affinity_header():
+    disabled = _make_agent(enabled=False)
+    native = _make_agent(enabled=True)
+    native.api_mode = "anthropic_messages"
+
+    for agent in (disabled, native):
+        with _Harness(agent) as harness:
+            agent._create_request_openai_client(reason="test")
+        assert not any(
+            key.lower() == _AFFINITY_HEADER.lower() for key in _built_headers(harness)
+        )
+
+
+def test_streaming_and_nonstreaming_reuse_same_route_scoped_value():
+    agent = _make_agent(session_id="stable-session")
+
+    with _Harness(agent) as harness:
+        first = agent._create_request_openai_client(reason="chat_completion_request")
+        agent._close_request_openai_client(first, reason="request_complete")
+        second = agent._create_request_openai_client(
+            reason="chat_completion_stream_request"
+        )
+
+    assert second is first
+    assert len(harness.built) == 1
+    assert _built_headers(harness)[_AFFINITY_HEADER] == build_session_affinity_key(
+        _ROUTE, "stable-session"
+    )
+
+
+def test_session_change_separates_request_client_cache():
+    agent = _make_agent(session_id="session-one")
+
+    with _Harness(agent) as harness:
+        first = agent._create_request_openai_client(reason="request-one")
+        first_key = _built_headers(harness)[_AFFINITY_HEADER]
+        agent._close_request_openai_client(first, reason="request_complete")
+        agent.session_id = "session-two"
+        second = agent._create_request_openai_client(reason="request-two")
+        second_key = _built_headers(harness)[_AFFINITY_HEADER]
+
+    assert second is not first
+    assert len(harness.built) == 2
+    assert first_key != second_key
+    assert any(client is first for client, _reason in harness.closed)
+
+
+def test_parent_and_delegated_child_agents_get_stable_distinct_keys():
+    parent = _make_agent(session_id="parent-session")
+    child = _make_agent(session_id="child-session")
+    values = []
+
+    for agent in (parent, child):
+        with _Harness(agent) as harness:
+            agent._create_request_openai_client(reason="primary-agent-request")
+        values.append(_built_headers(harness)[_AFFINITY_HEADER])
+
+    assert values[0] != values[1]
+    assert values[0] == build_session_affinity_key(_ROUTE, "parent-session")
+    assert values[1] == build_session_affinity_key(_ROUTE, "child-session")
+
+
+def test_route_switch_reevaluates_opt_in_and_does_not_leak_header():
+    agent = _make_agent(session_id="session")
+
+    with _Harness(agent) as harness:
+        first = agent._create_request_openai_client(reason="primary")
+        assert _AFFINITY_HEADER in _built_headers(harness)
+        agent._close_request_openai_client(first, reason="request_complete")
+
+        agent.provider = "custom"
+        agent.requested_provider = "custom:untrusted-fallback"
+        agent.base_url = "https://fallback.example/v1"
+        agent._custom_providers.append({
+            "name": "Untrusted Fallback",
+            "provider_key": "untrusted-fallback",
+            "base_url": "https://fallback.example/v1",
+            "model": "fallback-model",
+            "session_affinity": False,
+        })
+        agent.model = "fallback-model"
+        agent._client_kwargs = {
+            "api_key": "fallback-key",
+            "base_url": "https://fallback.example/v1",
+        }
+        second = agent._create_request_openai_client(reason="fallback")
+
+    assert second is not first
+    assert not any(
+        key.lower() == _AFFINITY_HEADER.lower() for key in _built_headers(harness)
+    )

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1214,11 +1214,42 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `session_affinity`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
 
 :::note Legacy format
 Older configs used a top-level `custom_providers:` list instead. It still works — Hermes reads both — and `hermes update` auto-migrates it to the `providers:` dict (config v12). Field names differ slightly in the dict format: legacy `model` is `default_model`, and legacy `api_mode` is `transport`.
 :::
+
+#### Session affinity for trusted self-hosted routers
+
+An OpenAI-compatible router can use a stable request key to keep sequential
+turns near the same healthy model replica and improve prompt-prefix cache
+locality. Enable this only on a named provider you trust:
+
+```yaml
+providers:
+  trusted-local-router:
+    api: https://llm.internal.example/v1
+    key_env: INTERNAL_LLM_API_KEY
+    transport: chat_completions
+    default_model: my-model
+    session_affinity: true
+```
+
+`session_affinity` is absent/`false` by default and only the YAML boolean
+`true` opts in. For opted-in `chat_completions` primary agent requests, Hermes
+sends `X-Hermes-Affinity-Key: v1.<sha256>`. The digest is scoped to the
+normalized effective provider URL and the current agent session; the raw
+session ID is not sent. Resumed turns reuse the key, while `/new`, a different
+provider route, and each delegated child agent get distinct values. Provider
+switches and fallbacks reevaluate the new route's opt-in, so the header does
+not leak to an untrusted route.
+
+This metadata is a routing hint, not authentication or authorization. Do not
+enable it for a third-party provider unless you intentionally trust that
+provider with pseudonymous session-linking metadata. Native transports and
+auxiliary work such as compression, title generation, memory processing,
+vision, and web extraction do not inherit the parent agent's affinity key.
 
 Some OpenAI-compatible endpoints need provider-specific request body fields. Add an `extra_body` map to the matching custom provider and Hermes will merge it into each chat-completions request for that endpoint:
 


### PR DESCRIPTION
## Summary

- add explicit per-custom-provider `session_affinity: true` opt-in
- derive a stable route-scoped pseudonymous `X-Hermes-Affinity-Key` from the active agent session without transmitting the raw session ID
- inject affinity metadata only into request-local OpenAI-compatible clients, preserving provider/fallback isolation, client reuse safety, Copilot request headers, and auxiliary/native transport boundaries
- document the trust and privacy contract for custom providers

## Verification

- focused provider/client/lifecycle suite: 57 tests passed
- Ruff check passed on changed Python files
- Ruff format check passed on new tests
- feature-owned-file Gitleaks scan: no leaks
- `git diff --check`
- full `scripts/run_tests.sh -j 4`: 9 failures in four unrelated files; the exact same 9 failures reproduce on detached clean upstream `470cf66b0` (LSP process-guard cleanup, compression timing, updater EOL normalization, and MCP event polling)

## Security

- default off; only literal boolean `true` enables a named provider
- raw session IDs are hashed with normalized effective route identity before transmission
- generated metadata overrides configured spelling variants and is not inherited by untrusted fallbacks, native providers, or auxiliary clients
