### PR TITLE
fix(moa,desktop): sticky route integrity + interim double-bubble

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1111,7 +1111,7 @@ def init_agent(
                 elif isinstance(effective_key, str) and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
     elif agent.provider == "moa":
-        from agent.moa_loop import build_moa_facade
+        from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
         agent.api_mode = "chat_completions"
 
         # build_moa_facade wires the reference relay that routes
@@ -1124,7 +1124,9 @@ def init_agent(
         # cache-safe — display-only events, they never touch the message
         # history. The factory is shared with the fallback-restore/recovery
         # paths so a restored facade keeps emitting these events (#53802).
-        agent.client = build_moa_facade(agent, agent.model)
+        preset = resolve_moa_preset_name(agent, agent.model)
+        agent.model = preset
+        agent.client = build_moa_facade(agent, preset)
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"
         agent.base_url = "moa://local"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1336,9 +1336,11 @@ def try_recover_primary_transport(
             # via _create_openai_client would raise "api_key client option
             # must be set". Recreate the facade through the shared factory so
             # the reference_callback relay survives recovery (#53802).
-            from agent.moa_loop import build_moa_facade
+            from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
-            agent.client = build_moa_facade(agent, agent.model)
+            preset = resolve_moa_preset_name(agent, getattr(agent, "model", None))
+            agent.model = preset
+            agent.client = build_moa_facade(agent, preset)
         else:
             agent.client = agent._create_openai_client(
                 dict(rt["client_kwargs"]),
@@ -1573,9 +1575,13 @@ def restore_primary_runtime(agent) -> bool:
             # shared factory so the restored facade keeps the reference_callback
             # relay wired at init — a bare MoAClient() would silently stop
             # emitting moa.reference/moa.aggregating display events (#53802).
-            from agent.moa_loop import build_moa_facade
+            from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
-            agent.client = build_moa_facade(agent, agent.model)
+            # Transport drift may leave provider=moa with a non-preset model id.
+            # Re-align sticky identity before rebuild.
+            preset = resolve_moa_preset_name(agent, getattr(agent, "model", None))
+            agent.model = preset
+            agent.client = build_moa_facade(agent, preset)
             agent._anthropic_client = None
         elif agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -2524,7 +2530,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
         # ── Build new client ──
         if (new_provider or "").strip().lower() == "moa":
-            from agent.moa_loop import build_moa_facade
+            from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
             # The MoA virtual provider speaks only chat.completions via the
             # MoAClient facade — the aggregator's real transport
@@ -2541,7 +2547,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
-            agent.client = build_moa_facade(agent, agent.model)
+            preset = resolve_moa_preset_name(agent, agent.model)
+            agent.model = preset
+            agent.client = build_moa_facade(agent, preset)
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1338,7 +1338,15 @@ def try_recover_primary_transport(
             # the reference_callback relay survives recovery (#53802).
             from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
-            preset = resolve_moa_preset_name(agent, getattr(agent, "model", None))
+            # Transient recovery rebuild: allow default realign only here.
+            preset = resolve_moa_preset_name(
+                agent,
+                getattr(agent, "model", None),
+                allow_default_realign=True,
+            )
+            # Intentional permanent adopt: the requested id is not a configured
+            # preset (transport drift / deleted config). There is nothing valid
+            # to restore *to*; sticky identity becomes the recovery default.
             agent.model = preset
             agent.client = build_moa_facade(agent, preset)
         else:
@@ -1579,7 +1587,15 @@ def restore_primary_runtime(agent) -> bool:
 
             # Transport drift may leave provider=moa with a non-preset model id.
             # Re-align sticky identity before rebuild.
-            preset = resolve_moa_preset_name(agent, getattr(agent, "model", None))
+            # Transient recovery rebuild: allow default realign only here.
+            preset = resolve_moa_preset_name(
+                agent,
+                getattr(agent, "model", None),
+                allow_default_realign=True,
+            )
+            # Intentional permanent adopt: the requested id is not a configured
+            # preset (transport drift / deleted config). There is nothing valid
+            # to restore *to*; sticky identity becomes the recovery default.
             agent.model = preset
             agent.client = build_moa_facade(agent, preset)
             agent._anthropic_client = None

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -882,7 +882,14 @@ def classify_api_error(
     from agent.errors import MoAPresetNotFoundError
 
     if isinstance(error, MoAPresetNotFoundError):
-        return _result(FailoverReason.model_not_found, retryable=False)
+        # Missing/renamed preset is deterministic config drift. Never fall
+        # back to a different standalone model — that is silent route
+        # replacement of the user's MoA selection.
+        return _result(
+            FailoverReason.model_not_found,
+            retryable=False,
+            should_fallback=False,
+        )
 
     # ── 3. Error code classification ────────────────────────────────
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -2286,20 +2286,27 @@ class MoAClient:
         )
 
 
-def resolve_moa_preset_name(agent, requested: Any = None) -> str:
+def resolve_moa_preset_name(
+    agent,
+    requested: Any = None,
+    *,
+    allow_default_realign: bool = False,
+) -> str:
     """Return a configured MoA preset name for agent construction.
 
     Prefer ``requested`` (or ``agent.model``) when it names a real preset.
-    On drift / missing name, return ``default_preset`` when that preset
-    exists — **without mutating** ``agent.model`` (callers decide whether to
-    adopt the resolved name). Always logs a warning on the fallback path so
-    sticky-route recovery is never silent. Raise
-    :class:`MoAPresetNotFoundError` only when no usable preset exists.
 
-    Construction call sites must use this *before* :func:`build_moa_facade`
-    so fail-closed facade lookup never sees a transport-drift model id.
-    Callers that need a hard miss (tests / explicit user errors) may still
-    pass a raw missing name straight to :func:`build_moa_facade`.
+    **Fail-closed by default:** a missing or unknown selected preset name
+    raises :class:`MoAPresetNotFoundError` so the facade's fail-closed
+    contract remains reachable (sticky route — no silent default swap).
+
+    **Recovery-only realign:** pass ``allow_default_realign=True`` only on
+    explicitly identified transient fallback / client-rebuild paths where
+    transport drift may leave ``provider=moa`` with a non-preset model id.
+    That path may return ``default_preset`` (with a warning + optional
+    status buffer) **without mutating** ``agent.model`` — callers adopt.
+
+    Construction call sites must use this *before* :func:`build_moa_facade`.
     """
     from agent.errors import MoAPresetNotFoundError
     from hermes_cli.config import load_config
@@ -2321,9 +2328,10 @@ def resolve_moa_preset_name(agent, requested: Any = None) -> str:
         return name
 
     default = str(moa_cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME).strip()
-    if default in presets:
+    if allow_default_realign and default in presets:
         logger.warning(
-            "MoA preset %r not configured; re-aligning construction to default preset %r",
+            "MoA preset %r not configured; recovery re-align to default preset %r "
+            "(allow_default_realign=True)",
             name or "(empty)",
             default,
         )
@@ -2331,7 +2339,7 @@ def resolve_moa_preset_name(agent, requested: Any = None) -> str:
             buffer_status = getattr(agent, "_buffer_status", None)
             if callable(buffer_status):
                 buffer_status(
-                    f"⚠️ MoA preset {name!r} not found; using default {default!r}."
+                    f"⚠️ MoA preset {name!r} not found; recovery using default {default!r}."
                 )
         except Exception:
             pass

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -2286,6 +2286,65 @@ class MoAClient:
         )
 
 
+def resolve_moa_preset_name(agent, requested: Any = None) -> str:
+    """Return a configured MoA preset name for agent construction.
+
+    Prefer ``requested`` (or ``agent.model``) when it names a real preset.
+    On drift / missing name, return ``default_preset`` when that preset
+    exists — **without mutating** ``agent.model`` (callers decide whether to
+    adopt the resolved name). Always logs a warning on the fallback path so
+    sticky-route recovery is never silent. Raise
+    :class:`MoAPresetNotFoundError` only when no usable preset exists.
+
+    Construction call sites must use this *before* :func:`build_moa_facade`
+    so fail-closed facade lookup never sees a transport-drift model id.
+    Callers that need a hard miss (tests / explicit user errors) may still
+    pass a raw missing name straight to :func:`build_moa_facade`.
+    """
+    from agent.errors import MoAPresetNotFoundError
+    from hermes_cli.config import load_config
+    from hermes_cli.moa_config import DEFAULT_MOA_PRESET_NAME, normalize_moa_config
+
+    try:
+        moa_cfg = normalize_moa_config(load_config().get("moa") or {})
+    except Exception as exc:
+        raise MoAPresetNotFoundError(
+            f"MoA preset could not be resolved ({type(exc).__name__}: {exc})."
+        ) from exc
+
+    presets = moa_cfg.get("presets") or {}
+    name = str(
+        requested if requested is not None else getattr(agent, "model", None) or ""
+    ).strip()
+
+    if name and name in presets:
+        return name
+
+    default = str(moa_cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME).strip()
+    if default in presets:
+        logger.warning(
+            "MoA preset %r not configured; re-aligning construction to default preset %r",
+            name or "(empty)",
+            default,
+        )
+        try:
+            buffer_status = getattr(agent, "_buffer_status", None)
+            if callable(buffer_status):
+                buffer_status(
+                    f"⚠️ MoA preset {name!r} not found; using default {default!r}."
+                )
+        except Exception:
+            pass
+        return default
+
+    available = ", ".join(sorted(presets)) or "(none)"
+    raise MoAPresetNotFoundError(
+        f"MoA preset '{name or '(empty)'}' was not found. "
+        f"Available presets: {available}. "
+        f"Run `hermes moa list` to inspect configured presets."
+    )
+
+
 def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
     """Build the MoA facade client for ``agent``, wiring the reference relay.
 
@@ -2363,17 +2422,36 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
     if resolved_preset is None and getattr(agent, "provider", None) == "moa":
         resolved_preset = getattr(agent, "model", None)
 
-    resolved_preset = str(resolved_preset or "default")
-    try:
-        from hermes_cli.config import load_config
-        from hermes_cli.moa_config import normalize_moa_config
+    resolved_preset = str(resolved_preset or "").strip()
+    from agent.errors import MoAPresetNotFoundError
+    from hermes_cli.config import load_config
+    from hermes_cli.moa_config import DEFAULT_MOA_PRESET_NAME, normalize_moa_config
 
+    try:
         moa_cfg = normalize_moa_config(load_config().get("moa") or {})
         presets = moa_cfg.get("presets") or {}
-        if resolved_preset not in presets:
-            resolved_preset = moa_cfg.get("default_preset") or "default"
-    except Exception:
-        resolved_preset = "default"
+    except Exception as exc:
+        raise MoAPresetNotFoundError(
+            f"MoA preset '{resolved_preset or '(empty)'}' could not be resolved "
+            f"({type(exc).__name__}: {exc})."
+        ) from exc
+
+    if not resolved_preset:
+        # Construction without a name may seed the factory default only.
+        resolved_preset = str(
+            moa_cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME
+        ).strip()
+    if resolved_preset not in presets:
+        # Fail closed: never silently run a different MoA route (or the
+        # factory default under a user's selected name). Callers that
+        # recover from transport drift must re-align agent.model to a
+        # real preset before invoking this factory.
+        available = ", ".join(sorted(presets)) or "(none)"
+        raise MoAPresetNotFoundError(
+            f"MoA preset '{resolved_preset}' was not found. "
+            f"Available presets: {available}. "
+            f"Run `hermes moa list` to inspect configured presets."
+        )
 
     return MoAClient(
         resolved_preset,

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -5,12 +5,12 @@ import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import {
+  getComposerModeSource,
   getComposerSelectionGeneration,
-  getCurrentModelSource,
   setAvailablePersonalities,
-  setCurrentFastMode,
+  setCurrentFastModeFromDefault,
   setCurrentPersonality,
-  setCurrentReasoningEffort,
+  setCurrentReasoningEffortFromDefault,
   setCurrentServiceTier,
   setDefaultReasoningEffort,
   setIntroPersonality
@@ -95,15 +95,20 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         // rendering/applying Hermes' built-in medium over the user's config.
         setDefaultReasoningEffort(reasoning)
 
-        const shouldSeedComposer =
-          !activeSessionIdRef.current &&
-          getComposerSelectionGeneration() === selectionGeneration &&
-          (force || getCurrentModelSource() !== 'manual')
+        // Seed effort/Fast independently of model ownership. A manual model
+        // pick must not unlock a config refresh to wipe an explicit Fast/effort
+        // choice — and a manual Fast must not be collapsed by a model-only seed.
+        const canSeedModes =
+          !activeSessionIdRef.current && getComposerSelectionGeneration() === selectionGeneration
 
-        if (shouldSeedComposer) {
-          setCurrentReasoningEffort(reasoning)
-          setCurrentFastMode(FAST_TIERS.has(tier.toLowerCase()))
+        if (canSeedModes && (force || getComposerModeSource('effort') !== 'manual')) {
+          setCurrentReasoningEffortFromDefault(reasoning)
         }
+
+        if (canSeedModes && (force || getComposerModeSource('fast') !== 'manual')) {
+          setCurrentFastModeFromDefault(FAST_TIERS.has(tier.toLowerCase()))
+        }
+
 
         setCurrentServiceTier(prev => (activeSessionIdRef.current ? prev : tier))
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -52,9 +52,9 @@ import {
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwdTransient,
-  setCurrentFastMode,
+  setCurrentFastModeTransient,
   setCurrentPersonality,
-  setCurrentReasoningEffort,
+  setCurrentReasoningEffortTransient,
   setCurrentServiceTier,
   setCurrentUsage,
   setMessages,
@@ -473,8 +473,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             setCurrentPersonality(normalizePersonalityValue(payload.personality))
           }
 
+          // Runtime paint only — session.info / heartbeats must not persist
+          // Fast/effort or mark provenance manual (teknium T2 / sticky).
           if (typeof payload?.reasoning_effort === 'string') {
-            setCurrentReasoningEffort(payload.reasoning_effort)
+            setCurrentReasoningEffortTransient(payload.reasoning_effort)
           }
 
           if (typeof payload?.service_tier === 'string') {
@@ -482,7 +484,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
 
           if (typeof payload?.fast === 'boolean') {
-            setCurrentFastMode(payload.fast)
+            setCurrentFastModeTransient(payload.fast)
           }
 
           if (typeof payload?.yolo === 'boolean') {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -602,6 +602,47 @@ export function useMessageStream({
 
         if (streamId && prev.some(m => m.id === streamId)) {
           nextMessages = prev.map(m => (m.id === streamId ? completeMessage(m) : m))
+
+          // Post-seal trailing deltas mint a NEW stream bubble after
+          // finalizeInterimAssistantMessage clears streamId. Completing onto
+          // that stream alone would leave the sealed interim beside the final
+          // (double bubble). When this turn sealed an interim, drop earlier
+          // sealed interim rows that the final continues/covers — same-turn
+          // continuity, not distinct pre-tool narration.
+          if (interimBoundaryPending && finalText) {
+            // Only the most recent sealed interim can be same-turn continuity
+            // with a post-seal stream bubble. Do not scan the whole thread —
+            // older multi-segment narration must stay (Claude peer R9).
+            const lastInterimIndex = (() => {
+              for (let i = nextMessages.length - 1; i >= 0; i -= 1) {
+                const message = nextMessages[i]
+
+                if (message.id === streamId) {
+                  continue
+                }
+
+                if (message.role === 'assistant' && !message.hidden && message.interim) {
+                  return i
+                }
+              }
+
+              return -1
+            })()
+
+            if (lastInterimIndex >= 0) {
+              const sealed = nextMessages[lastInterimIndex]
+              const sealedText = chatMessageText(sealed).trim()
+              const covered =
+                Boolean(sealedText) &&
+                (finalText === sealedText ||
+                  finalText.startsWith(sealedText) ||
+                  sealedText.startsWith(finalText))
+
+              if (covered || !sealedText) {
+                nextMessages = nextMessages.filter((_, index) => index !== lastInterimIndex)
+              }
+            }
+          }
         } else {
           const fallbackIndex = [...prev]
             .reverse()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -217,6 +217,40 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+
+  it('does not delete an earlier distinct interim when collapsing post-seal stream (R9 scope)', async () => {
+    await mountStream()
+    await start()
+
+    await interim('first narration segment')
+    await delta('The answer is 42.')
+    await interim('The answer is 42.')
+    await delta(' Verified.')
+    await complete('The answer is 42. Verified.')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('first narration segment')
+    expect(texts.filter(t => t === 'The answer is 42. Verified.')).toHaveLength(1)
+    expect(texts).toHaveLength(2)
+  })
+
+  it('collapses sealed interim + trailing post-seal deltas into one final bubble (R9 / double-bubble)', async () => {
+    await mountStream()
+    await start()
+
+    // Real double-bubble class: interim seals the stream (streamId cleared),
+    // then more deltas arrive before complete. Those mint a fresh stream
+    // bubble; complete must not leave BOTH the sealed interim and the final.
+    await delta('The answer is 42.')
+    await interim('The answer is 42.')
+    await delta(' Verified.')
+    await complete('The answer is 42. Verified.')
+
+    const texts = assistantMessages()
+    expect(texts).toHaveLength(1)
+    expect(texts[0]).toBe('The answer is 42. Verified.')
+  })
+
   it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -65,6 +65,24 @@ const complete = (text: string) =>
 const completePreviewed = (text: string) =>
   act(() => handleEvent!({ payload: { text, response_previewed: true }, session_id: SID, type: 'message.complete' }))
 
+const toolStart = (toolId = 'tool-1', name = 'terminal') =>
+  act(() =>
+    handleEvent!({
+      payload: { name, tool_id: toolId },
+      session_id: SID,
+      type: 'tool.start'
+    })
+  )
+
+const toolComplete = (toolId = 'tool-1', name = 'terminal') =>
+  act(() =>
+    handleEvent!({
+      payload: { name, tool_id: toolId },
+      session_id: SID,
+      type: 'tool.complete'
+    })
+  )
+
 function getState(): ClientSessionState {
   return sessionStates.get(SID) ?? createClientSessionState()
 }
@@ -200,6 +218,31 @@ describe('useMessageStream interim text sealing', () => {
 
     const texts = assistantMessages()
     expect(texts.filter(t => t === 'same reply')).toHaveLength(1)
+  })
+
+  it('settles identical final after real tool.start/tool.complete without double-bubble (JohnZhong #76191)', async () => {
+    await mountStream()
+    await start()
+
+    // Exact gateway sequence reported against main / older heads:
+    // message.start → message.interim → tool.start → tool.complete → message.complete
+    // The tool-reseed path must not mint a second assistant bubble for the same reply.
+    await interim('same reply')
+    await toolStart('tool-reseed-1', 'terminal')
+    await toolComplete('tool-reseed-1', 'terminal')
+    await complete('same reply')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t === 'same reply')).toHaveLength(1)
+
+    const assistants = getState().messages.filter(m => m.role === 'assistant' && !m.hidden)
+    const reply = assistants.find(m => chatMessageText(m) === 'same reply')
+    expect(reply).toBeTruthy()
+    // Tool events should have attached a tool-call part on the settled row.
+    const partTypes = (reply?.parts ?? []).map(part => part.type)
+    expect(partTypes).toContain('tool-call')
+    expect(partTypes).toContain('text')
+    expect(reply?.interim).not.toBe(true)
   })
 
   it('settles a prefix-extended final onto a non-previewed interim (streamed + trailing delta)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -6,7 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
-import { setCurrentModel, setCurrentProvider } from '@/store/session'
+import { writeKey } from '@/lib/storage'
+import {
+  $currentFastMode,
+  $currentReasoningEffort,
+  getComposerModeSource,
+  hasPersistedComposerFastMode,
+  setCurrentFastMode,
+  setCurrentModel,
+  setCurrentProvider,
+  setCurrentReasoningEffort,
+  snapshotPersistedComposerFastMode
+} from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -66,12 +77,29 @@ beforeEach(() => {
   queryClient = new QueryClient()
   setCurrentModel('')
   setCurrentProvider('')
+  writeKey('hermes.desktop.composer.fast', null)
+  writeKey('hermes.desktop.composer.fast-source', null)
+  writeKey('hermes.desktop.composer.reasoning-effort', null)
+  writeKey('hermes.desktop.composer.reasoning-effort-source', null)
+  setCurrentFastMode(false)
+  // clear durable after setting — leave absent for provenance tests
+  writeKey('hermes.desktop.composer.fast', null)
+  writeKey('hermes.desktop.composer.fast-source', null)
+  setCurrentReasoningEffort('')
+  writeKey('hermes.desktop.composer.reasoning-effort', null)
+  writeKey('hermes.desktop.composer.reasoning-effort-source', null)
+  $currentFastMode.set(false)
+  $currentReasoningEffort.set('')
 })
 
 afterEach(() => {
   cleanup()
   setCurrentModel('')
   setCurrentProvider('')
+  writeKey('hermes.desktop.composer.fast', null)
+  writeKey('hermes.desktop.composer.fast-source', null)
+  writeKey('hermes.desktop.composer.reasoning-effort', null)
+  writeKey('hermes.desktop.composer.reasoning-effort-source', null)
   vi.useRealTimers()
   vi.restoreAllMocks()
 })
@@ -156,3 +184,46 @@ describe('message.complete sidebar refresh coalescing', () => {
     expect(refreshSessions).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('session.info Fast/effort provenance (T2)', () => {
+  it('paints Fast/effort without persisting or marking manual', async () => {
+    await mountStream()
+
+    // Establish durable manual intent first.
+    setCurrentFastMode(true)
+    setCurrentReasoningEffort('high')
+    expect(hasPersistedComposerFastMode()).toBe(true)
+    expect(getComposerModeSource('fast')).toBe('manual')
+    expect(getComposerModeSource('effort')).toBe('manual')
+    expect(snapshotPersistedComposerFastMode()).toBe(true)
+
+    // Heartbeat / session.info runtime paint must not steal ownership.
+    sessionInfo(ACTIVE_SID, {
+      fast: false,
+      model: 'm1',
+      reasoning_effort: 'low',
+      running: true
+    })
+
+    expect($currentFastMode.get()).toBe(false)
+    expect($currentReasoningEffort.get()).toBe('low')
+    // Durable keys + provenance unchanged.
+    expect(snapshotPersistedComposerFastMode()).toBe(true)
+    expect(hasPersistedComposerFastMode()).toBe(true)
+    expect(getComposerModeSource('fast')).toBe('manual')
+    expect(getComposerModeSource('effort')).toBe('manual')
+  })
+
+  it('does not create Fast persistence from an absent baseline', async () => {
+    await mountStream()
+    expect(hasPersistedComposerFastMode()).toBe(false)
+
+    sessionInfo(ACTIVE_SID, { fast: true, model: 'm1', running: true })
+
+    expect($currentFastMode.get()).toBe(true)
+    expect(hasPersistedComposerFastMode()).toBe(false)
+    expect(snapshotPersistedComposerFastMode()).toBeNull()
+    expect(getComposerModeSource('fast')).not.toBe('manual')
+  })
+})
+

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -13,12 +13,12 @@ import {
   releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
   setCurrentBranch,
-  setCurrentCwdTransient,
-  setCurrentFastMode,
-  setCurrentModel,
+  setCurrentCwd,
+  setCurrentFastModeTransient,
+  setCurrentModelTransient,
   setCurrentPersonality,
-  setCurrentProvider,
-  setCurrentReasoningEffort,
+  setCurrentProviderTransient,
+  setCurrentReasoningEffortTransient,
   setCurrentServiceTier,
   setCurrentUsage,
   setSessions,
@@ -954,11 +954,11 @@ interface ApplyRuntimeInfoOptions {
  *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
   if (state.model !== undefined) {
-    setCurrentModel(state.model)
+    setCurrentModelTransient(state.model)
   }
 
   if (state.provider !== undefined) {
-    setCurrentProvider(state.provider)
+    setCurrentProviderTransient(state.provider)
   }
 
   if (state.cwd !== undefined) {
@@ -983,7 +983,7 @@ function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
   }
 
   if (state.reasoningEffort !== undefined) {
-    setCurrentReasoningEffort(state.reasoningEffort)
+    setCurrentReasoningEffortTransient(state.reasoningEffort)
   }
 
   if (state.serviceTier !== undefined) {
@@ -991,7 +991,7 @@ function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
   }
 
   if (state.fast !== undefined) {
-    setCurrentFastMode(state.fast)
+    setCurrentFastModeTransient(state.fast)
   }
 
   if (state.yolo !== undefined) {
@@ -1073,15 +1073,12 @@ export function applyRuntimeInfo(
   return sessionState
 }
 
-export function applyStoredSessionPreviewRuntimeInfo(
-  stored: { cwd?: null | string; model?: null | string } | undefined,
-  storedSessionId: null | string
-) {
-  setCurrentModel(stored?.model || '')
-  setCurrentProvider('')
-  setCurrentReasoningEffort('')
+export function applyStoredSessionPreviewRuntimeInfo(stored: { model?: null | string } | undefined) {
+  setCurrentModelTransient(stored?.model || '')
+  setCurrentProviderTransient('')
+  setCurrentReasoningEffortTransient('')
   setCurrentServiceTier('')
-  setCurrentFastMode(false)
+  setCurrentFastModeTransient(false)
   setYoloActive(false)
   setCurrentPersonality('')
 

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -11,11 +11,11 @@ import {
   $busy,
   $messages,
   setActiveSessionStoredIdRotation,
-  setCurrentFastMode,
-  setCurrentModel,
+  setCurrentFastModeTransient,
+  setCurrentModelTransient,
   setCurrentPersonality,
-  setCurrentProvider,
-  setCurrentReasoningEffort,
+  setCurrentProviderTransient,
+  setCurrentReasoningEffortTransient,
   setCurrentServiceTier,
   setTurnStartedAt,
   setYoloActive
@@ -36,11 +36,12 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
-  setCurrentReasoningEffort(state.reasoningEffort ?? '')
+  // Runtime paint only — must not overwrite durable future-chat intent.
+  setCurrentModelTransient(state.model ?? '')
+  setCurrentProviderTransient(state.provider ?? '')
+  setCurrentReasoningEffortTransient(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
-  setCurrentFastMode(state.fast ?? false)
+  setCurrentFastModeTransient(state.fast ?? false)
   setYoloActive(state.yolo ?? false)
   setCurrentPersonality(state.personality ?? '')
 }

--- a/apps/desktop/src/store/session-fast-tristate.test.ts
+++ b/apps/desktop/src/store/session-fast-tristate.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { readKey, writeKey } from '@/lib/storage'
+
+import {
+  $currentFastMode,
+  clearCurrentFastMode,
+  getComposerModeSource,
+  hasPersistedComposerFastMode,
+  setCurrentFastMode,
+  setCurrentFastModeFromDefault,
+  setCurrentFastModeTransient,
+  snapshotPersistedComposerFastMode
+} from './session'
+
+const FAST_KEY = 'hermes.desktop.composer.fast'
+const FAST_SOURCE_KEY = 'hermes.desktop.composer.fast-source'
+
+describe('composer Fast tri-state (absent ≠ false ≠ true)', () => {
+  beforeEach(() => {
+    writeKey(FAST_KEY, null)
+    writeKey(FAST_SOURCE_KEY, null)
+    $currentFastMode.set(false)
+  })
+
+  it('starts with absent durable Fast (no key)', () => {
+    expect(hasPersistedComposerFastMode()).toBe(false)
+    expect(snapshotPersistedComposerFastMode()).toBeNull()
+    expect(getComposerModeSource('fast')).toBe('')
+  })
+
+  it('manual true persists true and marks source manual', () => {
+    setCurrentFastMode(true)
+    expect($currentFastMode.get()).toBe(true)
+    expect(hasPersistedComposerFastMode()).toBe(true)
+    expect(snapshotPersistedComposerFastMode()).toBe(true)
+    expect(getComposerModeSource('fast')).toBe('manual')
+    expect(readKey(FAST_KEY)).toBe('true')
+  })
+
+  it('manual false is distinct from absent', () => {
+    setCurrentFastMode(false)
+    expect($currentFastMode.get()).toBe(false)
+    expect(hasPersistedComposerFastMode()).toBe(true)
+    expect(snapshotPersistedComposerFastMode()).toBe(false)
+    expect(getComposerModeSource('fast')).toBe('manual')
+    expect(readKey(FAST_KEY)).toBe('false')
+  })
+
+  it('clear returns to absent without leaving a false key', () => {
+    setCurrentFastMode(true)
+    clearCurrentFastMode()
+    expect(hasPersistedComposerFastMode()).toBe(false)
+    expect(snapshotPersistedComposerFastMode()).toBeNull()
+    expect(getComposerModeSource('fast')).toBe('')
+    expect(readKey(FAST_KEY)).toBeNull()
+  })
+
+  it('transient paint does not claim durable ownership', () => {
+    setCurrentFastMode(true)
+    expect(hasPersistedComposerFastMode()).toBe(true)
+
+    setCurrentFastModeTransient(false)
+    expect($currentFastMode.get()).toBe(false)
+    // Durable intent remains true under the key
+    expect(snapshotPersistedComposerFastMode()).toBe(true)
+    expect(getComposerModeSource('fast')).toBe('manual')
+  })
+
+  it('profile default seed does not mark Fast as manual', () => {
+    setCurrentFastModeFromDefault(true)
+    expect($currentFastMode.get()).toBe(true)
+    expect(hasPersistedComposerFastMode()).toBe(true)
+    expect(getComposerModeSource('fast')).toBe('default')
+  })
+
+  it('manual ownership blocks treating a later default as a wipe of explicit false', () => {
+    setCurrentFastMode(false)
+    // A later "default seed" path must check source !== manual before calling
+    // setCurrentFastModeFromDefault. Prove explicit false stays owned.
+    expect(getComposerModeSource('fast')).toBe('manual')
+    expect(snapshotPersistedComposerFastMode()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -10,6 +10,13 @@ import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 export type ComposerModelSource = '' | 'default' | 'manual'
+export type ComposerModeSource = '' | 'default' | 'manual'
+export type ComposerModeField = 'effort' | 'fast'
+
+export interface ComposerModeSources {
+  effort: ComposerModeSource
+  fast: ComposerModeSource
+}
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
@@ -22,7 +29,9 @@ const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
+const COMPOSER_EFFORT_SOURCE_KEY = 'hermes.desktop.composer.reasoning-effort-source'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
+const COMPOSER_FAST_SOURCE_KEY = 'hermes.desktop.composer.fast-source'
 
 // The last chat the user had open, so a relaunch lands back on it instead of an
 // empty new-chat. Stored (not runtime) id — the route is keyed by stored id.
@@ -620,13 +629,20 @@ export const setResumeExhaustedSessionId = (next: Updater<string | null>) => upd
 export const setBusy = (next: Updater<boolean>) => updateAtom($busy, next)
 export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($awaitingResponse, next)
 
+// Transient: paint focused-runtime metadata without claiming durable future-chat
+// intent. Durable setters persist + mark ownership so config refresh / delayed
+// runtime callbacks cannot silently replace a user selection (sticky route).
+export const setCurrentModelTransient = (next: Updater<string>) => updateAtom($currentModel, next)
+
 export const setCurrentModel = (next: Updater<string>) => {
-  updateAtom($currentModel, next)
+  setCurrentModelTransient(next)
   persistString(COMPOSER_MODEL_KEY, $currentModel.get() || null)
 }
 
+export const setCurrentProviderTransient = (next: Updater<string>) => updateAtom($currentProvider, next)
+
 export const setCurrentProvider = (next: Updater<string>) => {
-  updateAtom($currentProvider, next)
+  setCurrentProviderTransient(next)
   persistString(COMPOSER_PROVIDER_KEY, $currentProvider.get() || null)
 }
 
@@ -659,9 +675,57 @@ export const markComposerSelectionManual = (): void => {
   setCurrentModelSource('manual')
 }
 
-export const setCurrentReasoningEffort = (next: Updater<string>) => {
+const composerModeSourceKey: Record<ComposerModeField, string> = {
+  effort: COMPOSER_EFFORT_SOURCE_KEY,
+  fast: COMPOSER_FAST_SOURCE_KEY
+}
+
+const persistedComposerModeValueExists = (field: ComposerModeField): boolean =>
+  storedString(field === 'effort' ? COMPOSER_EFFORT_KEY : COMPOSER_FAST_KEY) !== null
+
+export const getComposerModeSource = (field: ComposerModeField): ComposerModeSource => {
+  const source = storedString(composerModeSourceKey[field])
+
+  if (source === 'default' || source === 'manual') {
+    return source
+  }
+
+  // Legacy builds persisted values without provenance. Preserve those as
+  // user-owned so a background config refresh cannot erase them.
+  return persistedComposerModeValueExists(field) ? 'manual' : ''
+}
+
+export const getComposerModeSources = (): ComposerModeSources => ({
+  effort: getComposerModeSource('effort'),
+  fast: getComposerModeSource('fast')
+})
+
+export const setComposerModeSource = (field: ComposerModeField, source: ComposerModeSource): void => {
+  persistString(composerModeSourceKey[field], source || null)
+}
+
+/** True when localStorage holds an explicit Fast override (true OR false).
+ *  Absent key means inherit / unset — distinct from explicit false. */
+export const hasPersistedComposerFastMode = (): boolean => storedString(COMPOSER_FAST_KEY) !== null
+
+/** Raw durable Fast: null = absent, true/false = explicit. */
+export const snapshotPersistedComposerFastMode = (): boolean | null => {
+  const raw = storedString(COMPOSER_FAST_KEY)
+
+  if (raw === null) {
+    return null
+  }
+
+  return raw === 'true'
+}
+
+export const setCurrentReasoningEffortTransient = (next: Updater<string>) =>
   updateAtom($currentReasoningEffort, next)
+
+export const setCurrentReasoningEffort = (next: Updater<string>) => {
+  setCurrentReasoningEffortTransient(next)
   persistString(COMPOSER_EFFORT_KEY, $currentReasoningEffort.get() || null)
+  setComposerModeSource('effort', 'manual')
 }
 
 // The profile's `agent.reasoning_effort`, mirrored from config so surfaces that
@@ -674,9 +738,32 @@ export const setDefaultReasoningEffort = (next: string) => updateAtom($defaultRe
 
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 
+export const setCurrentFastModeTransient = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
+
 export const setCurrentFastMode = (next: Updater<boolean>) => {
-  updateAtom($currentFastMode, next)
+  setCurrentFastModeTransient(next)
   persistBoolean(COMPOSER_FAST_KEY, $currentFastMode.get())
+  setComposerModeSource('fast', 'manual')
+}
+
+/** Profile/config default seed — durable paint with `default` provenance (not manual). */
+export const setCurrentFastModeFromDefault = (value: boolean): void => {
+  setCurrentFastModeTransient(value)
+  persistBoolean(COMPOSER_FAST_KEY, value)
+  setComposerModeSource('fast', 'default')
+}
+
+export const setCurrentReasoningEffortFromDefault = (value: string): void => {
+  setCurrentReasoningEffortTransient(value)
+  persistString(COMPOSER_EFFORT_KEY, value || null)
+  setComposerModeSource('effort', 'default')
+}
+
+/** Clear durable Fast override (absent). Runtime atom becomes false for wire. */
+export const clearCurrentFastMode = (): void => {
+  setCurrentFastModeTransient(false)
+  persistString(COMPOSER_FAST_KEY, null)
+  setComposerModeSource('fast', '')
 }
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)

--- a/cli.py
+++ b/cli.py
@@ -8410,6 +8410,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         model_config={
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
+                            "model": self.model,
+                            "provider": getattr(self, "provider", None),
+                            "base_url": getattr(self, "base_url", None) or None,
+                            "api_mode": getattr(self, "api_mode", None) or None,
                         },
                     )
                     self.agent._session_db_created = True

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -22,6 +22,36 @@ from rich.markup import escape as _escape
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
+    def _apply_session_route_from_meta(self, session_meta: dict | None) -> None:
+        """Re-apply sticky route identity stored on the session row before agent build.
+
+        Resume previously restored transcript + cwd only, so a MoA/standalone
+        selection made in that chat was silently replaced by the process-global
+        default. Apply opaque model/provider (and optional base_url/api_mode)
+        from the sessions row when present.
+        """
+        from hermes_cli.session_route import route_from_session_row
+
+        route = route_from_session_row(session_meta)
+        if not route:
+            return
+        model = route.get("model")
+        provider = route.get("provider")
+        if model:
+            self.model = model
+        if provider:
+            self.provider = provider
+            # Keep requested_provider aligned so runtime resolution does not
+            # second-guess the restored sticky identity.
+            if hasattr(self, "requested_provider"):
+                self.requested_provider = provider
+        base_url = route.get("base_url")
+        if base_url:
+            self.base_url = base_url
+        api_mode = route.get("api_mode")
+        if api_mode:
+            self.api_mode = api_mode
+
     def _ensure_runtime_credentials(self) -> bool:
         """
         Ensure runtime credentials are resolved before agent use.
@@ -446,6 +476,7 @@ class CLIAgentSetupMixin:
                     )
                 self._restore_session_cwd(session_meta, quiet=_quiet_mode)
                 self._restore_session_yolo(session_meta, quiet=_quiet_mode)
+                self._apply_session_route_from_meta(session_meta)
             else:
                 if _quiet_mode:
                     print(
@@ -456,6 +487,8 @@ class CLIAgentSetupMixin:
                     ChatConsole().print(
                         f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
                     )
+                # Empty-message resume still restores sticky route identity.
+                self._apply_session_route_from_meta(session_meta)
             # Re-open the session (clear ended_at so it's active again)
             try:
                 self._session_db._conn.execute(
@@ -716,12 +749,15 @@ class CLIAgentSetupMixin:
             )
             self._restore_session_cwd(session_meta)
             self._restore_session_yolo(session_meta)
+            self._apply_session_route_from_meta(session_meta)
         else:
             accent_color = _accent_hex()
             self._console_print(
                 f"[{accent_color}]Session {self.session_id} found but has no "
                 f"messages. Starting fresh.[/]"
             )
+            # Still restore sticky route when the row exists without messages.
+            self._apply_session_route_from_meta(session_meta)
             return False
 
         # Re-open the session (clear ended_at so it's active again)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1242,6 +1242,10 @@ class CLICommandsMixin:
                     "max_iterations": self.max_turns,
                     "reasoning_config": self.reasoning_config,
                     "_branched_from": parent_session_id,
+                    "model": self.model,
+                    "provider": getattr(self, "provider", None),
+                    "base_url": getattr(self, "base_url", None) or None,
+                    "api_mode": getattr(self, "api_mode", None) or None,
                 },
                 parent_session_id=parent_session_id,
             )

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -247,12 +247,14 @@ def _slot_problem(slot: Any) -> str | None:
 def validate_moa_payload(raw: Any) -> list[str]:
     """Return the problems ``normalize_moa_config`` would silently paper over.
 
-    ``normalize_moa_config`` is deliberately tolerant: at *read* time a
-    hand-edited config must degrade to defaults rather than crash the agent.
-    That same tolerance at *write* time is a corruption engine — a client that
-    sends a half-filled slot gets its whole preset silently replaced with the
-    hardcoded defaults (#64156). API write paths call this first and reject
-    invalid payloads loudly instead of saving something the user never chose.
+    ``normalize_moa_config`` is deliberately crash-safe at *read* time, but it
+    must not rewrite a *named user preset* into hardcoded factory defaults
+    (sticky-route corruption). Factory defaults apply only when seeding an
+    empty/missing MoA config. At *write* time, even that tolerance is a
+    corruption engine — a client that sends a half-filled slot must not get
+    its preset silently replaced with factory defaults (#64156). API write
+    paths call this first and reject invalid payloads loudly instead of
+    saving something the user never chose.
 
     Returns a list of human-readable problems; empty means safe to save.
     """
@@ -310,9 +312,20 @@ def _default_preset() -> dict[str, Any]:
     }
 
 
-def _normalize_preset(raw: Any) -> dict[str, Any]:
+def _normalize_preset(raw: Any, *, seed_factory_defaults: bool = False) -> dict[str, Any]:
+    """Normalize one MoA preset.
+
+    ``seed_factory_defaults=True`` is only for factory seed paths (empty MoA
+    config becoming the built-in ``default`` preset). Named user presets and
+    explicitly present empty/invalid slots must **not** be silently rewritten
+    into hardcoded factory GPT/product reference stacks — that is the sticky
+    route corruption class (read-time counterpart of #64156 write corruption).
+    """
     if not isinstance(raw, dict):
         raw = {}
+
+    refs_key_present = "reference_models" in raw
+    aggregator_key_present = "aggregator" in raw
 
     raw_refs = raw.get("reference_models")
     # reference_models may be a JSON string (hand-edited config.yaml) or a list.
@@ -322,16 +335,31 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         except (json.JSONDecodeError, ValueError):
             raw_refs = []
     if not isinstance(raw_refs, list):
-        # A hand-edited scalar / single mapping (or a bad type) must degrade to
-        # defaults instead of crashing the iteration, mirroring the tolerance
-        # for the scalar fields below (reference_temperature / max_tokens).
+        # A hand-edited scalar / single mapping (or a bad type) must not crash
+        # iteration. Mirror the tolerance for scalar fields below
+        # (reference_temperature / max_tokens) without inventing a different
+        # user's route identity.
         raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
     refs = [_clean_slot(item, include_enabled=True) for item in raw_refs]
     refs = [item for item in refs if item is not None]
     if not refs:
-        refs = _default_reference_models()
+        # Seed factory defaults only when building a brand-new factory preset
+        # from an absent reference_models key. An explicit empty list, wiped
+        # slots, or a named user preset stays empty (fail closed) rather than
+        # appearing as a healthy factory GPT stack under the user's name.
+        if seed_factory_defaults and not refs_key_present:
+            refs = _default_reference_models()
+        else:
+            refs = []
 
-    aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
+    cleaned_aggregator = _clean_slot(raw.get("aggregator"))
+    if cleaned_aggregator is not None:
+        aggregator = cleaned_aggregator
+    elif seed_factory_defaults and not aggregator_key_present:
+        aggregator = deepcopy(DEFAULT_MOA_AGGREGATOR)
+    else:
+        # Missing/invalid under user ownership: empty mapping, not factory ID.
+        aggregator = {}
 
     return {
         "enabled": _coerce_bool(raw.get("enabled"), True),
@@ -384,11 +412,18 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         for name, preset in presets_raw.items():
             clean_name = str(name or "").strip()
             if clean_name:
-                presets[clean_name] = _normalize_preset(preset)
+                # Named presets are user-owned route identity — never seed
+                # factory GPT/product defaults into them on read.
+                presets[clean_name] = _normalize_preset(
+                    preset, seed_factory_defaults=False
+                )
 
-    # Legacy flat config becomes the default preset.
+    # Legacy flat / empty config becomes the factory default preset only when
+    # no named presets exist. Seed factory defaults solely on that path.
     if not presets:
-        presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(raw)
+        presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(
+            raw, seed_factory_defaults=True
+        )
 
     default_name = str(raw.get("default_preset") or "").strip()
     if not default_name or default_name not in presets:

--- a/hermes_cli/session_route.py
+++ b/hermes_cli/session_route.py
@@ -1,0 +1,83 @@
+"""Session-row route identity helpers (CLI/TUI/Desktop sticky resume).
+
+Pure extraction of opaque provider+model (and optional endpoint knobs) from a
+``sessions`` table row so resume paths can re-apply the route the conversation
+actually used — without importing the TUI gateway server.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+def parse_model_config(raw: Any) -> dict[str, Any]:
+    """Return a dict model_config from JSON text, dict, or empty."""
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def route_from_session_row(row: Mapping[str, Any] | None) -> dict[str, str]:
+    """Extract sticky route fields from a SessionDB ``get_session`` row.
+
+    Returns only non-empty string fields among: model, provider, base_url,
+    api_mode. Never includes secrets. Missing/invalid rows yield {}.
+    """
+    if not isinstance(row, Mapping):
+        return {}
+
+    cfg = parse_model_config(row.get("model_config"))
+    model = str(row.get("model") or cfg.get("model") or "").strip()
+    provider = str(cfg.get("provider") or "").strip()
+    # billing_provider is a billing bucket, not always a routable identity
+    # (e.g. bare "custom"). Prefer explicit provider from model_config only.
+    base_url = str(cfg.get("base_url") or "").strip()
+    api_mode = str(cfg.get("api_mode") or "").strip()
+
+    out: dict[str, str] = {}
+    if model:
+        out["model"] = model
+    if provider and provider.lower() != "custom":
+        # bare "custom" is non-routable without entry identity; skip it so
+        # resume falls back to configured provider rather than OpenRouter.
+        out["provider"] = provider
+    elif provider.lower() == "custom" and base_url:
+        out["provider"] = "custom"
+    if base_url:
+        out["base_url"] = base_url
+    if api_mode:
+        out["api_mode"] = api_mode
+    return out
+
+
+def model_config_for_route(
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_mode: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a persistable model_config for create_session / update_session_meta."""
+    cfg: dict[str, Any] = dict(extra or {})
+    if model:
+        cfg["model"] = str(model).strip()
+    if provider:
+        cfg["provider"] = str(provider).strip()
+    if base_url:
+        cfg["base_url"] = str(base_url).strip()
+    elif "base_url" in cfg and not cfg.get("base_url"):
+        cfg.pop("base_url", None)
+    if api_mode:
+        cfg["api_mode"] = str(api_mode).strip()
+    elif "api_mode" in cfg and not cfg.get("api_mode"):
+        cfg.pop("api_mode", None)
+    return cfg

--- a/tests/hermes_cli/test_session_route_sticky.py
+++ b/tests/hermes_cli/test_session_route_sticky.py
@@ -1,0 +1,76 @@
+"""Sticky route identity from SessionDB rows (CLI resume / R5)."""
+
+from hermes_cli.session_route import model_config_for_route, route_from_session_row
+
+
+def test_route_from_session_row_reads_model_and_provider():
+    row = {
+        "model": "user-preset-alpha",
+        "model_config": {
+            "provider": "moa",
+            "model": "user-preset-alpha",
+            "api_mode": "chat_completions",
+        },
+    }
+    assert route_from_session_row(row) == {
+        "model": "user-preset-alpha",
+        "provider": "moa",
+        "api_mode": "chat_completions",
+    }
+
+
+def test_route_from_session_row_parses_json_model_config():
+    import json
+
+    row = {
+        "model": "opaque-model-a",
+        "model_config": json.dumps({"provider": "provider-alpha", "base_url": "https://example.test"}),
+    }
+    route = route_from_session_row(row)
+    assert route["model"] == "opaque-model-a"
+    assert route["provider"] == "provider-alpha"
+    assert route["base_url"] == "https://example.test"
+
+
+def test_route_from_session_row_skips_bare_custom_without_base_url():
+    row = {
+        "model": "opaque-model-a",
+        "model_config": {"provider": "custom"},
+    }
+    route = route_from_session_row(row)
+    assert route == {"model": "opaque-model-a"}
+
+
+def test_model_config_for_route_includes_provider():
+    cfg = model_config_for_route(
+        model="user-preset-alpha",
+        provider="moa",
+        extra={"max_iterations": 5},
+    )
+    assert cfg["model"] == "user-preset-alpha"
+    assert cfg["provider"] == "moa"
+    assert cfg["max_iterations"] == 5
+
+
+def test_apply_session_route_from_meta_sets_cli_fields():
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+    class _Stub(CLIAgentSetupMixin):
+        def __init__(self):
+            self.model = "global-default"
+            self.provider = "openrouter"
+            self.requested_provider = "openrouter"
+            self.base_url = ""
+            self.api_mode = ""
+
+    stub = _Stub()
+    stub._apply_session_route_from_meta(
+        {
+            "model": "user-preset-alpha",
+            "model_config": {"provider": "moa", "api_mode": "chat_completions"},
+        }
+    )
+    assert stub.model == "user-preset-alpha"
+    assert stub.provider == "moa"
+    assert stub.requested_provider == "moa"
+    assert stub.api_mode == "chat_completions"

--- a/tests/hermes_cli/test_sticky_route_moa_red.py
+++ b/tests/hermes_cli/test_sticky_route_moa_red.py
@@ -245,8 +245,37 @@ def test_moa_preset_not_found_never_triggers_provider_fallback():
     assert result.retryable is False
     assert result.should_fallback is False
 
-def test_resolve_moa_preset_name_realigns_drift_to_default(tmp_path, monkeypatch):
-    """Construction helper must re-align non-preset model ids under provider=moa."""
+def test_resolve_moa_preset_name_fails_closed_without_recovery_flag(tmp_path, monkeypatch):
+    """Missing selected preset must raise so facade fail-closed is reachable (T1)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "moa:\n"
+        "  default_preset: factory-default\n"
+        "  presets:\n"
+        "    factory-default:\n"
+        "      reference_models:\n"
+        "        - {provider: provider-alpha, model: opaque-a}\n"
+        "      aggregator: {provider: provider-beta, model: opaque-b}\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from types import SimpleNamespace
+
+    import pytest
+
+    from agent.errors import MoAPresetNotFoundError
+    from agent.moa_loop import resolve_moa_preset_name
+
+    agent = SimpleNamespace(provider="moa", model="deleted-user-preset", tool_progress_callback=None)
+    with pytest.raises(MoAPresetNotFoundError):
+        resolve_moa_preset_name(agent, agent.model)
+    # Default path must not mutate agent.model either.
+    assert agent.model == "deleted-user-preset"
+
+
+def test_resolve_moa_preset_name_realigns_only_when_recovery_flagged(tmp_path, monkeypatch):
+    """allow_default_realign=True is recovery-only (transport drift rebuild)."""
     home = tmp_path / ".hermes"
     home.mkdir()
     (home / "config.yaml").write_text(
@@ -265,7 +294,9 @@ def test_resolve_moa_preset_name_realigns_drift_to_default(tmp_path, monkeypatch
     from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
     agent = SimpleNamespace(provider="moa", model="deepseek-v4-flash", tool_progress_callback=None)
-    preset = resolve_moa_preset_name(agent, agent.model)
+    preset = resolve_moa_preset_name(
+        agent, agent.model, allow_default_realign=True
+    )
     assert preset == "factory-default"
     # Helper must not mutate agent.model; caller adopts.
     assert agent.model == "deepseek-v4-flash"

--- a/tests/hermes_cli/test_sticky_route_moa_red.py
+++ b/tests/hermes_cli/test_sticky_route_moa_red.py
@@ -1,0 +1,275 @@
+"""RED: sticky MoA route must not silently become factory GPT defaults.
+
+Product outcomes under test:
+1) Selected MoA preset identity (provider=moa + preset name) must survive
+   session override sanitize/persist.
+2) A *named user preset* whose slots are temporarily incomplete must not be
+   rewritten into factory DEFAULT_MOA_REFERENCE_MODELS (gpt-5.5) when the user
+   still owns that preset name — silent factory inject is the corruption class
+   described in moa_config.validate_moa_payload (#64156) extended to sticky
+   route selection.
+
+These tests document desired sticky behavior. On clean main some may FAIL (RED)
+until class fixes land. No Billy/daily-grok literals in production assertions
+beyond opaque fixture names.
+"""
+
+from __future__ import annotations
+
+from gateway.session import PERSISTABLE_MODEL_OVERRIDE_KEYS, sanitize_model_override
+from hermes_cli.moa_config import (
+    DEFAULT_MOA_REFERENCE_MODELS,
+    normalize_moa_config,
+    resolve_moa_preset,
+)
+
+
+def test_sanitize_keeps_moa_provider_and_opaque_preset_name():
+    """Session override for MoA is provider=moa + model=<preset name>."""
+    cleaned = sanitize_model_override(
+        {
+            "provider": "moa",
+            "model": "user-preset-alpha",
+            "api_key": "sk-should-never-persist",
+            "base_url": "",
+        }
+    )
+    assert cleaned == {"provider": "moa", "model": "user-preset-alpha"}
+
+
+def test_persistable_keys_are_documented_minimum_for_route_identity():
+    """Route identity needs at least provider+model; expand only with proof."""
+    assert "provider" in PERSISTABLE_MODEL_OVERRIDE_KEYS
+    assert "model" in PERSISTABLE_MODEL_OVERRIDE_KEYS
+    # Secrets must never be persistable via this path.
+    assert "api_key" not in PERSISTABLE_MODEL_OVERRIDE_KEYS
+
+
+def test_named_user_preset_empty_refs_must_not_silently_become_factory_gpt():
+    """Sticky integrity: named preset with empty refs must not look healthy.
+
+    Current main normalize_moa_config injects DEFAULT_MOA_REFERENCE_MODELS
+    (includes openai-codex/gpt-5.5) when cleaned refs are empty. For sticky
+    route product integrity, a *named user preset* should either:
+      - preserve last-known-good slots, or
+      - fail closed / mark invalid,
+    not silently present as a healthy preset whose refs are factory GPT.
+
+    RED until the class fix lands: assert factory GPT is NOT injected under
+    the user preset name.
+    """
+    factory_models = {(s["provider"], s["model"]) for s in DEFAULT_MOA_REFERENCE_MODELS}
+    assert ("openai-codex", "gpt-5.5") in factory_models  # fixture sanity on current main
+
+    raw = {
+        "default_preset": "user-preset-alpha",
+        "presets": {
+            "user-preset-alpha": {
+                "reference_models": [],  # incomplete / wiped
+                "aggregator": {
+                    "provider": "xai-oauth",
+                    "model": "grok-4.5",
+                },
+            }
+        },
+    }
+    cfg = normalize_moa_config(raw)
+    preset = resolve_moa_preset(cfg, "user-preset-alpha")
+    refs = preset.get("reference_models") or []
+    ref_pairs = {(r.get("provider"), r.get("model")) for r in refs if isinstance(r, dict)}
+
+    # Desired sticky behavior: do not silently substitute factory GPT stack.
+    assert ("openai-codex", "gpt-5.5") not in ref_pairs, (
+        "named user preset silently received factory GPT reference defaults — "
+        "this is the silent-route-corruption class"
+    )
+
+
+def test_standalone_override_survives_sanitize_without_secret_bleed():
+    cleaned = sanitize_model_override(
+        {
+            "provider": "xai-oauth",
+            "model": "grok-4.5",
+            "api_key": "sk-nope",
+            "api_mode": "chat",
+        }
+    )
+    assert cleaned == {"provider": "xai-oauth", "model": "grok-4.5"}
+    assert "api_key" not in (cleaned or {})
+
+
+def test_empty_moa_config_still_seeds_factory_default_preset():
+    """Factory empty config may still receive product seed defaults."""
+    cfg = normalize_moa_config({})
+    refs = cfg.get("reference_models") or []
+    pairs = {(r.get("provider"), r.get("model")) for r in refs}
+    # Seed path intentionally uses factory defaults — not a sticky bug.
+    assert ("openai-codex", "gpt-5.5") in pairs or len(pairs) >= 1
+    assert cfg.get("default_preset")
+
+
+def test_named_preset_keeps_valid_user_slots_without_factory_bleed():
+    """A healthy opaque preset must round-trip without factory GPT injection."""
+    raw = {
+        "default_preset": "user-preset-beta",
+        "presets": {
+            "user-preset-beta": {
+                "reference_models": [
+                    {"provider": "provider-alpha", "model": "opaque-model-a"},
+                ],
+                "aggregator": {
+                    "provider": "provider-beta",
+                    "model": "opaque-model-b",
+                },
+            }
+        },
+    }
+    cfg = normalize_moa_config(raw)
+    preset = resolve_moa_preset(cfg, "user-preset-beta")
+    refs = preset["reference_models"]
+    assert len(refs) == 1
+    assert refs[0]["provider"] == "provider-alpha"
+    assert refs[0]["model"] == "opaque-model-a"
+    assert preset["aggregator"]["provider"] == "provider-beta"
+    assert preset["aggregator"]["model"] == "opaque-model-b"
+    factory = {(s["provider"], s["model"]) for s in DEFAULT_MOA_REFERENCE_MODELS}
+    assert (refs[0]["provider"], refs[0]["model"]) not in factory
+
+
+def test_explicit_empty_reference_models_on_flat_seed_does_not_inject_gpt():
+    """Even the factory seed path must respect an explicit empty list."""
+    cfg = normalize_moa_config({"reference_models": [], "aggregator": {"provider": "provider-beta", "model": "opaque-model-b"}})
+    refs = cfg.get("reference_models") or []
+    pairs = {(r.get("provider"), r.get("model")) for r in refs if isinstance(r, dict)}
+    assert ("openai-codex", "gpt-5.5") not in pairs
+    assert pairs == set()
+    assert cfg["aggregator"]["provider"] == "provider-beta"
+
+
+def test_named_preset_invalid_ref_slots_do_not_become_factory_stack():
+    """Wiped/invalid slots under a named preset stay empty (fail closed)."""
+    raw = {
+        "default_preset": "user-preset-gamma",
+        "presets": {
+            "user-preset-gamma": {
+                "reference_models": [
+                    {"provider": "moa", "model": "recursive"},  # invalid recursive
+                    {"provider": "", "model": ""},
+                ],
+                "aggregator": {
+                    "provider": "provider-beta",
+                    "model": "opaque-model-b",
+                    "reasoning_effort": "Ultra",
+                },
+            }
+        },
+    }
+    cfg = normalize_moa_config(raw)
+    preset = resolve_moa_preset(cfg, "user-preset-gamma")
+    assert preset["reference_models"] == []
+    assert preset["aggregator"]["provider"] == "provider-beta"
+    assert preset["aggregator"]["model"] == "opaque-model-b"
+    # Product intent effort must survive clean when known on slot
+    assert preset["aggregator"].get("reasoning_effort") in (None, "Ultra", "ultra")
+
+
+def test_decode_moa_turn_does_not_seed_factory_into_empty_encoded_config():
+    from hermes_cli.moa_config import decode_moa_turn, encode_moa_turn
+
+    # Encode a healthy opaque preset, then decode — slots must match.
+    cfg = {
+        "default_preset": "user-preset-delta",
+        "presets": {
+            "user-preset-delta": {
+                "reference_models": [
+                    {"provider": "provider-alpha", "model": "opaque-model-a"},
+                ],
+                "aggregator": {"provider": "provider-beta", "model": "opaque-model-b"},
+            }
+        },
+    }
+    encoded = encode_moa_turn("hello", cfg, preset="user-preset-delta")
+    prompt, decoded = decode_moa_turn(encoded)
+    assert prompt == "hello"
+    assert decoded is not None
+    refs = decoded.get("reference_models") or []
+    assert len(refs) == 1
+    assert refs[0]["provider"] == "provider-alpha"
+    assert ("openai-codex", "gpt-5.5") not in {
+        (r.get("provider"), r.get("model")) for r in refs
+    }
+
+
+def test_build_moa_facade_missing_named_preset_fails_closed(tmp_path, monkeypatch):
+    """Selected MoA preset missing from config must not silently become default."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "moa:\n"
+        "  default_preset: factory-default\n"
+        "  presets:\n"
+        "    factory-default:\n"
+        "      reference_models:\n"
+        "        - {provider: provider-alpha, model: opaque-a}\n"
+        "      aggregator: {provider: provider-beta, model: opaque-b}\n"
+        "    user-preset-alive:\n"
+        "      reference_models:\n"
+        "        - {provider: provider-alpha, model: opaque-a}\n"
+        "      aggregator: {provider: provider-beta, model: opaque-b}\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from types import SimpleNamespace
+
+    import pytest
+
+    from agent.errors import MoAPresetNotFoundError
+    from agent.moa_loop import build_moa_facade
+
+    agent = SimpleNamespace(provider="moa", model="user-preset-missing", tool_progress_callback=None)
+    with pytest.raises(MoAPresetNotFoundError) as ei:
+        build_moa_facade(agent, "user-preset-missing")
+    assert "user-preset-missing" in str(ei.value)
+    assert "factory-default" not in str(ei.value).split("was not found")[0]
+
+
+def test_moa_preset_not_found_never_triggers_provider_fallback():
+    from agent.error_classifier import classify_api_error
+    from agent.errors import MoAPresetNotFoundError
+
+    result = classify_api_error(
+        MoAPresetNotFoundError("MoA preset 'gone' was not found"),
+        provider="moa",
+        model="gone",
+    )
+    assert result.retryable is False
+    assert result.should_fallback is False
+
+def test_resolve_moa_preset_name_realigns_drift_to_default(tmp_path, monkeypatch):
+    """Construction helper must re-align non-preset model ids under provider=moa."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "moa:\n"
+        "  default_preset: factory-default\n"
+        "  presets:\n"
+        "    factory-default:\n"
+        "      reference_models:\n"
+        "        - {provider: provider-alpha, model: opaque-a}\n"
+        "      aggregator: {provider: provider-beta, model: opaque-b}\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from types import SimpleNamespace
+
+    from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
+
+    agent = SimpleNamespace(provider="moa", model="deepseek-v4-flash", tool_progress_callback=None)
+    preset = resolve_moa_preset_name(agent, agent.model)
+    assert preset == "factory-default"
+    # Helper must not mutate agent.model; caller adopts.
+    assert agent.model == "deepseek-v4-flash"
+    agent.model = preset
+    client = build_moa_facade(agent, preset)
+    assert client.chat.completions.preset_name == "factory-default"
+

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -112,8 +112,14 @@ def test_build_moa_facade_ignores_fallback_model_name_when_restoring(monkeypatch
     with pytest.raises(MoAPresetNotFoundError):
         build_moa_facade(agent, agent.model)
 
-    # Construction/restore path uses the shared resolver (production contract).
-    preset = resolve_moa_preset_name(agent, agent.model)
+    # Default resolve must fail-closed for non-preset model ids (T1).
+    with pytest.raises(MoAPresetNotFoundError):
+        resolve_moa_preset_name(agent, agent.model)
+
+    # Recovery rebuild path may realign with the explicit flag.
+    preset = resolve_moa_preset_name(
+        agent, agent.model, allow_default_realign=True
+    )
     agent.model = preset
     client = build_moa_facade(agent, preset)
 

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -92,15 +92,15 @@ def test_create_streams_aggregator_when_requested(monkeypatch, tmp_path):
 
 def test_build_moa_facade_ignores_fallback_model_name_when_restoring(monkeypatch, tmp_path):
     """A fallback restore must not turn the temporary fallback model name into
-    a MoA preset. Sessions that drifted to e.g. deepseek-v4-flash previously
-    crashed on restore with MoAPresetNotFoundError because build_moa_facade()
-    reused agent.model as the preset (#MoA restore path).
+    a MoA preset. Callers re-align agent.model to a real preset before rebuild;
+    build_moa_facade itself fails closed on unknown names (sticky integrity).
     """
     home = tmp_path / ".hermes"
     _write_cfg(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    from agent.moa_loop import build_moa_facade
+    from agent.errors import MoAPresetNotFoundError
+    from agent.moa_loop import build_moa_facade, resolve_moa_preset_name
 
     agent = SimpleNamespace(
         provider="moa",
@@ -108,9 +108,18 @@ def test_build_moa_facade_ignores_fallback_model_name_when_restoring(monkeypatch
         tool_progress_callback=None,
     )
 
-    client = build_moa_facade(agent, None)
+    # Direct facade build with a non-preset model id must fail closed.
+    with pytest.raises(MoAPresetNotFoundError):
+        build_moa_facade(agent, agent.model)
+
+    # Construction/restore path uses the shared resolver (production contract).
+    preset = resolve_moa_preset_name(agent, agent.model)
+    agent.model = preset
+    client = build_moa_facade(agent, preset)
 
     assert client.chat.completions.preset_name == "review"
+    assert agent.model == "review"
+    assert preset == "review"
 
 
 def test_create_wraps_completed_aggregator_response_as_delta_chunk(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
Stops silent MoA/route identity loss and interim double-bubble rendering.

### Sticky route
- Named MoA presets no longer get factory GPT reference models injected on normalize (`seed_factory_defaults` only for empty factory seed).
- Missing MoA preset at the facade fails closed; construction uses `resolve_moa_preset_name` (warns on drift, does not mutate `agent.model`; callers adopt explicitly) at all agent-init/runtime rebuild sites.
- CLI resume restores provider+model from the session row; create/branch persist provider.
- Desktop: durable composer intent vs runtime paint (transient setters); Fast provenance so absent ≠ false ≠ true.

### Duplicate assistant text
- Sealed interim + post-seal trailing deltas collapse into one final bubble; only the most recent interim is considered so earlier narration is kept.

## Test plan
- [x] `pytest` sticky MoA RED + session_route + moa_config + moa streaming/loop (55)
- [x] vitest interim-sealing + Fast tri-state + hermes-config + session-state-cache (40)
- [ ] CI
- [ ] Manual: pick standalone route, restart twice
- [ ] Manual: pick MoA preset, restart twice; confirm not replaced by standalone GPT
- [ ] Manual: tool-call turn with interim + trailing delta → single final bubble

## Notes
- Intended MoA reference seats using GPT as private adviser while Grok aggregates is **not** a bug.
- Claude peer: PASS WITH RESERVATIONS on freeze v2; B3 silent re-align fixed before push.
- Head: `3a27afba0f86239375e536f22c29473744a182ad`

No secrets in this PR.
