### PR TITLE
fix: resolve passthrough env vars through secret scope under multiplexing

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1522,7 +1522,16 @@ class DockerEnvironment(BaseEnvironment):
         forward_keys = explicit_forward_keys | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
-            value = os.getenv(key)
+            # Under multiplexed profiles, resolve through the active secret
+            # scope so routed profiles get their own credentials (#76163).
+            try:
+                from agent.secret_scope import current_secret_scope, get_secret
+                if current_secret_scope() is not None:
+                    value = get_secret(key)
+                else:
+                    value = os.getenv(key)
+            except Exception:
+                value = os.getenv(key)
             if not value:
                 value = hermes_env.get(key)
             if value:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1235,6 +1235,21 @@ def _make_run_env(env: dict) -> dict:
             continue
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
+
+    # Under multiplexed profiles, resolve passthrough keys through the active
+    # secret scope so that routed profiles receive their own credentials
+    # instead of the default profile's os.environ values (#76163).
+    try:
+        from agent.secret_scope import current_secret_scope, get_secret
+        if current_secret_scope() is not None:
+            for k in list(run_env):
+                if _is_passthrough(k):
+                    scoped_val = get_secret(k)
+                    if scoped_val is not None:
+                        run_env[k] = scoped_val
+    except Exception:
+        pass
+
     path_key = _path_env_key(run_env)
     if path_key is not None:
         new_path = _append_missing_sane_path_entries(run_env.get(path_key, ""))


### PR DESCRIPTION
## Summary

Under `gateway.multiplex_profiles`, `terminal` and `execute_code` environments are built from `os.environ` directly, bypassing the active profile secret scope. This causes routed profiles to receive the **default profile's credentials** for any key configured via `terminal.env_passthrough`.

Since the default profile is typically the broadest, every narrower profile is silently promoted to its authority. The call succeeds with the wrong credentials, and nothing logs the mismatch — it fails **open**.

## Changes

- **`tools/environments/local.py::_make_run_env`**: After building the subprocess env, re-resolve passthrough keys through `get_secret()` when a profile secret scope is active.
- **`tools/environments/docker.py::_build_init_env_args`**: Same treatment for Docker forwarded env keys.

When no scope is installed (single-profile deployment), behavior is unchanged — `get_secret()` falls through to `os.environ` transparently.

## Test Plan

- [x] `tests/agent/test_secret_scope.py` — 12 passed
- [x] `tests/tools/test_local_env_blocklist.py` — 30 passed
- [x] `tests/tools/test_env_passthrough.py` — 24 passed
- [x] Syntax check on both modified files

Fixes #76163