### PR TITLE
test(kanban): lock the WAL exemption in the torn-extend invariant

### DIFF
--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -16,6 +16,7 @@ import pytest
 
 import hermes_state
 from hermes_cli import kanban_db as kb
+from hermes_cli.sqlite_safe_read import file_length_matches_header
 
 
 @pytest.fixture
@@ -1583,3 +1584,51 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Post-commit file-length invariant (torn-extend detector)
+# ---------------------------------------------------------------------------
+
+
+def test_write_txn_tolerates_wal_lagging_the_main_file(kanban_home):
+    """A committed page still sitting in the -wal is not a torn extend.
+
+    ``_check_file_length_invariant`` runs *after* COMMIT, so a false positive
+    here raises ``sqlite3.DatabaseError`` for a transaction that is already
+    durable -- and anything retrying on ``DatabaseError`` writes it twice.
+    Under WAL the main file lags its page count by design until a checkpoint,
+    which is the normal state of a busy board, so the invariant must not fire.
+
+    Reported from two platforms on #53819 (ext4/NVMe and APFS/NVMe), always
+    off by exactly one page with ``integrity_check`` clean. The WAL exemption
+    in ``_check_file_length_invariant`` is what prevents it; this locks it in.
+    """
+    conn = kb.connect()
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0].lower()
+        if mode != "wal":
+            pytest.skip(
+                f"runtime keeps journal_mode={mode} (WAL is withheld on SQLite "
+                f"{sqlite3.sqlite_version}); this false positive is WAL-only"
+            )
+        # Stop the -wal draining, so the main file stays behind its page count.
+        conn.execute("PRAGMA wal_autocheckpoint=0")
+
+        with kb.write_txn(conn) as c:
+            c.executemany(
+                "INSERT INTO task_events (task_id, kind, payload, created_at)"
+                " VALUES (?, ?, ?, ?)",
+                [("t_lag", "heartbeat", "x" * 2000, 0) for _ in range(400)],
+            )
+
+        # Guard the guard: if the write stops producing the lag, this test
+        # would keep passing while covering nothing.
+        assert file_length_matches_header(conn) is False, (
+            "expected the main file to lag its page count under WAL -- "
+            "without that lag this test no longer covers the false positive"
+        )
+        assert conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0] == 400
+    finally:
+        conn.close()


### PR DESCRIPTION
Test-only. Locks the WAL exemption in `_check_file_length_invariant` — the guard that stops the `torn-extend detected` false positive reported in #53819.

## Why

`_check_file_length_invariant()` (`hermes_cli/kanban_db_connect.py:1077`) runs **after** `COMMIT` in `write_txn` (called at `kanban_db_connect.py:1186`). A false positive there raises `sqlite3.DatabaseError` for a transaction that is already durable, and anything retrying on `DatabaseError` writes it twice.

Under WAL a just-committed page can still live in the `-wal`, so the main file legitimately lags its page count — the normal state of a busy board. The early return added with the lock-safe rewrite (`kanban_db_connect.py:1096`) is what keeps the invariant from firing there:

```python
if journal_mode == "wal":
    return
```

Nothing covered it. Removing those two lines leaves the whole suite green.

## Evidence the guard is load-bearing

With the early return deleted, this test fails with the exact message from the issue:

```
sqlite3.DatabaseError: torn-extend detected: the database file is shorter than
its header page count claims
```

Restored, it passes. So this is a red→green guard, not a change detector.

The scenario is deterministic and needs no storm, no concurrency and no corrupted file — `PRAGMA wal_autocheckpoint=0` pins committed pages in the `-wal`, and one bulk insert through the real `write_txn` path puts the main file behind its page count (4 KiB on disk vs 827 KiB of pages here).

## Notes on the test

- It goes through **`write_txn`**, the real caller, not the private helper — the post-commit position is the part that makes the false positive expensive.
- It forces `journal_mode=WAL` on its own temp board, so the branch is exercised even on runtimes where Hermes withholds WAL (this checkout links SQLite 3.50.4 and falls back to DELETE). If a runtime refuses WAL outright the test skips with the reason, since the false positive is WAL-only.
- It asserts the lag **actually happened** (`file_length_matches_header(conn) is False`). Without that, a future change that checkpoints eagerly would leave the test passing while covering nothing.

## One observation, not part of this PR

While constructing a companion test for the other arm — "a genuinely torn file under a rollback journal must still raise" — I could not get `_check_file_length_invariant` to raise at all. On a truncated DELETE-mode database SQLite fails `PRAGMA page_count` outright, so `page_count_bytes()` returns `None`, `file_length_matches_header()` returns `None`, and the `ok is False` branch is never reached. Reproduced on SQLite 3.50.4 and 3.53.3.

`test_file_length_check_never_reports_truncated_db_as_healthy` already documents the `None` behaviour at the helper level, so this may well be understood and intentional — SQLite detects the short file itself. I'm flagging it rather than asserting it, because if the raise is in fact unreachable then the comment above the call ("raise now rather than silently corrupt") describes something that can no longer happen. Happy to open a separate issue if that's worth pursuing.

## Verification

Rebased onto `245e480` and re-verified there. `_check_file_length_invariant` moved from `hermes_cli/kanban_db.py` to `hermes_cli/kanban_db_connect.py` since this branch was opened; the WAL exemption, the post-commit call site and the coverage gap all survived the move unchanged, and the test now uses `kanban_db_connect.connect` directly rather than the deprecated `kanban_db.connect` shim.

```
tests/hermes_cli/test_kanban_db.py
tests/test_sqlite_lock_safe_inspection.py
tests/hermes_cli/test_kanban_write_txn_busy_retry.py
42 passed, 1 skipped
```

Falsification, on the rebased tree: deleting `kanban_db_connect.py:1096-1097` makes `test_write_txn_tolerates_wal_lagging_the_main_file` fail at `kanban_db_connect.py:1098` with `sqlite3.DatabaseError: torn-extend detected: ...`; restoring the two lines returns it to green.

Refs #53819
