### PR TITLE
fix(photon): stop native iMessage poll votes being silently dropped (spectrum-ts 8 poll schemas)

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -66,6 +66,7 @@ import http from "node:http";
 import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
+import { patchSpectrumPollSchema } from "./patch-spectrum-poll-schema.mjs";
 import { chooseSendFormat } from "./send-format.mjs";
 import {
   classifyProbeRejection,
@@ -286,6 +287,12 @@ try {
   if (patchResult.patched) {
     console.error(
       `photon-sidecar: spectrum mixed attachment patch applied: ${patchResult.file}`
+    );
+  }
+  const pollPatchResult = patchSpectrumPollSchema();
+  if (pollPatchResult.patched) {
+    console.error(
+      `photon-sidecar: spectrum poll schema patch applied: ${pollPatchResult.file}`
     );
   }
 } catch (e) {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -281,7 +281,9 @@ if (!projectId || !projectSecret || !sharedToken) {
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import. Apply Hermes'
 // pinned-sdk compatibility patch first so existing installs self-heal at
-// runtime, not only during npm postinstall.
+// runtime, not only during npm postinstall. Each compatibility patch gets its
+// own failure boundary so a mixed-attachment patch failure can't skip the poll
+// patch (and vice versa), and each logs its own patch-specific message.
 try {
   const patchResult = patchSpectrumTs();
   if (patchResult.patched) {
@@ -289,6 +291,16 @@ try {
       `photon-sidecar: spectrum mixed attachment patch applied: ${patchResult.file}`
     );
   }
+} catch (e) {
+  console.error(
+    "photon-sidecar: spectrum mixed attachment patch failed. " +
+      "Run `npm install` inside plugins/platforms/photon/sidecar/ or " +
+      "upgrade the Photon sidecar patch for the pinned spectrum-ts version. " +
+      "Original error: " +
+      (e && e.stack ? e.stack : String(e))
+  );
+}
+try {
   const pollPatchResult = patchSpectrumPollSchema();
   if (pollPatchResult.patched) {
     console.error(
@@ -297,7 +309,7 @@ try {
   }
 } catch (e) {
   console.error(
-    "photon-sidecar: spectrum mixed attachment patch failed. " +
+    "photon-sidecar: spectrum poll schema patch failed. " +
       "Run `npm install` inside plugins/platforms/photon/sidecar/ or " +
       "upgrade the Photon sidecar patch for the pinned spectrum-ts version. " +
       "Original error: " +

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -7,7 +7,7 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node index.mjs",
-    "postinstall": "node patch-spectrum-mixed-attachments.mjs"
+    "postinstall": "node patch-spectrum-mixed-attachments.mjs && node patch-spectrum-poll-schema.mjs"
   },
   "engines": {
     "node": ">=18.17"

--- a/plugins/platforms/photon/sidecar/patch-spectrum-poll-schema.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-poll-schema.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Relax spectrum-ts 8.x poll schemas so empty/missing titles don't drop votes.
+//
+// Symptom (photon-hq/spectrum-ts#91, fix closed without merge in 8.0.0): when a
+// recipient taps a native iMessage poll, the inbound path runs
+// `toPollOptionMessage` → `resolvePoll` → `client.polls.get(...)` →
+// `toCachedPoll` → `asPoll({title, options})`. The metadata returned by the
+// cloud carries an empty `title`, and `pollSchema` rejected it via
+// `z.string().nonempty()` (`too_small`, path `["title"]`). `resolvePoll` caught
+// the throw, returned `undefined`, and `toPollOptionMessage` returned `[]` — the
+// vote was silently dropped before the agent could ever see it.
+//
+// Upstream's intended fix (photon-hq/spectrum-ts PR #91) relaxed the three poll
+// schemas to be lenient *on the wire* for inbound data, keeping outbound
+// validation at the customer-facing builders (Hermes' `/send-poll` still rejects
+// a blank title). We mirror that here against the compiled 8.0.0 chunk.
+//
+// The schemas live in @spectrum-ts/core/dist (chunk name is a content hash); we
+// scan core/dist for the `pollChoiceSchema` anchor rather than hardcoding the
+// chunk filename, and fail loudly if a future spectrum-ts reshapes them.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const MARKER = "Hermes patch: Relax spectrum-ts poll schemas for empty/missing inbound titles";
+
+function scriptDir() {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function replaceOnce(source, from, to, label) {
+  const count = source.split(from).length - 1;
+  if (count !== 1) {
+    throw new Error(`expected exactly one ${label} match, found ${count}`);
+  }
+  return source.replace(from, to);
+}
+
+export function patchSpectrumPollSchema(root = scriptDir()) {
+  const dist = path.join(root, "node_modules", "@spectrum-ts", "core", "dist");
+  if (!fs.existsSync(dist)) {
+    throw new Error(`@spectrum-ts/core dist not found: ${dist}`);
+  }
+  const files = fs.readdirSync(dist)
+    .filter((name) => name.endsWith(".js"))
+    .map((name) => path.join(dist, name));
+
+  for (const file of files) {
+    const raw = fs.readFileSync(file, "utf8");
+    if (raw.includes(MARKER)) {
+      return { patched: false, file, reason: "already patched" };
+    }
+    // Normalize to LF for matching so the patch works regardless of the
+    // checkout's line-ending style (CRLF would defeat \n-based anchors).
+    const CR = String.fromCharCode(13);
+    const CRLF = CR + "\n";
+    const usedCRLF = raw.includes(CRLF);
+    const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
+    if (!original.includes("const pollChoiceSchema")) {
+      continue;
+    }
+
+    let patched = original;
+    // pollChoiceSchema.title: accept empty option text on the wire.
+    patched = replaceOnce(
+      patched,
+      `const pollChoiceSchema = z.object({ title: z.string().nonempty() });`,
+      `const pollChoiceSchema = z.object({ title: z.string() });`,
+      "pollChoiceSchema.title"
+    );
+    // pollSchema.title: accept an empty/missing poll title on the wire.
+    patched = replaceOnce(
+      patched,
+      `\ttitle: z.string().nonempty().max(300),`,
+      `\ttitle: z.string().max(300).optional(),`,
+      "pollSchema.title"
+    );
+    // pollOptionSchema.title: again lenient on the wire; the superRefine still
+    //   enforces structural equality with option.title, so empty strings
+    //   round-trip without silently dropping the vote.
+    patched = replaceOnce(
+      patched,
+      `\tselected: z.boolean(),\n\ttitle: z.string().nonempty()`,
+      `\tselected: z.boolean(),\n\ttitle: z.string()`,
+      "pollOptionSchema.title"
+    );
+
+    patched = `// ${MARKER}\n${patched}`;
+    if (usedCRLF) {
+      patched = patched.split("\n").join(CRLF);
+    }
+    fs.writeFileSync(file, patched, "utf8");
+    return { patched: true, file };
+  }
+  throw new Error("could not find spectrum-ts core poll schema chunk to patch");
+}
+
+const _invokedDirectly =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (_invokedDirectly) {
+  try {
+    const root = process.argv[2] ? path.resolve(process.argv[2]) : scriptDir();
+    const result = patchSpectrumPollSchema(root);
+    const action = result.patched ? "patched" : "ok";
+    console.error(`photon-sidecar: spectrum poll schema patch ${action}: ${result.file}`);
+  } catch (err) {
+    console.error(`photon-sidecar: spectrum poll schema patch failed: ${err?.stack || err}`);
+    process.exit(1);
+  }
+}

--- a/tests/plugins/platforms/photon/test_spectrum_poll_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_poll_patch.py
@@ -37,17 +37,17 @@ def _tabify(src: str) -> str:
 # assert runtime behavior (empty-title poll) rather than only string shape.
 _SPECTRUM_POLL_FIXTURE = """
 const z = (() => {
-  const str = () => ({ kind: "string", nonEmpty: false, max: null, optional: false, min: null });
+  const str = () => ({ kind: "string", nonEmpty: false, max: null, isOptional: false, min: null });
   const withMethods = (s) => Object.assign(s, {
     nonempty() { this.nonEmpty = true; return this; },
     max(n) { this.max = n; return this; },
-    optional() { this.optional = true; return this; },
+    optional() { this.isOptional = true; return this; },
     min(n) { this.min = n; return this; },
     superRefine() { return this; },
     parse(v) { return parse(this, v); },
   });
   const parse = (s, v) => {
-    if (s.optional && v === undefined) return undefined;
+    if (s.isOptional && v === undefined) return undefined;
     switch (s.kind) {
       case "string": {
         if (typeof v !== "string") throw new Error("expected string");
@@ -126,6 +126,38 @@ def _run_as_poll(chunk: Path, title: str) -> str:
     return result.stdout.strip()
 
 
+def _run_as_poll_option(chunk: Path, option_title: str, poll_title: str | None) -> str:
+    """Execute the patched/unpatched fixture and report asPollOption().
+
+    Mirrors the agent-bound vote path: the chosen option title is read from
+    ``input.option.title`` and re-emitted as ``title`` on the parsed payload.
+    A parent poll with an empty/absent title is the production shape that
+    previously dropped the vote.
+    """
+    url = chunk.resolve().as_uri()
+    poll_field = (
+        "{ type: 'poll', options: [{ title: 'A' }, { title: 'B' }] }"
+        if poll_title is None
+        else f"{{ type: 'poll', title: {repr(poll_title)}, options: [{{ title: 'A' }}, {{ title: 'B' }}] }}"
+    )
+    script = (
+        f'import {{ asPollOption }} from "{url}";'
+        f'try {{ const out = asPollOption({{ option: {{ title: {option_title!r} }}, '
+        f'poll: {poll_field}, '
+        f'selected: true }});'
+        f'console.log("PARSED:" + out.title); }}'
+        f'catch (e) {{ console.log("THREW:" + e.message); }}'
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
 def test_spectrum_poll_schema_patch_accepts_empty_title(tmp_path: Path) -> None:
     """The poll-schema patch must let an inbound poll with an empty title reach
     the agent (the vote is no longer dropped), while keeping normal polls parsed."""
@@ -174,3 +206,40 @@ def test_spectrum_poll_schema_patch_accepts_empty_title(tmp_path: Path) -> None:
     )
     assert again.returncode == 0, again.stderr
     assert chunk.read_text(encoding="utf-8") == patched
+
+
+def test_spectrum_poll_schema_patch_accepts_empty_parent_title_for_vote(tmp_path: Path) -> None:
+    """The poll-schema patch must also let an inbound *poll_option* (agent-bound
+    vote path) with an empty/absent parent poll title round-trip, preserving the
+    chosen option title — not just the bare asPoll() poll shape."""
+    chunk = _write_core_fixture(tmp_path)
+
+    # Regression baseline: unpatched, an empty parent-poll title throws on the
+    # embedded pollSchema (what dropped the real vote on the agent-bound path).
+    pre_empty = _run_as_poll_option(chunk, option_title="A", poll_title="")
+    assert pre_empty.startswith("THREW:too small"), pre_empty
+    # An absent poll title (undefined) also throws on the non-optional schema.
+    pre_absent = _run_as_poll_option(chunk, option_title="A", poll_title=None)
+    assert pre_absent.startswith("THREW:expected"), pre_absent
+    # A titled poll still parses on the unpatched schema with the option kept.
+    pre_ok = _run_as_poll_option(chunk, option_title="A", poll_title="Lunch?")
+    assert pre_ok == "PARSED:A", pre_ok
+
+    # Apply the Hermes patch.
+    result = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    # Runtime: empty and absent parent titles both round-trip, chosen option kept.
+    post_empty = _run_as_poll_option(chunk, option_title="A", poll_title="")
+    assert post_empty == "PARSED:A", post_empty
+    post_absent = _run_as_poll_option(chunk, option_title="A", poll_title=None)
+    assert post_absent == "PARSED:A", post_absent
+    # Titled parent poll unaffected.
+    post_ok = _run_as_poll_option(chunk, option_title="A", poll_title="Lunch?")
+    assert post_ok == "PARSED:A", post_ok

--- a/tests/plugins/platforms/photon/test_spectrum_poll_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_poll_patch.py
@@ -1,0 +1,176 @@
+"""Regression tests for Hermes' Spectrum poll-schema workaround.
+
+Covers the bug where tapping a native iMessage poll dropped the vote: spectrum-ts
+8.x's `pollSchema.title` was `z.string().nonempty()`, but the poll metadata the
+cloud returns for an inbound vote carries an empty/missing title, so
+`toCachedPoll` -> `asPoll(...)` threw a ZodError and the vote was silently lost.
+Mirrors photon-hq/spectrum-ts#91 (closed, not merged) for the pinned 8.0.0 SDK.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+_PATCHER = Path("plugins/platforms/photon/sidecar/patch-spectrum-poll-schema.mjs")
+
+
+def _tabify(src: str) -> str:
+    """Convert two-space indentation to the tab indentation spectrum-ts ships in
+    `@spectrum-ts/core/dist`, so the patch anchors (which match tabs) apply
+    exactly as they do against a real install."""
+    out = []
+    for line in src.split("\n"):
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        out.append("\t" * (indent // 2) + " " * (indent % 2) + stripped)
+    return "\n".join(out)
+
+
+# A faithful, *executable* slice of spectrum-ts 8.x's poll schemas plus a tiny
+# inline `z` shim with just enough behavior (string/nonempty/max/optional,
+# object/literal/boolean/array+min+max, superRefine) to make `asPoll` run
+# without any external dependency. The schemas mirror the compiled
+# `@spectrum-ts/core/dist` output (tab-indented via `_tabify`), so the patch
+# anchors exercise the real code shape, and exporting `asPoll` lets the test
+# assert runtime behavior (empty-title poll) rather than only string shape.
+_SPECTRUM_POLL_FIXTURE = """
+const z = (() => {
+  const str = () => ({ kind: "string", nonEmpty: false, max: null, optional: false, min: null });
+  const withMethods = (s) => Object.assign(s, {
+    nonempty() { this.nonEmpty = true; return this; },
+    max(n) { this.max = n; return this; },
+    optional() { this.optional = true; return this; },
+    min(n) { this.min = n; return this; },
+    superRefine() { return this; },
+    parse(v) { return parse(this, v); },
+  });
+  const parse = (s, v) => {
+    if (s.optional && v === undefined) return undefined;
+    switch (s.kind) {
+      case "string": {
+        if (typeof v !== "string") throw new Error("expected string");
+        if (s.nonEmpty && v.length < 1) throw new Error("too small: expected string to have >=1 characters");
+        if (s.max !== null && v.length > s.max) throw new Error("too big");
+        return v;
+      }
+      case "boolean": return v;
+      case "literal": if (v !== s.v) throw new Error("invalid literal"); return v;
+      case "array": {
+        if (!Array.isArray(v)) throw new Error("expected array");
+        if (s.min !== null && v.length < s.min) throw new Error("too few");
+        if (s.max !== null && v.length > s.max) throw new Error("too many");
+        return v.map((x) => parse(s.elem, x));
+      }
+      case "object": {
+        const out = {};
+        for (const [k, sub] of Object.entries(s.shape)) out[k] = parse(sub, v[k]);
+        return out;
+      }
+    }
+  };
+  return {
+    string: () => withMethods(str()),
+    boolean: () => ({ kind: "boolean" }),
+    literal: (v) => ({ kind: "literal", v }),
+    array: (elem, min, max) => withMethods({ kind: "array", elem, min: min ?? null, max: max ?? null }),
+    object: (shape) => withMethods({ kind: "object", shape }),
+  };
+})();
+const pollChoiceSchema = z.object({ title: z.string().nonempty() });
+const pollSchema = z.object({
+  type: z.literal("poll"),
+  title: z.string().nonempty().max(300),
+  options: z.array(pollChoiceSchema).min(2).max(10)
+});
+const pollOptionSchema = z.object({
+  type: z.literal("poll_option"),
+  option: pollChoiceSchema,
+  poll: pollSchema,
+  selected: z.boolean(),
+  title: z.string().nonempty()
+}).superRefine((value, ctx) => { if (value.title !== value.option.title) ctx.addIssue({}); });
+const asPoll = (input) => pollSchema.parse({ type: "poll", ...input });
+const asPollOption = (input) => pollOptionSchema.parse({ type: "poll_option", ...input, title: input.option.title });
+export { asPoll, asPollOption };
+"""
+
+
+def _write_core_fixture(tmp_path: Path) -> Path:
+    core = tmp_path / "node_modules" / "@spectrum-ts" / "core"
+    dist = core / "dist"
+    dist.mkdir(parents=True)
+    (core / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
+    chunk = dist / "index.js"
+    chunk.write_text(_tabify(_SPECTRUM_POLL_FIXTURE), encoding="utf-8")
+    return chunk
+
+
+def _run_as_poll(chunk: Path, title: str) -> str:
+    """Execute the patched/unpatched fixture and report asPoll() with a title."""
+    url = chunk.resolve().as_uri()
+    script = (
+        f'import {{ asPoll }} from "{url}";'
+        f'try {{ const out = asPoll({{ title: {title!r}, options: [{{ title: "A" }}, {{ title: "B" }}] }});'
+        f'console.log("PARSED:" + out.title); }}'
+        f'catch (e) {{ console.log("THREW:" + e.message); }}'
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_spectrum_poll_schema_patch_accepts_empty_title(tmp_path: Path) -> None:
+    """The poll-schema patch must let an inbound poll with an empty title reach
+    the agent (the vote is no longer dropped), while keeping normal polls parsed."""
+    chunk = _write_core_fixture(tmp_path)
+
+    # Regression baseline: unpatched, an empty-title poll throws (what dropped
+    # the real vote in production).
+    pre = _run_as_poll(chunk, "")
+    assert pre.startswith("THREW:too small"), pre
+    # A normal title still parses on the unpatched schema.
+    pre_ok = _run_as_poll(chunk, "Lunch?")
+    assert pre_ok == "PARSED:Lunch?", pre_ok
+
+    # Apply the Hermes patch.
+    result = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    patched = chunk.read_text(encoding="utf-8")
+    assert "Relax spectrum-ts poll schemas" in patched
+    # The three title schemas are now lenient on the wire...
+    assert "const pollChoiceSchema = z.object({ title: z.string() });" in patched
+    assert "title: z.string().max(300).optional()," in patched
+    # ...and no `.nonempty()` survives on a title field.
+    assert "title: z.string().nonempty()" not in patched
+
+    # Runtime regression: empty-title poll now parses (vote no longer dropped).
+    post = _run_as_poll(chunk, "")
+    assert post == "PARSED:", post
+    # Normal polls still parse with their title preserved.
+    post_ok = _run_as_poll(chunk, "Lunch?")
+    assert post_ok == "PARSED:Lunch?", post_ok
+
+    # Re-running the patch is a no-op (idempotent self-heal on sidecar start).
+    again = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert again.returncode == 0, again.stderr
+    assert chunk.read_text(encoding="utf-8") == patched


### PR DESCRIPTION
## What

Fixes the Photon (iMessage) **native poll vote being silently dropped** — see **#76175**.

When a recipient taps an option on a native iMessage poll, the inbound path
(`toPollOptionMessage → resolvePoll → polls.get → toCachedPoll → asPoll`) throws
a ZodError because `pollSchema.title` in the pinned **spectrum-ts 8.0.0** is
`z.string().nonempty()`, and the poll metadata Photon returns for an inbound
vote carries an empty/missing title. `resolvePoll` swallows the error and the
vote never reaches the agent (no error to the user, just a sidecar log line).

This mirrors upstream `photon-hq/spectrum-ts#91` (closed, unmerged — not present
in 8.0.0): it relaxes `pollChoiceSchema.title` / `pollSchema.title` /
`pollOptionSchema.title` to be **lenient on the wire** for inbound data, while
keeping outbound validation at the customer-facing builders (`/send-poll` still
rejects a blank title).

## Why a sidecar patch instead of bumping the SDK

The Photon sidecar pins spectrum-ts **exactly to 8.0.0** on purpose (breaking
majors + the mixed-attachment patch anchors are tied to that build — see the
sidecar README "Upgrading spectrum-ts"). Bumping to 12.x is a deliberate,
separate migration that should land on its own. This PR applies the *same fix
upstream intended* (#91) to the pinned version through the sidecar's existing
patch mechanism, so it self-heals at startup and on `npm postinstall`.

## Changes (atomic)

- `sidecar/patch-spectrum-poll-schema.mjs` — new patch relaxing the three poll
  schemas, applied at sidecar startup and `npm postinstall`.
- `sidecar/index.mjs` — run the poll-schema patch alongside the existing
  mixed-attachment patch.
- `sidecar/package.json` — run both patches on `postinstall`.
- `tests/.../test_spectrum_poll_patch.py` — runtime regression: empty-title
  poll throws before the patch, parses after; normal title preserved; idempotent.

## Verification

- `pytest tests/plugins/platforms/photon/` → **130 passed**.
- End-to-end on a live Photon line: before the fix, tapping the poll produced
  the ZodError and no delivery; after, the vote arrives as a normal message and
  the error is gone.
