### PR TITLE
test: resolve Git Bash explicitly so bash -n tests pass on Windows

### DIFF
--- a/apps/desktop/electron/update-relaunch.test.ts
+++ b/apps/desktop/electron/update-relaunch.test.ts
@@ -25,6 +25,7 @@ import path from 'node:path'
 
 import { test } from 'vitest'
 
+import { findGitBash } from './find-git-bash'
 import {
   buildRelaunchScript,
   collectRelaunchArgs,
@@ -39,6 +40,21 @@ import {
 
 const ROOT = '/home/u/.hermes/hermes-agent'
 const UNPACKED = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
+
+// The `bash -n` lint steps below hand bash a native `os.tmpdir()` path. On
+// Windows `bash` on PATH is C:\Windows\System32\bash.exe — the WSL launcher —
+// and WSL's bash cannot open a `C:\...` argument: it eats the backslashes and
+// exits 127. Resolve Git for Windows instead; `findGitBash` without
+// `findOnPath` returns null rather than falling back to that PATH bash, so a
+// box without Git for Windows skips the lint instead of failing on it.
+const LINT_BASH: string | null =
+  process.platform === 'win32'
+    ? findGitBash({
+        isWindows: true,
+        env: process.env,
+        fileExists: (filePath) => fs.existsSync(filePath)
+      })
+    : 'bash'
 
 // ---------------------------------------------------------------------------
 // 1) The execPath split — the heart of the GUI/backend skew guard.
@@ -215,7 +231,7 @@ test('buildRelaunchScript embeds pid/exec/args/env/cwd and is valid bash', () =>
   fs.writeFileSync(tmp, script)
 
   try {
-    execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
+    if (LINT_BASH) execFileSync(LINT_BASH, ['-n', tmp], { stdio: 'pipe' })
   } finally {
     fs.rmSync(tmp, { force: true })
   }
@@ -234,7 +250,7 @@ test('buildRelaunchScript with no args/env still lints clean', () => {
   fs.writeFileSync(tmp, script)
 
   try {
-    execFileSync('bash', ['-n', tmp], { stdio: 'pipe' })
+    if (LINT_BASH) execFileSync(LINT_BASH, ['-n', tmp], { stdio: 'pipe' })
   } finally {
     fs.rmSync(tmp, { force: true })
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -785,6 +785,30 @@ def mock_config():
     }
 
 
+@pytest.fixture()
+def posix_bash():
+    """A bash that can open the native paths tests hand it.
+
+    Bare ``bash`` resolves to ``C:\\Windows\\System32\\bash.exe`` — the WSL
+    launcher — on any Windows box with WSL installed, and WSL's bash cannot
+    open a ``C:\\...`` argument: it strips the backslashes and exits 127.
+    ``_find_bash()`` already probes Git-for-Windows locations ahead of PATH
+    for exactly this reason; tests that shell out need the same lookup.
+    """
+    if sys.platform != "win32":
+        bash = shutil.which("bash")
+        if not bash:
+            pytest.skip("bash not on PATH")
+        return bash
+
+    from tools.environments.local import _find_bash
+
+    try:
+        return _find_bash()
+    except RuntimeError as exc:  # Git for Windows absent
+        pytest.skip(str(exc))
+
+
 # ── Per-test timeout — handled by the isolation plugin ─────────────────────
 #
 # The subprocess-per-test plugin enforces the configured ``isolate_timeout``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ import atexit
 import os
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -785,15 +786,20 @@ def mock_config():
     }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def posix_bash():
     """A bash that can open the native paths tests hand it.
 
     Bare ``bash`` resolves to ``C:\\Windows\\System32\\bash.exe`` — the WSL
     launcher — on any Windows box with WSL installed, and WSL's bash cannot
     open a ``C:\\...`` argument: it strips the backslashes and exits 127.
-    ``_find_bash()`` already probes Git-for-Windows locations ahead of PATH
-    for exactly this reason; tests that shell out need the same lookup.
+
+    ``_find_bash()`` prefers Git-for-Windows locations for that reason, but
+    it still appends the ``PATH`` result as a last-resort candidate and
+    accepts whichever candidate starts first, so on a box without Git for
+    Windows it hands back the WSL launcher. Preference is not a guarantee,
+    so the resolved bash is asked to open a native temp path before it is
+    handed out, and the test skips when it cannot.
     """
     if sys.platform != "win32":
         bash = shutil.which("bash")
@@ -804,9 +810,23 @@ def posix_bash():
     from tools.environments.local import _find_bash
 
     try:
-        return _find_bash()
-    except RuntimeError as exc:  # Git for Windows absent
+        bash = _find_bash()
+    except RuntimeError as exc:  # no usable bash at all
         pytest.skip(str(exc))
+
+    fd, probe = tempfile.mkstemp(suffix=".sh")
+    try:
+        os.write(fd, b":\n")
+        os.close(fd)
+        opens_native_paths = (
+            subprocess.run([bash, "-n", probe], capture_output=True).returncode == 0
+        )
+    finally:
+        os.unlink(probe)
+
+    if not opens_native_paths:
+        pytest.skip(f"{bash} cannot open native Windows paths (WSL bash?)")
+    return bash
 
 
 # ── Per-test timeout — handled by the isolation plugin ─────────────────────

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -84,14 +84,14 @@ class TestGenerateBash:
         assert "complete -F _hermes_completion hermes" in out
 
 
-    def test_valid_bash_syntax(self):
+    def test_valid_bash_syntax(self, posix_bash):
         """Script must pass `bash -n` syntax check."""
         out = generate_bash(_make_parser())
         with tempfile.NamedTemporaryFile(mode="w", suffix=".bash", delete=False) as f:
             f.write(out)
             path = f.name
         try:
-            result = subprocess.run(["bash", "-n", path], capture_output=True)
+            result = subprocess.run([posix_bash, "-n", path], capture_output=True)
             assert result.returncode == 0, result.stderr.decode()
         finally:
             os.unlink(path)

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -6,8 +6,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_SCRIPT = REPO_ROOT / "setup-hermes.sh"
 
 
-def test_setup_hermes_script_is_valid_shell():
-    result = subprocess.run(["bash", "-n", str(SETUP_SCRIPT)], capture_output=True, text=True)
+def test_setup_hermes_script_is_valid_shell(posix_bash):
+    result = subprocess.run(
+        [posix_bash, "-n", str(SETUP_SCRIPT)], capture_output=True, text=True
+    )
     assert result.returncode == 0, result.stderr
 
 


### PR DESCRIPTION
## What breaks

Two tests shell out with a bare `bash` and a native Windows path:

```python
# tests/hermes_cli/test_completion.py:94
subprocess.run(["bash", "-n", path], capture_output=True)

# tests/hermes_cli/test_setup_hermes_script.py:10
subprocess.run(["bash", "-n", str(SETUP_SCRIPT)], capture_output=True, text=True)
```

On any Windows box with WSL installed, both fail with exit 127:

```
FAILED tests/hermes_cli/test_completion.py::TestGenerateBash::test_valid_bash_syntax
E   AssertionError: /bin/bash: C:UsersDellAppDataLocalTemptmp1wkh5p9f.bash: No such file or directory
E   assert 127 == 0
E    +  where 127 = CompletedProcess(
E          args=['bash', '-n', 'C:\\Users\\Dell\\AppData\\Local\\Temp\\tmp1wkh5p9f.bash'],
E          returncode=127, ...)

FAILED tests/hermes_cli/test_setup_hermes_script.py::test_setup_hermes_script_is_valid_shell
E   AssertionError: /bin/bash: D:FilesClaudenoushermes-agentsetup-hermes.sh: No such file or directory
E   assert 127 == 0
```

Note the argv is correct — the backslashes are intact in `args`. They are gone
by the time bash reports the filename.

## Root cause

Bare `bash` does not resolve to Git Bash on Windows. It resolves to the WSL
launcher, which is on the default `PATH` ahead of Git:

```
>>> shutil.which('bash')
'C:\\Windows\\system32\\bash.EXE'
>>> subprocess.run(['bash', '-c', 'uname -s'], capture_output=True, text=True).stdout
'Linux\n'
```

WSL's bash is a Linux bash. It reads `C:\Users\...` as a string with escape
sequences, consumes the backslashes, and looks for a file that does not exist.
Forward slashes do not help either — `C:/Users/...` is simply not a path
inside the WSL filesystem:

```
bare bash + 'C:\Users\...\tmp.bash'   -> rc=127
bare bash + 'C:/Users/.../tmp.bash'   -> rc=127
_find_bash() + 'C:\Users\...\tmp.bash' -> rc=0
```

This is already a solved problem in product code. `tools/environments/local.py::_find_bash()`
probes Git-for-Windows locations *before* falling back to `PATH`, and the
comment there describes this exact failure:

```python
# Check known Git for Windows install locations before PATH lookup.
# On machines with both WSL and Git for Windows, shutil.which("bash")
# may return WSL's bash (which doesn't understand Windows paths and
# will fail silently).  Explicit Git-for-Windows paths avoid that.
```

These two tests were never brought in line with it.

CI does not catch this: every job in `.github/workflows/` runs on
`ubuntu-latest` (the two `matrix.runner` jobs are Docker `linux/arm64`), so
`bash` is always the system bash there and the tests pass.

## Side effect worth noting

Because bare `bash` starts WSL, a `bash -n` syntax check boots the WSL VM.
That is what makes these two files disproportionately slow on Windows, and on
machines whose WSLg cannot initialise it also raises modal
`Remote Desktop` / `RemoteApp` connection-error dialogs during a test run.

## The fix

A `posix_bash` fixture in `tests/conftest.py` that reuses `_find_bash()` on
Windows and skips when Git for Windows is absent; off Windows it is the
existing `shutil.which("bash")` behaviour. The two callers take the fixture.

## Verification

Windows 10 Pro 19043, WSL2 installed, Git for Windows present, Python 3.11.15.

Before:

```
tests\hermes_cli\test_completion.py            1 failed, 6 passed, 1 skipped
tests\hermes_cli\test_setup_hermes_script.py   1 failed, 1 passed
```

After, via the canonical runner:

```
$ scripts/run_tests.sh tests/hermes_cli/test_completion.py \
                       tests/hermes_cli/test_setup_hermes_script.py -q
=== Summary: 2 files, 9 tests passed, 0 failed (100% complete) in 2.4s ===
```

`ruff check` clean on the three touched files. No behaviour change on Linux or
macOS: `sys.platform != "win32"` keeps the previous `shutil.which("bash")`
lookup.
