### PR TITLE
fix(desktop): guard transcript reconciliation against duplicate message ids

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -6,6 +6,7 @@ import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { dedupeMessagesById, journalDuplicateMessages } from '@/lib/dedupe-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
@@ -143,7 +144,16 @@ function reconcileAuthoritativeMessages(
   const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
   const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
 
-  return preserveLocalAssistantErrors(withPendingTurn, previousMessages)
+  // Guard against duplicate message ids entering the renderer cache. A repeated
+  // id would render the same message twice (the 2026-07-31 "doubled but stored
+  // once" report). This collapses true repeats defensively and journals them in
+  // dev so a recurrence is observable, not a phantom.
+  const deduped = dedupeMessagesById(withPendingTurn)
+  if (deduped.removedAny) {
+    journalDuplicateMessages(deduped.removed, { source: 'reconcileAuthoritativeMessages' })
+  }
+
+  return preserveLocalAssistantErrors(deduped.messages, previousMessages)
 }
 
 // `session.create` params from the current profile + sticky-UI model/effort/fast,

--- a/apps/desktop/src/lib/dedupe-messages.test.ts
+++ b/apps/desktop/src/lib/dedupe-messages.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage, SessionMessage } from '@/lib/chat-messages'
+import { toChatMessages } from '@/lib/chat-messages'
+
+import { dedupeMessagesById, journalDuplicateMessages } from './dedupe-messages'
+
+/** A minimal raw backend row as the gateway/resume path would deliver it. */
+function rawRow(row_id: number, text: string, role: SessionMessage['role'] = 'assistant'): SessionMessage {
+  return { row_id, role, content: text, timestamp: 1754000000 + row_id }
+}
+
+/**
+ * The real failing mechanism the maintainer review called out: a backend that
+ * emits the SAME persisted row twice. `toChatMessages` stamps each with a
+ * DISTINCT ephemeral renderer id (timestamp+index+role), so a guard keyed on the
+ * renderer id would never fire. The durable identity is `row_id` — and that is
+ * what must be deduped. This test exercises the actual
+ * `SessionMessage -> toChatMessages -> dedupe` pipeline, not hand-faked ids.
+ */
+describe('dedupe via the real reconciliation pipeline', () => {
+  it('collapses two backend rows that share a row_id (distinct renderer ids)', () => {
+    const raw: SessionMessage[] = [
+      rawRow(10, 'first copy of message 10'),
+      rawRow(10, 'second copy of message 10'), // same persisted row, replayed
+      rawRow(11, 'message 11'),
+    ]
+
+    const chatMessages = toChatMessages(raw)
+    // Sanity: the two row_id=10 rows got DIFFERENT ephemeral renderer ids.
+    const rendererIds = chatMessages.map(m => m.id)
+    expect(new Set(rendererIds).size).toBe(rendererIds.length)
+
+    const result = dedupeMessagesById(chatMessages)
+
+    expect(result.removedAny).toBe(true)
+    expect(result.messages).toHaveLength(2)
+    expect(result.messages.map(m => m.rowId)).toEqual([10, 11])
+    // First-seen wins: the original content of row 10 is kept.
+    expect(chatMessageText(result.messages[0])).toContain('first copy')
+  })
+
+  it('keeps distinct row_ids and does not touch live rows without a row_id', () => {
+    const raw: SessionMessage[] = [
+      rawRow(20, 'a'),
+      rawRow(21, 'b'),
+      // A live/optimistic row has no row_id yet — must survive untouched.
+      { role: 'user', content: 'c', timestamp: 1754000099 },
+    ]
+
+    const result = dedupeMessagesById(toChatMessages(raw))
+
+    expect(result.removedAny).toBe(false)
+    expect(result.messages).toHaveLength(3)
+    expect(result.messages.map(m => m.rowId)).toEqual([20, 21, undefined])
+  })
+})
+
+describe('dedupeMessagesById (unit)', () => {
+  it('first-seen wins when two ChatMessages share a rowId', () => {
+    const input: ChatMessage[] = [
+      { id: 'r-1', rowId: 1, role: 'assistant', parts: [{ type: 'text', text: 'first' }] },
+      { id: 'r-2', rowId: 1, role: 'assistant', parts: [{ type: 'text', text: 'second' }] },
+      { id: 'r-3', rowId: 2, role: 'assistant', parts: [{ type: 'text', text: 'third' }] },
+    ]
+    const result = dedupeMessagesById(input)
+
+    expect(result.messages).toHaveLength(2)
+    expect(result.messages.map(m => m.rowId)).toEqual([1, 2])
+    expect(chatMessageText(result.messages[0])).toBe('first')
+  })
+
+  it('exempts rows without a durable key (live/optimistic)', () => {
+    const input: ChatMessage[] = [
+      { id: 'live-1', role: 'user', parts: [{ type: 'text', text: 'x' }] },
+      { id: 'live-2', role: 'user', parts: [{ type: 'text', text: 'y' }] },
+    ]
+    const result = dedupeMessagesById(input)
+
+    expect(result.removedAny).toBe(false)
+    expect(result.messages).toHaveLength(2)
+  })
+})
+
+describe('journalDuplicateMessages', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits a structured warning carrying the durable key + renderer id', () => {
+    dedupeMessagesById([
+      { id: 'r-1', rowId: 1, role: 'assistant', parts: [{ type: 'text', text: 'alpha' }] },
+      { id: 'r-2', rowId: 1, role: 'assistant', parts: [{ type: 'text', text: 'beta' }] },
+    ])
+
+    // journal is called by the caller; replicate the call shape here.
+    journalDuplicateMessages(
+      [{ durableKey: 1, rendererId: 'r-2', role: 'assistant', charLength: 4 }],
+      { source: 'reconcileAuthoritativeMessages', sessionId: 'sess-1' }
+    )
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    const [label, payload] = vi.mocked(console.warn).mock.calls[0]
+    expect(label).toBe('[transcript-dedup] duplicate durable message key(s) collapsed during merge')
+    expect(payload).toMatchObject({
+      source: 'reconcileAuthoritativeMessages',
+      sessionId: 'sess-1',
+      count: 1,
+      duplicates: [{ durableKey: 1, rendererId: 'r-2', role: 'assistant', charLength: 4 }],
+    })
+  })
+
+  it('is a no-op when there are no duplicates', () => {
+    journalDuplicateMessages([], { source: 'reconcileAuthoritativeMessages' })
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+})
+
+/** Local helper mirroring chatMessageText's plain-text extraction for assertions. */
+function chatMessageText(message: ChatMessage): string {
+  return message.parts
+    .map(part => (typeof part === 'object' && part !== null && 'text' in part ? (part as { text?: string }).text ?? '' : ''))
+    .join('')
+}

--- a/apps/desktop/src/lib/dedupe-messages.ts
+++ b/apps/desktop/src/lib/dedupe-messages.ts
@@ -1,0 +1,110 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+
+/**
+ * Transcript reconciliation must never inject a duplicate *persisted* message
+ * into the renderer cache. A backend that emits the same stored row twice
+ * (same `row_id` / numeric `id`) would otherwise render that message twice —
+ * the "message shows up doubled but the DB has it once" symptom reported
+ * 2026-07-31. The store has no dedup today, so this collapses any repeated
+ * durable identity defensively, then journals what it removed so a recurrence
+ * is observable instead of a phantom.
+ *
+ * KEY LAYER — read this before "fixing" the guard:
+ * The renderer's own `ChatMessage.id` is EPHEMERAL (derived from
+ * `timestamp + index + role` in `toChatMessages`). Two repeats of the same
+ * backend row get DIFFERENT renderer ids, so deduping on `ChatMessage.id`
+ * would NEVER fire. The durable identity is `row_id` (gateway resume) or the
+ * numeric `id` (REST transcript) — see `types/hermes.ts` and
+ * `chat-messages.ts:toChatMessages`. We dedupe on THAT.
+ *
+ * Rows with no durable identity (live/optimistic, still mid-stream) are
+ * exempt: they legitimately lack `rowId` and must never be collapsed.
+ */
+
+/** The durable backend identity for a row, or undefined if not yet persisted. */
+export function durableMessageKey(message: ChatMessage): number | undefined {
+  return message.rowId
+}
+
+export interface DedupeResult {
+  /** Messages with duplicate durable keys collapsed (first-seen wins). */
+  messages: ChatMessage[]
+  /** True when one or more duplicate durable keys were removed. */
+  removedAny: boolean
+  /** Per-duplicate detail, for journaling. */
+  removed: Array<{ durableKey: number; rendererId: string; role: string; charLength: number }>
+}
+
+/**
+ * Return a copy of `messages` with any repeated durable message key
+ * (`rowId`) collapsed to its FIRST occurrence. Stable order (first-seen
+ * position kept, later dup removed). First-seen wins: the repeat is the
+ * suspect, so it is discarded entirely (position + content).
+ *
+ * Rows without a durable key (live/optimistic) are never collapsed — they
+ * are unique per construction and must survive.
+ */
+export function dedupeMessagesById(messages: ChatMessage[]): DedupeResult {
+  const seen = new Set<number>()
+  const kept: ChatMessage[] = []
+  const removed: DedupeResult['removed'] = []
+
+  for (const message of messages) {
+    const key = durableMessageKey(message)
+    // No durable key → live/optimistic row; never collapse.
+    if (key === undefined) {
+      kept.push(message)
+      continue
+    }
+    if (seen.has(key)) {
+      removed.push({
+        durableKey: key,
+        rendererId: message.id,
+        role: message.role,
+        charLength: charLengthOf(message),
+      })
+      continue
+    }
+    seen.add(key)
+    kept.push(message)
+  }
+
+  return {
+    messages: kept,
+    removedAny: removed.length > 0,
+    removed,
+  }
+}
+
+/**
+ * Emit a structured, dev-only warning when duplicate durable message keys were
+ * found during a transcript merge. This is the evidence collector: in a dev
+ * build the duplicate is reported with enough context (durable key, renderer
+ * id, role, merge source) to file a reproduction-backed issue. No-op in
+ * production builds.
+ */
+export function journalDuplicateMessages(
+  removed: DedupeResult['removed'],
+  context: { source: string; sessionId?: string | null }
+): void {
+  if (!import.meta.env.DEV || removed.length === 0) {
+    return
+  }
+
+  console.warn('[transcript-dedup] duplicate durable message key(s) collapsed during merge', {
+    source: context.source,
+    sessionId: context.sessionId ?? null,
+    count: removed.length,
+    duplicates: removed,
+  })
+}
+
+function charLengthOf(message: ChatMessage): number {
+  let total = 0
+  for (const part of message.parts ?? []) {
+    if (typeof part === 'object' && part !== null && 'text' in part && typeof part.text === 'string') {
+      total += part.text.length
+    }
+  }
+  return total
+}


### PR DESCRIPTION
## Summary
A backend that emits the same persisted message twice (row_id repeated) would render that message twice in the desktop transcript. This adds a defensive guard at the single funnel all transcript-merge paths (resume / prefetch / activation / fallback / reconnect) flow through, deduplicating on the DURABLE message identity — not the ephemeral renderer id.

## Correction vs the first revision (per sweeper review)
The initial guard keyed on ChatMessage.id, which is **ephemeral** (derived from timestamp+index+role in toChatMessages). Two repeats of the same backend row get *different* renderer ids, so that guard would never fire. Fixed:
- Dedupe on the **durable** key (row_id / numeric id) — the identity that is actually equal when a row is replayed. See types/hermes.ts:553-562 and chat-messages.ts:1073.
- Rows without a durable key (live/optimistic, not yet persisted) are **exempt** — they legitimately lack rowId and must never be collapsed.
- Aligned the helper doc with the selected **first-seen-wins** policy.

## Test uses the REAL pipeline (reviewer's #2)
apps/desktop/src/lib/dedupe-messages.test.ts no longer hand-fakes ChatMessage ids. The headline case builds raw SessionMessages that share a row_id, runs them through toChatMessages() (where the durable key is set), then dedupeMessagesById(), and asserts:
- the two row_id=10 rows produced **distinct** renderer ids (proving the old guard was blind), and
- the duplicate row_id is collapsed (first-seen wins, original content kept).

This reproduces the actual reported mechanism, not a synthetic one.

## Changes
- apps/desktop/src/lib/dedupe-messages.ts (new) — dedupeMessagesById() keyed on rowId (durable), journalDuplicateMessages() dev-only console.warn (id/role/source; no-op in prod).
- apps/desktop/src/app/session/hooks/use-session-actions/index.ts — wired into reconcileAuthoritativeMessages.
- apps/desktop/src/lib/dedupe-messages.test.ts (new) — 6 vitest cases through the real pipeline.

## Verification
- npx vitest run src/lib/dedupe-messages.test.ts -> 6/6 pass (incl. real-pipeline duplicate collapse).
- Full tsc typecheck + lint + test gated on the CI check workflow.

## Note on the reported symptom
The 2026-07-31 report was a *screen* double with a **clean DB** (one stored row), so it may have been a pure render-path double rather than a duplicate row_id. This PR hardens the duplicate-row_id class (the structurally-correct layer). A separate render-path guard is the follow-up if it recurs.

Generated with Hermes (https://hermes-agent.nousresearch.com)
