### PR TITLE
fix(weixin): clamp server-suggested long-poll timeout

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -85,6 +85,10 @@ EP_GET_BOT_QR = "ilink/bot/get_bot_qrcode"
 EP_GET_QR_STATUS = "ilink/bot/get_qrcode_status"
 
 LONG_POLL_TIMEOUT_MS = 35_000
+# Hard ceiling for server-suggested long-poll budgets (see
+# ``_apply_long_poll_timeout_hint``). Default boot value stays 35s; iLink may
+# ask for longer, but never for an unbounded hang.
+MAX_LONG_POLL_TIMEOUT_MS = 120_000
 API_TIMEOUT_MS = 15_000
 CONFIG_TIMEOUT_MS = 10_000
 QR_TIMEOUT_MS = 35_000
@@ -106,6 +110,20 @@ def _is_stale_session_ret(
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
     return (errmsg or "").lower() == "unknown error"
+
+
+def _apply_long_poll_timeout_hint(current_ms: int, suggested) -> int:
+    """Return the next long-poll wait budget for getUpdates.
+
+    iLink may return ``longpolling_timeout_ms`` after each poll. Trust
+    positive ints so the server can lengthen the wait, but clamp to
+    ``MAX_LONG_POLL_TIMEOUT_MS`` so a bad or malicious suggestion cannot
+    pin ``_poll_loop`` (and delay disconnect cancellation) for an
+    unbounded wall-clock hang via ``asyncio.wait_for``.
+    """
+    if isinstance(suggested, int) and suggested > 0:
+        return min(suggested, MAX_LONG_POLL_TIMEOUT_MS)
+    return current_ms
 
 
 MEDIA_IMAGE = 1
@@ -1365,9 +1383,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     sync_buf=sync_buf,
                     timeout_ms=timeout_ms,
                 )
-                suggested_timeout = response.get("longpolling_timeout_ms")
-                if isinstance(suggested_timeout, int) and suggested_timeout > 0:
-                    timeout_ms = suggested_timeout
+                timeout_ms = _apply_long_poll_timeout_hint(
+                    timeout_ms, response.get("longpolling_timeout_ms")
+                )
 
                 ret = response.get("ret", 0)
                 errcode = response.get("errcode", 0)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -646,6 +646,42 @@ class TestWeixinApiTimeout:
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
 
 
+class TestWeixinLongPollTimeoutClamp:
+    """Regression: iLink may return ``longpolling_timeout_ms`` after getUpdates.
+
+    The value feeds ``asyncio.wait_for`` for the next poll. Without a ceiling,
+    a huge positive suggestion pins the poll task (and delays disconnect)
+    for an unbounded wall-clock hang.
+    """
+
+    def test_huge_server_suggestion_is_clamped(self):
+        clamped = weixin._apply_long_poll_timeout_hint(
+            weixin.LONG_POLL_TIMEOUT_MS,
+            10**12,
+        )
+        assert clamped == weixin.MAX_LONG_POLL_TIMEOUT_MS
+        assert clamped < 10**12
+
+    def test_normal_server_suggestion_is_kept(self):
+        assert (
+            weixin._apply_long_poll_timeout_hint(weixin.LONG_POLL_TIMEOUT_MS, 35_000)
+            == 35_000
+        )
+
+    def test_non_positive_or_non_int_keeps_current(self):
+        current = weixin.LONG_POLL_TIMEOUT_MS
+        assert weixin._apply_long_poll_timeout_hint(current, 0) == current
+        assert weixin._apply_long_poll_timeout_hint(current, -5) == current
+        assert weixin._apply_long_poll_timeout_hint(current, None) == current
+        assert weixin._apply_long_poll_timeout_hint(current, "35000") == current
+        assert weixin._apply_long_poll_timeout_hint(current, 35_000.5) == current
+
+    def test_ceiling_constant_is_above_default(self):
+        # Server may legitimately ask for longer than the default boot value,
+        # but still within a sane upper bound.
+        assert weixin.MAX_LONG_POLL_TIMEOUT_MS >= weixin.LONG_POLL_TIMEOUT_MS
+
+
 class TestWeixinVoiceAlwaysDownloaded:
     """Regression tests for #27300: when WeChat (Weixin) returns a
     ``voice_item.text`` (Tencent Cloud's STT) we must still download


### PR DESCRIPTION
## What does this PR do?

After each Weixin/iLink `getUpdates` call, the server may return `longpolling_timeout_ms`. Hermes stores that value and uses it as the next `asyncio.wait_for` budget for the long-poll.

Previously any **positive int** was accepted with **no upper bound**. A huge or malicious suggestion (for example `10**12`) pins `_poll_loop` for an unbounded wall-clock wait and delays disconnect cancellation while the wait is in progress.

This PR keeps trusting legitimate server suggestions (including values above the 35s default boot timeout) but clamps them to `MAX_LONG_POLL_TIMEOUT_MS` (120s).

## Related Issue

No open issue tracked; found during a scoped security/hang audit of `gateway/platforms/weixin.py` (audit finding F006).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: add `MAX_LONG_POLL_TIMEOUT_MS` and `_apply_long_poll_timeout_hint()`; use it in `_poll_loop` instead of unbounded assignment
- `tests/gateway/test_weixin.py`: unit tests for clamp, normal keep, and non-positive / non-int keep-current behavior

## How to Test

1. Red/green unit path (no live Weixin needed):

```bash
pytest tests/gateway/test_weixin.py -k TestWeixinLongPollTimeoutClamp -q
```

2. Expected without the fix: `AttributeError` / missing clamp (or huge values accepted).
3. Expected with the fix: 4 tests pass; `10**12` clamps to `MAX_LONG_POLL_TIMEOUT_MS`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open clamp PR; related merged timeout work: #35117)
- [x] My PR contains only changes related to this fix
- [x] I've run the new tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation N/A (internal hang guard, no user-facing config)
- [x] config example N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform N/A (pure timeout math)
- [x] Tool schemas N/A

## Origin

Unbounded assignment was introduced with native Weixin support in `5b63bf7f9a` (2026-04-10, "feat(gateway): add native Weixin/WeChat support via iLink Bot API"). Later work (#35117) moved API waits onto `asyncio.wait_for` but did not cap the server-suggested long-poll budget.

## Related

- Merged: #35117 `fix(weixin): asyncio.wait_for timeout in _api_post/_api_get`
- Open task-tracking PRs (out of scope here): #65966, #26049