### PR TITLE
fix: route GitHub webhook comments by target type

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1283,74 +1283,112 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _deliver_github_comment(
         self, content: str, delivery: dict
     ) -> SendResult:
-        """Post agent response as a GitHub PR/issue comment via ``gh`` CLI."""
+        """Post a GitHub conversation or review-thread reply via ``gh api``.
+
+        GitHub stores both Issue and PR conversation comments under the Issues
+        comments endpoint. Inline PR review comments are a separate resource;
+        ``review_comment_id`` makes the response a reply in that review thread.
+        ``pr_number`` remains supported for existing PR conversation routes.
+        """
         extra = delivery.get("deliver_extra", {})
         repo = extra.get("repo", "")
-        pr_number = extra.get("pr_number", "")
+        number = (
+            extra.get("number")
+            or extra.get("issue_number")
+            or extra.get("pr_number")
+        )
+        comment_type = str(
+            extra.get("comment_type")
+            or extra.get("target")
+            or ("review" if extra.get("review_comment_id") else "conversation")
+        ).lower()
+        review_comment_id = extra.get("review_comment_id")
 
-        if not repo or not pr_number:
+        if not repo or not number:
             logger.error(
-                "[webhook] github_comment delivery missing repo or pr_number"
+                "[webhook] github_comment delivery missing repo or issue/PR number"
             )
             return SendResult(
-                success=False, error="Missing repo or pr_number"
+                success=False, error="Missing repo or issue/PR number"
             )
+
+        if comment_type not in {
+            "conversation", "issue", "pr", "review", "review_comment",
+            "review_thread",
+        }:
+            logger.error("[webhook] invalid github comment type: %r", comment_type)
+            return SendResult(success=False, error="Invalid comment_type")
 
         # --- Input validation (prevent CLI argument injection) ---
-        # pr_number must be a positive integer.
         try:
-            pr_int = int(pr_number)
-            if pr_int <= 0:
+            number_int = int(number)
+            if number_int <= 0:
                 raise ValueError("non-positive")
         except (ValueError, TypeError):
-            logger.error(
-                "[webhook] invalid pr_number: %r", pr_number
-            )
-            return SendResult(
-                success=False, error="Invalid pr_number"
-            )
+            logger.error("[webhook] invalid issue/PR number: %r", number)
+            return SendResult(success=False, error="Invalid issue/PR number")
 
-        # repo must match owner/name (alphanumeric, hyphens, underscores, dots).
         if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
             logger.error("[webhook] invalid repo format: %r", repo)
-            return SendResult(
-                success=False, error="Invalid repo format"
-            )
+            return SendResult(success=False, error="Invalid repo format")
+
+        endpoint = f"repos/{repo}/issues/{number_int}/comments"
+        args = [
+            "gh", "api", endpoint,
+            "--method", "POST",
+            "--raw-field", f"body={content}",
+        ]
+
+        if comment_type in {"review", "review_comment", "review_thread"}:
+            if not review_comment_id:
+                logger.error(
+                    "[webhook] review comment delivery missing review_comment_id"
+                )
+                return SendResult(
+                    success=False, error="Missing review_comment_id"
+                )
+            try:
+                review_id_int = int(review_comment_id)
+                if review_id_int <= 0:
+                    raise ValueError("non-positive")
+            except (ValueError, TypeError):
+                logger.error(
+                    "[webhook] invalid review_comment_id: %r", review_comment_id
+                )
+                return SendResult(
+                    success=False, error="Invalid review_comment_id"
+                )
+            endpoint = f"repos/{repo}/pulls/{number_int}/comments"
+            args = [
+                "gh", "api", endpoint,
+                "--method", "POST",
+                "--raw-field", f"body={content}",
+                "--field", f"in_reply_to={review_id_int}",
+            ]
 
         try:
             result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "comment",
-                    str(pr_int),
-                    "--repo",
-                    repo,
-                    "--body",
-                    content,
-                ],
+                args,
                 capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             if result.returncode == 0:
                 logger.info(
-                    "[webhook] Posted comment on %s#%s", repo, pr_number
+                    "[webhook] Posted %s comment on %s#%s",
+                    "review" if comment_type in {"review", "review_comment", "review_thread"} else "conversation",
+                    repo,
+                    number_int,
                 )
                 return SendResult(success=True)
-            else:
-                logger.error(
-                    "[webhook] gh pr comment failed: %s", result.stderr
-                )
-                return SendResult(success=False, error=result.stderr)
+            logger.error("[webhook] gh api comment failed: %s", result.stderr)
+            return SendResult(success=False, error=result.stderr)
         except FileNotFoundError:
             logger.error(
                 "[webhook] 'gh' CLI not found — install GitHub CLI for "
                 "github_comment delivery"
             )
-            return SendResult(
-                success=False, error="gh CLI not installed"
-            )
+            return SendResult(success=False, error="gh CLI not installed")
         except Exception as e:
             logger.error("[webhook] github_comment delivery error: %s", e)
             return SendResult(success=False, error=str(e))

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -271,8 +271,7 @@ class TestGitHubCommentDelivery:
 
     @pytest.mark.asyncio
     async def test_github_comment_delivery(self):
-        """When deliver='github_comment', the adapter invokes
-        ``gh pr comment`` via subprocess.run (mocked)."""
+        """PR conversation comments use the shared GitHub issue-comments API."""
         routes = {
             "pr-bot": {
                 "secret": _INSECURE_NO_AUTH,
@@ -325,9 +324,9 @@ class TestGitHubCommentDelivery:
         assert result.success is True
         mock_run.assert_called_once_with(
             [
-                "gh", "pr", "comment", "42",
-                "--repo", "org/repo",
-                "--body", "LGTM! The code looks great.",
+                "gh", "api", "repos/org/repo/issues/42/comments",
+                "--method", "POST",
+                "--raw-field", "body=LGTM! The code looks great.",
             ],
             capture_output=True,
             text=True,
@@ -338,3 +337,122 @@ class TestGitHubCommentDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_issue_comment_delivery_uses_issue_comments_api(self):
+        """Issue comments use the same conversation endpoint as PR comments."""
+        routes = {
+            "issue-bot": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Issue: {issue.title}",
+                "deliver": "github_comment",
+                "deliver_extra": {
+                    "repo": "{repository.full_name}",
+                    "issue_number": "{issue.number}",
+                    "comment_type": "conversation",
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+        issue_payload = {
+            "action": "opened",
+            "issue": {"number": 464, "title": "Fix webhook comments"},
+            "repository": {"full_name": "org/repo"},
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/issue-bot",
+                json=issue_payload,
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "gh-issue-comment-001",
+                },
+            )
+            assert resp.status == 202
+
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "gateway.platforms.webhook.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            result = await adapter.send(
+                "webhook:issue-bot:gh-issue-comment-001", "Issue response"
+            )
+
+        assert result.success is True
+        mock_run.assert_called_once_with(
+            [
+                "gh", "api", "repos/org/repo/issues/464/comments",
+                "--method", "POST",
+                "--raw-field", "body=Issue response",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+
+    @pytest.mark.asyncio
+    async def test_review_comment_delivery_replies_to_review_thread(self):
+        """Review comments use the pulls-comments API and in_reply_to."""
+        routes = {
+            "review-bot": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Review comment: {comment.body}",
+                "deliver": "github_comment",
+                "deliver_extra": {
+                    "repo": "{repository.full_name}",
+                    "pr_number": "{pull_request.number}",
+                    "comment_type": "review",
+                    "review_comment_id": "{comment.id}",
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+        review_payload = {
+            "action": "created",
+            "pull_request": {"number": 42},
+            "comment": {"id": 9001, "body": "Please handle this error"},
+            "repository": {"full_name": "org/repo"},
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/review-bot",
+                json=review_payload,
+                headers={
+                    "X-GitHub-Event": "pull_request_review_comment",
+                    "X-GitHub-Delivery": "gh-review-comment-001",
+                },
+            )
+            assert resp.status == 202
+
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "gateway.platforms.webhook.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            result = await adapter.send(
+                "webhook:review-bot:gh-review-comment-001", "Review response"
+            )
+
+        assert result.success is True
+        mock_run.assert_called_once_with(
+            [
+                "gh", "api", "repos/org/repo/pulls/42/comments",
+                "--method", "POST",
+                "--raw-field", "body=Review response",
+                "--field", "in_reply_to=9001",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -71,10 +71,41 @@ platforms:
             3. Write a concise, actionable review comment and post it.
 
           deliver: github_comment
+          # GitHub conversation comments (works for both Issues and PRs).
           deliver_extra:
             repo: "{repository.full_name}"
-            pr_number: "{number}"
+            number: "{number}"
+            comment_type: "conversation"
 ```
+
+For a GitHub Issue route, use the same conversation endpoint with the Issue
+number:
+
+```yaml
+          deliver: github_comment
+          deliver_extra:
+            repo: "{repository.full_name}"
+            issue_number: "{issue.number}"
+            comment_type: "conversation"
+```
+
+For a `pull_request_review_comment` event, reply in the existing inline review
+thread by providing the PR number and the original review comment ID:
+
+```yaml
+          events:
+            - pull_request_review_comment
+          deliver: github_comment
+          deliver_extra:
+            repo: "{repository.full_name}"
+            pr_number: "{pull_request.number}"
+            comment_type: "review"
+            review_comment_id: "{comment.id}"
+```
+
+`github_comment` uses `gh api`, not a raw HTTP client. Conversation comments
+are posted to `repos/{repo}/issues/{number}/comments`; review-thread replies
+are posted to `repos/{repo}/pulls/{number}/comments` with `in_reply_to`.
 
 **Key fields:**
 
@@ -83,9 +114,11 @@ platforms:
 | `secret` (route-level) | HMAC secret for this route. Falls back to `extra.secret` global if omitted. |
 | `events` | List of `X-GitHub-Event` header values to accept. Empty list = accept all. |
 | `prompt` | Template; `{field}` and `{nested.field}` resolve from the GitHub payload. |
-| `deliver` | `github_comment` posts via `gh pr comment`. `log` just writes to the gateway log. |
+| `deliver` | `github_comment` posts through the GitHub CLI/API; `log` just writes to the gateway log. |
 | `deliver_extra.repo` | Resolves to e.g. `org/repo` from the payload. |
-| `deliver_extra.pr_number` | Resolves to the PR number from the payload. |
+| `deliver_extra.number` / `issue_number` / `pr_number` | Issue or PR number. `pr_number` remains supported for existing routes. |
+| `deliver_extra.comment_type` | `conversation` (default) for Issue/PR comments, or `review` for an inline PR review-thread reply. |
+| `deliver_extra.review_comment_id` | Original inline review comment ID required when `comment_type` is `review`. |
 
 :::note The payload does not contain code
 The GitHub webhook payload includes PR metadata (title, description, branch names, URLs) but **not the diff**. The prompt above instructs the agent to run `gh pr diff` to fetch the actual changes. The `terminal` tool is included in the default `hermes-webhook` toolset, so no extra configuration is needed.


### PR DESCRIPTION
## Summary
- use `gh api` Issues comments endpoint for Issue and PR conversation replies
- support inline PR review-thread replies through Pull Request review comments and `in_reply_to`
- preserve existing `pr_number` configuration and document target fields

## Verification
- `uv run --with pytest --with pytest-asyncio --with aiohttp --with aiohttp-sse-client --with pyyaml pytest tests/gateway/test_webhook_integration.py -q` — 6 passed
- `uv run --with ruff ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_integration.py` — passed
- `git diff --check` — passed

The full gateway test run also completed: 4415 passed, 31 skipped, 9 unrelated pre-existing environment/platform failures.