### PR TITLE
fix(update): skip gateway cold-start when desktop serve is running

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3055,6 +3055,44 @@ def _leftover_pausable_gateway_pids(
     return pids
 
 
+def _windows_serve_backend_is_running() -> bool:
+    """Return whether this install already has a live ``hermes serve`` backend.
+
+    Hermes Desktop launches its Python backend as ``hermes serve`` rather than
+    ``gateway run``. Gateway PID discovery intentionally matches only gateway
+    commands, so the desktop backend is invisible to the Windows update
+    cold-start path. When a stale Scheduled Task or Startup-folder launcher is
+    still installed, that mismatch makes ``hermes update`` spawn a second
+    standalone gateway alongside the desktop backend.
+
+    Reuse the venv-holder scan because it is already scoped to this checkout's
+    interpreter and handles uv/base-interpreter trampolines. That avoids a
+    ``hermes serve`` process from another Hermes installation suppressing this
+    install's legitimate gateway restart. Detection is best-effort; on scan
+    failure the updater preserves the existing cold-start behaviour.
+    """
+    if not _m()._is_windows():
+        return False
+
+    try:
+        matches = _detect_venv_python_processes()
+    except Exception as exc:
+        logger.debug("Could not scan for a Windows serve backend: %s", exc)
+        return False
+
+    serve_markers = (
+        "hermes serve",
+        "hermes.exe serve",
+        "hermes_cli.main serve",
+        "hermes_cli/main.py serve",
+    )
+    for _pid, _name, cmdline in matches:
+        normalized = str(cmdline).replace("\\", "/").lower()
+        if any(marker in normalized for marker in serve_markers):
+            return True
+    return False
+
+
 def _pause_windows_gateways_for_update() -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
@@ -3084,6 +3122,17 @@ def _pause_windows_gateways_for_update() -> dict | None:
         logger.debug("Could not discover Windows gateway PIDs before update: %s", exc)
         return None
     if not running_pids:
+        # Hermes Desktop owns the same messaging/runtime role through its
+        # ``hermes serve`` backend. A vestigial gateway autostart artifact must
+        # not turn that healthy desktop-owned runtime into a second standalone
+        # gateway after every update (#76129).
+        if _windows_serve_backend_is_running():
+            logger.debug(
+                "Skipping Windows gateway cold-start token because hermes serve "
+                "is already running"
+            )
+            return None
+
         # No gateway is running right now, but the user may have installed an
         # autostart entry (Scheduled Task or Startup-folder login item) — that
         # is an explicit "I want a gateway" signal. A gateway that died between
@@ -3233,6 +3282,11 @@ def _cold_start_windows_gateway_after_update() -> None:
     # process may have re-registered. Don't double-start.
     try:
         if list(find_gateway_pids(all_profiles=True)):
+            return
+        # The desktop backend may have started while the update was in
+        # progress. Treat ``hermes serve`` as gateway-equivalent at the final
+        # pre-spawn check too, closing the race between pause and resume.
+        if _windows_serve_backend_is_running():
             return
     except Exception as exc:
         logger.debug("Could not re-check gateway liveness before cold-start: %s", exc)

--- a/tests/hermes_cli/test_update_windows_desktop_gateway_cold_start.py
+++ b/tests/hermes_cli/test_update_windows_desktop_gateway_cold_start.py
@@ -1,0 +1,161 @@
+"""Regression tests for Windows desktop-owned gateway cold starts (#76129)."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+@pytest.fixture
+def windows_update_module(monkeypatch):
+    """Make the focused update helpers execute their native-Windows paths."""
+    fake_main = SimpleNamespace(_is_windows=lambda: True)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    return update_cmd
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        r'C:\Hermes\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1 --port 0',
+        r'C:\Hermes\venv\Scripts\hermes.exe serve --host 127.0.0.1 --port 0',
+        "/opt/hermes/venv/bin/python hermes_cli/main.py serve --host 127.0.0.1 --port 0",
+    ],
+)
+def test_serve_backend_detection_recognizes_desktop_commands(
+    windows_update_module, monkeypatch, cmdline
+):
+    monkeypatch.setattr(
+        windows_update_module,
+        "_detect_venv_python_processes",
+        lambda: [(4242, "python.exe", cmdline)],
+    )
+
+    assert windows_update_module._windows_serve_backend_is_running() is True
+
+
+def test_serve_backend_detection_ignores_plain_dashboard(
+    windows_update_module, monkeypatch
+):
+    monkeypatch.setattr(
+        windows_update_module,
+        "_detect_venv_python_processes",
+        lambda: [
+            (
+                4242,
+                "python.exe",
+                "python -m hermes_cli.main dashboard --port 8080",
+            ),
+        ],
+    )
+
+    assert windows_update_module._windows_serve_backend_is_running() is False
+
+
+def test_serve_backend_detection_fails_open_on_scan_error(
+    windows_update_module, monkeypatch
+):
+    def _raise():
+        raise OSError("process table unavailable")
+
+    monkeypatch.setattr(
+        windows_update_module, "_detect_venv_python_processes", _raise
+    )
+
+    assert windows_update_module._windows_serve_backend_is_running() is False
+
+
+def test_pause_does_not_arm_cold_start_when_desktop_serve_is_running(
+    windows_update_module, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+    from hermes_cli import gateway_windows
+
+    installed = Mock(return_value=True)
+    monkeypatch.setattr(
+        gateway_cli, "find_gateway_pids", lambda *, all_profiles: []
+    )
+    monkeypatch.setattr(gateway_windows, "is_installed", installed)
+    monkeypatch.setattr(
+        windows_update_module,
+        "_windows_serve_backend_is_running",
+        lambda: True,
+    )
+
+    token = windows_update_module._pause_windows_gateways_for_update()
+
+    assert token is None
+    installed.assert_not_called()
+
+
+def test_pause_keeps_existing_cold_start_for_installed_gateway_without_serve(
+    windows_update_module, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(
+        gateway_cli, "find_gateway_pids", lambda *, all_profiles: []
+    )
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(
+        windows_update_module,
+        "_windows_serve_backend_is_running",
+        lambda: False,
+    )
+
+    token = windows_update_module._pause_windows_gateways_for_update()
+
+    assert token == {
+        "resume_needed": True,
+        "profiles": {},
+        "unmapped_pids": [],
+        "unmapped": [],
+        "cold_start_if_installed": True,
+    }
+
+
+def test_cold_start_skips_spawn_when_desktop_serve_started_during_update(
+    windows_update_module, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+    from hermes_cli import gateway_windows
+
+    spawn = Mock(return_value=12345)
+    monkeypatch.setattr(
+        gateway_cli, "find_gateway_pids", lambda *, all_profiles: []
+    )
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", spawn)
+    monkeypatch.setattr(
+        windows_update_module,
+        "_windows_serve_backend_is_running",
+        lambda: True,
+    )
+
+    windows_update_module._cold_start_windows_gateway_after_update()
+
+    spawn.assert_not_called()
+
+
+def test_cold_start_still_spawns_when_runtime_role_is_unserved(
+    windows_update_module, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+    from hermes_cli import gateway_windows
+
+    spawn = Mock(return_value=12345)
+    monkeypatch.setattr(
+        gateway_cli, "find_gateway_pids", lambda *, all_profiles: []
+    )
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", spawn)
+    monkeypatch.setattr(
+        windows_update_module,
+        "_windows_serve_backend_is_running",
+        lambda: False,
+    )
+
+    windows_update_module._cold_start_windows_gateway_after_update()
+
+    spawn.assert_called_once_with()


### PR DESCRIPTION
## Summary

- recognize the Windows Desktop `hermes serve` backend as gateway-equivalent during update cold-start decisions
- scope the detection to processes using the current checkout's venv, so another Hermes installation cannot suppress a legitimate restart
- skip arming `cold_start_if_installed` when Desktop already owns the runtime role
- repeat the `hermes serve` liveness check immediately before `_spawn_detached()` to close the pause-to-resume race
- preserve the existing cold-start behavior when neither a gateway nor a Desktop backend is running
- add focused regression coverage for Desktop command variants, ordinary dashboard processes, scan failures, pre-update token creation, and post-update spawning

## Problem

On native Windows, gateway discovery only recognizes `gateway run` / `gateway restart` command lines. Hermes Desktop runs its backend as `hermes serve`, so it is invisible to the update gateway-liveness check.

When an old Scheduled Task or Startup-folder gateway launcher is still installed, `hermes update` interprets the missing gateway PID as a stopped installed gateway, arms `cold_start_if_installed`, and starts a detached standalone gateway after the update. That leaves the Desktop backend and the extra gateway running together, causing duplicate runtime ownership, state/port races, stale processes, and later venv-lock failures.

This change reuses the existing venv-holder scan to detect a `hermes serve` process belonging to the current installation. It checks both before the cold-start token is created and again immediately before spawning.

## Testing

Focused regression tests were added for:

- `python -m hermes_cli.main serve`
- `hermes.exe serve`
- script-path `hermes_cli/main.py serve`
- ignoring an ordinary `hermes dashboard` process
- fail-open behavior when process enumeration fails
- not arming a cold-start token while Desktop is serving
- preserving the installed-gateway cold start when no runtime is serving
- skipping a spawn when Desktop starts during the update
- preserving a spawn when the runtime role is genuinely unserved

```bash
python -m pytest -q tests/hermes_cli/test_update_windows_desktop_gateway_cold_start.py
```


Fixes #76129



