### PR TITLE
fix(state): keep the pinned "keep" flag when importing sessions

### DIFF
--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -514,6 +514,13 @@ class SessionPortabilityMixin:
                 if started_at is None:
                     started_at = time.time()
                 archived = 1 if raw.get("archived") else 0
+                # ``pinned`` is a durable user decision ("keep this session"),
+                # not live runtime state — the same class as ``archived``, which
+                # this import already restores. Dropping it meant a restored
+                # backup came back unpinned and the sessions.auto_archive stale
+                # sweep, which exists to honour the flag, then swept exactly the
+                # sessions the user marked keep.
+                pinned = 1 if raw.get("pinned") else 0
 
                 conn.execute(
                     """INSERT INTO sessions (
@@ -524,7 +531,7 @@ class SessionPortabilityMixin:
                            cwd, git_branch, git_repo_root,
                            billing_provider, billing_base_url, billing_mode,
                            estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
-                           pricing_version, title, api_call_count, archived
+                           pricing_version, title, api_call_count, archived, pinned
                        )
                        VALUES (
                            :id, :source, :user_id, :model, :model_config,
@@ -535,7 +542,7 @@ class SessionPortabilityMixin:
                            :billing_provider, :billing_base_url, :billing_mode,
                            :estimated_cost_usd, :actual_cost_usd, :cost_status,
                            :cost_source, :pricing_version, :title,
-                           :api_call_count, :archived
+                           :api_call_count, :archived, :pinned
                        )""",
                     {
                         "id": session_id,
@@ -576,6 +583,7 @@ class SessionPortabilityMixin:
                         "title": raw.get("title"),
                         "api_call_count": self._int_or_default(raw.get("api_call_count")),
                         "archived": archived,
+                        "pinned": pinned,
                     },
                 )
 

--- a/tests/hermes_state/test_session_import_pinned_roundtrip.py
+++ b/tests/hermes_state/test_session_import_pinned_roundtrip.py
@@ -1,0 +1,90 @@
+"""A restored session keeps the user's durable "keep" flag.
+
+``set_session_pinned``'s contract: *"pinned is a durable 'keep' flag: pinned
+sessions are exempt from the sessions.auto_archive stale sweep."* It is a user
+decision, not live runtime state — the same class as ``archived``, which
+``import_sessions`` already restores.
+
+``import_sessions`` wrote every other durable column but not ``pinned``, so a
+restored backup came back unpinned and the stale sweep — the very thing the
+flag exists to opt out of — then archived exactly the sessions the user marked
+keep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SessionDB
+
+SESSION_ID = "20260801_120000_abc123"
+
+
+def _seed(db_path, *, pinned: bool, archived: bool = False) -> dict:
+    db = SessionDB(db_path=db_path)
+    db.create_session(SESSION_ID, source="cli")
+    db.append_message(SESSION_ID, "user", "keep this one")
+    db.append_message(SESSION_ID, "assistant", "ok")
+    if pinned:
+        db.set_session_pinned(SESSION_ID, True)
+    if archived:
+        db.set_session_archived(SESSION_ID, True)
+    return db.export_session(SESSION_ID)
+
+
+@pytest.fixture
+def restore(tmp_path):
+    """Export from one DB and import into a fresh one; return the restored row."""
+
+    def _restore(*, pinned: bool, archived: bool = False):
+        payload = _seed(tmp_path / "source.db", pinned=pinned, archived=archived)
+        assert payload is not None
+        target = SessionDB(db_path=tmp_path / "target.db")
+        result = target.import_sessions([payload])
+        assert result["ok"] is True and result["imported"] == 1
+        return target, target.get_session(SESSION_ID), payload
+
+    return _restore
+
+
+def test_pinned_survives_the_export_import_roundtrip(restore):
+    """The regression: the keep-flag must not be dropped on restore."""
+    _, restored, payload = restore(pinned=True)
+
+    assert payload["pinned"], "sanity: the export payload carries the flag"
+    assert restored["pinned"]
+
+
+def test_unpinned_session_stays_unpinned(restore):
+    """Restoring must not pin everything either."""
+    _, restored, _ = restore(pinned=False)
+
+    assert not restored["pinned"]
+
+
+def test_archived_still_survives(restore):
+    """Guard the sibling durable flag this import already handled."""
+    _, restored, _ = restore(pinned=False, archived=True)
+
+    assert restored["archived"]
+
+
+def test_restored_pin_still_exempts_the_session_from_the_stale_sweep(restore):
+    """The consequence: the sweep the flag opts out of must honour it."""
+    target, restored, _ = restore(pinned=True)
+    assert restored["pinned"]
+
+    swept = target.archive_stale_sessions(idle_days=0, exclude_pinned=True)
+
+    assert swept == 0
+    assert not target.get_session(SESSION_ID)["archived"]
+
+
+def test_unpinned_restored_session_is_still_sweepable(restore):
+    """The exemption must be the pin, not the restore itself."""
+    target, _, _ = restore(pinned=False)
+
+    swept = target.archive_stale_sessions(idle_days=0, exclude_pinned=True)
+
+    assert swept == 1
+    assert target.get_session(SESSION_ID)["archived"]


### PR DESCRIPTION
## What

`set_session_pinned`'s contract:

> `pinned` is a durable "keep" flag: pinned sessions are exempt from the `sessions.auto_archive` stale sweep. Desktop is the current writer — its sidebar pins mirror here so a backend/other-surface sweep honours them.

`import_sessions` restores every other durable session column — **including `archived`, the sibling user flag** — but never wrote `pinned`. Its docstring justifies resetting *"gateway routing, handoff, rewind, and other live runtime state"*; a pin is none of those. It is a user decision, and `export_session` already carries it in the payload.

So a restored backup comes back unpinned, and `archive_stale_sessions(exclude_pinned=True)` — the sweep the flag exists to opt out of — then archives exactly the sessions the user marked keep:

```
source session   : pinned=1  archived=1
export payload   : pinned=1  archived=1
restored session : pinned=0  archived=1      <- flag dropped
import result    : {'ok': True, 'imported': 1}

archive_stale_sessions(exclude_pinned=True) archived 1 session(s)
```

After the fix the flag round-trips and the same sweep archives **0**.

Of the 17 session columns `import_sessions` skips, the other 16 are genuinely live runtime state (`session_key`, `chat_id`, `thread_id`, `handoff_*`, `compression_failure_*`, `rewind_count`, …). `pinned` is the one durable user decision in that set.

## Fix

Restore `pinned` alongside `archived`, normalized the same way (`1 if raw.get("pinned") else 0`).

## Tests

`tests/hermes_state/test_session_import_pinned_roundtrip.py` — 5 tests exporting from one DB and importing into a fresh one. The 2 that exercise the bug fail without the fix:

- the pin survives the export→import round-trip
- a restored pinned session is still exempt from the stale sweep (the consequence)
- an unpinned session stays unpinned — restoring must not pin everything
- `archived` still survives (guards the sibling flag)
- an unpinned restored session is still sweepable — the exemption tracks the pin, not the restore

```
scripts/run_tests.sh tests/hermes_state/test_session_import_pinned_roundtrip.py
=== Summary: 1 files, 5 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 3 tests passed, 2 failed ===
```

Broader run — `tests/hermes_state/`, `tests/state/`, `test_hermes_state.py`, `test_session_export.py`, `test_sessions_export_md_cli.py`: **18 files, 214 passed, 0 failed**.

