### PR TITLE
fix(agent): use module-level devnull sink in thread_scoped_silence

### DIFF
--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -31,6 +31,15 @@ _install_lock = threading.Lock()
 # never double-wrap and so we can recover the original stream.
 _installed: dict[str, "_ThreadRoutingStream"] = {}
 
+# Module-level devnull sink — opened once, never closed.  The previous design
+# opened a fresh ``/dev/null`` handle per ``thread_scoped_silence()`` call and
+# closed it on exit, but ``_ensure_installed`` is idempotent: it only captures
+# the sink on the *first* call.  Every subsequent call opened and closed a
+# handle that was never wired into the proxy, while the proxy's original sink
+# was already closed — causing silenced writes to fail silently.  A single
+# long-lived handle avoids the fd churn and the stale-sink bug.
+_DEVNULL: TextIO = open(os.devnull, "w", encoding="utf-8")
+
 
 class _ThreadRoutingStream:
     """A ``sys.stdout``/``sys.stderr`` stand-in that routes writes per-thread.
@@ -130,10 +139,9 @@ def thread_scoped_silence() -> Iterator[None]:
     thread's body instead of ``contextlib.redirect_stdout(devnull)`` when the
     process is multi-threaded and another thread must keep its console output.
     """
-    sink = open(os.devnull, "w", encoding="utf-8")
     ident = threading.get_ident()
-    out_proxy = _ensure_installed("stdout", sink)
-    err_proxy = _ensure_installed("stderr", sink)
+    out_proxy = _ensure_installed("stdout", _DEVNULL)
+    err_proxy = _ensure_installed("stderr", _DEVNULL)
     out_proxy.silence(ident)
     err_proxy.silence(ident)
     try:
@@ -141,7 +149,3 @@ def thread_scoped_silence() -> Iterator[None]:
     finally:
         out_proxy.unsilence(ident)
         err_proxy.unsilence(ident)
-        try:
-            sink.close()
-        except Exception:
-            pass

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -165,3 +165,31 @@ def test_sequential_silence_calls_both_silence_correctly():
     assert "first-silenced" not in captured
     assert "second-silenced" not in captured
     assert "loud" in captured
+
+
+def test_sequential_silence_keeps_proxy_sink_open_and_writable():
+    """Regression discriminator: the old design closed its per-call /dev/null
+    handle on exit, but _ensure_installed only captured the sink on the FIRST
+    call — leaving the proxy's retained sink closed for every subsequent call.
+    Because _ThreadRoutingStream.write() swallows write failures, output-level
+    asserts cannot distinguish old vs new behavior; asserting on the sink
+    itself can.  The module-level sink must stay open and writable across
+    sequential silence calls (issue #55769 / #55925)."""
+    from agent.thread_scoped_output import _installed
+
+    def body():
+        with thread_scoped_silence():
+            print("first-silenced")
+        with thread_scoped_silence():
+            print("second-silenced")
+
+    _run_with_real_stream(body)
+
+    for attr in ("stdout", "stderr"):
+        proxy = _installed[attr]
+        # Old code: first context exit closed the captured sink → this fails.
+        assert not proxy._sink.closed, f"{attr} proxy sink was closed after sequential calls"
+        # A write to the retained sink must land (old code raised ValueError on
+        # the closed handle, which write() swallowed).
+        written = proxy._sink.write("probe\n")
+        assert written == len("probe\n"), f"{attr} proxy sink rejected a write"

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -147,3 +147,21 @@ def test_many_concurrent_silenced_and_loud_threads():
     for i in range(5):
         assert f"S{i}" not in captured, f"silenced S{i} leaked"
         assert f"L{i}" in captured, f"loud L{i} swallowed"
+
+
+def test_sequential_silence_calls_both_silence_correctly():
+    """Regression: sequential calls must both silence — the old code opened a
+    fresh /dev/null per call but only the first was wired into the proxy.
+    After the first call closed its handle, the proxy's sink was stale and
+    subsequent silenced writes silently failed."""
+    def body():
+        with thread_scoped_silence():
+            print("first-silenced")
+        with thread_scoped_silence():
+            print("second-silenced")
+        print("loud")
+
+    captured = _run_with_real_stream(body)
+    assert "first-silenced" not in captured
+    assert "second-silenced" not in captured
+    assert "loud" in captured


### PR DESCRIPTION
Closing due to 10d stale threshold. No human maintainer engagement after sweeper review (teknium1) and re-review nudge on Aug 9. Merge state is dirty (conflicts with main). The fix is sound — feel free to resubmit when ready.