### PR TITLE
fix: Python 3.14 compat in DaemonThreadPoolExecutor

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -49,15 +49,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            import sys
+            if sys.version_info >= (3, 14):
+                # Python 3.14+ replaced _initializer/_initargs with WorkerContext
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Problem

Python 3.14 removed `_initializer` and `_initargs` from `concurrent.futures.ThreadPoolExecutor` internals. The `_worker` function signature changed from `(ref, work_queue, initializer, initargs)` to `(ref, ctx, work_queue)` where `ctx` comes from `self._create_worker_context()`.

`tools/daemon_pool.py:58` directly accesses the removed attributes, causing:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

This breaks **every** concurrent tool call — web_search, web_extract, read_file, parallel tool execution — when Hermes runs on Python 3.14.

## Fix

Version-check the thread construction to use the new 3.14 API (`_create_worker_context()` + 3-arg `_worker`) while maintaining backward compat with 3.8–3.13.

## Verified

```
python3.14 -c "from tools.daemon_pool import DaemonThreadPoolExecutor; p = DaemonThreadPoolExecutor(2); print(p.submit(lambda: 42).result())"
# Result: 42 ✓
```

No other `_initializer`/`_initargs` references in the codebase (verified with `rg`).