### PR TITLE
fix(update): silence three scary-but-benign update log warnings

### DIFF
--- a/apps/bootstrap-installer/vite.config.ts
+++ b/apps/bootstrap-installer/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // Hermes Setup — Tauri-targeted Vite config.
 //
@@ -12,13 +13,16 @@ import path from 'node:path'
 // `clearScreen: false` is the Tauri convention — they spawn vite as a child
 // process and want our errors to stay visible.
 
+const configDir =
+  import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url))
+
 const host = process.env.TAURI_DEV_HOST
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(configDir, './src')
     }
   },
   clearScreen: false,

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,8 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
-import fs from 'fs'
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Vite's native config loader does not inject CJS ``__dirname``.
+const configDir =
+  import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url))
 
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
@@ -18,9 +23,9 @@ const real = (p: string): string | null => {
 const fsAllow = [
   ...new Set(
     [
-      path.resolve(__dirname, '../..'),
-      real(path.resolve(__dirname, 'node_modules')),
-      real(path.resolve(__dirname, '../../node_modules'))
+      path.resolve(configDir, '../..'),
+      real(path.resolve(configDir, 'node_modules')),
+      real(path.resolve(configDir, '../../node_modules'))
     ].filter((p): p is string => p !== null)
   )
 ]
@@ -33,16 +38,16 @@ const fsAllow = [
 // the perf harness opts a production build back in with VITE_PERF_PROBE=1.
 const debugEntry = (command: string, env: Record<string, string>) =>
   command === 'serve' || env.VITE_PERF_PROBE === '1'
-    ? path.resolve(__dirname, './src/debug/dev-only.ts')
-    : path.resolve(__dirname, './src/debug/dev-only.noop.ts')
+    ? path.resolve(configDir, './src/debug/dev-only.ts')
+    : path.resolve(configDir, './src/debug/dev-only.noop.ts')
 
 // The emoji picker (frimousse) fetches `<emojibaseUrl>/<locale>/data.json` at
 // runtime. Its default is a CDN; Electron must work offline, so serve the
 // bundled emojibase-data package at a stable local path instead — middleware
 // in dev, emitted assets in the build. Only the files a locale actually needs.
 const emojibaseDir =
-  real(path.resolve(__dirname, 'node_modules/emojibase-data')) ??
-  real(path.resolve(__dirname, '../../node_modules/emojibase-data'))
+  real(path.resolve(configDir, 'node_modules/emojibase-data')) ??
+  real(path.resolve(configDir, '../../node_modules/emojibase-data'))
 
 const EMOJIBASE_PATH = /^[a-z-]+\/(data|messages|shortcodes\/emojibase)\.json$/
 
@@ -143,14 +148,14 @@ export default defineConfig(({ command }) => ({
   resolve: {
     alias: {
       '@/debug/dev-only': debugEntry(command, process.env as Record<string, string>),
-      '@': path.resolve(__dirname, './src'),
-      '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
-      '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
-      '@hermes/shared': path.resolve(__dirname, '../shared/src'),
-      react: path.resolve(__dirname, '../../node_modules/react'),
-      'react-dom': path.resolve(__dirname, '../../node_modules/react-dom'),
-      'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
-      'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
+      '@': path.resolve(configDir, './src'),
+      '@hermes/plugin-sdk': path.resolve(configDir, './src/sdk/index.ts'),
+      '@hermes/shared/billing': path.resolve(configDir, '../shared/src/billing-types.ts'),
+      '@hermes/shared': path.resolve(configDir, '../shared/src'),
+      react: path.resolve(configDir, '../../node_modules/react'),
+      'react-dom': path.resolve(configDir, '../../node_modules/react-dom'),
+      'react/jsx-dev-runtime': path.resolve(configDir, '../../node_modules/react/jsx-dev-runtime.js'),
+      'react/jsx-runtime': path.resolve(configDir, '../../node_modules/react/jsx-runtime.js')
     },
     dedupe: ['react', 'react-dom']
   },

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -384,9 +384,28 @@ def update_managed_uv(
 
 
 def _venv_python(venv_dir: Path) -> Path:
-    from hermes_constants import venv_python_path
+    """Resolve the interpreter path inside *venv_dir*.
 
-    return venv_python_path(venv_dir, windows=platform.system() == "Windows")
+    Update-boundary safe: ``hermes update`` keeps the pre-pull process alive,
+    so ``hermes_constants`` may still be the old module object in
+    ``sys.modules`` when this runs (before
+    ``_reload_updated_runtime_modules``). If the helper is missing, reload
+    ``hermes_constants`` from disk once and retry — never hand-roll the
+    Scripts/bin layout here (see the open-coded-layout guard in tests).
+    """
+    windows = platform.system() == "Windows"
+    try:
+        from hermes_constants import venv_python_path
+
+        return venv_python_path(venv_dir, windows=windows)
+    except ImportError:
+        import importlib
+
+        import hermes_constants
+
+        importlib.invalidate_caches()
+        importlib.reload(hermes_constants)
+        return hermes_constants.venv_python_path(venv_dir, windows=windows)
 
 
 def _remove_tree(path: Path, *, boundary: Path) -> None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -57,6 +57,7 @@ def _m():
 
 _UPDATE_RUNTIME_RELOAD_MODULES = (
     "hermes_constants",
+    "hermes_cli.managed_uv",
     "tools.environments.local",
     "tools.lazy_deps",
 )
@@ -879,6 +880,9 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
     _m()._record_bytecode_fingerprint()
+    # Same update-boundary reload as the git path — ZIP replace also leaves
+    # the pre-extract process holding stale ``sys.modules`` entries.
+    _m()._reload_updated_runtime_modules()
 
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -3834,6 +3838,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # uv can retain the same CPython patch while python-build-standalone
             # refreshes the embedded SQLite underneath it. Keep the existing
             # update-boundary hook active on this retry path too.
+            # Reload first so a process that started on an older checkout
+            # (or holds a stale hermes_constants) doesn't trip the repair
+            # path on a missing symbol that already exists on disk.
+            _m()._reload_updated_runtime_modules()
             from hermes_cli.managed_uv import ensure_uv, update_managed_uv
 
             runtime_repairs = []
@@ -4031,6 +4039,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
+        # Refresh update-sensitive modules BEFORE managed-uv/runtime repair.
+        # ``update_managed_uv`` imports symbols (e.g. ``venv_python_path``)
+        # that may not exist on the pre-pull ``hermes_constants`` still
+        # parked in ``sys.modules`` — without this reload the repair path
+        # prints a scary "Managed Python runtime repair skipped" warning
+        # even though the live checkout is already current.
+        _m()._reload_updated_runtime_modules()
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "tests-js"
   ],
   "scripts": {
-    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
     "install:tui": "npm install --workspace ui-tui",

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -103,6 +103,12 @@ def test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol(mon
     assert callable(hermes_constants.apply_subprocess_home_env)
 
 
+def test_reload_updated_runtime_modules_includes_managed_uv():
+    """managed_uv must be in the reload set — freshly needed right after pull."""
+    assert "hermes_cli.managed_uv" in hermes_main._UPDATE_RUNTIME_RELOAD_MODULES
+    assert "hermes_constants" in hermes_main._UPDATE_RUNTIME_RELOAD_MODULES
+
+
 
 
 

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -157,6 +157,26 @@ def test_managed_uv_helper_delegates_to_the_shared_one():
     assert _venv_python(v) == venv_python_path(v)
 
 
+def test_managed_uv_helper_survives_stale_hermes_constants(monkeypatch):
+    """Update-boundary: pre-pull hermes_constants may lack venv_python_path.
+
+    ``hermes update`` keeps the old process alive; after pull, freshly
+    imported managed_uv can see a stale hermes_constants in sys.modules.
+    The helper must reload and still return a correct path (not raise).
+    """
+    import hermes_constants
+    from hermes_cli.managed_uv import _venv_python
+
+    monkeypatch.delattr(hermes_constants, "venv_python_path", raising=False)
+    assert not hasattr(hermes_constants, "venv_python_path")
+
+    v = Path("/opt/proj/venv")
+    result = _venv_python(v)
+    # Reload restored the symbol; result matches the shared helper.
+    assert callable(getattr(hermes_constants, "venv_python_path", None))
+    assert result == venv_python_path(v)
+
+
 def test_no_open_coded_venv_layout_remains_in_hermes_cli():
     """Fails if a new call site hand-rolls Scripts/bin again (#76105).
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import path from "path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Vite's native config loader does not inject CJS ``__dirname``. Prefer
+// ``import.meta.dirname`` (Node ≥ 20.11); fall back for older 20.x.
+const configDir =
+  import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
 const BACKEND = process.env.HERMES_DASHBOARD_URL ?? "http://127.0.0.1:9119";
 
@@ -61,8 +67,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), hermesDevToken()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(configDir, "./src"),
+      "@hermes/shared": path.resolve(configDir, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,12 +1,16 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import path from "path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configDir =
+  import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(configDir, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Fix update-boundary `ImportError` on `venv_python_path` that printed a scary "Managed Python runtime repair skipped" warning after pull (stale `hermes_constants` still in `sys.modules`). Reload update-sensitive modules before `update_managed_uv`, and make `_venv_python` reload+retry on ImportError.
- Remove the root `package.json` postinstall echo that produced repeated yellow npm notices pointing at outdated `python run_agent.py --help`.
- Replace CJS `__dirname` in Vite configs with `import.meta.dirname` so Vite's native configLoader no longer warns during the web UI build.

## Test plan
- [x] `pytest` targeted: stale-`hermes_constants` reload path, shared venv helper, open-coded layout guard, reload module set
- [x] `vite build` in `web/` — succeeds with no dirname/configLoader warning
- [ ] `hermes update` on a checkout that previously showed the three warnings — log should no longer include them on a clean run