### PR TITLE
fix(desktop): reapply zoom when chat regains focus

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -73,7 +73,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-display moves on macOS and Windows', () => {
+test('installZoomReassertOnWindowEvents reasserts zoom after focus, show, restore, resize, and cross-display moves on macOS and Windows', () => {
   const handlers = new Map()
 
   const win = {
@@ -95,9 +95,10 @@ test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-d
   assert.deepEqual([...handlers.keys()], zoomReassertWindowEvents('win32'))
   handlers.get('show')()
   handlers.get('restore')()
+  handlers.get('focus')()
   handlers.get('resized')()
   handlers.get('moved')()
-  assert.equal(calls, 4)
+  assert.equal(calls, 5)
 })
 
 test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {
@@ -125,18 +126,20 @@ test('installZoomReassertOnWindowEvents debounces Linux resize and move events a
     )
 
     assert.deepEqual([...handlers.keys()], zoomReassertWindowEvents('linux'))
+    handlers.get('focus')()
+    assert.equal(calls, 1)
     handlers.get('resize')()
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     handlers.get('move')()
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
-    assert.equal(calls, 0)
-    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     assert.equal(calls, 1)
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
+    assert.equal(calls, 2)
 
     handlers.get('resize')()
     destroyed = true
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
-    assert.equal(calls, 1)
+    assert.equal(calls, 2)
   } finally {
     vi.useRealTimers()
   }

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -58,14 +58,16 @@ export function applyZoomLevel(webContents, level) {
 }
 
 // Chromium can drop webContents zoom when a BrowserWindow is resized, minimized
-// and restored, or crosses onto a monitor with different display scaling. macOS
-// and Windows provide trailing `resized`/`moved` events; Linux only provides the
-// noisy `resize`/`move` pair, so debounce those fallbacks before re-applying the
-// persisted level.
+// and restored, crosses onto a monitor with different display scaling, or regains
+// focus after another application. macOS and Windows provide trailing
+// `resized`/`moved` events; Linux only provides the noisy `resize`/`move` pair,
+// so debounce those fallbacks before re-applying the persisted level.
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux' ? ['show', 'restore', 'resize', 'move'] : ['show', 'restore', 'resized', 'moved']
+  return platform === 'linux'
+    ? ['show', 'restore', 'focus', 'resize', 'move']
+    : ['show', 'restore', 'focus', 'resized', 'moved']
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {


### PR DESCRIPTION
## Summary
- reapply the persisted UI zoom when a Desktop chat window regains focus
- cover the Alt+Tab/focus lifecycle path in the Electron zoom tests

## Reproduction
On Windows, set **UI Scale** to 125%, switch to another application, then return to Hermes. Chromium can return the window to 100% even though the saved zoom level remains 125%. The existing reassertion only listened for show, restore, resize, and move events; a normal focus return does not necessarily emit any of those.

## Test plan
- `npm exec vitest run electron/zoom.test.ts`

This keeps the existing single `applyZoomLevel()` funnel and its renderer notification; it only extends the lifecycle events that invoke the existing reassertion.