### PR TITLE
fix(kanban): honor explicit same-PR requeues

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7957,6 +7957,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        Like ``recent_success``, an explicit re-queue after that comment
+        bypasses the guard because it deliberately requests another run on
+        the existing task and PR.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8039,12 +8042,29 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A later explicit re-queue deliberately requests another run on that
+    #    same PR (for example, a review task promoted after remediation), so
+    #    it must bypass this duplicate-PR safety guard.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    recent_pr_at: Optional[int] = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? ORDER BY created_at DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            recent_pr_at = int(c["created_at"])
+            break
+
+    if recent_pr_at is not None:
+        requeued_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND created_at > ? "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "LIMIT 1",
+            (task_id, recent_pr_at),
+        ).fetchone()
+        if not requeued_after:
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -502,6 +502,84 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_respawn_guard_active_pr_yields_to_later_dependency_promotion(kanban_home):
+    """A deliberate dependency requeue must permit another run on the same PR."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fresh review", assignee="default")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (
+                task_id,
+                "Reviewed https://github.com/NousResearch/hermes-agent/pull/42",
+                now - 1,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, now),
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_respawn_guard_active_pr_still_blocks_without_later_requeue(kanban_home):
+    """An old requeue must not disable duplicate-PR protection for a newer PR."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="crashed builder", assignee="default")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, now - 2),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (
+                task_id,
+                "Opened https://github.com/NousResearch/hermes-agent/pull/42",
+                now - 1,
+            ),
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_dispatch_spawns_active_pr_task_after_explicit_requeue(
+    kanban_home, all_assignees_spawnable
+):
+    """The real dispatcher honors a deliberate same-PR re-review request."""
+    spawned: list[str] = []
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="same-PR re-review", assignee="default")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (
+                task_id,
+                "Review https://github.com/NousResearch/hermes-agent/pull/42",
+                now - 1,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'unblocked', ?)",
+            (task_id, now),
+        )
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, workspace: spawned.append(task.id),
+        )
+
+    assert spawned == [task_id]
+    assert result.respawn_guarded == []
+
+
 
 
 


### PR DESCRIPTION
## Summary
- preserve the active-PR duplicate-spawn guard until a deliberate requeue occurs
- allow promoted, unblocked, reclaimed, or status-requeued tasks to continue on an existing PR
- add direct guard and dispatcher regression coverage for same-PR review cycles

## Why
Kanban documents blocked → unblock → re-run and dependency promotion as supported workflows. The active-PR guard currently treats any recent PR URL as an unconditional 24-hour lock, stranding deliberate same-PR re-reviews even after remediation dependencies complete.

## Test plan
- RED confirmed: new dependency-promotion regression returned `active_pr` before the patch
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q` — 33 passed
- focused Kanban group — 63 passed
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` — passed
- live read-only probe against two currently stranded tasks returns no guard with patched code
- broader `tests/hermes_cli` run: 3,889 passed; 5 unrelated pre-existing failures in `test_update_eol_churn.py` reproduced when run alone