### PR TITLE
refactor(delegation): persist child-scoped delivery state

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -946,3 +946,102 @@ def test_batch_model_rejection_notice_requires_configured_model_in_text(monkeypa
     text = format_process_notification(evt)
     assert text is not None
     assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+    """The production aggregation callback closes the partial-crash window.
+
+    PR1 deliberately preserves legacy delivery timing: a finished child is
+    durable while its sibling is still running, but nothing reaches the shared
+    completion queue until the aggregate batch finalizes.
+    """
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "partial-crash-parent"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    first_persisted = threading.Event()
+    release_sibling = threading.Event()
+    sibling_returned = threading.Event()
+
+    def child_result(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 1:
+            assert release_sibling.wait(timeout=10)
+            sibling_returned.set()
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    real_persist = ad.persist_batch_child_completion
+
+    def observe_persist(delegation_id, task_index, result):
+        inserted = real_persist(delegation_id, task_index, result)
+        if task_index == 0 and inserted:
+            first_persisted.set()
+        return inserted
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", child_result)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+
+    out = dt.delegate_task(
+        tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
+        background=True,
+        parent_agent=parent,
+    )
+    parsed = json.loads(out)
+    delegation_id = parsed["delegation_id"]
+
+    try:
+        assert parsed["status"] == "dispatched"
+        assert first_persisted.wait(timeout=5)
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",)]
+        assert process_registry.completion_queue.empty()
+
+        # Simulate the owner disappearing in this exact pre-join state. Recovery
+        # must use the real callback's durable child row, not a test-fabricated row.
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+                "WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert ad.recover_abandoned_delegations() == 1
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",), ("terminal",)]
+    finally:
+        # A real crash would remove the worker and memory record. Make the
+        # in-process simulation match that before releasing the daemon child.
+        with ad._records_lock:
+            ad._records.pop(delegation_id, None)
+        release_sibling.set()
+        assert sibling_returned.wait(timeout=5)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -623,6 +623,105 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+    """The production aggregation callback closes the partial-crash window.
+
+    PR1 deliberately preserves legacy delivery timing: a finished child is
+    durable while its sibling is still running, but nothing reaches the shared
+    completion queue until the aggregate batch finalizes.
+    """
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "partial-crash-parent"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    first_persisted = threading.Event()
+    release_sibling = threading.Event()
+    sibling_returned = threading.Event()
+
+    def child_result(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 1:
+            assert release_sibling.wait(timeout=10)
+            sibling_returned.set()
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    real_persist = ad.persist_batch_child_completion
+
+    def observe_persist(delegation_id, task_index, result):
+        inserted = real_persist(delegation_id, task_index, result)
+        if task_index == 0 and inserted:
+            first_persisted.set()
+        return inserted
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", child_result)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+
+    out = dt.delegate_task(
+        tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
+        background=True,
+        parent_agent=parent,
+    )
+    parsed = json.loads(out)
+    delegation_id = parsed["delegation_id"]
+
+    try:
+        assert parsed["status"] == "dispatched"
+        assert first_persisted.wait(timeout=5)
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",)]
+        assert process_registry.completion_queue.empty()
+
+        # Simulate the owner disappearing in this exact pre-join state. Recovery
+        # must use the real callback's durable child row, not a test-fabricated row.
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+                "WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert ad.recover_abandoned_delegations() == 1
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",), ("terminal",)]
+    finally:
+        # A real crash would remove the worker and memory record. Make the
+        # in-process simulation match that before releasing the daemon child.
+        with ad._records_lock:
+            ad._records.pop(delegation_id, None)
+        release_sibling.set()
+        assert sibling_returned.wait(timeout=5)
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -1,0 +1,390 @@
+"""Durable child-event ledger contracts for async delegation batches."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_state():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _record(
+    *,
+    goals=("audit",),
+    parent_session_id="parent-session",
+):
+    delegation_id = f"deleg_test_{uuid.uuid4().hex}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": goals[0] if len(goals) == 1 else f"{len(goals)} tasks",
+        "goals": list(goals),
+        "context": "parent context",
+        "toolsets": ["file"],
+        "role": "leaf",
+        "model": "child-model",
+        "session_key": "agent:main:cli:dm:local",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": parent_session_id,
+        "status": "running",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "is_batch": True,
+    }
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    ad._persist_dispatch(record)
+    return delegation_id
+
+
+def _child(index: int, summary: str, *, status="completed", error=None):
+    return {
+        "task_index": index,
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": 2,
+        "duration_seconds": 0.25,
+    }
+
+
+def _queue_contents():
+    items = []
+    while not process_registry.completion_queue.empty():
+        items.append(process_registry.completion_queue.get_nowait())
+    for item in items:
+        process_registry.completion_queue.put(item)
+    return items
+
+
+def _event_state(delegation_id: str, event_key: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegation_events "
+            "WHERE delegation_id=? AND event_key=?",
+            (delegation_id, event_key),
+        ).fetchone()
+
+
+def _parent_state(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _durable_event_keys(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        ]
+
+def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
+    delegation_id = _record(goals=("A", "B"), )
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+
+    competing_claim = ad.claim_event_delivery(children[1], "competing-consumer")
+    assert competing_claim
+    assert ad.claim_event_delivery(grouped, "group-consumer") is None
+    # task:0's attempted group claim rolled back with the task:1 conflict.
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert _event_state(delegation_id, "task:1") == ("pending", 1)
+
+    assert ad.release_event_delivery(children[1], competing_claim)
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.complete_event_delivery(grouped, group_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert _event_state(delegation_id, "task:1") == ("delivered", 2)
+
+
+def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
+    delegation_id = _record(goals=("fresh", "near-cap"), )
+    for index, summary in enumerate(("fresh", "near-cap")):
+        assert ad.publish_batch_child_completion(
+            delegation_id, index, _child(index, summary)
+        )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    near_cap = children[1]
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS - 1):
+        claim = ad.claim_event_delivery(near_cap, "failing-consumer")
+        assert claim
+        assert ad.release_event_delivery(near_cap, claim)
+
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.release_event_delivery(grouped, group_claim)
+
+    assert grouped["delivery_event_keys"] == ["task:0"]
+    assert [result["summary"] for result in grouped["results"]] == ["fresh"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert _event_state(delegation_id, "task:1") == (
+        "dropped",
+        ad._MAX_DELIVERY_ATTEMPTS,
+    )
+    retry_claim = ad.claim_event_delivery(grouped, "retry-consumer")
+    assert retry_claim
+    assert ad.complete_event_delivery(grouped, retry_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 2)
+
+def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+    monkeypatch,
+):
+    delegation_id = _record(goals=("A", "B"))
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [_child(0, "A"), _child(1, "B")]}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "completed_at": time.time(),
+    }
+
+    def crash_before_parent_update(*_args, **_kwargs):
+        raise RuntimeError("simulated crash before parent terminal update")
+
+    monkeypatch.setattr(ad, "_update_completion_row", crash_before_parent_update)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        ad._persist_batch_child_finalization(
+            event_record, parent_event, combined, "completed"
+        )
+
+    assert _durable_event_keys(delegation_id) == []
+    assert _parent_state(delegation_id) == ("running", "pending")
+
+
+def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
+    delegation_id = _record(goals=("A", "B"), )
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    children = [_child(0, "A"), _child(1, "B")]
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_persisted_children_wait_for_legacy_batch_finalization():
+    delegation_id = _record(goals=("A", "B"))
+    children = [_child(0, "A"), _child(1, "B")]
+
+    assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
+    assert ad.persist_batch_child_completion(delegation_id, 1, children[1])
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    assert process_registry.completion_queue.empty()
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_published_child_is_not_requeued_by_batch_finalization():
+    delegation_id = _record(goals=("A",))
+    child = _child(0, "A")
+    assert ad.publish_batch_child_completion(delegation_id, 0, child)
+    assert process_registry.completion_queue.qsize() == 1
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [child], "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": [child],
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    assert process_registry.completion_queue.qsize() == 1
+    event = process_registry.completion_queue.get_nowait()
+    assert event["delivery_event_key"] == "task:0"
+
+
+def test_recovery_with_complete_children_suppresses_parent_aggregate():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("completed", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    grouped = restored.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert restored.empty()
+
+
+def test_recovery_with_partial_children_emits_only_terminal_gap_event():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "terminal"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    events = [restored.get_nowait() for _ in range(2)]
+    assert {
+        key
+        for event in events
+        for key in event.get("delivery_event_keys")
+        or [event.get("delivery_event_key")]
+    } == {
+        "task:0",
+        "terminal",
+    }
+    terminal = next(
+        event for event in events if event.get("delivery_event_key") == "terminal"
+    )
+    assert terminal["status"] == "unknown"
+    assert "1/2 batch child results" in terminal["error"]
+
+
+def test_recovery_requires_exact_expected_batch_child_keys():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    rogue = ad._build_batch_child_event(event_record, 99, _child(99, "rogue"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        assert ad._insert_batch_event(conn, rogue, now=time.time())
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:99", "terminal"]
+
+def test_durable_claim_renewal_prevents_expiry_steal():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "renew durable lease")
+    )
+    event = process_registry.completion_queue.get_nowait()
+    claim = ad.claim_event_delivery(event, "slow-main")
+    assert claim
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegation_events SET delivery_claimed_at=0 "
+            "WHERE delegation_id=? AND event_key='task:0'",
+            (delegation_id,),
+        )
+
+    assert ad.renew_event_delivery(event, claim) is True
+    assert ad.claim_event_delivery(event, "competing-main") is None
+    assert ad.complete_event_delivery(event, claim) is True
+
+def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = _record(goals=("restore me",))
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "restored result")
+    )
+    process_registry.completion_queue.get_nowait()
+
+    restored_queue = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    event = restored_queue.get_nowait()
+    assert event["restored"] is True
+    assert event["delegation_id"] == delegation_id
+    assert event["delivery_event_keys"] == ["task:0"]
+
+    claim = ad.claim_event_delivery(event, "restart-consumer")
+    assert claim
+    ad.complete_event_delivery(event, claim)
+    assert ad.restore_undelivered_completions(restored_queue) == 0

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -1,0 +1,438 @@
+"""Durable child-event ledger contracts for async delegation batches."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_state():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _record(
+    *,
+    goals=("audit",),
+    parent_session_id="parent-session",
+):
+    delegation_id = f"deleg_test_{uuid.uuid4().hex}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": goals[0] if len(goals) == 1 else f"{len(goals)} tasks",
+        "goals": list(goals),
+        "context": "parent context",
+        "toolsets": ["file"],
+        "role": "leaf",
+        "model": "child-model",
+        "session_key": "agent:main:cli:dm:local",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": parent_session_id,
+        "status": "running",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "is_batch": True,
+    }
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    ad._persist_dispatch(record)
+    return delegation_id
+
+
+def _child(index: int, summary: str, *, status="completed", error=None):
+    return {
+        "task_index": index,
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": 2,
+        "duration_seconds": 0.25,
+    }
+
+
+def _queue_contents():
+    items = []
+    while not process_registry.completion_queue.empty():
+        items.append(process_registry.completion_queue.get_nowait())
+    for item in items:
+        process_registry.completion_queue.put(item)
+    return items
+
+
+def _event_state(delegation_id: str, event_key: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegation_events "
+            "WHERE delegation_id=? AND event_key=?",
+            (delegation_id, event_key),
+        ).fetchone()
+
+
+def _parent_state(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _durable_event_keys(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        ]
+
+def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
+    delegation_id = _record(goals=("A", "B"), )
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+
+    competing_claim = ad.claim_event_delivery(children[1], "competing-consumer")
+    assert competing_claim
+    assert ad.claim_event_delivery(grouped, "group-consumer") is None
+    # task:0's attempted group claim rolled back with the task:1 conflict.
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert _event_state(delegation_id, "task:1") == ("pending", 1)
+
+    assert ad.release_event_delivery(children[1], competing_claim)
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.complete_event_delivery(grouped, group_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert _event_state(delegation_id, "task:1") == ("delivered", 2)
+
+
+def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
+    delegation_id = _record(goals=("fresh", "near-cap"), )
+    for index, summary in enumerate(("fresh", "near-cap")):
+        assert ad.publish_batch_child_completion(
+            delegation_id, index, _child(index, summary)
+        )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    near_cap = children[1]
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS - 1):
+        claim = ad.claim_event_delivery(near_cap, "failing-consumer")
+        assert claim
+        assert ad.release_event_delivery(near_cap, claim)
+
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.release_event_delivery(grouped, group_claim)
+
+    assert grouped["delivery_event_keys"] == ["task:0"]
+    assert [result["summary"] for result in grouped["results"]] == ["fresh"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert _event_state(delegation_id, "task:1") == (
+        "dropped",
+        ad._MAX_DELIVERY_ATTEMPTS,
+    )
+    retry_claim = ad.claim_event_delivery(grouped, "retry-consumer")
+    assert retry_claim
+    assert ad.complete_event_delivery(grouped, retry_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 2)
+
+def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+    monkeypatch,
+):
+    delegation_id = _record(goals=("A", "B"))
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [_child(0, "A"), _child(1, "B")]}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "completed_at": time.time(),
+    }
+
+    def crash_before_parent_update(*_args, **_kwargs):
+        raise RuntimeError("simulated crash before parent terminal update")
+
+    monkeypatch.setattr(ad, "_update_completion_row", crash_before_parent_update)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        ad._persist_batch_child_finalization(
+            event_record, parent_event, combined, "completed"
+        )
+
+    assert _durable_event_keys(delegation_id) == []
+    assert _parent_state(delegation_id) == ("running", "pending")
+
+
+def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
+    delegation_id = _record(goals=("A", "B"), )
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    children = [_child(0, "A"), _child(1, "B")]
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_persisted_children_wait_for_legacy_batch_finalization():
+    delegation_id = _record(goals=("A", "B"))
+    children = [_child(0, "A"), _child(1, "B")]
+
+    assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
+    assert ad.persist_batch_child_completion(delegation_id, 1, children[1])
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    assert process_registry.completion_queue.empty()
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_published_child_is_not_requeued_by_batch_finalization():
+    delegation_id = _record(goals=("A",))
+    child = _child(0, "A")
+    assert ad.publish_batch_child_completion(delegation_id, 0, child)
+    assert process_registry.completion_queue.qsize() == 1
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [child], "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": [child],
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    assert process_registry.completion_queue.qsize() == 1
+    event = process_registry.completion_queue.get_nowait()
+    assert event["delivery_event_key"] == "task:0"
+
+
+def test_recovery_with_complete_children_suppresses_parent_aggregate():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("completed", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    grouped = restored.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert restored.empty()
+
+
+def test_recovery_with_partial_children_emits_only_terminal_gap_event():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "terminal"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    events = [restored.get_nowait() for _ in range(2)]
+    assert {
+        key
+        for event in events
+        for key in event.get("delivery_event_keys")
+        or [event.get("delivery_event_key")]
+    } == {
+        "task:0",
+        "terminal",
+    }
+    terminal = next(
+        event for event in events if event.get("delivery_event_key") == "terminal"
+    )
+    assert terminal["status"] == "unknown"
+    assert "1/2 batch child results" in terminal["error"]
+
+
+def test_recovery_requires_exact_expected_batch_child_keys():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    rogue = ad._build_batch_child_event(event_record, 99, _child(99, "rogue"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        assert ad._insert_batch_event(conn, rogue, now=time.time())
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:99", "terminal"]
+
+def test_durable_claim_renewal_prevents_expiry_steal():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "renew durable lease")
+    )
+    event = process_registry.completion_queue.get_nowait()
+    claim = ad.claim_event_delivery(event, "slow-main")
+    assert claim
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegation_events SET delivery_claimed_at=0 "
+            "WHERE delegation_id=? AND event_key='task:0'",
+            (delegation_id,),
+        )
+
+    assert ad.renew_event_delivery(event, claim) is True
+    assert ad.claim_event_delivery(event, "competing-main") is None
+    assert ad.complete_event_delivery(event, claim) is True
+
+def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = _record(goals=("restore me",))
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "restored result")
+    )
+    process_registry.completion_queue.get_nowait()
+
+    # A new process recovers an exited owner, not another live batch's hidden rows.
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("UPDATE async_delegations SET owner_pid=99999999 WHERE delegation_id=?", (delegation_id,))
+    restored_queue = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    event = restored_queue.get_nowait()
+    assert event["restored"] is True
+    assert event["delegation_id"] == delegation_id
+    assert event["delivery_event_keys"] == ["task:0"]
+
+    claim = ad.claim_event_delivery(event, "restart-consumer")
+    assert claim
+    ad.complete_event_delivery(event, claim)
+    assert ad.restore_undelivered_completions(restored_queue) == 0
+
+
+@pytest.mark.parametrize("age", [0, ad._MAX_COMPLETION_REPLAY_AGE_S + 10])
+def test_child_recovery_preserves_origin_and_replay_age(age):
+    """Child and terminal-gap recovery keep upstream route isolation and age limits."""
+    delegation_id = _record(goals=("ready child", "unfinished sibling"))
+    routing = {"scope_id": "tenant-a", "user_id": "user-a", "user_name": "Alice"}
+    with ad._records_lock:
+        ad._records[delegation_id].update(routing)
+        record = dict(ad._records[delegation_id])
+    ad._persist_dispatch(record)
+    assert ad.persist_batch_child_completion(delegation_id, 0, _child(0, "ready"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("UPDATE async_delegations SET owner_pid=99999999 WHERE delegation_id=?", (delegation_id,))
+        conn.execute("UPDATE async_delegation_events SET created_at=? WHERE delegation_id=?",
+                     (time.time() - age, delegation_id))
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == (1 if age else 2)
+    while not restored.empty():
+        event = restored.get_nowait()
+        assert {key: event.get(key) for key in routing} == routing
+    assert _event_state(delegation_id, "task:0")[0] == ("dropped" if age else "pending")
+
+
+def test_partial_batch_is_hidden_while_live_and_retained_until_settled(monkeypatch):
+    """Bookkeeping-only parent completion cannot make undelivered children disposable."""
+    delegation_id = _record(goals=("ready", "missing"))
+    assert ad.persist_batch_child_completion(delegation_id, 0, _child(0, "ready"))
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 0
+    with ad._records_lock:
+        record = dict(ad._records[delegation_id])
+    parent = {**record, "type": "async_delegation", "status": "error", "completed_at": time.time()}
+    # A post-child exception must still enqueue its durable result plus the terminal gap.
+    ad._persist_batch_child_finalization(record, parent, {"results": [], "error": "runner failed"}, "error")
+    assert process_registry.completion_queue.qsize() == 2
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 0)
+    ad._prune_durable_records()
+    assert set(_durable_event_keys(delegation_id)) == {"task:0", "terminal"}
+    while not process_registry.completion_queue.empty():
+        event = process_registry.completion_queue.get_nowait()
+        claim = ad.claim_event_delivery(event, "consumer")
+        assert ad.complete_event_delivery(event, claim)
+    ad._prune_durable_records()
+    assert _durable_event_keys(delegation_id) == []

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,7 @@ _MAX_DELIVERY_ATTEMPTS = 8
 # Pending completions older than this are dropped on restart replay instead of
 # re-run as a full-context turn; 48h keeps weekend results deliverable.
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
+_DELIVERY_CLAIM_LEASE_SECONDS = 300
 _DB_LOCK = threading.Lock()
 
 # ── Stale-delegation detection (progress-based, on by default) ──────────────
@@ -128,6 +129,25 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
 
+    # Child-level delivery records extend the existing durable claim ledger.
+    # A batch parent remains one execution unit, while each completed child is
+    # independently claimable and recoverable on the between-turn rail.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegation_events (
+            delegation_id TEXT NOT NULL,
+            event_key TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (delegation_id, event_key)
+        )"""
+    )
+
 
 @contextmanager
 def _transaction() -> Iterator[sqlite3.Connection]:
@@ -186,36 +206,785 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
 def _prune_durable_records() -> None:
     """Bound terminal history, preferring delivered records for deletion."""
     cutoff = time.time() - _DURABLE_RETENTION_SECONDS
+    no_pending_children = (
+        "NOT EXISTS (SELECT 1 FROM async_delegation_events e "
+        "WHERE e.delegation_id=async_delegations.delegation_id AND e.delivery_state='pending')"
+    )
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?", (cutoff,))
+            f"DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ? AND {no_pending_children}", (cutoff,))
         terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')").fetchone()[0]
+            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','stalling','finalizing')").fetchone()[0]
         if terminal_count > _MAX_RETAINED_COMPLETED:
-            conn.execute("""DELETE FROM async_delegations WHERE delegation_id IN (
+            conn.execute(f"""DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
+                     WHERE state NOT IN ('running','stalling','finalizing') AND {no_pending_children}
                      ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
                               updated_at ASC LIMIT ?
                    )""", (terminal_count - _MAX_RETAINED_COMPLETED,))
         pending_count = conn.execute("""SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'""").fetchone()[0]
+               WHERE state NOT IN ('running','stalling','finalizing') AND delivery_state='pending'""").fetchone()[0]
         if pending_count > _MAX_DURABLE_PENDING:
             conn.execute("""DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                     WHERE state NOT IN ('running','stalling','finalizing') AND delivery_state='pending'
                      ORDER BY updated_at ASC LIMIT ?
                    )""", (pending_count - _MAX_DURABLE_PENDING,))
 
+        conn.execute("DELETE FROM async_delegation_events WHERE delegation_id NOT IN "
+                     "(SELECT delegation_id FROM async_delegations)")
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _update_completion_row(
+    conn,
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+    now: Optional[float] = None,
+) -> None:
+    now = time.time() if now is None else now
+    state = "delivered" if delivery_state == "delivered" else "pending"
+    delivered_at = now if state == "delivered" else None
+    conn.execute(
+        """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
+           event_json=?, result_json=?, delivery_state=?, delivered_at=?
+           WHERE delegation_id=?""",
+        (
+            event.get("status", "completed"),
+            event.get("completed_at", now),
+            now,
+            json.dumps(event),
+            json.dumps(result),
+            state,
+            delivered_at,
+            event["delegation_id"],
+        ),
+    )
+
+
+def _build_batch_child_event(
+    record: Dict[str, Any],
+    task_index: int,
+    result: Dict[str, Any],
+    *,
+    completed_at: Optional[float] = None,
+) -> Dict[str, Any]:
+    delegation_id = str(record.get("delegation_id") or "")
+    goals = list(record.get("goals") or [])
+    goal = goals[task_index] if 0 <= task_index < len(goals) else record.get("goal", "")
+    completed_at = time.time() if completed_at is None else completed_at
+    child_result = dict(result or {})
+    child_result.setdefault("task_index", task_index)
+    return {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": f"task:{task_index}",
+        "batch_id": delegation_id,
+        "task_index": task_index,
+        "batch_size": len(goals),
+        "session_key": record.get("session_key", ""),
+        "origin_ui_session_id": record.get("origin_ui_session_id", ""),
+        "origin_session_id": record.get("origin_session_id", ""),
+        "parent_session_id": record.get("parent_session_id"),
+        "goal": goal,
+        "goals": goals,
+        "context": record.get("context"),
+        "toolsets": record.get("toolsets"),
+        "role": record.get("role"),
+        "model": record.get("model"),
+        "status": child_result.get("status", "completed"),
+        "summary": child_result.get("summary"),
+        "error": child_result.get("error"),
+        "api_calls": child_result.get("api_calls"),
+        "duration_seconds": child_result.get("duration_seconds"),
+        "is_batch": True,
+        "results": [child_result],
+        "live_transcripts": (
+            [child_result.get("live_transcript")]
+            if child_result.get("live_transcript")
+            else None
+        ),
+        "dispatched_at": record.get("dispatched_at"),
+        "completed_at": completed_at,
+        **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
+        **{k: result[k] for k in _STALL_META_KEYS if k in result},
+    }
+
+
+def _insert_batch_event(conn, event: Dict[str, Any], *, now: float) -> bool:
+    cur = conn.execute(
+        """INSERT OR IGNORE INTO async_delegation_events
+           (delegation_id, event_key, event_json, delivery_state,
+            delivery_attempts, created_at, updated_at)
+           VALUES (?, ?, ?, 'pending', 0, ?, ?)""",
+        (
+            event["delegation_id"],
+            event["delivery_event_key"],
+            json.dumps(event),
+            now,
+            now,
+        ),
+    )
+    return cur.rowcount == 1
+
+
+def _persist_batch_child_completion_event(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return None
+    event = _build_batch_child_event(record, task_index, result)
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute("""UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]))
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return None
+    return event
+
+
+def persist_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Persist one completed batch child without changing delivery timing.
+
+    The production batch runner calls this before joining slower siblings so a
+    process crash cannot erase an already completed child. The legacy aggregate
+    finalizer remains the only queue publisher in this layer.
+    """
+    return _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    ) is not None
+
+
+def publish_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Durably enqueue one ready child from an asynchronous batch.
+
+    The parent batch remains the execution/stall unit. This function creates an
+    independently claimable between-turn delivery event, keyed by task index.
+    Repeated publication is idempotent and never resets a delivered claim.
+    """
+    event = _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    )
+    if event is None:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    # Process-local handoff marker only. It prevents the aggregate finalizer
+    # from adding a duplicate queue copy when a future layer publishes children
+    # early. A crash intentionally loses this marker; restart recovery then
+    # restores the still-pending durable row from SQLite.
+    event_key = event["delivery_event_key"]
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            queued_keys = record.setdefault("_queued_child_event_keys", [])
+            if event_key not in queued_keys:
+                queued_keys.append(event_key)
+    return True
+
+
+def _event_delivery_keys(event: Dict[str, Any]) -> list[str]:
+    raw_keys = event.get("delivery_event_keys")
+    if isinstance(raw_keys, (list, tuple)):
+        return list(dict.fromkeys(str(key) for key in raw_keys if key))
+    key = str(event.get("delivery_event_key") or "")
+    return [key] if key else []
+
+
+def coalesce_ready_after_turn_events(
+    events: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Combine ready child rows from each after-turn batch at one boundary.
+
+    SQLite and the shared queue retain one durable row per child. This helper
+    creates only a transient delivery envelope so every child remains
+    independently recoverable while one consumer can claim/ack the currently
+    ready set atomically. Envelopes are deliberately re-coalescible: a busy
+    consumer may requeue one while more siblings finish before its next boundary.
+    """
+
+    output: List[Dict[str, Any]] = []
+    groups: Dict[str, Dict[str, Any]] = {}
+    seen_keys: Dict[str, set[str]] = {}
+    for event in events:
+        event_keys = _event_delivery_keys(event)
+        delegation_id = str(event.get("delegation_id") or "")
+        coalescible = (
+            event.get("type") == "async_delegation"
+            and bool(event.get("is_batch"))
+            and bool(event_keys)
+            and all(key.startswith("task:") for key in event_keys)
+            and bool(delegation_id)
+        )
+        if not coalescible:
+            output.append(event)
+            continue
+
+        grouped = groups.get(delegation_id)
+        if grouped is None:
+            grouped = dict(event)
+            grouped.pop("delivery_event_key", None)
+            grouped["delivery_event_keys"] = []
+            grouped["task_indices"] = []
+            grouped["results"] = []
+            grouped["live_transcripts"] = []
+            grouped["coalesced_after_turn"] = True
+            groups[delegation_id] = grouped
+            seen_keys[delegation_id] = set()
+            output.append(grouped)
+
+        new_keys = [
+            key for key in event_keys if key not in seen_keys[delegation_id]
+        ]
+        if not new_keys:
+            continue
+        seen_keys[delegation_id].update(new_keys)
+        grouped["delivery_event_keys"].extend(new_keys)
+        new_key_set = set(new_keys)
+        for result in event.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            task_index = int(result.get("task_index", 0))
+            if f"task:{task_index}" not in new_key_set:
+                continue
+            grouped["task_indices"].append(task_index)
+            grouped["results"].append(result)
+        grouped["live_transcripts"].extend(
+            path for path in (event.get("live_transcripts") or []) if path
+        )
+        grouped["completed_at"] = max(
+            float(grouped.get("completed_at") or 0),
+            float(event.get("completed_at") or 0),
+        )
+
+    for grouped in groups.values():
+        grouped["delivery_event_keys"].sort(
+            key=lambda key: int(key.split(":", 1)[1])
+        )
+        grouped["task_indices"] = sorted(set(grouped["task_indices"]))
+        grouped["results"].sort(key=lambda result: int(result.get("task_index", 0)))
+        grouped["live_transcripts"] = list(
+            dict.fromkeys(grouped["live_transcripts"])
+        ) or None
+    return output
+
+
+def _build_batch_terminal_event(
+    event_record: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+    *,
+    force: bool = False,
+) -> Optional[Dict[str, Any]]:
+    if not force and (
+        status in {"completed", "success"} or (combined.get("results") or [])
+    ):
+        return None
+    delegation_id = str(event_record.get("delegation_id") or "")
+    now = time.time()
+    event: Dict[str, Any] = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": "terminal",
+        "batch_id": delegation_id,
+        "session_key": event_record.get("session_key", ""),
+        "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
+        "origin_session_id": event_record.get("origin_session_id", ""),
+        "parent_session_id": event_record.get("parent_session_id"),
+        "goal": event_record.get("goal", ""),
+        "goals": event_record.get("goals"),
+        "context": event_record.get("context"),
+        "toolsets": event_record.get("toolsets"),
+        "role": event_record.get("role"),
+        "model": event_record.get("model"),
+        "status": status,
+        "is_batch": True,
+        "results": [],
+        "error": combined.get("error"),
+        "dispatched_at": event_record.get("dispatched_at"),
+        "completed_at": now,
+        **{k: event_record[k] for k in _ROUTING_KEYS if event_record.get(k)},
+    }
+    for key in (
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_phase",
+        "stall_grace_seconds",
+    ):
+        if key in combined:
+            event[key] = combined[key]
+    return event
+
+
+def _persist_batch_child_finalization(
+    event_record: Dict[str, Any],
+    parent_event: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+) -> None:
+    """Atomically persist missing child events and the terminal parent row."""
+
+    now = time.time()
+    queue_event_keys: list[str] = []
+    queue_events: list[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        for child in combined.get("results") or []:
+            child_event = _build_batch_child_event(
+                event_record,
+                int(child.get("task_index", 0)),
+                child,
+                completed_at=now,
+            )
+            _insert_batch_event(conn, child_event, now=now)
+            queue_event_keys.append(child_event["delivery_event_key"])
+
+        durable_keys = {row[0] for row in conn.execute(
+            "SELECT event_key FROM async_delegation_events WHERE delegation_id=?",
+            (event_record["delegation_id"],),
+        )}
+        expected_keys = {f"task:{i}" for i in range(len(event_record.get("goals") or []))}
+        terminal_event = _build_batch_terminal_event(
+            event_record, combined, status,
+            force=status not in {"completed", "success"} and not expected_keys.issubset(durable_keys),
+        )
+        if terminal_event is not None:
+            _insert_batch_event(conn, terminal_event, now=now)
+            queue_event_keys.append(terminal_event["delivery_event_key"])
+
+        # The aggregate row is bookkeeping-only. Commit its terminal state in
+        # the same transaction as the idempotent child safety net so restart
+        # recovery can never observe a half-finalized parent.
+        _update_completion_row(
+            conn,
+            parent_event,
+            combined,
+            delivery_state="delivered",
+            now=now,
+        )
+
+        # Child callbacks may have inserted these rows before the aggregate
+        # join. Preserve legacy delivery timing by loading every still-pending
+        # aggregate member only after the parent terminal update commits.
+        already_queued = {
+            str(key) for key in (event_record.get("_queued_child_event_keys") or [])
+        }
+        event_keys = [key for key in durable_keys | set(queue_event_keys) if key not in already_queued]
+        if event_keys:
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                "SELECT event_json FROM async_delegation_events "
+                "WHERE delegation_id=? AND delivery_state='pending' "
+                f"AND event_key IN ({placeholders})",
+                (event_record["delegation_id"], *event_keys),
+            ).fetchall()
+            queue_events = [json.loads(row[0]) for row in rows]
+
+    from tools.process_registry import process_registry
+
+    queue_events = coalesce_ready_after_turn_events(queue_events)
+    with process_registry.completion_routing_lock:
+        for queued_event in queue_events:
+            process_registry.completion_queue.put(queued_event)
+
+
+class _DeliveryGroupConflict(RuntimeError):
+    """Rollback a multi-child settlement when any row lost ownership."""
+
+
+def _claim_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=?, delivery_claimed_at=?,
+                           delivery_attempts=delivery_attempts+1, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending'
+                         AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+                    (
+                        claim_id,
+                        now,
+                        now,
+                        delegation_id,
+                        event_key,
+                        now - _DELIVERY_CLAIM_LEASE_SECONDS,
+                    ),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _claim_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=?, delivery_claimed_at=?,
+                   delivery_attempts=delivery_attempts+1, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending'
+                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                event_key,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
+        )
+        return cur.rowcount == 1
+
+
+def renew_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Renew the lease held by the exact consumer claim."""
+
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return False
+    event_keys = _event_delivery_keys(evt)
+    now = time.time()
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        try:
+            with _DB_LOCK, _transaction() as conn:
+                for event_key in event_keys:
+                    cur = conn.execute(
+                        """UPDATE async_delegation_events
+                           SET delivery_claimed_at=?, updated_at=?
+                           WHERE delegation_id=? AND event_key=?
+                             AND delivery_state='pending' AND delivery_claim=?""",
+                        (now, now, delegation_id, event_key, claim_id),
+                    )
+                    if cur.rowcount != 1:
+                        raise _DeliveryGroupConflict(event_key)
+        except _DeliveryGroupConflict:
+            return False
+        return True
+    event_key = event_keys[0] if event_keys else ""
+    with _DB_LOCK, _transaction() as conn:
+        if event_key:
+            cur = conn.execute(
+                """UPDATE async_delegation_events
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND event_key=?
+                     AND delivery_state='pending' AND delivery_claim=?""",
+                (now, now, delegation_id, event_key, claim_id),
+            )
+        else:
+            cur = conn.execute(
+                """UPDATE async_delegations
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, now, delegation_id, claim_id),
+            )
+        return cur.rowcount == 1
+
+
+def get_event_delivery_state(evt: Dict[str, Any]) -> Optional[str]:
+    """Return the durable state for one aggregate or child event."""
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    event_keys = _event_delivery_keys(evt)
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT delivery_state FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            if len(rows) != len(event_keys):
+                return None
+            states = {str(row[0]) for row in rows}
+            return states.pop() if len(states) == 1 else "mixed"
+        event_key = event_keys[0] if event_keys else ""
+        if event_key:
+            row = conn.execute(
+                """SELECT delivery_state FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_key),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+                (delegation_id,),
+            ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _complete_child_event(
+    delegation_id: str, event_key: str, claim_id: str, state: str = "delivered"
+) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state=?, delivered_at=?, updated_at=?,
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (state, now, now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _release_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        capped = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state='dropped', delivery_claim=NULL,
+                   delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?
+                 AND delivery_attempts>=?""",
+            (now, delegation_id, event_key, claim_id, _MAX_DELIVERY_ATTEMPTS),
+        )
+        if capped.rowcount == 1:
+            return True
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _complete_child_event_group(
+    delegation_id: str,
+    event_keys: List[str],
+    claim_id: str,
+    state: str = "delivered",
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state=?, delivered_at=?, updated_at=?,
+                           delivery_claim=NULL, delivery_claimed_at=NULL
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (state, now, now, delegation_id, event_key, claim_id),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _release_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> tuple[bool, List[str]]:
+    now = time.time()
+    pending_keys: List[str] = []
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                capped = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state='dropped', delivery_claim=NULL,
+                           delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?
+                         AND delivery_attempts>=?""",
+                    (
+                        now,
+                        delegation_id,
+                        event_key,
+                        claim_id,
+                        _MAX_DELIVERY_ATTEMPTS,
+                    ),
+                )
+                if capped.rowcount == 1:
+                    continue
+                released = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (now, delegation_id, event_key, claim_id),
+                )
+                if released.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+                pending_keys.append(event_key)
+    except _DeliveryGroupConflict:
+        return False, event_keys
+    return True, pending_keys
+
+
+def _retain_group_event_keys(evt: Dict[str, Any], event_keys: List[str]) -> None:
+    """Keep only rows that remain pending after a grouped release."""
+
+    keep = set(event_keys)
+    evt["delivery_event_keys"] = list(event_keys)
+    evt["results"] = [
+        result
+        for result in (evt.get("results") or [])
+        if isinstance(result, dict)
+        and f"task:{int(result.get('task_index', 0))}" in keep
+    ]
+    evt["task_indices"] = sorted(
+        int(result.get("task_index", 0)) for result in evt["results"]
+    )
+
+
+def get_event_delivery_retry_delay(
+    evt: Dict[str, Any], *, now: Optional[float] = None
+) -> Optional[float]:
+    """Return a bounded delay for an unclaimed pending event, else ``None``.
+
+    A failed claim is ambiguous: another live process may own the pending row,
+    or this queue entry may be a duplicate whose durable row is already
+    delivered/dropped. Consumers use this oracle before deferred requeue so a
+    quick restart waits only for the remaining lease without spinning. Grouped
+    envelopes are narrowed to rows that are still pending.
+    """
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    current = time.time() if now is None else float(now)
+    event_keys = _event_delivery_keys(evt)
+    pending_rows: List[tuple[str, Optional[str], Optional[float]]] = []
+
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT event_key, delivery_state, delivery_claim,
+                           delivery_claimed_at
+                    FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            by_key = {str(row[0]): row for row in rows}
+            if len(by_key) != len(event_keys):
+                return None
+            pending_keys = [
+                key for key in event_keys if str(by_key[key][1]) == "pending"
+            ]
+            if not pending_keys:
+                return None
+            _retain_group_event_keys(evt, pending_keys)
+            pending_rows = [
+                (
+                    key,
+                    str(by_key[key][2]) if by_key[key][2] else None,
+                    float(by_key[key][3]) if by_key[key][3] is not None else None,
+                )
+                for key in pending_keys
+            ]
+        elif event_keys:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_keys[0]),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    event_keys[0],
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+        else:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    "aggregate",
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+
+    # A short guard covers claim races and strict SQL '<' lease comparison.
+    delay = 0.05
+    for _event_key, claim, claimed_at in pending_rows:
+        if not claim:
+            continue
+        if claimed_at is None:
+            delay = max(delay, float(_DELIVERY_CLAIM_LEASE_SECONDS))
+            continue
+        remaining = float(_DELIVERY_CLAIM_LEASE_SECONDS) - (current - claimed_at)
+        delay = max(delay, remaining)
+    return max(0.05, delay) + 0.05
+
+
+def drop_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if event_keys:
+            _complete_child_event_group(
+                delegation_id, event_keys, claim_id, state="dropped"
+            )
+    elif event_keys:
+        _complete_child_event(delegation_id, event_keys[0], claim_id, state="dropped")
+    else:
+        drop_completion_delivery(delegation_id, claim_id)
+
+
+
+def _persist_completion(
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+) -> None:
+    with _DB_LOCK, _transaction() as conn:
+        _update_completion_row(
+            conn, event, result, delivery_state=delivery_state
+        )
 
 
 def recover_abandoned_delegations() -> int:
@@ -224,72 +993,226 @@ def recover_abandoned_delegations() -> int:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
         return 0
-    now, recovered = time.time(), 0
+    now = time.time()
+    recovered = 0
     with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute("""SELECT delegation_id, origin_session, origin_ui_session_id,
+        rows = conn.execute(
+            """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
                       owner_started_at, task_json, origin_session_id
-               FROM async_delegations WHERE state IN ('running','finalizing')""").fetchall()
+               FROM async_delegations WHERE state IN ('running','stalling','finalizing')"""
+        ).fetchall()
         for row in rows:
-            delegation_id, session_key, origin_ui, parent_id, dispatched_at, pid, started, task_json, origin_sid = row
-            if pid and _pid_exists(int(pid)) and (started is None or get_process_start_time(int(pid)) == int(started)):
+            (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
+             pid, started, task_json, origin_session_id) = row
+            live = False
+            if pid:
+                live = _pid_exists(int(pid))
+                if live and started is not None:
+                    live = get_process_start_time(int(pid)) == int(started)
+            if live:
                 continue
             task = json.loads(task_json or "{}")
+            child_rows = []
+            if bool(task.get("is_batch")):
+                child_rows = conn.execute(
+                    """SELECT event_key, event_json FROM async_delegation_events
+                       WHERE delegation_id=? AND event_key LIKE 'task:%'
+                       ORDER BY event_key""",
+                    (delegation_id,),
+                ).fetchall()
+            if bool(task.get("is_batch")) and bool(child_rows):
+                # Child-scoped batches never recover through a contradictory
+                # aggregate. A crash after one or more child inserts must
+                # preserve the already-delivered/pending task identities.
+                goals = list(task.get("goals") or [])
+                expected_child_keys = [f"task:{index}" for index in range(len(goals))]
+                child_results_by_key: dict[str, Dict[str, Any]] = {}
+                for event_key, child_payload in child_rows:
+                    if event_key not in expected_child_keys:
+                        continue
+                    child_event = json.loads(child_payload or "{}")
+                    results = child_event.get("results") or []
+                    if results and isinstance(results[0], dict):
+                        child_results_by_key[event_key] = results[0]
+
+                child_results = [
+                    child_results_by_key[key]
+                    for key in expected_child_keys
+                    if key in child_results_by_key
+                ]
+                complete_children = bool(expected_child_keys) and all(
+                    key in child_results_by_key for key in expected_child_keys
+                )
+                status = "completed" if complete_children else "unknown"
+                recovery_error = None
+                if not complete_children:
+                    recovery_error = (
+                        "Delegation owner exited after recording "
+                        f"{len(child_results)}/{len(goals)} batch child results; "
+                        "remaining outcomes are unknown."
+                    )
+                combined = {
+                    "results": child_results,
+                    "error": recovery_error,
+                }
+                event_record = {
+                    "delegation_id": delegation_id,
+                    "session_key": session_key,
+                    "origin_ui_session_id": origin_ui,
+                    "origin_session_id": origin_session_id or "",
+                    "parent_session_id": parent_id,
+                    "goal": task.get("goal", ""),
+                    "goals": goals,
+                    "context": task.get("context"),
+                    "toolsets": task.get("toolsets"),
+                    "role": task.get("role"),
+                    "model": task.get("model"),
+                    "dispatched_at": dispatched_at,
+                    **{k: task[k] for k in _ROUTING_KEYS if task.get(k)},
+                }
+                if not complete_children:
+                    terminal_event = _build_batch_terminal_event(
+                        event_record, combined, status, force=True
+                    )
+                    if terminal_event is not None:
+                        _insert_batch_event(conn, terminal_event, now=now)
+
+                parent_event = {
+                    **event_record,
+                    "type": "async_delegation",
+                    "status": status,
+                    "is_batch": True,
+                    "results": child_results,
+                    "error": recovery_error,
+                    "completed_at": now,
+                }
+                _update_completion_row(
+                    conn,
+                    parent_event,
+                    combined,
+                    delivery_state="delivered",
+                    now=now,
+                )
+                recovered += 1
+                continue
             event = {
-                "type": "async_delegation", "delegation_id": delegation_id, "session_key": session_key,
-                "origin_ui_session_id": origin_ui, "origin_session_id": origin_sid or "",
-                "parent_session_id": parent_id, "goal": task.get("goal", ""), "goals": task.get("goals"),
-                "context": task.get("context"), "toolsets": task.get("toolsets"), "role": task.get("role"),
+                "type": "async_delegation", "delegation_id": delegation_id,
+                "session_key": session_key, "origin_ui_session_id": origin_ui,
+                # Restore the durable wake target so completions recovered
+                # after a restart remain routable to api_server sessions.
+                "origin_session_id": origin_session_id or "",
+                "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "goals": task.get("goals"), "context": task.get("context"),
+                "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
                 "status": "unknown", "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
-                **{k: task[k] for k in _ROUTING_KEYS if task.get(k)}}
+            }
+            # Routing origin persisted at dispatch (see _capture_routing_origin):
+            # restores scope_id/user_id for the reconstructed SessionSource so
+            # relay egress priming works after a restart.
+            for _k in ("scope_id", "user_id", "user_name"):
+                if task.get(_k):
+                    event[_k] = task[_k]
             result = {"status": "unknown", "summary": None, "error": event["error"]}
-            conn.execute("""UPDATE async_delegations SET state='unknown', completed_at=?,
+            conn.execute(
+                """UPDATE async_delegations SET state='unknown', completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
-                   WHERE delegation_id=?""", (now, now, json.dumps(event), json.dumps(result), delegation_id))
+                   WHERE delegation_id=?""",
+                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+            )
             recovered += 1
     return recovered
 
 
 def restore_undelivered_completions(target_queue) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
-    Restored events are stamped ``restored=True`` in memory only: they came from a PREVIOUS
-    process, so drains without an ownership filter must leave them for a consumer that can
-    prove ownership. Rows older than ``_MAX_COMPLETION_REPLAY_AGE_S`` are terminally dropped
-    instead of replaying a turn nobody is waiting on.
 
-    Every restored event is stamped ``restored=True`` (in-memory only — the stamp is added after the durable
-    payload is deserialized and is never persisted). Restored events originate from a *previous* process, so
-    no consumer in THIS process implicitly owns them: drain paths that run without an ownership filter (the
-    legacy single-session behavior) must leave them queued for a consumer that can positively prove
-    ownership, otherwise a brand-new session adopts a dead session's delegation results seconds after boot
-    (#64484).
+    Every restored event is stamped ``restored=True`` (in-memory only — the
+    stamp is added after the durable payload is deserialized and is never
+    persisted). Restored events originate from a *previous* process, so no
+    consumer in THIS process implicitly owns them: drain paths that run
+    without an ownership filter (the legacy single-session behavior) must
+    leave them queued for a consumer that can positively prove ownership,
+    otherwise a brand-new session adopts a dead session's delegation
+    results seconds after boot (#64484).
+
+    Staleness cap: a pending completion older than
+    ``_MAX_COMPLETION_REPLAY_AGE_S`` is terminally dropped instead of
+    replayed. Replaying a weeks-old completion re-runs its parent session as
+    a full-context turn (a July session replayed in August burned a
+    102K-token context on the staging fleet) for a result nobody is waiting
+    on anymore; the payload stays queryable on the dropped row.
     """
     recover_abandoned_delegations()
-    now, restored = time.time(), 0
+    now = time.time()
+    restored = 0
+    parent_events: list[Dict[str, Any]] = []
+    child_events: list[Dict[str, Any]] = []
     with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute("""SELECT delegation_id, event_json, completed_at, dispatched_at
+        rows = conn.execute(
+            """SELECT delegation_id, event_json, completed_at, dispatched_at
                FROM async_delegations
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
-               ORDER BY completed_at, delegation_id""").fetchall()
+               ORDER BY completed_at, delegation_id"""
+        ).fetchall()
+        child_rows = conn.execute(
+            """SELECT e.delegation_id, e.event_key, e.event_json, e.created_at
+               FROM async_delegation_events e JOIN async_delegations p
+                 ON p.delegation_id=e.delegation_id
+               WHERE e.delivery_state='pending'
+                 AND p.state NOT IN ('running','stalling','finalizing')
+               ORDER BY e.created_at, e.delegation_id, e.event_key"""
+        ).fetchall()
         for delegation_id, payload, completed_at, dispatched_at in rows:
             age_basis = completed_at or dispatched_at
             if age_basis and (now - age_basis) > _MAX_COMPLETION_REPLAY_AGE_S:
-                conn.execute("""UPDATE async_delegations SET delivery_state='dropped',
+                conn.execute(
+                    """UPDATE async_delegations SET delivery_state='dropped',
                               delivery_claim=NULL, delivery_claimed_at=NULL,
                               updated_at=?
-                       WHERE delegation_id=? AND delivery_state='pending'""", (now, delegation_id))
-                logger.warning("Async delegation %s: pending completion is %.1fh old "
-                               "(cap %.1fh); terminally dropping the replay (result remains queryable).",
-                               delegation_id, (now - age_basis) / 3600.0, _MAX_COMPLETION_REPLAY_AGE_S / 3600.0)
+                       WHERE delegation_id=? AND delivery_state='pending'""",
+                    (now, delegation_id),
+                )
+                logger.warning(
+                    "Async delegation %s: pending completion is %.1fh old "
+                    "(cap %.1fh); terminally dropping the replay (result "
+                    "remains queryable).",
+                    delegation_id,
+                    (now - age_basis) / 3600.0,
+                    _MAX_COMPLETION_REPLAY_AGE_S / 3600.0,
+                )
                 continue
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
-            target_queue.put(evt)
+            parent_events.append(evt)
             restored += 1
+        for delegation_id, event_key, payload, created_at in child_rows:
+            if created_at and now - created_at > _MAX_COMPLETION_REPLAY_AGE_S:
+                conn.execute(
+                    "UPDATE async_delegation_events SET delivery_state='dropped', "
+                    "delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=? "
+                    "WHERE delegation_id=? AND event_key=? AND delivery_state='pending'",
+                    (now, delegation_id, event_key),
+                )
+                continue
+            evt = json.loads(payload)
+            if isinstance(evt, dict):
+                evt["restored"] = True
+                evt.setdefault("delegation_id", delegation_id)
+                evt.setdefault("delivery_event_key", event_key)
+            child_events.append(evt)
+            restored += 1
+    # Queue only after the SQLite read transaction closes. Default after-turn
+    # batches retain the legacy one-envelope restart shape even though each
+    # child now has an independently durable identity underneath it.
+    for evt in parent_events:
+        target_queue.put(evt)
+    for evt in coalesce_ready_after_turn_events(child_events):
+        target_queue.put(evt)
     return restored
 
 
@@ -319,17 +1242,28 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                       delivery_attempts=delivery_attempts+1, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300))
+            (claim_id, now, now, delegation_id, now - _DELIVERY_CLAIM_LEASE_SECONDS))
         return cur.rowcount == 1
 
 
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     """Claim a durable delegation event; non-durable events need no token."""
-    delegation_id = str(evt.get("delegation_id") or "") if evt.get("type") == "async_delegation" else ""
+    if evt.get("type") != "async_delegation":
+        return ""
+    delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
     claim_id = f"{consumer}:{os.getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        claimed = bool(event_keys) and _claim_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        claimed = _claim_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        claimed = claim_completion_delivery(delegation_id, claim_id)
+    return claim_id if claimed else None
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -377,17 +1311,41 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
              AND delivery_claim=?""", (now, now, delegation_id, claim_id))
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(complete_completion_delivery, evt, claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        completed = bool(event_keys) and _complete_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        completed = _complete_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        completed = complete_completion_delivery(delegation_id, claim_id)
+    return completed or get_event_delivery_state(evt) == "delivered"
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(release_completion_delivery, evt, claim_id)
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        released, pending_keys = _release_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+        if released:
+            _retain_group_event_keys(evt, pending_keys)
+        return released
+    if event_keys:
+        return _release_child_event(delegation_id, event_keys[0], claim_id)
+    return release_completion_delivery(delegation_id, claim_id)
 
 
-def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        fn(str(evt.get("delegation_id") or ""), claim_id)
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -544,6 +1502,7 @@ def _dispatch(
         with _records_lock:
             _records.pop(delegation_id, None)
         with _DB_LOCK, _transaction() as conn:
+            conn.execute("DELETE FROM async_delegation_events WHERE delegation_id=?", (delegation_id,))
             conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
         return {"status": "rejected", "error": f"Failed to schedule async delegation{label}: {exc}"}
     if progress_fn is not None:
@@ -670,6 +1629,9 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
         **({} if is_batch else {"exit_reason": result.get("exit_reason")}),
         **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
         **{k: result[k] for k in _STALL_META_KEYS if k in result}}
+    if is_batch:
+        _persist_batch_child_finalization(record, evt, result, status)
+        return
     _persist_completion(evt, result)
     try:
         process_registry.completion_queue.put(evt)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -6,27 +6,17 @@ Backs ``delegate_task(background=true)``: the parent agent dispatches a
 subagent that runs on a module-level daemon executor and returns a handle
 immediately, so the user and the model can keep working while the child runs.
 
-When the child finishes, a completion event is pushed onto the SHARED
-``process_registry.completion_queue`` with ``type="async_delegation"``. The
-CLI (``cli.py`` process_loop) and gateway (``_run_process_watcher`` /
-``completion_queue`` drain) already poll that queue while the agent is idle
-and forge a fresh user/internal turn from each event. We deliberately reuse
-that rail rather than reaching into a running agent loop:
+When a child finishes, its completion event is written to the durable ledger
+and pushed onto the shared ``process_registry.completion_queue`` for existing
+between-turn delivery. Batch children have independent durable identities,
+while all-ready finalization and restart recovery expose one transient grouped
+envelope for backward compatibility.
 
-  - completions surface as a NEW turn when the agent is idle, never spliced
-    between a tool result and an assistant message. That keeps strict
-    message-role alternation legal and the prompt cache intact (hard
-    invariant: never mutate past context).
-  - we inherit the queue's de-dup, crash-recovery checkpoint, and the
-    existing CLI + gateway drain wiring for free — no new drain loops in the
-    two largest files in the repo.
-
-The completion payload carries a RICH, self-contained task-source block (the
+The completion payload carries a rich, self-contained task-source block (the
 original goal, the context the parent supplied, toolsets, model, dispatch
-time, status, and the full result summary). When the result re-enters the
-conversation the parent may be deep in unrelated context and won't remember
-why the subagent existed; the block lets it either use the result or
-re-dispatch if the world has moved on.
+time, status, and the full result summary). When a result arrives after the
+originating turn, that block lets the parent use it or re-dispatch if the world
+has moved on.
 
 This module owns ONLY the async lifecycle. The actual child build + run is
 delegated back to ``delegate_tool._run_single_child`` via an injected
@@ -83,6 +73,9 @@ _MAX_DURABLE_PENDING = 1000
 # attempts so an unroutable row converges to a terminal 'dropped' state
 # instead of replaying on every restart forever.
 _MAX_DELIVERY_ATTEMPTS = 8
+# Durable claims are leases, not ownership transfers. A live consumer renews
+# this timestamp; after a process crash another consumer can recover the row.
+_DELIVERY_CLAIM_LEASE_SECONDS = 300
 _DB_LOCK = threading.Lock()
 
 # ---------------------------------------------------------------------------
@@ -176,6 +169,24 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    # Child-level delivery records extend the existing durable claim ledger.
+    # A batch parent remains one execution unit, while each completed child is
+    # independently claimable and recoverable on the between-turn rail.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegation_events (
+            delegation_id TEXT NOT NULL,
+            event_key TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (delegation_id, event_key)
+        )"""
+    )
 
 
 @contextmanager
@@ -206,7 +217,15 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         owner_started_at = None
     task_payload = {
         key: record.get(key)
-        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch")
+        for key in (
+            "goal",
+            "goals",
+            "context",
+            "toolsets",
+            "role",
+            "model",
+            "is_batch",
+        )
         if key in record
     }
     with _DB_LOCK, _transaction() as conn:
@@ -228,6 +247,10 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
 
 def _delete_durable_delegation(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            "DELETE FROM async_delegation_events WHERE delegation_id=?",
+            (delegation_id,),
+        )
         conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
 
 
@@ -268,18 +291,402 @@ def _prune_durable_records() -> None:
                    )""",
                 (overflow,),
             )
+        conn.execute(
+            """DELETE FROM async_delegation_events
+               WHERE delegation_id NOT IN (
+                   SELECT delegation_id FROM async_delegations
+               )"""
+        )
 
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _update_completion_row(
+    conn,
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+    now: Optional[float] = None,
+) -> None:
+    now = time.time() if now is None else now
+    state = "delivered" if delivery_state == "delivered" else "pending"
+    delivered_at = now if state == "delivered" else None
+    conn.execute(
+        """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
+           event_json=?, result_json=?, delivery_state=?, delivered_at=?
+           WHERE delegation_id=?""",
+        (
+            event.get("status", "completed"),
+            event.get("completed_at", now),
+            now,
+            json.dumps(event),
+            json.dumps(result),
+            state,
+            delivered_at,
+            event["delegation_id"],
+        ),
+    )
+
+
+def _persist_completion(
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+) -> None:
+    with _DB_LOCK, _transaction() as conn:
+        _update_completion_row(
+            conn, event, result, delivery_state=delivery_state
+        )
+
+
+def _build_batch_child_event(
+    record: Dict[str, Any],
+    task_index: int,
+    result: Dict[str, Any],
+    *,
+    completed_at: Optional[float] = None,
+) -> Dict[str, Any]:
+    delegation_id = str(record.get("delegation_id") or "")
+    goals = list(record.get("goals") or [])
+    goal = goals[task_index] if 0 <= task_index < len(goals) else record.get("goal", "")
+    completed_at = time.time() if completed_at is None else completed_at
+    child_result = dict(result or {})
+    child_result.setdefault("task_index", task_index)
+    return {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": f"task:{task_index}",
+        "batch_id": delegation_id,
+        "task_index": task_index,
+        "batch_size": len(goals),
+        "session_key": record.get("session_key", ""),
+        "origin_ui_session_id": record.get("origin_ui_session_id", ""),
+        "origin_session_id": record.get("origin_session_id", ""),
+        "parent_session_id": record.get("parent_session_id"),
+        "goal": goal,
+        "goals": goals,
+        "context": record.get("context"),
+        "toolsets": record.get("toolsets"),
+        "role": record.get("role"),
+        "model": record.get("model"),
+        "status": child_result.get("status", "completed"),
+        "summary": child_result.get("summary"),
+        "error": child_result.get("error"),
+        "api_calls": child_result.get("api_calls"),
+        "duration_seconds": child_result.get("duration_seconds"),
+        "is_batch": True,
+        "results": [child_result],
+        "live_transcripts": (
+            [child_result.get("live_transcript")]
+            if child_result.get("live_transcript")
+            else None
+        ),
+        "dispatched_at": record.get("dispatched_at"),
+        "completed_at": completed_at,
+    }
+
+
+def _insert_batch_event(conn, event: Dict[str, Any], *, now: float) -> bool:
+    cur = conn.execute(
+        """INSERT OR IGNORE INTO async_delegation_events
+           (delegation_id, event_key, event_json, delivery_state,
+            delivery_attempts, created_at, updated_at)
+           VALUES (?, ?, ?, 'pending', 0, ?, ?)""",
+        (
+            event["delegation_id"],
+            event["delivery_event_key"],
+            json.dumps(event),
+            now,
+            now,
+        ),
+    )
+    return cur.rowcount == 1
+
+
+def _persist_batch_child_completion_event(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return None
+    event = _build_batch_child_event(record, task_index, result)
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return None
+    return event
+
+
+def persist_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Persist one completed batch child without changing delivery timing.
+
+    The production batch runner calls this before joining slower siblings so a
+    process crash cannot erase an already completed child. The legacy aggregate
+    finalizer remains the only queue publisher in this layer.
+    """
+    return _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    ) is not None
+
+
+def publish_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Durably enqueue one ready child from an asynchronous batch.
+
+    The parent batch remains the execution/stall unit. This function creates an
+    independently claimable between-turn delivery event, keyed by task index.
+    Repeated publication is idempotent and never resets a delivered claim.
+    """
+    event = _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    )
+    if event is None:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    # Process-local handoff marker only. It prevents the aggregate finalizer
+    # from adding a duplicate queue copy when a future layer publishes children
+    # early. A crash intentionally loses this marker; restart recovery then
+    # restores the still-pending durable row from SQLite.
+    event_key = event["delivery_event_key"]
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            queued_keys = record.setdefault("_queued_child_event_keys", [])
+            if event_key not in queued_keys:
+                queued_keys.append(event_key)
+    return True
+
+
+def _event_delivery_keys(event: Dict[str, Any]) -> list[str]:
+    raw_keys = event.get("delivery_event_keys")
+    if isinstance(raw_keys, (list, tuple)):
+        return list(dict.fromkeys(str(key) for key in raw_keys if key))
+    key = str(event.get("delivery_event_key") or "")
+    return [key] if key else []
+
+
+def coalesce_ready_after_turn_events(
+    events: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Combine ready child rows from each after-turn batch at one boundary.
+
+    SQLite and the shared queue retain one durable row per child. This helper
+    creates only a transient delivery envelope so every child remains
+    independently recoverable while one consumer can claim/ack the currently
+    ready set atomically. Envelopes are deliberately re-coalescible: a busy
+    consumer may requeue one while more siblings finish before its next boundary.
+    """
+
+    output: List[Dict[str, Any]] = []
+    groups: Dict[str, Dict[str, Any]] = {}
+    seen_keys: Dict[str, set[str]] = {}
+    for event in events:
+        event_keys = _event_delivery_keys(event)
+        delegation_id = str(event.get("delegation_id") or "")
+        coalescible = (
+            event.get("type") == "async_delegation"
+            and bool(event.get("is_batch"))
+            and bool(event_keys)
+            and all(key.startswith("task:") for key in event_keys)
+            and bool(delegation_id)
         )
+        if not coalescible:
+            output.append(event)
+            continue
+
+        grouped = groups.get(delegation_id)
+        if grouped is None:
+            grouped = dict(event)
+            grouped.pop("delivery_event_key", None)
+            grouped["delivery_event_keys"] = []
+            grouped["task_indices"] = []
+            grouped["results"] = []
+            grouped["live_transcripts"] = []
+            grouped["coalesced_after_turn"] = True
+            groups[delegation_id] = grouped
+            seen_keys[delegation_id] = set()
+            output.append(grouped)
+
+        new_keys = [
+            key for key in event_keys if key not in seen_keys[delegation_id]
+        ]
+        if not new_keys:
+            continue
+        seen_keys[delegation_id].update(new_keys)
+        grouped["delivery_event_keys"].extend(new_keys)
+        new_key_set = set(new_keys)
+        for result in event.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            task_index = int(result.get("task_index", 0))
+            if f"task:{task_index}" not in new_key_set:
+                continue
+            grouped["task_indices"].append(task_index)
+            grouped["results"].append(result)
+        grouped["live_transcripts"].extend(
+            path for path in (event.get("live_transcripts") or []) if path
+        )
+        grouped["completed_at"] = max(
+            float(grouped.get("completed_at") or 0),
+            float(event.get("completed_at") or 0),
+        )
+
+    for grouped in groups.values():
+        grouped["delivery_event_keys"].sort(
+            key=lambda key: int(key.split(":", 1)[1])
+        )
+        grouped["task_indices"] = sorted(set(grouped["task_indices"]))
+        grouped["results"].sort(key=lambda result: int(result.get("task_index", 0)))
+        grouped["live_transcripts"] = list(
+            dict.fromkeys(grouped["live_transcripts"])
+        ) or None
+    return output
+
+
+def _build_batch_terminal_event(
+    event_record: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+    *,
+    force: bool = False,
+) -> Optional[Dict[str, Any]]:
+    if not force and (
+        status in {"completed", "success"} or (combined.get("results") or [])
+    ):
+        return None
+    delegation_id = str(event_record.get("delegation_id") or "")
+    now = time.time()
+    event: Dict[str, Any] = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": "terminal",
+        "batch_id": delegation_id,
+        "session_key": event_record.get("session_key", ""),
+        "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
+        "origin_session_id": event_record.get("origin_session_id", ""),
+        "parent_session_id": event_record.get("parent_session_id"),
+        "goal": event_record.get("goal", ""),
+        "goals": event_record.get("goals"),
+        "context": event_record.get("context"),
+        "toolsets": event_record.get("toolsets"),
+        "role": event_record.get("role"),
+        "model": event_record.get("model"),
+        "status": status,
+        "is_batch": True,
+        "results": [],
+        "error": combined.get("error"),
+        "dispatched_at": event_record.get("dispatched_at"),
+        "completed_at": now,
+    }
+    for key in (
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_phase",
+        "stall_grace_seconds",
+    ):
+        if key in combined:
+            event[key] = combined[key]
+    return event
+
+
+def _publish_batch_terminal_event(
+    event_record: Dict[str, Any], combined: Dict[str, Any], status: str
+) -> bool:
+    """Deliver a batch-level failure not represented by child events."""
+    event = _build_batch_terminal_event(event_record, combined, status)
+    if event is None:
+        return False
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    return True
+
+
+def _persist_batch_child_finalization(
+    event_record: Dict[str, Any],
+    parent_event: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+) -> None:
+    """Atomically persist missing child events and the terminal parent row."""
+
+    now = time.time()
+    queue_event_keys: list[str] = []
+    queue_events: list[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        for child in combined.get("results") or []:
+            child_event = _build_batch_child_event(
+                event_record,
+                int(child.get("task_index", 0)),
+                child,
+                completed_at=now,
+            )
+            _insert_batch_event(conn, child_event, now=now)
+            queue_event_keys.append(child_event["delivery_event_key"])
+
+        terminal_event = _build_batch_terminal_event(
+            event_record, combined, status
+        )
+        if terminal_event is not None:
+            _insert_batch_event(conn, terminal_event, now=now)
+            queue_event_keys.append(terminal_event["delivery_event_key"])
+
+        # The aggregate row is bookkeeping-only. Commit its terminal state in
+        # the same transaction as the idempotent child safety net so restart
+        # recovery can never observe a half-finalized parent.
+        _update_completion_row(
+            conn,
+            parent_event,
+            combined,
+            delivery_state="delivered",
+            now=now,
+        )
+
+        # Child callbacks may have inserted these rows before the aggregate
+        # join. Preserve legacy delivery timing by loading every still-pending
+        # aggregate member only after the parent terminal update commits.
+        already_queued = {
+            str(key) for key in (event_record.get("_queued_child_event_keys") or [])
+        }
+        event_keys = [
+            key
+            for key in dict.fromkeys(queue_event_keys)
+            if key not in already_queued
+        ]
+        if event_keys:
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                "SELECT event_json FROM async_delegation_events "
+                "WHERE delegation_id=? AND delivery_state='pending' "
+                f"AND event_key IN ({placeholders})",
+                (event_record["delegation_id"], *event_keys),
+            ).fetchall()
+            queue_events = [json.loads(row[0]) for row in rows]
+
+    from tools.process_registry import process_registry
+
+    queue_events = coalesce_ready_after_turn_events(queue_events)
+    with process_registry.completion_routing_lock:
+        for queued_event in queue_events:
+            process_registry.completion_queue.put(queued_event)
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -316,6 +723,88 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            child_rows = []
+            if bool(task.get("is_batch")):
+                child_rows = conn.execute(
+                    """SELECT event_key, event_json FROM async_delegation_events
+                       WHERE delegation_id=? AND event_key LIKE 'task:%'
+                       ORDER BY event_key""",
+                    (delegation_id,),
+                ).fetchall()
+            if bool(task.get("is_batch")) and bool(child_rows):
+                # Child-scoped batches never recover through a contradictory
+                # aggregate. A crash after one or more child inserts must
+                # preserve the already-delivered/pending task identities.
+                goals = list(task.get("goals") or [])
+                expected_child_keys = [f"task:{index}" for index in range(len(goals))]
+                child_results_by_key: dict[str, Dict[str, Any]] = {}
+                for event_key, child_payload in child_rows:
+                    if event_key not in expected_child_keys:
+                        continue
+                    child_event = json.loads(child_payload or "{}")
+                    results = child_event.get("results") or []
+                    if results and isinstance(results[0], dict):
+                        child_results_by_key[event_key] = results[0]
+
+                child_results = [
+                    child_results_by_key[key]
+                    for key in expected_child_keys
+                    if key in child_results_by_key
+                ]
+                complete_children = bool(expected_child_keys) and all(
+                    key in child_results_by_key for key in expected_child_keys
+                )
+                status = "completed" if complete_children else "unknown"
+                recovery_error = None
+                if not complete_children:
+                    recovery_error = (
+                        "Delegation owner exited after recording "
+                        f"{len(child_results)}/{len(goals)} batch child results; "
+                        "remaining outcomes are unknown."
+                    )
+                combined = {
+                    "results": child_results,
+                    "error": recovery_error,
+                }
+                event_record = {
+                    "delegation_id": delegation_id,
+                    "session_key": session_key,
+                    "origin_ui_session_id": origin_ui,
+                    "origin_session_id": origin_session_id or "",
+                    "parent_session_id": parent_id,
+                    "goal": task.get("goal", ""),
+                    "goals": goals,
+                    "context": task.get("context"),
+                    "toolsets": task.get("toolsets"),
+                    "role": task.get("role"),
+                    "model": task.get("model"),
+                    "dispatched_at": dispatched_at,
+                }
+                if not complete_children:
+                    terminal_event = _build_batch_terminal_event(
+                        event_record, combined, status, force=True
+                    )
+                    if terminal_event is not None:
+                        _insert_batch_event(conn, terminal_event, now=now)
+
+                parent_event = {
+                    **event_record,
+                    "type": "async_delegation",
+                    "status": status,
+                    "is_batch": True,
+                    "results": child_results,
+                    "error": recovery_error,
+                    "completed_at": now,
+                }
+                _update_completion_row(
+                    conn,
+                    parent_event,
+                    combined,
+                    delivery_state="delivered",
+                    now=now,
+                )
+                recovered += 1
+                continue
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -354,22 +843,47 @@ def restore_undelivered_completions(target_queue) -> int:
     results seconds after boot (#64484).
     """
     recover_abandoned_delegations()
+    restored = 0
+    parent_events: list[Dict[str, Any]] = []
+    child_events: list[Dict[str, Any]] = []
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT delegation_id, event_json FROM async_delegations
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
+        child_rows = conn.execute(
+            """SELECT delegation_id, event_key, event_json
+               FROM async_delegation_events
+               WHERE delivery_state='pending'
+               ORDER BY created_at, delegation_id, event_key"""
+        ).fetchall()
         for _delegation_id, payload in rows:
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
-            target_queue.put(evt)
-    return len(rows)
+            parent_events.append(evt)
+            restored += 1
+        for delegation_id, event_key, payload in child_rows:
+            evt = json.loads(payload)
+            if isinstance(evt, dict):
+                evt["restored"] = True
+                evt.setdefault("delegation_id", delegation_id)
+                evt.setdefault("delivery_event_key", event_key)
+            child_events.append(evt)
+            restored += 1
+    # Queue only after the SQLite read transaction closes. Default after-turn
+    # batches retain the legacy one-envelope restart shape even though each
+    # child now has an independently durable identity underneath it.
+    for evt in parent_events:
+        target_queue.put(evt)
+    for evt in coalesce_ready_after_turn_events(child_events):
+        target_queue.put(evt)
+    return restored
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
-    """Atomically acknowledge successful injection of a durable completion."""
+    """Atomically acknowledge successful delivery of a durable completion."""
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
@@ -395,7 +909,69 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                       delivery_attempts=delivery_attempts+1, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300),
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
+        )
+        return cur.rowcount == 1
+
+
+class _DeliveryGroupConflict(RuntimeError):
+    """Rollback a multi-child settlement when any row lost ownership."""
+
+
+def _claim_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=?, delivery_claimed_at=?,
+                           delivery_attempts=delivery_attempts+1, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending'
+                         AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+                    (
+                        claim_id,
+                        now,
+                        now,
+                        delegation_id,
+                        event_key,
+                        now - _DELIVERY_CLAIM_LEASE_SECONDS,
+                    ),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _claim_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=?, delivery_claimed_at=?,
+                   delivery_attempts=delivery_attempts+1, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending'
+                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                event_key,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
         )
         return cur.rowcount == 1
 
@@ -408,7 +984,103 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     if not delegation_id:
         return ""
     claim_id = f"{consumer}:{__import__('os').getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        claimed = bool(event_keys) and _claim_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        claimed = _claim_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        claimed = claim_completion_delivery(delegation_id, claim_id)
+    return claim_id if claimed else None
+
+
+def renew_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Renew the lease held by the exact consumer claim."""
+
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return False
+    event_keys = _event_delivery_keys(evt)
+    now = time.time()
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        try:
+            with _DB_LOCK, _transaction() as conn:
+                for event_key in event_keys:
+                    cur = conn.execute(
+                        """UPDATE async_delegation_events
+                           SET delivery_claimed_at=?, updated_at=?
+                           WHERE delegation_id=? AND event_key=?
+                             AND delivery_state='pending' AND delivery_claim=?""",
+                        (now, now, delegation_id, event_key, claim_id),
+                    )
+                    if cur.rowcount != 1:
+                        raise _DeliveryGroupConflict(event_key)
+        except _DeliveryGroupConflict:
+            return False
+        return True
+    event_key = event_keys[0] if event_keys else ""
+    with _DB_LOCK, _transaction() as conn:
+        if event_key:
+            cur = conn.execute(
+                """UPDATE async_delegation_events
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND event_key=?
+                     AND delivery_state='pending' AND delivery_claim=?""",
+                (now, now, delegation_id, event_key, claim_id),
+            )
+        else:
+            cur = conn.execute(
+                """UPDATE async_delegations
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, now, delegation_id, claim_id),
+            )
+        return cur.rowcount == 1
+
+
+def get_event_delivery_state(evt: Dict[str, Any]) -> Optional[str]:
+    """Return the durable state for one aggregate or child event."""
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    event_keys = _event_delivery_keys(evt)
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT delivery_state FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            if len(rows) != len(event_keys):
+                return None
+            states = {str(row[0]) for row in rows}
+            return states.pop() if len(states) == 1 else "mixed"
+        event_key = event_keys[0] if event_keys else ""
+        if event_key:
+            row = conn.execute(
+                """SELECT delivery_state FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_key),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+                (delegation_id,),
+            ).fetchone()
+    return str(row[0]) if row is not None else None
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -484,14 +1156,271 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
         return cur.rowcount == 1
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def _complete_child_event(
+    delegation_id: str, event_key: str, claim_id: str, state: str = "delivered"
+) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state=?, delivered_at=?, updated_at=?,
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (state, now, now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def _release_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        capped = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state='dropped', delivery_claim=NULL,
+                   delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?
+                 AND delivery_attempts>=?""",
+            (now, delegation_id, event_key, claim_id, _MAX_DELIVERY_ATTEMPTS),
+        )
+        if capped.rowcount == 1:
+            return True
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _complete_child_event_group(
+    delegation_id: str,
+    event_keys: List[str],
+    claim_id: str,
+    state: str = "delivered",
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state=?, delivered_at=?, updated_at=?,
+                           delivery_claim=NULL, delivery_claimed_at=NULL
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (state, now, now, delegation_id, event_key, claim_id),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _release_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> tuple[bool, List[str]]:
+    now = time.time()
+    pending_keys: List[str] = []
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                capped = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state='dropped', delivery_claim=NULL,
+                           delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?
+                         AND delivery_attempts>=?""",
+                    (
+                        now,
+                        delegation_id,
+                        event_key,
+                        claim_id,
+                        _MAX_DELIVERY_ATTEMPTS,
+                    ),
+                )
+                if capped.rowcount == 1:
+                    continue
+                released = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (now, delegation_id, event_key, claim_id),
+                )
+                if released.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+                pending_keys.append(event_key)
+    except _DeliveryGroupConflict:
+        return False, event_keys
+    return True, pending_keys
+
+
+def _retain_group_event_keys(evt: Dict[str, Any], event_keys: List[str]) -> None:
+    """Keep only rows that remain pending after a grouped release."""
+
+    keep = set(event_keys)
+    evt["delivery_event_keys"] = list(event_keys)
+    evt["results"] = [
+        result
+        for result in (evt.get("results") or [])
+        if isinstance(result, dict)
+        and f"task:{int(result.get('task_index', 0))}" in keep
+    ]
+    evt["task_indices"] = sorted(
+        int(result.get("task_index", 0)) for result in evt["results"]
+    )
+
+
+def get_event_delivery_retry_delay(
+    evt: Dict[str, Any], *, now: Optional[float] = None
+) -> Optional[float]:
+    """Return a bounded delay for an unclaimed pending event, else ``None``.
+
+    A failed claim is ambiguous: another live process may own the pending row,
+    or this queue entry may be a duplicate whose durable row is already
+    delivered/dropped. Consumers use this oracle before deferred requeue so a
+    quick restart waits only for the remaining lease without spinning. Grouped
+    envelopes are narrowed to rows that are still pending.
+    """
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    current = time.time() if now is None else float(now)
+    event_keys = _event_delivery_keys(evt)
+    pending_rows: List[tuple[str, Optional[str], Optional[float]]] = []
+
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT event_key, delivery_state, delivery_claim,
+                           delivery_claimed_at
+                    FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            by_key = {str(row[0]): row for row in rows}
+            if len(by_key) != len(event_keys):
+                return None
+            pending_keys = [
+                key for key in event_keys if str(by_key[key][1]) == "pending"
+            ]
+            if not pending_keys:
+                return None
+            _retain_group_event_keys(evt, pending_keys)
+            pending_rows = [
+                (
+                    key,
+                    str(by_key[key][2]) if by_key[key][2] else None,
+                    float(by_key[key][3]) if by_key[key][3] is not None else None,
+                )
+                for key in pending_keys
+            ]
+        elif event_keys:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_keys[0]),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    event_keys[0],
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+        else:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    "aggregate",
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+
+    # A short guard covers claim races and strict SQL '<' lease comparison.
+    delay = 0.05
+    for _event_key, claim, claimed_at in pending_rows:
+        if not claim:
+            continue
+        if claimed_at is None:
+            delay = max(delay, float(_DELIVERY_CLAIM_LEASE_SECONDS))
+            continue
+        remaining = float(_DELIVERY_CLAIM_LEASE_SECONDS) - (current - claimed_at)
+        delay = max(delay, remaining)
+    return max(0.05, delay) + 0.05
+
+
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        completed = bool(event_keys) and _complete_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        completed = _complete_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        completed = complete_completion_delivery(delegation_id, claim_id)
+    return completed or get_event_delivery_state(evt) == "delivered"
+
+
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        released, pending_keys = _release_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+        if released:
+            _retain_group_event_keys(evt, pending_keys)
+        return released
+    if event_keys:
+        return _release_child_event(delegation_id, event_keys[0], claim_id)
+    return release_completion_delivery(delegation_id, claim_id)
+
+
+def drop_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if event_keys:
+            _complete_child_event_group(
+                delegation_id, event_keys, claim_id, state="dropped"
+            )
+    elif event_keys:
+        _complete_child_event(delegation_id, event_keys[0], claim_id, state="dropped")
+    else:
+        drop_completion_delivery(delegation_id, claim_id)
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -956,11 +1885,9 @@ def dispatch_async_delegation_batch(
     parallelism is bounded separately by ``max_concurrent_children``), so a
     single ``delegate_task`` fan-out never exhausts the async pool by itself.
 
-    When the batch finishes, a SINGLE completion event is pushed onto the
-    shared ``process_registry.completion_queue`` carrying the full per-task
-    ``results`` list, so the consolidated summaries re-enter the conversation
-    as one message once every child is done — the chat is never blocked while
-    they run.
+    Each child uses an independently durable row. Finalization preserves the
+    existing between-turn grouped envelope and idempotently fills any child row
+    missed by a completion callback.
 
     Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
     ``{"status": "rejected", "error": ...}`` when the async pool is at
@@ -1064,7 +1991,7 @@ def dispatch_async_delegation_batch(
 def _finalize_batch(
     delegation_id: str, combined: Dict[str, Any], status: str
 ) -> None:
-    """Mark a batch record complete and push ONE combined completion event."""
+    """Mark a batch complete and persist any missing child delivery events."""
     claimed = _begin_finalization(delegation_id)
     if claimed is None:
         return
@@ -1077,17 +2004,7 @@ def _finalize_batch(
 def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
-    """Push a combined async-delegation batch completion event."""
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s finished but process_registry import "
-            "failed; result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
-        return
-
+    """Finalize one child-scoped async-delegation batch."""
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
     evt = {
@@ -1127,15 +2044,10 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s: failed to enqueue completion event; "
-            "result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
+    # Child callbacks persist incrementally without changing legacy delivery
+    # timing. The finalizer idempotently inserts any missed child, commits the
+    # parent terminal row, then queues one grouped envelope after commit.
+    _persist_batch_child_finalization(event_record, evt, combined, status)
 
 
 def _ensure_stale_monitor() -> None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3288,6 +3288,12 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    if not live_deleg_id:
+        # Child-scoped durable rows and the optional live transcript must share
+        # one stable parent identity, even when transcript creation is disabled.
+        from tools.async_delegation import _new_delegation_id
+
+        live_deleg_id = _new_delegation_id()
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls
@@ -3369,6 +3375,27 @@ def delegate_task(
             child._live_transcript_path = str(_writer.path)
         children.append((i, t, child))
 
+    def _persist_ready_result(entry: Dict[str, Any]) -> None:
+        """Persist one ready child while preserving aggregate delivery timing."""
+        if not background:
+            return
+        task_index = int(entry.get("task_index", 0))
+        payload = dict(entry)
+        if 0 <= task_index < len(live_paths):
+            payload.setdefault("live_transcript", live_paths[task_index])
+        try:
+            from tools.async_delegation import persist_batch_child_completion
+
+            persist_batch_child_completion(live_deleg_id, task_index, payload)
+        except Exception:
+            # Batch finalization inserts every missing child idempotently as the
+            # durable safety net for callback/persistence failures.
+            logger.exception(
+                "Failed to persist ready child %s/%s",
+                live_deleg_id,
+                task_index,
+            )
+
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
@@ -3392,6 +3419,7 @@ def delegate_task(
                 owner_session_record=_origin_owner_session_record,
             )
             results.append(result)
+            _persist_ready_result(result)
         else:
             # Batch -- run in parallel with per-task progress lines
             completed_count = 0
@@ -3466,6 +3494,7 @@ def delegate_task(
                                     ),
                                 }
                             results.append(entry)
+                            _persist_ready_result(entry)
                             completed_count += 1
                         break
 
@@ -3491,6 +3520,7 @@ def delegate_task(
                                 ),
                             }
                         results.append(entry)
+                        _persist_ready_result(entry)
                         completed_count += 1
 
                         # Print per-task completion line above the spinner

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -89,6 +89,19 @@ def _report_child_done(parent_agent, spinner_ref, entry, tag, task_labels, n_tas
         with _quiet("Spinner update_text failed: %s"):
             spinner_ref.update_text(f"🔀 {'[' + tag + '] ' if tag else ''}{remaining} task{'s' if remaining != 1 else ''} remaining")
 
+def _persist_ready_result(batch: _Batch, entry: Dict[str, Any]) -> None:
+    """Commit a finished child before joining its siblings; finalization is the retry safety net."""
+    task_index = int(entry.get("task_index", 0))
+    payload = dict(entry)
+    if 0 <= task_index < len(batch.live_paths):
+        payload.setdefault("live_transcript", batch.live_paths[task_index])
+    try:
+        from tools.async_delegation import persist_batch_child_completion
+        persist_batch_child_completion(batch.live_deleg_id, task_index, payload)
+    except Exception:
+        logger.exception("Failed to persist ready child %s/%s", batch.live_deleg_id, task_index)
+
+
 def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interrupt: bool) -> None:
     """Run the batch's children in parallel, appending entries to ``results`` (sorted by task_index on return, one
     completion line printed per child). Polls futures with a short ``wait()`` timeout instead of ``as_completed()``
@@ -119,12 +132,18 @@ def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interru
         pending = set(futures)
         while pending:
             if honor_parent_interrupt and getattr(parent_agent, "_interrupt_requested", False) is True:
-                results.extend(_entry_of(f, futures[f]) for f in pending)
+                for future in pending:
+                    entry = _entry_of(future, futures[future])
+                    results.append(entry)
+                    if not honor_parent_interrupt:
+                        _persist_ready_result(batch, entry)
                 break
             done, pending = _cf_wait(pending, timeout=0.5, return_when=FIRST_COMPLETED)
             for future in done:
                 entry = _entry_of(future, futures[future])
                 results.append(entry)
+                if not honor_parent_interrupt:
+                    _persist_ready_result(batch, entry)
                 _report_child_done(parent_agent, spinner_ref, entry, _tag, task_labels, n_tasks, n_tasks - len(results))
     results.sort(key=lambda r: r["task_index"])  # match input order
 
@@ -137,6 +156,8 @@ def _execute_and_aggregate(batch: _Batch, *, honor_parent_interrupt: bool = True
     results: list = []
     if len(batch.task_list) == 1:
         results.append(batch.run_child(*batch.children[0]))
+        if not honor_parent_interrupt:
+            _persist_ready_result(batch, results[-1])
     else:
         _run_children_parallel(batch, results, honor_parent_interrupt=honor_parent_interrupt)
 
@@ -299,6 +320,9 @@ def _dispatch_background(batch: _Batch) -> str:
         logger.info("delegate_task: async delivery unsupported on this session runtime; running the batch synchronously instead.")
         return _run_sync_with_note(batch, "no_async")
 
+    if not batch.live_deleg_id:
+        from tools.async_delegation import _new_delegation_id
+        batch.live_deleg_id = _new_delegation_id()
     parent_agent = batch.parent_agent
     session_key, origin_ui_session_id = _resolve_async_session_key(parent_agent, batch.origin_ui_session_id)
     child_agents = [c for (_, _, c) in batch.children]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -403,6 +403,7 @@ class ProcessRegistry:
         # process_loop and the gateway drain it after each agent turn to trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        self.completion_routing_lock = threading.RLock()
         # Rehydrate durable delegation completions once, at registry startup.
         try:
             from tools.async_delegation import restore_undelivered_completions

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -423,6 +423,9 @@ class ProcessRegistry:
         # gateway drain this after each agent turn to auto-trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        # Shared reservation seam for atomic child-event publication and later
+        # consumer routing. Publication is non-blocking and holds it briefly.
+        self.completion_routing_lock = threading.RLock()
         # Rehydrate durable delegation completions only at registry startup.
         # Consumers still inject them as fresh turns through this existing rail.
         try:


### PR DESCRIPTION
## Decision summary

This is the standalone durability foundation requested in #74378's close review. It changes **how completed batch children are settled and recovered**, while deliberately preserving Hermes' existing between-turn delivery behavior.

If only this PR merges, users and models get no new option and no active-loop behavior change.

## Stack navigation

| PR | Owned commit | Responsibility | Standalone behavior |
|---|---|---|---|
| **#76228 (this PR)** | `21a283276` | durable child identity and settlement | existing between-turn delivery |
| #76229 | `aa4038d03` | expose ready children without waiting for siblings | improved `after_turn` routing |
| #76230 | `554957424` | opt-in tool-result carrier | dependent results may affect the active turn |

The later PRs are cumulative only because a fork branch cannot be the upstream base of a normal cross-repository PR. This PR itself contains one commit and five changed files.

## Why child-scoped durability is the right unit

A batch aggregate can say that a delegation finished, but cannot answer after a crash:

- which child was already presented;
- which sibling is still pending;
- whether a partial batch may be retried without duplicating a delivered child;
- whether two consumers are settling the same ready subset.

This PR makes `delegation_id + task:N` the durable delivery identity. The parent remains execution/finalization bookkeeping; child rows own claim, lease, acknowledgement, release, retry, drop, and recovery.

That separation is useful to the current between-turn rail by itself. It is also the correctness prerequisite for later ready-set and carrier policies: visibility timing may change, but delivery identity never does.

## Exact behavior

- persist each real production child completion before joining slower siblings;
- keep that pre-join row off the completion queue until legacy aggregate finalization;
- insert every child row idempotently so finalization remains the safety net for callback failures;
- commit missing child rows and the parent terminal transition in one SQLite transaction;
- claim/ack/release a grouped envelope transactionally: one consumer owns the whole set or none of it;
- suppress a contradictory aggregate parent when the exact expected child set is recoverable;
- preserve known child identities and add one terminal gap event for a partial recovery;
- require exact `task:0..N-1` keys before considering a recovered batch complete;
- format before claiming, so local formatter failures do not burn delivery attempts;
- keep legacy aggregate rows readable.

## Intentional exclusions

This PR does **not** add:

- `result_delivery`;
- same-turn injection or active-loop hooks;
- synthetic conversation messages;
- model-tool schema, UI, or config changes;
- ready-before-sibling delivery (owned by #76229).

The compatibility adapter still exposes a fully completed default batch as one transient between-turn envelope.

## Review focus

The reviewable question here is only:

> Can independently completed batch children be recovered and settled exactly once without changing current model-visible behavior?

The model-facing carrier design belongs to #76230, not this diff.

## Verification

- focused ledger/process/delegation matrix: **145 passed, 0 failed**;
- the matrix includes an event-driven real `delegate_task` batch with one completed and one blocked child, followed by simulated owner-loss recovery;
- full GitHub CI: **27 successful checks, 0 failures**;
- Ruff, `py_compile`, and `git diff --check`: **passed**;
- current head (rebased): `21a28327634a534bcc69438c07cf577951b9e24b`.

## Coordination graph

- **Issue interlock:** Fixes #85646
- **Stack siblings:** #76229 and #76230
- **Dependency edges:** foundation; #76229 depends on this PR, and #76230 transitively depends on it
- **Collision constraints:** #75117, #65824, #61719, and #70899 overlap the delegation ledger/process-registry surface; this PR owns child-event durability, not origin persistence, timeout redaction, UI-session notification ownership, or the agents panel
- **Merge order:** #76228 → #76229 → #76230. Rebase the later heads after each lower layer lands
- **Closed predecessor:** #74378 supplied the maintainer constraints; this PR is the independently useful durability extraction requested there

## Hermes triage dashboard graph

Live dashboard neighbourhood: https://hermes-triage.gottz.de/?node=76228

```mermaid
flowchart LR
    classDef focus fill:#fef3c7,stroke:#b45309,stroke-width:3px,color:#451a03
    classDef issue fill:#ede9fe,stroke:#6d28d9,color:#2e1065
    classDef open fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a
    classDef closed fill:#e5e7eb,stroke:#6b7280,color:#1f2937
    P76228["PR #76228 (open)"]
    I85646(["issue #85646 (open)"])
    P52452["PR #52452 (closed)"]
    P61789["PR #61789 (closed)"]
    P63133["PR #63133 (open)"]
    P63494["PR #63494 (merged)"]
    P65886["PR #65886 (closed)"]
    P68426["PR #68426 (closed)"]
    P72122["PR #72122 (open)"]
    P72123["PR #72123 (closed)"]
    P72620["PR #72620 (closed)"]
    P74378["PR #74378 (closed)"]
    P75068["PR #75068 (open)"]
    P76229["PR #76229 (open)"]
    P76228 -->|closes| I85646
    P76228 -->|related| I85646
    P76228 -.->|duplicate of 0.77| P76229
    P74378 -.->|duplicate of 0.76| P76228
    P75068 -.->|duplicate of 0.73| P76228
    P63133 -.->|duplicate of 0.70| P76228
    P61789 -.->|duplicate of 0.68| P76228
    P72122 -.->|duplicate of 0.68| P76228
    P68426 -.->|duplicate of 0.68| P76228
    P63494 -.->|duplicate of 0.68| P76228
    P52452 -.->|duplicate of 0.68| P76228
    P72620 -.->|duplicate of 0.67| P76228
    P65886 -.->|duplicate of 0.67| P76228
    P72123 -.->|duplicate of 0.63| P76228
    class P76228 focus
    click P76228 "https://github.com/NousResearch/hermes-agent/pull/76228"
    class I85646 issue
    click I85646 "https://github.com/NousResearch/hermes-agent/issues/85646"
    class P52452 closed
    click P52452 "https://github.com/NousResearch/hermes-agent/pull/52452"
    class P61789 closed
    click P61789 "https://github.com/NousResearch/hermes-agent/pull/61789"
    class P63133 open
    click P63133 "https://github.com/NousResearch/hermes-agent/pull/63133"
    class P63494 merged
    click P63494 "https://github.com/NousResearch/hermes-agent/pull/63494"
    class P65886 closed
    click P65886 "https://github.com/NousResearch/hermes-agent/pull/65886"
    class P68426 closed
    click P68426 "https://github.com/NousResearch/hermes-agent/pull/68426"
    class P72122 open
    click P72122 "https://github.com/NousResearch/hermes-agent/pull/72122"
    class P72123 closed
    click P72123 "https://github.com/NousResearch/hermes-agent/pull/72123"
    class P72620 closed
    click P72620 "https://github.com/NousResearch/hermes-agent/pull/72620"
    class P74378 closed
    click P74378 "https://github.com/NousResearch/hermes-agent/pull/74378"
    class P75068 open
    click P75068 "https://github.com/NousResearch/hermes-agent/pull/75068"
    class P76229 open
    click P76229 "https://github.com/NousResearch/hermes-agent/pull/76229"
```

Dashboard interpretation:

- solid edges are structural GitHub links (`closes` / `related`);
- dashed edges are embedding-discovery candidates and show the dashboard score;
- the fold thresholds reported by the dashboard are embedding `0.88` and file overlap `0.75`;
- a dashed `duplicate of` edge below the fold threshold is a similarity lead for review, **not** an accepted duplicate or merge-order edge;
- the gold node is this PR; purple nodes are issues; blue/gray nodes are open/closed neighbouring PRs.

This graph is additive to the hand-audited coordination block above: the dashboard supplies discovery neighbourhoods, while the declared dependency, collision, ownership, and merge-order edges remain the reviewed coordination contract.

