### PR TITLE
feat: use OpenRouter's reported usage.cost for exact per-session cost

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -23,6 +23,7 @@ import random
 import re
 import ssl
 import time
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -81,13 +82,41 @@ from agent.retry_utils import (
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import CostResult, estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
+
+
+def _openrouter_reported_cost(response: Any) -> Optional[float]:
+    """Return the actual dollar cost OpenRouter reports for a response.
+
+    OpenRouter's chat/completions response includes ``usage.cost`` — the real
+    amount charged to the account (as opposed to an estimate derived from list
+    prices). Kilo Code / Cline read this field directly to show per-session
+    costs that match the OpenRouter dashboard. Preferring it over
+    estimate_usage_cost() makes the per-call accumulator match the bill even
+    when a request is routed to a provider (e.g. GMICloud) whose effective
+    rate differs from the model's published list price.
+
+    Returns None when unavailable (non-OpenRouter route, missing field).
+    """
+    try:
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return None
+        cost = getattr(usage, "cost", None)
+        if cost is None:
+            return None
+        cost = float(cost)
+        if cost != cost or cost < 0:  # NaN guard
+            return None
+        return cost
+    except (TypeError, ValueError, AttributeError):  # pragma: no cover - defensive
+        return None
 
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
@@ -3275,13 +3304,31 @@ def run_conversation(
                         _agg_cost_model = _agg_slot["model"]
                         _agg_cost_provider = _agg_slot.get("provider") or agent.provider
                         _agg_cost_base_url = _agg_slot.get("base_url") or agent.base_url
-                    cost_result = estimate_usage_cost(
-                        _agg_cost_model,
-                        aggregator_usage,
-                        provider=_agg_cost_provider,
-                        base_url=_agg_cost_base_url,
-                        api_key=getattr(agent, "api_key", ""),
+                    # Prefer the actual cost OpenRouter reports (usage.cost) —
+                    # the same field Kilo Code / Cline read so their session
+                    # costs match the dashboard. It is the real charged amount
+                    # and already accounts for dynamic provider routing; only
+                    # fall back to a list-price estimate when it's absent.
+                    _reported_cost = (
+                        _openrouter_reported_cost(response)
+                        if (agent.provider or "").strip().lower() == "openrouter"
+                        else None
                     )
+                    if _reported_cost is not None:
+                        cost_result = CostResult(
+                            amount_usd=Decimal(str(_reported_cost)),
+                            status="actual",
+                            source="provider_cost_api",
+                            label=f"${_reported_cost:.4f}",
+                        )
+                    else:
+                        cost_result = estimate_usage_cost(
+                            _agg_cost_model,
+                            aggregator_usage,
+                            provider=_agg_cost_provider,
+                            base_url=_agg_cost_base_url,
+                            api_key=getattr(agent, "api_key", ""),
+                        )
                     if cost_result.amount_usd is not None:
                         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
                     # Add MoA advisor cost (already priced per-advisor at each

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import random
 import re
 import ssl
 import time
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -89,13 +91,36 @@ from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
 from agent.turn_finalizer import finalize_turn
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import CostResult, estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
+
+
+def _openrouter_reported_cost(response: Any) -> Optional[float]:
+    """Return a finite, non-negative cost reported by OpenRouter."""
+    try:
+        usage = getattr(response, "usage", None)
+        cost = getattr(usage, "cost", None)
+        if cost is None:
+            return None
+        cost = float(cost)
+        if not math.isfinite(cost) or cost < 0:
+            return None
+        return cost
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _is_openrouter_billing_route(provider: Any, base_url: Any) -> bool:
+    """Identify OpenRouter after provider/MoA route resolution."""
+    return (
+        str(provider or "").strip().lower() == "openrouter"
+        or base_url_host_matches(str(base_url or ""), "openrouter.ai")
+    )
 
 
 # Scaffold marker used by _apply_active_turn_redirect and the ghost-row filter
@@ -160,7 +185,6 @@ _HANDOFF_SKIP_FINAL_RESPONSE = (
     "Context was compacted. The previous response is complete — "
     "awaiting your next message."
 )
-
 
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
@@ -3687,13 +3711,33 @@ def run_conversation(
                         _agg_cost_model = _agg_slot["model"]
                         _agg_cost_provider = _agg_slot.get("provider") or agent.provider
                         _agg_cost_base_url = _agg_slot.get("base_url") or agent.base_url
-                    cost_result = estimate_usage_cost(
-                        _agg_cost_model,
-                        aggregator_usage,
-                        provider=_agg_cost_provider,
-                        base_url=_agg_cost_base_url,
-                        api_key=getattr(agent, "api_key", ""),
+                    # Prefer the actual cost OpenRouter reports (usage.cost) —
+                    # the same field Kilo Code / Cline read so their session
+                    # costs match the dashboard. It is the real charged amount
+                    # and already accounts for dynamic provider routing; only
+                    # fall back to a list-price estimate when it's absent.
+                    _reported_cost = (
+                        _openrouter_reported_cost(response)
+                        if _is_openrouter_billing_route(
+                            _agg_cost_provider, _agg_cost_base_url
+                        )
+                        else None
                     )
+                    if _reported_cost is not None:
+                        cost_result = CostResult(
+                            amount_usd=Decimal(str(_reported_cost)),
+                            status="actual",
+                            source="provider_cost_api",
+                            label=f"${_reported_cost:.4f}",
+                        )
+                    else:
+                        cost_result = estimate_usage_cost(
+                            _agg_cost_model,
+                            aggregator_usage,
+                            provider=_agg_cost_provider,
+                            base_url=_agg_cost_base_url,
+                            api_key=getattr(agent, "api_key", ""),
+                        )
                     if cost_result.amount_usd is not None:
                         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
                     # Add MoA advisor cost (already priced per-advisor at each

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -103,6 +103,11 @@ class OpenRouterProfile(ProviderProfile):
         if prefs:
             body["provider"] = prefs
 
+        # Ask OpenRouter to include the actual charged amount in usage.cost.
+        # The conversation loop uses it for exact session accounting and falls
+        # back to list-price estimation when an endpoint omits it.
+        body["usage"] = {"include": True}
+
         # Pareto Code router — model-gated. The plugins block is only
         # meaningful for openrouter/pareto-code; sending it on any other
         # model has no documented effect and would be confusing in logs.

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -312,3 +312,25 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_openrouter_reported_cost_helper():
+    """_openrouter_reported_cost reads usage.cost and guards bad values."""
+    from agent.conversation_loop import _openrouter_reported_cost
+
+    # OpenRouter returns the real charged amount in usage.cost.
+    resp = SimpleNamespace(usage=SimpleNamespace(cost=0.0142))
+    assert _openrouter_reported_cost(resp) == 0.0142
+
+    # Missing field -> None (caller falls back to estimate).
+    resp_nocost = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=100))
+    assert _openrouter_reported_cost(resp_nocost) is None
+
+    # Non-numeric / NaN / negative -> None (defensive).
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost="oops"))) is None
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost=float("nan")))) is None
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost=-1))) is None
+
+    # No usage at all -> None.
+    assert _openrouter_reported_cost(SimpleNamespace(usage=None)) is None
+    assert _openrouter_reported_cost(SimpleNamespace()) is None

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -370,3 +370,24 @@ def test_normalize_usage_native_anthropic_no_cache_observability(caplog):
     assert result.input_tokens == 100
     assert result.cache_read_tokens == 50
     assert result.cache_write_tokens == 10
+def test_openrouter_reported_cost_helper():
+    """_openrouter_reported_cost reads usage.cost and guards bad values."""
+    from agent.conversation_loop import _openrouter_reported_cost
+
+    # OpenRouter returns the real charged amount in usage.cost.
+    resp = SimpleNamespace(usage=SimpleNamespace(cost=0.0142))
+    assert _openrouter_reported_cost(resp) == 0.0142
+
+    # Missing field -> None (caller falls back to estimate).
+    resp_nocost = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=100))
+    assert _openrouter_reported_cost(resp_nocost) is None
+
+    # Non-numeric / NaN / negative -> None (defensive).
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost="oops"))) is None
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost=float("nan")))) is None
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost=float("inf")))) is None
+    assert _openrouter_reported_cost(SimpleNamespace(usage=SimpleNamespace(cost=-1))) is None
+
+    # No usage at all -> None.
+    assert _openrouter_reported_cost(SimpleNamespace(usage=None)) is None
+    assert _openrouter_reported_cost(SimpleNamespace()) is None


### PR DESCRIPTION
## Summary

Hermes estimates per-session cost by multiplying token counts by the model's published `/models` list price. When OpenRouter routes a request to a provider whose effective rate differs from that list price (e.g. a GMICloud cache-read rate 10x DeepSeek's), the estimate diverges from the actual bill by ~4x.

Kilo Code / Cline avoid this by reading the **real charged amount** OpenRouter returns in every chat/completions response as `usage.cost`. This PR does the same.

## Changes

- Add `agent.conversation_loop._openrouter_reported_cost()` — defensively extracts `response.usage.cost`.
- In the per-call accumulator, prefer that actual cost for OpenRouter routes (`status='actual'`, `source='provider_cost_api'`), falling back to the list-price estimate only when absent. `session_estimated_cost_usd` now matches the OpenRouter dashboard even for fallback / MoA / provider-routed sessions.
- Guard rails: ignores missing, non-numeric, NaN, and negative values so the estimate fallback stays safe.

## Test Plan

- `tests/agent/test_usage_pricing.py` — helper guards for missing/non-numeric/NaN/negative/None usage.
- `tests/agent/test_moa_aggregator_cost_slot.py`, `tests/run_agent/test_moa_loop_mode.py` still pass (accumulator path).

Verified: 40 tests pass.

## Note

This is a companion to #75465 (status-bar `display.show_cost`). Split so the core-accounting change is independently reviewable/mergeable.