### PR TITLE
fix(desktop): remove session.new keybind hijacking typed N keys

### DIFF
--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -76,7 +76,11 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   { id: 'profile.create', category: 'profiles', defaults: [] },
 
   // ── Session ──────────────────────────────────────────────────────────────
-  { id: 'session.new', category: 'session', defaults: ['mod+n', 'shift+n'] },
+  // NOTE: both 'mod+n' and 'shift+n' were removed from session.new defaults
+  // (2026-08-01) — they hijacked normal typing (uppercase N) and accidental
+  // Ctrl+N presses, creating new sessions unexpectedly. New session is
+  // available via the sidebar button only.
+  { id: 'session.new', category: 'session', defaults: [] },
   { id: 'session.newTab', category: 'session', defaults: ['mod+t'] },
   { id: 'session.newWindow', category: 'session', defaults: ['mod+shift+n'] },
   // ⌃Tab / ⌃⇧Tab — the universal tab-cycle chord. Literally Control, not Cmd


### PR DESCRIPTION
Removes mod+n and shift+n from session.new defaults so typing uppercase N or using a Chinese IME does not accidentally create new sessions. New Session remains available via the sidebar button.