### PR TITLE
fix(webhook): stop dropping events whose route script prints non-object JSON

### DIFF
--- a/gateway/platforms/webhook_filters.py
+++ b/gateway/platforms/webhook_filters.py
@@ -292,8 +292,15 @@ class WebhookRouteProcessor:
         except json.JSONDecodeError:
             transformed = {**payload, "script_output": stdout}
         if not isinstance(transformed, dict):
-            logger.warning("[webhook] script stdout must be a JSON object or text")
-            return False, None
+            # Stdout parsed, but not as an object. A JSON array/number/bool/
+            # null/string cannot REPLACE the payload, so carry it through as
+            # ``script_output`` exactly like non-JSON text. Dropping here made
+            # the ignore rule depend on whether the output happened to be
+            # JSON-parseable: ``print("hello")`` kept the webhook while
+            # ``print(json.dumps(items))`` silently discarded it, even though
+            # the documented ignore conditions are only empty stdout,
+            # ``[SILENT]``, and a nonzero exit.
+            transformed = {**payload, "script_output": stdout}
         if (
             transformed.get("[SILENT]") is True
             or transformed.get("__hermes_ignore__") is True

--- a/tests/gateway/test_webhook_route_script_output.py
+++ b/tests/gateway/test_webhook_route_script_output.py
@@ -1,0 +1,100 @@
+"""A route script only ignores a webhook for the three documented reasons.
+
+The documented contract for route scripts is:
+
+    "JSON stdout replaces the payload before prompt templating; empty stdout,
+     [SILENT], or a nonzero exit ignores the webhook."
+
+Stdout that parses as JSON but is not an object cannot *replace* the payload,
+and it used to drop the webhook. That made the ignore rule depend on whether
+the text happened to be JSON-parseable: ``print("hello")`` kept the event while
+``print(json.dumps(items))`` — a list, one of the most natural transform
+outputs — silently discarded it. Non-object JSON now rides along in
+``script_output`` exactly like non-JSON text.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.webhook_filters import WebhookRouteProcessor
+
+PAYLOAD = {"id": 7, "action": "opened"}
+
+
+@pytest.fixture
+def run_script(tmp_path, monkeypatch):
+    """Run a route script body under a throwaway HERMES_HOME."""
+    (tmp_path / "scripts").mkdir()
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    processor = WebhookRouteProcessor()
+    counter = {"n": 0}
+
+    def _run(body: str):
+        counter["n"] += 1
+        script = tmp_path / "scripts" / f"route_{counter['n']}.py"
+        script.write_text(body, encoding="utf-8")
+        return processor.run_route_script(script.name, PAYLOAD)
+
+    return _run
+
+
+@pytest.mark.parametrize(
+    "body, expected_output",
+    [
+        ('import json; print(json.dumps([1, 2, 3]))', "[1, 2, 3]"),
+        ('print(42)', "42"),
+        ('print("true")', "true"),
+        ('print("null")', "null"),
+        ('import json; print(json.dumps("done"))', '"done"'),
+    ],
+)
+def test_non_object_json_stdout_keeps_the_webhook(run_script, body, expected_output):
+    """The regression: JSON that isn't an object must not drop the event."""
+    keep, transformed = run_script(body)
+
+    assert keep is True
+    assert transformed is not None
+    # Carried through like text, with the original payload preserved.
+    assert transformed["script_output"] == expected_output
+    assert transformed["id"] == PAYLOAD["id"]
+
+
+def test_json_object_stdout_replaces_the_payload(run_script):
+    keep, transformed = run_script('import json; print(json.dumps({"a": 1}))')
+
+    assert keep is True
+    assert transformed == {"a": 1}
+
+
+def test_plain_text_stdout_rides_along_in_script_output(run_script):
+    keep, transformed = run_script('print("hello")')
+
+    assert keep is True
+    assert transformed["script_output"] == "hello"
+    assert transformed["action"] == PAYLOAD["action"]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "pass",                      # empty stdout
+        'print("[SILENT]")',         # explicit quiet marker
+        "import sys; sys.exit(3)",   # nonzero exit
+    ],
+)
+def test_documented_ignore_conditions_still_ignore(run_script, body):
+    """The three documented ignores must keep ignoring."""
+    keep, transformed = run_script(body)
+
+    assert keep is False
+    assert transformed is None
+
+
+def test_explicit_ignore_markers_in_json_object_still_ignore(run_script):
+    """An object carrying the opt-out keys stays an explicit ignore."""
+    keep, _ = run_script('import json; print(json.dumps({"__hermes_ignore__": True}))')
+
+    assert keep is False


### PR DESCRIPTION
## What

The documented route-script contract is explicit about when a webhook is dropped:

> JSON stdout replaces the payload before prompt templating; **empty stdout, `[SILENT]`, or a nonzero exit** ignores the webhook.

Three ignore conditions. `run_route_script` added a fourth, silently.

Stdout that *fails* to parse as JSON is wrapped into `script_output` and the event continues. Stdout that *does* parse but isn't an object returned `(False, None)` — and the caller turns that into `{"status": "ignored", "reason": "script"}`. So whether the webhook survived depended on whether the script's output happened to be JSON-parseable:

```
script stdout          kept?   documented?
plain text             True    keep         OK
JSON object            True    keep         OK
JSON array             False   keep         <-- DROPPED, undocumented
JSON number            False   keep         <-- DROPPED, undocumented
JSON true              False   keep         <-- DROPPED, undocumented
JSON null              False   keep         <-- DROPPED, undocumented
JSON quoted string     False   keep         <-- DROPPED, undocumented
empty stdout           False   ignore       OK
[SILENT]               False   ignore       OK
nonzero exit           False   ignore       OK
```

`print(json.dumps(items))` where `items` is a list — one of the most natural things a transform script emits — silently loses the delivery. The operator sees a deliberate-looking `reason: script` skip rather than a malformed-output warning, so it reads as "my filter matched nothing", not "my script's output shape was rejected".

The code's own log line — *"script stdout must be a JSON object **or text**"* — shows text was meant to be acceptable; JSON-parseable text just fell through the wrong branch.

## Fix

Carry non-object JSON through as `script_output`, exactly like non-JSON text. An array/number/bool/null/string cannot *replace* the payload, but it is still output the script chose to emit.

Untouched: the three documented ignores, and the explicit `[SILENT]` / `__hermes_ignore__` object markers.

## Tests

`tests/gateway/test_webhook_route_script_output.py` — 11 tests driving the real `run_route_script` with scripts under a throwaway `HERMES_HOME`. The 5 non-object-JSON cases fail without the fix:

- non-object JSON (array / number / `true` / `null` / quoted string) keeps the webhook and lands in `script_output`, with the original payload preserved
- a JSON object still replaces the payload
- plain text still rides along in `script_output`
- the three documented ignores still ignore
- an object carrying `__hermes_ignore__` still ignores

```
scripts/run_tests.sh tests/gateway/test_webhook_route_script_output.py
=== Summary: 1 files, 11 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 6 tests passed, 5 failed ===
```

All 10 `tests/gateway/*webhook*.py` files: **76 passed, 0 failed**.

