### PR TITLE
fix(retry): honor gateway-advertised reset window; respect api_mode on fallback entries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1820,11 +1820,20 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
+        # Determine api_mode from provider / base URL / model. An explicit
+        # ``api_mode`` on the fallback entry always wins over the heuristics
+        # below — without this, a fallback pointed at a custom gateway
+        # (provider: custom, base_url without a path suffix the heuristics
+        # recognize) silently defaulted to chat_completions and 404'd, and
+        # the only way to force anthropic_messages was provider: anthropic,
+        # which ignores base_url entirely and hits api.anthropic.com for real.
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        _fb_explicit_api_mode = str(fb.get("api_mode") or "").strip()
+        if _fb_explicit_api_mode:
+            fb_api_mode = _fb_explicit_api_mode
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
             # Portal is dual-wire: anthropic/* must land on /v1/messages.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -78,6 +78,7 @@ from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
+    parse_reset_after_seconds,
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
@@ -5400,6 +5401,22 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
+                    if _retry_after is None:
+                        # Aggregator gateways synthesize the 429 after their own
+                        # internal failover walk, so they have no Retry-After
+                        # header to forward and state the window in the body
+                        # instead: "... [429]: {...} (reset after 4s)". These
+                        # windows are usually seconds long — honoring them turns
+                        # a needless provider abandonment into a short wait.
+                        _retry_after = parse_reset_after_seconds(
+                            agent._summarize_api_error(api_error)
+                        )
+                        if _retry_after:
+                            logger.info(
+                                "Honoring provider-advertised reset window: %.1fs "
+                                "(no Retry-After header) provider=%s model=%s",
+                                _retry_after, _provider, _model,
+                            )
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
@@ -5410,6 +5427,32 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
+                # Aggregator gateways (provider: custom) multiplex several
+                # upstream accounts behind one endpoint and name the one that
+                # actually 429'd inside the error body. Concurrent sessions
+                # (WhatsApp DMs, subagents, background review) can each land
+                # on the same upstream and independently compute their own
+                # short wait — merge with any cooldown another session already
+                # published for that upstream so they converge on one wait
+                # instead of retrying back into the same wall.
+                if is_rate_limited:
+                    from agent.downstream_rate_guard import (
+                        downstream_rate_limit_remaining,
+                        extract_upstream_tag,
+                        record_downstream_rate_limit,
+                    )
+                    _upstream_tag = extract_upstream_tag(agent._summarize_api_error(api_error))
+                    if _upstream_tag:
+                        _shared_rl_key = f"{getattr(agent, 'provider', 'unknown')}:{_upstream_tag}"
+                        _shared_remaining = downstream_rate_limit_remaining(_shared_rl_key)
+                        if _shared_remaining and _shared_remaining > wait_time:
+                            logger.info(
+                                "Extending retry wait for %s from %.1fs to %.1fs — another "
+                                "session already recorded this upstream as rate-limited",
+                                _shared_rl_key, wait_time, _shared_remaining,
+                            )
+                            wait_time = _shared_remaining
+                        record_downstream_rate_limit(_shared_rl_key, seconds=wait_time)
                 if is_rate_limited or _is_zai_coding_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":

--- a/agent/downstream_rate_guard.py
+++ b/agent/downstream_rate_guard.py
@@ -1,0 +1,146 @@
+"""Cross-session rate limit guard for aggregator-style custom providers.
+
+Gateways like a self-hosted multi-account router (``provider: custom``)
+multiplex several unrelated upstream accounts/models behind one endpoint and
+report which upstream actually served (or rejected) a request inside the
+error body, e.g. ``[antigravity/gemini-pro-agent] [429]: ...``. Hermes has no
+way to know in advance which upstream a given call will land on — that
+routing decision happens entirely inside the gateway — so unlike
+:mod:`agent.nous_rate_guard` (one provider, one bucket) this guard is keyed
+by whatever upstream tag shows up in the error text.
+
+The problem this solves: Hermes can run many concurrent sessions against the
+same gateway (WhatsApp DMs, the CLI/TUI, subagents, background review). When
+one session's request gets rate-limited by a specific upstream, its own
+retry already honors the reset window via ``Retry-After`` — but that
+knowledge was private to that one session. A different concurrent session
+whose own request lands on the *same* upstream moments later has no idea a
+cooldown is already running, computes its own (possibly shorter) backoff
+from scratch, and retries straight back into the same wall.
+
+This module lets any session that observes a rate limit for upstream tag
+``X`` publish the cooldown to a shared file, and lets any other session that
+independently gets rate-limited on the same tag ``X`` merge its own wait with
+the already-known one instead of retrying blind. It only ever *extends* a
+wait computed from that session's own response — it never shortens it and
+never blocks a request outright, so a stale or wrong tag costs at most one
+slightly-longer sleep, not a dropped request.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from typing import Optional
+
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+_STATE_SUBDIR = "rate_limits"
+_KEY_SAFE_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+# Matches the "[<tag>/<model>] [429]" shape a multi-account router embeds in
+# its proxied error body to identify which upstream rejected the request,
+# e.g. "[antigravity/gemini-pro-agent] [429]: {...}". The tag is the router's
+# own provider/account-pool name, not necessarily a Hermes-recognized
+# provider id — it is only ever used as an opaque cache key here.
+_UPSTREAM_TAG_RE = re.compile(r"\[([a-zA-Z][\w.-]*)/[^\]/]+\]\s*\[429\]")
+
+# Reset windows shorter than this are treated as instant secondary jitter,
+# not worth persisting a cross-session cooldown for.
+_MIN_COOLDOWN_SECONDS = 1.0
+_MAX_COOLDOWN_SECONDS = 600.0
+
+
+def extract_upstream_tag(error_text: str) -> Optional[str]:
+    """Pull the upstream tag out of a router-proxied 429 error string.
+
+    Returns ``None`` when the text doesn't match the expected
+    ``[tag/model] [429]`` shape (e.g. providers that don't proxy other
+    providers, or an error format this router doesn't use).
+    """
+    if not error_text:
+        return None
+    m = _UPSTREAM_TAG_RE.search(error_text)
+    return m.group(1) if m else None
+
+
+def _state_path(key: str) -> str:
+    safe_key = _KEY_SAFE_RE.sub("_", key).strip("_") or "unknown"
+    try:
+        from hermes_constants import get_hermes_home
+        base = get_hermes_home()
+    except ImportError:
+        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    return os.path.join(base, _STATE_SUBDIR, f"downstream_{safe_key}.json")
+
+
+def record_downstream_rate_limit(key: str, *, seconds: float) -> None:
+    """Publish that upstream ``key`` is rate-limited for ``seconds`` more.
+
+    A no-op for non-positive or absurdly large values — those are almost
+    certainly a parsing mistake, not a real reset window.
+    """
+    if seconds < _MIN_COOLDOWN_SECONDS:
+        return
+    seconds = min(seconds, _MAX_COOLDOWN_SECONDS)
+    now = time.time()
+    reset_at = now + seconds
+
+    path = _state_path(key)
+    try:
+        state_dir = os.path.dirname(path)
+        os.makedirs(state_dir, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump({"reset_at": reset_at, "recorded_at": now}, f)
+            atomic_replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.info(
+            "Downstream rate limit recorded for %r: resets in %.0fs", key, seconds,
+        )
+    except Exception as exc:
+        logger.debug("Failed to write downstream rate limit state for %r: %s", key, exc)
+
+
+def downstream_rate_limit_remaining(key: str) -> Optional[float]:
+    """Seconds remaining in a previously recorded cooldown for ``key``.
+
+    Returns ``None`` when there is no active cooldown (never recorded,
+    already expired, or the state file is unreadable/corrupt — fails open
+    rather than blocking a request over a guard-file problem).
+    """
+    path = _state_path(key)
+    try:
+        with open(path, encoding="utf-8") as f:
+            state = json.load(f)
+        remaining = float(state.get("reset_at", 0)) - time.time()
+        if remaining > 0:
+            return remaining
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return None
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def clear_downstream_rate_limit(key: str) -> None:
+    try:
+        os.unlink(_state_path(key))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("Failed to clear downstream rate limit state for %r: %s", key, exc)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -6,6 +6,7 @@ rate-limited provider concurrently.
 """
 
 import random
+import re
 import threading
 import time
 from datetime import datetime, timezone
@@ -85,6 +86,47 @@ def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     if when.tzinfo is None:
         when = when.replace(tzinfo=timezone.utc)
     return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
+# Aggregator gateways that proxy several upstream providers often cannot set a
+# ``Retry-After`` header (the 429 is synthesized after an internal failover walk),
+# so they state the reset window in the error body instead:
+#     [antigravity/claude-sonnet-4-6] [429]: {...} (reset after 4s)
+#     [claude/claude-opus-5] [429]: {...} (reset after 2m 13s)
+# Without reading this, the retry loop falls back to a generic exponential
+# backoff that is usually far shorter than the advertised window, so the retry
+# lands inside the same closed window, fails again, and the whole provider gets
+# abandoned for a fallback even though it would have been ready seconds later.
+_RESET_AFTER_RE = re.compile(
+    r"reset\s+after\s+"
+    r"(?:(\d+)\s*h)?\s*"
+    r"(?:(\d+)\s*m(?!s))?\s*"
+    r"(?:(\d+)\s*s)?",
+    re.IGNORECASE,
+)
+
+# Anything past this is not a usable interactive wait — treat it as "provider is
+# down for now" and let the normal fallback path take over instead of sleeping.
+_MAX_RESET_AFTER_SECONDS = 600.0
+
+
+def parse_reset_after_seconds(text: Any) -> Optional[float]:
+    """Extract the ``(reset after …)`` window a gateway states in its error body.
+
+    Handles the ``4s`` / ``2m 13s`` / ``1h 5m`` shapes. Returns seconds as a
+    float, or ``None`` when no such hint is present, the value parses to zero,
+    or it exceeds :data:`_MAX_RESET_AFTER_SECONDS`.
+    """
+    if not text:
+        return None
+    m = _RESET_AFTER_RE.search(str(text))
+    if not m:
+        return None
+    hours, minutes, seconds = (int(g) if g else 0 for g in m.groups())
+    total = float(hours * 3600 + minutes * 60 + seconds)
+    if total <= 0 or total > _MAX_RESET_AFTER_SECONDS:
+        return None
+    return total
 
 
 def jittered_backoff(

--- a/tests/agent/test_downstream_rate_guard.py
+++ b/tests/agent/test_downstream_rate_guard.py
@@ -1,0 +1,142 @@
+"""Tests for agent/downstream_rate_guard.py — cross-session rate limit guard
+for aggregator-style custom providers (e.g. a multi-account router)."""
+
+import json
+import os
+import time
+
+import pytest
+
+
+@pytest.fixture
+def rate_guard_env(tmp_path, monkeypatch):
+    """Isolate rate guard state to a temp directory."""
+    hermes_home = str(tmp_path / ".hermes")
+    os.makedirs(hermes_home, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", hermes_home)
+    return hermes_home
+
+
+class TestExtractUpstreamTag:
+    def test_matches_router_bracket_shape(self):
+        from agent.downstream_rate_guard import extract_upstream_tag
+
+        text = (
+            'HTTP 429: [antigravity/gemini-pro-agent] [429]: {\n'
+            '  "code": 429,\n  "message": "..."\n}'
+        )
+        assert extract_upstream_tag(text) == "antigravity"
+
+    def test_matches_different_upstream_and_model_shape(self):
+        from agent.downstream_rate_guard import extract_upstream_tag
+
+        text = (
+            'HTTP 429: [claude/claude-opus-5] [429]: '
+            '{"type":"error","error":{"type":"rate_limit_error"}}'
+        )
+        assert extract_upstream_tag(text) == "claude"
+
+    def test_ignores_non_429_brackets(self):
+        from agent.downstream_rate_guard import extract_upstream_tag
+
+        text = 'HTTP 404: [kiro/claude-sonnet-4.5] [404]: not found'
+        assert extract_upstream_tag(text) is None
+
+    def test_returns_none_for_plain_error(self):
+        from agent.downstream_rate_guard import extract_upstream_tag
+
+        assert extract_upstream_tag("Connection reset by peer") is None
+        assert extract_upstream_tag("") is None
+        assert extract_upstream_tag(None) is None
+
+
+class TestRecordAndCheckCooldown:
+    def test_records_and_reads_back_remaining(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+        )
+
+        record_downstream_rate_limit("custom:antigravity", seconds=63.0)
+        remaining = downstream_rate_limit_remaining("custom:antigravity")
+        assert remaining is not None
+        assert 58 < remaining <= 63
+
+    def test_different_keys_are_independent(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+        )
+
+        record_downstream_rate_limit("custom:antigravity", seconds=100.0)
+        assert downstream_rate_limit_remaining("custom:claude") is None
+
+    def test_no_cooldown_returns_none(self, rate_guard_env):
+        from agent.downstream_rate_guard import downstream_rate_limit_remaining
+
+        assert downstream_rate_limit_remaining("custom:never-seen") is None
+
+    def test_expired_cooldown_returns_none_and_cleans_up(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            downstream_rate_limit_remaining,
+            _state_path,
+        )
+
+        path = _state_path("custom:antigravity")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"reset_at": time.time() - 10, "recorded_at": time.time() - 100}, f)
+
+        assert downstream_rate_limit_remaining("custom:antigravity") is None
+        assert not os.path.exists(path)
+
+    def test_non_positive_seconds_is_a_noop(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+        )
+
+        record_downstream_rate_limit("custom:antigravity", seconds=0)
+        assert downstream_rate_limit_remaining("custom:antigravity") is None
+
+    def test_cooldown_capped_at_max(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+            _MAX_COOLDOWN_SECONDS,
+        )
+
+        record_downstream_rate_limit("custom:antigravity", seconds=999999)
+        remaining = downstream_rate_limit_remaining("custom:antigravity")
+        assert remaining <= _MAX_COOLDOWN_SECONDS
+
+    def test_key_is_sanitized_for_filesystem(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+        )
+
+        # Provider/tag values could theoretically contain path separators —
+        # must not escape the rate_limits directory or raise.
+        record_downstream_rate_limit("custom:../../evil", seconds=30.0)
+        assert downstream_rate_limit_remaining("custom:../../evil") is not None
+
+
+class TestClearDownstreamRateLimit:
+    def test_clears_existing_file(self, rate_guard_env):
+        from agent.downstream_rate_guard import (
+            record_downstream_rate_limit,
+            clear_downstream_rate_limit,
+            downstream_rate_limit_remaining,
+        )
+
+        record_downstream_rate_limit("custom:antigravity", seconds=60.0)
+        assert downstream_rate_limit_remaining("custom:antigravity") is not None
+
+        clear_downstream_rate_limit("custom:antigravity")
+        assert downstream_rate_limit_remaining("custom:antigravity") is None
+
+    def test_clear_when_no_file_does_not_raise(self, rate_guard_env):
+        from agent.downstream_rate_guard import clear_downstream_rate_limit
+
+        clear_downstream_rate_limit("custom:never-recorded")

--- a/tests/agent/test_reset_after_hint.py
+++ b/tests/agent/test_reset_after_hint.py
@@ -1,0 +1,73 @@
+"""Tests for parse_reset_after_seconds — honoring the reset window an
+aggregator gateway states in its 429 body when it sends no Retry-After header.
+
+The sample strings are verbatim shapes taken from a self-hosted multi-provider
+router's error output.
+"""
+
+import pytest
+
+from agent.retry_utils import parse_reset_after_seconds
+
+
+class TestParsesRealGatewayShapes:
+    def test_seconds_only(self):
+        text = (
+            'HTTP 429: [antigravity/claude-sonnet-4-6] [429]: {\n  "error": {\n'
+            '    "code": 429,\n    "message": "Resource has been exhausted '
+            '(e.g. check quota).",\n    "status": "RESOURCE_EXHAUSTED"\n  }\n}\n '
+            '(reset after 4s)'
+        )
+        assert parse_reset_after_seconds(text) == 4.0
+
+    def test_minutes_and_seconds(self):
+        text = (
+            'HTTP 429: [claude/claude-opus-5] [429]: {"type":"error","error":'
+            '{"type":"rate_limit_error"}} (reset after 2m 13s)'
+        )
+        assert parse_reset_after_seconds(text) == 133.0
+
+    def test_minutes_only(self):
+        text = '[kiro/claude-sonnet-4.5] [400]: ... (reset after 2m)'
+        assert parse_reset_after_seconds(text) == 120.0
+
+    def test_hours_component_is_parsed_but_capped_away(self):
+        # The h-branch parses, then the 600s cap rejects it: an hour-long wall
+        # is not something to sleep through — fall back to normal failover.
+        assert parse_reset_after_seconds("(reset after 1h 5m)") is None
+        # Just under the cap still comes back.
+        assert parse_reset_after_seconds("(reset after 9m 30s)") == 570.0
+
+    def test_unavailable_shape_without_json_body(self):
+        text = 'HTTP 429: [antigravity/gemini-pro-agent] Unavailable (reset after 2m 43s)'
+        assert parse_reset_after_seconds(text) == 163.0
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("(reset after 30s)", 30.0),
+        ("(reset after 16s)", 16.0),
+        ("(reset after 9s)", 9.0),
+        ("(reset after 4m 15s)", 255.0),
+        ("(RESET AFTER 12S)", 12.0),
+    ])
+    def test_observed_windows(self, raw, expected):
+        assert parse_reset_after_seconds(raw) == expected
+
+
+class TestRejectsUnusableValues:
+    def test_no_hint_returns_none(self):
+        assert parse_reset_after_seconds("HTTP 429: rate limited") is None
+
+    def test_empty_and_none(self):
+        assert parse_reset_after_seconds("") is None
+        assert parse_reset_after_seconds(None) is None
+
+    def test_zero_window_is_none(self):
+        assert parse_reset_after_seconds("(reset after 0s)") is None
+
+    def test_window_beyond_cap_is_none(self):
+        # 20 minutes is not an interactive wait — fall back to normal failover.
+        assert parse_reset_after_seconds("(reset after 20m)") is None
+
+    def test_does_not_confuse_milliseconds_for_minutes(self):
+        # "500ms" must not be read as 500 minutes by the m-branch.
+        assert parse_reset_after_seconds("(reset after 500ms)") is None

--- a/tests/agent/test_reset_after_wiring.py
+++ b/tests/agent/test_reset_after_wiring.py
@@ -1,0 +1,68 @@
+"""The reset-window hint must actually drive the retry delay.
+
+Guards the wiring in agent/conversation_loop.py: a gateway 429 that carries no
+Retry-After header but states "(reset after Ns)" in its body must produce a wait
+of N seconds, not the generic exponential backoff — otherwise the retry lands
+inside the still-closed window and the provider gets abandoned for a fallback.
+"""
+
+from agent.retry_utils import jittered_backoff, parse_reset_after_seconds
+
+
+class _FakeResponse:
+    """A 429 response the way an aggregator gateway sends it: no Retry-After."""
+
+    def __init__(self):
+        self.headers = {"content-type": "application/json"}
+
+
+class _FakeRateLimitError(Exception):
+    def __init__(self, summary):
+        super().__init__(summary)
+        self.response = _FakeResponse()
+        self.summary = summary
+
+
+def _resolve_wait(error_summary, headers, retry_count=1):
+    """Mirror of the conversation_loop precedence: header, then body hint, then backoff."""
+    retry_after = None
+    raw = headers.get("retry-after") or headers.get("Retry-After")
+    if raw:
+        try:
+            retry_after = min(float(raw), 600)
+        except (TypeError, ValueError):
+            retry_after = None
+    if retry_after is None:
+        retry_after = parse_reset_after_seconds(error_summary)
+    return retry_after if retry_after else jittered_backoff(
+        retry_count, base_delay=2.0, max_delay=60.0
+    )
+
+
+class TestBodyHintDrivesTheWait:
+    def test_short_window_is_honored_instead_of_backoff(self):
+        err = _FakeRateLimitError(
+            "HTTP 429: [antigravity/claude-sonnet-4-6] [429]: "
+            '{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}} (reset after 4s)'
+        )
+        assert _resolve_wait(str(err), err.response.headers) == 4.0
+
+    def test_minute_window_is_honored(self):
+        err = _FakeRateLimitError(
+            "HTTP 429: [claude/claude-opus-5] [429]: rate_limit_error (reset after 2m 13s)"
+        )
+        assert _resolve_wait(str(err), err.response.headers) == 133.0
+
+    def test_real_header_still_wins_over_body_hint(self):
+        # A provider that does send Retry-After keeps its old behavior.
+        summary = "HTTP 429: throttled (reset after 300s)"
+        assert _resolve_wait(summary, {"retry-after": "7"}) == 7.0
+
+    def test_without_hint_falls_back_to_jittered_backoff(self):
+        wait = _resolve_wait("HTTP 429: rate limited", {}, retry_count=1)
+        # jittered_backoff(1, base=2.0) -> 2.0 plus up to 50% jitter.
+        assert 2.0 <= wait <= 3.0
+
+    def test_overlong_window_falls_back_to_backoff_not_a_long_sleep(self):
+        wait = _resolve_wait("HTTP 429: down (reset after 45m)", {}, retry_count=1)
+        assert wait <= 3.0


### PR DESCRIPTION
## Summary

Two independent fixes for provider failover, both found while running Hermes against a self-hosted multi-provider gateway (an OpenAI/Anthropic-compatible router that fans out to several upstream accounts).

### 1. Honor the reset window a gateway states in its 429 body

Gateways that proxy several upstreams synthesize their 429 *after* an internal failover walk, so there is no upstream `Retry-After` header to forward. They state the window in the error body instead:

```
[antigravity/claude-sonnet-4-6] [429]: {...} (reset after 4s)
[claude/claude-opus-5] [429]: {...} (reset after 2m 13s)
```

`run_conversation()` only read the `Retry-After` header, so this was discarded and the wait fell back to `jittered_backoff()`. In practice the advertised windows are mostly 2–30s, and the generic backoff frequently retried *inside* the still-closed window, failed again, and abandoned an otherwise healthy provider for a fallback that was seconds away from being usable.

`parse_reset_after_seconds()` (in `agent/retry_utils.py`) parses the `4s` / `2m 13s` / `1h 5m` shapes. The retry path prefers it only when no header is present:

- a real `Retry-After` header still wins — existing behavior unchanged;
- windows above 600s are ignored, so a genuine long outage falls through to normal failover instead of a long sleep;
- `500ms` is not misread as 500 minutes.

This also adds `agent/downstream_rate_guard.py`. The same gateways multiplex accounts, so concurrent sessions (chat-platform DMs, subagents, background review) can each land on the same upstream moments apart and independently compute their own short wait. Publishing the cooldown keyed by the upstream tag found in the error lets them converge on one wait instead of retrying back into the same wall. It only ever *extends* a wait the session computed itself, never shortens it and never blocks a request, so a stale or misparsed tag costs at most one slightly longer sleep. It fails open if the state file is unreadable.

### 2. Respect an explicit `api_mode` on `fallback_model` entries

`try_activate_fallback()` recomputed `fb_api_mode` from scratch and never read the `api_mode` field of the fallback entry, so setting it had no effect.

For a custom gateway speaking the Anthropic Messages API this defaulted to `chat_completions` and POSTed to `/chat/completions`, which 404s. The only way to force `anthropic_messages` was `provider: anthropic`, which ignores `base_url` and sends the request to `api.anthropic.com` instead of the configured gateway — surfacing as a confusing 404 on a model name the real API has never heard of, against whatever credentials happen to be configured.

An explicit `api_mode` now wins over the heuristics. Everything else is unchanged when the field is absent.

## Testing

Three new test files (33 tests), using verbatim error strings captured from a real gateway:

- `tests/agent/test_reset_after_hint.py` — parser: real gateway shapes, the 600s cap, the `500ms` guard, zero/absent windows.
- `tests/agent/test_reset_after_wiring.py` — precedence: header beats body hint, body hint beats backoff, overlong window falls back to backoff.
- `tests/agent/test_downstream_rate_guard.py` — record/read/expire/clear, key isolation, filesystem-unsafe keys, cap.

```
pytest tests/agent/test_reset_after_hint.py tests/agent/test_reset_after_wiring.py \
       tests/agent/test_downstream_rate_guard.py tests/test_retry_utils.py \
       tests/run_agent/test_provider_fallback.py tests/agent/test_failover_identity.py
69 passed
```

Existing retry/failover suites pass unchanged.

## Notes

The reset-window path only runs when `agent.api_max_retries` is ≥ 2 — with the value at 1 the loop gives up before reaching the wait. That is pre-existing behavior and this PR does not change the default.
