### PR TITLE
feat(provider): add Agnes AI model provider plugin

### DIFF
--- a/plugins/model-providers/agnes/__init__.py
+++ b/plugins/model-providers/agnes/__init__.py
@@ -1,0 +1,16 @@
+"""Agnes AI provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+agnes = ProviderProfile(
+    name="agnes",
+    display_name="Agnes AI",
+    description="Agnes AI (agnes-2.0-flash)",
+    signup_url="https://agnes-ai.com",
+    env_vars=("AGNES_API_KEY", "AGNES_BASE_URL"),
+    base_url="https://apihub.agnes-ai.com/v1",
+    fallback_models=("agnes-2.0-flash",),
+)
+
+register_provider(agnes)

--- a/plugins/model-providers/agnes/plugin.yaml
+++ b/plugins/model-providers/agnes/plugin.yaml
@@ -1,0 +1,4 @@
+name: agnes-provider
+kind: model-provider
+version: 1.0.0
+description: Agnes AI provider (agnes-2.0-flash)


### PR DESCRIPTION
Register Agnes AI (agnes-2.0-flash) as a model provider plugin.

- `AGNES_API_KEY` / `AGNES_BASE_URL` env vars
- Base URL: `https://apihub.agnes-ai.com/v1`
- Fallback model: `agnes-2.0-flash`

Closes: N/A