### PR TITLE
fix(discord): tear down voice before cancelling bot task to avoid 5s timeout (#76044)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1677,6 +1677,17 @@ class DiscordAdapter(BasePlatformAdapter):
         # Cancel the liveness probe first so it can't fire a spurious fatal
         # error / reconnect while we're intentionally tearing the adapter down.
         await self._cancel_liveness_task()
+        # Tear down voice connections BEFORE cancelling the bot task.
+        # VoiceClient.disconnect() sends a voice state update over the main
+        # gateway websocket and waits for the voice websocket to close.  If
+        # the bot task (which runs client.start() / the gateway loop) is
+        # cancelled first, the voice disconnect handshake has no transport
+        # and blocks until the caller's shutdown timeout fires (~5s delay).
+        for guild_id in list(self._voice_clients.keys()):
+            try:
+                await self.leave_voice_channel(guild_id)
+            except Exception as e:  # pragma: no cover - defensive logging
+                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
         # Cancel the bot task before closing the client.  If connect() timed out
         # and returned False, the background client.start() task may still be
         # running; calling client.close() alone is not enough to stop it because
@@ -1684,12 +1695,6 @@ class DiscordAdapter(BasePlatformAdapter):
         # WebSocket handshake is in flight.  Explicitly cancelling the task here
         # ensures the zombie client cannot receive or dispatch any further events.
         await self._cancel_bot_task()
-        # Clean up all active voice connections before closing the client
-        for guild_id in list(self._voice_clients.keys()):
-            try:
-                await self.leave_voice_channel(guild_id)
-            except Exception as e:  # pragma: no cover - defensive logging
-                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
 
         if self._client:
             try:


### PR DESCRIPTION
## Summary

Fixes #76044.

When the Discord bot is connected to a voice channel, every gateway shutdown loses ~5 seconds to the disconnect timeout. The voice disconnect never completes — it is abandoned by the timeout rather than finishing.

## Root Cause

Ordering bug in `DiscordAdapter.disconnect()`: the bot task was cancelled **before** voice clients were cleaned up. `VoiceClient.disconnect()` sends a voice state update over the **main gateway websocket** and waits for the voice websocket to close. The bot task IS the loop running that gateway connection (`client.start()`). Cancelling it first left the voice-disconnect handshake with no transport, so it blocked until the caller's 5s shutdown timeout fired.

## Changes

- **`plugins/platforms/discord/adapter.py`**: Moved voice connection cleanup to **before** `_cancel_bot_task()` in `disconnect()`. The voice teardown now completes in <1s because the gateway transport is still alive when needed.

## Testing

With voice connection open, shutdown now completes immediately instead of waiting 5s. Without voice connection, behavior is unchanged.
