### PR TITLE
fix(buzz): adopt channels joined during runtime

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -803,8 +803,8 @@ class BuzzAdapter(BasePlatformAdapter):
         subscribe to any new ones (fresh DMs dispatch from their beginning)."""
         self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
         before = set(self._channel_state)
-        await self._discover_dms(seed=False)
         await self._discover_joined_channels()
+        await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
             if channel_id in before:
                 continue
@@ -982,7 +982,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state:
+            if ch_id in self._channel_state or self._may_reclassify_as_dm(ch_id):
                 continue
             await self._seed_channel(ch_id, chat_type="group")
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -947,11 +947,8 @@ class BuzzAdapter(BasePlatformAdapter):
                     self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
                 self._channel_names.setdefault(dm_id, "DM")
 
-        code, out, err = await self._run_cli(["channels", "list"])
+        code, out, _err = await self._run_cli(["channels", "list"])
         if code != 0:
-            logger.debug(
-                "Buzz: could not discover newly joined channels — %s", _cli_error_message(err, code)
-            )
             return
         for ch in _parse_json_list(out):
             ch_id = str(ch.get("channel_id") or "")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -976,8 +976,11 @@ class BuzzAdapter(BasePlatformAdapter):
         """
         if self.channels:
             return
-        code, out, _err = await self._run_cli(["channels", "list"])
+        code, out, err = await self._run_cli(["channels", "list"])
         if code != 0:
+            logger.debug(
+                "Buzz: could not discover newly joined channels — %s", _cli_error_message(err, code)
+            )
             return
         for ch in _parse_json_list(out):
             ch_id = str(ch.get("channel_id") or "")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -947,8 +947,11 @@ class BuzzAdapter(BasePlatformAdapter):
                     self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
                 self._channel_names.setdefault(dm_id, "DM")
 
-        code, out, _err = await self._run_cli(["channels", "list"])
+        code, out, err = await self._run_cli(["channels", "list"])
         if code != 0:
+            logger.debug(
+                "Buzz: could not discover newly joined channels — %s", _cli_error_message(err, code)
+            )
             return
         for ch in _parse_json_list(out):
             ch_id = str(ch.get("channel_id") or "")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -804,6 +804,7 @@ class BuzzAdapter(BasePlatformAdapter):
         self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
         before = set(self._channel_state)
         await self._discover_dms(seed=False)
+        await self._discover_joined_channels(seed=True)
         for channel_id in self._channel_state:
             if channel_id in before:
                 continue
@@ -956,6 +957,30 @@ class BuzzAdapter(BasePlatformAdapter):
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
             if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+                continue
+            if seed:
+                await self._seed_channel(ch_id, chat_type="group")
+            else:
+                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+
+    async def _discover_joined_channels(self, *, seed: bool) -> None:
+        """Adopt community channels joined after startup when no watch list is pinned.
+
+        This is deliberately separate from the DM fallback: real channels must
+        never be reclassified as DMs merely because their membership changes.
+        """
+        if self.channels:
+            return
+        code, out, _err = await self._run_cli(["channels", "list"])
+        if code != 0:
+            return
+        for ch in _parse_json_list(out):
+            ch_id = str(ch.get("channel_id") or "")
+            if not ch_id:
+                continue
+            self._channel_meta[ch_id] = ch
+            self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
+            if ch_id in self._channel_state:
                 continue
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -804,7 +804,7 @@ class BuzzAdapter(BasePlatformAdapter):
         self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
         before = set(self._channel_state)
         await self._discover_dms(seed=False)
-        await self._discover_joined_channels(seed=True)
+        await self._discover_joined_channels()
         for channel_id in self._channel_state:
             if channel_id in before:
                 continue
@@ -963,11 +963,13 @@ class BuzzAdapter(BasePlatformAdapter):
             else:
                 self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
 
-    async def _discover_joined_channels(self, *, seed: bool) -> None:
-        """Adopt community channels joined after startup when no watch list is pinned.
+    async def _discover_joined_channels(self) -> None:
+        """Adopt newly joined community channels when no watch list is pinned.
 
-        This is deliberately separate from the DM fallback: real channels must
-        never be reclassified as DMs merely because their membership changes.
+        The initial high-water mark suppresses pre-membership history, matching
+        startup channel discovery. This is deliberately separate from the DM
+        fallback: real channels must never be reclassified as DMs merely
+        because their membership changes.
         """
         if self.channels:
             return
@@ -982,10 +984,7 @@ class BuzzAdapter(BasePlatformAdapter):
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
             if ch_id in self._channel_state:
                 continue
-            if seed:
-                await self._seed_channel(ch_id, chat_type="group")
-            else:
-                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+            await self._seed_channel(ch_id, chat_type="group")
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -9,6 +9,7 @@ lifecycle as wired into BuzzAdapter.
 import asyncio
 import json
 import time
+from collections import OrderedDict
 
 import pytest
 
@@ -119,3 +120,55 @@ async def test_websocket_auth_raises_on_rejection():
         await adapter._authenticate_websocket(RejectingWs())
 
 
+
+
+@pytest.mark.asyncio
+async def test_membership_event_adopts_new_named_channel_when_unpinned():
+    """A new community membership must subscribe without a gateway restart (#75107)."""
+    adapter = _make_adapter()
+    new_channel = "new-community-channel"
+
+    async def run_cli(args, **_kwargs):
+        if args == ["dms", "list"]:
+            return 0, "[]", ""
+        if args == ["channels", "list"]:
+            return 0, json.dumps([
+                {"channel_id": new_channel, "name": "release-team", "description": "Announcements"}
+            ]), ""
+        if args[:2] == ["messages", "get"]:
+            return 0, "[]", ""
+        raise AssertionError(f"unexpected CLI command: {args}")
+
+    class WebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, raw):
+            self.sent.append(json.loads(raw))
+
+    adapter._run_cli = run_cli
+    websocket = WebSocket()
+    subscriptions = {"membership": None}
+    await adapter._handle_membership_event(websocket, subscriptions, {"created_at": 42})
+
+    assert adapter._channel_state[new_channel]["chat_type"] == "group"
+    assert adapter._channel_state[new_channel]["last_ts"] == 0
+    assert any(channel_id == new_channel for channel_id in subscriptions.values())
+
+
+@pytest.mark.asyncio
+async def test_membership_event_does_not_adopt_channel_outside_explicit_watch_list():
+    adapter = _make_adapter({"channels": [CHANNEL]})
+
+    async def run_cli(args, **_kwargs):
+        if args == ["dms", "list"]:
+            return 0, "[]", ""
+        if args == ["channels", "list"]:
+            return 0, json.dumps([
+                {"channel_id": "not-configured", "name": "release-team", "description": "Announcements"}
+            ]), ""
+        raise AssertionError(f"unexpected CLI command: {args}")
+
+    adapter._run_cli = run_cli
+    await adapter._handle_membership_event(_FakeWebSocket(), {"membership": None}, {"created_at": 42})
+    assert "not-configured" not in adapter._channel_state

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -135,7 +135,7 @@ async def test_membership_event_adopts_new_named_channel_when_unpinned():
                 {"channel_id": new_channel, "name": "release-team", "description": "Announcements"}
             ]), ""
         if args[:2] == ["messages", "get"]:
-            return 0, "[]", ""
+            return 0, json.dumps([{"id": "pre-join", "created_at": 41}]), ""
         raise AssertionError(f"unexpected CLI command: {args}")
 
     class WebSocket:
@@ -150,9 +150,14 @@ async def test_membership_event_adopts_new_named_channel_when_unpinned():
     subscriptions = {"membership": None}
     await adapter._handle_membership_event(websocket, subscriptions, {"created_at": 42})
 
-    assert adapter._channel_state[new_channel]["chat_type"] == "group"
-    assert adapter._channel_state[new_channel]["last_ts"] == 0
-    assert any(channel_id == new_channel for channel_id in subscriptions.values())
+    state = adapter._channel_state[new_channel]
+    assert state["chat_type"] == "group"
+    assert state["last_ts"] == 41
+    assert "pre-join" in state["seen"]
+    subscription_id = next(key for key, value in subscriptions.items() if value == new_channel)
+    assert websocket.sent == [[
+        "REQ", subscription_id, {"kinds": [9], "#h": [new_channel], "since": 40}
+    ]]
 
 
 @pytest.mark.asyncio
@@ -171,3 +176,21 @@ async def test_membership_event_does_not_adopt_channel_outside_explicit_watch_li
     adapter._run_cli = run_cli
     await adapter._handle_membership_event(_FakeWebSocket(), {"membership": None}, {"created_at": 42})
     assert "not-configured" not in adapter._channel_state
+
+
+@pytest.mark.asyncio
+async def test_membership_event_leaves_state_unchanged_when_channel_lookup_fails():
+    adapter = _make_adapter()
+
+    async def run_cli(args, **_kwargs):
+        if args == ["dms", "list"]:
+            return 0, "[]", ""
+        if args == ["channels", "list"]:
+            return 1, "", "unavailable"
+        raise AssertionError(f"unexpected CLI command: {args}")
+
+    adapter._run_cli = run_cli
+    subscriptions = {"membership": None}
+    await adapter._handle_membership_event(_FakeWebSocket(), subscriptions, {"created_at": 42})
+    assert adapter._channel_state == {}
+    assert subscriptions == {"membership": None}

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -120,14 +120,16 @@ async def test_websocket_auth_raises_on_rejection():
 
 
 
-
 @pytest.mark.asyncio
 async def test_membership_event_adopts_new_named_channel_when_unpinned():
     """A new community membership must subscribe without a gateway restart (#75107)."""
     adapter = _make_adapter()
     new_channel = "new-community-channel"
 
+    messages_get_calls = 0
+
     async def run_cli(args, **_kwargs):
+        nonlocal messages_get_calls
         if args == ["dms", "list"]:
             return 0, "[]", ""
         if args == ["channels", "list"]:
@@ -135,6 +137,7 @@ async def test_membership_event_adopts_new_named_channel_when_unpinned():
                 {"channel_id": new_channel, "name": "release-team", "description": "Announcements"}
             ]), ""
         if args[:2] == ["messages", "get"]:
+            messages_get_calls += 1
             return 0, json.dumps([{"id": "pre-join", "created_at": 41}]), ""
         raise AssertionError(f"unexpected CLI command: {args}")
 
@@ -159,6 +162,9 @@ async def test_membership_event_adopts_new_named_channel_when_unpinned():
         "REQ", subscription_id, {"kinds": [9], "#h": [new_channel], "since": 40}
     ]]
 
+    await adapter._handle_membership_event(websocket, subscriptions, {"created_at": 43})
+    assert messages_get_calls == 1
+    assert len(websocket.sent) == 1
 
 @pytest.mark.asyncio
 async def test_membership_event_does_not_adopt_channel_outside_explicit_watch_list():
@@ -176,7 +182,6 @@ async def test_membership_event_does_not_adopt_channel_outside_explicit_watch_li
     adapter._run_cli = run_cli
     await adapter._handle_membership_event(_FakeWebSocket(), {"membership": None}, {"created_at": 42})
     assert "not-configured" not in adapter._channel_state
-
 
 @pytest.mark.asyncio
 async def test_membership_event_leaves_state_unchanged_when_channel_lookup_fails():

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -131,7 +131,7 @@ async def test_membership_event_adopts_new_named_channel_when_unpinned():
     async def run_cli(args, **_kwargs):
         nonlocal messages_get_calls
         if args == ["dms", "list"]:
-            return 0, "[]", ""
+            return 0, json.dumps([{"dm_id": new_channel}]), ""
         if args == ["channels", "list"]:
             return 0, json.dumps([
                 {"channel_id": new_channel, "name": "release-team", "description": "Announcements"}

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -9,7 +9,6 @@ lifecycle as wired into BuzzAdapter.
 import asyncio
 import json
 import time
-from collections import OrderedDict
 
 import pytest
 


### PR DESCRIPTION
Fixes #75107.

When `BUZZ_CHANNELS` is unset, a membership event now discovers newly joined named community channels, seeds their high-water mark, and subscribes to them without requiring a gateway restart. Explicit channel lists remain authoritative; DM-shaped fallback conversations continue through the existing DM path.

Verification:
- Red regression test committed first (`69d53af`).
- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py` — 30 passed.
- `uv run --extra dev --frozen ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_websocket.py` — passed.
- `git diff --check origin/main` — clean.
- `reviewer-claude-review diff origin/main --narrow` — no blockers.