### PR TITLE
fix(tools): match deny-rule segments to bypass shell prefix evasion (#76037)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -522,6 +522,11 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+# Pattern to strip leading VAR=value assignments from command segments
+# before deny-rule matching, so that 'VAR=1 git push --force' is caught.
+_LEADING_DENY_ASSIGNMENTS = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)+")
+
+
 def _match_user_deny_rule(command: str) -> str | None:
     """Return the matching ``approvals.deny`` glob, or None.
 
@@ -548,9 +553,17 @@ def _match_user_deny_rule(command: str) -> str | None:
         return None
     for command_variant in _command_detection_variants(command):
         candidate = command_variant.lower().strip()
-        for pattern in globs:
-            if fnmatch.fnmatchcase(candidate, pattern.lower()):
-                return pattern
+        candidates = [candidate]
+        marked = _mark_command_starts(command_variant)
+        if marked != command_variant:
+            candidates.extend(marked.split("\n"))
+        for raw in candidates:
+            stripped = _LEADING_DENY_ASSIGNMENTS.sub("", raw.lower().strip()).lstrip("({ ").strip()
+            if not stripped:
+                continue
+            for pattern in globs:
+                if fnmatch.fnmatchcase(stripped, pattern.lower()):
+                    return pattern
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #76037.

`approvals.deny` globs are matched with `fnmatch.fnmatchcase` which is anchored at both ends. A deny rule like `git push --force*` therefore only matches when `git` is the very first word. Any shell prefix (`cd repo &&`, `true;`, `VAR=1`, `(subshell)`, `echo hi |`) silently bypasses the rule.

## Changes

- **`tools/approval.py`**: `_match_user_deny_rule` now splits each detection variant on command-start boundaries (via `_mark_command_starts`) and tests each segment independently. Leading `VAR=value` assignments and subshell/brace openers (`(`, `{`) are stripped before matching. Added `_LEADING_DENY_ASSIGNMENTS` regex constant.

## Why not widen globs?

`*git push --force*` would false-positive on `grep -r 'git push --force' docs/` and any command that *mentions* the denied string in arguments. The per-segment approach avoids this trap.

## Testing

Verified against the 12 cases from the issue:
- All 5 bypasses (`cd repo && git push --force`, `true; git push --force`, `VAR=1 git push --force`, `(git push --force)`, `echo hi | git push --force`) now **block**
- All 5 negative controls (`echo hello`, `grep -r 'git push --force' docs/`, etc.) still **allow**
- No change to glob syntax users write in `config.yaml`
