### PR TITLE
fix(acp): persist compacted state via in-place compaction on /compress

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2366,12 +2366,15 @@ class HermesACPAgent(acp.Agent):
             approx_tokens = estimate_request_tokens_rough(
                 state.history, system_prompt=_sys_prompt, tools=_tools
             )
-            original_session_db = getattr(agent, "_session_db", None)
-
+            # Force in-place compaction so archive_and_compact() persists
+            # the compacted transcript under the same session id.  The old
+            # code set agent._session_db = None to suppress session rotation,
+            # but that also suppressed the in-place persistence path — the
+            # compacted history existed only in memory and was lost on
+            # process restart (#76215).
+            original_in_place = getattr(agent, "compression_in_place", True)
             try:
-                # ACP sessions must keep a stable session id, so avoid the
-                # SQLite session-splitting side effect inside _compress_context.
-                agent._session_db = None
+                agent.compression_in_place = True
                 compressed, _ = agent._compress_context(
                     state.history,
                     getattr(agent, "_cached_system_prompt", "") or "",
@@ -2380,7 +2383,7 @@ class HermesACPAgent(acp.Agent):
                     force=True,
                 )
             finally:
-                agent._session_db = original_session_db
+                agent.compression_in_place = original_in_place
 
             state.history = compressed
             self.session_manager.save_session(state.session_id)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -495,7 +495,10 @@ class TestSlashCommands:
         state.agent._session_db = original_session_db
 
         def _compress_context(messages, system_prompt, *, approx_tokens, task_id, force):
-            assert state.agent._session_db is None
+            # _session_db must remain attached so archive_and_compact can
+            # persist the compacted transcript (#76215).
+            assert state.agent._session_db is original_session_db
+            assert state.agent.compression_in_place is True
             assert messages == state.history
             assert system_prompt == "system"
             assert approx_tokens == 40


### PR DESCRIPTION
## Summary

Fixes #76215. The ACP `/compress` handler set `agent._session_db = None` before calling `_compress_context()` to suppress session rotation. This also suppressed the in-place persistence path (`archive_and_compact`), so the compacted transcript existed only in process memory -- a restart restored stale pre-compaction rows from `state.db`.

## Root Cause

`acp_adapter/server.py::_cmd_compress` (line ~2369):

```python
agent._session_db = None  # suppresses rotation AND persistence
compressed, _ = agent._compress_context(...)
```

`conversation_compression.py::_compress_context` checks `if agent._session_db:` (line 2059) before entering the persistence block. When `_session_db` is None, the entire `archive_and_compact()` call is skipped.

## Fix

Replace `_session_db = None` with `compression_in_place = True`. This keeps `_session_db` attached so `archive_and_compact()` atomically soft-archives old rows and inserts the compacted set under the same session id. No rotation, no id change, durable across restarts.

`compression_in_place` already defaults to `True` (line 1408), so the forced assignment is a belt-and-suspenders guard for ACP sessions that must never rotate.

## Changes

- `acp_adapter/server.py`: Replace `_session_db = None` guard with `compression_in_place = True` guard

## Test Plan

- [ ] Verify syntax passes
- [ ] Verify `archive_and_compact` is called when ACP /compress runs
- [ ] Verify session id remains stable after compaction
- [ ] Verify compacted state survives process restart