### PR TITLE
fix(gateway): expose cronjob tool in messaging sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25093,6 +25093,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    # ``cronjob`` is service-gated through HERMES_GATEWAY_SESSION.  This is a
+    # process-role marker (not per-chat routing state), so bind it once for the
+    # lifetime of the gateway before any agent snapshots its tool schemas.
+    # Session-specific values remain on gateway.session_context ContextVars.
+    os.environ["HERMES_GATEWAY_SESSION"] = "1"
+
     # Snapshot the checkout revision now, while sys.modules still matches disk,
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale

--- a/tests/gateway/test_cronjob_tool_exposure.py
+++ b/tests/gateway/test_cronjob_tool_exposure.py
@@ -1,0 +1,44 @@
+"""Gateway tool-surface regressions for cronjob management."""
+
+import asyncio
+
+import pytest
+
+
+def test_gateway_start_exposes_cronjob_tool_before_agent_construction(monkeypatch):
+    """A real gateway process must advertise cronjob without external env setup."""
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+    from gateway import code_skew
+    from gateway.run import start_gateway
+    from tools.cronjob_tools import check_cronjob_requirements
+
+    class StopAfterGatewayContext(RuntimeError):
+        pass
+
+    def stop_after_gateway_context():
+        raise StopAfterGatewayContext
+
+    # Stop at the first startup side effect. The process-role marker must be
+    # bound before this point so every later AIAgent sees the cronjob schema.
+    monkeypatch.setattr(
+        code_skew, "record_boot_fingerprint", stop_after_gateway_context
+    )
+
+    with pytest.raises(StopAfterGatewayContext):
+        asyncio.run(start_gateway())
+
+    assert check_cronjob_requirements() is True
+
+    # Exercise the same registry-to-model schema path used by AIAgent rather
+    # than stopping at the requirement predicate.
+    from model_tools import get_tool_definitions
+
+    definitions = get_tool_definitions(
+        enabled_toolsets=["cronjob"],
+        quiet_mode=False,
+        skip_tool_search_assembly=True,
+    )
+    assert "cronjob" in {definition["function"]["name"] for definition in definitions}


### PR DESCRIPTION
## Summary

- bind the existing `HERMES_GATEWAY_SESSION` process-role marker at gateway startup, before any `AIAgent` snapshots its tool schemas
- add a regression test that follows startup through the real registry-to-model definition path

## Root cause

`check_cronjob_requirements()` explicitly allows gateway sessions through `HERMES_GATEWAY_SESSION`, but the gateway startup path never sets that marker. Per-chat routing moved to task-local `HERMES_SESSION_*` ContextVars; the process-role gate was left unwired. As a result, `registry.get_definitions()` filters `cronjob` out before the model sees it, even for Telegram/other messaging turns.

The marker is process-wide by design and carries no per-chat state. Platform/chat/thread identity remains on `gateway.session_context` ContextVars.

## Tests

```text
scripts/run_tests.sh tests/gateway/test_cronjob_tool_exposure.py tests/tools/test_cronjob_tools.py -q
69 passed
```
