### PR TITLE
fix(kanban): silent-COMMIT race persists despite --verify-create (#76153)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1521,10 +1521,54 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
-    if getattr(args, "json", False):
-        print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
+
+    # Post-commit durability verification (#76153, #57967): the COMMIT
+    # happened inside create_task/write_txn, but the read above used the
+    # SAME connection that wrote the row. A row visible to the writer is
+    # not proof the commit is visible to other processes — under WAL
+    # page-count lag, a torn checkpoint, or a journal-mode fallback the
+    # row can be readable in the writer's own snapshot yet absent for
+    # every other reader (the "silent COMMIT" symptom: exit 0, "Created
+    # t_<hex>" printed, row never in kanban.db). Re-read from a FRESH
+    # connection; if the row is not durably visible, fail closed with a
+    # clear error instead of reporting success.
+    board_slug = kb.get_current_board()
+    db_path = kb.kanban_db_path()
+    try:
+        with kb.connect_closing() as verify_conn:
+            verified = kb.get_task(verify_conn, task_id)
+    except Exception as exc:
+        verified = None
+        verify_error = f"verification connection failed: {exc}"
     else:
-        print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+        verify_error = None
+    if verified is None:
+        print(
+            "kanban: ERROR: created task is not durably visible after COMMIT — "
+            "the row did not persist to the database.",
+            file=sys.stderr,
+        )
+        if verify_error:
+            print(f"kanban: {verify_error}", file=sys.stderr)
+        print(
+            f"kanban: board={board_slug} db={db_path}",
+            file=sys.stderr,
+        )
+        print(
+            "kanban: the task was NOT created; retry the create, or check "
+            "journal_mode / filesystem WAL support for the database above.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if getattr(args, "json", False):
+        payload = _task_to_dict(task)
+        payload["board"] = board_slug
+        payload["db_path"] = str(db_path)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        board_hint = f", board={board_slug}" if board_slug != kb.DEFAULT_BOARD else ""
+        print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'}{board_hint})")
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are
@@ -1537,6 +1581,11 @@ def _cmd_create(args: argparse.Namespace) -> int:
             running, message = _check_dispatcher_presence()
             if not running and message:
                 print(f"\n⚠  {message}", file=sys.stderr)
+        # Non-default boards keep their DB under <root>/kanban/boards/<slug>/;
+        # say where the row actually landed so external verifiers (sqlite3,
+        # wrapper scripts) check the right file instead of the default one.
+        if board_slug != kb.DEFAULT_BOARD:
+            print(f"  (board={board_slug}; db={db_path})", file=sys.stderr)
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -154,6 +154,117 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+def _create_args(**overrides):
+    """Build a minimal argparse.Namespace for ``_cmd_create``."""
+    import argparse
+
+    base = {
+        "workspace": "scratch",
+        "branch": None,
+        "max_runtime": None,
+        "max_retries": None,
+        "title": "durability test task",
+        "body": None,
+        "assignee": None,
+        "created_by": None,
+        "project": None,
+        "tenant": None,
+        "priority": 0,
+        "parent": [],
+        "triage": False,
+        "idempotency_key": None,
+        "skills": [],
+        "model_override": None,
+        "provider_override": None,
+        "goal_mode": False,
+        "goal_max_turns": None,
+        "initial_status": "running",
+        "json": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_cmd_create_fails_closed_when_row_not_durable(kanban_home, monkeypatch, capsys):
+    """#76153: a row visible to the writer's own connection but missing for a
+    FRESH connection (the silent-COMMIT symptom) must fail closed with a
+    non-zero exit and a clear message — never print ``Created`` + exit 0."""
+    real_get_task = kb.get_task
+    calls = {"n": 0}
+
+    def flaky_get_task(conn, task_id):
+        # First read (inside the write block, same connection) sees the row;
+        # the post-commit verification read (fresh connection) does not —
+        # exactly the "Created t_<hex> printed, row never in kanban.db" shape.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_get_task(conn, task_id)
+        return None
+
+    monkeypatch.setattr(kb, "get_task", flaky_get_task)
+
+    rc = kc._cmd_create(_create_args(title="silent commit check"))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Created" not in captured.out, captured.out
+    assert "not durably visible" in captured.err, captured.err
+
+
+def test_cmd_create_verifies_row_from_fresh_connection(kanban_home, capsys):
+    """Happy path: after create, the row must be readable from a brand-new
+    connection (proof the COMMIT is visible to other processes, not just the
+    writer)."""
+    rc = kc._cmd_create(_create_args(title="fresh-conn check"))
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "Created t_" in captured.out, captured.out
+    m = __import__("re").search(r"(t_[a-f0-9]+)", captured.out)
+    assert m
+    # The row is really there from a separate connection.
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, m.group(1)) is not None
+
+
+def test_cmd_create_non_default_board_reports_db_path(kanban_home, monkeypatch, capsys):
+    """#76153 reproduction: `HERMES_KANBAN_BOARD=operations` writes to the
+    board's own kanban.db, NOT the default `<root>/kanban.db`. The CLI must
+    surface which board/db the row landed in so external verifiers (sqlite3,
+    wrapper scripts) check the right file instead of reporting a phantom
+    silent-COMMIT."""
+    import sqlite3
+
+    from hermes_cli import kanban_db as kb
+
+    kb.create_board("operations")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "operations")
+
+    rc = kc._cmd_create(_create_args(title="board-scoped create", assignee="ashitaka"))
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "board=operations" in captured.out, captured.out
+    assert "db=" in captured.err, captured.err
+
+    # The row lives in the board's own DB — the default kanban.db has nothing.
+    board_db = kb.kanban_db_path()  # resolves via HERMES_KANBAN_BOARD -> operations
+    assert "boards" in str(board_db), board_db
+    m = __import__("re").search(r"(t_[a-f0-9]+)", captured.out)
+    assert m
+    with sqlite3.connect(board_db) as c:
+        rows = c.execute(
+            "SELECT id FROM tasks WHERE id=?", (m.group(1),)
+        ).fetchall()
+    assert rows, "row must be present in the board-scoped database"
+    default_db = kanban_home / "kanban.db"
+    with sqlite3.connect(default_db) as c:
+        rows = c.execute(
+            "SELECT id FROM tasks WHERE id=?", (m.group(1),)
+        ).fetchall()
+    assert not rows, "row must NOT be in the default kanban.db"
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #76153

## Summary

`hermes kanban create` could return exit 0 and print `Created t_<hex>` while the row never appears in the database the caller verifies. The issue's reproduction shows the exact shape: with `HERMES_KANBAN_BOARD=operations`, the CLI prints the card id, and `sqlite3 ~/.hermes/kanban.db` finds nothing.

## Root cause

Two compounding gaps, neither of which was the "COMMIT retry" race the original #57967 blamed:

1. **No cross-connection durability proof.** `_cmd_create` read the row back through the *same* connection that wrote it (`task = kb.get_task(conn, task_id)` inside the `with kb.connect_closing()` block). A row visible to the writer's own snapshot is not proof the COMMIT is visible to every other process (WAL page-count lag, torn checkpoint, journal-mode fallback). The fix for #57967 hardened `write_txn` (BUSY retry + post-commit file-length invariant) but never added a CLI-level verify of the committed row from a *fresh* connection — the `--verify-create` flag referenced in the issue does not exist in the codebase (confirmed: no such flag or `verify_create` path in source or history).

2. **Board-scoped DB is opaque to callers.** With `HERMES_KANBAN_BOARD=operations` (an existing board), the row lands in `<root>/kanban/boards/operations/kanban.db` — *not* the default `<root>/kanban.db`. The CLI never said which board/db it wrote to, so the reporter's external `sqlite3` check looked at the default DB and concluded "silent COMMIT" — a phantom failure. Reproduced locally: the row **is** present in the board's own DB.

## Change

`hermes_cli/kanban.py` `_cmd_create`:

- **Post-commit verify from a fresh connection** (fail-closed): after the write block closes (COMMIT durable), reopen a brand-new connection and re-read the task. If the row is not visible, exit 1 with a clear "not durably visible after COMMIT" message naming the board and DB path — never print `Created` + exit 0.
- **Board/DB transparency**: non-default boards now print `board=<slug>` inline and the resolved `db=<path>` to stderr; `--json` output gains `board` and `db_path` fields. External verifiers can check the right file.

## Verification

- New regression tests in `tests/hermes_cli/test_kanban_cli.py`:
  - `test_cmd_create_fails_closed_when_row_not_durable` — mocks the writer-sees/reader-doesn't split; asserts exit 1, no `Created` on stdout, clear stderr.
  - `test_cmd_create_verifies_row_from_fresh_connection` — happy path; row readable from a separate connection.
  - `test_cmd_create_non_default_board_reports_db_path` — reproduces the issue's `HERMES_KANBAN_BOARD=operations` scenario; asserts the row is in the board's own DB, not the default one, and the CLI reports board/db.
- Full targeted run: `test_kanban_cli.py` 6/6 pass; `test_kanban_db.py` + `test_kanban_write_txn_busy_retry.py` + `test_kanban_boards.py` 54/54 pass. The 7 failures seen when running the whole kanban glob are pre-existing test-interference failures present on unmodified `upstream/main` (verified via `git stash`), not caused by this change.
- `ruff check` clean on both modified files.
