### PR TITLE
fix(discord): prioritize plugin commands under slash cap

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5478,12 +5478,45 @@ class DiscordAdapter(BasePlatformAdapter):
         slot_cap = _DISCORD_MAX_APP_COMMANDS - 1
         dropped_over_cap = 0
         try:
-            from hermes_cli.commands import COMMAND_REGISTRY, _is_gateway_available, _resolve_config_gates
+            already_registered = {cmd.name for cmd in tree.get_commands()}
+        except Exception:
+            pass
 
-            try:
-                already_registered = {cmd.name for cmd in tree.get_commands()}
-            except Exception:
-                pass
+        # ── Plugin-registered slash commands ──
+        # Plugins register via PluginContext.register_command(); we mirror
+        # those into Discord's native slash picker so users get the same
+        # autocomplete UX as for built-in commands. Explicit user plugin
+        # commands take priority over lower-priority generated built-ins, so
+        # they remain reachable when Discord's 100-command cap is full.
+        try:
+            from hermes_cli.commands import _iter_plugin_command_entries
+
+            for plugin_name, plugin_desc, plugin_args_hint in _iter_plugin_command_entries():
+                discord_name = plugin_name.lower()[:32]
+                if discord_name in already_registered:
+                    continue
+                if len(already_registered) >= slot_cap:
+                    dropped_over_cap += 1
+                    continue
+                auto_cmd = _build_auto_slash_command(
+                    plugin_name,
+                    plugin_desc,
+                    plugin_args_hint,
+                )
+                try:
+                    tree.add_command(auto_cmd)
+                    already_registered.add(discord_name)
+                except Exception:
+                    # Silently skip commands that fail registration (e.g.
+                    # name conflict with a subcommand group).
+                    pass
+        except Exception as e:
+            logger.warning(
+                "Discord auto-register from plugin commands failed: %s", e
+            )
+
+        try:
+            from hermes_cli.commands import COMMAND_REGISTRY, _is_gateway_available, _resolve_config_gates
 
             config_overrides = _resolve_config_gates()
 
@@ -5516,38 +5549,6 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.warning("Discord auto-register from COMMAND_REGISTRY failed: %s", e)
-
-        # ── Plugin-registered slash commands ──
-        # Plugins register via PluginContext.register_command(); we mirror
-        # those into Discord's native slash picker so users get the same
-        # autocomplete UX as for built-in commands. No per-platform plugin
-        # API needed — plugin commands are platform-agnostic.
-        try:
-            from hermes_cli.commands import _iter_plugin_command_entries
-
-            for plugin_name, plugin_desc, plugin_args_hint in _iter_plugin_command_entries():
-                discord_name = plugin_name.lower()[:32]
-                if discord_name in already_registered:
-                    continue
-                if len(already_registered) >= slot_cap:
-                    dropped_over_cap += 1
-                    continue
-                auto_cmd = _build_auto_slash_command(
-                    plugin_name,
-                    plugin_desc,
-                    plugin_args_hint,
-                )
-                try:
-                    tree.add_command(auto_cmd)
-                    already_registered.add(discord_name)
-                except Exception:
-                    # Silently skip commands that fail registration (e.g.
-                    # name conflict with a subcommand group).
-                    pass
-        except Exception as e:
-            logger.warning(
-                "Discord auto-register from plugin commands failed: %s", e
-            )
 
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -284,6 +284,48 @@ async def test_slash_command_registration_stays_under_discord_limit(adapter):
     assert len(registered_plugins) < 200, "cap did not drop any overflow commands"
 
 
+@pytest.mark.asyncio
+async def test_plugin_commands_precede_generated_builtins_at_discord_cap(adapter):
+    """Explicit plugin commands survive generated built-in overflow.
+
+    Native commands remain first, and the consolidated /skill command still
+    gets its reserved final slot. This reproduces the Discord picker symptom
+    where a valid user plugin command (for example /krieger) vanished once
+    generated gateway commands filled the 100-command application cap.
+    """
+    from hermes_cli.commands import CommandDef
+
+    generated_builtins = [
+        CommandDef(f"generated{i:03d}", "Generated built-in", "Info")
+        for i in range(200)
+    ]
+    krieger = {
+        "krieger": {
+            "handler": lambda _a: "ok",
+            "description": "Run the Krieger plugin command",
+            "args_hint": "",
+            "plugin": "krieger",
+        }
+    }
+
+    with patch("hermes_cli.commands.COMMAND_REGISTRY", generated_builtins), \
+         patch("hermes_cli.commands._is_gateway_available", return_value=True), \
+         patch("hermes_cli.commands._resolve_config_gates", return_value={}), \
+         patch("hermes_cli.plugins.get_plugin_commands", return_value=krieger), \
+         patch(
+             "hermes_cli.commands.discord_skill_commands_by_category",
+             return_value=({"tools": [("demo", "Demo skill", "/demo")]}, [], 0),
+         ):
+        adapter._register_slash_commands()
+
+    tree_names = set(adapter._client.tree.commands)
+    for native in ("status", "stop", "new", "model", "help"):
+        assert native in tree_names
+    assert "krieger" in tree_names
+    assert "skill" in tree_names
+    assert len(tree_names) <= 100
+
+
 # ------------------------------------------------------------------
 # _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Discord rejects a global application-command sync above its 100-command cap (error 30032). Native commands are registered first and must remain highest priority. Previously, generated gateway built-ins were considered before explicit user plugin commands, so a full command catalog could silently omit a valid plugin command such as `/krieger`.

This reorders only the overflow tiers: after native commands, register explicit plugin commands before lower-priority generated built-ins. The existing conflict checks and the reserved final slot for the consolidated `/skill` command remain intact.

## Tests

- Added a deterministic cap regression that proves native commands, `/krieger`, and `/skill` all survive while the tree remains at or below 100 commands.
- The regression fails on upstream `main` without this change (`/krieger` is absent) and passes with it.
- `scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_sync_limit.py tests/gateway/test_discord_plugin_setup.py`
- `python3 -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
- `git diff --check`

No managed-checkout cleanup or unrelated changes are included.