### PR TITLE
feat(desktop): expose host.selectModel to plugins for model switching

### DIFF
--- a/apps/desktop/src/app/contrib/actions-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/actions-bridge.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { host } from '@/sdk'
+import type { ModelSelection } from '@/types/model-selection'
+
+import { publishPluginActions, runPluginSelectModel } from './actions-bridge'
+
+const selection: ModelSelection = { provider: 'deepseek', model: 'deepseek-v4-flash' }
+
+afterEach(() => publishPluginActions(null))
+
+describe('actions-bridge', () => {
+  it('returns false before the controller publishes an action', async () => {
+    publishPluginActions(null)
+    await expect(runPluginSelectModel(selection)).resolves.toBe(false)
+  })
+
+  it('forwards the selection to the published action and normalizes true', async () => {
+    const action = vi.fn().mockResolvedValue(true)
+    publishPluginActions({ selectModel: action })
+    await expect(runPluginSelectModel(selection)).resolves.toBe(true)
+    expect(action).toHaveBeenCalledWith(selection)
+  })
+
+  it('normalizes a rejected switch to false', async () => {
+    const action = vi.fn().mockResolvedValue(false)
+    publishPluginActions({ selectModel: action })
+    await expect(runPluginSelectModel(selection)).resolves.toBe(false)
+  })
+
+  it('treats a sync void handler as accepted (no false failure toast)', async () => {
+    const action = vi.fn()
+    publishPluginActions({ selectModel: action })
+    await expect(runPluginSelectModel(selection)).resolves.toBe(true)
+  })
+
+  it('treats an async void handler as accepted — same contract as sync void', async () => {
+    const action = vi.fn().mockResolvedValue(undefined)
+    publishPluginActions({ selectModel: action })
+    await expect(runPluginSelectModel(selection)).resolves.toBe(true)
+  })
+
+  it('surfaces a synchronous throw from the handler as a rejection', async () => {
+    const action = vi.fn().mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    publishPluginActions({ selectModel: action })
+    await expect(runPluginSelectModel(selection)).rejects.toThrow('boom')
+  })
+})
+
+describe('host.selectModel (public SDK door)', () => {
+  it('forwards to the published controller action', async () => {
+    const action = vi.fn().mockResolvedValue(true)
+    publishPluginActions({ selectModel: action })
+    await expect(host.selectModel(selection)).resolves.toBe(true)
+    expect(action).toHaveBeenCalledWith(selection)
+  })
+
+  it('returns false when the controller clears the bridge (unmount lifecycle)', async () => {
+    const action = vi.fn().mockResolvedValue(true)
+    publishPluginActions({ selectModel: action })
+    await expect(host.selectModel(selection)).resolves.toBe(true)
+    publishPluginActions(null)
+    await expect(host.selectModel(selection)).resolves.toBe(false)
+  })
+
+  it('propagates a handler failure as a rejected promise (async-safe door)', async () => {
+    const action = vi.fn().mockRejectedValue(new Error('switch failed'))
+    publishPluginActions({ selectModel: action })
+    await expect(host.selectModel(selection)).rejects.toThrow('switch failed')
+  })
+})

--- a/apps/desktop/src/app/contrib/actions-bridge.ts
+++ b/apps/desktop/src/app/contrib/actions-bridge.ts
@@ -1,0 +1,34 @@
+import type { ModelSelection } from '@/types/model-selection'
+
+import type { WiringActions } from './types'
+
+/**
+ * Narrow module-level bridge so the plugin SDK can invoke controller-owned
+ * actions without reaching into React internals. Same shape as
+ * `sessionTileDelegate` in store/session-states.ts: the wiring publishes the
+ * live action (stable identity, latest closure) and the SDK reads it on
+ * demand. Null until the controller mounts; a plugin calling early gets a
+ * clean `false` instead of a crash.
+ */
+let selectModelAction: WiringActions['selectModel'] | null = null
+
+/** Controller-side: hand the live `selectModel` action to the plugin bridge. */
+export function publishPluginActions(next: Pick<WiringActions, 'selectModel'> | null): void {
+  selectModelAction = next?.selectModel ?? null
+}
+
+/** SDK-side: invoke the controller's model switch if one is attached. */
+export function runPluginSelectModel(selection: ModelSelection): Promise<boolean> {
+  const action = selectModelAction
+
+  if (!action) {
+    return Promise.resolve(false)
+  }
+
+  // One promise boundary for sync/async/void handlers: a synchronous throw
+  // becomes a rejection, a `void` handler means accepted, and only an
+  // explicit `false` is a failure.
+  return Promise.resolve()
+    .then(() => action(selection) ?? true)
+    .then(result => result !== false)
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -114,6 +114,7 @@ import { titlebarControlsPosition } from '../shell/titlebar'
 import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
 
+import { publishPluginActions } from './actions-bridge'
 import { ContribWiringContext } from './context'
 import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
@@ -910,6 +911,20 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }
 
   const actions = actionsRef.current
+
+  // Publish the live model-switch action to the plugin SDK bridge so plugins
+  // can drive the same picker semantics (composer atom + session config.set).
+  // Effect-managed, not render-body: an uncommitted render must not leak a
+  // closure, and unmount clears the bridge so a torn-down controller can't be
+  // invoked. The wrapper dereferences actionsRef at call time so it always
+  // runs the latest closure.
+  useEffect(() => {
+    publishPluginActions({
+      selectModel: selection => actionsRef.current!.selectModel(selection)
+    })
+
+    return () => publishPluginActions(null)
+  }, [])
 
   // Each pane node is memoized on ONLY the reactive inputs it truly consumes;
   // everything else reaches its surface through `actions` (stable) or the

--- a/apps/desktop/src/app/model-picker-overlay.tsx
+++ b/apps/desktop/src/app/model-picker-overlay.tsx
@@ -1,6 +1,5 @@
 import { useStore } from '@nanostores/react'
 
-import type { ModelSelection } from '@/app/shell/model-menu-panel'
 import { ModelPickerDialog } from '@/components/model-picker'
 import type { HermesGateway } from '@/hermes'
 import { useStoreSelector } from '@/lib/use-session-slice'
@@ -13,6 +12,7 @@ import {
   setModelPickerOpen
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState } from '@/store/session-states'
+import type { ModelSelection } from '@/types/model-selection'
 
 interface ModelPickerOverlayProps {
   gateway?: HermesGateway

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -1,7 +1,6 @@
 import { type QueryClient } from '@tanstack/react-query'
 import { useCallback, useRef } from 'react'
 
-import type { ModelSelection } from '@/app/shell/model-menu-panel'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
@@ -21,6 +20,7 @@ import {
 } from '@/store/session'
 import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
+import type { ModelSelection } from '@/types/model-selection'
 
 interface ModelControlsOptions {
   queryClient: QueryClient

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -22,18 +22,13 @@ import {
 } from '@/store/session'
 import { sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
+import type { ModelSelection } from '@/types/model-selection'
 
 import { ModelCatalogMenu, type ModelMenuController } from './model-catalog-menu'
 
 export { ModelMenuCloseContext } from './model-catalog-menu'
 
-export interface ModelSelection {
-  model: string
-  provider: string
-  /** Runtime id of the surface that opened the menu. When set, the switch
-   *  targets that session (a tile) instead of the primary `$activeSessionId`. */
-  sessionId?: null | string
-}
+export type { ModelSelection }
 
 interface ModelMenuPanelProps {
   gateway?: HermesGateway

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -20,6 +20,7 @@
 
 import { atom, type ReadableAtom } from 'nanostores'
 
+import { runPluginSelectModel } from '@/app/contrib/actions-bridge'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
@@ -28,6 +29,7 @@ import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
+import type { ModelSelection } from '@/types/model-selection'
 
 // -- state: readonly views over the app's live atoms -------------------------
 
@@ -94,6 +96,14 @@ export const host = {
 
   /** Restart the backend gateway (progress surfaces in the core statusbar). */
   restartGateway: async () => runGatewayRestart(),
+
+  /** Switch the model exactly like the in-app picker: updates the composer
+   *  atoms for a fresh draft and applies a session-scoped `config.set` for a
+   *  live session (deferred mid-turn). Resolves `true` when the switch is
+   *  accepted; resolves `false` when the controller is unavailable or the
+   *  controller rejects/rolls back the switch; unexpected handler exceptions
+   *  reject the promise. */
+  selectModel: async (selection: ModelSelection) => runPluginSelectModel(selection),
 
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),
@@ -266,6 +276,7 @@ export { coarseElapsed, fmtDateTime, fmtDayTime, relativeTime } from '@/lib/time
 export { cn } from '@/lib/utils'
 export { THEMES_AREA } from '@/themes/user-themes'
 export type { RpcEvent, StatusResponse } from '@/types/hermes'
+export type { ModelSelection } from '@/types/model-selection'
 /** Subscribe a component to a `host.state` atom. */
 export { useStore as useValue } from '@nanostores/react'
 /** The app's data-fetching layer. Plugins share the ONE QueryClient mounted at

--- a/apps/desktop/src/types/model-selection.ts
+++ b/apps/desktop/src/types/model-selection.ts
@@ -1,0 +1,12 @@
+/**
+ * Model switch payload shared by the in-app model picker and the plugin SDK's
+ * `host.selectModel` action. Lives in a neutral contract module so the public
+ * SDK surface is not coupled to a UI component.
+ */
+export interface ModelSelection {
+  model: string
+  provider: string
+  /** Runtime id of the surface that opened the menu. When set, the switch
+   *  targets that session (a tile) instead of the primary `$activeSessionId`. */
+  sessionId?: null | string
+}

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -41,7 +41,7 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
 - **`host.state.*`** — readonly views over the app's live state (nanostore
   atoms): active session, cwd, gateway status, model, profile, viewport.
 - **`host.*` actions** — curated safe verbs: toast, navigate, tail logs,
-  restart the gateway, subscribe to the gateway event stream.
+  restart the gateway, switch the model, subscribe to the gateway event stream.
 - **`host.request`** — the gateway JSON-RPC door: sessions, config, skills,
   cron — everything the app itself calls.
 - **`ctx.rest` / `ctx.socket`** — your plugin's own backend namespace
@@ -375,6 +375,7 @@ host.onEvent(type, fn)                     // gateway event stream ('*' = all); 
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot
 host.restartGateway()                      // restart the backend gateway
+host.selectModel({ provider, model, sessionId? })  // switch model like the in-app picker
 host.request<T>(method, params?)           // gateway JSON-RPC — the real power
 ```
 
@@ -384,6 +385,26 @@ session lifecycle, tool activity). Listeners are isolated — a throw in your
 listener can't affect app dispatch. Every `host` door is async-safe: a sync throw
 from an internal helper (e.g. no desktop bridge in a plain browser) becomes a
 rejection your `.catch()` sees, never an error-boundary crash.
+
+### `host.selectModel({ provider, model, sessionId? })`
+
+Switches the model with the exact semantics of the in-app model picker.
+Resolves `Promise<boolean>` — `true` when the switch is accepted; `false`
+when the controller is unavailable or the controller rejects/rolls back
+the switch; unexpected handler exceptions reject the promise.
+
+- **Fresh draft (no live session):** updates the composer model/provider state,
+  which is what the next `session.create` ships. No config is written.
+- **Live session:** applies a session-scoped switch via the backend
+  (`config.set --session`). Mid-turn picks are deferred and applied at the next
+  turn start; a failed switch rolls the composer state back.
+- **`sessionId`** is the runtime session id. Omit it to target the active
+  session; pass one to target a specific session tile.
+- **Never writes the profile default** — that stays owned by Settings → Model.
+- Because the composer atoms are updated through the same controller action the
+  picker uses, a plugin-triggered switch is treated as an explicit user
+  selection, not runtime synchronization (and is unaffected by the composer
+  atom sync changes in PR #75518).
 
 ## Data layer — React Query + nanostores
 


### PR DESCRIPTION
## What does this PR do?

Desktop plugins can read the active model (`host.state.model`) but have no way to switch it. `host.request('config.set', ...)` only affects a live session — it cannot update the renderer's composer state for a fresh draft — and writing the profile default would mutate global config (that stays owned by Settings → Model). This widens the generic plugin surface with a curated `host.selectModel({ provider, model, sessionId? })` SDK action that forwards to the app's existing `selectModel` controller action — the single owner of picker semantics: composer atoms on a fresh draft, session-scoped `config.set` on a live session (deferred mid-turn, rolled back on failure), never the profile default.

The consumer is a user-installed disk plugin (provider-usage model badges — clicking a badge switches the active model/provider), external to this repo. Per the plugin doctrine in AGENTS.md ("if a plugin needs more, widen the generic plugin surface — never special-case it in core"), the SDK gets one generic verb; the plugin stays at the edge.

## Related Issue

No issue — the change has a concrete external consumer, so it is not speculative infrastructure (AGENTS.md's non-speculative exception). It is deliberately compatible with #75518 (stop syncing session runtime model/provider to composer atoms): `selectModel` is the explicit user-selection path that PR keeps writing the composer atoms; this verb reuses it and introduces no new runtime→composer sync. Different files — no merge conflict, no required order.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/sdk/index.ts` — new curated host action `host.selectModel` + `ModelSelection` type export
- `apps/desktop/src/app/contrib/actions-bridge.ts` — narrow module-level bridge mirroring the existing `sessionTileDelegate` pattern; controller action published from wiring, cleared on unmount
- `apps/desktop/src/app/contrib/wiring.tsx` — publishes `selectModel` via `useEffect` with cleanup (never during render)
- `apps/desktop/src/app/contrib/actions-bridge.test.ts` — 9 tests: forwarding, promise normalization (sync/async `void`, explicit `false`, sync throw → rejection), the public `host.selectModel` door, and unmount cleanup
- `website/docs/developer-guide/desktop-plugin-sdk.md` — documents action semantics (return contract, `sessionId`, fresh-draft vs live-session, deferred mid-turn, no profile-default mutation)

## How to Test

1. Load a disk plugin that calls `host.selectModel` (e.g. the provider-usage badge plugin) in Hermes Desktop.
2. **Fresh draft:** click a badge → the composer model pill updates; the next `session.create` ships it. No config is written.
3. **Live session:** click a badge → session-scoped `config.set` applies (deferred mid-turn if the agent is busy); a rejected switch rolls the composer state back and resolves `false`.
4. Confirm `host.selectModel` resolves `false` with no controller attached, and that Settings → Model (profile default) is never touched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (5 files, no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only TypeScript; the repo's change classifier routes TS changes to the desktop UI suite, which is the relevant gate here
- [x] I've added tests for my changes (9 bridge tests + existing 19 model-controls tests)
- [x] I've tested on my platform: macOS (desktop UI suite 372 files / 3240 tests passed; `check:lint` 0 errors across 3 tsconfigs; `scripts/check-windows-footguns.py` clean)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `desktop-plugin-sdk.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (follows the existing plugin-surface doctrine)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer JS only, no OS calls
