### PR TITLE
feat(delegation): surface ready dependencies before the next decision

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1461,6 +1461,10 @@ def run_conversation(
     active_system_prompt = _ctx.active_system_prompt
     effective_task_id = _ctx.effective_task_id
     turn_id = _ctx.turn_id
+    # Async child events bind to the exact foreground turn that dispatched
+    # them. This is identity exposure only; delivery still occurs exclusively
+    # at the tool boundary or after the turn.
+    agent._active_turn_id = turn_id
     current_turn_user_idx = _ctx.current_turn_user_idx
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1447,6 +1447,9 @@ def run_conversation(
     except PreflightCompressionTimedOut as _preflight_timeout_exc:
         return _preflight_timeout_result(agent, _preflight_timeout_exc, conversation_history)
 
+    # Bind detached results to this foreground turn, never a later conversation turn.
+    agent._active_turn_id = _ctx.turn_id
+
     # Per-turn agent state (the gateway caches agents across turns, so none of this may
     # leak into the next message): interim-commentary dedup spans the whole turn but not
     # the next; a SessionDB append failure (and its classified cause) halts only this turn;

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -1,0 +1,378 @@
+"""Tool-boundary delivery of completed background delegations.
+
+The async registry and its durable claims remain the authority for delivery.
+This module only carries already-ready ``result_delivery=inject`` events on a
+new tool result before that result's append-only transcript commit. It never
+waits for a child or manufactures a conversation role.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import threading
+from copy import deepcopy
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+_PENDING_CLAIMS_ATTR = "_pending_delegation_inject_claims"
+_CLAIM_HEARTBEAT_ATTR = "_delegation_inject_claim_heartbeat"
+_CLAIM_HEARTBEAT_INTERVAL_SECONDS = 60.0
+
+
+def _event_identity(event: dict[str, Any]) -> str:
+    return (
+        f"{event.get('delegation_id') or ''}:"
+        f"{event.get('delivery_event_key') or 'aggregate'}"
+    )
+
+
+def _message_event_ids(message: dict[str, Any]) -> set[str]:
+    metadata = message.get("display_metadata")
+    if isinstance(metadata, dict):
+        values = metadata.get("delegation_event_ids") or []
+    else:
+        values = message.get("_delegation_event_ids") or []
+    return {str(value) for value in values if value}
+
+
+def _clear_carrier_metadata(message: dict[str, Any]) -> None:
+    message.pop("_delegation_delivery_original_content", None)
+    message.pop("_delegation_event_ids", None)
+
+
+def _remove_carrier_identity(message: dict[str, Any]) -> None:
+    _clear_carrier_metadata(message)
+    metadata = message.get("display_metadata")
+    if not isinstance(metadata, dict):
+        return
+    metadata.pop("delegation_event_ids", None)
+    metadata.pop("delegation_delivery", None)
+    if not metadata:
+        message.pop("display_metadata", None)
+
+
+def _append_carrier_text(message: dict[str, Any], text: str) -> None:
+    marker = (
+        "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
+        "not a new user request]\n"
+        + text
+    )
+    content = message.get("content", "")
+    if isinstance(content, str):
+        message["content"] = content + marker
+        return
+    try:
+        blocks = list(content) if content else []
+        blocks.append({"type": "text", "text": marker.lstrip()})
+        message["content"] = blocks
+    except Exception:
+        message["content"] = f"{content}{marker}"
+
+
+def _durable_event_is_in_history(
+    messages: list[dict[str, Any]], event_id: str
+) -> bool:
+    return any(
+        message.get("_db_persisted") is True
+        and event_id in _message_event_ids(message)
+        for message in messages
+        if isinstance(message, dict)
+    )
+
+
+def _stop_claim_heartbeat_if_idle(agent: Any) -> None:
+    if getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return
+    heartbeat = getattr(agent, _CLAIM_HEARTBEAT_ATTR, None)
+    if isinstance(heartbeat, dict):
+        stop = heartbeat.get("stop")
+        if isinstance(stop, threading.Event):
+            stop.set()
+
+
+def ensure_pending_inject_heartbeat(agent: Any) -> bool:
+    """Renew live same-turn claims throughout provider retries and backoff."""
+
+    if not getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return False
+    existing = getattr(agent, _CLAIM_HEARTBEAT_ATTR, None)
+    if isinstance(existing, dict):
+        thread = existing.get("thread")
+        existing_stop = existing.get("stop")
+        if (
+            isinstance(thread, threading.Thread)
+            and thread.is_alive()
+            and isinstance(existing_stop, threading.Event)
+            and not existing_stop.is_set()
+        ):
+            return True
+
+    stop = threading.Event()
+
+    def _heartbeat() -> None:
+        from tools.async_delegation import renew_event_delivery
+
+        while not stop.wait(_CLAIM_HEARTBEAT_INTERVAL_SECONDS):
+            pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+            if not pending:
+                break
+            for entry in pending:
+                try:
+                    if not renew_event_delivery(entry["event"], entry["claim_id"]):
+                        logger.warning(
+                            "Could not renew same-turn delegation claim %s",
+                            entry.get("event_id"),
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to renew same-turn delegation claim %s",
+                        entry.get("event_id"),
+                        exc_info=True,
+                    )
+
+    thread = threading.Thread(
+        target=_heartbeat,
+        daemon=True,
+        name="delegation-inject-claim-heartbeat",
+    )
+    setattr(agent, _CLAIM_HEARTBEAT_ATTR, {"stop": stop, "thread": thread})
+    thread.start()
+    return True
+
+
+def acknowledge_pending_injects(agent: Any, *, turn_id: str | None = None) -> int:
+    """Acknowledge tool-boundary claims after durable transcript persistence."""
+
+    from tools.async_delegation import complete_event_delivery
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    keep: list[dict[str, Any]] = []
+    acknowledged_messages: list[dict[str, Any]] = []
+    acknowledged = 0
+    for entry in pending:
+        if turn_id is not None and str(entry.get("turn_id") or "") != str(turn_id):
+            keep.append(entry)
+            continue
+        if complete_event_delivery(entry["event"], entry["claim_id"]):
+            acknowledged += 1
+            message = entry.get("message")
+            if isinstance(message, dict):
+                acknowledged_messages.append(message)
+        else:
+            keep.append(entry)
+            logger.warning(
+                "Delegation carrier persisted but durable event ack did not commit: %s",
+                entry.get("event_id"),
+            )
+    setattr(agent, _PENDING_CLAIMS_ATTR, keep)
+    still_pending_ids = {str(entry.get("event_id") or "") for entry in keep}
+    for message in acknowledged_messages:
+        if not (_message_event_ids(message) & still_pending_ids):
+            _clear_carrier_metadata(message)
+    _stop_claim_heartbeat_if_idle(agent)
+    return acknowledged
+
+
+def release_pending_injects(
+    agent: Any,
+    messages: list[dict[str, Any]],
+    *,
+    turn_id: str | None = None,
+) -> int:
+    """Roll back unconsumed RAM injects, preserving already-durable copies."""
+
+    from tools.async_delegation import (
+        complete_event_delivery,
+        get_event_delivery_state,
+        release_event_delivery,
+    )
+    from tools.process_registry import process_registry
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    keep: list[dict[str, Any]] = []
+    removable_event_ids: set[str] = set()
+    settled = 0
+    for entry in pending:
+        if turn_id is not None and str(entry.get("turn_id") or "") != str(turn_id):
+            keep.append(entry)
+            continue
+        event = entry["event"]
+        event_id = str(entry["event_id"])
+        if _durable_event_is_in_history(messages, event_id):
+            if complete_event_delivery(event, entry["claim_id"]):
+                settled += 1
+            else:
+                keep.append(entry)
+        else:
+            # Remove the unconsumed marker by durable identity even when
+            # compression replaced the Python dict object.
+            removable_event_ids.add(event_id)
+            committed = release_event_delivery(event, entry["claim_id"])
+            state = get_event_delivery_state(event)
+            if committed:
+                # At the attempt cap release transitions to dropped, not pending.
+                if state == "pending":
+                    process_registry.completion_queue.put(event)
+                settled += 1
+            elif state == "delivered":
+                settled += 1
+            else:
+                keep.append(entry)
+
+    if removable_event_ids:
+        retained: list[dict[str, Any]] = []
+        for message in messages:
+            if not (_message_event_ids(message) & removable_event_ids):
+                retained.append(message)
+                continue
+            if "_delegation_delivery_original_content" in message:
+                message["content"] = deepcopy(
+                    message["_delegation_delivery_original_content"]
+                )
+                _remove_carrier_identity(message)
+            retained.append(message)
+        messages[:] = retained
+        agent._session_messages = messages
+    setattr(agent, _PENDING_CLAIMS_ATTR, keep)
+    _stop_claim_heartbeat_if_idle(agent)
+    return settled
+
+
+def _normal_budget_available(agent: Any) -> bool:
+    """Mirror the conversation-loop's normal iteration-budget predicate."""
+
+    max_iterations = getattr(agent, "max_iterations", None)
+    budget = getattr(agent, "iteration_budget", None)
+    # Lightweight helper users/tests do not necessarily expose loop-budget
+    # state. In production both attributes exist; absent state must not make a
+    # non-blocking queue drain manufacture a grace-call contract of its own.
+    if max_iterations is None or budget is None:
+        return True
+    api_calls = int(getattr(agent, "_api_call_count", 0) or 0)
+    remaining = int(getattr(budget, "remaining", 0) or 0)
+    return api_calls < int(max_iterations or 0) and remaining > 0
+
+
+def attach_ready_injects_to_tool_results(
+    agent: Any,
+    messages: list[dict[str, Any]],
+    num_tool_msgs: int,
+    *,
+    turn_id: str | None = None,
+) -> int:
+    """Carry ready delegation results on a newly produced tool result.
+
+    The carrier is restricted to the tail slice produced by the current tool
+    batch. Historical messages are never scanned or rewritten. Claims stay
+    live only through the append-only transcript commit; a failed commit lets
+    ``release_pending_injects`` restore the original tool content and return
+    the durable event to the ordinary after-turn rail.
+    """
+
+    if num_tool_msgs <= 0 or not messages:
+        return 0
+    active_turn_id = str(turn_id or getattr(agent, "_active_turn_id", "") or "")
+    if not active_turn_id:
+        return 0
+    if not _normal_budget_available(agent):
+        return 0
+    if getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return 0
+
+    target: dict[str, Any] | None = None
+    tail_start = max(0, len(messages) - num_tool_msgs)
+    for message in reversed(messages[tail_start:]):
+        if isinstance(message, dict) and message.get("role") == "tool":
+            target = message
+            break
+    if target is None:
+        return 0
+
+    from tools.async_delegation import (
+        claim_event_delivery,
+        get_event_delivery_state,
+        release_event_delivery,
+    )
+    from tools.process_registry import _format_async_delegation, process_registry
+
+    accepted: list[tuple[dict[str, Any], str, str, str]] = []
+    completion_queue = process_registry.completion_queue
+    with process_registry.completion_routing_lock:
+        try:
+            scan_count = completion_queue.qsize()
+        except Exception:
+            return 0
+        for _ in range(max(0, scan_count)):
+            try:
+                event = completion_queue.get_nowait()
+            except queue.Empty:
+                break
+            except Exception:
+                break
+            delivery = str(event.get("result_delivery") or "after_turn").strip().lower()
+            if (
+                event.get("type") != "async_delegation"
+                or delivery != "inject"
+                or str(event.get("parent_turn_id") or "") != active_turn_id
+            ):
+                completion_queue.put(event)
+                continue
+            parent_session_id = str(event.get("parent_session_id") or "")
+            agent_session_id = str(getattr(agent, "session_id", "") or "")
+            if parent_session_id and parent_session_id != agent_session_id:
+                completion_queue.put(event)
+                continue
+            try:
+                text = _format_async_delegation(event)
+            except Exception:
+                logger.debug("Failed to format tool-boundary delegation event", exc_info=True)
+                completion_queue.put(event)
+                continue
+            if not text:
+                completion_queue.put(event)
+                continue
+            claim_id = claim_event_delivery(event, f"tool-boundary:{os.getpid()}")
+            if claim_id is None:
+                process_registry.defer_unclaimed_delivery(event)
+                continue
+            accepted.append((event, claim_id, text, _event_identity(event)))
+
+    if not accepted:
+        return 0
+
+    original_content = deepcopy(target.get("content", ""))
+    event_ids = [item[3] for item in accepted]
+    try:
+        _append_carrier_text(target, "\n\n".join(item[2] for item in accepted))
+        target["_delegation_delivery_original_content"] = original_content
+        target["_delegation_event_ids"] = event_ids
+        display_metadata = dict(target.get("display_metadata") or {})
+        display_metadata["delegation_event_ids"] = event_ids
+        display_metadata["delegation_delivery"] = "tool_boundary"
+        target["display_metadata"] = display_metadata
+        agent._session_messages = messages
+    except Exception:
+        for event, claim_id, _text, _event_id in accepted:
+            if release_event_delivery(event, claim_id):
+                if get_event_delivery_state(event) == "pending":
+                    completion_queue.put(event)
+        raise
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    pending.extend(
+        {
+            "event": event,
+            "claim_id": claim_id,
+            "event_id": event_id,
+            "message": target,
+            "turn_id": active_turn_id,
+        }
+        for event, claim_id, _text, event_id in accepted
+    )
+    setattr(agent, _PENDING_CLAIMS_ATTR, pending)
+    ensure_pending_inject_heartbeat(agent)
+    return len(accepted)

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -13,6 +13,7 @@ import os
 import queue
 import threading
 from copy import deepcopy
+from dataclasses import replace
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,11 @@ logger = logging.getLogger(__name__)
 _PENDING_CLAIMS_ATTR = "_pending_delegation_inject_claims"
 _CLAIM_HEARTBEAT_ATTR = "_delegation_inject_claim_heartbeat"
 _CLAIM_HEARTBEAT_INTERVAL_SECONDS = 60.0
+_CARRIER_SPILL_TOOL_NAME = "__delegation_carrier__"
+_CARRIER_MARKER = (
+    "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
+    "not a new user request]\n"
+)
 
 
 def _event_identity(event: dict[str, Any]) -> str:
@@ -56,11 +62,7 @@ def _remove_carrier_identity(message: dict[str, Any]) -> None:
 
 
 def _append_carrier_text(message: dict[str, Any], text: str) -> None:
-    marker = (
-        "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
-        "not a new user request]\n"
-        + text
-    )
+    marker = _CARRIER_MARKER + text
     content = message.get("content", "")
     if isinstance(content, str):
         message["content"] = content + marker
@@ -71,6 +73,67 @@ def _append_carrier_text(message: dict[str, Any], text: str) -> None:
         message["content"] = blocks
     except Exception:
         message["content"] = f"{content}{marker}"
+
+
+def _content_text_size(content: Any) -> int:
+    """Count provider-visible text without charging binary image payloads."""
+
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        total = 0
+        for block in content:
+            if isinstance(block, str):
+                total += len(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    total += len(text)
+        return total
+    return len(str(content)) if content is not None else 0
+
+
+def _bounded_carrier_text(
+    text: str,
+    *,
+    max_chars: int | None,
+    event_id: str,
+    storage_env: Any,
+    budget_config: Any,
+) -> str | None:
+    """Return a bounded carrier or persist its full report in the active env.
+
+    A missing/failed sandbox is a delivery deferral, not permission to lose the
+    full child report through inline truncation. The durable event therefore
+    remains pending for the ordinary after-turn rail.
+    """
+
+    if max_chars is None or len(text) <= max_chars:
+        return text
+    if max_chars <= 0 or storage_env is None or budget_config is None:
+        return None
+
+    from tools.tool_result_storage import PERSISTED_OUTPUT_TAG, maybe_persist_tool_result
+
+    preview_size = max(0, min(int(budget_config.preview_size), max_chars))
+    for _ in range(3):
+        carrier_budget = replace(budget_config, preview_size=preview_size)
+        bounded = maybe_persist_tool_result(
+            content=text,
+            tool_name=_CARRIER_SPILL_TOOL_NAME,
+            tool_use_id=f"delegation-{event_id}",
+            env=storage_env,
+            config=carrier_budget,
+            threshold=0,
+        )
+        if PERSISTED_OUTPUT_TAG not in bounded:
+            return None
+        if len(bounded) <= max_chars:
+            return bounded
+        if preview_size == 0:
+            return None
+        preview_size = max(0, preview_size - (len(bounded) - max_chars) - 16)
+    return None
 
 
 def _durable_event_is_in_history(
@@ -263,6 +326,8 @@ def attach_ready_injects_to_tool_results(
     num_tool_msgs: int,
     *,
     turn_id: str | None = None,
+    storage_env: Any = None,
+    budget_config: Any = None,
 ) -> int:
     """Carry ready delegation results on a newly produced tool result.
 
@@ -291,6 +356,20 @@ def attach_ready_injects_to_tool_results(
             break
     if target is None:
         return 0
+
+    carrier_capacity: int | None = None
+    if budget_config is not None:
+        carrier_limit = min(
+            int(budget_config.default_result_size),
+            int(budget_config.turn_budget),
+        )
+        carrier_capacity = (
+            carrier_limit
+            - _content_text_size(target.get("content", ""))
+            - len(_CARRIER_MARKER)
+        )
+        if carrier_capacity <= 0:
+            return 0
 
     from tools.async_delegation import (
         claim_event_delivery,
@@ -335,16 +414,37 @@ def attach_ready_injects_to_tool_results(
             if not text:
                 completion_queue.put(event)
                 continue
+            event_id = _event_identity(event)
+            separator_size = 2 if accepted else 0
+            available = (
+                None
+                if carrier_capacity is None
+                else carrier_capacity - separator_size
+            )
+            bounded_text = _bounded_carrier_text(
+                text,
+                max_chars=available,
+                event_id=event_id,
+                storage_env=storage_env,
+                budget_config=budget_config,
+            )
+            if bounded_text is None:
+                completion_queue.put(event)
+                continue
             claim_id = claim_event_delivery(event, f"tool-boundary:{os.getpid()}")
             if claim_id is None:
                 process_registry.defer_unclaimed_delivery(event)
                 continue
-            accepted.append((event, claim_id, text, _event_identity(event)))
+            accepted.append((event, claim_id, bounded_text, event_id))
+            if carrier_capacity is not None:
+                carrier_capacity -= separator_size + len(bounded_text)
 
     if not accepted:
         return 0
 
+    original_target = deepcopy(target)
     original_content = deepcopy(target.get("content", ""))
+    original_pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
     event_ids = [item[3] for item in accepted]
     try:
         _append_carrier_text(target, "\n\n".join(item[2] for item in accepted))
@@ -355,24 +455,36 @@ def attach_ready_injects_to_tool_results(
         display_metadata["delegation_delivery"] = "tool_boundary"
         target["display_metadata"] = display_metadata
         agent._session_messages = messages
+
+        pending = list(original_pending)
+        pending.extend(
+            {
+                "event": event,
+                "claim_id": claim_id,
+                "event_id": event_id,
+                "message": target,
+                "turn_id": active_turn_id,
+            }
+            for event, claim_id, _text, event_id in accepted
+        )
+        setattr(agent, _PENDING_CLAIMS_ATTR, pending)
+        ensure_pending_inject_heartbeat(agent)
     except Exception:
+        target.clear()
+        target.update(original_target)
+        try:
+            setattr(agent, _PENDING_CLAIMS_ATTR, original_pending)
+            _stop_claim_heartbeat_if_idle(agent)
+        except Exception:
+            logger.debug("Failed to restore delegation claim bookkeeping", exc_info=True)
         for event, claim_id, _text, _event_id in accepted:
-            if release_event_delivery(event, claim_id):
-                if get_event_delivery_state(event) == "pending":
-                    completion_queue.put(event)
+            try:
+                released = release_event_delivery(event, claim_id)
+            except Exception:
+                logger.exception("Failed to release rolled-back delegation claim")
+                continue
+            if released and get_event_delivery_state(event) == "pending":
+                completion_queue.put(event)
         raise
 
-    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
-    pending.extend(
-        {
-            "event": event,
-            "claim_id": claim_id,
-            "event_id": event_id,
-            "message": target,
-            "turn_id": active_turn_id,
-        }
-        for event, claim_id, _text, event_id in accepted
-    )
-    setattr(agent, _PENDING_CLAIMS_ATTR, pending)
-    ensure_pending_inject_heartbeat(agent)
     return len(accepted)

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -1,0 +1,379 @@
+"""Tool-boundary delivery of completed background delegations.
+
+The async registry and its durable claims remain the authority for delivery.
+This module only carries already-ready ``result_delivery=inject`` events on a
+new tool result before that result's append-only transcript commit. It never
+waits for a child or manufactures a conversation role.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import threading
+from copy import deepcopy
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+_PENDING_CLAIMS_ATTR = "_pending_delegation_inject_claims"
+_CLAIM_HEARTBEAT_ATTR = "_delegation_inject_claim_heartbeat"
+_CLAIM_HEARTBEAT_INTERVAL_SECONDS = 60.0
+
+
+def _event_identity(event: dict[str, Any]) -> str:
+    return (
+        f"{event.get('delegation_id') or ''}:"
+        f"{event.get('delivery_event_key') or 'aggregate'}"
+    )
+
+
+def _message_event_ids(message: dict[str, Any]) -> set[str]:
+    metadata = message.get("display_metadata")
+    if isinstance(metadata, dict):
+        values = metadata.get("delegation_event_ids") or []
+    else:
+        values = message.get("_delegation_event_ids") or []
+    return {str(value) for value in values if value}
+
+
+def _clear_carrier_metadata(message: dict[str, Any]) -> None:
+    message.pop("_delegation_delivery_original_content", None)
+    message.pop("_delegation_event_ids", None)
+
+
+def _remove_carrier_identity(message: dict[str, Any]) -> None:
+    _clear_carrier_metadata(message)
+    metadata = message.get("display_metadata")
+    if not isinstance(metadata, dict):
+        return
+    metadata.pop("delegation_event_ids", None)
+    metadata.pop("delegation_delivery", None)
+    if not metadata:
+        message.pop("display_metadata", None)
+
+
+def _append_carrier_text(message: dict[str, Any], text: str) -> None:
+    marker = (
+        "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
+        "not a new user request]\n"
+        + text
+    )
+    content = message.get("content", "")
+    if isinstance(content, str):
+        message["content"] = content + marker
+        return
+    try:
+        blocks = list(content) if content else []
+        blocks.append({"type": "text", "text": marker.lstrip()})
+        message["content"] = blocks
+    except Exception:
+        message["content"] = f"{content}{marker}"
+
+
+def _durable_event_is_in_history(
+    messages: list[dict[str, Any]], event_id: str
+) -> bool:
+    return any(
+        message.get("_db_persisted") is True
+        and event_id in _message_event_ids(message)
+        for message in messages
+        if isinstance(message, dict)
+    )
+
+
+def _stop_claim_heartbeat_if_idle(agent: Any) -> None:
+    if getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return
+    heartbeat = getattr(agent, _CLAIM_HEARTBEAT_ATTR, None)
+    if isinstance(heartbeat, dict):
+        stop = heartbeat.get("stop")
+        if isinstance(stop, threading.Event):
+            stop.set()
+
+
+def ensure_pending_inject_heartbeat(agent: Any) -> bool:
+    """Renew live same-turn claims throughout provider retries and backoff."""
+
+    if not getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return False
+    existing = getattr(agent, _CLAIM_HEARTBEAT_ATTR, None)
+    if isinstance(existing, dict):
+        thread = existing.get("thread")
+        existing_stop = existing.get("stop")
+        if (
+            isinstance(thread, threading.Thread)
+            and thread.is_alive()
+            and isinstance(existing_stop, threading.Event)
+            and not existing_stop.is_set()
+        ):
+            return True
+
+    stop = threading.Event()
+
+    def _heartbeat() -> None:
+        from tools.async_delegation import renew_event_delivery
+
+        while not stop.wait(_CLAIM_HEARTBEAT_INTERVAL_SECONDS):
+            pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+            if not pending:
+                break
+            for entry in pending:
+                try:
+                    if not renew_event_delivery(entry["event"], entry["claim_id"]):
+                        logger.warning(
+                            "Could not renew same-turn delegation claim %s",
+                            entry.get("event_id"),
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to renew same-turn delegation claim %s",
+                        entry.get("event_id"),
+                        exc_info=True,
+                    )
+
+    thread = threading.Thread(
+        target=_heartbeat,
+        daemon=True,
+        name="delegation-inject-claim-heartbeat",
+    )
+    setattr(agent, _CLAIM_HEARTBEAT_ATTR, {"stop": stop, "thread": thread})
+    thread.start()
+    return True
+
+
+def acknowledge_pending_injects(agent: Any, *, turn_id: str | None = None) -> int:
+    """Acknowledge tool-boundary claims after durable transcript persistence."""
+
+    from tools.async_delegation import complete_event_delivery
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    keep: list[dict[str, Any]] = []
+    acknowledged_messages: list[dict[str, Any]] = []
+    acknowledged = 0
+    for entry in pending:
+        if turn_id is not None and str(entry.get("turn_id") or "") != str(turn_id):
+            keep.append(entry)
+            continue
+        if complete_event_delivery(entry["event"], entry["claim_id"]):
+            acknowledged += 1
+            message = entry.get("message")
+            if isinstance(message, dict):
+                acknowledged_messages.append(message)
+        else:
+            keep.append(entry)
+            logger.warning(
+                "Delegation carrier persisted but durable event ack did not commit: %s",
+                entry.get("event_id"),
+            )
+    setattr(agent, _PENDING_CLAIMS_ATTR, keep)
+    still_pending_ids = {str(entry.get("event_id") or "") for entry in keep}
+    for message in acknowledged_messages:
+        if not (_message_event_ids(message) & still_pending_ids):
+            _clear_carrier_metadata(message)
+    _stop_claim_heartbeat_if_idle(agent)
+    return acknowledged
+
+
+def release_pending_injects(
+    agent: Any,
+    messages: list[dict[str, Any]],
+    *,
+    turn_id: str | None = None,
+) -> int:
+    """Roll back unconsumed RAM injects, preserving already-durable copies."""
+
+    from tools.async_delegation import (
+        complete_event_delivery,
+        get_event_delivery_state,
+        release_event_delivery,
+    )
+    from tools.process_registry import process_registry
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    keep: list[dict[str, Any]] = []
+    removable_event_ids: set[str] = set()
+    settled = 0
+    for entry in pending:
+        if turn_id is not None and str(entry.get("turn_id") or "") != str(turn_id):
+            keep.append(entry)
+            continue
+        event = entry["event"]
+        event_id = str(entry["event_id"])
+        if _durable_event_is_in_history(messages, event_id):
+            if complete_event_delivery(event, entry["claim_id"]):
+                settled += 1
+            else:
+                keep.append(entry)
+        else:
+            # Remove the unconsumed marker by durable identity even when
+            # compression replaced the Python dict object.
+            removable_event_ids.add(event_id)
+            committed = release_event_delivery(event, entry["claim_id"])
+            state = get_event_delivery_state(event)
+            if committed:
+                # At the attempt cap release transitions to dropped, not pending.
+                if state == "pending":
+                    process_registry.completion_queue.put(event)
+                settled += 1
+            elif state == "delivered":
+                settled += 1
+            else:
+                keep.append(entry)
+
+    if removable_event_ids:
+        retained: list[dict[str, Any]] = []
+        for message in messages:
+            if not (_message_event_ids(message) & removable_event_ids):
+                retained.append(message)
+                continue
+            if "_delegation_delivery_original_content" in message:
+                message["content"] = deepcopy(
+                    message["_delegation_delivery_original_content"]
+                )
+                _remove_carrier_identity(message)
+            retained.append(message)
+        messages[:] = retained
+        agent._session_messages = messages
+    setattr(agent, _PENDING_CLAIMS_ATTR, keep)
+    _stop_claim_heartbeat_if_idle(agent)
+    return settled
+
+
+def _normal_budget_available(agent: Any) -> bool:
+    """Mirror the conversation-loop's normal iteration-budget predicate."""
+
+    max_iterations = getattr(agent, "max_iterations", None)
+    budget = getattr(agent, "iteration_budget", None)
+    # Lightweight helper users/tests do not necessarily expose loop-budget
+    # state. In production both attributes exist; absent state must not make a
+    # non-blocking queue drain manufacture a grace-call contract of its own.
+    if max_iterations is None or budget is None:
+        return True
+    api_calls = int(getattr(agent, "_api_call_count", 0) or 0)
+    remaining = int(getattr(budget, "remaining", 0) or 0)
+    return api_calls < int(max_iterations or 0) and remaining > 0
+
+
+def attach_ready_injects_to_tool_results(
+    agent: Any,
+    messages: list[dict[str, Any]],
+    num_tool_msgs: int,
+    *,
+    turn_id: str | None = None,
+) -> int:
+    """Carry ready delegation results on a newly produced tool result.
+
+    The carrier is restricted to the tail slice produced by the current tool
+    batch. Historical messages are never scanned or rewritten. Claims stay
+    live only through the append-only transcript commit; a failed commit lets
+    ``release_pending_injects`` restore the original tool content and return
+    the durable event to the ordinary after-turn rail.
+    """
+
+    if num_tool_msgs <= 0 or not messages:
+        return 0
+    active_turn_id = str(turn_id or getattr(agent, "_active_turn_id", "") or "")
+    if not active_turn_id:
+        return 0
+    if not _normal_budget_available(agent):
+        return 0
+    if getattr(agent, _PENDING_CLAIMS_ATTR, None):
+        return 0
+
+    target: dict[str, Any] | None = None
+    tail_start = max(0, len(messages) - num_tool_msgs)
+    for message in reversed(messages[tail_start:]):
+        if isinstance(message, dict) and message.get("role") == "tool":
+            target = message
+            break
+    if target is None:
+        return 0
+
+    from tools.async_delegation import (
+        claim_event_delivery,
+        get_event_delivery_state,
+        release_event_delivery,
+    )
+    from tools.process_registry import process_registry
+    from tools.process_registry_notifications import _format_async_delegation
+
+    accepted: list[tuple[dict[str, Any], str, str, str]] = []
+    completion_queue = process_registry.completion_queue
+    with process_registry.completion_routing_lock:
+        try:
+            scan_count = completion_queue.qsize()
+        except Exception:
+            return 0
+        for _ in range(max(0, scan_count)):
+            try:
+                event = completion_queue.get_nowait()
+            except queue.Empty:
+                break
+            except Exception:
+                break
+            delivery = str(event.get("result_delivery") or "after_turn").strip().lower()
+            if (
+                event.get("type") != "async_delegation"
+                or delivery != "inject"
+                or str(event.get("parent_turn_id") or "") != active_turn_id
+            ):
+                completion_queue.put(event)
+                continue
+            parent_session_id = str(event.get("parent_session_id") or "")
+            agent_session_id = str(getattr(agent, "session_id", "") or "")
+            if parent_session_id and parent_session_id != agent_session_id:
+                completion_queue.put(event)
+                continue
+            try:
+                text = _format_async_delegation(event)
+            except Exception:
+                logger.debug("Failed to format tool-boundary delegation event", exc_info=True)
+                completion_queue.put(event)
+                continue
+            if not text:
+                completion_queue.put(event)
+                continue
+            claim_id = claim_event_delivery(event, f"tool-boundary:{os.getpid()}")
+            if claim_id is None:
+                process_registry.defer_unclaimed_delivery(event)
+                continue
+            accepted.append((event, claim_id, text, _event_identity(event)))
+
+    if not accepted:
+        return 0
+
+    original_content = deepcopy(target.get("content", ""))
+    event_ids = [item[3] for item in accepted]
+    try:
+        _append_carrier_text(target, "\n\n".join(item[2] for item in accepted))
+        target["_delegation_delivery_original_content"] = original_content
+        target["_delegation_event_ids"] = event_ids
+        display_metadata = dict(target.get("display_metadata") or {})
+        display_metadata["delegation_event_ids"] = event_ids
+        display_metadata["delegation_delivery"] = "tool_boundary"
+        target["display_metadata"] = display_metadata
+        agent._session_messages = messages
+    except Exception:
+        for event, claim_id, _text, _event_id in accepted:
+            if release_event_delivery(event, claim_id):
+                if get_event_delivery_state(event) == "pending":
+                    completion_queue.put(event)
+        raise
+
+    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
+    pending.extend(
+        {
+            "event": event,
+            "claim_id": claim_id,
+            "event_id": event_id,
+            "message": target,
+            "turn_id": active_turn_id,
+        }
+        for event, claim_id, _text, event_id in accepted
+    )
+    setattr(agent, _PENDING_CLAIMS_ATTR, pending)
+    ensure_pending_inject_heartbeat(agent)
+    return len(accepted)

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -197,8 +197,10 @@ def ensure_pending_inject_heartbeat(agent: Any) -> bool:
                         exc_info=True,
                     )
 
+    from tools.thread_context import propagate_context_to_thread
+
     thread = threading.Thread(
-        target=_heartbeat,
+        target=propagate_context_to_thread(_heartbeat),
         daemon=True,
         name="delegation-inject-claim-heartbeat",
     )
@@ -220,7 +222,17 @@ def acknowledge_pending_injects(agent: Any, *, turn_id: str | None = None) -> in
         if turn_id is not None and str(entry.get("turn_id") or "") != str(turn_id):
             keep.append(entry)
             continue
-        if complete_event_delivery(entry["event"], entry["claim_id"]):
+        message = entry.get("message")
+        # A successful no-op flush (persistence-disabled agents) is NOT a receipt.
+        if not isinstance(message, dict) or message.get("_db_persisted") is not True:
+            keep.append(entry)
+            continue
+        try:
+            committed = complete_event_delivery(entry["event"], entry["claim_id"])
+        except Exception:
+            logger.warning("Could not acknowledge persisted delegation carrier", exc_info=True)
+            committed = False
+        if committed:
             acknowledged += 1
             message = entry.get("message")
             if isinstance(message, dict):
@@ -348,26 +360,28 @@ def attach_ready_injects_to_tool_results(
     if getattr(agent, _PENDING_CLAIMS_ATTR, None):
         return 0
 
-    target: dict[str, Any] | None = None
-    tail_start = max(0, len(messages) - num_tool_msgs)
-    for message in reversed(messages[tail_start:]):
-        if isinstance(message, dict) and message.get("role") == "tool":
-            target = message
-            break
-    if target is None:
+    # Only the newest result is eligible. Never search backwards past an already
+    # committed tail or mutate a replayed tool result after a process restart.
+    target = messages[-1]
+    if (not isinstance(target, dict) or target.get("role") != "tool"
+            or target.get("_db_persisted") is True):
         return 0
+    tail_start = max(0, len(messages) - num_tool_msgs)
 
     carrier_capacity: int | None = None
     if budget_config is not None:
-        carrier_limit = min(
-            int(budget_config.default_result_size),
-            int(budget_config.turn_budget),
+        target_size = _content_text_size(target.get("content", ""))
+        batch_size = sum(
+            _content_text_size(message.get("content", ""))
+            for message in messages[tail_start:] if isinstance(message, dict)
         )
-        carrier_capacity = (
-            carrier_limit
-            - _content_text_size(target.get("content", ""))
-            - len(_CARRIER_MARKER)
-        )
+        # The executor enforces the aggregate budget after per-result flushes.
+        # Reserve space for ALL siblings so it cannot later truncate a carrier
+        # whose durable event has already been acknowledged.
+        carrier_capacity = min(
+            int(budget_config.default_result_size) - target_size,
+            int(budget_config.turn_budget) - batch_size,
+        ) - len(_CARRIER_MARKER)
         if carrier_capacity <= 0:
             return 0
 
@@ -381,6 +395,16 @@ def attach_ready_injects_to_tool_results(
 
     accepted: list[tuple[dict[str, Any], str, str, str]] = []
     completion_queue = process_registry.completion_queue
+
+    def requeue(event):
+        try:
+            with process_registry.completion_routing_lock:
+                completion_queue.put(event)
+        except Exception:
+            # Preserve a pending row's RAM delivery path on transient queue failure.
+            process_registry.defer_unclaimed_delivery(event)
+
+    candidates = []
     with process_registry.completion_routing_lock:
         try:
             scan_count = completion_queue.qsize()
@@ -398,47 +422,43 @@ def attach_ready_injects_to_tool_results(
                 event.get("type") != "async_delegation"
                 or delivery != "inject"
                 or str(event.get("parent_turn_id") or "") != active_turn_id
+                or str(event.get("parent_session_id") or "") != str(getattr(agent, "session_id", "") or "")
+                or not event.get("parent_session_id")
             ):
-                completion_queue.put(event)
+                requeue(event)
                 continue
-            parent_session_id = str(event.get("parent_session_id") or "")
-            agent_session_id = str(getattr(agent, "session_id", "") or "")
-            if parent_session_id and parent_session_id != agent_session_id:
-                completion_queue.put(event)
-                continue
-            try:
-                text = _format_async_delegation(event)
-            except Exception:
-                logger.debug("Failed to format tool-boundary delegation event", exc_info=True)
-                completion_queue.put(event)
-                continue
+            candidates.append(event)
+
+    # Formatting / sandbox I/O must never hold the shared routing reservation.
+    # Dequeue gives this consumer the RAM item; the durable claim arbitrates a
+    # concurrently restored copy before any transcript mutation.
+    for event in candidates:
+        try:
+            text = _format_async_delegation(event)
             if not text:
-                completion_queue.put(event)
+                requeue(event)
                 continue
             event_id = _event_identity(event)
             separator_size = 2 if accepted else 0
-            available = (
-                None
-                if carrier_capacity is None
-                else carrier_capacity - separator_size
-            )
+            available = None if carrier_capacity is None else carrier_capacity - separator_size
             bounded_text = _bounded_carrier_text(
-                text,
-                max_chars=available,
-                event_id=event_id,
-                storage_env=storage_env,
-                budget_config=budget_config,
+                text, max_chars=available, event_id=event_id,
+                storage_env=storage_env, budget_config=budget_config,
             )
             if bounded_text is None:
-                completion_queue.put(event)
+                requeue(event)
                 continue
             claim_id = claim_event_delivery(event, f"tool-boundary:{os.getpid()}")
-            if claim_id is None:
-                process_registry.defer_unclaimed_delivery(event)
-                continue
-            accepted.append((event, claim_id, bounded_text, event_id))
-            if carrier_capacity is not None:
-                carrier_capacity -= separator_size + len(bounded_text)
+        except Exception:
+            logger.warning("Failed to prepare tool-boundary delegation event", exc_info=True)
+            requeue(event)
+            continue
+        if claim_id is None:
+            process_registry.defer_unclaimed_delivery(event)
+            continue
+        accepted.append((event, claim_id, bounded_text, event_id))
+        if carrier_capacity is not None:
+            carrier_capacity -= separator_size + len(bounded_text)
 
     if not accepted:
         return 0

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -13,6 +13,7 @@ import os
 import queue
 import threading
 from copy import deepcopy
+from dataclasses import replace
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,11 @@ logger = logging.getLogger(__name__)
 _PENDING_CLAIMS_ATTR = "_pending_delegation_inject_claims"
 _CLAIM_HEARTBEAT_ATTR = "_delegation_inject_claim_heartbeat"
 _CLAIM_HEARTBEAT_INTERVAL_SECONDS = 60.0
+_CARRIER_SPILL_TOOL_NAME = "__delegation_carrier__"
+_CARRIER_MARKER = (
+    "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
+    "not a new user request]\n"
+)
 
 
 def _event_identity(event: dict[str, Any]) -> str:
@@ -56,11 +62,7 @@ def _remove_carrier_identity(message: dict[str, Any]) -> None:
 
 
 def _append_carrier_text(message: dict[str, Any], text: str) -> None:
-    marker = (
-        "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
-        "not a new user request]\n"
-        + text
-    )
+    marker = _CARRIER_MARKER + text
     content = message.get("content", "")
     if isinstance(content, str):
         message["content"] = content + marker
@@ -71,6 +73,67 @@ def _append_carrier_text(message: dict[str, Any], text: str) -> None:
         message["content"] = blocks
     except Exception:
         message["content"] = f"{content}{marker}"
+
+
+def _content_text_size(content: Any) -> int:
+    """Count provider-visible text without charging binary image payloads."""
+
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        total = 0
+        for block in content:
+            if isinstance(block, str):
+                total += len(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    total += len(text)
+        return total
+    return len(str(content)) if content is not None else 0
+
+
+def _bounded_carrier_text(
+    text: str,
+    *,
+    max_chars: int | None,
+    event_id: str,
+    storage_env: Any,
+    budget_config: Any,
+) -> str | None:
+    """Return a bounded carrier or persist its full report in the active env.
+
+    A missing/failed sandbox is a delivery deferral, not permission to lose the
+    full child report through inline truncation. The durable event therefore
+    remains pending for the ordinary after-turn rail.
+    """
+
+    if max_chars is None or len(text) <= max_chars:
+        return text
+    if max_chars <= 0 or storage_env is None or budget_config is None:
+        return None
+
+    from tools.tool_result_storage import PERSISTED_OUTPUT_TAG, maybe_persist_tool_result
+
+    preview_size = max(0, min(int(budget_config.preview_size), max_chars))
+    for _ in range(3):
+        carrier_budget = replace(budget_config, preview_size=preview_size)
+        bounded = maybe_persist_tool_result(
+            content=text,
+            tool_name=_CARRIER_SPILL_TOOL_NAME,
+            tool_use_id=f"delegation-{event_id}",
+            env=storage_env,
+            config=carrier_budget,
+            threshold=0,
+        )
+        if PERSISTED_OUTPUT_TAG not in bounded:
+            return None
+        if len(bounded) <= max_chars:
+            return bounded
+        if preview_size == 0:
+            return None
+        preview_size = max(0, preview_size - (len(bounded) - max_chars) - 16)
+    return None
 
 
 def _durable_event_is_in_history(
@@ -263,6 +326,8 @@ def attach_ready_injects_to_tool_results(
     num_tool_msgs: int,
     *,
     turn_id: str | None = None,
+    storage_env: Any = None,
+    budget_config: Any = None,
 ) -> int:
     """Carry ready delegation results on a newly produced tool result.
 
@@ -291,6 +356,20 @@ def attach_ready_injects_to_tool_results(
             break
     if target is None:
         return 0
+
+    carrier_capacity: int | None = None
+    if budget_config is not None:
+        carrier_limit = min(
+            int(budget_config.default_result_size),
+            int(budget_config.turn_budget),
+        )
+        carrier_capacity = (
+            carrier_limit
+            - _content_text_size(target.get("content", ""))
+            - len(_CARRIER_MARKER)
+        )
+        if carrier_capacity <= 0:
+            return 0
 
     from tools.async_delegation import (
         claim_event_delivery,
@@ -336,16 +415,37 @@ def attach_ready_injects_to_tool_results(
             if not text:
                 completion_queue.put(event)
                 continue
+            event_id = _event_identity(event)
+            separator_size = 2 if accepted else 0
+            available = (
+                None
+                if carrier_capacity is None
+                else carrier_capacity - separator_size
+            )
+            bounded_text = _bounded_carrier_text(
+                text,
+                max_chars=available,
+                event_id=event_id,
+                storage_env=storage_env,
+                budget_config=budget_config,
+            )
+            if bounded_text is None:
+                completion_queue.put(event)
+                continue
             claim_id = claim_event_delivery(event, f"tool-boundary:{os.getpid()}")
             if claim_id is None:
                 process_registry.defer_unclaimed_delivery(event)
                 continue
-            accepted.append((event, claim_id, text, _event_identity(event)))
+            accepted.append((event, claim_id, bounded_text, event_id))
+            if carrier_capacity is not None:
+                carrier_capacity -= separator_size + len(bounded_text)
 
     if not accepted:
         return 0
 
+    original_target = deepcopy(target)
     original_content = deepcopy(target.get("content", ""))
+    original_pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
     event_ids = [item[3] for item in accepted]
     try:
         _append_carrier_text(target, "\n\n".join(item[2] for item in accepted))
@@ -356,24 +456,36 @@ def attach_ready_injects_to_tool_results(
         display_metadata["delegation_delivery"] = "tool_boundary"
         target["display_metadata"] = display_metadata
         agent._session_messages = messages
+
+        pending = list(original_pending)
+        pending.extend(
+            {
+                "event": event,
+                "claim_id": claim_id,
+                "event_id": event_id,
+                "message": target,
+                "turn_id": active_turn_id,
+            }
+            for event, claim_id, _text, event_id in accepted
+        )
+        setattr(agent, _PENDING_CLAIMS_ATTR, pending)
+        ensure_pending_inject_heartbeat(agent)
     except Exception:
+        target.clear()
+        target.update(original_target)
+        try:
+            setattr(agent, _PENDING_CLAIMS_ATTR, original_pending)
+            _stop_claim_heartbeat_if_idle(agent)
+        except Exception:
+            logger.debug("Failed to restore delegation claim bookkeeping", exc_info=True)
         for event, claim_id, _text, _event_id in accepted:
-            if release_event_delivery(event, claim_id):
-                if get_event_delivery_state(event) == "pending":
-                    completion_queue.put(event)
+            try:
+                released = release_event_delivery(event, claim_id)
+            except Exception:
+                logger.exception("Failed to release rolled-back delegation claim")
+                continue
+            if released and get_event_delivery_state(event) == "pending":
+                completion_queue.put(event)
         raise
 
-    pending = list(getattr(agent, _PENDING_CLAIMS_ATTR, []) or [])
-    pending.extend(
-        {
-            "event": event,
-            "claim_id": claim_id,
-            "event_id": event_id,
-            "message": target,
-            "turn_id": active_turn_id,
-        }
-        for event, claim_id, _text, event_id in accepted
-    )
-    setattr(agent, _PENDING_CLAIMS_ATTR, pending)
-    ensure_pending_inject_heartbeat(agent)
     return len(accepted)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -175,26 +175,101 @@ def _resolve_concurrent_tool_timeout() -> float | None:
     return value
 
 
+def _completed_tool_batch_size(messages: list) -> int:
+    """Return the size of a complete, not-yet-checked tool-result tail."""
+
+    if not messages or not isinstance(messages[-1], dict):
+        return 0
+    tail = messages[-1]
+    if tail.get("role") != "tool" or tail.get("_external_input_boundary_checked"):
+        return 0
+
+    start = len(messages) - 1
+    while start >= 0 and isinstance(messages[start], dict) and messages[start].get("role") == "tool":
+        start -= 1
+    if start < 0:
+        return 0
+    assistant = messages[start]
+    if assistant.get("role") != "assistant" or not assistant.get("tool_calls"):
+        return 0
+
+    expected_ids: list[str] = []
+    for call in assistant.get("tool_calls") or []:
+        call_id = call.get("id") if isinstance(call, dict) else getattr(call, "id", None)
+        if call_id:
+            expected_ids.append(str(call_id))
+    actual_ids = [
+        str(message.get("tool_call_id") or "")
+        for message in messages[start + 1 :]
+        if isinstance(message, dict) and message.get("role") == "tool"
+    ]
+    if not expected_ids or len(actual_ids) != len(expected_ids):
+        return 0
+    if set(actual_ids) != set(expected_ids):
+        return 0
+    return len(actual_ids)
+
+
 def _flush_session_db_after_tool_progress(
     agent,
     messages: list,
     *,
     stage: str,
 ) -> bool:
-    """Flush tool-call progress before projecting it to any UI surface.
+    """Persist tool progress, carrying ready delegation evidence once per batch.
 
-    Tool execution can perform side effects that terminate or restart the
-    current Hermes process before the normal turn-end persistence path runs.
-    Flush the already-appended assistant/tool messages immediately so the
-    transcript survives destructive-but-valid tool calls.
+    The last result of a complete tool batch is the only same-turn carrier. It
+    is enriched before the batch's first durable commit, so history remains
+    append-only and every provider sees the ordinary assistant/tool role shape.
     """
+    completed_batch_size = _completed_tool_batch_size(messages)
+    if completed_batch_size:
+        messages[-1]["_external_input_boundary_checked"] = True
+        try:
+            from agent.delegation_inject import attach_ready_injects_to_tool_results
+
+            attach_ready_injects_to_tool_results(
+                agent,
+                messages,
+                num_tool_msgs=completed_batch_size,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
+        except Exception as exc:
+            logger.warning("Delegation tool-boundary preparation failed: %s", exc)
+
+    def _release_unpersisted_carrier() -> None:
+        if not completed_batch_size:
+            return
+        try:
+            from agent.delegation_inject import release_pending_injects
+
+            release_pending_injects(
+                agent,
+                messages,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
+        except Exception:
+            logger.warning(
+                "Could not release unpersisted delegation tool carrier",
+                exc_info=True,
+            )
+
     try:
         persisted = agent._flush_messages_to_session_db(messages) is not False
         if not persisted:
             agent._incremental_persistence_failed = True
+            _release_unpersisted_carrier()
+        elif completed_batch_size:
+            from agent.delegation_inject import acknowledge_pending_injects
+
+            acknowledge_pending_injects(
+                agent,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
         return persisted
     except Exception as exc:
         agent._incremental_persistence_failed = True
+        _release_unpersisted_carrier()
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -215,6 +215,8 @@ def _flush_session_db_after_tool_progress(
     messages: list,
     *,
     stage: str,
+    storage_env=None,
+    budget_config=None,
 ) -> bool:
     """Persist tool progress, carrying ready delegation evidence once per batch.
 
@@ -233,6 +235,8 @@ def _flush_session_db_after_tool_progress(
                 messages,
                 num_tool_msgs=completed_batch_size,
                 turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+                storage_env=storage_env,
+                budget_config=budget_config,
             )
         except Exception as exc:
             logger.warning("Delegation tool-boundary preparation failed: %s", exc)
@@ -869,6 +873,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 agent,
                 messages,
                 stage=f"cancelled tool result {tc.function.name}",
+                storage_env=get_active_env(effective_task_id),
+                budget_config=_tool_budget,
             )
         return
 
@@ -1573,6 +1579,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             agent,
             messages,
             stage=f"tool result {name}",
+            storage_env=get_active_env(effective_task_id),
+            budget_config=_tool_budget,
         ):
             return
 
@@ -1714,6 +1722,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent,
                     messages,
                     stage=f"cancelled tool result {skipped_name}",
+                    storage_env=get_active_env(effective_task_id),
+                    budget_config=_tool_budget,
                 ):
                     return
             break
@@ -1746,6 +1756,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent,
                 messages,
                 stage=f"invalid tool arguments {function_name}",
+                storage_env=get_active_env(effective_task_id),
+                budget_config=_tool_budget,
             ):
                 return
             continue
@@ -2319,6 +2331,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent,
             messages,
             stage=f"tool result {function_name}",
+            storage_env=get_active_env(effective_task_id),
+            budget_config=_tool_budget,
         ):
             return
 
@@ -2390,6 +2404,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent,
                     messages,
                     stage=f"skipped tool result {skipped_name}",
+                    storage_env=get_active_env(effective_task_id),
+                    budget_config=_tool_budget,
                 ):
                     return
             break

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -211,6 +211,8 @@ def _flush_session_db_after_tool_progress(
     messages: list,
     *,
     stage: str,
+    storage_env=None,
+    budget_config=None,
 ) -> bool:
     """Persist tool progress, carrying ready delegation evidence once per batch.
 
@@ -229,6 +231,8 @@ def _flush_session_db_after_tool_progress(
                 messages,
                 num_tool_msgs=completed_batch_size,
                 turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+                storage_env=storage_env,
+                budget_config=budget_config,
             )
         except Exception as exc:
             logger.warning("Delegation tool-boundary preparation failed: %s", exc)
@@ -404,7 +408,10 @@ def _append_skipped_tool_results(
                 status="cancelled", error_type=hook_error_type, error_message="Tool execution skipped due to user interrupt",
             )
         if flush_stage is not None:
-            flushed = _flush_session_db_after_tool_progress(agent, messages, stage=f"{flush_stage} {name}")
+            flushed = _flush_session_db_after_tool_progress(
+                agent, messages, stage=f"{flush_stage} {name}",
+                storage_env=get_active_env(effective_task_id), budget_config=_budget_for_agent(agent),
+            )
             if not flushed and stop_on_flush_failure:
                 return False
     return True
@@ -1100,7 +1107,10 @@ def _commit_tool_result(
     _tool_content = agent._tool_result_content_for_active_model(function_name, persisted_result)
     tool_message = make_tool_result_message(function_name, _tool_content, tool_call_id, effect_disposition=effect_disposition)
     messages.append(tool_message)
-    if not _flush_session_db_after_tool_progress(agent, messages, stage=f"tool result {function_name}"):
+    if not _flush_session_db_after_tool_progress(
+        agent, messages, stage=f"tool result {function_name}",
+        storage_env=get_active_env(effective_task_id), budget_config=budget,
+    ):
         return None
 
     if not blocked:
@@ -1640,7 +1650,10 @@ def _append_invalid_arguments_result(agent, messages: list, ref: _ToolCallRef, p
     """Emit + append the parse-error result for a call whose arguments were not a JSON object."""
     ref.emit_invalid_arguments(agent, parse_error)
     messages.append(make_tool_result_message(ref.name, parse_error, ref.call_id))
-    return _flush_session_db_after_tool_progress(agent, messages, stage=f"invalid tool arguments {ref.name}")
+    return _flush_session_db_after_tool_progress(
+        agent, messages, stage=f"invalid tool arguments {ref.name}",
+        storage_env=get_active_env(ref.task_id), budget_config=_budget_for_agent(agent),
+    )
 
 
 def _run_sequential_call(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -176,7 +176,8 @@ def _completed_tool_batch_size(messages: list) -> int:
     if not messages or not isinstance(messages[-1], dict):
         return 0
     tail = messages[-1]
-    if tail.get("role") != "tool" or tail.get("_external_input_boundary_checked"):
+    if (tail.get("role") != "tool" or tail.get("_external_input_boundary_checked")
+            or tail.get("_db_persisted") is True):
         return 0
 
     start = len(messages) - 1
@@ -200,7 +201,7 @@ def _completed_tool_batch_size(messages: list) -> int:
     ]
     if not expected_ids or len(actual_ids) != len(expected_ids):
         return 0
-    if set(actual_ids) != set(expected_ids):
+    if len(set(expected_ids)) != len(expected_ids) or set(actual_ids) != set(expected_ids):
         return 0
     return len(actual_ids)
 
@@ -220,7 +221,14 @@ def _flush_session_db_after_tool_progress(
     is enriched before the batch's first durable commit, so history remains
     append-only and every provider sees the ordinary assistant/tool role shape.
     """
-    completed_batch_size = _completed_tool_batch_size(messages)
+    # A known no-op persistence path cannot accept a durable carrier. Do not
+    # acquire/release its claim at every tool batch: that would exhaust the
+    # delivery-attempt cap without ever offering the after-turn fallback.
+    persistence_unavailable = (
+        getattr(agent, "_persist_disabled", False) is True
+        or getattr(agent, "_session_db", True) is None
+    )
+    completed_batch_size = 0 if persistence_unavailable else _completed_tool_batch_size(messages)
     if completed_batch_size:
         messages[-1]["_external_input_boundary_checked"] = True
         try:
@@ -255,7 +263,8 @@ def _flush_session_db_after_tool_progress(
             )
 
     try:
-        persisted = agent._flush_messages_to_session_db(messages) is not False
+        flush_result = agent._flush_messages_to_session_db(messages)
+        persisted = flush_result is not False
         if not persisted:
             agent._incremental_persistence_failed = True
             # The flush caught its own exception and returned False; the
@@ -263,6 +272,12 @@ def _flush_session_db_after_tool_progress(
             # fall back to 'unknown' when nothing more specific is recorded.
             if getattr(agent, "_last_persistence_error_cause", None) is None:
                 agent._last_persistence_error_cause = "unknown"
+            _release_unpersisted_carrier()
+        elif completed_batch_size and (
+            flush_result is not True or messages[-1].get("_db_persisted") is not True
+        ):
+            # None is the established non-fatal return for a disabled/no-DB
+            # flush. Keep that contract, but do not consume durable evidence.
             _release_unpersisted_carrier()
         elif completed_batch_size:
             from agent.delegation_inject import acknowledge_pending_injects

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -170,21 +170,110 @@ def _resolve_concurrent_tool_timeout() -> float | None:
     )
 
 
-def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) -> bool:
-    """Flush tool-call progress to the session DB before projecting it to any UI: tool side
-    effects can kill/restart the process before turn-end persistence runs."""
+def _completed_tool_batch_size(messages: list) -> int:
+    """Return the size of a complete, not-yet-checked tool-result tail."""
+
+    if not messages or not isinstance(messages[-1], dict):
+        return 0
+    tail = messages[-1]
+    if tail.get("role") != "tool" or tail.get("_external_input_boundary_checked"):
+        return 0
+
+    start = len(messages) - 1
+    while start >= 0 and isinstance(messages[start], dict) and messages[start].get("role") == "tool":
+        start -= 1
+    if start < 0:
+        return 0
+    assistant = messages[start]
+    if assistant.get("role") != "assistant" or not assistant.get("tool_calls"):
+        return 0
+
+    expected_ids: list[str] = []
+    for call in assistant.get("tool_calls") or []:
+        call_id = call.get("id") if isinstance(call, dict) else getattr(call, "id", None)
+        if call_id:
+            expected_ids.append(str(call_id))
+    actual_ids = [
+        str(message.get("tool_call_id") or "")
+        for message in messages[start + 1 :]
+        if isinstance(message, dict) and message.get("role") == "tool"
+    ]
+    if not expected_ids or len(actual_ids) != len(expected_ids):
+        return 0
+    if set(actual_ids) != set(expected_ids):
+        return 0
+    return len(actual_ids)
+
+
+
+def _flush_session_db_after_tool_progress(
+    agent,
+    messages: list,
+    *,
+    stage: str,
+) -> bool:
+    """Persist tool progress, carrying ready delegation evidence once per batch.
+
+    The last result of a complete tool batch is the only same-turn carrier. It
+    is enriched before the batch's first durable commit, so history remains
+    append-only and every provider sees the ordinary assistant/tool role shape.
+    """
+    completed_batch_size = _completed_tool_batch_size(messages)
+    if completed_batch_size:
+        messages[-1]["_external_input_boundary_checked"] = True
+        try:
+            from agent.delegation_inject import attach_ready_injects_to_tool_results
+
+            attach_ready_injects_to_tool_results(
+                agent,
+                messages,
+                num_tool_msgs=completed_batch_size,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
+        except Exception as exc:
+            logger.warning("Delegation tool-boundary preparation failed: %s", exc)
+
+    def _release_unpersisted_carrier() -> None:
+        if not completed_batch_size:
+            return
+        try:
+            from agent.delegation_inject import release_pending_injects
+
+            release_pending_injects(
+                agent,
+                messages,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
+        except Exception:
+            logger.warning(
+                "Could not release unpersisted delegation tool carrier",
+                exc_info=True,
+            )
+
     try:
         persisted = agent._flush_messages_to_session_db(messages) is not False
         if not persisted:
             agent._incremental_persistence_failed = True
-            # The flush recorded any classified cause; default to 'unknown' only if nothing more specific exists.
+            # The flush caught its own exception and returned False; the
+            # classified cause (if any) was captured at the catch site. Only
+            # fall back to 'unknown' when nothing more specific is recorded.
             if getattr(agent, "_last_persistence_error_cause", None) is None:
                 agent._last_persistence_error_cause = "unknown"
+            _release_unpersisted_carrier()
+        elif completed_batch_size:
+            from agent.delegation_inject import acknowledge_pending_injects
+
+            acknowledge_pending_injects(
+                agent,
+                turn_id=str(getattr(agent, "_active_turn_id", "") or ""),
+            )
         return persisted
     except Exception as exc:
         agent._incremental_persistence_failed = True
         from hermes_state import classify_persistence_error
+
         agent._last_persistence_error_cause = classify_persistence_error(exc)
+        _release_unpersisted_carrier()
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -91,6 +91,20 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    # Common rollback boundary for tool-carried delegation evidence that never
+    # reached a normalized provider response. The helper restores only the
+    # current unsent carrier and releases its durable child claims; events then
+    # continue through the existing after-turn path.
+    try:
+        from agent.delegation_inject import release_pending_injects
+
+        release_pending_injects(agent, messages, turn_id=turn_id)
+    except Exception:
+        logger.debug(
+            "Failed to release unconsumed delegation result claims",
+            exc_info=True,
+        )
+
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -439,6 +439,13 @@ def finalize_turn(
     """Run the post-loop finalization and return the turn ``result`` dict."""
     from agent.conversation_loop import logger
 
+    # Release only carriers not committed to the transcript; durable evidence stays put.
+    try:
+        from agent.delegation_inject import release_pending_injects
+        release_pending_injects(agent, messages, turn_id=turn_id)
+    except Exception:
+        logger.warning("Could not settle remaining delegation carriers", exc_info=True)
+
     final_response, _turn_exit_reason, preserved_verification_fallback = _resolve_budget_fallback(
         agent, final_response=final_response, api_call_count=api_call_count,
         interrupted=interrupted, failed=failed, messages=messages,

--- a/cli.py
+++ b/cli.py
@@ -3406,6 +3406,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         ):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
+                process_registry.defer_unclaimed_delivery(event)
                 continue
             self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)

--- a/cli.py
+++ b/cli.py
@@ -10705,6 +10705,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         ):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
+                process_registry.defer_unclaimed_delivery(event)
                 continue
             self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22613,14 +22613,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     async_events = coalesce_ready_after_turn_events(async_events)
                     for evt in async_events:
                         self._enrich_async_delegation_routing(evt)
-                        # Delivery is next-turn by definition in this layer. A
-                        # live parent retains ownership; the watcher retries
-                        # after that turn reaches its idle boundary.
+                        # Busy-session routing is part of the same queue
+                        # reservation as dequeue/coalescing. Otherwise the active
+                        # conversation loop can observe a temporary-empty queue
+                        # and miss an inject that was already ready at its safe
+                        # boundary.
+                        _rd = str(
+                            evt.get("result_delivery") or "after_turn"
+                        ).strip().lower()
                         _route_key = str(evt.get("session_key") or "").strip()
+                        _event_turn_id = str(evt.get("parent_turn_id") or "")
                         _running_parent = getattr(self, "_running_agents", {}).get(
                             _route_key
                         )
-                        if _running_parent is not None:
+                        if _running_parent is _AGENT_PENDING_SENTINEL:
+                            _pr.completion_queue.put(evt)
+                            continue
+                        if _rd == "after_turn" and _running_parent is not None:
+                            _pr.completion_queue.put(evt)
+                            continue
+                        if (
+                            _rd == "inject"
+                            and _running_parent is not None
+                            and _event_turn_id
+                            and str(
+                                getattr(_running_parent, "_active_turn_id", "") or ""
+                            )
+                            == _event_turn_id
+                        ):
                             _pr.completion_queue.put(evt)
                             continue
                         idle_events.append(evt)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22357,7 +22357,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         evt_type = str(evt.get("type") or "")
         if evt_type == "async_delegation":
             producer_id = str(evt.get("delegation_id") or "")
-            return (evt_type, producer_id, "") if producer_id else None
+            raw_keys = evt.get("delivery_event_keys")
+            if isinstance(raw_keys, (list, tuple)):
+                event_identity: object = tuple(str(key) for key in raw_keys if key)
+            else:
+                event_identity = str(evt.get("delivery_event_key") or "")
+            return (evt_type, producer_id, event_identity) if producer_id else None
         if evt_type == "completion":
             producer_id = str(evt.get("session_id") or "")
             started_at = evt.get("started_at")
@@ -22436,12 +22441,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             durable_delegation_id = str(evt.get("delegation_id") or "")
             if durable_delegation_id:
                 try:
-                    from tools.async_delegation import claim_completion_delivery
+                    from tools.async_delegation import claim_event_delivery
 
-                    durable_claim_id = f"gateway:{id(self)}:{__import__('uuid').uuid4().hex}"
-                    if not claim_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    ):
+                    durable_claim_id = claim_event_delivery(
+                        evt, f"gateway:{id(self)}"
+                    ) or ""
+                    if not durable_claim_id:
+                        from tools.process_registry import process_registry
+
+                        process_registry.defer_unclaimed_delivery(evt)
                         return None
                 except Exception as exc:
                     logger.warning(
@@ -22467,11 +22475,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     if durable_claim_id:
                         try:
-                            from tools.async_delegation import drop_completion_delivery
+                            from tools.async_delegation import drop_event_delivery
 
-                            drop_completion_delivery(
-                                durable_delegation_id, durable_claim_id,
-                            )
+                            drop_event_delivery(evt, durable_claim_id)
                         except Exception:
                             logger.debug(
                                 "Could not drop durable completion claim",
@@ -22481,11 +22487,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if verdict == "retry":
                     if durable_claim_id:
                         try:
-                            from tools.async_delegation import release_completion_delivery
+                            from tools.async_delegation import release_event_delivery
 
-                            release_completion_delivery(
-                                durable_delegation_id, durable_claim_id,
-                            )
+                            release_event_delivery(evt, durable_claim_id)
                         except Exception:
                             logger.debug(
                                 "Could not release durable completion claim",
@@ -22523,11 +22527,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # after adapter acceptance; this gateway keeps no parallel ledger.
             if durable_claim_id:
                 try:
-                    from tools.async_delegation import complete_completion_delivery
+                    from tools.async_delegation import complete_event_delivery
 
-                    complete_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    )
+                    complete_event_delivery(evt, durable_claim_id)
                 except Exception as exc:
                     logger.warning(
                         "Could not acknowledge durable async completion %s: %s",
@@ -22540,11 +22542,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._completion_deliveries_inflight.discard(identity)
             if durable_claim_id and not accepted:
                 try:
-                    from tools.async_delegation import release_completion_delivery
+                    from tools.async_delegation import release_event_delivery
 
-                    release_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    )
+                    release_event_delivery(evt, durable_claim_id)
                 except Exception:
                     logger.debug("Could not release durable completion claim", exc_info=True)
 
@@ -22591,20 +22591,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # consume watch/completion events here (other drains own them),
                 # so requeue anything that isn't ours.
                 requeue = []
-                async_events = []
-                while not _pr.completion_queue.empty():
-                    try:
-                        evt = _pr.completion_queue.get_nowait()
-                    except Exception:
-                        break
-                    if evt.get("type") == "async_delegation":
-                        async_events.append(evt)
-                    else:
-                        requeue.append(evt)
-                for evt in requeue:
-                    _pr.completion_queue.put(evt)
-                for evt in async_events:
-                    self._enrich_async_delegation_routing(evt)
+                idle_events = []
+                with _pr.completion_routing_lock:
+                    async_events = []
+                    while not _pr.completion_queue.empty():
+                        try:
+                            evt = _pr.completion_queue.get_nowait()
+                        except Exception:
+                            break
+                        if evt.get("type") == "async_delegation":
+                            async_events.append(evt)
+                        else:
+                            requeue.append(evt)
+                    for evt in requeue:
+                        _pr.completion_queue.put(evt)
+
+                    from tools.async_delegation import (
+                        coalesce_ready_after_turn_events,
+                    )
+
+                    async_events = coalesce_ready_after_turn_events(async_events)
+                    for evt in async_events:
+                        self._enrich_async_delegation_routing(evt)
+                        # Delivery is next-turn by definition in this layer. A
+                        # live parent retains ownership; the watcher retries
+                        # after that turn reaches its idle boundary.
+                        _route_key = str(evt.get("session_key") or "").strip()
+                        _running_parent = getattr(self, "_running_agents", {}).get(
+                            _route_key
+                        )
+                        if _running_parent is not None:
+                            _pr.completion_queue.put(evt)
+                            continue
+                        idle_events.append(evt)
+
+                # Formatting and adapter/network delivery must never hold the
+                # routing lock. Only events classified idle above leave it.
+                for evt in idle_events:
                     synth_text = _format_gateway_process_notification(evt)
                     if not synth_text:
                         continue
@@ -22614,7 +22637,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _pr.completion_queue.put(evt)
                     except Exception as e:
                         _pr.completion_queue.put(evt)
-                        logger.error("Async delegation injection error: %s", e)
+                        logger.error("Async delegation delivery error: %s", e)
             except Exception as e:
                 logger.debug("Async delegation watcher error: %s", e)
             await asyncio.sleep(interval)

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -31,8 +31,8 @@ _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
 
 # Durable async-delegation claim transitions: kind -> (tools.async_delegation function, failure log).
 _DURABLE_CLAIM_OPS = {
-    "drop": ("drop_completion_delivery", "Could not drop durable completion claim"),
-    "release": ("release_completion_delivery", "Could not release durable completion claim"),
+    "drop": ("drop_event_delivery", "Could not drop durable completion claim"),
+    "release": ("release_event_delivery", "Could not release durable completion claim"),
 }
 
 
@@ -950,7 +950,10 @@ class GatewayNotificationsMixin:
         evt_type = str(evt.get("type") or "")
         if evt_type == "async_delegation":
             producer_id = str(evt.get("delegation_id") or "")
-            return (evt_type, producer_id, "") if producer_id else None
+            raw_keys = evt.get("delivery_event_keys")
+            event_identity = (tuple(str(key) for key in raw_keys if key)
+                              if isinstance(raw_keys, (list, tuple)) else str(evt.get("delivery_event_key") or ""))
+            return (evt_type, producer_id, event_identity) if producer_id else None
         if evt_type == "completion":
             producer_id = str(evt.get("session_id") or "")
             started_at = evt.get("started_at")
@@ -1017,12 +1020,12 @@ class GatewayNotificationsMixin:
         return "deliver"
 
     @staticmethod
-    def _settle_durable_claim(kind: str, delegation_id: str, claim_id: str) -> None:
+    def _settle_durable_claim(kind: str, evt: dict, claim_id: str) -> None:
         """Best-effort ``drop``/``release`` of a durable completion claim."""
         fn_name, fail_msg = _DURABLE_CLAIM_OPS[kind]
         try:
             import tools.async_delegation as _ad
-            getattr(_ad, fn_name)(delegation_id, claim_id)
+            getattr(_ad, fn_name)(evt, claim_id)
         except Exception:
             logger.debug(fail_msg, exc_info=True)
 
@@ -1039,9 +1042,11 @@ class GatewayNotificationsMixin:
             claim.delegation_id = str(evt.get("delegation_id") or "")
             if claim.delegation_id:
                 try:
-                    from tools.async_delegation import claim_completion_delivery
-                    claim.claim_id = f"gateway:{id(self)}:{__import__('uuid').uuid4().hex}"
-                    if not claim_completion_delivery(claim.delegation_id, claim.claim_id):
+                    from tools.async_delegation import claim_event_delivery
+                    claim.claim_id = claim_event_delivery(evt, f"gateway:{id(self)}") or ""
+                    if not claim.claim_id:
+                        from tools.process_registry import process_registry
+                        process_registry.defer_unclaimed_delivery(evt)
                         claim.proceed = False
                         return claim
                 except Exception as exc:
@@ -1068,7 +1073,7 @@ class GatewayNotificationsMixin:
                     claim.delegation_id or "<legacy>", parent_session_id,
                 )
                 if claim.claim_id:
-                    self._settle_durable_claim("drop", claim.delegation_id, claim.claim_id)
+                    self._settle_durable_claim("drop", evt, claim.claim_id)
             else:
                 logger.warning(
                     "Background process %s completion targets "
@@ -1080,7 +1085,7 @@ class GatewayNotificationsMixin:
         elif verdict == "retry":
             # Transient uncertainty: tell the watcher to re-poll rather than drop or misroute.
             if claim.claim_id:
-                self._settle_durable_claim("release", claim.delegation_id, claim.claim_id)
+                self._settle_durable_claim("release", evt, claim.claim_id)
             claim.proceed, claim.early_result = False, False
         return claim
 
@@ -1095,6 +1100,8 @@ class GatewayNotificationsMixin:
         if not claim.proceed:
             return claim.early_result
         if identity is not None and self._completion_identity_seen(identity, claim=True):
+            if claim.claim_id:
+                self._settle_durable_claim("release", evt, claim.claim_id)
             return None
         accepted = False
         try:
@@ -1108,8 +1115,8 @@ class GatewayNotificationsMixin:
             # The durable row is the authoritative replay state — ack it after adapter acceptance.
             if claim.claim_id:
                 try:
-                    from tools.async_delegation import complete_completion_delivery
-                    complete_completion_delivery(claim.delegation_id, claim.claim_id)
+                    from tools.async_delegation import complete_event_delivery
+                    complete_event_delivery(evt, claim.claim_id)
                 except Exception as exc:
                     logger.warning("Could not acknowledge durable async completion %s: %s", claim.delegation_id, exc)
             return True
@@ -1118,7 +1125,7 @@ class GatewayNotificationsMixin:
                 with self._completion_delivery_lock:
                     self._completion_deliveries_inflight.discard(identity)
             if claim.claim_id and not accepted:
-                self._settle_durable_claim("release", claim.delegation_id, claim.claim_id)
+                self._settle_durable_claim("release", evt, claim.claim_id)
 
     @staticmethod
     def _event_route_key(evt: dict, fields: tuple[str, ...]) -> tuple[str, ...]:
@@ -1304,7 +1311,8 @@ class GatewayNotificationsMixin:
         for evt, synth_text in deliverable[1:]:
             claim_id = claim_event_delivery(evt, f"gateway-batch:{id(self)}")
             if claim_id is None:
-                # Another consumer owns this row: keep it out of our text so it is never double-injected.
+                # Leave competing live leases eligible for retry, but not in our text.
+                _pr.defer_unclaimed_delivery(evt)
                 continue
             siblings.append((evt, claim_id))
             blocks.append(synth_text)
@@ -1346,24 +1354,28 @@ class GatewayNotificationsMixin:
         while self._running:
             with _log_suppressed(logging.DEBUG, "Async delegation watcher error: %s"):
                 # Take async-delegation events only; requeue watch/completion events for their own drains.
-                requeue = []
-                async_events = []
-                while not _pr.completion_queue.empty():
-                    try:
-                        evt = _pr.completion_queue.get_nowait()
-                    except Exception:
-                        break
-                    (async_events if evt.get("type") == "async_delegation" else requeue).append(evt)
-                for evt in requeue:
-                    _pr.completion_queue.put(evt)
-                # A fan-out finishing together yields N completions for one session; group by full route +
-                # parent session so each group becomes ONE consolidated turn.
-                # A same-tick drain often carries several completions for the SAME originating session (a
-                # fan-out of background subagents finishing together). Events for different sessions never
-                # coalesce. See #70300.
+                idle_events = []
+                with _pr.completion_routing_lock:
+                    requeue, async_events = [], []
+                    for _ in range(_pr.completion_queue.qsize()):
+                        try:
+                            evt = _pr.completion_queue.get_nowait()
+                        except Exception:
+                            break
+                        (async_events if evt.get("type") == "async_delegation" else requeue).append(evt)
+                    for evt in requeue:
+                        _pr.completion_queue.put(evt)
+                    from tools.async_delegation import coalesce_ready_after_turn_events
+                    for evt in coalesce_ready_after_turn_events(async_events):
+                        self._enrich_async_delegation_routing(evt)
+                        key = str(evt.get("session_key") or "").strip()
+                        if getattr(self, "_running_agents", {}).get(key) is not None:
+                            _pr.completion_queue.put(evt)
+                        else:
+                            idle_events.append(evt)
+                # Format and deliver after releasing the short queue reservation.
                 groups: dict[tuple[str, ...], list[dict]] = {}
-                for evt in async_events:
-                    self._enrich_async_delegation_routing(evt)
+                for evt in idle_events:
                     groups.setdefault(self._event_route_key(evt, self._ASYNC_GROUP_KEY_FIELDS), []).append(evt)
                 for group in groups.values():
                     try:

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1369,7 +1369,14 @@ class GatewayNotificationsMixin:
                     for evt in coalesce_ready_after_turn_events(async_events):
                         self._enrich_async_delegation_routing(evt)
                         key = str(evt.get("session_key") or "").strip()
-                        if getattr(self, "_running_agents", {}).get(key) is not None:
+                        from gateway.run import _AGENT_PENDING_SENTINEL
+                        parent = getattr(self, "_running_agents", {}).get(key)
+                        delivery = str(evt.get("result_delivery") or "after_turn").strip().lower()
+                        event_turn = str(evt.get("parent_turn_id") or "")
+                        if (parent is _AGENT_PENDING_SENTINEL
+                                or (parent is not None and delivery != "inject")
+                                or (parent is not None and event_turn
+                                    and str(getattr(parent, "_active_turn_id", "") or "") == event_turn)):
                             _pr.completion_queue.put(evt)
                         else:
                             idle_events.append(evt)

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1380,7 +1380,7 @@ class GatewayNotificationsMixin:
                             _pr.completion_queue.put(evt)
                         else:
                             idle_events.append(evt)
-                # Format and deliver after releasing the short queue reservation.
+                # Group, format and deliver outside the queue reservation; never mix sessions/routes.
                 groups: dict[tuple[str, ...], list[dict]] = {}
                 for evt in idle_events:
                     groups.setdefault(self._event_route_key(evt, self._ASYNC_GROUP_KEY_FIELDS), []).append(evt)

--- a/run_agent.py
+++ b/run_agent.py
@@ -7683,12 +7683,10 @@ class AIAgent:
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
-        # Delegations from the top-level MODEL always run in the background —
-        # the model does not get to choose. delegate_task returns immediately
-        # with a handle (one per task) and each subagent's result re-enters the
-        # conversation as a new message when it finishes. This applies to BOTH
-        # a single task and a fan-out batch (each task becomes its own
-        # independent background subagent). The one exception:
+        # Delegations from the top-level model always run in the background —
+        # the model chooses only result delivery. ``after_turn`` keeps the legacy
+        # separate-turn route; ``inject`` uses a newly produced tool-result
+        # carrier when one is safely available. The one exception:
         #   - A delegation from an ORCHESTRATOR SUBAGENT (depth > 0) stays
         #     synchronous: the orchestrator needs its workers' results within
         #     its own turn to compose a summary, and a subagent doesn't own the
@@ -7702,6 +7700,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            result_delivery=function_args.get("result_delivery"),
             parent_agent=self,
         )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1305,7 +1305,8 @@ class AIAgent(
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"), role=function_args.get("role"),
             background=not (getattr(self, "_delegate_depth", 0) > 0), action=function_args.get("action"),
-            subagent_id=function_args.get("subagent_id"), message=function_args.get("message"), parent_agent=self,
+            subagent_id=function_args.get("subagent_id"), message=function_args.get("message"),
+            result_delivery=function_args.get("result_delivery"), parent_agent=self,
         )
 
     _invoke_tool = _forward("agent.agent_runtime_helpers", "invoke_tool")

--- a/tests/agent/test_delegation_delivery.py
+++ b/tests/agent/test_delegation_delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 from copy import deepcopy
 import io
+import re
 from pathlib import Path
 from types import SimpleNamespace
 import threading
@@ -312,29 +313,26 @@ def test_large_tool_boundary_inject_uses_canonical_spill_budget():
         turn_budget=20_000,
         preview_size=512,
     )
-    # Force the in-sandbox stdin-write path: upstream tool_result_storage
-    # prefers the host-side spillover dir and, for remote backends, a
-    # bind-mount probe — neither routes the payload through env.execute
-    # stdin. This test pins the carrier contract on the stdin write.
-    with patch(
-        "tools.tool_result_storage._is_host_side_env", return_value=False
-    ), patch(
-        "tools.tool_result_storage._sandbox_visible_spillover_path",
-        return_value=None,
-    ):
-        assert attach_ready_injects_to_tool_results(
-            agent,
-            messages,
-            num_tool_msgs=1,
-            storage_env=env,
-            budget_config=budget,
-        ) == 1
+
+    assert attach_ready_injects_to_tool_results(
+        agent,
+        messages,
+        num_tool_msgs=1,
+        storage_env=env,
+        budget_config=budget,
+    ) == 1
 
     assert len(messages[0]["content"]) <= budget.default_result_size
     assert PERSISTED_OUTPUT_TAG in messages[0]["content"]
     assert delegation_id in messages[0]["content"]
     assert env.execute.call_count == 1
-    persisted_report = env.execute.call_args.kwargs["stdin_data"]
+    # Canonical spill home: the full report is written host-side by
+    # maybe_persist_tool_result ($HERMES_HOME/cache/spillover); env.execute
+    # only probes sandbox visibility, so the payload rides on disk, not stdin.
+    saved_path = re.search(
+        r"Full output saved to: (.+)", messages[0]["content"]
+    ).group(1)
+    persisted_report = Path(saved_path).read_text()
     assert "HUGE_CHILD_REPORT:" in persisted_report
     assert persisted_report.endswith("x" * 1_000)
     assert len(persisted_report) > len(huge_summary)
@@ -984,27 +982,30 @@ def test_persisted_bounded_carrier_survives_production_compressor_payload(
         turn_budget=20_000,
         preview_size=512,
     )
-    # Force the in-sandbox stdin-write path (see the carrier-budget test
-    # above): host-side spillover and the bind-mount probe bypass stdin.
-    with patch(
-        "tools.tool_result_storage._is_host_side_env", return_value=False
-    ), patch(
-        "tools.tool_result_storage._sandbox_visible_spillover_path",
-        return_value=None,
-    ):
-        assert _flush_session_db_after_tool_progress(
-            agent,
-            messages,
-            stage="persist bounded carrier before compression",
-            storage_env=env,
-            budget_config=budget,
-        )
+
+    assert _flush_session_db_after_tool_progress(
+        agent,
+        messages,
+        stage="persist bounded carrier before compression",
+        storage_env=env,
+        budget_config=budget,
+    )
     assert _event_state(delegation_id, "task:0") == ("delivered", 1)
 
     durable = agent._session_db.get_messages_as_conversation(agent.session_id)
-    assert PERSISTED_OUTPUT_TAG in str(durable)
-    assert delegation_id in str(durable)
-    assert "COMPRESSOR_CARRIER_EVIDENCE:" in env.execute.call_args.kwargs["stdin_data"]
+    durable_str = str(durable)
+    assert PERSISTED_OUTPUT_TAG in durable_str
+    assert delegation_id in durable_str
+    # Carrier evidence survives in the canonical host-side spillover file.
+    carrier_content = next(
+        message.get("content", "")
+        for message in durable
+        if isinstance(message, dict)
+        and isinstance(message.get("content"), str)
+        and PERSISTED_OUTPUT_TAG in message["content"]
+    )
+    saved_path = re.search(r"Full output saved to: (.+)", carrier_content).group(1)
+    assert "COMPRESSOR_CARRIER_EVIDENCE:" in Path(saved_path).read_text()
 
     compressor = ContextCompressor(
         model="test/model",

--- a/tests/agent/test_delegation_delivery.py
+++ b/tests/agent/test_delegation_delivery.py
@@ -23,7 +23,9 @@ from agent.delegation_inject import (
 )
 from tools import async_delegation as ad
 from tools import delegate_tool
+from tools.budget_config import BudgetConfig
 from tools.process_registry import process_registry
+from tools.tool_result_storage import PERSISTED_OUTPUT_TAG
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -285,6 +287,132 @@ def test_consumed_tool_boundary_inject_acknowledges_without_removing_carrier():
 
     assert "accepted audit" in messages[0]["content"]
     assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+
+def test_large_tool_boundary_inject_uses_canonical_spill_budget():
+    delegation_id = _record()
+    huge_summary = "HUGE_CHILD_REPORT:" + ("x" * 250_000)
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, huge_summary)
+    )
+    agent = _tool_boundary_agent()
+    messages = [
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "tc-large-carrier",
+            "content": "original tool result",
+        }
+    ]
+    env = MagicMock()
+    env.execute.return_value = {"output": "", "returncode": 0}
+    env.get_temp_dir.return_value = ""
+    budget = BudgetConfig(
+        default_result_size=10_000,
+        turn_budget=20_000,
+        preview_size=512,
+    )
+    # Force the in-sandbox stdin-write path: upstream tool_result_storage
+    # prefers the host-side spillover dir and, for remote backends, a
+    # bind-mount probe — neither routes the payload through env.execute
+    # stdin. This test pins the carrier contract on the stdin write.
+    with patch(
+        "tools.tool_result_storage._is_host_side_env", return_value=False
+    ), patch(
+        "tools.tool_result_storage._sandbox_visible_spillover_path",
+        return_value=None,
+    ):
+        assert attach_ready_injects_to_tool_results(
+            agent,
+            messages,
+            num_tool_msgs=1,
+            storage_env=env,
+            budget_config=budget,
+        ) == 1
+
+    assert len(messages[0]["content"]) <= budget.default_result_size
+    assert PERSISTED_OUTPUT_TAG in messages[0]["content"]
+    assert delegation_id in messages[0]["content"]
+    assert env.execute.call_count == 1
+    persisted_report = env.execute.call_args.kwargs["stdin_data"]
+    assert "HUGE_CHILD_REPORT:" in persisted_report
+    assert persisted_report.endswith("x" * 1_000)
+    assert len(persisted_report) > len(huge_summary)
+
+
+def test_oversized_inject_without_storage_defers_without_claim_or_truncation():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "FULL_REPORT_MUST_SURVIVE" + ("x" * 20_000))
+    )
+    agent = _tool_boundary_agent()
+    messages = [
+        {"role": "tool", "tool_call_id": "tc-no-env", "content": "ORIGINAL"}
+    ]
+    budget = BudgetConfig(
+        default_result_size=8_000,
+        turn_budget=16_000,
+        preview_size=512,
+    )
+
+    assert attach_ready_injects_to_tool_results(
+        agent,
+        messages,
+        num_tool_msgs=1,
+        storage_env=None,
+        budget_config=budget,
+    ) == 0
+
+    assert messages == [
+        {"role": "tool", "tool_call_id": "tc-no-env", "content": "ORIGINAL"}
+    ]
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
+
+
+def test_attach_exception_after_carrier_mutation_restores_target_and_requeues():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "FAULT_INJECTED_EVIDENCE")
+    )
+
+    class RaisingSessionAgent:
+        session_id = "parent-session"
+        _active_turn_id = "turn-current"
+        _session_messages = []
+
+        @property
+        def _pending_delegation_inject_claims(self):
+            return []
+
+        @_pending_delegation_inject_claims.setter
+        def _pending_delegation_inject_claims(self, _value):
+            raise RuntimeError("fault after carrier mutation")
+
+    messages = [{
+        "role": "tool",
+        "tool_call_id": "tc",
+        "content": "ORIGINAL_CONTENT",
+        "display_metadata": {"risk": "keep"},
+    }]
+
+    with pytest.raises(RuntimeError, match="fault after carrier mutation"):
+        attach_ready_injects_to_tool_results(
+            RaisingSessionAgent(), messages, num_tool_msgs=1
+        )
+
+    assert messages == [{
+        "role": "tool",
+        "tool_call_id": "tc",
+        "content": "ORIGINAL_CONTENT",
+        "display_metadata": {"risk": "keep"},
+    }]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
 
 
 def test_tool_carrier_preserves_provider_roles_and_existing_prefix_items():
@@ -797,6 +925,109 @@ def test_run_conversation_persists_tool_carrier_before_provider_error(
     heartbeat = agent._delegation_inject_claim_heartbeat
     heartbeat["thread"].join(timeout=1)
     assert not heartbeat["thread"].is_alive()
+
+
+def test_persisted_bounded_carrier_survives_production_compressor_payload(
+    tmp_path,
+):
+    from agent.context_compressor import ContextCompressor
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    agent = _make_loop_agent(tmp_path)
+    agent._active_turn_id = "turn-current"
+    agent._pending_delegation_inject_claims = []
+    agent._incremental_persistence_failed = False
+    delegation_id = _record(
+        turn_id="turn-current",
+        parent_session_id=agent.session_id,
+    )
+    huge_summary = "COMPRESSOR_CARRIER_EVIDENCE:" + ("z" * 250_000)
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, huge_summary)
+    )
+
+    messages = [{"role": "system", "content": "system"}]
+    for index in range(8):
+        messages.extend(
+            [
+                {"role": "user", "content": f"old user {index}"},
+                {"role": "assistant", "content": f"old assistant {index}"},
+            ]
+        )
+    messages.extend(
+        [
+            {"role": "user", "content": "current task"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc-compress",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_call_id": "tc-compress",
+                "content": "tool boundary complete",
+            },
+        ]
+    )
+    env = MagicMock()
+    env.execute.return_value = {"output": "", "returncode": 0}
+    env.get_temp_dir.return_value = ""
+    budget = BudgetConfig(
+        default_result_size=10_000,
+        turn_budget=20_000,
+        preview_size=512,
+    )
+    # Force the in-sandbox stdin-write path (see the carrier-budget test
+    # above): host-side spillover and the bind-mount probe bypass stdin.
+    with patch(
+        "tools.tool_result_storage._is_host_side_env", return_value=False
+    ), patch(
+        "tools.tool_result_storage._sandbox_visible_spillover_path",
+        return_value=None,
+    ):
+        assert _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage="persist bounded carrier before compression",
+            storage_env=env,
+            budget_config=budget,
+        )
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+    durable = agent._session_db.get_messages_as_conversation(agent.session_id)
+    assert PERSISTED_OUTPUT_TAG in str(durable)
+    assert delegation_id in str(durable)
+    assert "COMPRESSOR_CARRIER_EVIDENCE:" in env.execute.call_args.kwargs["stdin_data"]
+
+    compressor = ContextCompressor(
+        model="test/model",
+        provider="openai",
+        base_url="https://example.invalid/v1",
+        api_key="test-key",
+        config_context_length=100_000,
+        protect_first_n=3,
+        protect_last_n=3,
+        summary_target_ratio=0.10,
+        quiet_mode=True,
+    )
+    compressor.threshold_tokens = 2_000
+    compressor.tail_token_budget = 1_000
+    compressor._generate_summary = lambda *_args, **_kwargs: "compressed old context"
+
+    compressed = compressor.compress(durable, current_tokens=80_000, force=True)
+    provider_payload = AIAgent._sanitize_api_messages(deepcopy(compressed))
+
+    assert compressor._last_compression_made_progress is True
+    assert delegation_id in str(provider_payload)
+    assert PERSISTED_OUTPUT_TAG in str(provider_payload)
+    assert len(provider_payload[-1]["content"]) <= budget.default_result_size
 
 
 def test_same_turn_claim_conflict_defers_pending_event(monkeypatch):

--- a/tests/agent/test_delegation_delivery.py
+++ b/tests/agent/test_delegation_delivery.py
@@ -1,0 +1,968 @@
+"""Contracts for durable async delegation delivery and tool-boundary evidence."""
+
+from __future__ import annotations
+
+import contextlib
+from copy import deepcopy
+import io
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+import time
+from typing import Any
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import delegation_inject as inject
+from agent.delegation_inject import (
+    acknowledge_pending_injects,
+    attach_ready_injects_to_tool_results,
+    release_pending_injects,
+)
+from tools import async_delegation as ad
+from tools import delegate_tool
+from tools.process_registry import process_registry
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_state():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _record(
+    *,
+    goals=("audit",),
+    turn_id="turn-current",
+    delivery="inject",
+    parent_session_id="parent-session",
+):
+    delegation_id = f"deleg_test_{uuid.uuid4().hex}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": goals[0] if len(goals) == 1 else f"{len(goals)} tasks",
+        "goals": list(goals),
+        "context": "parent context",
+        "toolsets": ["file"],
+        "role": "leaf",
+        "model": "child-model",
+        "session_key": "agent:main:cli:dm:local",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": parent_session_id,
+        "parent_turn_id": turn_id,
+        "status": "running",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "is_batch": True,
+        "result_delivery": delivery,
+    }
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    ad._persist_dispatch(record)
+    return delegation_id
+
+
+def _child(index: int, summary: str, *, status="completed", error=None):
+    return {
+        "task_index": index,
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": 2,
+        "duration_seconds": 0.25,
+    }
+
+
+def _queue_contents():
+    items = []
+    while not process_registry.completion_queue.empty():
+        items.append(process_registry.completion_queue.get_nowait())
+    for item in items:
+        process_registry.completion_queue.put(item)
+    return items
+
+
+def _event_state(delegation_id: str, event_key: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegation_events "
+            "WHERE delegation_id=? AND event_key=?",
+            (delegation_id, event_key),
+        ).fetchone()
+
+
+def _parent_state(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _durable_event_keys(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        ]
+
+
+def _loop_response(*, content, finish_reason="stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _loop_tool_call():
+    return SimpleNamespace(
+        id="call-inject",
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments="{}"),
+    )
+
+
+def _make_loop_agent(tmp_path: Path) -> AIAgent:
+    tool_defs = [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "test boundary",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai",
+            api_mode="chat_completions",
+            model="test/model",
+            quiet_mode=True,
+            max_iterations=4,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=SessionDB(db_path=tmp_path / "state.db"),
+            session_id=f"inject-loop-{uuid.uuid4().hex}",
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent._disable_streaming = True
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.tool_delay = 0
+    agent.valid_tool_names = {"terminal"}
+    return agent
+
+
+def _tool_boundary_agent():
+    return SimpleNamespace(
+        session_id="parent-session",
+        _active_turn_id="turn-current",
+        _pending_delegation_inject_claims=[],
+        _session_messages=[],
+    )
+
+
+def test_tool_boundary_inject_enriches_only_new_tool_result_without_user_tail():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "review changed the implementation")
+    )
+    agent = _tool_boundary_agent()
+    messages = [
+        {"role": "user", "content": "implement"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "old", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "old", "content": "historical result"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "new", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "new", "content": "new result"},
+    ]
+    agent._session_messages = messages
+
+    assert attach_ready_injects_to_tool_results(agent, messages, num_tool_msgs=1) == 1
+
+    assert [message["role"] for message in messages] == [
+        "user", "assistant", "tool", "assistant", "tool"
+    ]
+    assert messages[2]["content"] == "historical result"
+    assert messages[4]["content"].startswith("new result")
+    assert "review changed the implementation" in messages[4]["content"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+
+
+def test_tool_boundary_inject_without_new_tool_carrier_stays_pending():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "late audit"))
+    agent = _tool_boundary_agent()
+    messages = [{"role": "user", "content": "implement"}]
+    agent._session_messages = messages
+
+    assert attach_ready_injects_to_tool_results(agent, messages, num_tool_msgs=0) == 0
+
+    assert messages == [{"role": "user", "content": "implement"}]
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert [event["delivery_event_key"] for event in _queue_contents()] == ["task:0"]
+
+
+def test_tool_boundary_inject_without_followup_budget_stays_after_turn_pending():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "arrived at exhausted boundary")
+    )
+    agent = _tool_boundary_agent()
+    agent.max_iterations = 1
+    agent._api_call_count = 1
+    agent.iteration_budget = SimpleNamespace(remaining=0)
+    agent._budget_grace_call = False
+    messages = [{"role": "tool", "tool_call_id": "new", "content": "result"}]
+
+    assert attach_ready_injects_to_tool_results(
+        agent, messages, num_tool_msgs=1
+    ) == 0
+
+    assert messages[0]["content"] == "result"
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert [event["delivery_event_key"] for event in _queue_contents()] == ["task:0"]
+
+
+def test_unconsumed_tool_boundary_inject_restores_carrier_and_requeues():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "retry later"))
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "new", "content": "original"}]
+    agent._session_messages = messages
+
+    assert attach_ready_injects_to_tool_results(agent, messages, num_tool_msgs=1) == 1
+    assert release_pending_injects(agent, messages, turn_id="turn-current") == 1
+
+    assert messages == [{"role": "tool", "tool_call_id": "new", "content": "original"}]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert [event["delivery_event_key"] for event in _queue_contents()] == ["task:0"]
+
+
+def test_consumed_tool_boundary_inject_acknowledges_without_removing_carrier():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "accepted audit"))
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "new", "content": "original"}]
+    agent._session_messages = messages
+
+    assert attach_ready_injects_to_tool_results(agent, messages, num_tool_msgs=1) == 1
+    assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
+
+    assert "accepted audit" in messages[0]["content"]
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+
+def test_tool_carrier_preserves_provider_roles_and_existing_prefix_items():
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    from agent.gemini_native_adapter import _build_gemini_contents
+    from agent.prompt_caching import apply_anthropic_cache_control
+
+    prefix = [{"role": "user", "content": "continue the current task"}]
+    messages = prefix + [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "base result\n[DELEGATION RESULT READY] MATRIX_MARKER",
+        },
+    ]
+
+    chat = AIAgent._sanitize_api_messages(deepcopy(messages))
+    assert chat[: len(prefix)] == prefix
+    assert chat[-1]["role"] == "tool"
+    assert "MATRIX_MARKER" in chat[-1]["content"]
+
+    _system_prefix, anthropic_prefix = convert_messages_to_anthropic(prefix)
+    _system, anthropic = convert_messages_to_anthropic(messages)
+    assert anthropic[: len(anthropic_prefix)] == anthropic_prefix
+    assert anthropic[-1]["role"] == "user"
+    assert anthropic[-1]["content"][0]["type"] == "tool_result"
+    assert "MATRIX_MARKER" in anthropic[-1]["content"][0]["content"]
+
+    gemini_prefix, _ = _build_gemini_contents(prefix)
+    gemini, _ = _build_gemini_contents(messages)
+    assert gemini[: len(gemini_prefix)] == gemini_prefix
+    function_response = gemini[-1]["parts"][0]["functionResponse"]
+    assert "MATRIX_MARKER" in function_response["response"]["output"]
+
+    responses_prefix = _chat_messages_to_responses_input(prefix)
+    responses = _chat_messages_to_responses_input(messages)
+    assert responses[: len(responses_prefix)] == responses_prefix
+    assert responses[-1]["type"] == "function_call_output"
+    assert "MATRIX_MARKER" in responses[-1]["output"]
+
+    cache_prefix = [
+        {"role": "system", "content": "stable system prefix"},
+        {"role": "user", "content": "stable user prefix"},
+    ]
+    cached_prefix = apply_anthropic_cache_control(
+        deepcopy(cache_prefix), native_anthropic=True
+    )
+    cached_extended = apply_anthropic_cache_control(
+        deepcopy(cache_prefix + messages[1:]), native_anthropic=True
+    )
+    assert cached_extended[: len(cached_prefix)] == cached_prefix
+
+
+def test_tool_boundary_opens_only_after_the_complete_result_batch():
+    from agent.tool_executor import _completed_tool_batch_size
+
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "a", "function": {"name": "first"}},
+                {"id": "b", "function": {"name": "second"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a", "content": "one"},
+    ]
+    assert _completed_tool_batch_size(messages) == 0
+
+    messages.append({"role": "tool", "tool_call_id": "b", "content": "two"})
+    assert _completed_tool_batch_size(messages) == 2
+
+    messages[-1]["_external_input_boundary_checked"] = True
+    assert _completed_tool_batch_size(messages) == 0
+
+
+def test_tool_boundary_flush_failure_restores_carrier_and_requeues_event():
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "must retry after flush failure")
+    )
+    agent = _tool_boundary_agent()
+    agent._incremental_persistence_failed = False
+    agent._flush_messages_to_session_db = lambda _messages: False
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc", "content": "original"},
+    ]
+
+    assert not _flush_session_db_after_tool_progress(
+        agent, messages, stage="test flush failure"
+    )
+    assert messages[-1]["content"] == "original"
+    assert agent._incremental_persistence_failed is True
+    assert not agent._pending_delegation_inject_claims
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
+
+
+def test_inject_batch_publishes_first_child_without_waiting_for_sibling():
+    gate = threading.Event()
+    ready = threading.Event()
+    delegation_id = f"deleg_partial_{uuid.uuid4().hex}"
+
+    def runner():
+        assert ad.publish_batch_child_completion(
+            delegation_id, 0, _child(0, "fast result")
+        )
+        ready.set()
+        gate.wait(timeout=5)
+        return {
+            "results": [_child(0, "fast result"), _child(1, "slow result")],
+            "total_duration_seconds": 0.5,
+        }
+
+    dispatched = ad.dispatch_async_delegation_batch(
+        goals=["fast", "slow"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="agent:main:cli:dm:local",
+        parent_session_id="parent",
+        parent_turn_id="turn-current",
+        runner=runner,
+        max_async_children=1,
+        delegation_id=delegation_id,
+        result_delivery="inject",
+    )
+    assert dispatched["status"] == "dispatched"
+    assert ready.wait(timeout=2)
+    first = process_registry.completion_queue.get(timeout=2)
+    assert first["delivery_event_key"] == "task:0"
+    assert first["results"][0]["summary"] == "fast result"
+    assert ad.get_durable_delegation(delegation_id)["state"] == "running"
+
+    gate.set()
+    deadline = time.monotonic() + 3
+    second = None
+    while time.monotonic() < deadline:
+        try:
+            candidate = process_registry.completion_queue.get(timeout=0.05)
+        except Exception:
+            continue
+        if candidate.get("delivery_event_key") == "task:1":
+            second = candidate
+            break
+    assert second is not None
+    assert second["results"][0]["summary"] == "slow result"
+    assert "delivery_event_key" not in {
+        e.get("delivery_event_key") for e in _queue_contents()
+    }
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ad.get_durable_delegation(delegation_id)["delivery_state"] == "delivered"
+
+    restored_queue = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 2
+    restored = [restored_queue.get_nowait(), restored_queue.get_nowait()]
+    assert {event.get("delivery_event_key") for event in restored} == {
+        "task:0",
+        "task:1",
+    }
+    assert all(event.get("delivery_event_key") for event in restored)
+
+
+def test_after_turn_remains_default_and_coalesces_all_ready_children():
+    gate = threading.Event()
+
+    def runner():
+        gate.wait(timeout=5)
+        return {
+            "results": [_child(0, "A"), _child(1, "B")],
+            "total_duration_seconds": 0.1,
+        }
+
+    dispatched = ad.dispatch_async_delegation_batch(
+        goals=["A", "B"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="", runner=runner, max_async_children=1,
+    )
+    assert process_registry.completion_queue.empty()
+    gate.set()
+    deadline = time.time() + 3
+    while process_registry.completion_queue.qsize() < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    drained = process_registry.drain_notifications(
+        owns_event=lambda _event: True,
+        skip_poll_observed=False,
+    )
+    assert len(drained) == 1
+    event, text = drained[0]
+    assert event["delegation_id"] == dispatched["delegation_id"]
+    assert event["result_delivery"] == "after_turn"
+    assert event["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [r["summary"] for r in event["results"]] == ["A", "B"]
+    assert "RESULTS READY" in text
+    claim = ad.claim_event_delivery(event, "test-after-turn-default")
+    assert claim
+    assert ad.complete_event_delivery(event, claim)
+
+
+def test_batch_finalization_enqueues_ready_set_under_routing_lock(monkeypatch):
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
+    with ad._records_lock:
+        record = dict(ad._records[delegation_id])
+    children = [_child(0, "A"), _child(1, "B")]
+
+    class TrackingLock:
+        def __init__(self):
+            self.inner = threading.RLock()
+            self.depth = 0
+
+        def __enter__(self):
+            self.inner.acquire()
+            self.depth += 1
+            return self
+
+        def __exit__(self, *_exc):
+            self.depth -= 1
+            self.inner.release()
+
+    tracking_lock = TrackingLock()
+
+    class GuardedQueue(__import__("queue").Queue):
+        def put(self, item, *args, **kwargs):
+            assert tracking_lock.depth > 0
+            return super().put(item, *args, **kwargs)
+
+    guarded_queue = GuardedQueue()
+    monkeypatch.setattr(process_registry, "completion_routing_lock", tracking_lock)
+    monkeypatch.setattr(process_registry, "completion_queue", guarded_queue)
+    combined = {"results": children, "total_duration_seconds": 1.0}
+    parent_event = {
+        **record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        record, parent_event, combined, "completed"
+    )
+
+    grouped = guarded_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert guarded_queue.empty()
+
+
+def test_requeued_after_turn_envelope_absorbs_newly_ready_sibling():
+    delegation_id = _record(goals=("A", "B", "C"), delivery="after_turn")
+    for index, summary in enumerate(("A", "B", "C")):
+        assert ad.publish_batch_child_completion(
+            delegation_id, index, _child(index, summary)
+        )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    requeued_envelope = ad.coalesce_ready_after_turn_events(children[:2])[0]
+    process_registry.completion_queue.put(children[2])
+
+    merged = process_registry.collect_ready_after_turn_siblings(requeued_envelope)
+
+    assert merged["delivery_event_keys"] == ["task:0", "task:1", "task:2"]
+    assert [result["summary"] for result in merged["results"]] == ["A", "B", "C"]
+    assert process_registry.completion_queue.empty()
+    claim = ad.claim_event_delivery(merged, "requeued-group-consumer")
+    assert claim
+    assert ad.complete_event_delivery(merged, claim)
+
+
+def test_child_timeout_error_is_injectable_and_durable():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id,
+        0,
+        _child(0, "", status="timeout", error="child exceeded 10s"),
+    )
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
+    agent = _tool_boundary_agent()
+    assert attach_ready_injects_to_tool_results(
+        agent, messages, num_tool_msgs=1, turn_id="turn-current"
+    ) == 1
+    assert "timeout" in messages[-1]["content"]
+    assert "child exceeded 10s" in messages[-1]["content"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+
+def test_failed_ack_keeps_ram_claim_for_later_reconciliation(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "ack must commit")
+    )
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
+    agent = _tool_boundary_agent()
+    assert attach_ready_injects_to_tool_results(
+        agent, messages, num_tool_msgs=1, turn_id="turn-current"
+    ) == 1
+
+    monkeypatch.setattr(ad, "complete_event_delivery", lambda *_args: False)
+    assert acknowledge_pending_injects(agent, turn_id="turn-current") == 0
+    assert len(agent._pending_delegation_inject_claims) == 1
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+
+
+def test_failed_release_neither_requeues_nor_forgets_claim(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "release must commit")
+    )
+    original = {"role": "tool", "tool_call_id": "tc", "content": "done"}
+    messages = [original]
+    agent = _tool_boundary_agent()
+    assert attach_ready_injects_to_tool_results(
+        agent, messages, num_tool_msgs=1, turn_id="turn-current"
+    ) == 1
+
+    monkeypatch.setattr(ad, "release_event_delivery", lambda *_args: False)
+    assert release_pending_injects(agent, messages, turn_id="turn-current") == 0
+    assert messages == [original]
+    assert process_registry.completion_queue.empty()
+    assert len(agent._pending_delegation_inject_claims) == 1
+
+
+def test_pending_claim_heartbeat_renews_until_ack(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "slow provider")
+    )
+    renewed = threading.Event()
+
+    def fake_renew(_event, _claim_id):
+        renewed.set()
+        return True
+
+    monkeypatch.setattr(ad, "renew_event_delivery", fake_renew, raising=False)
+    monkeypatch.setattr(
+        inject, "_CLAIM_HEARTBEAT_INTERVAL_SECONDS", 0.01, raising=False
+    )
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
+    agent = _tool_boundary_agent()
+
+    assert attach_ready_injects_to_tool_results(
+        agent, messages, num_tool_msgs=1, turn_id="turn-current"
+    ) == 1
+    assert inject.ensure_pending_inject_heartbeat(agent) is True
+    assert renewed.wait(timeout=1), "pending inject claim was not renewed"
+    assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
+    heartbeat = agent._delegation_inject_claim_heartbeat
+    heartbeat["thread"].join(timeout=1)
+    assert not heartbeat["thread"].is_alive()
+
+
+def test_run_conversation_inject_transport_normalize_and_ack(monkeypatch, tmp_path):
+    agent = _make_loop_agent(tmp_path)
+    cached_system_prompt = deepcopy(getattr(agent, "_cached_system_prompt"))
+    requests = []
+    responses = [
+        _loop_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_loop_tool_call()],
+        ),
+        _loop_response(content="model consumed LIVE_LOOP_INJECT"),
+    ]
+
+    def create(**kwargs):
+        requests.append(deepcopy(kwargs["messages"]))
+        return responses.pop(0)
+
+    agent.client.chat.completions.create.side_effect = create
+    published = {}
+
+    def handle_tool(*_args, **_kwargs):
+        delegation_id = _record(
+            turn_id=str(agent._active_turn_id),
+            parent_session_id=agent.session_id,
+        )
+        published["delegation_id"] = delegation_id
+        assert ad.publish_batch_child_completion(
+            delegation_id, 0, _child(0, "LIVE_LOOP_INJECT")
+        )
+        return "tool boundary complete"
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=handle_tool),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("exercise inject lifecycle")
+
+    delegation_id = published["delegation_id"]
+    assert result["completed"] is True
+    assert len(requests) == 2
+    assert requests[1][: len(requests[0])] == requests[0]
+    assert [message["role"] for message in requests[1][len(requests[0]):]] == [
+        "assistant",
+        "tool",
+    ]
+    assert requests[1][-1]["role"] == "tool"
+    assert "display_metadata" not in requests[1][-1]
+    assert not any(key.startswith("_") for key in requests[1][-1])
+    assert getattr(agent, "_cached_system_prompt") == cached_system_prompt
+    assert "LIVE_LOOP_INJECT" in str(requests[1])
+    assert "not a new user request" in requests[1][-1]["content"]
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert not agent._pending_delegation_inject_claims
+    heartbeat = agent._delegation_inject_claim_heartbeat
+    heartbeat["thread"].join(timeout=1)
+    assert not heartbeat["thread"].is_alive()
+
+
+def test_run_conversation_persists_tool_carrier_before_provider_error(
+    monkeypatch, tmp_path
+):
+    agent = _make_loop_agent(tmp_path)
+    calls = {"provider": 0, "compress": 0, "marker_compress": 0}
+    provider_error = RuntimeError("provider rejected request")
+    provider_error.status_code = 400
+
+    def create(**_kwargs):
+        calls["provider"] += 1
+        if calls["provider"] == 1:
+            return _loop_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_loop_tool_call()],
+            )
+        raise provider_error
+
+    agent.client.chat.completions.create.side_effect = create
+    published = {}
+
+    def handle_tool(*_args, **_kwargs):
+        delegation_id = _record(
+            turn_id=str(agent._active_turn_id),
+            parent_session_id=agent.session_id,
+        )
+        published["delegation_id"] = delegation_id
+        assert ad.publish_batch_child_completion(
+            delegation_id, 0, _child(0, "COPY_THEN_RELEASE")
+        )
+        agent.compression_enabled = True
+        agent.context_compressor.should_compress = lambda _tokens: True
+        return "tool boundary complete"
+
+    def copy_compress(messages, system_message, **_kwargs):
+        calls["compress"] += 1
+        if "COPY_THEN_RELEASE" not in str(messages):
+            return messages, system_message
+        calls["marker_compress"] += 1
+        heartbeat = agent._delegation_inject_claim_heartbeat
+        assert heartbeat["stop"].is_set()
+        agent.compression_enabled = False
+        return deepcopy(messages), system_message
+
+    def persist_with_durable_carrier(messages, *_args, **_kwargs):
+        if any(message.get("role") == "tool" for message in messages):
+            assert "COPY_THEN_RELEASE" in str(messages)
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=handle_tool),
+        patch.object(agent, "_compress_context", side_effect=copy_compress),
+        patch.object(
+            agent,
+            "_persist_session",
+            side_effect=persist_with_durable_carrier,
+        ),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("exercise rollback lifecycle")
+
+    delegation_id = published["delegation_id"]
+    assert result["failed"] is True
+    assert calls["compress"] >= 1
+    assert calls["marker_compress"] == 1
+    assert "COPY_THEN_RELEASE" in str(agent._session_messages)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert not any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
+    assert not agent._pending_delegation_inject_claims
+    heartbeat = agent._delegation_inject_claim_heartbeat
+    heartbeat["thread"].join(timeout=1)
+    assert not heartbeat["thread"].is_alive()
+
+
+def test_same_turn_claim_conflict_defers_pending_event(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "leased elsewhere")
+    )
+    deferred = []
+    monkeypatch.setattr(ad, "claim_event_delivery", lambda *_args: None)
+    monkeypatch.setattr(
+        process_registry,
+        "defer_unclaimed_delivery",
+        lambda evt: deferred.append(evt) or True,
+    )
+
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
+    assert attach_ready_injects_to_tool_results(
+        _tool_boundary_agent(), messages, num_tool_msgs=1, turn_id="turn-current"
+    ) == 0
+
+    assert len(deferred) == 1
+    assert deferred[0]["delegation_id"] == delegation_id
+    assert deferred[0]["delivery_event_key"] == "task:0"
+    assert len(messages) == 1
+
+
+def test_formatter_failure_does_not_consume_delivery_attempts(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "format me")
+    )
+
+    def broken_formatter(_event):
+        raise ValueError("broken spill")
+
+    monkeypatch.setattr(
+        "tools.process_registry._format_async_delegation", broken_formatter
+    )
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS + 2):
+        assert attach_ready_injects_to_tool_results(
+            _tool_boundary_agent(), messages, num_tool_msgs=1, turn_id="turn-current"
+        ) == 0
+
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert len(_queue_contents()) == 1
+
+
+def test_quick_restart_requeues_after_live_delivery_lease_expires(
+    tmp_path, monkeypatch
+):
+    """A restored live-claimed row wakes without another process restart."""
+    import queue as queue_module
+
+    import tools.process_registry as registry_mod
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(ad, "_DELIVERY_CLAIM_LEASE_SECONDS", 0.15)
+    monkeypatch.setattr(
+        registry_mod, "CHECKPOINT_PATH", tmp_path / "processes.json"
+    )
+
+    delegation_id = _record(goals=("survive quick restart",))
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "restored after lease")
+    )
+    original = process_registry.completion_queue.get_nowait()
+    old_claim = ad.claim_event_delivery(original, "old-process")
+    assert old_claim
+
+    restarted = registry_mod.ProcessRegistry()
+    restored = restarted.completion_queue.get_nowait()
+    assert restored["restored"] is True
+    assert ad.claim_event_delivery(restored, "new-process") is None
+
+    assert restarted.defer_unclaimed_delivery(restored) is True
+    with pytest.raises(queue_module.Empty):
+        restarted.completion_queue.get_nowait()
+
+    woke = restarted.completion_queue.get(timeout=1)
+    assert woke["delegation_id"] == delegation_id
+    assert woke["delivery_event_key"] == "task:0"
+    new_claim = ad.claim_event_delivery(woke, "new-process")
+    assert new_claim
+    assert ad.complete_event_delivery(woke, new_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 2)
+    assert restarted.defer_unclaimed_delivery(woke) is False
+    with pytest.raises(queue_module.Empty):
+        restarted.completion_queue.get_nowait()
+
+
+def test_live_lease_retry_prunes_terminal_group_sibling(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(ad, "_DELIVERY_CLAIM_LEASE_SECONDS", 0.15)
+
+    delegation_id = _record(
+        goals=("already delivered", "still leased"), delivery="after_turn"
+    )
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "delivered result")
+    )
+    assert ad.publish_batch_child_completion(
+        delegation_id, 1, _child(1, "leased result")
+    )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+    by_key = {event["delivery_event_key"]: event for event in children}
+
+    delivered_claim = ad.claim_event_delivery(by_key["task:0"], "first-consumer")
+    assert delivered_claim
+    assert ad.complete_event_delivery(by_key["task:0"], delivered_claim)
+    live_claim = ad.claim_event_delivery(by_key["task:1"], "old-process")
+    assert live_claim
+    assert ad.claim_event_delivery(grouped, "new-process") is None
+
+    assert process_registry.defer_unclaimed_delivery(grouped)
+    assert grouped["delivery_event_keys"] == ["task:1"]
+    assert [result["task_index"] for result in grouped["results"]] == [1]
+
+    woke = process_registry.completion_queue.get(timeout=1)
+    assert woke["delivery_event_keys"] == ["task:1"]
+    retry_claim = ad.claim_event_delivery(woke, "new-process")
+    assert retry_claim
+    assert ad.complete_event_delivery(woke, retry_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert _event_state(delegation_id, "task:1") == ("delivered", 2)
+
+
+def test_model_schema_defaults_after_turn_and_dispatch_forwards_explicit_mode(monkeypatch):
+    delivery_schema = delegate_tool.DELEGATE_TASK_SCHEMA["parameters"]["properties"][
+        "result_delivery"
+    ]
+    assert delivery_schema["enum"] == ["inject", "after_turn"]
+    assert delivery_schema["default"] == "after_turn"
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(delegate_tool, "delegate_task", fake_delegate_task)
+    from run_agent import AIAgent
+
+    result = AIAgent._dispatch_delegate_task(
+        SimpleNamespace(_delegate_depth=0),
+        {"goal": "audit", "result_delivery": "inject"},
+    )
+    assert result == "ok"
+    assert captured["background"] is True
+    assert captured["result_delivery"] == "inject"
+
+    # The registry fallback is a distinct model-facing dispatch path. It must
+    # preserve the same delivery choice if the run_agent intercept is bypassed.
+    captured.clear()
+    from tools.registry import registry
+
+    entry = registry.get_entry("delegate_task")
+    assert entry is not None
+    result = entry.handler(
+        {"goal": "audit", "result_delivery": "inject"},
+        parent_agent=SimpleNamespace(_delegate_depth=0),
+    )
+    assert result == "ok"
+    assert captured["background"] is True
+    assert captured["result_delivery"] == "inject"

--- a/tests/agent/test_delegation_delivery.py
+++ b/tests/agent/test_delegation_delivery.py
@@ -23,7 +23,9 @@ from agent.delegation_inject import (
 )
 from tools import async_delegation as ad
 from tools import delegate_tool
+from tools.budget_config import BudgetConfig
 from tools.process_registry import process_registry
+from tools.tool_result_storage import PERSISTED_OUTPUT_TAG
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -285,6 +287,123 @@ def test_consumed_tool_boundary_inject_acknowledges_without_removing_carrier():
 
     assert "accepted audit" in messages[0]["content"]
     assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+
+def test_large_tool_boundary_inject_uses_canonical_spill_budget():
+    delegation_id = _record()
+    huge_summary = "HUGE_CHILD_REPORT:" + ("x" * 250_000)
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, huge_summary)
+    )
+    agent = _tool_boundary_agent()
+    messages = [
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "tc-large-carrier",
+            "content": "original tool result",
+        }
+    ]
+    env = MagicMock()
+    env.execute.return_value = {"output": "", "returncode": 0}
+    env.get_temp_dir.return_value = ""
+    budget = BudgetConfig(
+        default_result_size=10_000,
+        turn_budget=20_000,
+        preview_size=512,
+    )
+
+    assert attach_ready_injects_to_tool_results(
+        agent,
+        messages,
+        num_tool_msgs=1,
+        storage_env=env,
+        budget_config=budget,
+    ) == 1
+
+    assert len(messages[0]["content"]) <= budget.default_result_size
+    assert PERSISTED_OUTPUT_TAG in messages[0]["content"]
+    assert delegation_id in messages[0]["content"]
+    assert env.execute.call_count == 1
+    persisted_report = env.execute.call_args.kwargs["stdin_data"]
+    assert "HUGE_CHILD_REPORT:" in persisted_report
+    assert persisted_report.endswith("x" * 1_000)
+    assert len(persisted_report) > len(huge_summary)
+
+
+def test_oversized_inject_without_storage_defers_without_claim_or_truncation():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "FULL_REPORT_MUST_SURVIVE" + ("x" * 20_000))
+    )
+    agent = _tool_boundary_agent()
+    messages = [
+        {"role": "tool", "tool_call_id": "tc-no-env", "content": "ORIGINAL"}
+    ]
+    budget = BudgetConfig(
+        default_result_size=8_000,
+        turn_budget=16_000,
+        preview_size=512,
+    )
+
+    assert attach_ready_injects_to_tool_results(
+        agent,
+        messages,
+        num_tool_msgs=1,
+        storage_env=None,
+        budget_config=budget,
+    ) == 0
+
+    assert messages == [
+        {"role": "tool", "tool_call_id": "tc-no-env", "content": "ORIGINAL"}
+    ]
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
+
+
+def test_attach_exception_after_carrier_mutation_restores_target_and_requeues():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "FAULT_INJECTED_EVIDENCE")
+    )
+
+    class RaisingSessionAgent:
+        session_id = "parent-session"
+        _active_turn_id = "turn-current"
+        _session_messages = []
+
+        @property
+        def _pending_delegation_inject_claims(self):
+            return []
+
+        @_pending_delegation_inject_claims.setter
+        def _pending_delegation_inject_claims(self, _value):
+            raise RuntimeError("fault after carrier mutation")
+
+    messages = [{
+        "role": "tool",
+        "tool_call_id": "tc",
+        "content": "ORIGINAL_CONTENT",
+        "display_metadata": {"risk": "keep"},
+    }]
+
+    with pytest.raises(RuntimeError, match="fault after carrier mutation"):
+        attach_ready_injects_to_tool_results(
+            RaisingSessionAgent(), messages, num_tool_msgs=1
+        )
+
+    assert messages == [{
+        "role": "tool",
+        "tool_call_id": "tc",
+        "content": "ORIGINAL_CONTENT",
+        "display_metadata": {"risk": "keep"},
+    }]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert any(
+        event.get("delegation_id") == delegation_id for event in _queue_contents()
+    )
 
 
 def test_tool_carrier_preserves_provider_roles_and_existing_prefix_items():
@@ -797,6 +916,102 @@ def test_run_conversation_persists_tool_carrier_before_provider_error(
     heartbeat = agent._delegation_inject_claim_heartbeat
     heartbeat["thread"].join(timeout=1)
     assert not heartbeat["thread"].is_alive()
+
+
+def test_persisted_bounded_carrier_survives_production_compressor_payload(
+    tmp_path,
+):
+    from agent.context_compressor import ContextCompressor
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    agent = _make_loop_agent(tmp_path)
+    agent._active_turn_id = "turn-current"
+    agent._pending_delegation_inject_claims = []
+    agent._incremental_persistence_failed = False
+    delegation_id = _record(
+        turn_id="turn-current",
+        parent_session_id=agent.session_id,
+    )
+    huge_summary = "COMPRESSOR_CARRIER_EVIDENCE:" + ("z" * 250_000)
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, huge_summary)
+    )
+
+    messages = [{"role": "system", "content": "system"}]
+    for index in range(8):
+        messages.extend(
+            [
+                {"role": "user", "content": f"old user {index}"},
+                {"role": "assistant", "content": f"old assistant {index}"},
+            ]
+        )
+    messages.extend(
+        [
+            {"role": "user", "content": "current task"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc-compress",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_call_id": "tc-compress",
+                "content": "tool boundary complete",
+            },
+        ]
+    )
+    env = MagicMock()
+    env.execute.return_value = {"output": "", "returncode": 0}
+    env.get_temp_dir.return_value = ""
+    budget = BudgetConfig(
+        default_result_size=10_000,
+        turn_budget=20_000,
+        preview_size=512,
+    )
+
+    assert _flush_session_db_after_tool_progress(
+        agent,
+        messages,
+        stage="persist bounded carrier before compression",
+        storage_env=env,
+        budget_config=budget,
+    )
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+
+    durable = agent._session_db.get_messages_as_conversation(agent.session_id)
+    assert PERSISTED_OUTPUT_TAG in str(durable)
+    assert delegation_id in str(durable)
+    assert "COMPRESSOR_CARRIER_EVIDENCE:" in env.execute.call_args.kwargs["stdin_data"]
+
+    compressor = ContextCompressor(
+        model="test/model",
+        provider="openai",
+        base_url="https://example.invalid/v1",
+        api_key="test-key",
+        config_context_length=100_000,
+        protect_first_n=3,
+        protect_last_n=3,
+        summary_target_ratio=0.10,
+        quiet_mode=True,
+    )
+    compressor.threshold_tokens = 2_000
+    compressor.tail_token_budget = 1_000
+    compressor._generate_summary = lambda *_args, **_kwargs: "compressed old context"
+
+    compressed = compressor.compress(durable, current_tokens=80_000, force=True)
+    provider_payload = AIAgent._sanitize_api_messages(deepcopy(compressed))
+
+    assert compressor._last_compression_made_progress is True
+    assert delegation_id in str(provider_payload)
+    assert PERSISTED_OUTPUT_TAG in str(provider_payload)
+    assert len(provider_payload[-1]["content"]) <= budget.default_result_size
 
 
 def test_same_turn_claim_conflict_defers_pending_event(monkeypatch):

--- a/tests/agent/test_delegation_delivery.py
+++ b/tests/agent/test_delegation_delivery.py
@@ -155,9 +155,9 @@ def _make_loop_agent(tmp_path: Path) -> AIAgent:
     ]
     with (
         contextlib.redirect_stdout(io.StringIO()),
-        patch("run_agent.get_tool_definitions", return_value=tool_defs),
-        patch("run_agent.check_toolset_requirements", return_value={}),
-        patch("run_agent.OpenAI"),
+        patch("model_tools.get_tool_definitions", return_value=tool_defs),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
     ):
         agent = AIAgent(
             api_key="test-key",
@@ -284,6 +284,7 @@ def test_consumed_tool_boundary_inject_acknowledges_without_removing_carrier():
     agent._session_messages = messages
 
     assert attach_ready_injects_to_tool_results(agent, messages, num_tool_msgs=1) == 1
+    messages[-1]["_db_persisted"] = True
     assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
 
     assert "accepted audit" in messages[0]["content"]
@@ -720,6 +721,7 @@ def test_child_timeout_error_is_injectable_and_durable():
     assert "timeout" in messages[-1]["content"]
     assert "child exceeded 10s" in messages[-1]["content"]
     assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    messages[-1]["_db_persisted"] = True
     assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
     assert _event_state(delegation_id, "task:0") == ("delivered", 1)
 
@@ -735,6 +737,7 @@ def test_failed_ack_keeps_ram_claim_for_later_reconciliation(monkeypatch):
         agent, messages, num_tool_msgs=1, turn_id="turn-current"
     ) == 1
 
+    messages[-1]["_db_persisted"] = True
     monkeypatch.setattr(ad, "complete_event_delivery", lambda *_args: False)
     assert acknowledge_pending_injects(agent, turn_id="turn-current") == 0
     assert len(agent._pending_delegation_inject_claims) == 1
@@ -783,6 +786,7 @@ def test_pending_claim_heartbeat_renews_until_ack(monkeypatch):
     ) == 1
     assert inject.ensure_pending_inject_heartbeat(agent) is True
     assert renewed.wait(timeout=1), "pending inject claim was not renewed"
+    messages[-1]["_db_persisted"] = True
     assert acknowledge_pending_injects(agent, turn_id="turn-current") == 1
     heartbeat = agent._delegation_inject_claim_heartbeat
     heartbeat["thread"].join(timeout=1)
@@ -821,7 +825,7 @@ def test_run_conversation_inject_transport_normalize_and_ack(monkeypatch, tmp_pa
         return "tool boundary complete"
 
     with (
-        patch("run_agent.handle_function_call", side_effect=handle_tool),
+        patch("model_tools.handle_function_call", side_effect=handle_tool),
         patch.object(agent, "_persist_session"),
         patch.object(agent, "_save_trajectory"),
         patch.object(agent, "_cleanup_task_resources"),
@@ -898,7 +902,7 @@ def test_run_conversation_persists_tool_carrier_before_provider_error(
             assert "COPY_THEN_RELEASE" in str(messages)
 
     with (
-        patch("run_agent.handle_function_call", side_effect=handle_tool),
+        patch("model_tools.handle_function_call", side_effect=handle_tool),
         patch.object(agent, "_compress_context", side_effect=copy_compress),
         patch.object(
             agent,
@@ -1065,7 +1069,7 @@ def test_formatter_failure_does_not_consume_delivery_attempts(monkeypatch):
         raise ValueError("broken spill")
 
     monkeypatch.setattr(
-        "tools.process_registry._format_async_delegation", broken_formatter
+        "tools.process_registry_notifications._format_async_delegation", broken_formatter
     )
     messages = [{"role": "tool", "tool_call_id": "tc", "content": "done"}]
     for _ in range(ad._MAX_DELIVERY_ATTEMPTS + 2):
@@ -1096,6 +1100,14 @@ def test_quick_restart_requeues_after_live_delivery_lease_expires(
         delegation_id, 0, _child(0, "restored after lease")
     )
     original = process_registry.completion_queue.get_nowait()
+    # The lease is live, not the parent execution. Complete the parent through
+    # production finalization; a genuinely live partial batch is not restart work.
+    with ad._records_lock:
+        record = dict(ad._records[delegation_id])
+    ad._persist_batch_child_finalization(
+        record, {**record, "type": "async_delegation", "status": "completed", "completed_at": time.time()},
+        {"results": [_child(0, "restored after lease")]}, "completed",
+    )
     old_claim = ad.claim_event_delivery(original, "old-process")
     assert old_claim
 
@@ -1198,3 +1210,275 @@ def test_model_schema_defaults_after_turn_and_dispatch_forwards_explicit_mode(mo
     assert result == "ok"
     assert captured["background"] is True
     assert captured["result_delivery"] == "inject"
+
+
+@pytest.mark.parametrize("flush_result", [None, True])
+def test_flush_without_durable_marker_does_not_acknowledge(flush_result):
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "must remain pending"))
+    agent = _tool_boundary_agent()
+    agent._flush_messages_to_session_db = lambda _messages: flush_result
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "tc"}]},
+        {"role": "tool", "tool_call_id": "tc", "content": "original"},
+    ]
+    assert _flush_session_db_after_tool_progress(agent, messages, stage="no durable receipt")
+    assert messages[-1]["content"] == "original"
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert not agent._pending_delegation_inject_claims
+    assert len(_queue_contents()) == 1
+
+
+def test_ack_requires_actual_transcript_marker():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "not persisted"))
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "original"}]
+    assert attach_ready_injects_to_tool_results(agent, messages, 1) == 1
+    assert acknowledge_pending_injects(agent) == 0
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert release_pending_injects(agent, messages) == 1
+
+
+def test_persisted_or_invalid_tool_tail_is_never_a_carrier():
+    from agent.tool_executor import _completed_tool_batch_size
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "new evidence"))
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "tc"}]},
+        {"role": "tool", "tool_call_id": "tc", "content": "historical", "_db_persisted": True},
+    ]
+    before = deepcopy(messages)
+    assert _completed_tool_batch_size(messages) == 0
+    assert attach_ready_injects_to_tool_results(_tool_boundary_agent(), messages, 1) == 0
+    assert messages == before
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    malformed = [
+        {"role": "assistant", "tool_calls": [{"id": "tc"}, {"id": "tc"}]},
+        {"role": "tool", "tool_call_id": "tc", "content": "first"},
+        {"role": "tool", "tool_call_id": "tc", "content": "duplicate"},
+    ]
+    assert _completed_tool_batch_size(malformed) == 0
+
+
+def test_batch_siblings_leave_no_space_so_carrier_is_deferred():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "report " * 300))
+    messages = [
+        {"role": "tool", "tool_call_id": "first", "content": "s" * 4_900},
+        {"role": "tool", "tool_call_id": "last", "content": "last"},
+    ]
+    before = deepcopy(messages)
+    budget = BudgetConfig(default_result_size=6_000, turn_budget=6_000)
+    assert attach_ready_injects_to_tool_results(
+        _tool_boundary_agent(), messages, 2, budget_config=budget,
+    ) == 0
+    assert messages == before
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert len(_queue_contents()) == 1
+
+
+def test_spilled_carrier_survives_subsequent_aggregate_budgeting():
+    from agent.tool_executor import _finalize_tool_batch
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "report " * 50_000))
+    agent = _tool_boundary_agent()
+    agent._apply_pending_steer_to_tool_results = lambda *_args: None
+    messages = [
+        {"role": "tool", "tool_call_id": "first", "content": "s" * 9_000},
+        {"role": "tool", "tool_call_id": "last", "content": "last"},
+    ]
+    budget = BudgetConfig(default_result_size=10_000, turn_budget=10_000, preview_size=512)
+    env = MagicMock()
+    env.execute.return_value = {"output": "", "returncode": 0}
+    env.get_temp_dir.return_value = ""
+    assert attach_ready_injects_to_tool_results(agent, messages, 2, storage_env=env, budget_config=budget) == 1
+    assert sum(len(m["content"]) for m in messages) <= budget.turn_budget
+    before = deepcopy(messages)
+    with patch("agent.tool_executor.get_active_env", return_value=env):
+        _finalize_tool_batch(agent, messages, "test", 2, budget)
+    assert messages == before
+    assert PERSISTED_OUTPUT_TAG in messages[-1]["content"]
+    assert release_pending_injects(agent, messages) == 1
+
+
+def test_spill_exception_requeues_unclaimed_event(monkeypatch):
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "spill failure"))
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "original"}]
+
+    def broken_spill(*_args, **_kwargs):
+        raise OSError("storage unavailable")
+
+    monkeypatch.setattr(inject, "_bounded_carrier_text", broken_spill)
+    assert attach_ready_injects_to_tool_results(_tool_boundary_agent(), messages, 1) == 0
+    assert messages[-1]["content"] == "original"
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert len(_queue_contents()) == 1
+
+
+def test_formatter_runs_outside_shared_routing_reservation(monkeypatch):
+    from tools.process_registry_notifications import _format_async_delegation
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "format outside lock"))
+    unlocked = []
+
+    def formatter(event):
+        def probe():
+            acquired = process_registry.completion_routing_lock.acquire(blocking=False)
+            unlocked.append(acquired)
+            if acquired:
+                process_registry.completion_routing_lock.release()
+        thread = threading.Thread(target=probe)
+        thread.start()
+        thread.join(timeout=1)
+        return _format_async_delegation(event)
+
+    monkeypatch.setattr("tools.process_registry_notifications._format_async_delegation", formatter)
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "original"}]
+    assert attach_ready_injects_to_tool_results(agent, messages, 1) == 1
+    assert unlocked == [True]
+    assert release_pending_injects(agent, messages) == 1
+
+
+def test_heartbeat_preserves_parent_context(monkeypatch):
+    from contextvars import ContextVar
+
+    profile = ContextVar("inject_test_profile", default="wrong-profile")
+    profile.set("active-profile")
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "profile-scoped lease"))
+    seen = []
+    renewed = threading.Event()
+
+    def renew(*_args):
+        seen.append(profile.get())
+        renewed.set()
+        return True
+
+    monkeypatch.setattr(ad, "renew_event_delivery", renew)
+    monkeypatch.setattr(inject, "_CLAIM_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "original"}]
+    assert attach_ready_injects_to_tool_results(agent, messages, 1) == 1
+    assert renewed.wait(timeout=1)
+    assert seen and set(seen) == {"active-profile"}
+    assert release_pending_injects(agent, messages) == 1
+    agent._delegation_inject_claim_heartbeat["thread"].join(timeout=1)
+
+
+def test_ack_exception_does_not_reclassify_successful_transcript_flush(monkeypatch):
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "durably stored"))
+    agent = _tool_boundary_agent()
+    agent._incremental_persistence_failed = False
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "tc"}]},
+        {"role": "tool", "tool_call_id": "tc", "content": "original"},
+    ]
+
+    def flush(messages):
+        for message in messages:
+            message["_db_persisted"] = True
+        return True
+
+    agent._flush_messages_to_session_db = flush
+    with patch.object(ad, "complete_event_delivery", side_effect=OSError("ack temporarily unavailable")):
+        assert _flush_session_db_after_tool_progress(agent, messages, stage="ack retry")
+    assert not agent._incremental_persistence_failed
+    assert "durably stored" in messages[-1]["content"]
+    assert len(agent._pending_delegation_inject_claims) == 1
+    assert acknowledge_pending_injects(agent) == 1
+
+
+def test_restart_does_not_redeliver_committed_carrier_without_ack(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "receipt.db")
+    db = SessionDB(db_path=tmp_path / "receipt.db")
+    db.create_session("parent-session", source="cli", model="test")
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "receipt survives crash"))
+    agent = _tool_boundary_agent()
+    messages = [{"role": "tool", "tool_call_id": "tc", "tool_name": "terminal", "content": "original"}]
+    assert attach_ready_injects_to_tool_results(agent, messages, 1) == 1
+    event = agent._pending_delegation_inject_claims[0]["event"]
+    db.append_message("parent-session", "tool", messages[0]["content"], tool_call_id="tc",
+                      tool_name="terminal", display_metadata=messages[0]["display_metadata"])
+    # Simulate a hard exit after the transcript transaction but BEFORE ack.
+    agent._delegation_inject_claim_heartbeat["stop"].set()
+    agent._delegation_inject_claim_heartbeat["thread"].join(timeout=1)
+    agent._pending_delegation_inject_claims = []
+    ad._reset_for_tests()
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert ad.claim_event_delivery(event, "restarted-after-turn") is None
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert process_registry.defer_unclaimed_delivery(event) is False
+    db.close()
+
+
+@pytest.mark.parametrize("wrong_field", ["session", "role", "identity", "kind", "malformed"])
+def test_unrelated_transcript_metadata_cannot_suppress_delivery(tmp_path, monkeypatch, wrong_field):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "receipt.db")
+    db = SessionDB(db_path=tmp_path / "receipt.db")
+    db.create_session("parent-session", source="cli", model="test")
+    db.create_session("different-session", source="cli", model="test")
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "must deliver"))
+    event = process_registry.completion_queue.get_nowait()
+    metadata = {"delegation_delivery": "tool_boundary", "delegation_event_ids": [f"{delegation_id}:task:0"]}
+    if wrong_field == "identity":
+        metadata["delegation_event_ids"] = [f"{delegation_id}:task:1"]
+    elif wrong_field == "kind":
+        metadata["delegation_delivery"] = "not_a_receipt"
+    sid = "different-session" if wrong_field == "session" else "parent-session"
+    role = "assistant" if wrong_field == "role" else "tool"
+    db.append_message(sid, role, "unrelated row", display_metadata=metadata)
+    if wrong_field == "malformed":
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute("UPDATE messages SET display_metadata=?", (f"broken metadata {delegation_id}",))
+    claim = ad.claim_event_delivery(event, "actual-consumer")
+    assert claim
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert ad.complete_event_delivery(event, claim)
+    db.close()
+
+
+@pytest.mark.parametrize("parent_id", ["", "different-parent"])
+def test_inject_requires_positive_parent_session_ownership(parent_id):
+    delegation_id = _record(parent_session_id=parent_id)
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "not for this session"))
+    messages = [{"role": "tool", "tool_call_id": "tc", "content": "original"}]
+    assert attach_ready_injects_to_tool_results(_tool_boundary_agent(), messages, 1) == 0
+    assert messages[-1]["content"] == "original"
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert len(_queue_contents()) == 1
+
+
+@pytest.mark.parametrize("disabled_state", ["explicit", "missing_db"])
+def test_disabled_persistence_never_burns_delivery_attempts(disabled_state):
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "after-turn fallback"))
+    agent = _tool_boundary_agent()
+    if disabled_state == "explicit":
+        agent._persist_disabled = True
+    else:
+        agent._session_db = None
+    agent._flush_messages_to_session_db = lambda _messages: None
+    for index in range(ad._MAX_DELIVERY_ATTEMPTS + 2):
+        messages = [
+            {"role": "assistant", "tool_calls": [{"id": f"tc-{index}"}]},
+            {"role": "tool", "tool_call_id": f"tc-{index}", "content": "original"},
+        ]
+        assert _flush_session_db_after_tool_progress(agent, messages, stage="persistence disabled")
+        assert messages[-1]["content"] == "original"
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert len(_queue_contents()) == 1

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -47,6 +47,38 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     assert completed == [(event, "claim-token")]
 
 
+def test_cli_claim_conflict_defers_pending_durable_event(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_live_lease",
+        "session_key": "visible-session",
+    }
+    deferred = []
+
+    class FakeRegistry:
+        def drain_notifications(self, *, session_key="", owns_event=None):
+            assert session_key == "visible-session"
+            assert owns_event is not None and owns_event(event)
+            return [(event, "completion payload")]
+
+        def defer_unclaimed_delivery(self, evt):
+            deferred.append(evt)
+            return True
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: None
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert deferred == [event]
+    assert cli._pending_input.empty()
+
+
 def test_cli_completion_ownership_rejects_foreign_session():
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -113,6 +113,125 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     adapter.handle_message.assert_awaited_once()
 
 
+def test_gateway_claim_conflict_defers_pending_durable_event(
+    monkeypatch, isolated_registry,
+):
+    import tools.async_delegation as delegation_mod
+
+    event = _async_event("deleg_gateway_live_lease")
+    deferred = []
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", lambda *_args: None)
+    monkeypatch.setattr(
+        isolated_registry,
+        "defer_unclaimed_delivery",
+        lambda evt: deferred.append(evt) or True,
+    )
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    result = asyncio.run(runner._deliver_completion_notification("ready", event))
+
+    assert result is None
+    assert deferred == [event]
+
+
+def test_gateway_watcher_coalesces_ready_after_turn_batch_children(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    base = {
+        **_async_event("deleg_after_turn_group"),
+        "result_delivery": "after_turn",
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+    }
+    for index in (0, 1):
+        isolated.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    deliver = AsyncMock(return_value=True)
+    runner._deliver_completion_notification = deliver
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_awaited_once()
+    text, grouped = deliver.await_args_list[0].args
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["task_index"] for result in grouped["results"]] == [0, 1]
+    assert "RESULTS READY" in text and "2/3" in text
+    assert isolated.empty()
+
+
+def test_gateway_after_turn_waits_for_idle_boundary_then_delivers_ready_group(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    base = {
+        **_async_event("deleg_after_turn_busy"),
+        "result_delivery": "after_turn",
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+    }
+    for index in (0, 1):
+        isolated.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    deliver = AsyncMock(return_value=True)
+    runner._deliver_completion_notification = deliver
+    runner._running_agents = {base["session_key"]: SimpleNamespace()}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_not_awaited()
+    assert isolated.qsize() == 1
+    queued_group = isolated.get_nowait()
+    assert queued_group["delivery_event_keys"] == ["task:0", "task:1"]
+    isolated.put(queued_group)
+
+    runner._running = True
+    runner._running_agents = {}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_awaited_once()
+    _text, delivered_group = deliver.await_args_list[0].args
+    assert delivered_group["delivery_event_keys"] == ["task:0", "task:1"]
+    assert isolated.empty()
+
+
 def test_unroutable_async_event_is_not_requeued_forever(
     monkeypatch, isolated_registry,
 ):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -134,6 +134,109 @@ def test_gateway_claim_conflict_defers_pending_durable_event(
     assert deferred == [event]
 
 
+def test_gateway_busy_route_is_atomic_with_tool_boundary_carrier(
+    monkeypatch, isolated_registry,
+):
+    """The watcher cannot hide a dequeued inject before active-turn requeue."""
+    import threading
+
+    import agent.delegation_inject as inject_mod
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry as registry_mod
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    monkeypatch.setattr(registry_mod, "_format_async_delegation", lambda _evt: "ready")
+    monkeypatch.setattr(inject_mod, "ensure_pending_inject_heartbeat", lambda _agent: True)
+    monkeypatch.setattr(
+        delegation_mod,
+        "claim_event_delivery",
+        lambda _event, _owner: "gateway-race-claim",
+    )
+
+    route_paused = threading.Event()
+    release_route = threading.Event()
+    original_coalesce = delegation_mod.coalesce_ready_after_turn_events
+
+    def _pause_after_dequeue(events):
+        route_paused.set()
+        if not release_route.wait(3):
+            raise TimeoutError("test did not release paused gateway route")
+        return original_coalesce(events)
+
+    monkeypatch.setattr(
+        delegation_mod, "coalesce_ready_after_turn_events", _pause_after_dequeue
+    )
+
+    turn_id = "turn-gateway-inject"
+    session_key = "agent:main:telegram:dm:12345:678"
+    active_agent = SimpleNamespace(
+        _active_turn_id=turn_id,
+        _iteration_calls_made=0,
+        max_iterations=1,
+        session_id="",
+    )
+    event = {
+        **_async_event("deleg_gateway_inject_race"),
+        "delivery_event_key": "task:0",
+        "result_delivery": "inject",
+        "parent_turn_id": turn_id,
+        "session_key": session_key,
+    }
+    isolated.put(event)
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    runner._running_agents = {session_key: active_agent}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    watcher_thread = threading.Thread(
+        target=lambda: asyncio.run(runner._async_delegation_watcher(interval=0))
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc", "content": "working"},
+    ]
+    drained = {}
+    drain_done = threading.Event()
+
+    def _drain():
+        drained["count"] = inject_mod.attach_ready_injects_to_tool_results(
+            active_agent, messages, 1, turn_id=turn_id
+        )
+        drain_done.set()
+
+    drain_thread = threading.Thread(target=_drain)
+    try:
+        watcher_thread.start()
+        assert route_paused.wait(3), "gateway watcher did not reach post-dequeue route"
+        drain_thread.start()
+
+        # Dequeue, coalesce, active-parent classification, and requeue must be one
+        # routing critical section. Returning here would degrade inject to late.
+        assert not drain_done.wait(0.5)
+
+        release_route.set()
+        watcher_thread.join(3)
+        drain_thread.join(3)
+
+        assert not watcher_thread.is_alive()
+        assert not drain_thread.is_alive()
+        assert drained == {"count": 1}
+        assert messages[-1]["role"] == "tool"
+        assert "ready" in messages[-1]["content"]
+        assert isolated.empty()
+    finally:
+        release_route.set()
+        runner._running = False
+        watcher_thread.join(3)
+        drain_thread.join(3)
+        while not isolated.empty():
+            isolated.get_nowait()
+
+
 def test_gateway_watcher_coalesces_ready_after_turn_batch_children(
     monkeypatch, isolated_registry,
 ):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -133,6 +133,109 @@ def test_gateway_claim_conflict_defers_pending_durable_event(
     assert deferred == [event]
 
 
+def test_gateway_busy_route_is_atomic_with_tool_boundary_carrier(
+    monkeypatch, isolated_registry,
+):
+    """The watcher cannot hide a dequeued inject before active-turn requeue."""
+    import threading
+
+    import agent.delegation_inject as inject_mod
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry as registry_mod
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    monkeypatch.setattr(registry_mod, "_format_async_delegation", lambda _evt: "ready")
+    monkeypatch.setattr(inject_mod, "ensure_pending_inject_heartbeat", lambda _agent: True)
+    monkeypatch.setattr(
+        delegation_mod,
+        "claim_event_delivery",
+        lambda _event, _owner: "gateway-race-claim",
+    )
+
+    route_paused = threading.Event()
+    release_route = threading.Event()
+    original_coalesce = delegation_mod.coalesce_ready_after_turn_events
+
+    def _pause_after_dequeue(events):
+        route_paused.set()
+        if not release_route.wait(3):
+            raise TimeoutError("test did not release paused gateway route")
+        return original_coalesce(events)
+
+    monkeypatch.setattr(
+        delegation_mod, "coalesce_ready_after_turn_events", _pause_after_dequeue
+    )
+
+    turn_id = "turn-gateway-inject"
+    session_key = "agent:main:telegram:dm:12345:678"
+    active_agent = SimpleNamespace(
+        _active_turn_id=turn_id,
+        _iteration_calls_made=0,
+        max_iterations=1,
+        session_id="",
+    )
+    event = {
+        **_async_event("deleg_gateway_inject_race"),
+        "delivery_event_key": "task:0",
+        "result_delivery": "inject",
+        "parent_turn_id": turn_id,
+        "session_key": session_key,
+    }
+    isolated.put(event)
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    runner._running_agents = {session_key: active_agent}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    watcher_thread = threading.Thread(
+        target=lambda: asyncio.run(runner._async_delegation_watcher(interval=0))
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc", "content": "working"},
+    ]
+    drained = {}
+    drain_done = threading.Event()
+
+    def _drain():
+        drained["count"] = inject_mod.attach_ready_injects_to_tool_results(
+            active_agent, messages, 1, turn_id=turn_id
+        )
+        drain_done.set()
+
+    drain_thread = threading.Thread(target=_drain)
+    try:
+        watcher_thread.start()
+        assert route_paused.wait(3), "gateway watcher did not reach post-dequeue route"
+        drain_thread.start()
+
+        # Dequeue, coalesce, active-parent classification, and requeue must be one
+        # routing critical section. Returning here would degrade inject to late.
+        assert not drain_done.wait(0.5)
+
+        release_route.set()
+        watcher_thread.join(3)
+        drain_thread.join(3)
+
+        assert not watcher_thread.is_alive()
+        assert not drain_thread.is_alive()
+        assert drained == {"count": 1}
+        assert messages[-1]["role"] == "tool"
+        assert "ready" in messages[-1]["content"]
+        assert isolated.empty()
+    finally:
+        release_route.set()
+        runner._running = False
+        watcher_thread.join(3)
+        drain_thread.join(3)
+        while not isolated.empty():
+            isolated.get_nowait()
+
+
 def test_gateway_watcher_coalesces_ready_after_turn_batch_children(
     monkeypatch, isolated_registry,
 ):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -112,6 +112,125 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     adapter.handle_message.assert_awaited_once()
 
 
+def test_gateway_claim_conflict_defers_pending_durable_event(
+    monkeypatch, isolated_registry,
+):
+    import tools.async_delegation as delegation_mod
+
+    event = _async_event("deleg_gateway_live_lease")
+    deferred = []
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", lambda *_args: None)
+    monkeypatch.setattr(
+        isolated_registry,
+        "defer_unclaimed_delivery",
+        lambda evt: deferred.append(evt) or True,
+    )
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    result = asyncio.run(runner._deliver_completion_notification("ready", event))
+
+    assert result is None
+    assert deferred == [event]
+
+
+def test_gateway_watcher_coalesces_ready_after_turn_batch_children(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    base = {
+        **_async_event("deleg_after_turn_group"),
+        "result_delivery": "after_turn",
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+    }
+    for index in (0, 1):
+        isolated.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    deliver = AsyncMock(return_value=True)
+    runner._deliver_completion_notification = deliver
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_awaited_once()
+    text, grouped = deliver.await_args_list[0].args
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["task_index"] for result in grouped["results"]] == [0, 1]
+    assert "RESULTS READY" in text and "2/3" in text
+    assert isolated.empty()
+
+
+def test_gateway_after_turn_waits_for_idle_boundary_then_delivers_ready_group(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    base = {
+        **_async_event("deleg_after_turn_busy"),
+        "result_delivery": "after_turn",
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+    }
+    for index in (0, 1):
+        isolated.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    deliver = AsyncMock(return_value=True)
+    runner._deliver_completion_notification = deliver
+    runner._running_agents = {base["session_key"]: SimpleNamespace()}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_not_awaited()
+    assert isolated.qsize() == 1
+    queued_group = isolated.get_nowait()
+    assert queued_group["delivery_event_keys"] == ["task:0", "task:1"]
+    isolated.put(queued_group)
+
+    runner._running = True
+    runner._running_agents = {}
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    deliver.assert_awaited_once()
+    _text, delivered_group = deliver.await_args_list[0].args
+    assert delivered_group["delivery_event_keys"] == ["task:0", "task:1"]
+    assert isolated.empty()
+
+
 def test_unroutable_async_event_is_not_requeued_forever(
     monkeypatch, isolated_registry,
 ):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -142,7 +142,7 @@ def test_gateway_busy_route_is_atomic_with_tool_boundary_carrier(
 
     import agent.delegation_inject as inject_mod
     import tools.async_delegation as delegation_mod
-    import tools.process_registry as registry_mod
+    import tools.process_registry_notifications as registry_mod
 
     isolated = queue.Queue()
     monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
@@ -174,13 +174,14 @@ def test_gateway_busy_route_is_atomic_with_tool_boundary_carrier(
         _active_turn_id=turn_id,
         _iteration_calls_made=0,
         max_iterations=1,
-        session_id="",
+        session_id="parent-gateway-inject",
     )
     event = {
         **_async_event("deleg_gateway_inject_race"),
         "delivery_event_key": "task:0",
         "result_delivery": "inject",
         "parent_turn_id": turn_id,
+        "parent_session_id": "parent-gateway-inject",
         "session_key": session_key,
     }
     isolated.put(event)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -18214,6 +18214,144 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
+def test_tui_claim_loss_does_not_leave_session_busy(monkeypatch):
+    """A competing durable consumer cannot strand the TUI in running state."""
+    import queue as _queue_mod
+
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry_notifications as registry_mod
+    from tools.process_registry import process_registry
+
+    stop_poller = threading.Event()
+
+    class _StopOnGetQueue(_queue_mod.Queue):
+        def get(self, block=True, timeout=None):
+            item = super().get(block=block, timeout=timeout)
+            stop_poller.set()
+            return item
+
+    isolated_queue: _queue_mod.Queue = _StopOnGetQueue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(registry_mod, "format_process_notification", lambda _evt: "ready")
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", lambda *_args: None)
+    deferred = []
+    monkeypatch.setattr(
+        process_registry,
+        "defer_unclaimed_delivery",
+        lambda evt: deferred.append(evt) or True,
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    sid = "sid-tui-claim-loss"
+    sess = _session(running=False, session_key="session-tui-claim-loss")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-claim-loss",
+        "delivery_event_key": "task:0",
+        "result_delivery": "after_turn",
+        "origin_ui_session_id": sid,
+        "session_key": "session-tui-claim-loss",
+    }
+    isolated_queue.put(event)
+    server._sessions[sid] = sess
+
+    try:
+        server._notification_poller_loop(stop_poller, sid, sess)
+
+        assert sess["running"] is False
+        assert deferred == [event]
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_tui_after_turn_coalesces_all_ready_batch_children(monkeypatch):
+    """The idle TUI starts one synthetic turn for the ready child set."""
+    import queue as _queue_mod
+
+    import tools.async_delegation as delegation_mod
+    from tools.process_registry import process_registry
+
+    stop_poller = threading.Event()
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    turns = []
+    claims = []
+    completions = []
+
+    def claim(event, consumer):
+        claims.append((event, consumer))
+        return "group-claim"
+
+    def complete(event, claim_id):
+        completions.append((event, claim_id))
+        return True
+
+    def run_prompt(_rid, _sid, current_session, text, **_kwargs):
+        turns.append(text)
+        with current_session["history_lock"]:
+            current_session["running"] = False
+        stop_poller.set()
+
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", claim)
+    monkeypatch.setattr(delegation_mod, "complete_event_delivery", complete)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    sid = "sid-tui-after-turn-group"
+    session_key = "session-tui-after-turn-group"
+    sess = _session(running=False, session_key=session_key)
+    base = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-after-turn-group",
+        "result_delivery": "after_turn",
+        "origin_ui_session_id": sid,
+        "session_key": session_key,
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+        "role": "leaf",
+        "model": "m",
+    }
+    for index in (0, 1):
+        isolated_queue.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+    server._sessions[sid] = sess
+
+    try:
+        server._notification_poller_loop(stop_poller, sid, sess)
+
+        assert len(turns) == 1
+        assert "RESULTS READY" in turns[0]
+        assert "2/3" in turns[0]
+        assert "ready-0" in turns[0] and "ready-1" in turns[0]
+        assert len(claims) == 1
+        grouped = claims[0][0]
+        assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+        assert claims[0][1] == "tui-poller"
+        assert completions == [(grouped, "group-claim")]
+        assert isolated_queue.empty()
+    finally:
+        stop_poller.set()
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
     """TUI /save (session.save RPC) must snapshot under the Hermes profile
     home — not the project/workspace CWD — and include the system prompt,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13978,6 +13978,144 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
+def test_tui_claim_loss_does_not_leave_session_busy(monkeypatch):
+    """A competing durable consumer cannot strand the TUI in running state."""
+    import queue as _queue_mod
+
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry as registry_mod
+    from tools.process_registry import process_registry
+
+    stop_poller = threading.Event()
+
+    class _StopOnGetQueue(_queue_mod.Queue):
+        def get(self, block=True, timeout=None):
+            item = super().get(block=block, timeout=timeout)
+            stop_poller.set()
+            return item
+
+    isolated_queue: _queue_mod.Queue = _StopOnGetQueue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(registry_mod, "format_process_notification", lambda _evt: "ready")
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", lambda *_args: None)
+    deferred = []
+    monkeypatch.setattr(
+        process_registry,
+        "defer_unclaimed_delivery",
+        lambda evt: deferred.append(evt) or True,
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    sid = "sid-tui-claim-loss"
+    sess = _session(running=False, session_key="session-tui-claim-loss")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-claim-loss",
+        "delivery_event_key": "task:0",
+        "result_delivery": "after_turn",
+        "origin_ui_session_id": sid,
+        "session_key": "session-tui-claim-loss",
+    }
+    isolated_queue.put(event)
+    server._sessions[sid] = sess
+
+    try:
+        server._notification_poller_loop(stop_poller, sid, sess)
+
+        assert sess["running"] is False
+        assert deferred == [event]
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_tui_after_turn_coalesces_all_ready_batch_children(monkeypatch):
+    """The idle TUI starts one synthetic turn for the ready child set."""
+    import queue as _queue_mod
+
+    import tools.async_delegation as delegation_mod
+    from tools.process_registry import process_registry
+
+    stop_poller = threading.Event()
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    turns = []
+    claims = []
+    completions = []
+
+    def claim(event, consumer):
+        claims.append((event, consumer))
+        return "group-claim"
+
+    def complete(event, claim_id):
+        completions.append((event, claim_id))
+        return True
+
+    def run_prompt(_rid, _sid, current_session, text, **_kwargs):
+        turns.append(text)
+        with current_session["history_lock"]:
+            current_session["running"] = False
+        stop_poller.set()
+
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", claim)
+    monkeypatch.setattr(delegation_mod, "complete_event_delivery", complete)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    sid = "sid-tui-after-turn-group"
+    session_key = "session-tui-after-turn-group"
+    sess = _session(running=False, session_key=session_key)
+    base = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-after-turn-group",
+        "result_delivery": "after_turn",
+        "origin_ui_session_id": sid,
+        "session_key": session_key,
+        "is_batch": True,
+        "batch_size": 3,
+        "goals": ["zero", "one", "two"],
+        "role": "leaf",
+        "model": "m",
+    }
+    for index in (0, 1):
+        isolated_queue.put(
+            {
+                **base,
+                "delivery_event_key": f"task:{index}",
+                "task_index": index,
+                "results": [
+                    {
+                        "task_index": index,
+                        "status": "completed",
+                        "summary": f"ready-{index}",
+                    }
+                ],
+            }
+        )
+    server._sessions[sid] = sess
+
+    try:
+        server._notification_poller_loop(stop_poller, sid, sess)
+
+        assert len(turns) == 1
+        assert "RESULTS READY" in turns[0]
+        assert "2/3" in turns[0]
+        assert "ready-0" in turns[0] and "ready-1" in turns[0]
+        assert len(claims) == 1
+        grouped = claims[0][0]
+        assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+        assert claims[0][1] == "tui-poller"
+        assert completions == [(grouped, "group-claim")]
+        assert isolated_queue.empty()
+    finally:
+        stop_poller.set()
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
     """TUI /save (session.save RPC) must snapshot under the Hermes profile
     home — not the project/workspace CWD — and include the system prompt,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13978,6 +13978,123 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
+def test_busy_tui_poller_cannot_hide_inject_from_tool_boundary(monkeypatch):
+    """A dequeued/requeued TUI event remains atomic with its tool carrier."""
+    import queue as _queue_mod
+
+    import agent.delegation_inject as inject_mod
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry as registry_mod
+    from tools.process_registry import process_registry
+
+    dequeued = threading.Event()
+    release_dequeue = threading.Event()
+    stop_poller = threading.Event()
+
+    class _PausedAfterDequeueQueue(_queue_mod.Queue):
+        def get(self, block=True, timeout=None):
+            event = super().get(block=block, timeout=timeout)
+            dequeued.set()
+            if not release_dequeue.wait(3):
+                raise TimeoutError("test did not release paused TUI dequeue")
+            stop_poller.set()
+            return event
+
+    isolated_queue = _PausedAfterDequeueQueue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(registry_mod, "format_process_notification", lambda _evt: "ready")
+    monkeypatch.setattr(registry_mod, "_format_async_delegation", lambda _evt: "ready")
+    monkeypatch.setattr(inject_mod, "ensure_pending_inject_heartbeat", lambda _agent: True)
+
+    claims = []
+
+    def _claim(event, owner):
+        claims.append((event["delivery_event_key"], owner))
+        return "claim-active-loop"
+
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", _claim)
+
+    turn_id = "turn-tui-inject"
+    sid = "sid-tui-inject"
+    agent = types.SimpleNamespace(
+        _active_turn_id=turn_id,
+        _iteration_calls_made=0,
+        max_iterations=1,
+        session_id="",
+    )
+    sess = _session(
+        agent=agent,
+        running=True,
+        session_key="session-tui-inject",
+    )
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-inject",
+        "delivery_event_key": "task:0",
+        "result_delivery": "inject",
+        "parent_turn_id": turn_id,
+        "origin_ui_session_id": sid,
+        "session_key": "session-tui-inject",
+    }
+    isolated_queue.put(event)
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc", "content": "working"},
+    ]
+    drained = {}
+    drain_done = threading.Event()
+
+    def _drain():
+        drained["count"] = inject_mod.attach_ready_injects_to_tool_results(
+            agent, messages, 1, turn_id=turn_id
+        )
+        drain_done.set()
+
+    poller_thread = threading.Thread(
+        target=server._notification_poller_loop,
+        args=(stop_poller, sid, sess),
+    )
+    drain_thread = threading.Thread(target=_drain)
+
+    try:
+        poller_thread.start()
+        assert dequeued.wait(3), "TUI poller did not dequeue the inject event"
+        drain_thread.start()
+
+        # The active loop must wait for the poller's atomic route/requeue section;
+        # returning here would miss a ready same-turn result because the queue is
+        # temporarily empty.
+        assert not drain_done.wait(0.5)
+
+        release_dequeue.set()
+        poller_thread.join(3)
+        drain_thread.join(3)
+
+        assert not poller_thread.is_alive()
+        assert not drain_thread.is_alive()
+        assert drained == {"count": 1}
+        assert messages[-1]["role"] == "tool"
+        assert "ready" in messages[-1]["content"]
+        assert len(claims) == 1
+        assert claims[0][0] == "task:0"
+        assert claims[0][1].startswith("tool-boundary:")
+        assert isolated_queue.empty()
+    finally:
+        release_dequeue.set()
+        stop_poller.set()
+        poller_thread.join(3)
+        drain_thread.join(3)
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def test_tui_claim_loss_does_not_leave_session_busy(monkeypatch):
     """A competing durable consumer cannot strand the TUI in running state."""
     import queue as _queue_mod

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -18220,7 +18220,7 @@ def test_busy_tui_poller_cannot_hide_inject_from_tool_boundary(monkeypatch):
 
     import agent.delegation_inject as inject_mod
     import tools.async_delegation as delegation_mod
-    import tools.process_registry as registry_mod
+    import tools.process_registry_notifications as registry_mod
     from tools.process_registry import process_registry
 
     dequeued = threading.Event()
@@ -18256,7 +18256,7 @@ def test_busy_tui_poller_cannot_hide_inject_from_tool_boundary(monkeypatch):
         _active_turn_id=turn_id,
         _iteration_calls_made=0,
         max_iterations=1,
-        session_id="",
+        session_id="parent-tui-inject",
     )
     sess = _session(
         agent=agent,
@@ -18269,6 +18269,7 @@ def test_busy_tui_poller_cannot_hide_inject_from_tool_boundary(monkeypatch):
         "delivery_event_key": "task:0",
         "result_delivery": "inject",
         "parent_turn_id": turn_id,
+        "parent_session_id": "parent-tui-inject",
         "origin_ui_session_id": sid,
         "session_key": "session-tui-inject",
     }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -18214,6 +18214,123 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
+def test_busy_tui_poller_cannot_hide_inject_from_tool_boundary(monkeypatch):
+    """A dequeued/requeued TUI event remains atomic with its tool carrier."""
+    import queue as _queue_mod
+
+    import agent.delegation_inject as inject_mod
+    import tools.async_delegation as delegation_mod
+    import tools.process_registry as registry_mod
+    from tools.process_registry import process_registry
+
+    dequeued = threading.Event()
+    release_dequeue = threading.Event()
+    stop_poller = threading.Event()
+
+    class _PausedAfterDequeueQueue(_queue_mod.Queue):
+        def get(self, block=True, timeout=None):
+            event = super().get(block=block, timeout=timeout)
+            dequeued.set()
+            if not release_dequeue.wait(3):
+                raise TimeoutError("test did not release paused TUI dequeue")
+            stop_poller.set()
+            return event
+
+    isolated_queue = _PausedAfterDequeueQueue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(registry_mod, "format_process_notification", lambda _evt: "ready")
+    monkeypatch.setattr(registry_mod, "_format_async_delegation", lambda _evt: "ready")
+    monkeypatch.setattr(inject_mod, "ensure_pending_inject_heartbeat", lambda _agent: True)
+
+    claims = []
+
+    def _claim(event, owner):
+        claims.append((event["delivery_event_key"], owner))
+        return "claim-active-loop"
+
+    monkeypatch.setattr(delegation_mod, "claim_event_delivery", _claim)
+
+    turn_id = "turn-tui-inject"
+    sid = "sid-tui-inject"
+    agent = types.SimpleNamespace(
+        _active_turn_id=turn_id,
+        _iteration_calls_made=0,
+        max_iterations=1,
+        session_id="",
+    )
+    sess = _session(
+        agent=agent,
+        running=True,
+        session_key="session-tui-inject",
+    )
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-inject",
+        "delivery_event_key": "task:0",
+        "result_delivery": "inject",
+        "parent_turn_id": turn_id,
+        "origin_ui_session_id": sid,
+        "session_key": "session-tui-inject",
+    }
+    isolated_queue.put(event)
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "tc", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc", "content": "working"},
+    ]
+    drained = {}
+    drain_done = threading.Event()
+
+    def _drain():
+        drained["count"] = inject_mod.attach_ready_injects_to_tool_results(
+            agent, messages, 1, turn_id=turn_id
+        )
+        drain_done.set()
+
+    poller_thread = threading.Thread(
+        target=server._notification_poller_loop,
+        args=(stop_poller, sid, sess),
+    )
+    drain_thread = threading.Thread(target=_drain)
+
+    try:
+        poller_thread.start()
+        assert dequeued.wait(3), "TUI poller did not dequeue the inject event"
+        drain_thread.start()
+
+        # The active loop must wait for the poller's atomic route/requeue section;
+        # returning here would miss a ready same-turn result because the queue is
+        # temporarily empty.
+        assert not drain_done.wait(0.5)
+
+        release_dequeue.set()
+        poller_thread.join(3)
+        drain_thread.join(3)
+
+        assert not poller_thread.is_alive()
+        assert not drain_thread.is_alive()
+        assert drained == {"count": 1}
+        assert messages[-1]["role"] == "tool"
+        assert "ready" in messages[-1]["content"]
+        assert len(claims) == 1
+        assert claims[0][0] == "task:0"
+        assert claims[0][1].startswith("tool-boundary:")
+        assert isolated_queue.empty()
+    finally:
+        release_dequeue.set()
+        stop_poller.set()
+        poller_thread.join(3)
+        drain_thread.join(3)
+        server._sessions.pop(sid, None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def test_tui_claim_loss_does_not_leave_session_busy(monkeypatch):
     """A competing durable consumer cannot strand the TUI in running state."""
     import queue as _queue_mod

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -623,12 +623,11 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
-def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+def test_real_batch_publishes_finished_child_before_sibling_join(monkeypatch):
     """The production aggregation callback closes the partial-crash window.
 
-    PR1 deliberately preserves legacy delivery timing: a finished child is
-    durable while its sibling is still running, but nothing reaches the shared
-    completion queue until the aggregate batch finalizes.
+    PR2 keeps PR1's pre-join durability and additionally makes the finished
+    child visible on the shared completion queue before its sibling finishes.
     """
     from unittest.mock import MagicMock
     import tools.delegate_tool as dt
@@ -642,7 +641,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
 
     fake_child = MagicMock()
     fake_child._delegate_role = "leaf"
-    first_persisted = threading.Event()
+    first_published = threading.Event()
     release_sibling = threading.Event()
     sibling_returned = threading.Event()
 
@@ -660,12 +659,12 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
             "exit_reason": "completed",
         }
 
-    real_persist = ad.persist_batch_child_completion
+    real_publish = ad.publish_batch_child_completion
 
-    def observe_persist(delegation_id, task_index, result):
-        inserted = real_persist(delegation_id, task_index, result)
+    def observe_publish(delegation_id, task_index, result):
+        inserted = real_publish(delegation_id, task_index, result)
         if task_index == 0 and inserted:
-            first_persisted.set()
+            first_published.set()
         return inserted
 
     creds = {
@@ -675,7 +674,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
     monkeypatch.setattr(dt, "_run_single_child", child_result)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
-    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+    monkeypatch.setattr(ad, "publish_batch_child_completion", observe_publish)
 
     out = dt.delegate_task(
         tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
@@ -687,7 +686,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
 
     try:
         assert parsed["status"] == "dispatched"
-        assert first_persisted.wait(timeout=5)
+        assert first_published.wait(timeout=5)
         with ad._DB_LOCK, ad._transaction() as conn:
             rows = conn.execute(
                 "SELECT event_key FROM async_delegation_events "
@@ -695,6 +694,8 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
                 (delegation_id,),
             ).fetchall()
         assert rows == [("task:0",)]
+        queued = process_registry.completion_queue.get_nowait()
+        assert queued["delivery_event_key"] == "task:0"
         assert process_registry.completion_queue.empty()
 
         # Simulate the owner disappearing in this exact pre-join state. Recovery

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -946,3 +946,102 @@ def test_batch_model_rejection_notice_requires_configured_model_in_text(monkeypa
     text = format_process_notification(evt)
     assert text is not None
     assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+    """The production aggregation callback closes the partial-crash window.
+
+    PR1 deliberately preserves legacy delivery timing: a finished child is
+    durable while its sibling is still running, but nothing reaches the shared
+    completion queue until the aggregate batch finalizes.
+    """
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "partial-crash-parent"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    first_persisted = threading.Event()
+    release_sibling = threading.Event()
+    sibling_returned = threading.Event()
+
+    def child_result(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 1:
+            assert release_sibling.wait(timeout=10)
+            sibling_returned.set()
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    real_persist = ad.persist_batch_child_completion
+
+    def observe_persist(delegation_id, task_index, result):
+        inserted = real_persist(delegation_id, task_index, result)
+        if task_index == 0 and inserted:
+            first_persisted.set()
+        return inserted
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", child_result)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+
+    out = dt.delegate_task(
+        tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
+        background=True,
+        parent_agent=parent,
+    )
+    parsed = json.loads(out)
+    delegation_id = parsed["delegation_id"]
+
+    try:
+        assert parsed["status"] == "dispatched"
+        assert first_persisted.wait(timeout=5)
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",)]
+        assert process_registry.completion_queue.empty()
+
+        # Simulate the owner disappearing in this exact pre-join state. Recovery
+        # must use the real callback's durable child row, not a test-fabricated row.
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+                "WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert ad.recover_abandoned_delegations() == 1
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",), ("terminal",)]
+    finally:
+        # A real crash would remove the worker and memory record. Make the
+        # in-process simulation match that before releasing the daemon child.
+        with ad._records_lock:
+            ad._records.pop(delegation_id, None)
+        release_sibling.set()
+        assert sibling_returned.wait(timeout=5)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -948,12 +948,11 @@ def test_batch_model_rejection_notice_requires_configured_model_in_text(monkeypa
     assert "SUBAGENT MODEL REJECTED" not in text
 
 
-def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+def test_real_batch_publishes_finished_child_before_sibling_join(monkeypatch):
     """The production aggregation callback closes the partial-crash window.
 
-    PR1 deliberately preserves legacy delivery timing: a finished child is
-    durable while its sibling is still running, but nothing reaches the shared
-    completion queue until the aggregate batch finalizes.
+    PR2 keeps PR1's pre-join durability and additionally makes the finished
+    child visible on the shared completion queue before its sibling finishes.
     """
     from unittest.mock import MagicMock
     import tools.delegate_tool as dt
@@ -967,7 +966,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
 
     fake_child = MagicMock()
     fake_child._delegate_role = "leaf"
-    first_persisted = threading.Event()
+    first_published = threading.Event()
     release_sibling = threading.Event()
     sibling_returned = threading.Event()
 
@@ -985,12 +984,12 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
             "exit_reason": "completed",
         }
 
-    real_persist = ad.persist_batch_child_completion
+    real_publish = ad.publish_batch_child_completion
 
-    def observe_persist(delegation_id, task_index, result):
-        inserted = real_persist(delegation_id, task_index, result)
+    def observe_publish(delegation_id, task_index, result):
+        inserted = real_publish(delegation_id, task_index, result)
         if task_index == 0 and inserted:
-            first_persisted.set()
+            first_published.set()
         return inserted
 
     creds = {
@@ -1000,7 +999,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
     monkeypatch.setattr(dt, "_run_single_child", child_result)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
-    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+    monkeypatch.setattr(ad, "publish_batch_child_completion", observe_publish)
 
     out = dt.delegate_task(
         tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
@@ -1012,7 +1011,7 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
 
     try:
         assert parsed["status"] == "dispatched"
-        assert first_persisted.wait(timeout=5)
+        assert first_published.wait(timeout=5)
         with ad._DB_LOCK, ad._transaction() as conn:
             rows = conn.execute(
                 "SELECT event_key FROM async_delegation_events "
@@ -1020,6 +1019,8 @@ def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
                 (delegation_id,),
             ).fetchall()
         assert rows == [("task:0",)]
+        queued = process_registry.completion_queue.get_nowait()
+        assert queued["delivery_event_key"] == "task:0"
         assert process_registry.completion_queue.empty()
 
         # Simulate the owner disappearing in this exact pre-join state. Recovery

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -623,6 +623,105 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_real_batch_persists_finished_child_before_sibling_join(monkeypatch):
+    """The production aggregation callback closes the partial-crash window.
+
+    PR1 deliberately preserves legacy delivery timing: a finished child is
+    durable while its sibling is still running, but nothing reaches the shared
+    completion queue until the aggregate batch finalizes.
+    """
+    from unittest.mock import MagicMock
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "partial-crash-parent"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    first_persisted = threading.Event()
+    release_sibling = threading.Event()
+    sibling_returned = threading.Event()
+
+    def child_result(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 1:
+            assert release_sibling.wait(timeout=10)
+            sibling_returned.set()
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    real_persist = ad.persist_batch_child_completion
+
+    def observe_persist(delegation_id, task_index, result):
+        inserted = real_persist(delegation_id, task_index, result)
+        if task_index == 0 and inserted:
+            first_persisted.set()
+        return inserted
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", child_result)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(ad, "persist_batch_child_completion", observe_persist)
+
+    out = dt.delegate_task(
+        tasks=[{"goal": "fast child"}, {"goal": "blocked child"}],
+        background=True,
+        parent_agent=parent,
+    )
+    parsed = json.loads(out)
+    delegation_id = parsed["delegation_id"]
+
+    try:
+        assert parsed["status"] == "dispatched"
+        assert first_persisted.wait(timeout=5)
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",)]
+        assert process_registry.completion_queue.empty()
+
+        # Simulate the owner disappearing in this exact pre-join state. Recovery
+        # must use the real callback's durable child row, not a test-fabricated row.
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+                "WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert ad.recover_abandoned_delegations() == 1
+        with ad._DB_LOCK, ad._transaction() as conn:
+            rows = conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        assert rows == [("task:0",), ("terminal",)]
+    finally:
+        # A real crash would remove the worker and memory record. Make the
+        # in-process simulation match that before releasing the daemon child.
+        with ad._records_lock:
+            ad._records.pop(delegation_id, None)
+        release_sibling.set()
+        assert sibling_returned.wait(timeout=5)
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -1,0 +1,390 @@
+"""Durable child-event ledger contracts for async delegation batches."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_state():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _record(
+    *,
+    goals=("audit",),
+    parent_session_id="parent-session",
+):
+    delegation_id = f"deleg_test_{uuid.uuid4().hex}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": goals[0] if len(goals) == 1 else f"{len(goals)} tasks",
+        "goals": list(goals),
+        "context": "parent context",
+        "toolsets": ["file"],
+        "role": "leaf",
+        "model": "child-model",
+        "session_key": "agent:main:cli:dm:local",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": parent_session_id,
+        "status": "running",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "is_batch": True,
+    }
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    ad._persist_dispatch(record)
+    return delegation_id
+
+
+def _child(index: int, summary: str, *, status="completed", error=None):
+    return {
+        "task_index": index,
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": 2,
+        "duration_seconds": 0.25,
+    }
+
+
+def _queue_contents():
+    items = []
+    while not process_registry.completion_queue.empty():
+        items.append(process_registry.completion_queue.get_nowait())
+    for item in items:
+        process_registry.completion_queue.put(item)
+    return items
+
+
+def _event_state(delegation_id: str, event_key: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegation_events "
+            "WHERE delegation_id=? AND event_key=?",
+            (delegation_id, event_key),
+        ).fetchone()
+
+
+def _parent_state(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _durable_event_keys(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        ]
+
+def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
+    delegation_id = _record(goals=("A", "B"), )
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+
+    competing_claim = ad.claim_event_delivery(children[1], "competing-consumer")
+    assert competing_claim
+    assert ad.claim_event_delivery(grouped, "group-consumer") is None
+    # task:0's attempted group claim rolled back with the task:1 conflict.
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert _event_state(delegation_id, "task:1") == ("pending", 1)
+
+    assert ad.release_event_delivery(children[1], competing_claim)
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.complete_event_delivery(grouped, group_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert _event_state(delegation_id, "task:1") == ("delivered", 2)
+
+
+def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
+    delegation_id = _record(goals=("fresh", "near-cap"), )
+    for index, summary in enumerate(("fresh", "near-cap")):
+        assert ad.publish_batch_child_completion(
+            delegation_id, index, _child(index, summary)
+        )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    near_cap = children[1]
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS - 1):
+        claim = ad.claim_event_delivery(near_cap, "failing-consumer")
+        assert claim
+        assert ad.release_event_delivery(near_cap, claim)
+
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.release_event_delivery(grouped, group_claim)
+
+    assert grouped["delivery_event_keys"] == ["task:0"]
+    assert [result["summary"] for result in grouped["results"]] == ["fresh"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert _event_state(delegation_id, "task:1") == (
+        "dropped",
+        ad._MAX_DELIVERY_ATTEMPTS,
+    )
+    retry_claim = ad.claim_event_delivery(grouped, "retry-consumer")
+    assert retry_claim
+    assert ad.complete_event_delivery(grouped, retry_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 2)
+
+def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+    monkeypatch,
+):
+    delegation_id = _record(goals=("A", "B"))
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [_child(0, "A"), _child(1, "B")]}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "completed_at": time.time(),
+    }
+
+    def crash_before_parent_update(*_args, **_kwargs):
+        raise RuntimeError("simulated crash before parent terminal update")
+
+    monkeypatch.setattr(ad, "_update_completion_row", crash_before_parent_update)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        ad._persist_batch_child_finalization(
+            event_record, parent_event, combined, "completed"
+        )
+
+    assert _durable_event_keys(delegation_id) == []
+    assert _parent_state(delegation_id) == ("running", "pending")
+
+
+def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
+    delegation_id = _record(goals=("A", "B"), )
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    children = [_child(0, "A"), _child(1, "B")]
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_persisted_children_wait_for_legacy_batch_finalization():
+    delegation_id = _record(goals=("A", "B"))
+    children = [_child(0, "A"), _child(1, "B")]
+
+    assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
+    assert ad.persist_batch_child_completion(delegation_id, 1, children[1])
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    assert process_registry.completion_queue.empty()
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_published_child_is_not_requeued_by_batch_finalization():
+    delegation_id = _record(goals=("A",))
+    child = _child(0, "A")
+    assert ad.publish_batch_child_completion(delegation_id, 0, child)
+    assert process_registry.completion_queue.qsize() == 1
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [child], "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": [child],
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    assert process_registry.completion_queue.qsize() == 1
+    event = process_registry.completion_queue.get_nowait()
+    assert event["delivery_event_key"] == "task:0"
+
+
+def test_recovery_with_complete_children_suppresses_parent_aggregate():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("completed", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    grouped = restored.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert restored.empty()
+
+
+def test_recovery_with_partial_children_emits_only_terminal_gap_event():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "terminal"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    events = [restored.get_nowait() for _ in range(2)]
+    assert {
+        key
+        for event in events
+        for key in event.get("delivery_event_keys")
+        or [event.get("delivery_event_key")]
+    } == {
+        "task:0",
+        "terminal",
+    }
+    terminal = next(
+        event for event in events if event.get("delivery_event_key") == "terminal"
+    )
+    assert terminal["status"] == "unknown"
+    assert "1/2 batch child results" in terminal["error"]
+
+
+def test_recovery_requires_exact_expected_batch_child_keys():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    rogue = ad._build_batch_child_event(event_record, 99, _child(99, "rogue"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        assert ad._insert_batch_event(conn, rogue, now=time.time())
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:99", "terminal"]
+
+def test_durable_claim_renewal_prevents_expiry_steal():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "renew durable lease")
+    )
+    event = process_registry.completion_queue.get_nowait()
+    claim = ad.claim_event_delivery(event, "slow-main")
+    assert claim
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegation_events SET delivery_claimed_at=0 "
+            "WHERE delegation_id=? AND event_key='task:0'",
+            (delegation_id,),
+        )
+
+    assert ad.renew_event_delivery(event, claim) is True
+    assert ad.claim_event_delivery(event, "competing-main") is None
+    assert ad.complete_event_delivery(event, claim) is True
+
+def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = _record(goals=("restore me",))
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "restored result")
+    )
+    process_registry.completion_queue.get_nowait()
+
+    restored_queue = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    event = restored_queue.get_nowait()
+    assert event["restored"] is True
+    assert event["delegation_id"] == delegation_id
+    assert event["delivery_event_keys"] == ["task:0"]
+
+    claim = ad.claim_event_delivery(event, "restart-consumer")
+    assert claim
+    ad.complete_event_delivery(event, claim)
+    assert ad.restore_undelivered_completions(restored_queue) == 0

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -28,6 +28,8 @@ def _clean_async_state():
 def _record(
     *,
     goals=("audit",),
+    turn_id="turn-current",
+    delivery="inject",
     parent_session_id="parent-session",
 ):
     delegation_id = f"deleg_test_{uuid.uuid4().hex}"
@@ -43,10 +45,12 @@ def _record(
         "origin_ui_session_id": "",
         "origin_session_id": "",
         "parent_session_id": parent_session_id,
+        "parent_turn_id": turn_id,
         "status": "running",
         "dispatched_at": time.time(),
         "completed_at": None,
         "is_batch": True,
+        "result_delivery": delivery,
     }
     with ad._records_lock:
         ad._records[delegation_id] = record
@@ -104,7 +108,7 @@ def _durable_event_keys(delegation_id: str):
         ]
 
 def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
-    delegation_id = _record(goals=("A", "B"), )
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
     children = [
@@ -129,7 +133,7 @@ def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
 
 
 def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
-    delegation_id = _record(goals=("fresh", "near-cap"), )
+    delegation_id = _record(goals=("fresh", "near-cap"), delivery="after_turn")
     for index, summary in enumerate(("fresh", "near-cap")):
         assert ad.publish_batch_child_completion(
             delegation_id, index, _child(index, summary)
@@ -161,7 +165,7 @@ def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
     assert ad.complete_event_delivery(grouped, retry_claim)
     assert _event_state(delegation_id, "task:0") == ("delivered", 2)
 
-def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+def test_inject_batch_finalization_rolls_back_children_if_parent_update_fails(
     monkeypatch,
 ):
     delegation_id = _record(goals=("A", "B"))
@@ -189,7 +193,7 @@ def test_batch_finalization_rolls_back_children_if_parent_update_fails(
 
 
 def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
-    delegation_id = _record(goals=("A", "B"), )
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     with ad._records_lock:
         event_record = dict(ad._records[delegation_id])
     children = [_child(0, "A"), _child(1, "B")]
@@ -214,7 +218,7 @@ def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
 
 
 def test_persisted_children_wait_for_legacy_batch_finalization():
-    delegation_id = _record(goals=("A", "B"))
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     children = [_child(0, "A"), _child(1, "B")]
 
     assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
@@ -244,8 +248,9 @@ def test_persisted_children_wait_for_legacy_batch_finalization():
     assert process_registry.completion_queue.empty()
 
 
-def test_published_child_is_not_requeued_by_batch_finalization():
-    delegation_id = _record(goals=("A",))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_published_child_is_not_requeued_by_batch_finalization(delivery):
+    delegation_id = _record(goals=("A",), delivery=delivery)
     child = _child(0, "A")
     assert ad.publish_batch_child_completion(delegation_id, 0, child)
     assert process_registry.completion_queue.qsize() == 1
@@ -269,10 +274,12 @@ def test_published_child_is_not_requeued_by_batch_finalization():
     assert process_registry.completion_queue.qsize() == 1
     event = process_registry.completion_queue.get_nowait()
     assert event["delivery_event_key"] == "task:0"
+    assert event["result_delivery"] == delivery
 
 
-def test_recovery_with_complete_children_suppresses_parent_aggregate():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_with_complete_children_suppresses_parent_aggregate(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
     while not process_registry.completion_queue.empty():
@@ -290,14 +297,21 @@ def test_recovery_with_complete_children_suppresses_parent_aggregate():
     assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
     restored = __import__("queue").Queue()
     assert ad.restore_undelivered_completions(restored) == 2
-    grouped = restored.get_nowait()
-    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
-    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
-    assert restored.empty()
+    if delivery == "after_turn":
+        grouped = restored.get_nowait()
+        assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+        assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+        assert restored.empty()
+    else:
+        assert {restored.get_nowait()["delivery_event_key"] for _ in range(2)} == {
+            "task:0",
+            "task:1",
+        }
 
 
-def test_recovery_with_partial_children_emits_only_terminal_gap_event():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_with_partial_children_emits_only_terminal_gap_event(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     process_registry.completion_queue.get_nowait()
     with ad._DB_LOCK, ad._transaction() as conn:
@@ -327,11 +341,13 @@ def test_recovery_with_partial_children_emits_only_terminal_gap_event():
         event for event in events if event.get("delivery_event_key") == "terminal"
     )
     assert terminal["status"] == "unknown"
+    assert terminal["result_delivery"] == delivery
     assert "1/2 batch child results" in terminal["error"]
 
 
-def test_recovery_requires_exact_expected_batch_child_keys():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_requires_exact_expected_batch_child_keys(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     process_registry.completion_queue.get_nowait()
     with ad._records_lock:
@@ -382,7 +398,7 @@ def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monke
     event = restored_queue.get_nowait()
     assert event["restored"] is True
     assert event["delegation_id"] == delegation_id
-    assert event["delivery_event_keys"] == ["task:0"]
+    assert event["delivery_event_key"] == "task:0"
 
     claim = ad.claim_event_delivery(event, "restart-consumer")
     assert claim

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -1,0 +1,438 @@
+"""Durable child-event ledger contracts for async delegation batches."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_state():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _record(
+    *,
+    goals=("audit",),
+    parent_session_id="parent-session",
+):
+    delegation_id = f"deleg_test_{uuid.uuid4().hex}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": goals[0] if len(goals) == 1 else f"{len(goals)} tasks",
+        "goals": list(goals),
+        "context": "parent context",
+        "toolsets": ["file"],
+        "role": "leaf",
+        "model": "child-model",
+        "session_key": "agent:main:cli:dm:local",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": parent_session_id,
+        "status": "running",
+        "dispatched_at": time.time(),
+        "completed_at": None,
+        "is_batch": True,
+    }
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    ad._persist_dispatch(record)
+    return delegation_id
+
+
+def _child(index: int, summary: str, *, status="completed", error=None):
+    return {
+        "task_index": index,
+        "status": status,
+        "summary": summary,
+        "error": error,
+        "api_calls": 2,
+        "duration_seconds": 0.25,
+    }
+
+
+def _queue_contents():
+    items = []
+    while not process_registry.completion_queue.empty():
+        items.append(process_registry.completion_queue.get_nowait())
+    for item in items:
+        process_registry.completion_queue.put(item)
+    return items
+
+
+def _event_state(delegation_id: str, event_key: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegation_events "
+            "WHERE delegation_id=? AND event_key=?",
+            (delegation_id, event_key),
+        ).fetchone()
+
+
+def _parent_state(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _durable_event_keys(delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT event_key FROM async_delegation_events "
+                "WHERE delegation_id=? ORDER BY event_key",
+                (delegation_id,),
+            ).fetchall()
+        ]
+
+def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
+    delegation_id = _record(goals=("A", "B"), )
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+
+    competing_claim = ad.claim_event_delivery(children[1], "competing-consumer")
+    assert competing_claim
+    assert ad.claim_event_delivery(grouped, "group-consumer") is None
+    # task:0's attempted group claim rolled back with the task:1 conflict.
+    assert _event_state(delegation_id, "task:0") == ("pending", 0)
+    assert _event_state(delegation_id, "task:1") == ("pending", 1)
+
+    assert ad.release_event_delivery(children[1], competing_claim)
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.complete_event_delivery(grouped, group_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 1)
+    assert _event_state(delegation_id, "task:1") == ("delivered", 2)
+
+
+def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
+    delegation_id = _record(goals=("fresh", "near-cap"), )
+    for index, summary in enumerate(("fresh", "near-cap")):
+        assert ad.publish_batch_child_completion(
+            delegation_id, index, _child(index, summary)
+        )
+    children = [
+        process_registry.completion_queue.get_nowait(),
+        process_registry.completion_queue.get_nowait(),
+    ]
+    near_cap = children[1]
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS - 1):
+        claim = ad.claim_event_delivery(near_cap, "failing-consumer")
+        assert claim
+        assert ad.release_event_delivery(near_cap, claim)
+
+    grouped = ad.coalesce_ready_after_turn_events(children)[0]
+    group_claim = ad.claim_event_delivery(grouped, "group-consumer")
+    assert group_claim
+    assert ad.release_event_delivery(grouped, group_claim)
+
+    assert grouped["delivery_event_keys"] == ["task:0"]
+    assert [result["summary"] for result in grouped["results"]] == ["fresh"]
+    assert _event_state(delegation_id, "task:0") == ("pending", 1)
+    assert _event_state(delegation_id, "task:1") == (
+        "dropped",
+        ad._MAX_DELIVERY_ATTEMPTS,
+    )
+    retry_claim = ad.claim_event_delivery(grouped, "retry-consumer")
+    assert retry_claim
+    assert ad.complete_event_delivery(grouped, retry_claim)
+    assert _event_state(delegation_id, "task:0") == ("delivered", 2)
+
+def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+    monkeypatch,
+):
+    delegation_id = _record(goals=("A", "B"))
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [_child(0, "A"), _child(1, "B")]}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "completed_at": time.time(),
+    }
+
+    def crash_before_parent_update(*_args, **_kwargs):
+        raise RuntimeError("simulated crash before parent terminal update")
+
+    monkeypatch.setattr(ad, "_update_completion_row", crash_before_parent_update)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        ad._persist_batch_child_finalization(
+            event_record, parent_event, combined, "completed"
+        )
+
+    assert _durable_event_keys(delegation_id) == []
+    assert _parent_state(delegation_id) == ("running", "pending")
+
+
+def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
+    delegation_id = _record(goals=("A", "B"), )
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    children = [_child(0, "A"), _child(1, "B")]
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_persisted_children_wait_for_legacy_batch_finalization():
+    delegation_id = _record(goals=("A", "B"))
+    children = [_child(0, "A"), _child(1, "B")]
+
+    assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
+    assert ad.persist_batch_child_completion(delegation_id, 1, children[1])
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    assert process_registry.completion_queue.empty()
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": children, "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": children,
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    grouped = process_registry.completion_queue.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert process_registry.completion_queue.empty()
+
+
+def test_published_child_is_not_requeued_by_batch_finalization():
+    delegation_id = _record(goals=("A",))
+    child = _child(0, "A")
+    assert ad.publish_batch_child_completion(delegation_id, 0, child)
+    assert process_registry.completion_queue.qsize() == 1
+
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    combined = {"results": [child], "total_duration_seconds": 0.1}
+    parent_event = {
+        **event_record,
+        "type": "async_delegation",
+        "status": "completed",
+        "is_batch": True,
+        "results": [child],
+        "completed_at": time.time(),
+    }
+
+    ad._persist_batch_child_finalization(
+        event_record, parent_event, combined, "completed"
+    )
+
+    assert process_registry.completion_queue.qsize() == 1
+    event = process_registry.completion_queue.get_nowait()
+    assert event["delivery_event_key"] == "task:0"
+
+
+def test_recovery_with_complete_children_suppresses_parent_aggregate():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("completed", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    grouped = restored.get_nowait()
+    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+    assert restored.empty()
+
+
+def test_recovery_with_partial_children_emits_only_terminal_gap_event():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "terminal"]
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 2
+    events = [restored.get_nowait() for _ in range(2)]
+    assert {
+        key
+        for event in events
+        for key in event.get("delivery_event_keys")
+        or [event.get("delivery_event_key")]
+    } == {
+        "task:0",
+        "terminal",
+    }
+    terminal = next(
+        event for event in events if event.get("delivery_event_key") == "terminal"
+    )
+    assert terminal["status"] == "unknown"
+    assert "1/2 batch child results" in terminal["error"]
+
+
+def test_recovery_requires_exact_expected_batch_child_keys():
+    delegation_id = _record(goals=("A", "B"))
+    assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
+    process_registry.completion_queue.get_nowait()
+    with ad._records_lock:
+        event_record = dict(ad._records[delegation_id])
+    rogue = ad._build_batch_child_event(event_record, 99, _child(99, "rogue"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        assert ad._insert_batch_event(conn, rogue, now=time.time())
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=99999999, owner_started_at=0 "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    assert _parent_state(delegation_id) == ("unknown", "delivered")
+    assert _durable_event_keys(delegation_id) == ["task:0", "task:99", "terminal"]
+
+def test_durable_claim_renewal_prevents_expiry_steal():
+    delegation_id = _record()
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "renew durable lease")
+    )
+    event = process_registry.completion_queue.get_nowait()
+    claim = ad.claim_event_delivery(event, "slow-main")
+    assert claim
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegation_events SET delivery_claimed_at=0 "
+            "WHERE delegation_id=? AND event_key='task:0'",
+            (delegation_id,),
+        )
+
+    assert ad.renew_event_delivery(event, claim) is True
+    assert ad.claim_event_delivery(event, "competing-main") is None
+    assert ad.complete_event_delivery(event, claim) is True
+
+def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = _record(goals=("restore me",))
+    assert ad.publish_batch_child_completion(
+        delegation_id, 0, _child(0, "restored result")
+    )
+    process_registry.completion_queue.get_nowait()
+
+    # A new process recovers an exited owner, not another live batch's hidden rows.
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("UPDATE async_delegations SET owner_pid=99999999 WHERE delegation_id=?", (delegation_id,))
+    restored_queue = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    event = restored_queue.get_nowait()
+    assert event["restored"] is True
+    assert event["delegation_id"] == delegation_id
+    assert event["delivery_event_keys"] == ["task:0"]
+
+    claim = ad.claim_event_delivery(event, "restart-consumer")
+    assert claim
+    ad.complete_event_delivery(event, claim)
+    assert ad.restore_undelivered_completions(restored_queue) == 0
+
+
+@pytest.mark.parametrize("age", [0, ad._MAX_COMPLETION_REPLAY_AGE_S + 10])
+def test_child_recovery_preserves_origin_and_replay_age(age):
+    """Child and terminal-gap recovery keep upstream route isolation and age limits."""
+    delegation_id = _record(goals=("ready child", "unfinished sibling"))
+    routing = {"scope_id": "tenant-a", "user_id": "user-a", "user_name": "Alice"}
+    with ad._records_lock:
+        ad._records[delegation_id].update(routing)
+        record = dict(ad._records[delegation_id])
+    ad._persist_dispatch(record)
+    assert ad.persist_batch_child_completion(delegation_id, 0, _child(0, "ready"))
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("UPDATE async_delegations SET owner_pid=99999999 WHERE delegation_id=?", (delegation_id,))
+        conn.execute("UPDATE async_delegation_events SET created_at=? WHERE delegation_id=?",
+                     (time.time() - age, delegation_id))
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == (1 if age else 2)
+    while not restored.empty():
+        event = restored.get_nowait()
+        assert {key: event.get(key) for key in routing} == routing
+    assert _event_state(delegation_id, "task:0")[0] == ("dropped" if age else "pending")
+
+
+def test_partial_batch_is_hidden_while_live_and_retained_until_settled(monkeypatch):
+    """Bookkeeping-only parent completion cannot make undelivered children disposable."""
+    delegation_id = _record(goals=("ready", "missing"))
+    assert ad.persist_batch_child_completion(delegation_id, 0, _child(0, "ready"))
+    restored = __import__("queue").Queue()
+    assert ad.restore_undelivered_completions(restored) == 0
+    with ad._records_lock:
+        record = dict(ad._records[delegation_id])
+    parent = {**record, "type": "async_delegation", "status": "error", "completed_at": time.time()}
+    # A post-child exception must still enqueue its durable result plus the terminal gap.
+    ad._persist_batch_child_finalization(record, parent, {"results": [], "error": "runner failed"}, "error")
+    assert process_registry.completion_queue.qsize() == 2
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 0)
+    ad._prune_durable_records()
+    assert set(_durable_event_keys(delegation_id)) == {"task:0", "terminal"}
+    while not process_registry.completion_queue.empty():
+        event = process_registry.completion_queue.get_nowait()
+        claim = ad.claim_event_delivery(event, "consumer")
+        assert ad.complete_event_delivery(event, claim)
+    ad._prune_durable_records()
+    assert _durable_event_keys(delegation_id) == []

--- a/tests/tools/test_async_delegation_events.py
+++ b/tests/tools/test_async_delegation_events.py
@@ -28,6 +28,8 @@ def _clean_async_state():
 def _record(
     *,
     goals=("audit",),
+    turn_id="turn-current",
+    delivery="inject",
     parent_session_id="parent-session",
 ):
     delegation_id = f"deleg_test_{uuid.uuid4().hex}"
@@ -43,10 +45,12 @@ def _record(
         "origin_ui_session_id": "",
         "origin_session_id": "",
         "parent_session_id": parent_session_id,
+        "parent_turn_id": turn_id,
         "status": "running",
         "dispatched_at": time.time(),
         "completed_at": None,
         "is_batch": True,
+        "result_delivery": delivery,
     }
     with ad._records_lock:
         ad._records[delegation_id] = record
@@ -104,7 +108,7 @@ def _durable_event_keys(delegation_id: str):
         ]
 
 def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
-    delegation_id = _record(goals=("A", "B"), )
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
     children = [
@@ -129,7 +133,7 @@ def test_after_turn_coalesced_claim_is_atomic_across_ready_children():
 
 
 def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
-    delegation_id = _record(goals=("fresh", "near-cap"), )
+    delegation_id = _record(goals=("fresh", "near-cap"), delivery="after_turn")
     for index, summary in enumerate(("fresh", "near-cap")):
         assert ad.publish_batch_child_completion(
             delegation_id, index, _child(index, summary)
@@ -161,7 +165,7 @@ def test_group_release_prunes_attempt_capped_child_without_blocking_sibling():
     assert ad.complete_event_delivery(grouped, retry_claim)
     assert _event_state(delegation_id, "task:0") == ("delivered", 2)
 
-def test_batch_finalization_rolls_back_children_if_parent_update_fails(
+def test_inject_batch_finalization_rolls_back_children_if_parent_update_fails(
     monkeypatch,
 ):
     delegation_id = _record(goals=("A", "B"))
@@ -189,7 +193,7 @@ def test_batch_finalization_rolls_back_children_if_parent_update_fails(
 
 
 def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
-    delegation_id = _record(goals=("A", "B"), )
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     with ad._records_lock:
         event_record = dict(ad._records[delegation_id])
     children = [_child(0, "A"), _child(1, "B")]
@@ -214,7 +218,7 @@ def test_after_turn_finalization_keeps_one_legacy_queue_envelope():
 
 
 def test_persisted_children_wait_for_legacy_batch_finalization():
-    delegation_id = _record(goals=("A", "B"))
+    delegation_id = _record(goals=("A", "B"), delivery="after_turn")
     children = [_child(0, "A"), _child(1, "B")]
 
     assert ad.persist_batch_child_completion(delegation_id, 0, children[0])
@@ -244,8 +248,9 @@ def test_persisted_children_wait_for_legacy_batch_finalization():
     assert process_registry.completion_queue.empty()
 
 
-def test_published_child_is_not_requeued_by_batch_finalization():
-    delegation_id = _record(goals=("A",))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_published_child_is_not_requeued_by_batch_finalization(delivery):
+    delegation_id = _record(goals=("A",), delivery=delivery)
     child = _child(0, "A")
     assert ad.publish_batch_child_completion(delegation_id, 0, child)
     assert process_registry.completion_queue.qsize() == 1
@@ -269,10 +274,12 @@ def test_published_child_is_not_requeued_by_batch_finalization():
     assert process_registry.completion_queue.qsize() == 1
     event = process_registry.completion_queue.get_nowait()
     assert event["delivery_event_key"] == "task:0"
+    assert event["result_delivery"] == delivery
 
 
-def test_recovery_with_complete_children_suppresses_parent_aggregate():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_with_complete_children_suppresses_parent_aggregate(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     assert ad.publish_batch_child_completion(delegation_id, 1, _child(1, "B"))
     while not process_registry.completion_queue.empty():
@@ -290,14 +297,21 @@ def test_recovery_with_complete_children_suppresses_parent_aggregate():
     assert _durable_event_keys(delegation_id) == ["task:0", "task:1"]
     restored = __import__("queue").Queue()
     assert ad.restore_undelivered_completions(restored) == 2
-    grouped = restored.get_nowait()
-    assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
-    assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
-    assert restored.empty()
+    if delivery == "after_turn":
+        grouped = restored.get_nowait()
+        assert grouped["delivery_event_keys"] == ["task:0", "task:1"]
+        assert [result["summary"] for result in grouped["results"]] == ["A", "B"]
+        assert restored.empty()
+    else:
+        assert {restored.get_nowait()["delivery_event_key"] for _ in range(2)} == {
+            "task:0",
+            "task:1",
+        }
 
 
-def test_recovery_with_partial_children_emits_only_terminal_gap_event():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_with_partial_children_emits_only_terminal_gap_event(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     process_registry.completion_queue.get_nowait()
     with ad._DB_LOCK, ad._transaction() as conn:
@@ -327,11 +341,13 @@ def test_recovery_with_partial_children_emits_only_terminal_gap_event():
         event for event in events if event.get("delivery_event_key") == "terminal"
     )
     assert terminal["status"] == "unknown"
+    assert terminal["result_delivery"] == delivery
     assert "1/2 batch child results" in terminal["error"]
 
 
-def test_recovery_requires_exact_expected_batch_child_keys():
-    delegation_id = _record(goals=("A", "B"))
+@pytest.mark.parametrize("delivery", ["inject", "after_turn"])
+def test_recovery_requires_exact_expected_batch_child_keys(delivery):
+    delegation_id = _record(goals=("A", "B"), delivery=delivery)
     assert ad.publish_batch_child_completion(delegation_id, 0, _child(0, "A"))
     process_registry.completion_queue.get_nowait()
     with ad._records_lock:
@@ -385,7 +401,7 @@ def test_pending_child_event_restores_with_same_durable_identity(tmp_path, monke
     event = restored_queue.get_nowait()
     assert event["restored"] is True
     assert event["delegation_id"] == delegation_id
-    assert event["delivery_event_keys"] == ["task:0"]
+    assert event["delivery_event_key"] == "task:0"
 
     claim = ad.claim_event_delivery(event, "restart-consumer")
     assert claim

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -107,6 +107,96 @@ def _patch_delegate(monkeypatch):
     return dt
 
 
+def test_after_turn_batch_delivers_ready_children_without_waiting_and_coalesces(monkeypatch):
+    """Ready siblings share one turn; an unfinished sibling cannot block them."""
+    dt = _patch_delegate(monkeypatch)
+    threading = __import__("threading")
+    slow_gate = threading.Event()
+    first_pair_ready = threading.Event()
+    ready_lock = threading.Lock()
+    ready_indices = set()
+
+    def staggered_child(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 2:
+            slow_gate.wait(timeout=5)
+        with ready_lock:
+            ready_indices.add(task_index)
+            if {0, 1}.issubset(ready_indices):
+                first_pair_ready.set()
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    monkeypatch.setattr(dt, "_run_single_child", staggered_child)
+    set_session_vars(
+        platform="telegram",
+        chat_id="7",
+        session_key="agent:main:telegram:dm:7",
+        session_id="parent-sess",
+        async_delivery=True,
+    )
+    parsed = json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": "task number zero"}, {"goal": "task number one"}, {"goal": "task number two"}],
+            background=True,
+            parent_agent=_fake_parent(),
+        )
+    )
+    assert parsed["status"] == "dispatched", parsed
+    assert first_pair_ready.wait(timeout=2)
+    publish_deadline = time.time() + 2
+    while process_registry.completion_queue.qsize() < 2 and time.time() < publish_deadline:
+        time.sleep(0.01)
+    assert process_registry.completion_queue.qsize() >= 2
+
+    drained = process_registry.drain_notifications(
+        owns_event=lambda _event: True,
+        skip_poll_observed=False,
+    )
+    assert len(drained) == 1
+    first_event, first_text = drained[0]
+    assert first_event["delivery_event_keys"] == ["task:0", "task:1"]
+    assert [result["task_index"] for result in first_event["results"]] == [0, 1]
+    assert "done: task number zero" in first_text
+    assert "done: task number one" in first_text
+    assert "done: task number two" not in first_text
+
+    import tools.async_delegation as ad
+
+    claim = ad.claim_event_delivery(first_event, "test-after-turn")
+    assert claim
+    assert ad.complete_event_delivery(first_event, claim)
+
+    slow_gate.set()
+    deadline = time.time() + 2
+    late = []
+    while time.time() < deadline and not late:
+        late = process_registry.drain_notifications(
+            owns_event=lambda _event: True,
+            skip_poll_observed=False,
+        )
+        if not late:
+            time.sleep(0.02)
+    assert len(late) == 1
+    late_event, late_text = late[0]
+    assert late_event["delivery_event_keys"] == ["task:2"]
+    assert [result["task_index"] for result in late_event["results"]] == [2]
+    assert "done: task number two" in late_text
+    claim = ad.claim_event_delivery(late_event, "test-after-turn")
+    assert claim
+    assert ad.complete_event_delivery(late_event, claim)
+    finalize_deadline = time.time() + 2
+    while ad.active_count() and time.time() < finalize_deadline:
+        time.sleep(0.01)
+    assert ad.active_count() == 0
+
+
 def test_apiserver_session_with_id_dispatches_background(monkeypatch):
     """async_delivery=False + a raw session id (HERMES_SESSION_ID) →
     background dispatch (the completion wakes the session via the

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -107,6 +107,69 @@ def _patch_delegate(monkeypatch):
     return dt
 
 
+def test_inject_batch_emits_fast_child_before_slow_child(monkeypatch):
+    """Exercise delegate_tool's real per-child callback seam, not just ledger APIs."""
+    dt = _patch_delegate(monkeypatch)
+    slow_gate = __import__("threading").Event()
+
+    def staggered_child(task_index, goal, child=None, parent_agent=None, **kw):
+        if task_index == 1:
+            slow_gate.wait(timeout=5)
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    monkeypatch.setattr(dt, "_run_single_child", staggered_child)
+    set_session_vars(
+        platform="telegram",
+        chat_id="7",
+        session_key="agent:main:telegram:dm:7",
+        session_id="parent-sess",
+        async_delivery=True,
+    )
+    parent = _fake_parent()
+    parent._active_turn_id = "turn-live"
+    parsed = json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": "fast child"}, {"goal": "slow child"}],
+            background=True,
+            result_delivery="inject",
+            parent_agent=parent,
+        )
+    )
+    assert parsed["status"] == "dispatched", parsed
+
+    first = _drain_one(timeout=2)
+    assert first is not None
+    assert first["delivery_event_key"] == "task:0"
+    assert first["parent_turn_id"] == "turn-live"
+    assert first["results"][0]["summary"] == "done: fast child"
+    import tools.async_delegation as ad
+
+    claim = ad.claim_event_delivery(first, "test-consumer")
+    assert claim
+    ad.complete_event_delivery(first, claim)
+
+    slow_gate.set()
+    second = _drain_one(timeout=2)
+    assert second is not None
+    assert second["delivery_event_key"] == "task:1"
+    assert second["results"][0]["summary"] == "done: slow child"
+    claim = ad.claim_event_delivery(second, "test-consumer")
+    assert claim
+    ad.complete_event_delivery(second, claim)
+    deadline = time.time() + 2
+    while ad.active_count() and time.time() < deadline:
+        time.sleep(0.01)
+    assert ad.active_count() == 0
+
+
 def test_after_turn_batch_delivers_ready_children_without_waiting_and_coalesces(monkeypatch):
     """Ready siblings share one turn; an unfinished sibling cannot block them."""
     dt = _patch_delegate(monkeypatch)
@@ -145,6 +208,7 @@ def test_after_turn_batch_delivers_ready_children_without_waiting_and_coalesces(
         dt.delegate_task(
             tasks=[{"goal": "task number zero"}, {"goal": "task number one"}, {"goal": "task number two"}],
             background=True,
+            result_delivery="after_turn",
             parent_agent=_fake_parent(),
         )
     )

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -145,6 +145,40 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
     return False
 
 
+def test_deferred_completion_put_failure_is_rescheduled(monkeypatch, registry):
+    import queue
+
+    import tools.async_delegation as delegation_mod
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-deferred-put-retry",
+        "delivery_event_key": "task:0",
+    }
+
+    class _FailOnceQueue(queue.Queue):
+        def __init__(self):
+            super().__init__()
+            self.put_attempts = 0
+
+        def put(self, item, block=True, timeout=None):
+            self.put_attempts += 1
+            if self.put_attempts == 1:
+                raise RuntimeError("synthetic transient put failure")
+            return super().put(item, block=block, timeout=timeout)
+
+    completion_queue = _FailOnceQueue()
+    registry.completion_queue = completion_queue
+    monkeypatch.setattr(
+        delegation_mod, "get_event_delivery_retry_delay", lambda _event: 0.0
+    )
+
+    assert registry.defer_unclaimed_delivery(event)
+    assert _wait_until(lambda: not completion_queue.empty())
+    assert completion_queue.get_nowait() == event
+    assert completion_queue.put_attempts == 2
+
+
 @pytest.mark.windows_only
 def test_write_stdin_uses_str_for_windows_pty(registry):
     """pywinpty expects str input; bytes raises a PyString conversion error.

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -144,6 +144,40 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
     return False
 
 
+def test_deferred_completion_put_failure_is_rescheduled(monkeypatch, registry):
+    import queue
+
+    import tools.async_delegation as delegation_mod
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-deferred-put-retry",
+        "delivery_event_key": "task:0",
+    }
+
+    class _FailOnceQueue(queue.Queue):
+        def __init__(self):
+            super().__init__()
+            self.put_attempts = 0
+
+        def put(self, item, block=True, timeout=None):
+            self.put_attempts += 1
+            if self.put_attempts == 1:
+                raise RuntimeError("synthetic transient put failure")
+            return super().put(item, block=block, timeout=timeout)
+
+    completion_queue = _FailOnceQueue()
+    registry.completion_queue = completion_queue
+    monkeypatch.setattr(
+        delegation_mod, "get_event_delivery_retry_delay", lambda _event: 0.0
+    )
+
+    assert registry.defer_unclaimed_delivery(event)
+    assert _wait_until(lambda: not completion_queue.empty())
+    assert completion_queue.get_nowait() == event
+    assert completion_queue.put_attempts == 2
+
+
 def test_write_stdin_uses_str_for_windows_pty(monkeypatch, registry):
     """pywinpty expects str input; bytes raises a PyString conversion error."""
     written = []

--- a/tests/tools/test_ready_set_port.py
+++ b/tests/tools/test_ready_set_port.py
@@ -1,0 +1,46 @@
+"""Boundary regressions for the ready-set port onto extracted consumers."""
+
+import threading
+
+from tools import async_delegation as ad
+from tools.process_registry import ProcessRegistry
+
+
+def test_drain_formats_after_releasing_routing_reservation(monkeypatch):
+    import tools.process_registry as pr
+    registry = ProcessRegistry()
+    event = {"type": "completion", "session_id": "sample"}
+    registry.completion_queue.put(event)
+    states = []
+
+    def formatter(_event):
+        def probe():
+            acquired = registry.completion_routing_lock.acquire(timeout=0.1)
+            states.append(acquired)
+            if acquired:
+                registry.completion_routing_lock.release()
+        thread = threading.Thread(target=probe)
+        thread.start()
+        thread.join(timeout=1)
+        return "formatted"
+
+    monkeypatch.setattr(pr, "format_process_notification", formatter)
+    assert registry.drain_notifications() == [(event, "formatted")]
+    assert states == [True]
+
+
+def test_formatter_failure_requeues_without_claim(monkeypatch):
+    import tools.process_registry as pr
+    registry = ProcessRegistry()
+    event = {"type": "async_delegation", "delegation_id": "sample", "session_key": "mine"}
+    registry.completion_queue.put(event)
+    claims = []
+    monkeypatch.setattr(ad, "claim_event_delivery", lambda *_a: claims.append(True))
+
+    def fail(_event):
+        raise ValueError("formatter unavailable")
+
+    monkeypatch.setattr(pr, "format_process_notification", fail)
+    assert registry.drain_notifications(session_key="mine") == []
+    assert registry.completion_queue.get_nowait() == event
+    assert claims == []

--- a/tests/tools/test_restored_delegation_ownership.py
+++ b/tests/tools/test_restored_delegation_ownership.py
@@ -30,6 +30,7 @@ def _make_registry():
     reg._running = {}
     reg._finished = {}
     reg._lock = threading.Lock()
+    reg.completion_routing_lock = threading.RLock()
     reg.completion_queue = queue.Queue()
     reg._completion_consumed = set()
     reg._poll_observed = set()

--- a/tests/tools/test_restored_delegation_ownership.py
+++ b/tests/tools/test_restored_delegation_ownership.py
@@ -24,6 +24,7 @@ def _make_registry():
     reg._running = {}
     reg._finished = {}
     reg._lock = threading.Lock()
+    reg.completion_routing_lock = threading.RLock()
     reg.completion_queue = queue.Queue()
     reg._completion_consumed = set()
     reg._poll_observed = set()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Async (background) delegation registry behind ``delegate_task(background=true)``.
+"""Background delegation with durable child identities and ready-set delivery.
 
-The parent dispatches a subagent on a module-level daemon executor and returns a handle
-immediately. On completion a ``type="async_delegation"`` event (self-contained task-source
-block) is pushed onto the SHARED ``process_registry.completion_queue`` the CLI/gateway drain
-while idle, so results surface as a NEW turn (never mid-turn) and inherit its de-dup and
-crash-recovery wiring. Only the async lifecycle lives here; the child run is an injected ``runner``."""
+Each finished child is persisted and published before waiting for slower siblings.
+Existing between-turn consumers coalesce the children ready at their boundary;
+there is no active-loop carrier at this layer. Parent rows remain execution and
+recovery bookkeeping, and every result uses the shared completion queue and ledger.
+"""
 
 from __future__ import annotations
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,7 @@ _MAX_DELIVERY_ATTEMPTS = 8
 # Pending completions older than this are dropped on restart replay instead of
 # re-run as a full-context turn; 48h keeps weekend results deliverable.
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
+_DELIVERY_CLAIM_LEASE_SECONDS = 300
 _DB_LOCK = threading.Lock()
 
 # ── Stale-delegation detection (progress-based, on by default) ──────────────
@@ -128,6 +129,25 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
 
+    # Child-level delivery records extend the existing durable claim ledger.
+    # A batch parent remains one execution unit, while each completed child is
+    # independently claimable and recoverable on the between-turn rail.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegation_events (
+            delegation_id TEXT NOT NULL,
+            event_key TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (delegation_id, event_key)
+        )"""
+    )
+
 
 @contextmanager
 def _transaction() -> Iterator[sqlite3.Connection]:
@@ -186,36 +206,785 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
 def _prune_durable_records() -> None:
     """Bound terminal history, preferring delivered records for deletion."""
     cutoff = time.time() - _DURABLE_RETENTION_SECONDS
+    no_pending_children = (
+        "NOT EXISTS (SELECT 1 FROM async_delegation_events e "
+        "WHERE e.delegation_id=async_delegations.delegation_id AND e.delivery_state='pending')"
+    )
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?", (cutoff,))
+            f"DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ? AND {no_pending_children}", (cutoff,))
         terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')").fetchone()[0]
+            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','stalling','finalizing')").fetchone()[0]
         if terminal_count > _MAX_RETAINED_COMPLETED:
-            conn.execute("""DELETE FROM async_delegations WHERE delegation_id IN (
+            conn.execute(f"""DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
+                     WHERE state NOT IN ('running','stalling','finalizing') AND {no_pending_children}
                      ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
                               updated_at ASC LIMIT ?
                    )""", (terminal_count - _MAX_RETAINED_COMPLETED,))
         pending_count = conn.execute("""SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'""").fetchone()[0]
+               WHERE state NOT IN ('running','stalling','finalizing') AND delivery_state='pending'""").fetchone()[0]
         if pending_count > _MAX_DURABLE_PENDING:
             conn.execute("""DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                     WHERE state NOT IN ('running','stalling','finalizing') AND delivery_state='pending'
                      ORDER BY updated_at ASC LIMIT ?
                    )""", (pending_count - _MAX_DURABLE_PENDING,))
 
+        conn.execute("DELETE FROM async_delegation_events WHERE delegation_id NOT IN "
+                     "(SELECT delegation_id FROM async_delegations)")
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _update_completion_row(
+    conn,
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+    now: Optional[float] = None,
+) -> None:
+    now = time.time() if now is None else now
+    state = "delivered" if delivery_state == "delivered" else "pending"
+    delivered_at = now if state == "delivered" else None
+    conn.execute(
+        """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
+           event_json=?, result_json=?, delivery_state=?, delivered_at=?
+           WHERE delegation_id=?""",
+        (
+            event.get("status", "completed"),
+            event.get("completed_at", now),
+            now,
+            json.dumps(event),
+            json.dumps(result),
+            state,
+            delivered_at,
+            event["delegation_id"],
+        ),
+    )
+
+
+def _build_batch_child_event(
+    record: Dict[str, Any],
+    task_index: int,
+    result: Dict[str, Any],
+    *,
+    completed_at: Optional[float] = None,
+) -> Dict[str, Any]:
+    delegation_id = str(record.get("delegation_id") or "")
+    goals = list(record.get("goals") or [])
+    goal = goals[task_index] if 0 <= task_index < len(goals) else record.get("goal", "")
+    completed_at = time.time() if completed_at is None else completed_at
+    child_result = dict(result or {})
+    child_result.setdefault("task_index", task_index)
+    return {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": f"task:{task_index}",
+        "batch_id": delegation_id,
+        "task_index": task_index,
+        "batch_size": len(goals),
+        "session_key": record.get("session_key", ""),
+        "origin_ui_session_id": record.get("origin_ui_session_id", ""),
+        "origin_session_id": record.get("origin_session_id", ""),
+        "parent_session_id": record.get("parent_session_id"),
+        "goal": goal,
+        "goals": goals,
+        "context": record.get("context"),
+        "toolsets": record.get("toolsets"),
+        "role": record.get("role"),
+        "model": record.get("model"),
+        "status": child_result.get("status", "completed"),
+        "summary": child_result.get("summary"),
+        "error": child_result.get("error"),
+        "api_calls": child_result.get("api_calls"),
+        "duration_seconds": child_result.get("duration_seconds"),
+        "is_batch": True,
+        "results": [child_result],
+        "live_transcripts": (
+            [child_result.get("live_transcript")]
+            if child_result.get("live_transcript")
+            else None
+        ),
+        "dispatched_at": record.get("dispatched_at"),
+        "completed_at": completed_at,
+        **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
+        **{k: result[k] for k in _STALL_META_KEYS if k in result},
+    }
+
+
+def _insert_batch_event(conn, event: Dict[str, Any], *, now: float) -> bool:
+    cur = conn.execute(
+        """INSERT OR IGNORE INTO async_delegation_events
+           (delegation_id, event_key, event_json, delivery_state,
+            delivery_attempts, created_at, updated_at)
+           VALUES (?, ?, ?, 'pending', 0, ?, ?)""",
+        (
+            event["delegation_id"],
+            event["delivery_event_key"],
+            json.dumps(event),
+            now,
+            now,
+        ),
+    )
+    return cur.rowcount == 1
+
+
+def _persist_batch_child_completion_event(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return None
+    event = _build_batch_child_event(record, task_index, result)
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute("""UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]))
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return None
+    return event
+
+
+def persist_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Persist one completed batch child without changing delivery timing.
+
+    The production batch runner calls this before joining slower siblings so a
+    process crash cannot erase an already completed child. The legacy aggregate
+    finalizer remains the only queue publisher in this layer.
+    """
+    return _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    ) is not None
+
+
+def publish_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Durably enqueue one ready child from an asynchronous batch.
+
+    The parent batch remains the execution/stall unit. This function creates an
+    independently claimable between-turn delivery event, keyed by task index.
+    Repeated publication is idempotent and never resets a delivered claim.
+    """
+    event = _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    )
+    if event is None:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    # Process-local handoff marker only. It prevents the aggregate finalizer
+    # from adding a duplicate queue copy when a future layer publishes children
+    # early. A crash intentionally loses this marker; restart recovery then
+    # restores the still-pending durable row from SQLite.
+    event_key = event["delivery_event_key"]
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            queued_keys = record.setdefault("_queued_child_event_keys", [])
+            if event_key not in queued_keys:
+                queued_keys.append(event_key)
+    return True
+
+
+def _event_delivery_keys(event: Dict[str, Any]) -> list[str]:
+    raw_keys = event.get("delivery_event_keys")
+    if isinstance(raw_keys, (list, tuple)):
+        return list(dict.fromkeys(str(key) for key in raw_keys if key))
+    key = str(event.get("delivery_event_key") or "")
+    return [key] if key else []
+
+
+def coalesce_ready_after_turn_events(
+    events: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Combine ready child rows from each after-turn batch at one boundary.
+
+    SQLite and the shared queue retain one durable row per child. This helper
+    creates only a transient delivery envelope so every child remains
+    independently recoverable while one consumer can claim/ack the currently
+    ready set atomically. Envelopes are deliberately re-coalescible: a busy
+    consumer may requeue one while more siblings finish before its next boundary.
+    """
+
+    output: List[Dict[str, Any]] = []
+    groups: Dict[str, Dict[str, Any]] = {}
+    seen_keys: Dict[str, set[str]] = {}
+    for event in events:
+        event_keys = _event_delivery_keys(event)
+        delegation_id = str(event.get("delegation_id") or "")
+        coalescible = (
+            event.get("type") == "async_delegation"
+            and bool(event.get("is_batch"))
+            and bool(event_keys)
+            and all(key.startswith("task:") for key in event_keys)
+            and bool(delegation_id)
+        )
+        if not coalescible:
+            output.append(event)
+            continue
+
+        grouped = groups.get(delegation_id)
+        if grouped is None:
+            grouped = dict(event)
+            grouped.pop("delivery_event_key", None)
+            grouped["delivery_event_keys"] = []
+            grouped["task_indices"] = []
+            grouped["results"] = []
+            grouped["live_transcripts"] = []
+            grouped["coalesced_after_turn"] = True
+            groups[delegation_id] = grouped
+            seen_keys[delegation_id] = set()
+            output.append(grouped)
+
+        new_keys = [
+            key for key in event_keys if key not in seen_keys[delegation_id]
+        ]
+        if not new_keys:
+            continue
+        seen_keys[delegation_id].update(new_keys)
+        grouped["delivery_event_keys"].extend(new_keys)
+        new_key_set = set(new_keys)
+        for result in event.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            task_index = int(result.get("task_index", 0))
+            if f"task:{task_index}" not in new_key_set:
+                continue
+            grouped["task_indices"].append(task_index)
+            grouped["results"].append(result)
+        grouped["live_transcripts"].extend(
+            path for path in (event.get("live_transcripts") or []) if path
+        )
+        grouped["completed_at"] = max(
+            float(grouped.get("completed_at") or 0),
+            float(event.get("completed_at") or 0),
+        )
+
+    for grouped in groups.values():
+        grouped["delivery_event_keys"].sort(
+            key=lambda key: int(key.split(":", 1)[1])
+        )
+        grouped["task_indices"] = sorted(set(grouped["task_indices"]))
+        grouped["results"].sort(key=lambda result: int(result.get("task_index", 0)))
+        grouped["live_transcripts"] = list(
+            dict.fromkeys(grouped["live_transcripts"])
+        ) or None
+    return output
+
+
+def _build_batch_terminal_event(
+    event_record: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+    *,
+    force: bool = False,
+) -> Optional[Dict[str, Any]]:
+    if not force and (
+        status in {"completed", "success"} or (combined.get("results") or [])
+    ):
+        return None
+    delegation_id = str(event_record.get("delegation_id") or "")
+    now = time.time()
+    event: Dict[str, Any] = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": "terminal",
+        "batch_id": delegation_id,
+        "session_key": event_record.get("session_key", ""),
+        "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
+        "origin_session_id": event_record.get("origin_session_id", ""),
+        "parent_session_id": event_record.get("parent_session_id"),
+        "goal": event_record.get("goal", ""),
+        "goals": event_record.get("goals"),
+        "context": event_record.get("context"),
+        "toolsets": event_record.get("toolsets"),
+        "role": event_record.get("role"),
+        "model": event_record.get("model"),
+        "status": status,
+        "is_batch": True,
+        "results": [],
+        "error": combined.get("error"),
+        "dispatched_at": event_record.get("dispatched_at"),
+        "completed_at": now,
+        **{k: event_record[k] for k in _ROUTING_KEYS if event_record.get(k)},
+    }
+    for key in (
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_phase",
+        "stall_grace_seconds",
+    ):
+        if key in combined:
+            event[key] = combined[key]
+    return event
+
+
+def _persist_batch_child_finalization(
+    event_record: Dict[str, Any],
+    parent_event: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+) -> None:
+    """Atomically persist missing child events and the terminal parent row."""
+
+    now = time.time()
+    queue_event_keys: list[str] = []
+    queue_events: list[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        for child in combined.get("results") or []:
+            child_event = _build_batch_child_event(
+                event_record,
+                int(child.get("task_index", 0)),
+                child,
+                completed_at=now,
+            )
+            _insert_batch_event(conn, child_event, now=now)
+            queue_event_keys.append(child_event["delivery_event_key"])
+
+        durable_keys = {row[0] for row in conn.execute(
+            "SELECT event_key FROM async_delegation_events WHERE delegation_id=?",
+            (event_record["delegation_id"],),
+        )}
+        expected_keys = {f"task:{i}" for i in range(len(event_record.get("goals") or []))}
+        terminal_event = _build_batch_terminal_event(
+            event_record, combined, status,
+            force=status not in {"completed", "success"} and not expected_keys.issubset(durable_keys),
+        )
+        if terminal_event is not None:
+            _insert_batch_event(conn, terminal_event, now=now)
+            queue_event_keys.append(terminal_event["delivery_event_key"])
+
+        # The aggregate row is bookkeeping-only. Commit its terminal state in
+        # the same transaction as the idempotent child safety net so restart
+        # recovery can never observe a half-finalized parent.
+        _update_completion_row(
+            conn,
+            parent_event,
+            combined,
+            delivery_state="delivered",
+            now=now,
+        )
+
+        # Child callbacks may have inserted these rows before the aggregate
+        # join. Preserve legacy delivery timing by loading every still-pending
+        # aggregate member only after the parent terminal update commits.
+        already_queued = {
+            str(key) for key in (event_record.get("_queued_child_event_keys") or [])
+        }
+        event_keys = [key for key in durable_keys | set(queue_event_keys) if key not in already_queued]
+        if event_keys:
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                "SELECT event_json FROM async_delegation_events "
+                "WHERE delegation_id=? AND delivery_state='pending' "
+                f"AND event_key IN ({placeholders})",
+                (event_record["delegation_id"], *event_keys),
+            ).fetchall()
+            queue_events = [json.loads(row[0]) for row in rows]
+
+    from tools.process_registry import process_registry
+
+    queue_events = coalesce_ready_after_turn_events(queue_events)
+    with process_registry.completion_routing_lock:
+        for queued_event in queue_events:
+            process_registry.completion_queue.put(queued_event)
+
+
+class _DeliveryGroupConflict(RuntimeError):
+    """Rollback a multi-child settlement when any row lost ownership."""
+
+
+def _claim_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=?, delivery_claimed_at=?,
+                           delivery_attempts=delivery_attempts+1, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending'
+                         AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+                    (
+                        claim_id,
+                        now,
+                        now,
+                        delegation_id,
+                        event_key,
+                        now - _DELIVERY_CLAIM_LEASE_SECONDS,
+                    ),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _claim_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=?, delivery_claimed_at=?,
+                   delivery_attempts=delivery_attempts+1, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending'
+                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                event_key,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
+        )
+        return cur.rowcount == 1
+
+
+def renew_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Renew the lease held by the exact consumer claim."""
+
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return False
+    event_keys = _event_delivery_keys(evt)
+    now = time.time()
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        try:
+            with _DB_LOCK, _transaction() as conn:
+                for event_key in event_keys:
+                    cur = conn.execute(
+                        """UPDATE async_delegation_events
+                           SET delivery_claimed_at=?, updated_at=?
+                           WHERE delegation_id=? AND event_key=?
+                             AND delivery_state='pending' AND delivery_claim=?""",
+                        (now, now, delegation_id, event_key, claim_id),
+                    )
+                    if cur.rowcount != 1:
+                        raise _DeliveryGroupConflict(event_key)
+        except _DeliveryGroupConflict:
+            return False
+        return True
+    event_key = event_keys[0] if event_keys else ""
+    with _DB_LOCK, _transaction() as conn:
+        if event_key:
+            cur = conn.execute(
+                """UPDATE async_delegation_events
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND event_key=?
+                     AND delivery_state='pending' AND delivery_claim=?""",
+                (now, now, delegation_id, event_key, claim_id),
+            )
+        else:
+            cur = conn.execute(
+                """UPDATE async_delegations
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, now, delegation_id, claim_id),
+            )
+        return cur.rowcount == 1
+
+
+def get_event_delivery_state(evt: Dict[str, Any]) -> Optional[str]:
+    """Return the durable state for one aggregate or child event."""
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    event_keys = _event_delivery_keys(evt)
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT delivery_state FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            if len(rows) != len(event_keys):
+                return None
+            states = {str(row[0]) for row in rows}
+            return states.pop() if len(states) == 1 else "mixed"
+        event_key = event_keys[0] if event_keys else ""
+        if event_key:
+            row = conn.execute(
+                """SELECT delivery_state FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_key),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+                (delegation_id,),
+            ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _complete_child_event(
+    delegation_id: str, event_key: str, claim_id: str, state: str = "delivered"
+) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state=?, delivered_at=?, updated_at=?,
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (state, now, now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _release_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        capped = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state='dropped', delivery_claim=NULL,
+                   delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?
+                 AND delivery_attempts>=?""",
+            (now, delegation_id, event_key, claim_id, _MAX_DELIVERY_ATTEMPTS),
+        )
+        if capped.rowcount == 1:
+            return True
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _complete_child_event_group(
+    delegation_id: str,
+    event_keys: List[str],
+    claim_id: str,
+    state: str = "delivered",
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state=?, delivered_at=?, updated_at=?,
+                           delivery_claim=NULL, delivery_claimed_at=NULL
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (state, now, now, delegation_id, event_key, claim_id),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _release_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> tuple[bool, List[str]]:
+    now = time.time()
+    pending_keys: List[str] = []
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                capped = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state='dropped', delivery_claim=NULL,
+                           delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?
+                         AND delivery_attempts>=?""",
+                    (
+                        now,
+                        delegation_id,
+                        event_key,
+                        claim_id,
+                        _MAX_DELIVERY_ATTEMPTS,
+                    ),
+                )
+                if capped.rowcount == 1:
+                    continue
+                released = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (now, delegation_id, event_key, claim_id),
+                )
+                if released.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+                pending_keys.append(event_key)
+    except _DeliveryGroupConflict:
+        return False, event_keys
+    return True, pending_keys
+
+
+def _retain_group_event_keys(evt: Dict[str, Any], event_keys: List[str]) -> None:
+    """Keep only rows that remain pending after a grouped release."""
+
+    keep = set(event_keys)
+    evt["delivery_event_keys"] = list(event_keys)
+    evt["results"] = [
+        result
+        for result in (evt.get("results") or [])
+        if isinstance(result, dict)
+        and f"task:{int(result.get('task_index', 0))}" in keep
+    ]
+    evt["task_indices"] = sorted(
+        int(result.get("task_index", 0)) for result in evt["results"]
+    )
+
+
+def get_event_delivery_retry_delay(
+    evt: Dict[str, Any], *, now: Optional[float] = None
+) -> Optional[float]:
+    """Return a bounded delay for an unclaimed pending event, else ``None``.
+
+    A failed claim is ambiguous: another live process may own the pending row,
+    or this queue entry may be a duplicate whose durable row is already
+    delivered/dropped. Consumers use this oracle before deferred requeue so a
+    quick restart waits only for the remaining lease without spinning. Grouped
+    envelopes are narrowed to rows that are still pending.
+    """
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    current = time.time() if now is None else float(now)
+    event_keys = _event_delivery_keys(evt)
+    pending_rows: List[tuple[str, Optional[str], Optional[float]]] = []
+
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT event_key, delivery_state, delivery_claim,
+                           delivery_claimed_at
+                    FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            by_key = {str(row[0]): row for row in rows}
+            if len(by_key) != len(event_keys):
+                return None
+            pending_keys = [
+                key for key in event_keys if str(by_key[key][1]) == "pending"
+            ]
+            if not pending_keys:
+                return None
+            _retain_group_event_keys(evt, pending_keys)
+            pending_rows = [
+                (
+                    key,
+                    str(by_key[key][2]) if by_key[key][2] else None,
+                    float(by_key[key][3]) if by_key[key][3] is not None else None,
+                )
+                for key in pending_keys
+            ]
+        elif event_keys:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_keys[0]),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    event_keys[0],
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+        else:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    "aggregate",
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+
+    # A short guard covers claim races and strict SQL '<' lease comparison.
+    delay = 0.05
+    for _event_key, claim, claimed_at in pending_rows:
+        if not claim:
+            continue
+        if claimed_at is None:
+            delay = max(delay, float(_DELIVERY_CLAIM_LEASE_SECONDS))
+            continue
+        remaining = float(_DELIVERY_CLAIM_LEASE_SECONDS) - (current - claimed_at)
+        delay = max(delay, remaining)
+    return max(0.05, delay) + 0.05
+
+
+def drop_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if event_keys:
+            _complete_child_event_group(
+                delegation_id, event_keys, claim_id, state="dropped"
+            )
+    elif event_keys:
+        _complete_child_event(delegation_id, event_keys[0], claim_id, state="dropped")
+    else:
+        drop_completion_delivery(delegation_id, claim_id)
+
+
+
+def _persist_completion(
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+) -> None:
+    with _DB_LOCK, _transaction() as conn:
+        _update_completion_row(
+            conn, event, result, delivery_state=delivery_state
+        )
 
 
 def recover_abandoned_delegations() -> int:
@@ -224,72 +993,226 @@ def recover_abandoned_delegations() -> int:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
         return 0
-    now, recovered = time.time(), 0
+    now = time.time()
+    recovered = 0
     with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute("""SELECT delegation_id, origin_session, origin_ui_session_id,
+        rows = conn.execute(
+            """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
                       owner_started_at, task_json, origin_session_id
-               FROM async_delegations WHERE state IN ('running','finalizing')""").fetchall()
+               FROM async_delegations WHERE state IN ('running','stalling','finalizing')"""
+        ).fetchall()
         for row in rows:
-            delegation_id, session_key, origin_ui, parent_id, dispatched_at, pid, started, task_json, origin_sid = row
-            if pid and _pid_exists(int(pid)) and (started is None or get_process_start_time(int(pid)) == int(started)):
+            (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
+             pid, started, task_json, origin_session_id) = row
+            live = False
+            if pid:
+                live = _pid_exists(int(pid))
+                if live and started is not None:
+                    live = get_process_start_time(int(pid)) == int(started)
+            if live:
                 continue
             task = json.loads(task_json or "{}")
+            child_rows = []
+            if bool(task.get("is_batch")):
+                child_rows = conn.execute(
+                    """SELECT event_key, event_json FROM async_delegation_events
+                       WHERE delegation_id=? AND event_key LIKE 'task:%'
+                       ORDER BY event_key""",
+                    (delegation_id,),
+                ).fetchall()
+            if bool(task.get("is_batch")) and bool(child_rows):
+                # Child-scoped batches never recover through a contradictory
+                # aggregate. A crash after one or more child inserts must
+                # preserve the already-delivered/pending task identities.
+                goals = list(task.get("goals") or [])
+                expected_child_keys = [f"task:{index}" for index in range(len(goals))]
+                child_results_by_key: dict[str, Dict[str, Any]] = {}
+                for event_key, child_payload in child_rows:
+                    if event_key not in expected_child_keys:
+                        continue
+                    child_event = json.loads(child_payload or "{}")
+                    results = child_event.get("results") or []
+                    if results and isinstance(results[0], dict):
+                        child_results_by_key[event_key] = results[0]
+
+                child_results = [
+                    child_results_by_key[key]
+                    for key in expected_child_keys
+                    if key in child_results_by_key
+                ]
+                complete_children = bool(expected_child_keys) and all(
+                    key in child_results_by_key for key in expected_child_keys
+                )
+                status = "completed" if complete_children else "unknown"
+                recovery_error = None
+                if not complete_children:
+                    recovery_error = (
+                        "Delegation owner exited after recording "
+                        f"{len(child_results)}/{len(goals)} batch child results; "
+                        "remaining outcomes are unknown."
+                    )
+                combined = {
+                    "results": child_results,
+                    "error": recovery_error,
+                }
+                event_record = {
+                    "delegation_id": delegation_id,
+                    "session_key": session_key,
+                    "origin_ui_session_id": origin_ui,
+                    "origin_session_id": origin_session_id or "",
+                    "parent_session_id": parent_id,
+                    "goal": task.get("goal", ""),
+                    "goals": goals,
+                    "context": task.get("context"),
+                    "toolsets": task.get("toolsets"),
+                    "role": task.get("role"),
+                    "model": task.get("model"),
+                    "dispatched_at": dispatched_at,
+                    **{k: task[k] for k in _ROUTING_KEYS if task.get(k)},
+                }
+                if not complete_children:
+                    terminal_event = _build_batch_terminal_event(
+                        event_record, combined, status, force=True
+                    )
+                    if terminal_event is not None:
+                        _insert_batch_event(conn, terminal_event, now=now)
+
+                parent_event = {
+                    **event_record,
+                    "type": "async_delegation",
+                    "status": status,
+                    "is_batch": True,
+                    "results": child_results,
+                    "error": recovery_error,
+                    "completed_at": now,
+                }
+                _update_completion_row(
+                    conn,
+                    parent_event,
+                    combined,
+                    delivery_state="delivered",
+                    now=now,
+                )
+                recovered += 1
+                continue
             event = {
-                "type": "async_delegation", "delegation_id": delegation_id, "session_key": session_key,
-                "origin_ui_session_id": origin_ui, "origin_session_id": origin_sid or "",
-                "parent_session_id": parent_id, "goal": task.get("goal", ""), "goals": task.get("goals"),
-                "context": task.get("context"), "toolsets": task.get("toolsets"), "role": task.get("role"),
+                "type": "async_delegation", "delegation_id": delegation_id,
+                "session_key": session_key, "origin_ui_session_id": origin_ui,
+                # Restore the durable wake target so completions recovered
+                # after a restart remain routable to api_server sessions.
+                "origin_session_id": origin_session_id or "",
+                "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "goals": task.get("goals"), "context": task.get("context"),
+                "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
                 "status": "unknown", "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
-                **{k: task[k] for k in _ROUTING_KEYS if task.get(k)}}
+            }
+            # Routing origin persisted at dispatch (see _capture_routing_origin):
+            # restores scope_id/user_id for the reconstructed SessionSource so
+            # relay egress priming works after a restart.
+            for _k in ("scope_id", "user_id", "user_name"):
+                if task.get(_k):
+                    event[_k] = task[_k]
             result = {"status": "unknown", "summary": None, "error": event["error"]}
-            conn.execute("""UPDATE async_delegations SET state='unknown', completed_at=?,
+            conn.execute(
+                """UPDATE async_delegations SET state='unknown', completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
-                   WHERE delegation_id=?""", (now, now, json.dumps(event), json.dumps(result), delegation_id))
+                   WHERE delegation_id=?""",
+                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+            )
             recovered += 1
     return recovered
 
 
 def restore_undelivered_completions(target_queue) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
-    Restored events are stamped ``restored=True`` in memory only: they came from a PREVIOUS
-    process, so drains without an ownership filter must leave them for a consumer that can
-    prove ownership. Rows older than ``_MAX_COMPLETION_REPLAY_AGE_S`` are terminally dropped
-    instead of replaying a turn nobody is waiting on.
 
-    Every restored event is stamped ``restored=True`` (in-memory only — the stamp is added after the durable
-    payload is deserialized and is never persisted). Restored events originate from a *previous* process, so
-    no consumer in THIS process implicitly owns them: drain paths that run without an ownership filter (the
-    legacy single-session behavior) must leave them queued for a consumer that can positively prove
-    ownership, otherwise a brand-new session adopts a dead session's delegation results seconds after boot
-    (#64484).
+    Every restored event is stamped ``restored=True`` (in-memory only — the
+    stamp is added after the durable payload is deserialized and is never
+    persisted). Restored events originate from a *previous* process, so no
+    consumer in THIS process implicitly owns them: drain paths that run
+    without an ownership filter (the legacy single-session behavior) must
+    leave them queued for a consumer that can positively prove ownership,
+    otherwise a brand-new session adopts a dead session's delegation
+    results seconds after boot (#64484).
+
+    Staleness cap: a pending completion older than
+    ``_MAX_COMPLETION_REPLAY_AGE_S`` is terminally dropped instead of
+    replayed. Replaying a weeks-old completion re-runs its parent session as
+    a full-context turn (a July session replayed in August burned a
+    102K-token context on the staging fleet) for a result nobody is waiting
+    on anymore; the payload stays queryable on the dropped row.
     """
     recover_abandoned_delegations()
-    now, restored = time.time(), 0
+    now = time.time()
+    restored = 0
+    parent_events: list[Dict[str, Any]] = []
+    child_events: list[Dict[str, Any]] = []
     with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute("""SELECT delegation_id, event_json, completed_at, dispatched_at
+        rows = conn.execute(
+            """SELECT delegation_id, event_json, completed_at, dispatched_at
                FROM async_delegations
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
-               ORDER BY completed_at, delegation_id""").fetchall()
+               ORDER BY completed_at, delegation_id"""
+        ).fetchall()
+        child_rows = conn.execute(
+            """SELECT e.delegation_id, e.event_key, e.event_json, e.created_at
+               FROM async_delegation_events e JOIN async_delegations p
+                 ON p.delegation_id=e.delegation_id
+               WHERE e.delivery_state='pending'
+                 AND p.state NOT IN ('running','stalling','finalizing')
+               ORDER BY e.created_at, e.delegation_id, e.event_key"""
+        ).fetchall()
         for delegation_id, payload, completed_at, dispatched_at in rows:
             age_basis = completed_at or dispatched_at
             if age_basis and (now - age_basis) > _MAX_COMPLETION_REPLAY_AGE_S:
-                conn.execute("""UPDATE async_delegations SET delivery_state='dropped',
+                conn.execute(
+                    """UPDATE async_delegations SET delivery_state='dropped',
                               delivery_claim=NULL, delivery_claimed_at=NULL,
                               updated_at=?
-                       WHERE delegation_id=? AND delivery_state='pending'""", (now, delegation_id))
-                logger.warning("Async delegation %s: pending completion is %.1fh old "
-                               "(cap %.1fh); terminally dropping the replay (result remains queryable).",
-                               delegation_id, (now - age_basis) / 3600.0, _MAX_COMPLETION_REPLAY_AGE_S / 3600.0)
+                       WHERE delegation_id=? AND delivery_state='pending'""",
+                    (now, delegation_id),
+                )
+                logger.warning(
+                    "Async delegation %s: pending completion is %.1fh old "
+                    "(cap %.1fh); terminally dropping the replay (result "
+                    "remains queryable).",
+                    delegation_id,
+                    (now - age_basis) / 3600.0,
+                    _MAX_COMPLETION_REPLAY_AGE_S / 3600.0,
+                )
                 continue
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
-            target_queue.put(evt)
+            parent_events.append(evt)
             restored += 1
+        for delegation_id, event_key, payload, created_at in child_rows:
+            if created_at and now - created_at > _MAX_COMPLETION_REPLAY_AGE_S:
+                conn.execute(
+                    "UPDATE async_delegation_events SET delivery_state='dropped', "
+                    "delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=? "
+                    "WHERE delegation_id=? AND event_key=? AND delivery_state='pending'",
+                    (now, delegation_id, event_key),
+                )
+                continue
+            evt = json.loads(payload)
+            if isinstance(evt, dict):
+                evt["restored"] = True
+                evt.setdefault("delegation_id", delegation_id)
+                evt.setdefault("delivery_event_key", event_key)
+            child_events.append(evt)
+            restored += 1
+    # Queue only after the SQLite read transaction closes. Default after-turn
+    # batches retain the legacy one-envelope restart shape even though each
+    # child now has an independently durable identity underneath it.
+    for evt in parent_events:
+        target_queue.put(evt)
+    for evt in coalesce_ready_after_turn_events(child_events):
+        target_queue.put(evt)
     return restored
 
 
@@ -319,17 +1242,28 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                       delivery_attempts=delivery_attempts+1, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300))
+            (claim_id, now, now, delegation_id, now - _DELIVERY_CLAIM_LEASE_SECONDS))
         return cur.rowcount == 1
 
 
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     """Claim a durable delegation event; non-durable events need no token."""
-    delegation_id = str(evt.get("delegation_id") or "") if evt.get("type") == "async_delegation" else ""
+    if evt.get("type") != "async_delegation":
+        return ""
+    delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
     claim_id = f"{consumer}:{os.getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        claimed = bool(event_keys) and _claim_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        claimed = _claim_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        claimed = claim_completion_delivery(delegation_id, claim_id)
+    return claim_id if claimed else None
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -377,17 +1311,41 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
              AND delivery_claim=?""", (now, now, delegation_id, claim_id))
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(complete_completion_delivery, evt, claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        completed = bool(event_keys) and _complete_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        completed = _complete_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        completed = complete_completion_delivery(delegation_id, claim_id)
+    return completed or get_event_delivery_state(evt) == "delivered"
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(release_completion_delivery, evt, claim_id)
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        released, pending_keys = _release_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+        if released:
+            _retain_group_event_keys(evt, pending_keys)
+        return released
+    if event_keys:
+        return _release_child_event(delegation_id, event_keys[0], claim_id)
+    return release_completion_delivery(delegation_id, claim_id)
 
 
-def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        fn(str(evt.get("delegation_id") or ""), claim_id)
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -544,6 +1502,7 @@ def _dispatch(
         with _records_lock:
             _records.pop(delegation_id, None)
         with _DB_LOCK, _transaction() as conn:
+            conn.execute("DELETE FROM async_delegation_events WHERE delegation_id=?", (delegation_id,))
             conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
         return {"status": "rejected", "error": f"Failed to schedule async delegation{label}: {exc}"}
     if progress_fn is not None:
@@ -670,6 +1629,9 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
         **({} if is_batch else {"exit_reason": result.get("exit_reason")}),
         **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
         **{k: result[k] for k in _STALL_META_KEYS if k in result}}
+    if is_batch:
+        _persist_batch_child_finalization(record, evt, result, status)
+        return
     _persist_completion(evt, result)
     try:
         process_registry.completion_queue.put(evt)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -7,10 +7,21 @@ subagent that runs on a module-level daemon executor and returns a handle
 immediately, so the user and the model can keep working while the child runs.
 
 When a child finishes, its completion event is written to the durable ledger
-and pushed onto the shared ``process_registry.completion_queue`` for existing
-between-turn delivery. Batch children have independent durable identities,
-while all-ready finalization and restart recovery expose one transient grouped
-envelope for backward compatibility.
+and pushed onto the shared ``process_registry.completion_queue``. The event's
+``result_delivery`` selects one of two consumers without creating a parallel
+execution system:
+
+  - ``after_turn`` (default) keeps the existing CLI/gateway synthetic-turn
+    path. A batch publishes one consolidated result after all children finish.
+  - ``inject`` lets the originating conversation loop claim already-ready
+    events at append-only safe boundaries, after a complete tool-result block
+    and before the next model request. Batch children publish independently as
+    they finish. A result that misses its originating turn remains on the same
+    queue and follows the normal synthetic-turn path.
+
+Both paths use the same durable claim/recovery ledger. Neither waits or polls
+for a running child, past history is never rewritten, and competing consumers
+cannot acknowledge the same event twice.
 
 The completion payload carries a rich, self-contained task-source block (the
 original goal, the context the parent supplied, toolsets, model, dispatch
@@ -73,8 +84,9 @@ _MAX_DURABLE_PENDING = 1000
 # attempts so an unroutable row converges to a terminal 'dropped' state
 # instead of replaying on every restart forever.
 _MAX_DELIVERY_ATTEMPTS = 8
-# Durable claims are leases, not ownership transfers. A live consumer renews
-# this timestamp; after a process crash another consumer can recover the row.
+# Durable claims are leases, not ownership transfers. Active same-turn injects
+# renew this timestamp while the provider request/retry lifecycle is alive;
+# after a process crash the absent heartbeat lets another consumer recover it.
 _DELIVERY_CLAIM_LEASE_SECONDS = 300
 _DB_LOCK = threading.Lock()
 
@@ -166,12 +178,16 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        # Delivery mode captured at dispatch: 'inject' delivers at safe
+        # conversation-loop boundaries; 'after_turn' preserves the legacy
+        # synthetic-turn path. Missing/invalid values mean 'after_turn'.
+        ("result_delivery", "TEXT"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
     # Child-level delivery records extend the existing durable claim ledger.
     # A batch parent remains one execution unit, while each completed child is
-    # independently claimable and recoverable on the between-turn rail.
+    # independently claimable/recoverable for result_delivery=inject.
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegation_events (
             delegation_id TEXT NOT NULL,
@@ -225,22 +241,27 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
             "role",
             "model",
             "is_batch",
+            "result_delivery",
+            "parent_turn_id",
         )
         if key in record
     }
+    _result_delivery = str(record.get("result_delivery") or "after_turn").strip().lower()
+    if _result_delivery not in {"inject", "after_turn"}:
+        _result_delivery = "after_turn"
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
             """INSERT OR REPLACE INTO async_delegations
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id, result_delivery)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
              owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+             record.get("origin_session_id", ""), _result_delivery),
         )
     _prune_durable_records()
 
@@ -363,6 +384,7 @@ def _build_batch_child_event(
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
         "goal": goal,
         "goals": goals,
         "context": record.get("context"),
@@ -383,6 +405,9 @@ def _build_batch_child_event(
         ),
         "dispatched_at": record.get("dispatched_at"),
         "completed_at": completed_at,
+        "result_delivery": str(
+            record.get("result_delivery") or "after_turn"
+        ).strip().lower(),
     }
 
 
@@ -444,10 +469,22 @@ def publish_batch_child_completion(
 ) -> bool:
     """Durably enqueue one ready child from an asynchronous batch.
 
-    The parent batch remains the execution/stall unit. This function creates an
-    independently claimable between-turn delivery event, keyed by task index.
-    Repeated publication is idempotent and never resets a delivered claim.
+    The parent batch remains the execution/stall unit. This function only
+    creates an independently claimable delivery event, keyed by task index.
+    ``result_delivery`` changes which consumer may claim it, not when the child
+    row becomes durable. Repeated publication is idempotent and never resets a
+    delivered claim.
     """
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return False
+    if str(record.get("result_delivery") or "after_turn").lower() not in {
+        "inject",
+        "after_turn",
+    }:
+        return False
+
     event = _persist_batch_child_completion_event(
         delegation_id, task_index, result
     )
@@ -494,10 +531,12 @@ def coalesce_ready_after_turn_events(
     groups: Dict[str, Dict[str, Any]] = {}
     seen_keys: Dict[str, set[str]] = {}
     for event in events:
+        delivery = str(event.get("result_delivery") or "after_turn").strip().lower()
         event_keys = _event_delivery_keys(event)
         delegation_id = str(event.get("delegation_id") or "")
         coalescible = (
             event.get("type") == "async_delegation"
+            and delivery == "after_turn"
             and bool(event.get("is_batch"))
             and bool(event_keys)
             and all(key.startswith("task:") for key in event_keys)
@@ -578,6 +617,7 @@ def _build_batch_terminal_event(
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "parent_turn_id": event_record.get("parent_turn_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),
@@ -590,6 +630,9 @@ def _build_batch_terminal_event(
         "error": combined.get("error"),
         "dispatched_at": event_record.get("dispatched_at"),
         "completed_at": now,
+        "result_delivery": str(
+            event_record.get("result_delivery") or "after_turn"
+        ).strip().lower(),
     }
     for key in (
         "stalled_after_quiet_seconds",
@@ -649,9 +692,9 @@ def _persist_batch_child_finalization(
             _insert_batch_event(conn, terminal_event, now=now)
             queue_event_keys.append(terminal_event["delivery_event_key"])
 
-        # The aggregate row is bookkeeping-only. Commit its terminal state in
-        # the same transaction as the idempotent child safety net so restart
-        # recovery can never observe a half-finalized parent.
+        # The aggregate row is bookkeeping-only for inject batches. Commit its
+        # terminal state in the same transaction as the idempotent child safety
+        # net so restart recovery can never observe a half-finalized parent.
         _update_completion_row(
             conn,
             parent_event,
@@ -709,12 +752,13 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      result_delivery
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, result_delivery) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -723,6 +767,9 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            restored_delivery = str(
+                result_delivery or task.get("result_delivery") or "after_turn"
+            ).lower()
             child_rows = []
             if bool(task.get("is_batch")):
                 child_rows = conn.execute(
@@ -731,7 +778,9 @@ def recover_abandoned_delegations() -> int:
                        ORDER BY event_key""",
                     (delegation_id,),
                 ).fetchall()
-            if bool(task.get("is_batch")) and bool(child_rows):
+            if bool(task.get("is_batch")) and (
+                restored_delivery == "inject" or bool(child_rows)
+            ):
                 # Child-scoped batches never recover through a contradictory
                 # aggregate. A crash after one or more child inserts must
                 # preserve the already-delivered/pending task identities.
@@ -772,6 +821,7 @@ def recover_abandoned_delegations() -> int:
                     "origin_ui_session_id": origin_ui,
                     "origin_session_id": origin_session_id or "",
                     "parent_session_id": parent_id,
+                    "parent_turn_id": task.get("parent_turn_id", ""),
                     "goal": task.get("goal", ""),
                     "goals": goals,
                     "context": task.get("context"),
@@ -779,6 +829,7 @@ def recover_abandoned_delegations() -> int:
                     "role": task.get("role"),
                     "model": task.get("model"),
                     "dispatched_at": dispatched_at,
+                    "result_delivery": restored_delivery,
                 }
                 if not complete_children:
                     terminal_event = _build_batch_terminal_event(
@@ -795,6 +846,7 @@ def recover_abandoned_delegations() -> int:
                     "results": child_results,
                     "error": recovery_error,
                     "completed_at": now,
+                    "result_delivery": restored_delivery,
                 }
                 _update_completion_row(
                     conn,
@@ -812,9 +864,11 @@ def recover_abandoned_delegations() -> int:
                 # after a restart remain routable to api_server sessions.
                 "origin_session_id": origin_session_id or "",
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "parent_turn_id": task.get("parent_turn_id", ""),
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
+                "result_delivery": restored_delivery,
                 "status": "unknown", "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
@@ -883,7 +937,7 @@ def restore_undelivered_completions(target_queue) -> int:
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
-    """Atomically acknowledge successful delivery of a durable completion."""
+    """Atomically acknowledge successful injection of a durable completion."""
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
@@ -1618,6 +1672,8 @@ def dispatch_async_delegation(
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    result_delivery: Optional[str] = None,
+    parent_turn_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
 
@@ -1683,6 +1739,11 @@ def dispatch_async_delegation(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        # Delivery mode: 'inject' (new tool-result carrier)
+        # or 'after_turn' (legacy completion_queue path). Default 'after_turn'
+        # for backward compatibility with old task_json entries.
+        "result_delivery": str(result_delivery or "after_turn").strip().lower(),
+        "parent_turn_id": str(parent_turn_id or ""),
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
@@ -1821,6 +1882,7 @@ def _push_completion_event(
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -1836,6 +1898,10 @@ def _push_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
+        # Delivery mode: 'inject' (new tool-result carrier) or 'after_turn'
+        # (legacy completion_queue path). Consumers use this to choose a live
+        # carrier or the next available separate-turn boundary.
+        "result_delivery": record.get("result_delivery", "after_turn"),
     }
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
@@ -1874,6 +1940,8 @@ def dispatch_async_delegation_batch(
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    result_delivery: Optional[str] = None,
+    parent_turn_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit.
 
@@ -1885,9 +1953,11 @@ def dispatch_async_delegation_batch(
     parallelism is bounded separately by ``max_concurrent_children``), so a
     single ``delegate_task`` fan-out never exhausts the async pool by itself.
 
-    Each child uses an independently durable row. Finalization preserves the
-    existing between-turn grouped envelope and idempotently fills any child row
-    missed by a completion callback.
+    Both delivery modes publish each child into an independently durable row as
+    it becomes ready. ``inject`` may claim rows at same-turn safe boundaries;
+    ``after_turn`` coalesces every ready row at the next available turn boundary.
+    Finalization only persists aggregate status for observability/recovery and
+    idempotently fills any child row missed by its completion callback.
 
     Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
     ``{"status": "rejected", "error": ...}`` when the async pool is at
@@ -1921,6 +1991,9 @@ def dispatch_async_delegation_batch(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        # Delivery mode for the batch; missing values preserve after_turn.
+        "result_delivery": str(result_delivery or "after_turn").strip().lower(),
+        "parent_turn_id": str(parent_turn_id or ""),
     }
     with _records_lock:
         running = sum(
@@ -2014,6 +2087,7 @@ def _push_batch_completion_event(
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "parent_turn_id": event_record.get("parent_turn_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),
@@ -2033,6 +2107,8 @@ def _push_batch_completion_event(
         "total_duration_seconds": combined.get("total_duration_seconds"),
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
+        # Delivery mode for the batch: 'inject' or 'after_turn'.
+        "result_delivery": event_record.get("result_delivery", "after_turn"),
     }
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
@@ -2044,9 +2120,12 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    # Child callbacks persist incrementally without changing legacy delivery
-    # timing. The finalizer idempotently inserts any missed child, commits the
-    # parent terminal row, then queues one grouped envelope after commit.
+    # Child callbacks publish incrementally in both delivery modes. The
+    # finalizer idempotently inserts any missed child and commits the parent
+    # terminal row in one SQLite transaction; only events without a successful
+    # process-local queue handoff are queued after commit. Consumers decide
+    # whether ready children belong in the current turn (inject) or the next
+    # turn (after_turn).
     _persist_batch_child_finalization(event_record, evt, combined, status)
 
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -6,27 +6,17 @@ Backs ``delegate_task(background=true)``: the parent agent dispatches a
 subagent that runs on a module-level daemon executor and returns a handle
 immediately, so the user and the model can keep working while the child runs.
 
-When the child finishes, a completion event is pushed onto the SHARED
-``process_registry.completion_queue`` with ``type="async_delegation"``. The
-CLI (``cli.py`` process_loop) and gateway (``_run_process_watcher`` /
-``completion_queue`` drain) already poll that queue while the agent is idle
-and forge a fresh user/internal turn from each event. We deliberately reuse
-that rail rather than reaching into a running agent loop:
+When a child finishes, its completion event is written to the durable ledger
+and pushed onto the shared ``process_registry.completion_queue`` for existing
+between-turn delivery. Batch children have independent durable identities,
+while all-ready finalization and restart recovery expose one transient grouped
+envelope for backward compatibility.
 
-  - completions surface as a NEW turn when the agent is idle, never spliced
-    between a tool result and an assistant message. That keeps strict
-    message-role alternation legal and the prompt cache intact (hard
-    invariant: never mutate past context).
-  - we inherit the queue's de-dup, crash-recovery checkpoint, and the
-    existing CLI + gateway drain wiring for free — no new drain loops in the
-    two largest files in the repo.
-
-The completion payload carries a RICH, self-contained task-source block (the
+The completion payload carries a rich, self-contained task-source block (the
 original goal, the context the parent supplied, toolsets, model, dispatch
-time, status, and the full result summary). When the result re-enters the
-conversation the parent may be deep in unrelated context and won't remember
-why the subagent existed; the block lets it either use the result or
-re-dispatch if the world has moved on.
+time, status, and the full result summary). When a result arrives after the
+originating turn, that block lets the parent use it or re-dispatch if the world
+has moved on.
 
 This module owns ONLY the async lifecycle. The actual child build + run is
 delegated back to ``delegate_tool._run_single_child`` via an injected
@@ -83,6 +73,9 @@ _MAX_DURABLE_PENDING = 1000
 # attempts so an unroutable row converges to a terminal 'dropped' state
 # instead of replaying on every restart forever.
 _MAX_DELIVERY_ATTEMPTS = 8
+# Durable claims are leases, not ownership transfers. A live consumer renews
+# this timestamp; after a process crash another consumer can recover the row.
+_DELIVERY_CLAIM_LEASE_SECONDS = 300
 _DB_LOCK = threading.Lock()
 
 # ---------------------------------------------------------------------------
@@ -176,6 +169,24 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    # Child-level delivery records extend the existing durable claim ledger.
+    # A batch parent remains one execution unit, while each completed child is
+    # independently claimable and recoverable on the between-turn rail.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegation_events (
+            delegation_id TEXT NOT NULL,
+            event_key TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (delegation_id, event_key)
+        )"""
+    )
 
 
 @contextmanager
@@ -206,7 +217,15 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         owner_started_at = None
     task_payload = {
         key: record.get(key)
-        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch")
+        for key in (
+            "goal",
+            "goals",
+            "context",
+            "toolsets",
+            "role",
+            "model",
+            "is_batch",
+        )
         if key in record
     }
     with _DB_LOCK, _transaction() as conn:
@@ -228,6 +247,10 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
 
 def _delete_durable_delegation(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            "DELETE FROM async_delegation_events WHERE delegation_id=?",
+            (delegation_id,),
+        )
         conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
 
 
@@ -268,18 +291,402 @@ def _prune_durable_records() -> None:
                    )""",
                 (overflow,),
             )
+        conn.execute(
+            """DELETE FROM async_delegation_events
+               WHERE delegation_id NOT IN (
+                   SELECT delegation_id FROM async_delegations
+               )"""
+        )
 
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _update_completion_row(
+    conn,
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+    now: Optional[float] = None,
+) -> None:
+    now = time.time() if now is None else now
+    state = "delivered" if delivery_state == "delivered" else "pending"
+    delivered_at = now if state == "delivered" else None
+    conn.execute(
+        """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
+           event_json=?, result_json=?, delivery_state=?, delivered_at=?
+           WHERE delegation_id=?""",
+        (
+            event.get("status", "completed"),
+            event.get("completed_at", now),
+            now,
+            json.dumps(event),
+            json.dumps(result),
+            state,
+            delivered_at,
+            event["delegation_id"],
+        ),
+    )
+
+
+def _persist_completion(
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    delivery_state: str = "pending",
+) -> None:
+    with _DB_LOCK, _transaction() as conn:
+        _update_completion_row(
+            conn, event, result, delivery_state=delivery_state
+        )
+
+
+def _build_batch_child_event(
+    record: Dict[str, Any],
+    task_index: int,
+    result: Dict[str, Any],
+    *,
+    completed_at: Optional[float] = None,
+) -> Dict[str, Any]:
+    delegation_id = str(record.get("delegation_id") or "")
+    goals = list(record.get("goals") or [])
+    goal = goals[task_index] if 0 <= task_index < len(goals) else record.get("goal", "")
+    completed_at = time.time() if completed_at is None else completed_at
+    child_result = dict(result or {})
+    child_result.setdefault("task_index", task_index)
+    return {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": f"task:{task_index}",
+        "batch_id": delegation_id,
+        "task_index": task_index,
+        "batch_size": len(goals),
+        "session_key": record.get("session_key", ""),
+        "origin_ui_session_id": record.get("origin_ui_session_id", ""),
+        "origin_session_id": record.get("origin_session_id", ""),
+        "parent_session_id": record.get("parent_session_id"),
+        "goal": goal,
+        "goals": goals,
+        "context": record.get("context"),
+        "toolsets": record.get("toolsets"),
+        "role": record.get("role"),
+        "model": record.get("model"),
+        "status": child_result.get("status", "completed"),
+        "summary": child_result.get("summary"),
+        "error": child_result.get("error"),
+        "api_calls": child_result.get("api_calls"),
+        "duration_seconds": child_result.get("duration_seconds"),
+        "is_batch": True,
+        "results": [child_result],
+        "live_transcripts": (
+            [child_result.get("live_transcript")]
+            if child_result.get("live_transcript")
+            else None
+        ),
+        "dispatched_at": record.get("dispatched_at"),
+        "completed_at": completed_at,
+    }
+
+
+def _insert_batch_event(conn, event: Dict[str, Any], *, now: float) -> bool:
+    cur = conn.execute(
+        """INSERT OR IGNORE INTO async_delegation_events
+           (delegation_id, event_key, event_json, delivery_state,
+            delivery_attempts, created_at, updated_at)
+           VALUES (?, ?, ?, 'pending', 0, ?, ?)""",
+        (
+            event["delegation_id"],
+            event["delivery_event_key"],
+            json.dumps(event),
+            now,
+            now,
+        ),
+    )
+    return cur.rowcount == 1
+
+
+def _persist_batch_child_completion_event(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return None
+    event = _build_batch_child_event(record, task_index, result)
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return None
+    return event
+
+
+def persist_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Persist one completed batch child without changing delivery timing.
+
+    The production batch runner calls this before joining slower siblings so a
+    process crash cannot erase an already completed child. The legacy aggregate
+    finalizer remains the only queue publisher in this layer.
+    """
+    return _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    ) is not None
+
+
+def publish_batch_child_completion(
+    delegation_id: str,
+    task_index: int,
+    result: Dict[str, Any],
+) -> bool:
+    """Durably enqueue one ready child from an asynchronous batch.
+
+    The parent batch remains the execution/stall unit. This function creates an
+    independently claimable between-turn delivery event, keyed by task index.
+    Repeated publication is idempotent and never resets a delivered claim.
+    """
+    event = _persist_batch_child_completion_event(
+        delegation_id, task_index, result
+    )
+    if event is None:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    # Process-local handoff marker only. It prevents the aggregate finalizer
+    # from adding a duplicate queue copy when a future layer publishes children
+    # early. A crash intentionally loses this marker; restart recovery then
+    # restores the still-pending durable row from SQLite.
+    event_key = event["delivery_event_key"]
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            queued_keys = record.setdefault("_queued_child_event_keys", [])
+            if event_key not in queued_keys:
+                queued_keys.append(event_key)
+    return True
+
+
+def _event_delivery_keys(event: Dict[str, Any]) -> list[str]:
+    raw_keys = event.get("delivery_event_keys")
+    if isinstance(raw_keys, (list, tuple)):
+        return list(dict.fromkeys(str(key) for key in raw_keys if key))
+    key = str(event.get("delivery_event_key") or "")
+    return [key] if key else []
+
+
+def coalesce_ready_after_turn_events(
+    events: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Combine ready child rows from each after-turn batch at one boundary.
+
+    SQLite and the shared queue retain one durable row per child. This helper
+    creates only a transient delivery envelope so every child remains
+    independently recoverable while one consumer can claim/ack the currently
+    ready set atomically. Envelopes are deliberately re-coalescible: a busy
+    consumer may requeue one while more siblings finish before its next boundary.
+    """
+
+    output: List[Dict[str, Any]] = []
+    groups: Dict[str, Dict[str, Any]] = {}
+    seen_keys: Dict[str, set[str]] = {}
+    for event in events:
+        event_keys = _event_delivery_keys(event)
+        delegation_id = str(event.get("delegation_id") or "")
+        coalescible = (
+            event.get("type") == "async_delegation"
+            and bool(event.get("is_batch"))
+            and bool(event_keys)
+            and all(key.startswith("task:") for key in event_keys)
+            and bool(delegation_id)
         )
+        if not coalescible:
+            output.append(event)
+            continue
+
+        grouped = groups.get(delegation_id)
+        if grouped is None:
+            grouped = dict(event)
+            grouped.pop("delivery_event_key", None)
+            grouped["delivery_event_keys"] = []
+            grouped["task_indices"] = []
+            grouped["results"] = []
+            grouped["live_transcripts"] = []
+            grouped["coalesced_after_turn"] = True
+            groups[delegation_id] = grouped
+            seen_keys[delegation_id] = set()
+            output.append(grouped)
+
+        new_keys = [
+            key for key in event_keys if key not in seen_keys[delegation_id]
+        ]
+        if not new_keys:
+            continue
+        seen_keys[delegation_id].update(new_keys)
+        grouped["delivery_event_keys"].extend(new_keys)
+        new_key_set = set(new_keys)
+        for result in event.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            task_index = int(result.get("task_index", 0))
+            if f"task:{task_index}" not in new_key_set:
+                continue
+            grouped["task_indices"].append(task_index)
+            grouped["results"].append(result)
+        grouped["live_transcripts"].extend(
+            path for path in (event.get("live_transcripts") or []) if path
+        )
+        grouped["completed_at"] = max(
+            float(grouped.get("completed_at") or 0),
+            float(event.get("completed_at") or 0),
+        )
+
+    for grouped in groups.values():
+        grouped["delivery_event_keys"].sort(
+            key=lambda key: int(key.split(":", 1)[1])
+        )
+        grouped["task_indices"] = sorted(set(grouped["task_indices"]))
+        grouped["results"].sort(key=lambda result: int(result.get("task_index", 0)))
+        grouped["live_transcripts"] = list(
+            dict.fromkeys(grouped["live_transcripts"])
+        ) or None
+    return output
+
+
+def _build_batch_terminal_event(
+    event_record: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+    *,
+    force: bool = False,
+) -> Optional[Dict[str, Any]]:
+    if not force and (
+        status in {"completed", "success"} or (combined.get("results") or [])
+    ):
+        return None
+    delegation_id = str(event_record.get("delegation_id") or "")
+    now = time.time()
+    event: Dict[str, Any] = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "delivery_event_key": "terminal",
+        "batch_id": delegation_id,
+        "session_key": event_record.get("session_key", ""),
+        "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
+        "origin_session_id": event_record.get("origin_session_id", ""),
+        "parent_session_id": event_record.get("parent_session_id"),
+        "goal": event_record.get("goal", ""),
+        "goals": event_record.get("goals"),
+        "context": event_record.get("context"),
+        "toolsets": event_record.get("toolsets"),
+        "role": event_record.get("role"),
+        "model": event_record.get("model"),
+        "status": status,
+        "is_batch": True,
+        "results": [],
+        "error": combined.get("error"),
+        "dispatched_at": event_record.get("dispatched_at"),
+        "completed_at": now,
+    }
+    for key in (
+        "stalled_after_quiet_seconds",
+        "stall_threshold_seconds",
+        "stall_phase",
+        "stall_grace_seconds",
+    ):
+        if key in combined:
+            event[key] = combined[key]
+    return event
+
+
+def _publish_batch_terminal_event(
+    event_record: Dict[str, Any], combined: Dict[str, Any], status: str
+) -> bool:
+    """Deliver a batch-level failure not represented by child events."""
+    event = _build_batch_terminal_event(event_record, combined, status)
+    if event is None:
+        return False
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        inserted = _insert_batch_event(conn, event, now=now)
+    if not inserted:
+        return False
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(event)
+    return True
+
+
+def _persist_batch_child_finalization(
+    event_record: Dict[str, Any],
+    parent_event: Dict[str, Any],
+    combined: Dict[str, Any],
+    status: str,
+) -> None:
+    """Atomically persist missing child events and the terminal parent row."""
+
+    now = time.time()
+    queue_event_keys: list[str] = []
+    queue_events: list[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        for child in combined.get("results") or []:
+            child_event = _build_batch_child_event(
+                event_record,
+                int(child.get("task_index", 0)),
+                child,
+                completed_at=now,
+            )
+            _insert_batch_event(conn, child_event, now=now)
+            queue_event_keys.append(child_event["delivery_event_key"])
+
+        terminal_event = _build_batch_terminal_event(
+            event_record, combined, status
+        )
+        if terminal_event is not None:
+            _insert_batch_event(conn, terminal_event, now=now)
+            queue_event_keys.append(terminal_event["delivery_event_key"])
+
+        # The aggregate row is bookkeeping-only. Commit its terminal state in
+        # the same transaction as the idempotent child safety net so restart
+        # recovery can never observe a half-finalized parent.
+        _update_completion_row(
+            conn,
+            parent_event,
+            combined,
+            delivery_state="delivered",
+            now=now,
+        )
+
+        # Child callbacks may have inserted these rows before the aggregate
+        # join. Preserve legacy delivery timing by loading every still-pending
+        # aggregate member only after the parent terminal update commits.
+        already_queued = {
+            str(key) for key in (event_record.get("_queued_child_event_keys") or [])
+        }
+        event_keys = [
+            key
+            for key in dict.fromkeys(queue_event_keys)
+            if key not in already_queued
+        ]
+        if event_keys:
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                "SELECT event_json FROM async_delegation_events "
+                "WHERE delegation_id=? AND delivery_state='pending' "
+                f"AND event_key IN ({placeholders})",
+                (event_record["delegation_id"], *event_keys),
+            ).fetchall()
+            queue_events = [json.loads(row[0]) for row in rows]
+
+    from tools.process_registry import process_registry
+
+    queue_events = coalesce_ready_after_turn_events(queue_events)
+    with process_registry.completion_routing_lock:
+        for queued_event in queue_events:
+            process_registry.completion_queue.put(queued_event)
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -316,6 +723,88 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            child_rows = []
+            if bool(task.get("is_batch")):
+                child_rows = conn.execute(
+                    """SELECT event_key, event_json FROM async_delegation_events
+                       WHERE delegation_id=? AND event_key LIKE 'task:%'
+                       ORDER BY event_key""",
+                    (delegation_id,),
+                ).fetchall()
+            if bool(task.get("is_batch")) and bool(child_rows):
+                # Child-scoped batches never recover through a contradictory
+                # aggregate. A crash after one or more child inserts must
+                # preserve the already-delivered/pending task identities.
+                goals = list(task.get("goals") or [])
+                expected_child_keys = [f"task:{index}" for index in range(len(goals))]
+                child_results_by_key: dict[str, Dict[str, Any]] = {}
+                for event_key, child_payload in child_rows:
+                    if event_key not in expected_child_keys:
+                        continue
+                    child_event = json.loads(child_payload or "{}")
+                    results = child_event.get("results") or []
+                    if results and isinstance(results[0], dict):
+                        child_results_by_key[event_key] = results[0]
+
+                child_results = [
+                    child_results_by_key[key]
+                    for key in expected_child_keys
+                    if key in child_results_by_key
+                ]
+                complete_children = bool(expected_child_keys) and all(
+                    key in child_results_by_key for key in expected_child_keys
+                )
+                status = "completed" if complete_children else "unknown"
+                recovery_error = None
+                if not complete_children:
+                    recovery_error = (
+                        "Delegation owner exited after recording "
+                        f"{len(child_results)}/{len(goals)} batch child results; "
+                        "remaining outcomes are unknown."
+                    )
+                combined = {
+                    "results": child_results,
+                    "error": recovery_error,
+                }
+                event_record = {
+                    "delegation_id": delegation_id,
+                    "session_key": session_key,
+                    "origin_ui_session_id": origin_ui,
+                    "origin_session_id": origin_session_id or "",
+                    "parent_session_id": parent_id,
+                    "goal": task.get("goal", ""),
+                    "goals": goals,
+                    "context": task.get("context"),
+                    "toolsets": task.get("toolsets"),
+                    "role": task.get("role"),
+                    "model": task.get("model"),
+                    "dispatched_at": dispatched_at,
+                }
+                if not complete_children:
+                    terminal_event = _build_batch_terminal_event(
+                        event_record, combined, status, force=True
+                    )
+                    if terminal_event is not None:
+                        _insert_batch_event(conn, terminal_event, now=now)
+
+                parent_event = {
+                    **event_record,
+                    "type": "async_delegation",
+                    "status": status,
+                    "is_batch": True,
+                    "results": child_results,
+                    "error": recovery_error,
+                    "completed_at": now,
+                }
+                _update_completion_row(
+                    conn,
+                    parent_event,
+                    combined,
+                    delivery_state="delivered",
+                    now=now,
+                )
+                recovered += 1
+                continue
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -354,22 +843,47 @@ def restore_undelivered_completions(target_queue) -> int:
     results seconds after boot (#64484).
     """
     recover_abandoned_delegations()
+    restored = 0
+    parent_events: list[Dict[str, Any]] = []
+    child_events: list[Dict[str, Any]] = []
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT delegation_id, event_json FROM async_delegations
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
+        child_rows = conn.execute(
+            """SELECT delegation_id, event_key, event_json
+               FROM async_delegation_events
+               WHERE delivery_state='pending'
+               ORDER BY created_at, delegation_id, event_key"""
+        ).fetchall()
         for _delegation_id, payload in rows:
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
-            target_queue.put(evt)
-    return len(rows)
+            parent_events.append(evt)
+            restored += 1
+        for delegation_id, event_key, payload in child_rows:
+            evt = json.loads(payload)
+            if isinstance(evt, dict):
+                evt["restored"] = True
+                evt.setdefault("delegation_id", delegation_id)
+                evt.setdefault("delivery_event_key", event_key)
+            child_events.append(evt)
+            restored += 1
+    # Queue only after the SQLite read transaction closes. Default after-turn
+    # batches retain the legacy one-envelope restart shape even though each
+    # child now has an independently durable identity underneath it.
+    for evt in parent_events:
+        target_queue.put(evt)
+    for evt in coalesce_ready_after_turn_events(child_events):
+        target_queue.put(evt)
+    return restored
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
-    """Atomically acknowledge successful injection of a durable completion."""
+    """Atomically acknowledge successful delivery of a durable completion."""
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
@@ -395,7 +909,69 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                       delivery_attempts=delivery_attempts+1, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300),
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
+        )
+        return cur.rowcount == 1
+
+
+class _DeliveryGroupConflict(RuntimeError):
+    """Rollback a multi-child settlement when any row lost ownership."""
+
+
+def _claim_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=?, delivery_claimed_at=?,
+                           delivery_attempts=delivery_attempts+1, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending'
+                         AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+                    (
+                        claim_id,
+                        now,
+                        now,
+                        delegation_id,
+                        event_key,
+                        now - _DELIVERY_CLAIM_LEASE_SECONDS,
+                    ),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _claim_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=?, delivery_claimed_at=?,
+                   delivery_attempts=delivery_attempts+1, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending'
+                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
+            (
+                claim_id,
+                now,
+                now,
+                delegation_id,
+                event_key,
+                now - _DELIVERY_CLAIM_LEASE_SECONDS,
+            ),
         )
         return cur.rowcount == 1
 
@@ -408,7 +984,103 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     if not delegation_id:
         return ""
     claim_id = f"{consumer}:{__import__('os').getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        claimed = bool(event_keys) and _claim_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        claimed = _claim_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        claimed = claim_completion_delivery(delegation_id, claim_id)
+    return claim_id if claimed else None
+
+
+def renew_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Renew the lease held by the exact consumer claim."""
+
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return False
+    event_keys = _event_delivery_keys(evt)
+    now = time.time()
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        try:
+            with _DB_LOCK, _transaction() as conn:
+                for event_key in event_keys:
+                    cur = conn.execute(
+                        """UPDATE async_delegation_events
+                           SET delivery_claimed_at=?, updated_at=?
+                           WHERE delegation_id=? AND event_key=?
+                             AND delivery_state='pending' AND delivery_claim=?""",
+                        (now, now, delegation_id, event_key, claim_id),
+                    )
+                    if cur.rowcount != 1:
+                        raise _DeliveryGroupConflict(event_key)
+        except _DeliveryGroupConflict:
+            return False
+        return True
+    event_key = event_keys[0] if event_keys else ""
+    with _DB_LOCK, _transaction() as conn:
+        if event_key:
+            cur = conn.execute(
+                """UPDATE async_delegation_events
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND event_key=?
+                     AND delivery_state='pending' AND delivery_claim=?""",
+                (now, now, delegation_id, event_key, claim_id),
+            )
+        else:
+            cur = conn.execute(
+                """UPDATE async_delegations
+                   SET delivery_claimed_at=?, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, now, delegation_id, claim_id),
+            )
+        return cur.rowcount == 1
+
+
+def get_event_delivery_state(evt: Dict[str, Any]) -> Optional[str]:
+    """Return the durable state for one aggregate or child event."""
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    event_keys = _event_delivery_keys(evt)
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT delivery_state FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            if len(rows) != len(event_keys):
+                return None
+            states = {str(row[0]) for row in rows}
+            return states.pop() if len(states) == 1 else "mixed"
+        event_key = event_keys[0] if event_keys else ""
+        if event_key:
+            row = conn.execute(
+                """SELECT delivery_state FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_key),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+                (delegation_id,),
+            ).fetchone()
+    return str(row[0]) if row is not None else None
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -484,14 +1156,271 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
         return cur.rowcount == 1
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def _complete_child_event(
+    delegation_id: str, event_key: str, claim_id: str, state: str = "delivered"
+) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state=?, delivered_at=?, updated_at=?,
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (state, now, now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def _release_child_event(delegation_id: str, event_key: str, claim_id: str) -> bool:
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        capped = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_state='dropped', delivery_claim=NULL,
+                   delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?
+                 AND delivery_attempts>=?""",
+            (now, delegation_id, event_key, claim_id, _MAX_DELIVERY_ATTEMPTS),
+        )
+        if capped.rowcount == 1:
+            return True
+        cur = conn.execute(
+            """UPDATE async_delegation_events
+               SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND event_key=?
+                 AND delivery_state='pending' AND delivery_claim=?""",
+            (now, delegation_id, event_key, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def _complete_child_event_group(
+    delegation_id: str,
+    event_keys: List[str],
+    claim_id: str,
+    state: str = "delivered",
+) -> bool:
+    now = time.time()
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                cur = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state=?, delivered_at=?, updated_at=?,
+                           delivery_claim=NULL, delivery_claimed_at=NULL
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (state, now, now, delegation_id, event_key, claim_id),
+                )
+                if cur.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+    except _DeliveryGroupConflict:
+        return False
+    return True
+
+
+def _release_child_event_group(
+    delegation_id: str, event_keys: List[str], claim_id: str
+) -> tuple[bool, List[str]]:
+    now = time.time()
+    pending_keys: List[str] = []
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            for event_key in event_keys:
+                capped = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_state='dropped', delivery_claim=NULL,
+                           delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?
+                         AND delivery_attempts>=?""",
+                    (
+                        now,
+                        delegation_id,
+                        event_key,
+                        claim_id,
+                        _MAX_DELIVERY_ATTEMPTS,
+                    ),
+                )
+                if capped.rowcount == 1:
+                    continue
+                released = conn.execute(
+                    """UPDATE async_delegation_events
+                       SET delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+                       WHERE delegation_id=? AND event_key=?
+                         AND delivery_state='pending' AND delivery_claim=?""",
+                    (now, delegation_id, event_key, claim_id),
+                )
+                if released.rowcount != 1:
+                    raise _DeliveryGroupConflict(event_key)
+                pending_keys.append(event_key)
+    except _DeliveryGroupConflict:
+        return False, event_keys
+    return True, pending_keys
+
+
+def _retain_group_event_keys(evt: Dict[str, Any], event_keys: List[str]) -> None:
+    """Keep only rows that remain pending after a grouped release."""
+
+    keep = set(event_keys)
+    evt["delivery_event_keys"] = list(event_keys)
+    evt["results"] = [
+        result
+        for result in (evt.get("results") or [])
+        if isinstance(result, dict)
+        and f"task:{int(result.get('task_index', 0))}" in keep
+    ]
+    evt["task_indices"] = sorted(
+        int(result.get("task_index", 0)) for result in evt["results"]
+    )
+
+
+def get_event_delivery_retry_delay(
+    evt: Dict[str, Any], *, now: Optional[float] = None
+) -> Optional[float]:
+    """Return a bounded delay for an unclaimed pending event, else ``None``.
+
+    A failed claim is ambiguous: another live process may own the pending row,
+    or this queue entry may be a duplicate whose durable row is already
+    delivered/dropped. Consumers use this oracle before deferred requeue so a
+    quick restart waits only for the remaining lease without spinning. Grouped
+    envelopes are narrowed to rows that are still pending.
+    """
+
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    current = time.time() if now is None else float(now)
+    event_keys = _event_delivery_keys(evt)
+    pending_rows: List[tuple[str, Optional[str], Optional[float]]] = []
+
+    with _DB_LOCK, _transaction() as conn:
+        if "delivery_event_keys" in evt:
+            if not event_keys:
+                return None
+            placeholders = ",".join("?" for _ in event_keys)
+            rows = conn.execute(
+                f"""SELECT event_key, delivery_state, delivery_claim,
+                           delivery_claimed_at
+                    FROM async_delegation_events
+                    WHERE delegation_id=? AND event_key IN ({placeholders})""",
+                (delegation_id, *event_keys),
+            ).fetchall()
+            by_key = {str(row[0]): row for row in rows}
+            if len(by_key) != len(event_keys):
+                return None
+            pending_keys = [
+                key for key in event_keys if str(by_key[key][1]) == "pending"
+            ]
+            if not pending_keys:
+                return None
+            _retain_group_event_keys(evt, pending_keys)
+            pending_rows = [
+                (
+                    key,
+                    str(by_key[key][2]) if by_key[key][2] else None,
+                    float(by_key[key][3]) if by_key[key][3] is not None else None,
+                )
+                for key in pending_keys
+            ]
+        elif event_keys:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegation_events
+                   WHERE delegation_id=? AND event_key=?""",
+                (delegation_id, event_keys[0]),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    event_keys[0],
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+        else:
+            row = conn.execute(
+                """SELECT delivery_state, delivery_claim, delivery_claimed_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+            if row is None or str(row[0]) != "pending":
+                return None
+            pending_rows = [
+                (
+                    "aggregate",
+                    str(row[1]) if row[1] else None,
+                    float(row[2]) if row[2] is not None else None,
+                )
+            ]
+
+    # A short guard covers claim races and strict SQL '<' lease comparison.
+    delay = 0.05
+    for _event_key, claim, claimed_at in pending_rows:
+        if not claim:
+            continue
+        if claimed_at is None:
+            delay = max(delay, float(_DELIVERY_CLAIM_LEASE_SECONDS))
+            continue
+        remaining = float(_DELIVERY_CLAIM_LEASE_SECONDS) - (current - claimed_at)
+        delay = max(delay, remaining)
+    return max(0.05, delay) + 0.05
+
+
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        completed = bool(event_keys) and _complete_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+    elif event_keys:
+        completed = _complete_child_event(delegation_id, event_keys[0], claim_id)
+    else:
+        completed = complete_completion_delivery(delegation_id, claim_id)
+    return completed or get_event_delivery_state(evt) == "delivered"
+
+
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if not event_keys:
+            return False
+        released, pending_keys = _release_child_event_group(
+            delegation_id, event_keys, claim_id
+        )
+        if released:
+            _retain_group_event_keys(evt, pending_keys)
+        return released
+    if event_keys:
+        return _release_child_event(delegation_id, event_keys[0], claim_id)
+    return release_completion_delivery(delegation_id, claim_id)
+
+
+def drop_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return
+    delegation_id = str(evt.get("delegation_id") or "")
+    event_keys = _event_delivery_keys(evt)
+    if "delivery_event_keys" in evt:
+        if event_keys:
+            _complete_child_event_group(
+                delegation_id, event_keys, claim_id, state="dropped"
+            )
+    elif event_keys:
+        _complete_child_event(delegation_id, event_keys[0], claim_id, state="dropped")
+    else:
+        drop_completion_delivery(delegation_id, claim_id)
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -956,11 +1885,9 @@ def dispatch_async_delegation_batch(
     parallelism is bounded separately by ``max_concurrent_children``), so a
     single ``delegate_task`` fan-out never exhausts the async pool by itself.
 
-    When the batch finishes, a SINGLE completion event is pushed onto the
-    shared ``process_registry.completion_queue`` carrying the full per-task
-    ``results`` list, so the consolidated summaries re-enter the conversation
-    as one message once every child is done — the chat is never blocked while
-    they run.
+    Each child uses an independently durable row. Finalization preserves the
+    existing between-turn grouped envelope and idempotently fills any child row
+    missed by a completion callback.
 
     Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
     ``{"status": "rejected", "error": ...}`` when the async pool is at
@@ -1064,7 +1991,7 @@ def dispatch_async_delegation_batch(
 def _finalize_batch(
     delegation_id: str, combined: Dict[str, Any], status: str
 ) -> None:
-    """Mark a batch record complete and push ONE combined completion event."""
+    """Mark a batch complete and persist any missing child delivery events."""
     claimed = _begin_finalization(delegation_id)
     if claimed is None:
         return
@@ -1077,17 +2004,7 @@ def _finalize_batch(
 def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
-    """Push a combined async-delegation batch completion event."""
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s finished but process_registry import "
-            "failed; result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
-        return
-
+    """Finalize one child-scoped async-delegation batch."""
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
     evt = {
@@ -1127,15 +2044,10 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s: failed to enqueue completion event; "
-            "result lost: %s",
-            event_record.get("delegation_id"), exc,
-        )
+    # Child callbacks persist incrementally without changing legacy delivery
+    # timing. The finalizer idempotently inserts any missed child, commits the
+    # parent terminal row, then queues one grouped envelope after commit.
+    _persist_batch_child_finalization(event_record, evt, combined, status)
 
 
 def _ensure_stale_monitor() -> None:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -3,7 +3,7 @@
 
 Each finished child is persisted and published before waiting for slower siblings.
 Existing between-turn consumers coalesce the children ready at their boundary;
-there is no active-loop carrier at this layer. Parent rows remain execution and
+opted-in results may instead use an unsent tool-result carrier in the originating turn. Parent rows remain execution and
 recovery bookkeeping, and every result uses the shared completion queue and ledger.
 """
 
@@ -125,7 +125,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     # origin_session_id: raw api_server session id of the ORIGINATING request
     # (wake target); without it restart-recovered completions are unroutable there.
     for name, sql_type in (("owner_pid", "INTEGER"), ("owner_started_at", "INTEGER"), ("task_json", "TEXT"),
-                           ("delivery_claim", "TEXT"), ("delivery_claimed_at", "REAL"), ("origin_session_id", "TEXT")):
+                           ("delivery_claim", "TEXT"), ("delivery_claimed_at", "REAL"), ("origin_session_id", "TEXT"),
+                           ("result_delivery", "TEXT")):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
 
@@ -188,18 +189,19 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         owner_started_at = None
     task_payload = {
         key: record.get(key)
-        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch", *_ROUTING_KEYS)
+        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch", "result_delivery", "parent_turn_id", *_ROUTING_KEYS)
         if key in record}
     with _DB_LOCK, _transaction() as conn:
         conn.execute("""INSERT OR REPLACE INTO async_delegations
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id, result_delivery)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""), record.get("origin_ui_session_id", ""),
              record.get("parent_session_id"), record["dispatched_at"], now, os.getpid(), owner_started_at,
-             json.dumps(task_payload), record.get("origin_session_id", "")))
+             json.dumps(task_payload), record.get("origin_session_id", ""),
+             record.get("result_delivery", "after_turn")))
     _prune_durable_records()
 
 
@@ -286,6 +288,7 @@ def _build_batch_child_event(
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
         "goal": goal,
         "goals": goals,
         "context": record.get("context"),
@@ -308,6 +311,9 @@ def _build_batch_child_event(
         "completed_at": completed_at,
         **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
         **{k: result[k] for k in _STALL_META_KEYS if k in result},
+        "result_delivery": str(
+            record.get("result_delivery") or "after_turn"
+        ).strip().lower(),
     }
 
 
@@ -369,10 +375,22 @@ def publish_batch_child_completion(
 ) -> bool:
     """Durably enqueue one ready child from an asynchronous batch.
 
-    The parent batch remains the execution/stall unit. This function creates an
-    independently claimable between-turn delivery event, keyed by task index.
-    Repeated publication is idempotent and never resets a delivered claim.
+    The parent batch remains the execution/stall unit. This function only
+    creates an independently claimable delivery event, keyed by task index.
+    ``result_delivery`` changes which consumer may claim it, not when the child
+    row becomes durable. Repeated publication is idempotent and never resets a
+    delivered claim.
     """
+    with _records_lock:
+        record = dict(_records.get(delegation_id) or {})
+    if not record or not bool(record.get("is_batch")):
+        return False
+    if str(record.get("result_delivery") or "after_turn").lower() not in {
+        "inject",
+        "after_turn",
+    }:
+        return False
+
     event = _persist_batch_child_completion_event(
         delegation_id, task_index, result
     )
@@ -419,10 +437,12 @@ def coalesce_ready_after_turn_events(
     groups: Dict[str, Dict[str, Any]] = {}
     seen_keys: Dict[str, set[str]] = {}
     for event in events:
+        delivery = str(event.get("result_delivery") or "after_turn").strip().lower()
         event_keys = _event_delivery_keys(event)
         delegation_id = str(event.get("delegation_id") or "")
         coalescible = (
             event.get("type") == "async_delegation"
+            and delivery == "after_turn"
             and bool(event.get("is_batch"))
             and bool(event_keys)
             and all(key.startswith("task:") for key in event_keys)
@@ -503,6 +523,7 @@ def _build_batch_terminal_event(
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "parent_turn_id": event_record.get("parent_turn_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),
@@ -516,6 +537,9 @@ def _build_batch_terminal_event(
         "dispatched_at": event_record.get("dispatched_at"),
         "completed_at": now,
         **{k: event_record[k] for k in _ROUTING_KEYS if event_record.get(k)},
+        "result_delivery": str(
+            event_record.get("result_delivery") or "after_turn"
+        ).strip().lower(),
     }
     for key in (
         "stalled_after_quiet_seconds",
@@ -563,9 +587,9 @@ def _persist_batch_child_finalization(
             _insert_batch_event(conn, terminal_event, now=now)
             queue_event_keys.append(terminal_event["delivery_event_key"])
 
-        # The aggregate row is bookkeeping-only. Commit its terminal state in
-        # the same transaction as the idempotent child safety net so restart
-        # recovery can never observe a half-finalized parent.
+        # The aggregate row is bookkeeping-only for all child-scoped batches. Commit its
+        # terminal state in the same transaction as the idempotent child safety
+        # net so restart recovery can never observe a half-finalized parent.
         _update_completion_row(
             conn,
             parent_event,
@@ -999,12 +1023,13 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      result_delivery
                FROM async_delegations WHERE state IN ('running','stalling','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, result_delivery) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -1013,6 +1038,9 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            restored_delivery = str(
+                result_delivery or task.get("result_delivery") or "after_turn"
+            ).lower()
             child_rows = []
             if bool(task.get("is_batch")):
                 child_rows = conn.execute(
@@ -1021,7 +1049,9 @@ def recover_abandoned_delegations() -> int:
                        ORDER BY event_key""",
                     (delegation_id,),
                 ).fetchall()
-            if bool(task.get("is_batch")) and bool(child_rows):
+            if bool(task.get("is_batch")) and (
+                restored_delivery == "inject" or bool(child_rows)
+            ):
                 # Child-scoped batches never recover through a contradictory
                 # aggregate. A crash after one or more child inserts must
                 # preserve the already-delivered/pending task identities.
@@ -1062,6 +1092,7 @@ def recover_abandoned_delegations() -> int:
                     "origin_ui_session_id": origin_ui,
                     "origin_session_id": origin_session_id or "",
                     "parent_session_id": parent_id,
+                    "parent_turn_id": task.get("parent_turn_id", ""),
                     "goal": task.get("goal", ""),
                     "goals": goals,
                     "context": task.get("context"),
@@ -1070,6 +1101,7 @@ def recover_abandoned_delegations() -> int:
                     "model": task.get("model"),
                     "dispatched_at": dispatched_at,
                     **{k: task[k] for k in _ROUTING_KEYS if task.get(k)},
+                    "result_delivery": restored_delivery,
                 }
                 if not complete_children:
                     terminal_event = _build_batch_terminal_event(
@@ -1086,6 +1118,7 @@ def recover_abandoned_delegations() -> int:
                     "results": child_results,
                     "error": recovery_error,
                     "completed_at": now,
+                    "result_delivery": restored_delivery,
                 }
                 _update_completion_row(
                     conn,
@@ -1103,9 +1136,11 @@ def recover_abandoned_delegations() -> int:
                 # after a restart remain routable to api_server sessions.
                 "origin_session_id": origin_session_id or "",
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "parent_turn_id": task.get("parent_turn_id", ""),
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
+                "result_delivery": restored_delivery,
                 "status": "unknown", "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
@@ -1455,12 +1490,16 @@ def _dispatch(
     parent_session_id: Optional[str], runner: Callable[[], Dict[str, Any]], origin_ui_session_id: str,
     origin_session_id: str, interrupt_fn: Optional[Callable[[], None]], max_async_children: int,
     progress_fn: Optional[Callable[[], tuple]], capacity_error: str,
+    result_delivery: str = "after_turn", parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Shared dispatch core for single (``goals is None``) and batch units. Capacity check +
     record insert happen under ONE lock hold so concurrent dispatches can't both pass the check
     and exceed the cap. At capacity the dispatch is REJECTED (never queued) so a runaway model
     can't pile up unbounded background work."""
     is_batch = goals is not None
+    result_delivery = str(result_delivery or "after_turn").strip().lower()
+    if result_delivery not in {"inject", "after_turn"}:
+        result_delivery = "after_turn"
     label = " batch" if is_batch else ""
     classify = _batch_status if is_batch else (lambda r: r.get("status") or "completed")
     crash_result = _batch_crash if is_batch else _single_crash
@@ -1470,6 +1509,7 @@ def _dispatch(
         "context": context, "toolsets": list(toolsets) if toolsets else None, "role": role, "model": model,
         "session_key": session_key, "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id, "parent_session_id": parent_session_id,
+        "result_delivery": result_delivery, "parent_turn_id": parent_turn_id,
         **_capture_routing_origin(),
         "status": "running", "dispatched_at": dispatched_at, "completed_at": None,
         "interrupt_fn": interrupt_fn, **({"is_batch": True} if is_batch else {}), "progress_fn": progress_fn,
@@ -1515,6 +1555,7 @@ def dispatch_async_delegation(
     session_key: str, parent_session_id: Optional[str] = None, runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "", origin_session_id: str = "", interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN, progress_fn: Optional[Callable[[], tuple]] = None,
+    result_delivery: Optional[str] = None, parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
     ``session_key``/``parent_session_id`` are captured on the parent thread (the worker carries
@@ -1526,6 +1567,7 @@ def dispatch_async_delegation(
         delegation_id=delegation_id, goal=goal, goals=None, context=context,
         toolsets=toolsets, role=role, model=model, session_key=session_key,
         parent_session_id=parent_session_id, runner=runner,
+        result_delivery=result_delivery, parent_turn_id=parent_turn_id,
         origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
         interrupt_fn=interrupt_fn, max_async_children=max_async_children, progress_fn=progress_fn,
         capacity_error=(
@@ -1544,6 +1586,7 @@ def dispatch_async_delegation_batch(
     origin_ui_session_id: str = "", origin_session_id: str = "", interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN, delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    result_delivery: Optional[str] = None, parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit: ``runner`` runs the
     entire batch and returns the combined ``{"results": [...], "total_duration_seconds": N}``
@@ -1556,6 +1599,7 @@ def dispatch_async_delegation_batch(
         delegation_id=delegation_id, goal=combined_goal, goals=goals, context=context,
         toolsets=toolsets, role=role, model=model, session_key=session_key,
         parent_session_id=parent_session_id, runner=runner,
+        result_delivery=result_delivery, parent_turn_id=parent_turn_id,
         origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
         interrupt_fn=interrupt_fn, max_async_children=max_async_children, progress_fn=progress_fn,
         capacity_error=(
@@ -1622,6 +1666,8 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
+        "result_delivery": record.get("result_delivery", "after_turn"),
         "goal": record.get("goal", ""), **({"goals": record.get("goals")} if is_batch else {}),
         "context": record.get("context"), "toolsets": record.get("toolsets"), "role": record.get("role"),
         "model": record.get("model") if is_batch else (result.get("model") or record.get("model")),

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1281,6 +1281,62 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
         return cur.rowcount == 1
 
 
+def _reconcile_persisted_tool_carrier(evt: Dict[str, Any]) -> bool:
+    """Close the crash window between transcript commit and ledger acknowledgement.
+
+    The transcript and this ledger share profile-local state.db. A tool-boundary
+    receipt proves acceptance even if the process died before clearing its lease.
+    Scope by parent session and exact event identity; unrelated metadata must not
+    suppress another session's delivery. Legacy databases without transcript
+    metadata keep the ordinary claim path.
+    """
+    if evt.get("result_delivery") != "inject" or not evt.get("parent_session_id"):
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    keys = _event_delivery_keys(evt)
+    identities = {f"{delegation_id}:{key}" for key in keys} if keys else {f"{delegation_id}:aggregate"}
+    with _DB_LOCK, _transaction() as conn:
+        try:
+            rows = conn.execute(
+                "SELECT display_metadata FROM messages WHERE session_id=? AND role='tool' "
+                "AND display_metadata IS NOT NULL AND instr(display_metadata, ?) > 0",
+                (evt["parent_session_id"], delegation_id),
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc) or "no such column" in str(exc):
+                return False
+            raise
+        receipts = set()
+        for (raw,) in rows:
+            try:
+                metadata = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(metadata, dict) and metadata.get("delegation_delivery") == "tool_boundary":
+                values = metadata.get("delegation_event_ids")
+                if isinstance(values, list):
+                    receipts.update(value for value in values if isinstance(value, str))
+        if not identities.issubset(receipts):
+            return False
+        now = time.time()
+        if keys:
+            for key in keys:
+                conn.execute(
+                    "UPDATE async_delegation_events SET delivery_state='delivered', delivered_at=?, "
+                    "updated_at=?, delivery_claim=NULL, delivery_claimed_at=NULL "
+                    "WHERE delegation_id=? AND event_key=? AND delivery_state='pending'",
+                    (now, now, delegation_id, key),
+                )
+        else:
+            conn.execute(
+                "UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, "
+                "updated_at=?, delivery_claim=NULL, delivery_claimed_at=NULL "
+                "WHERE delegation_id=? AND delivery_state='pending'",
+                (now, now, delegation_id),
+            )
+    return True
+
+
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     """Claim a durable delegation event; non-durable events need no token."""
     if evt.get("type") != "async_delegation":
@@ -1288,6 +1344,8 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
+    if _reconcile_persisted_tool_carrier(evt):
+        return None
     claim_id = f"{consumer}:{os.getpid()}:{uuid.uuid4().hex}"
     event_keys = _event_delivery_keys(evt)
     if "delivery_event_keys" in evt:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3375,8 +3375,8 @@ def delegate_task(
             child._live_transcript_path = str(_writer.path)
         children.append((i, t, child))
 
-    def _persist_ready_result(entry: Dict[str, Any]) -> None:
-        """Persist one ready child while preserving aggregate delivery timing."""
+    def _publish_ready_result(entry: Dict[str, Any]) -> None:
+        """Publish one ready child without waiting for its batch siblings."""
         if not background:
             return
         task_index = int(entry.get("task_index", 0))
@@ -3384,14 +3384,14 @@ def delegate_task(
         if 0 <= task_index < len(live_paths):
             payload.setdefault("live_transcript", live_paths[task_index])
         try:
-            from tools.async_delegation import persist_batch_child_completion
+            from tools.async_delegation import publish_batch_child_completion
 
-            persist_batch_child_completion(live_deleg_id, task_index, payload)
+            publish_batch_child_completion(live_deleg_id, task_index, payload)
         except Exception:
-            # Batch finalization inserts every missing child idempotently as the
+            # Batch finalization republishes all children idempotently as the
             # durable safety net for callback/persistence failures.
             logger.exception(
-                "Failed to persist ready child %s/%s",
+                "Failed to publish ready child %s/%s",
                 live_deleg_id,
                 task_index,
             )
@@ -3419,7 +3419,7 @@ def delegate_task(
                 owner_session_record=_origin_owner_session_record,
             )
             results.append(result)
-            _persist_ready_result(result)
+            _publish_ready_result(result)
         else:
             # Batch -- run in parallel with per-task progress lines
             completed_count = 0
@@ -3494,7 +3494,7 @@ def delegate_task(
                                     ),
                                 }
                             results.append(entry)
-                            _persist_ready_result(entry)
+                            _publish_ready_result(entry)
                             completed_count += 1
                         break
 
@@ -3520,7 +3520,7 @@ def delegate_task(
                                 ),
                             }
                         results.append(entry)
-                        _persist_ready_result(entry)
+                        _publish_ready_result(entry)
                         completed_count += 1
 
                         # Print per-task completion line above the spinner
@@ -3783,10 +3783,10 @@ def delegate_task(
                 "continue."
                 if n == 1 else
                 f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"and the user can keep working; every result ready at the next "
+                f"turn boundary re-enters in one grouped message without waiting "
+                f"for slower siblings. Later results arrive in later grouped "
+                f"messages. Do not wait or poll — just continue."
             )
             payload = {
                 "status": "dispatched",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3288,6 +3288,12 @@ def delegate_task(
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
         task_list, context
     )
+    if not live_deleg_id:
+        # Child-scoped durable rows and the optional live transcript must share
+        # one stable parent identity, even when transcript creation is disabled.
+        from tools.async_delegation import _new_delegation_id
+
+        live_deleg_id = _new_delegation_id()
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls
@@ -3369,6 +3375,27 @@ def delegate_task(
             child._live_transcript_path = str(_writer.path)
         children.append((i, t, child))
 
+    def _persist_ready_result(entry: Dict[str, Any]) -> None:
+        """Persist one ready child while preserving aggregate delivery timing."""
+        if not background:
+            return
+        task_index = int(entry.get("task_index", 0))
+        payload = dict(entry)
+        if 0 <= task_index < len(live_paths):
+            payload.setdefault("live_transcript", live_paths[task_index])
+        try:
+            from tools.async_delegation import persist_batch_child_completion
+
+            persist_batch_child_completion(live_deleg_id, task_index, payload)
+        except Exception:
+            # Batch finalization inserts every missing child idempotently as the
+            # durable safety net for callback/persistence failures.
+            logger.exception(
+                "Failed to persist ready child %s/%s",
+                live_deleg_id,
+                task_index,
+            )
+
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
@@ -3392,6 +3419,7 @@ def delegate_task(
                 owner_session_record=_origin_owner_session_record,
             )
             results.append(result)
+            _persist_ready_result(result)
         else:
             # Batch -- run in parallel with per-task progress lines
             completed_count = 0
@@ -3466,6 +3494,7 @@ def delegate_task(
                                     ),
                                 }
                             results.append(entry)
+                            _persist_ready_result(entry)
                             completed_count += 1
                         break
 
@@ -3491,6 +3520,7 @@ def delegate_task(
                                 ),
                             }
                         results.append(entry)
+                        _persist_ready_result(entry)
                         completed_count += 1
 
                         # Print per-task completion line above the spinner

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3124,6 +3124,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    result_delivery: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3155,14 +3156,22 @@ def delegate_task(
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
 
-    # Background (async) delegation now applies to BOTH single tasks and
-    # batches. A batch is dispatched as ONE async unit: the whole fan-out runs
-    # on the daemon executor, joins on every child (see _execute_and_aggregate
-    # / dispatch_async_delegation_batch), and pushes a SINGLE completion event
-    # carrying the consolidated per-task results. It re-enters the conversation
-    # as one message once ALL children finish — the chat is not blocked while
-    # they run.
+    # Background delegation applies to both single tasks and batches. A top-level
+    # call is one async execution/stall unit. result_delivery determines whether
+    # ready children surface at same-turn tool-result boundaries or are
+    # coalesced with every ready sibling at the next available turn boundary.
     background = is_truthy_value(background, default=False) if background is not None else False
+
+    # result_delivery controls how child results reach the parent:
+    #   'inject'      — ready evidence carried by a newly produced tool result
+    #                   before its append-only transcript commit.
+    #   'after_turn'  — legacy completion_queue path; surfaces as a new turn
+    #                   only after the current agent turn fully completes.
+    # Default is 'after_turn' for backward compatibility: old task_json entries
+    # that lack this field are treated as after_turn.
+    _delivery = str(result_delivery or "").strip().lower()
+    if _delivery not in {"inject", "after_turn"}:
+        _delivery = "after_turn"
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -3289,8 +3298,8 @@ def delegate_task(
         task_list, context
     )
     if not live_deleg_id:
-        # Child-scoped durable rows and the optional live transcript must share
-        # one stable parent identity, even when transcript creation is disabled.
+        # Child-level durable delivery needs a stable id even when the optional
+        # live-transcript side channel could not be created.
         from tools.async_delegation import _new_delegation_id
 
         live_deleg_id = _new_delegation_id()
@@ -3388,8 +3397,8 @@ def delegate_task(
 
             publish_batch_child_completion(live_deleg_id, task_index, payload)
         except Exception:
-            # Batch finalization republishes all children idempotently as the
-            # durable safety net for callback/persistence failures.
+            # _push_batch_completion_event republishes all children
+            # idempotently as a durable safety net.
             logger.exception(
                 "Failed to publish ready child %s/%s",
                 live_deleg_id,
@@ -3401,10 +3410,9 @@ def delegate_task(
         fire subagent_stop hooks + cost rollup, and return the combined result
         dict. Used by BOTH the synchronous path and the background runner. In
         the background case this whole function runs on the daemon executor, so
-        the parent turn isn't blocked — but the batch still JOINS on itself
-        here (all children must finish) before producing ONE consolidated
-        results block. That is the contract: fan-out runs in the background,
-        waits on each other, and returns together.
+        the parent turn isn't blocked. Each child is published independently as
+        it becomes ready; this final aggregate is bookkeeping plus an idempotent
+        safety net for any child callback that failed before persistence.
         """
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
@@ -3590,12 +3598,10 @@ def delegate_task(
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
-    # When background is true, the entire fan-out runs on the daemon executor
-    # via a single async delegation. _execute_and_aggregate() joins on every
-    # child and produces ONE consolidated results block, which re-enters the
-    # conversation as a single message when ALL children finish. The chat is
-    # not blocked in the meantime. This is the contract: dispatch N subagents,
-    # keep chatting, get the combined summaries back together at the end.
+    # _execute_and_aggregate owns child execution and still returns one ordered
+    # bookkeeping aggregate. Its completion callback publishes each child
+    # immediately in both delivery modes; consumers choose current-turn inject
+    # versus next-turn ready-set coalescing.
     if background:
         from tools.async_delegation import dispatch_async_delegation_batch
         from tools.approval import get_current_session_key
@@ -3689,6 +3695,7 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
+        _parent_turn_id = str(getattr(parent_agent, "_active_turn_id", "") or "")
         _child_agents = [c for (_, _, c) in children]
 
         # Detach every child from the parent's interrupt-propagation list — the
@@ -3772,25 +3779,45 @@ def delegate_task(
             # returned delegation_id matches cache/delegation/live/<id>/.
             delegation_id=live_deleg_id,
             progress_fn=_batch_progress,
+            # Delivery mode: 'inject' (new tool-result carriers) or
+            # 'after_turn' (ready children coalesced at the next available turn
+            # boundary). Default 'after_turn' preserves compatibility with old
+            # task_json entries.
+            result_delivery=_delivery,
+            parent_turn_id=_parent_turn_id,
         )
 
         if dispatch.get("status") == "dispatched":
             n = len(_goals)
-            note = (
-                "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
-                if n == 1 else
-                f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; every result ready at the next "
-                f"turn boundary re-enters in one grouped message without waiting "
-                f"for slower siblings. Later results arrive in later grouped "
-                f"messages. Do not wait or poll — just continue."
-            )
+            if _delivery == "inject":
+                note = (
+                    "Subagent is running asynchronously. Keep working; each ready "
+                    "result can be carried by the next new tool result in this "
+                    "turn. A result that misses that carrier becomes a separate "
+                    "late-result turn. Never wait or poll."
+                    if n == 1 else
+                    f"{n} subagents are running asynchronously. Keep working; "
+                    "children ready at the next new tool-result boundary share "
+                    "that carrier without waiting for slower siblings. Late "
+                    "results become separate result turns. Never wait or poll."
+                )
+            else:
+                note = (
+                    "Subagent is running in the background. You and the user can "
+                    "keep working; its full result re-enters the conversation as a "
+                    "new message when it finishes. Do not wait or poll — just "
+                    "continue."
+                    if n == 1 else
+                    f"{n} subagents are running in parallel in the background. You "
+                    f"and the user can keep working; every result ready at the next "
+                    f"turn boundary re-enters in one grouped message without waiting "
+                    f"for slower siblings. Later results arrive in later grouped "
+                    f"messages. Do not wait or poll — just continue."
+                )
             payload = {
                 "status": "dispatched",
                 "mode": "background",
+                "result_delivery": _delivery,
                 "count": n,
                 "delegation_id": dispatch["delegation_id"],
                 "goals": _goals,
@@ -4103,9 +4130,8 @@ def _build_top_level_description() -> str:
         "you. Provide 'goal' for a single task or 'tasks' for a parallel batch "
         "(limits and nesting rules are in the parameter descriptions).\n\n"
         "Runs in the background: dispatch returns immediately with live "
-        "transcript paths, and the completed result (one consolidated message "
-        "for a batch) re-enters the conversation on its own. Do NOT wait or "
-        "poll; continue other work.\n\n"
+        "transcript paths. Result timing follows the 'result_delivery' parameter. "
+        "Do NOT wait or poll; continue other work.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
@@ -4296,11 +4322,30 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "DEPRECATED / IGNORED. Top-level single and batch "
                     "delegations run in the background automatically — you do "
-                    "not need to (and cannot) opt in or out. A single result or "
-                    "consolidated batch result re-enters the conversation when "
-                    "the work finishes; just continue working in the meantime. "
+                    "not need to (and cannot) opt in or out. Ready results re-enter "
+                    "the conversation according to result_delivery; just continue "
+                    "working in the meantime. "
                     "Setting this has no effect; the parameter remains only for "
                     "backward compatibility."
+                ),
+            },
+            "result_delivery": {
+                "type": "string",
+                "enum": ["inject", "after_turn"],
+                "default": "after_turn",
+                "description": (
+                    "How child results are delivered back to the parent context. "
+                    "'inject': use for auditors, reviewers, and dependent work "
+                    "whose result can affect the current turn; a result that is "
+                    "ready when a new tool batch completes is carried on that batch's "
+                    "last tool result before the next model request. Ready batch "
+                    "siblings share one carrier; results that miss the bounded tool "
+                    "boundary become separate late-result turns. "
+                    "'after_turn' (default): use for independent background work; "
+                    "at each available turn boundary, all currently ready children "
+                    "are grouped into one synthetic turn, while slower siblings "
+                    "arrive in later grouped turns. Running children are never "
+                    "waited on."
                 ),
             },
         },
@@ -4364,6 +4409,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        result_delivery=args.get("result_delivery"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -350,6 +350,7 @@ def delegate_task(
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
     message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    result_delivery: Optional[str] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -373,8 +374,12 @@ def delegate_task(
 
     top_role = _normalize_role(role)
     # background applies to single tasks AND batches: a batch is ONE async unit
-    # that joins on every child and re-enters as a single consolidated message.
+    # with child-scoped delivery; result_delivery selects the eligible continuation boundary.
     background = is_truthy_value(background, default=False) if background is not None else False
+
+    _delivery = str(result_delivery or "after_turn").strip().lower()
+    if _delivery not in {"inject", "after_turn"}:
+        _delivery = "after_turn"
 
     depth = getattr(parent_agent, "_delegate_depth", 0)
     max_spawn = _get_max_spawn_depth()
@@ -427,7 +432,7 @@ def delegate_task(
         return tool_error(err)
     batch = _Batch(
         task_list, children, parent_agent, creds, context, top_role, max_children,
-        live_deleg_id, live_writers, live_paths, *origin, overall_start,
+        live_deleg_id, live_writers, live_paths, *origin, overall_start, result_delivery=_delivery,
     )
     return _run_batch(batch, background)
 
@@ -457,8 +462,8 @@ _DESCRIPTION_HEAD = (
     "Spawn subagents in isolated contexts; each gets its own conversation, terminal session, and toolset, and only its "
     "final summary returns to you. Pass every task in `tasks` — one entry spawns one subagent, several run in parallel "
     "(limit in the tasks description).\n\n"
-    "Runs in the background: dispatch returns immediately with live transcript paths, and the completed result (one "
-    "consolidated message, results in task order) re-enters the conversation on its own. Do NOT wait or poll; continue "
+    "Runs in the background: dispatch returns immediately with live transcript paths. Result timing follows "
+    "result_delivery. Do NOT wait or poll; continue "
     "other work. While children run, `action` (list/steer/stop) controls them live — steer when a transcript shows a "
     "child drifting.\n\n"
     "USE FOR: reasoning-heavy subtasks, work that would flood your context with intermediate data, or independent "
@@ -569,6 +574,25 @@ DELEGATE_TASK_SCHEMA = {
                 "For action='steer': the course correction, appended to "
                 "the child's next tool result mid-run. Be directive and specific.",
             ),
+            "result_delivery": {
+                "type": "string",
+                "enum": ["inject", "after_turn"],
+                "default": "after_turn",
+                "description": (
+                    "How child results are delivered back to the parent context. "
+                    "'inject': use for auditors, reviewers, and dependent work "
+                    "whose result can affect the current turn; a result that is "
+                    "ready when a new tool batch completes is carried on that batch's "
+                    "last tool result before the next model request. Ready batch "
+                    "siblings share one carrier; results that miss the bounded tool "
+                    "boundary become separate late-result turns. "
+                    "'after_turn' (default): use for independent background work; "
+                    "at each available turn boundary, all currently ready children "
+                    "are grouped into one synthetic turn, while slower siblings "
+                    "arrive in later grouped turns. Running children are never "
+                    "waited on."
+                ),
+            },
         },
         "required": [],
     },
@@ -604,6 +628,7 @@ registry.register(
         max_iterations=args.get("max_iterations"), role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
         action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
+        result_delivery=args.get("result_delivery"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -89,17 +89,17 @@ def _report_child_done(parent_agent, spinner_ref, entry, tag, task_labels, n_tas
         with _quiet("Spinner update_text failed: %s"):
             spinner_ref.update_text(f"🔀 {'[' + tag + '] ' if tag else ''}{remaining} task{'s' if remaining != 1 else ''} remaining")
 
-def _persist_ready_result(batch: _Batch, entry: Dict[str, Any]) -> None:
-    """Commit a finished child before joining its siblings; finalization is the retry safety net."""
+def _publish_ready_result(batch: _Batch, entry: Dict[str, Any]) -> None:
+    """Commit and publish a finished child without waiting for its siblings."""
     task_index = int(entry.get("task_index", 0))
     payload = dict(entry)
     if 0 <= task_index < len(batch.live_paths):
         payload.setdefault("live_transcript", batch.live_paths[task_index])
     try:
-        from tools.async_delegation import persist_batch_child_completion
-        persist_batch_child_completion(batch.live_deleg_id, task_index, payload)
+        from tools.async_delegation import publish_batch_child_completion
+        publish_batch_child_completion(batch.live_deleg_id, task_index, payload)
     except Exception:
-        logger.exception("Failed to persist ready child %s/%s", batch.live_deleg_id, task_index)
+        logger.exception("Failed to publish ready child %s/%s", batch.live_deleg_id, task_index)
 
 
 def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interrupt: bool) -> None:
@@ -136,14 +136,14 @@ def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interru
                     entry = _entry_of(future, futures[future])
                     results.append(entry)
                     if not honor_parent_interrupt:
-                        _persist_ready_result(batch, entry)
+                        _publish_ready_result(batch, entry)
                 break
             done, pending = _cf_wait(pending, timeout=0.5, return_when=FIRST_COMPLETED)
             for future in done:
                 entry = _entry_of(future, futures[future])
                 results.append(entry)
                 if not honor_parent_interrupt:
-                    _persist_ready_result(batch, entry)
+                    _publish_ready_result(batch, entry)
                 _report_child_done(parent_agent, spinner_ref, entry, _tag, task_labels, n_tasks, n_tasks - len(results))
     results.sort(key=lambda r: r["task_index"])  # match input order
 
@@ -157,7 +157,7 @@ def _execute_and_aggregate(batch: _Batch, *, honor_parent_interrupt: bool = True
     if len(batch.task_list) == 1:
         results.append(batch.run_child(*batch.children[0]))
         if not honor_parent_interrupt:
-            _persist_ready_result(batch, results[-1])
+            _publish_ready_result(batch, results[-1])
     else:
         _run_children_parallel(batch, results, honor_parent_interrupt=honor_parent_interrupt)
 
@@ -277,9 +277,9 @@ _BACKGROUND_NOTES = {
         "conversation as a new message when it finishes. Do not wait or poll — just continue."
     ),
     "many": (
-        "{n} subagents are running in parallel in the background. You and the user can keep working; they wait on "
-        "each other and their consolidated results re-enter the conversation as a single message once ALL of them "
-        "finish. Do not wait or poll — just continue."
+        "{n} subagents are running in parallel in the background. You and the user can keep working; completed "
+        "children are grouped at the next available turn boundary without waiting for unfinished siblings. "
+        "Do not wait or poll — just continue."
     ),
     "control_hint": (
         "While a child runs you can orchestrate it live with this same tool: delegate_task(action='list') to see live "
@@ -309,10 +309,9 @@ def _dispatched_payload(dispatch: dict, goals: List[str], child_agents: List[Any
     return payload
 
 def _dispatch_background(batch: _Batch) -> str:
-    """Dispatch the WHOLE batch as one async unit and return the tool result JSON. The runner joins on every child and
-    yields ONE consolidated results block that re-enters the conversation as a single message when ALL children
-    finish. Falls back to running synchronously (with an explanatory ``note``) when the session cannot receive
-    detached completions or the async pool is at capacity."""
+    """Dispatch one async execution unit; publish each ready child before the aggregate join.
+    The next between-turn consumer coalesces available children without waiting for siblings.
+    Fall back to sync when detached delivery is unsupported or the async pool is at capacity."""
     from tools.delegate_tool import _get_max_async_children
     from tools.async_delegation import dispatch_async_delegation_batch
     wake_sid = _resolve_async_wake_sid(batch.origin_wake_sid)

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -89,6 +89,19 @@ def _report_child_done(parent_agent, spinner_ref, entry, tag, task_labels, n_tas
         with _quiet("Spinner update_text failed: %s"):
             spinner_ref.update_text(f"🔀 {'[' + tag + '] ' if tag else ''}{remaining} task{'s' if remaining != 1 else ''} remaining")
 
+def _persist_ready_result(batch: _Batch, entry: Dict[str, Any]) -> None:
+    """Commit a finished child before joining its siblings; finalization is the retry safety net."""
+    task_index = int(entry.get("task_index", 0))
+    payload = dict(entry)
+    if 0 <= task_index < len(batch.live_paths):
+        payload.setdefault("live_transcript", batch.live_paths[task_index])
+    try:
+        from tools.async_delegation import persist_batch_child_completion
+        persist_batch_child_completion(batch.live_deleg_id, task_index, payload)
+    except Exception:
+        logger.exception("Failed to persist ready child %s/%s", batch.live_deleg_id, task_index)
+
+
 def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interrupt: bool) -> None:
     """Run the batch's children in parallel, appending entries to ``results`` (sorted by task_index on return, one
     completion line printed per child). Polls futures with a short ``wait()`` timeout instead of ``as_completed()``
@@ -119,12 +132,18 @@ def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interru
         pending = set(futures)
         while pending:
             if honor_parent_interrupt and getattr(parent_agent, "_interrupt_requested", False) is True:
-                results.extend(_entry_of(f, futures[f]) for f in pending)
+                for future in pending:
+                    entry = _entry_of(future, futures[future])
+                    results.append(entry)
+                    if not honor_parent_interrupt:
+                        _persist_ready_result(batch, entry)
                 break
             done, pending = _cf_wait(pending, timeout=0.5, return_when=FIRST_COMPLETED)
             for future in done:
                 entry = _entry_of(future, futures[future])
                 results.append(entry)
+                if not honor_parent_interrupt:
+                    _persist_ready_result(batch, entry)
                 _report_child_done(parent_agent, spinner_ref, entry, _tag, task_labels, n_tasks, n_tasks - len(results))
     results.sort(key=lambda r: r["task_index"])  # match input order
 
@@ -137,6 +156,8 @@ def _execute_and_aggregate(batch: _Batch, *, honor_parent_interrupt: bool = True
     results: list = []
     if len(batch.task_list) == 1:
         results.append(batch.run_child(*batch.children[0]))
+        if not honor_parent_interrupt:
+            _persist_ready_result(batch, results[-1])
     else:
         _run_children_parallel(batch, results, honor_parent_interrupt=honor_parent_interrupt)
 
@@ -299,6 +320,9 @@ def _dispatch_background(batch: _Batch) -> str:
         logger.info("delegate_task: async delivery unsupported on this session runtime; running the batch synchronously instead.")
         return _run_sync_with_note(batch, "no_async")
 
+    if not batch.live_deleg_id:
+        from tools.async_delegation import _new_delegation_id
+        batch.live_deleg_id = _new_delegation_id()
     parent_agent = batch.parent_agent
     session_key, origin_ui_session_id = _resolve_async_session_key(parent_agent, batch.origin_ui_session_id)
     child_agents = [c for (_, _, c) in batch.children]

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -42,6 +42,7 @@ class _Batch:
     origin_owner_transport: Any
     origin_owner_session_record: Any
     overall_start: float
+    result_delivery: str = "after_turn"
 
     def owner_kwargs(self) -> Dict[str, Any]:
         """Steer/stop authority of the originating session, passed to every child run."""
@@ -292,13 +293,21 @@ _BACKGROUND_NOTES = {
     ),
 }
 
-def _dispatched_payload(dispatch: dict, goals: List[str], child_agents: List[Any], live_paths: List[str]) -> dict:
+def _dispatched_payload(dispatch: dict, goals: List[str], child_agents: List[Any], live_paths: List[str],
+                        result_delivery: str = "after_turn") -> dict:
     """Model-facing handle for an accepted background batch."""
     n = len(goals)
     payload = {
         "status": "dispatched", "mode": "background", "count": n, "delegation_id": dispatch["delegation_id"],
         "goals": goals, "note": _BACKGROUND_NOTES["one"] if n == 1 else _BACKGROUND_NOTES["many"].format(n=n),
     }
+    payload["result_delivery"] = result_delivery
+    if result_delivery == "inject":
+        payload["note"] = (
+            "Subagents are running asynchronously. Keep working; ready children can share the next "
+            "new tool-result carrier in this turn without waiting for slower siblings. "
+            "Results that miss that boundary follow normal after-turn delivery. Never wait or poll."
+        )
     sids = [getattr(c, "_subagent_id", None) for c in child_agents]
     if any(isinstance(s, str) and s for s in sids):
         payload["subagent_ids"] = sids
@@ -342,6 +351,8 @@ def _dispatch_background(batch: _Batch) -> str:
         role=batch.top_role, model=batch.creds["model"], session_key=session_key,
         origin_ui_session_id=origin_ui_session_id, origin_session_id=wake_sid,
         parent_session_id=getattr(parent_agent, "session_id", None),
+        result_delivery=batch.result_delivery,
+        parent_turn_id=str(getattr(parent_agent, "_active_turn_id", "") or ""),
         runner=lambda: _execute_and_aggregate(batch, honor_parent_interrupt=False),
         interrupt_fn=_batch_interrupt, max_async_children=_get_max_async_children(),
         # Reuse the live-transcript directory's id (when created) so the returned delegation_id matches
@@ -350,7 +361,7 @@ def _dispatch_background(batch: _Batch) -> str:
         progress_fn=lambda: _batch_progress_token(child_agents),
     )
     if dispatch.get("status") == "dispatched":
-        return json.dumps(_dispatched_payload(dispatch, goals, child_agents, batch.live_paths), ensure_ascii=False)
+        return json.dumps(_dispatched_payload(dispatch, goals, child_agents, batch.live_paths, batch.result_delivery), ensure_ascii=False)
     # Pool at capacity / schedule failure: the async unit was never accepted, so just run inline (re-attaching to the
     # parent list is not needed).
     logger.info(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -31,6 +31,7 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.config import get_hermes_home
 
 from agent.redact import redact_sensitive_text
+from tools.process_registry_delivery import CompletionDeliveryMixin
 from tools.process_registry_notifications import format_process_notification
 
 logger = logging.getLogger(__name__)
@@ -384,7 +385,7 @@ _CHECKPOINT_DEFAULTS = {
 }
 
 
-class ProcessRegistry:
+class ProcessRegistry(CompletionDeliveryMixin):
     """In-memory registry of running and finished background processes.
     Thread-safe: accessed from executor threads (terminal_tool, process handlers),
     the gateway asyncio loop (watchers, reset checks) and the cleanup thread."""
@@ -404,6 +405,12 @@ class ProcessRegistry:
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
         self.completion_routing_lock = threading.RLock()
+        # One lazy scheduler retries competing durable leases without a hot poll loop.
+        self._deferred_completion_condition = threading.Condition()
+        self._deferred_completion_heap: list[tuple[float, int, tuple, dict]] = []
+        self._deferred_completion_deadlines: dict[tuple, float] = {}
+        self._deferred_completion_sequence = 0
+        self._deferred_completion_thread: Optional[threading.Thread] = None
         # Rehydrate durable delegation completions once, at registry startup.
         try:
             from tools.async_delegation import restore_undelivered_completions
@@ -1332,49 +1339,60 @@ class ProcessRegistry:
         compression-chain-aware check) consumes ONLY on True, ``session_key`` uses plain
         equality; non-owned events are re-queued for their owner. No filter consumes
         everything (legacy single-session) except restored delegation payloads (fail-closed)."""
-        results: "list[tuple[dict, str]]" = []
+        owned_events: "list[dict]" = []
         requeue: "list[dict]" = []
         # delegation.surface_child_process_notifications, read at most once per drain
         # and only when an sa- event shows up.
         surface_child: "bool | None" = None
-        while not self.completion_queue.empty():
-            try:
-                evt = self.completion_queue.get_nowait()
-            except Exception:
-                break
-            is_async_delegation = evt.get("type") == "async_delegation"
-            if not self._owns_event(evt, session_key, owns_event, is_async_delegation):
-                requeue.append(evt)
-                continue
-            # Routing happened first so a foreign session cannot drop the owner's
-            # event via its own consumed/observed state.
-            _evt_sid = evt.get("session_id", "")
-            if evt.get("type") == "completion" and self._drain_should_skip(
-                _evt_sid, skip_poll_observed=skip_poll_observed):
-                continue
-            # Subagent-owned process notifications are suppressed by default — the
-            # child's delegation result is the deliverable. Judge ownership on
-            # owner_task_id (RAW spawning id; task_id is the container key, collapsed
-            # by _resolve_container_task_id). Dropped, NOT requeued: children never
-            # drain, so a requeue would pin the event forever. 'async_delegation'
-            # is the result itself and is NEVER suppressed.
-            _evt_task_id = str(evt.get("owner_task_id") or evt.get("task_id") or "")
-            if not is_async_delegation and _evt_task_id.startswith("sa-"):
-                if surface_child is None:
-                    surface_child = self._surface_child_process_notifications()
-                if not surface_child:
-                    logger.debug(
-                        "Suppressed subagent-owned process notification "
-                        "(delegation.surface_child_process_notifications=false): "
-                        "type=%s session_id=%s task_id=%s",
-                        evt.get("type", "completion"), _evt_sid, _evt_task_id)
+        with self.completion_routing_lock:
+            for _ in range(self.completion_queue.qsize()):
+                try:
+                    evt = self.completion_queue.get_nowait()
+                except Exception:
+                    break
+                is_async_delegation = evt.get("type") == "async_delegation"
+                if not self._owns_event(evt, session_key, owns_event, is_async_delegation):
+                    requeue.append(evt)
                     continue
-            if text := format_process_notification(evt):
+                # Routing happened first so a foreign session cannot drop the owner's
+                # event via its own consumed/observed state.
+                _evt_sid = evt.get("session_id", "")
+                if evt.get("type") == "completion" and self._drain_should_skip(
+                    _evt_sid, skip_poll_observed=skip_poll_observed):
+                    continue
+                # Subagent-owned process notifications are suppressed by default — the
+                # child's delegation result is the deliverable. Judge ownership on
+                # owner_task_id (RAW spawning id; task_id is the container key, collapsed
+                # by _resolve_container_task_id). Dropped, NOT requeued: children never
+                # drain, so a requeue would pin the event forever. 'async_delegation'
+                # is the result itself and is NEVER suppressed.
+                _evt_task_id = str(evt.get("owner_task_id") or evt.get("task_id") or "")
+                if not is_async_delegation and _evt_task_id.startswith("sa-"):
+                    if surface_child is None:
+                        surface_child = self._surface_child_process_notifications()
+                    if not surface_child:
+                        logger.debug(
+                            "Suppressed subagent-owned process notification "
+                            "(delegation.surface_child_process_notifications=false): "
+                            "type=%s session_id=%s task_id=%s",
+                            evt.get("type", "completion"), _evt_sid, _evt_task_id)
+                        continue
+                owned_events.append(evt)
+            for evt in requeue:
+                self.completion_queue.put(evt)
+        from tools.async_delegation import coalesce_ready_after_turn_events
+        results: "list[tuple[dict, str]]" = []
+        # No formatter, model, or adapter I/O while reserving the shared queue.
+        for evt in coalesce_ready_after_turn_events(owned_events):
+            try:
+                text = format_process_notification(evt)
+            except Exception:
+                self.completion_queue.put(evt)
+                logger.exception("Could not format completion; kept for retry")
+                continue
+            if text:
                 results.append((evt, text))
-        for evt in requeue:
-            self.completion_queue.put(evt)
         return results
-
     # Minimum suffix chars for prefix resolution; "p"/"proc_1" are too collision-prone.
     _MIN_PREFIX_CHARS = 4
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -403,6 +403,7 @@ class ProcessRegistry:
         # process_loop and the gateway drain it after each agent turn to trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        self.completion_routing_lock = threading.RLock()
         # Rehydrate durable delegation completions once, at registry startup.
         try:
             from tools.async_delegation import restore_undelivered_completions

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -423,6 +423,9 @@ class ProcessRegistry:
         # gateway drain this after each agent turn to auto-trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        # Shared reservation seam for atomic child-event publication and later
+        # consumer routing. Publication is non-blocking and holds it briefly.
+        self.completion_routing_lock = threading.RLock()
         # Rehydrate durable delegation completions only at registry startup.
         # Consumers still inject them as fresh turns through this existing rail.
         try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -30,6 +30,7 @@ Usage:
 """
 
 import codecs
+import heapq
 import json
 import logging
 import os
@@ -423,9 +424,22 @@ class ProcessRegistry:
         # gateway drain this after each agent turn to auto-trigger new turns.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
-        # Shared reservation seam for atomic child-event publication and later
-        # consumer routing. Publication is non-blocking and holds it briefly.
+        # Queue.get() removes an event before a consumer has decided whether to
+        # claim, drop, or requeue it.  The TUI poller and an active conversation
+        # loop can otherwise race in that temporary-empty window, making a ready
+        # result_delivery=inject event miss its same-turn boundary.  Consumers
+        # that route/claim completion events hold this lock only for the bounded
+        # dequeue -> decision handoff, never while an agent/model turn runs.
         self.completion_routing_lock = threading.RLock()
+        # Durable events that lose a claim race must not disappear until the
+        # next process restart, but immediate requeue would make fast TUI
+        # pollers spin. One lazy daemon scheduler owns all delayed retries for
+        # this registry. Exact durable identities are deduplicated in the heap.
+        self._deferred_completion_condition = threading.Condition()
+        self._deferred_completion_heap: list[tuple[float, int, tuple, dict]] = []
+        self._deferred_completion_deadlines: dict[tuple, float] = {}
+        self._deferred_completion_sequence = 0
+        self._deferred_completion_thread: Optional[threading.Thread] = None
         # Rehydrate durable delegation completions only at registry startup.
         # Consumers still inject them as fresh turns through this existing rail.
         try:
@@ -1626,6 +1640,161 @@ class ProcessRegistry:
             skip_poll_observed and session_id in self._poll_observed
         )
 
+    @staticmethod
+    def _deferred_completion_key(event: dict) -> tuple:
+        raw_keys = event.get("delivery_event_keys")
+        if isinstance(raw_keys, (list, tuple)):
+            event_keys = tuple(str(key) for key in raw_keys if key)
+        else:
+            event_key = str(event.get("delivery_event_key") or "")
+            event_keys = (event_key,) if event_key else ("aggregate",)
+        return (
+            "async_delegation",
+            str(event.get("delegation_id") or ""),
+            event_keys,
+        )
+
+    def defer_unclaimed_delivery(self, event: dict) -> bool:
+        """Requeue a pending durable event after its competing lease expires.
+
+        ``claim_event_delivery()`` returning ``None`` is not enough to drop the
+        RAM copy: after a quick restart the old process's lease can still be
+        live. Terminal duplicates return ``False`` and disappear; pending rows
+        enter one deduplicated heap and wake under the routing lock.
+        """
+
+        try:
+            from tools.async_delegation import get_event_delivery_retry_delay
+
+            delay = get_event_delivery_retry_delay(event)
+        except Exception:
+            logger.exception("Could not classify unclaimed delegation event")
+            return False
+        if delay is None:
+            return False
+
+        key = self._deferred_completion_key(event)
+        if not key[1]:
+            return False
+        deadline = time.monotonic() + max(0.05, float(delay))
+        with self._deferred_completion_condition:
+            existing = self._deferred_completion_deadlines.get(key)
+            if existing is not None and existing <= deadline:
+                return True
+            self._deferred_completion_sequence += 1
+            self._deferred_completion_deadlines[key] = deadline
+            heapq.heappush(
+                self._deferred_completion_heap,
+                (
+                    deadline,
+                    self._deferred_completion_sequence,
+                    key,
+                    event,
+                ),
+            )
+            thread = self._deferred_completion_thread
+            if thread is None or not thread.is_alive():
+                thread = threading.Thread(
+                    target=self._deferred_completion_loop,
+                    name="completion-lease-retry",
+                    daemon=True,
+                )
+                self._deferred_completion_thread = thread
+                thread.start()
+            self._deferred_completion_condition.notify()
+        return True
+
+    def _deferred_completion_loop(self) -> None:
+        while True:
+            with self._deferred_completion_condition:
+                while not self._deferred_completion_heap:
+                    self._deferred_completion_condition.wait()
+                deadline, _sequence, key, event = self._deferred_completion_heap[0]
+                current = self._deferred_completion_deadlines.get(key)
+                if current != deadline:
+                    heapq.heappop(self._deferred_completion_heap)
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
+                    self._deferred_completion_condition.wait(timeout=remaining)
+                    continue
+                heapq.heappop(self._deferred_completion_heap)
+                self._deferred_completion_deadlines.pop(key, None)
+
+            try:
+                with self.completion_routing_lock:
+                    self.completion_queue.put(event)
+            except Exception:
+                logger.exception(
+                    "Deferred completion requeue failed; rescheduling %r", key
+                )
+                # The heap entry was already removed. Reclassify the durable
+                # row and schedule it again rather than silently losing the
+                # only in-memory copy on a transient/custom queue failure.
+                self.defer_unclaimed_delivery(event)
+
+    def collect_ready_after_turn_siblings(self, seed: dict) -> dict:
+        """Fold queued ready siblings into one transient after-turn envelope.
+
+        The caller may already hold ``completion_routing_lock``; it is an RLock
+        so this helper is safe at both direct-consumer and shared-drain seams.
+        Only the bounded queue snapshot present at this delivery boundary is
+        inspected. Foreign delegations and later arrivals remain queued.
+        """
+
+        from tools.async_delegation import coalesce_ready_after_turn_events
+
+        def delivery_keys(event: dict) -> "list[str]":
+            raw_keys = event.get("delivery_event_keys")
+            if isinstance(raw_keys, (list, tuple)):
+                return [str(key) for key in raw_keys if key]
+            key = str(event.get("delivery_event_key") or "")
+            return [key] if key else []
+
+        delivery = str(seed.get("result_delivery") or "after_turn").strip().lower()
+        seed_keys = delivery_keys(seed)
+        delegation_id = str(seed.get("delegation_id") or "")
+        if not (
+            seed.get("type") == "async_delegation"
+            and delivery == "after_turn"
+            and bool(seed.get("is_batch"))
+            and bool(seed_keys)
+            and all(key.startswith("task:") for key in seed_keys)
+            and delegation_id
+        ):
+            return seed
+
+        siblings = [seed]
+        requeue: "list[dict]" = []
+        with self.completion_routing_lock:
+            try:
+                scan_count = self.completion_queue.qsize()
+            except Exception:
+                scan_count = 0
+            for _ in range(max(0, scan_count)):
+                try:
+                    candidate = self.completion_queue.get_nowait()
+                except Exception:
+                    break
+                candidate_keys = delivery_keys(candidate)
+                if (
+                    candidate.get("type") == "async_delegation"
+                    and str(
+                        candidate.get("result_delivery") or "after_turn"
+                    ).strip().lower()
+                    == "after_turn"
+                    and bool(candidate.get("is_batch"))
+                    and str(candidate.get("delegation_id") or "") == delegation_id
+                    and bool(candidate_keys)
+                    and all(key.startswith("task:") for key in candidate_keys)
+                ):
+                    siblings.append(candidate)
+                else:
+                    requeue.append(candidate)
+            for candidate in requeue:
+                self.completion_queue.put(candidate)
+        return coalesce_ready_after_turn_events(siblings)[0]
+
     def drain_notifications(
         self,
         session_key: str = "",
@@ -1662,55 +1831,69 @@ class ProcessRegistry:
         filter is provided, ownerless async-delegation events remain
         fail-closed and require positive proof.
         """
-        results: "list[tuple[dict, str]]" = []
+        owned_events: "list[dict]" = []
         requeue: "list[dict]" = []
-        while not self.completion_queue.empty():
-            try:
-                evt = self.completion_queue.get_nowait()
-            except Exception:
-                break
-            # Positive-proof ownership beats bare key equality. Delegation
-            # payloads always require proof; ordinary events require it once
-            # they carry routing metadata. Ownerless ordinary events preserve
-            # legacy single-session delivery.
-            is_async_delegation = evt.get("type") == "async_delegation"
-            evt_session_key = str(evt.get("session_key") or "")
-            evt_origin_sid = str(evt.get("origin_ui_session_id") or "")
-            requires_positive_proof = is_async_delegation or bool(
-                evt_session_key or evt_origin_sid
-            )
-            if owns_event is not None and requires_positive_proof:
+        # One routing boundary owns the queue snapshot. This is the same lock
+        # used by the TUI poller and same-turn inject drain; it closes the
+        # temporary-empty race without spanning formatting or any model turn.
+        with self.completion_routing_lock:
+            while not self.completion_queue.empty():
                 try:
-                    owned = bool(owns_event(evt))
+                    evt = self.completion_queue.get_nowait()
                 except Exception:
-                    owned = False  # fail closed — never leak on a broken check
-                if not owned:
+                    break
+                # Positive-proof ownership beats bare key equality. Delegation
+                # payloads always require proof; ordinary events require it once
+                # they carry routing metadata. Ownerless ordinary events preserve
+                # legacy single-session delivery.
+                is_async_delegation = evt.get("type") == "async_delegation"
+                evt_session_key = str(evt.get("session_key") or "")
+                evt_origin_sid = str(evt.get("origin_ui_session_id") or "")
+                requires_positive_proof = is_async_delegation or bool(
+                    evt_session_key or evt_origin_sid
+                )
+                if owns_event is not None and requires_positive_proof:
+                    try:
+                        owned = bool(owns_event(evt))
+                    except Exception:
+                        owned = False  # fail closed — never leak on a broken check
+                    if not owned:
+                        requeue.append(evt)
+                        continue
+                elif session_key and requires_positive_proof:
+                    if evt_session_key != session_key:
+                        requeue.append(evt)
+                        continue
+                elif is_async_delegation and evt.get("restored"):
+                    # Durable restore can enqueue previous-process payloads into a
+                    # fresh registry. An unfiltered legacy drain cannot prove
+                    # ownership, so leave those events queued for the owner.
                     requeue.append(evt)
                     continue
-            elif session_key and requires_positive_proof:
-                if evt_session_key != session_key:
-                    requeue.append(evt)
+                # Local consumed/observed state may suppress only events this
+                # session owns (or legacy ownerless ordinary events). Routing must
+                # happen first so a foreign session cannot drop the owner's event.
+                _evt_sid = evt.get("session_id", "")
+                if evt.get("type") == "completion" and self._drain_should_skip(
+                    _evt_sid, skip_poll_observed=skip_poll_observed
+                ):
                     continue
-            elif is_async_delegation and evt.get("restored"):
-                # Durable restore can enqueue previous-process payloads into a
-                # fresh registry. An unfiltered legacy drain cannot prove
-                # ownership, so leave those events queued for the owner.
-                requeue.append(evt)
-                continue
-            # Local consumed/observed state may suppress only events this
-            # session owns (or legacy ownerless ordinary events). Routing must
-            # happen first so a foreign session cannot drop the owner's event.
-            _evt_sid = evt.get("session_id", "")
-            if evt.get("type") == "completion" and self._drain_should_skip(
-                _evt_sid, skip_poll_observed=skip_poll_observed
-            ):
-                continue
+                owned_events.append(evt)
+            for evt in requeue:
+                self.completion_queue.put(evt)
 
+        try:
+            from tools.async_delegation import coalesce_ready_after_turn_events
+
+            owned_events = coalesce_ready_after_turn_events(owned_events)
+        except Exception:
+            logger.exception("Could not coalesce ready after-turn delegation events")
+
+        results: "list[tuple[dict, str]]" = []
+        for evt in owned_events:
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))
-        for evt in requeue:
-            self.completion_queue.put(evt)
         return results
 
     def get(self, session_id: str) -> Optional[ProcessSession]:
@@ -2639,24 +2822,61 @@ def _format_async_delegation(evt: dict) -> str:
     dispatched_at = evt.get("dispatched_at")
     completed_at = evt.get("completed_at") or _time.time()
 
-    # ----- Batch (fan-out) completion: consolidated multi-task block -----
-    # A whole delegate_task fan-out dispatched as one background unit finishes
-    # together and carries a per-task `results` list. Render every subagent's
-    # summary in one block so the model gets the consolidated outcome at once.
+    # ----- Batch result: legacy aggregate or child-scoped delivery envelope -----
+    # Durable child rows may arrive singly (inject) or be coalesced at an
+    # after-turn consumer boundary. Both use the same stable per-task renderer.
     batch_results = evt.get("results")
     if evt.get("is_batch") or isinstance(batch_results, list):
         results = batch_results or []
         goals = evt.get("goals") or []
-        n = len(results) if results else len(goals)
+        raw_event_keys = evt.get("delivery_event_keys")
+        grouped_event_keys = (
+            [str(key) for key in raw_event_keys if key]
+            if isinstance(raw_event_keys, (list, tuple))
+            else []
+        )
+        child_event = str(evt.get("delivery_event_key") or "").startswith("task:")
+        child_scoped = child_event or bool(grouped_event_keys)
+        n = int(evt.get("batch_size") or 0) if child_scoped else 0
+        if n <= 0:
+            n = len(results) if results else len(goals)
         total_dur = evt.get("total_duration_seconds", duration)
-        lines = [
-            f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]",
-            f"A background fan-out of {n} subagent(s) you dispatched earlier "
-            "has finished. All ran in parallel and waited on each other; their "
-            "consolidated results are below. You may have moved on since "
-            "dispatching — act on these or re-dispatch if things have changed.",
-            "",
-        ]
+        if child_event:
+            child_idx = int(evt.get("task_index") or 0)
+            lines = [
+                f"[ASYNC DELEGATION RESULT READY — {deleg_id} — TASK {child_idx + 1}/{n}]",
+                "A background subagent result is ready. It was requested for "
+                "same-turn reconciliation; use it before continuing the current work.",
+                "",
+            ]
+        elif grouped_event_keys:
+            ready_count = len(results)
+            lines = [
+                f"[ASYNC DELEGATION RESULTS READY — {deleg_id} — {ready_count}/{n}]",
+            ]
+            if ready_count >= n:
+                lines.append(
+                    f"All {ready_count} background subagent results were ready at "
+                    "this delivery boundary and are grouped below."
+                )
+            else:
+                remaining = max(0, n - ready_count)
+                lines.append(
+                    f"{ready_count} background subagent result(s) were ready at "
+                    f"this delivery boundary and are grouped below. {remaining} "
+                    "sibling(s) are still running; their results will arrive in a "
+                    "later grouped delivery without blocking this one."
+                )
+            lines.append("")
+        else:
+            lines = [
+                f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]",
+                f"A background fan-out of {n} subagent(s) you dispatched earlier "
+                "has finished. Its consolidated results are below. You may have "
+                "moved on since dispatching — act on these or re-dispatch if things "
+                "have changed.",
+                "",
+            ]
         if isinstance(dispatched_at, (int, float)):
             ts = _time.strftime("%Y-%m-%d %H:%M:%S", _time.localtime(dispatched_at))
             age = f" ({_format_age(completed_at - dispatched_at)} ago)"

--- a/tools/process_registry_delivery.py
+++ b/tools/process_registry_delivery.py
@@ -1,0 +1,173 @@
+"""Bounded ready-set reservations and delayed retry for the process completion queue.
+
+The registry owns the queue/locks; this mixin never formats a result or runs a model.
+"""
+
+import heapq
+import logging
+import threading
+import time
+
+logger = logging.getLogger("tools.process_registry")
+
+
+class CompletionDeliveryMixin:
+    """Shared queue protocol for CLI, gateway, API server, and TUI consumers."""
+
+    @staticmethod
+    def _deferred_completion_key(event: dict) -> tuple:
+        raw_keys = event.get("delivery_event_keys")
+        if isinstance(raw_keys, (list, tuple)):
+            event_keys = tuple(str(key) for key in raw_keys if key)
+        else:
+            event_key = str(event.get("delivery_event_key") or "")
+            event_keys = (event_key,) if event_key else ("aggregate",)
+        return (
+            "async_delegation",
+            str(event.get("delegation_id") or ""),
+            event_keys,
+        )
+
+
+    def defer_unclaimed_delivery(self, event: dict) -> bool:
+        """Requeue a pending durable event after its competing lease expires.
+
+        ``claim_event_delivery()`` returning ``None`` is not enough to drop the
+        RAM copy: after a quick restart the old process's lease can still be
+        live. Terminal duplicates return ``False`` and disappear; pending rows
+        enter one deduplicated heap and wake under the routing lock.
+        """
+
+        try:
+            from tools.async_delegation import get_event_delivery_retry_delay
+
+            delay = get_event_delivery_retry_delay(event)
+        except Exception:
+            logger.exception("Could not classify unclaimed delegation event")
+            return False
+        if delay is None:
+            return False
+
+        key = self._deferred_completion_key(event)
+        if not key[1]:
+            return False
+        deadline = time.monotonic() + max(0.05, float(delay))
+        with self._deferred_completion_condition:
+            existing = self._deferred_completion_deadlines.get(key)
+            if existing is not None and existing <= deadline:
+                return True
+            self._deferred_completion_sequence += 1
+            self._deferred_completion_deadlines[key] = deadline
+            heapq.heappush(
+                self._deferred_completion_heap,
+                (
+                    deadline,
+                    self._deferred_completion_sequence,
+                    key,
+                    event,
+                ),
+            )
+            thread = self._deferred_completion_thread
+            if thread is None or not thread.is_alive():
+                thread = threading.Thread(
+                    target=self._deferred_completion_loop,
+                    name="completion-lease-retry",
+                    daemon=True,
+                )
+                self._deferred_completion_thread = thread
+                thread.start()
+            self._deferred_completion_condition.notify()
+        return True
+
+
+    def _deferred_completion_loop(self) -> None:
+        while True:
+            with self._deferred_completion_condition:
+                while not self._deferred_completion_heap:
+                    self._deferred_completion_condition.wait()
+                deadline, _sequence, key, event = self._deferred_completion_heap[0]
+                current = self._deferred_completion_deadlines.get(key)
+                if current != deadline:
+                    heapq.heappop(self._deferred_completion_heap)
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
+                    self._deferred_completion_condition.wait(timeout=remaining)
+                    continue
+                heapq.heappop(self._deferred_completion_heap)
+                self._deferred_completion_deadlines.pop(key, None)
+
+            try:
+                with self.completion_routing_lock:
+                    self.completion_queue.put(event)
+            except Exception:
+                logger.exception(
+                    "Deferred completion requeue failed; rescheduling %r", key
+                )
+                # The heap entry was already removed. Reclassify the durable
+                # row and schedule it again rather than silently losing the
+                # only in-memory copy on a transient/custom queue failure.
+                self.defer_unclaimed_delivery(event)
+
+
+    def collect_ready_after_turn_siblings(self, seed: dict) -> dict:
+        """Fold queued ready siblings into one transient after-turn envelope.
+
+        The caller may already hold ``completion_routing_lock``; it is an RLock
+        so this helper is safe at both direct-consumer and shared-drain seams.
+        Only the bounded queue snapshot present at this delivery boundary is
+        inspected. Foreign delegations and later arrivals remain queued.
+        """
+
+        from tools.async_delegation import coalesce_ready_after_turn_events
+
+        def delivery_keys(event: dict) -> "list[str]":
+            raw_keys = event.get("delivery_event_keys")
+            if isinstance(raw_keys, (list, tuple)):
+                return [str(key) for key in raw_keys if key]
+            key = str(event.get("delivery_event_key") or "")
+            return [key] if key else []
+
+        delivery = str(seed.get("result_delivery") or "after_turn").strip().lower()
+        seed_keys = delivery_keys(seed)
+        delegation_id = str(seed.get("delegation_id") or "")
+        if not (
+            seed.get("type") == "async_delegation"
+            and delivery == "after_turn"
+            and bool(seed.get("is_batch"))
+            and bool(seed_keys)
+            and all(key.startswith("task:") for key in seed_keys)
+            and delegation_id
+        ):
+            return seed
+
+        siblings = [seed]
+        requeue: "list[dict]" = []
+        with self.completion_routing_lock:
+            try:
+                scan_count = self.completion_queue.qsize()
+            except Exception:
+                scan_count = 0
+            for _ in range(max(0, scan_count)):
+                try:
+                    candidate = self.completion_queue.get_nowait()
+                except Exception:
+                    break
+                candidate_keys = delivery_keys(candidate)
+                if (
+                    candidate.get("type") == "async_delegation"
+                    and str(
+                        candidate.get("result_delivery") or "after_turn"
+                    ).strip().lower()
+                    == "after_turn"
+                    and bool(candidate.get("is_batch"))
+                    and str(candidate.get("delegation_id") or "") == delegation_id
+                    and bool(candidate_keys)
+                    and all(key.startswith("task:") for key in candidate_keys)
+                ):
+                    siblings.append(candidate)
+                else:
+                    requeue.append(candidate)
+            for candidate in requeue:
+                self.completion_queue.put(candidate)
+        return coalesce_ready_after_turn_events(siblings)[0]

--- a/tools/process_registry_notifications.py
+++ b/tools/process_registry_notifications.py
@@ -116,14 +116,21 @@ def _preamble(evt: dict, title: str, intro: str, completed_at: float, *, with_go
 def _format_batch_delegation(evt: dict, deleg_id: str, completed_at: float) -> str:
     """Consolidated block for a delegate_task fan-out that finished as one unit."""
     results, goals = evt.get("results") or [], evt.get("goals") or []
-    n = len(results) if results else len(goals)
+    n = evt.get("batch_size") or len(goals) or len(results)
+    keys = evt.get("delivery_event_keys") or ([evt["delivery_event_key"]] if evt.get("delivery_event_key") else [])
+    ready_set = bool(keys) and all(str(key).startswith("task:") for key in keys)
+    ready_count = len(results)
+    title = (f"[ASYNC DELEGATION RESULTS READY — {deleg_id} — {ready_count}/{n}]"
+             if ready_set else f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]")
+    intro = (f"{ready_count}/{n} children of a background fan-out have results ready at this boundary. "
+             "The results below may be used now without waiting for other children. "
+             "Other results may have arrived earlier or may arrive at a later boundary."
+             if ready_set else f"A background fan-out of {n} subagent(s) you dispatched earlier "
+             "has finished. Its consolidated results are below. You may have moved on since "
+             "dispatching — act on these or re-dispatch if things have changed.")
     lines = _preamble(
         evt,
-        f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]",
-        f"A background fan-out of {n} subagent(s) you dispatched earlier "
-        "has finished. All ran in parallel and waited on each other; their "
-        "consolidated results are below. You may have moved on since "
-        "dispatching — act on these or re-dispatch if things have changed.",
+        title, intro,
         completed_at, with_goal=False)
     lines[-1] += f"   Total duration: {evt.get('total_duration_seconds', evt.get('duration_seconds', '?'))}s"
     if evt.get("error") and not results:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8952,10 +8952,16 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
             evt.get("suppressed", 0),
         )
     if evt_type == "async_delegation":
-        # Async-delegation completions have no process session_id; without
-        # this the fallthrough keys every one as ("", "async_delegation")
-        # and the second completion's status update is suppressed forever.
-        return (evt.get("delegation_id", ""), evt_type)
+        # Child-scoped batches may deliver several ready rows together and the
+        # remaining rows later. Include the exact durable key set so a later
+        # portion of the same delegation is not visually suppressed.
+        raw_keys = evt.get("delivery_event_keys")
+        if isinstance(raw_keys, (list, tuple)):
+            event_keys = tuple(str(key) for key in raw_keys if key)
+        else:
+            event_key = str(evt.get("delivery_event_key") or "")
+            event_keys = (event_key,) if event_key else ()
+        return (evt.get("delegation_id", ""), evt_type, event_keys)
     return (evt_sid, evt_type)
 
 
@@ -9187,81 +9193,112 @@ def _notification_poller_loop(
                         )
                         with session["history_lock"]:
                             session["running"] = False
-        try:
-            evt = process_registry.completion_queue.get(timeout=0.5)
-        except Exception:
-            continue
+        # Route one completion atomically with the active conversation-loop
+        # drain. Queue.get() removes the event before we know whether this TUI
+        # owns it or must requeue it; without the shared routing lock, the
+        # conversation loop can observe a temporary-empty queue and miss a ready
+        # same-turn inject at its safe boundary.
+        _route_action = "empty"
+        evt = None
+        text = None
+        _claim = None
+        with process_registry.completion_routing_lock:
+            try:
+                evt = process_registry.completion_queue.get_nowait()
+            except Exception:
+                evt = None
 
-        # Multiple desktop sessions share this one process-wide queue. Only
-        # consume events that belong to *this* session — otherwise a background
-        # process started in session A would surface its completion in whichever
-        # session's poller happened to wake first (Ben's "reported in a
-        # different session" bug). Leave foreign events for their owner.
-        if _notification_event_belongs_elsewhere(sid, session, evt):
-            process_registry.completion_queue.put(evt)
+            if evt is not None:
+                # Multiple desktop sessions share this one process-wide queue.
+                # Leave foreign events for their proven owner.
+                if _notification_event_belongs_elsewhere(sid, session, evt):
+                    process_registry.completion_queue.put(evt)
+                    _route_action = "requeued_foreign"
+                else:
+                    # Addressed events require positive ownership proof. Truly
+                    # ownerless ordinary notifications retain legacy global
+                    # delivery.
+                    requires_owner = _notification_event_requires_owner(evt)
+                    if requires_owner and not _session_owns_notification_event(
+                        sid, session, evt
+                    ):
+                        log = (
+                            logger.warning
+                            if evt.get("type") == "async_delegation"
+                            else logger.debug
+                        )
+                        log(
+                            "Dropping unowned %s notification (origin=%r key=%r) "
+                            "instead of delivering to session %s",
+                            evt.get("type", "completion"),
+                            str(evt.get("origin_ui_session_id") or ""),
+                            str(evt.get("session_key") or ""),
+                            sid,
+                        )
+                        _route_action = "dropped"
+                    else:
+                        evt = process_registry.collect_ready_after_turn_siblings(evt)
+                        _evt_sid = evt.get("session_id", "")
+                        if (
+                            evt.get("type") == "completion"
+                            and process_registry.is_completion_consumed(_evt_sid)
+                        ):
+                            _route_action = "dropped"
+                        else:
+                            text = format_process_notification(evt)
+                            if not text:
+                                _route_action = "dropped"
+                            else:
+                                # Only emit the same notification identity once;
+                                # busy-session requeues otherwise surface the same
+                                # status every poll tick.
+                                _dedup_key = _notification_event_dedup_key(evt)
+                                if _dedup_key not in _emitted:
+                                    _emit(
+                                        "status.update",
+                                        sid,
+                                        {"kind": "process", "text": text},
+                                    )
+                                    _emitted.add(_dedup_key)
+
+                                with session["history_lock"]:
+                                    if session.get("running"):
+                                        process_registry.completion_queue.put(evt)
+                                        _route_action = "requeued_busy"
+                                    else:
+                                        from tools.async_delegation import (
+                                            claim_event_delivery,
+                                        )
+
+                                        _claim = claim_event_delivery(evt, "tui-poller")
+                                        if _claim is None:
+                                            # Keep a live-claimed restored row out
+                                            # of the hot poll loop until its lease
+                                            # expires. Terminal duplicates are
+                                            # discarded by the durable classifier.
+                                            process_registry.defer_unclaimed_delivery(evt)
+                                            _route_action = "deferred_claim"
+                                        else:
+                                            session["running"] = True
+                                            _route_action = "dispatch"
+
+        if _route_action == "empty":
+            time.sleep(0.5)
+            continue
+        if _route_action == "requeued_foreign":
             time.sleep(0.1)
             continue
-
-        # What reaches here is not owned by another LIVE session. Addressed
-        # events still require positive proof before injection: exact UI origin,
-        # direct durable key, or compression lineage. If none proves ownership,
-        # the event is orphaned and must not be adopted by this chat. Truly
-        # ownerless ordinary notifications retain legacy global delivery.
-        requires_owner = _notification_event_requires_owner(evt)
-        if requires_owner and not _session_owns_notification_event(sid, session, evt):
-            log = (
-                logger.warning
-                if evt.get("type") == "async_delegation"
-                else logger.debug
-            )
-            log(
-                "Dropping unowned %s notification (origin=%r key=%r) instead "
-                "of delivering to session %s",
-                evt.get("type", "completion"),
-                str(evt.get("origin_ui_session_id") or ""),
-                str(evt.get("session_key") or ""),
-                sid,
-            )
-            continue
-
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        _requeued = False
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                _requeued = True
-            else:
-                session["running"] = True
-        if _requeued:
-            # Back off before re-polling: the re-queued event keeps the queue
-            # non-empty, so without a sleep this loop spins at full speed
-            # (100% CPU, GIL churn) for as long as the session stays busy.
+        if _route_action == "requeued_busy":
+            # The queue stays non-empty while the session is busy. Back off
+            # outside the routing lock so the active loop can claim the event.
             time.sleep(0.25)
             continue
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
+        if _route_action != "dispatch":
             continue
+
+        assert evt is not None and text is not None and _claim is not None
+        rid = f"__notif__{int(time.time() * 1000)}"
+        from tools.async_delegation import complete_event_delivery, release_event_delivery
         try:
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
@@ -9286,60 +9323,85 @@ def _notification_poller_loop(
             with session["history_lock"]:
                 session["running"] = False
 
-    # Drain any remaining events after stop signal (process all pending
-    # before exiting so nothing is lost on shutdown). Events owned by other
-    # live sessions are set aside and re-queued so their poller still sees them.
-    # Orphaned events (owner gone) are dropped — same guard as the main loop.
-    deferred: list = []
-    while not process_registry.completion_queue.empty():
-        try:
-            evt = process_registry.completion_queue.get_nowait()
-        except Exception:
-            break
-        if _notification_event_belongs_elsewhere(sid, session, evt):
-            deferred.append(evt)
-            continue
-        # Same positive-proof rule as the live loop. Preserve the existing
-        # shutdown behavior for orphaned delegation payloads by deferring them
-        # for a later resume; ordinary addressed orphans are dropped.
-        requires_owner = _notification_event_requires_owner(evt)
-        if requires_owner and not _session_owns_notification_event(sid, session, evt):
-            if evt.get("type") == "async_delegation":
-                deferred.append(evt)
-            else:
-                logger.debug(
-                    "Dropping unowned %s notification during shutdown drain "
-                    "(origin=%r key=%r)",
-                    evt.get("type", "completion"),
-                    str(evt.get("origin_ui_session_id") or ""),
-                    str(evt.get("session_key") or ""),
-                )
-            continue
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
+    # Drain the bounded queue snapshot after stop so pending notifications are
+    # not lost. Route each dequeue atomically with an active conversation-loop
+    # drain: teardown can signal this poller while its agent turn is still
+    # unwinding. Foreign/orphaned delegation events are requeued immediately;
+    # the fixed snapshot bound prevents spinning on them.
+    try:
+        shutdown_scan_count = process_registry.completion_queue.qsize()
+    except Exception:
+        shutdown_scan_count = 0
+    for _ in range(max(0, shutdown_scan_count)):
+        evt = None
+        text = None
+        _claim = None
+        _shutdown_action = "skip"
+        with process_registry.completion_routing_lock:
+            try:
+                evt = process_registry.completion_queue.get_nowait()
+            except Exception:
                 break
-            session["running"] = True
 
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
+            if _notification_event_belongs_elsewhere(sid, session, evt):
+                process_registry.completion_queue.put(evt)
+                continue
+
+            requires_owner = _notification_event_requires_owner(evt)
+            if requires_owner and not _session_owns_notification_event(
+                sid, session, evt
+            ):
+                if evt.get("type") == "async_delegation":
+                    process_registry.completion_queue.put(evt)
+                else:
+                    logger.debug(
+                        "Dropping unowned %s notification during shutdown drain "
+                        "(origin=%r key=%r)",
+                        evt.get("type", "completion"),
+                        str(evt.get("origin_ui_session_id") or ""),
+                        str(evt.get("session_key") or ""),
+                    )
+                continue
+
+            evt = process_registry.collect_ready_after_turn_siblings(evt)
+            _evt_sid = evt.get("session_id", "")
+            if (
+                evt.get("type") == "completion"
+                and process_registry.is_completion_consumed(_evt_sid)
+            ):
+                continue
+            text = format_process_notification(evt)
+            if not text:
+                continue
+
+            _dedup_key = _notification_event_dedup_key(evt)
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
+
+            with session["history_lock"]:
+                if session.get("running"):
+                    process_registry.completion_queue.put(evt)
+                    _shutdown_action = "busy"
+                else:
+                    from tools.async_delegation import claim_event_delivery
+
+                    _claim = claim_event_delivery(evt, "tui-poller")
+                    if _claim is None:
+                        process_registry.defer_unclaimed_delivery(evt)
+                    else:
+                        session["running"] = True
+                        _shutdown_action = "dispatch"
+
+        if _shutdown_action == "busy":
+            break
+        if _shutdown_action != "dispatch":
             continue
+
+        assert evt is not None and text is not None and _claim is not None
+        rid = f"__notif__{int(time.time() * 1000)}"
+        from tools.async_delegation import complete_event_delivery, release_event_delivery
+
         try:
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
@@ -9363,10 +9425,6 @@ def _notification_poller_loop(
             )
             with session["history_lock"]:
                 session["running"] = False
-
-    # Hand any other sessions' events back to the shared queue.
-    for evt in deferred:
-        process_registry.completion_queue.put(evt)
 
 
 def _async_delegation_display_metadata(evt: dict) -> dict:
@@ -10307,17 +10365,21 @@ def _run_prompt_submit(
                 owns_event=lambda e: _session_owns_notification_event(sid, session, e),
                 skip_poll_observed=False,
             )
+            from tools.async_delegation import (
+                claim_event_delivery, complete_event_delivery, release_event_delivery,
+            )
             for index, (_evt, synth) in enumerate(drained):
+                _claim = None
                 with session["history_lock"]:
                     if session.get("running"):
                         for pending_evt, _pending_synth in drained[index:]:
                             process_registry.completion_queue.put(pending_evt)
                         break
-                    session["running"] = True
-                from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
-                )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
+                    _claim = claim_event_delivery(_evt, "tui-post-turn")
+                    if _claim is None:
+                        process_registry.defer_unclaimed_delivery(_evt)
+                    else:
+                        session["running"] = True
                 if _claim is None:
                     continue
                 try:

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -100,13 +100,46 @@ _DEDUP_EXTRA_FIELDS = {
 
 
 def _notification_event_dedup_key(evt: dict) -> tuple:
-    """UI-emission identity for a process notification event."""
+    """Return the UI-emission identity for a process notification event.
+
+    Completion events are terminal notifications for a background process, so
+    they remain one-shot per process session. Watch-match events are not
+    terminal: a single background process can legitimately match the same or
+    different patterns many times, so include event-specific content to avoid
+    suppressing later distinct matches from the same process.
+    """
     evt_type = evt.get("type", "completion")
+    evt_sid = evt.get("session_id", "")
+    if evt_type == "watch_match":
+        return (
+            evt_sid,
+            evt_type,
+            evt.get("command", ""),
+            evt.get("pattern", ""),
+            evt.get("output", ""),
+            evt.get("suppressed", 0),
+            evt.get("message_id", ""),
+        )
+    if evt_type.startswith("watch_overflow_") or evt_type == "watch_disabled":
+        return (
+            evt_sid,
+            evt_type,
+            evt.get("command", ""),
+            evt.get("message", ""),
+            evt.get("suppressed", 0),
+        )
     if evt_type == "async_delegation":
-        # No process session_id: else every completion keys as ("", "async_delegation") and the second is suppressed forever.
-        return (evt.get("delegation_id", ""), evt_type)
-    extra = _DEDUP_EXTRA_FIELDS.get("watch_overflow_" if evt_type.startswith("watch_overflow_") else evt_type, ())
-    return (evt.get("session_id", ""), evt_type, *(evt.get(f, 0 if f == "suppressed" else "") for f in extra))
+        # Child-scoped batches may deliver several ready rows together and the
+        # remaining rows later. Include the exact durable key set so a later
+        # portion of the same delegation is not visually suppressed.
+        raw_keys = evt.get("delivery_event_keys")
+        if isinstance(raw_keys, (list, tuple)):
+            event_keys = tuple(str(key) for key in raw_keys if key)
+        else:
+            event_key = str(evt.get("delivery_event_key") or "")
+            event_keys = (event_key,) if event_key else ()
+        return (evt.get("delegation_id", ""), evt_type, event_keys)
+    return (evt_sid, evt_type)
 
 
 # Mirror gateway/kanban_watchers.py TERMINAL_KINDS: claim silent kinds (archived/unblocked) too so the cursor advances
@@ -340,66 +373,83 @@ def _notif_poll_kanban(sid: str, session: dict) -> None:
         _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, "\n".join(batch), "kanban notification dispatch failed")
 
 
-def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str) -> None:
-    """Run the claimed (running=True) agent turn for one notification event."""
-    from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
-    if (claim := claim_event_delivery(evt, "tui-poller")) is None:
-        return
-    kwargs = ({"display_kind": "async_delegation_complete", "display_metadata": _async_delegation_display_metadata(evt)}
-              if evt.get("type") == "async_delegation" else {})
+def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str, claim: str) -> None:
+    """Dispatch outside the routing lock, after both the event and idle session were claimed."""
+    from tools.async_delegation import complete_event_delivery, release_event_delivery
+    from tools.process_registry import process_registry
     try:
+        kwargs = ({"display_kind": "async_delegation_complete", "display_metadata": _async_delegation_display_metadata(evt)}
+                  if evt.get("type") == "async_delegation" else {})
         _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text, "notification poller dispatch failed", **kwargs)
     except Exception:
+        _notif_release_turn(session)
         release_event_delivery(evt, claim)
+        process_registry.defer_unclaimed_delivery(evt)
         return
     complete_event_delivery(evt, claim)
 
+def _notif_reserve_event(sid: str, session: dict, registry, *, shutdown: bool = False):
+    """Dequeue/coalesce/classify one bounded ready set. Caller holds the routing RLock.
 
-def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred) -> bool:
-    """Route one dequeued event: foreign (another live session owns it) → requeued, or onto ``deferred`` during the
-    shutdown drain; unowned (addressed but unprovable — never adopt an orphan) → dropped, except delegation payloads
-    deferred for a resume; ours (or ownerless legacy, kept process-global) → status.update once, then an agent turn if
-    idle. False = the drain must stop (session busy)."""
+    No formatting, UI emission, sleep, or model call is performed in this reservation.
+    Busy/foreign rows are returned immediately so active consumers never see a false empty queue.
+    """
     queue = registry.completion_queue
-    evt_type, is_delegation = evt.get("type", "completion"), evt.get("type") == "async_delegation"
+    try:
+        evt = queue.get_nowait()
+    except Exception:
+        return None, "empty"
+    evt_type = evt.get("type", "completion")
     if _notification_event_belongs_elsewhere(sid, session, evt):
-        if deferred is not None:
-            deferred.append(evt)
-        else:  # otherwise a process started in session A surfaces in whichever poller wakes first
-            queue.put(evt)
-            time.sleep(0.1)
-        return True
+        queue.put(evt)
+        return None, "foreign"
     if _notification_event_requires_owner(evt) and not _session_owns_notification_event(sid, session, evt):
-        origin, key = str(evt.get("origin_ui_session_id") or ""), str(evt.get("session_key") or "")
-        if deferred is None:
-            (logger.warning if is_delegation else logger.debug)(
-                "Dropping unowned %s notification (origin=%r key=%r) instead of delivering to session %s",
-                evt_type, origin, key, sid)
-        elif is_delegation:
-            deferred.append(evt)
+        if shutdown and evt_type == "async_delegation":
+            queue.put(evt)
         else:
-            logger.debug("Dropping unowned %s notification during shutdown drain (origin=%r key=%r)", evt_type, origin, key)
-        return True
+            logger.debug("Skipping unowned %s notification for session %s", evt_type, sid)
+        return None, "unowned"
     if evt_type == "completion" and registry.is_completion_consumed(evt.get("session_id", "")):
-        return True
-    text = fmt(evt)
+        return None, "consumed"
+    evt = registry.collect_ready_after_turn_siblings(evt)
+    with session["history_lock"]:
+        if session.get("running"):
+            queue.put(evt)
+            return evt, "busy"
+    return evt, "reserved"
+
+
+def _notif_handle_event(sid, session, evt, emitted, registry, fmt, action) -> None:
+    """Format/emit outside the reservation, then claim the idle session and durable event together."""
+    try:
+        text = fmt(evt)
+    except Exception:
+        if action == "reserved":
+            registry.completion_queue.put(evt)
+        logger.exception("Could not format notification; kept for retry")
+        return
     if not text:
-        return True
-    # Emit once per dedup key: a re-queued completion would otherwise re-emit every 0.5s while the session is busy,
-    # while distinct watch_match events from one process must stay visible.
+        return
     dedup_key = _notification_event_dedup_key(evt)
     if dedup_key not in emitted:
         _emit("status.update", sid, {"kind": "process", "text": text})
         emitted.add(dedup_key)
-    if not _notif_claim_turn(session):
-        queue.put(evt)
-        if deferred is not None:
-            return False
-        time.sleep(0.25)  # back off: the re-queued event keeps the queue non-empty, else this loop spins at 100% CPU
-        return True
-    _notif_dispatch_event(sid, session, evt, text)
-    return True
-
+    if action != "reserved":
+        return
+    from tools.async_delegation import claim_event_delivery
+    # A user prompt may have claimed the idle session while formatting. Give it priority.
+    # Never hold history_lock while acquiring the routing lock (opposite lock order).
+    with session["history_lock"]:
+        if session.get("running") or session.get("_finalized"):
+            registry.completion_queue.put(evt)
+            return
+        claim = claim_event_delivery(evt, "tui-poller")
+        if claim is not None:
+            session["running"] = True
+    if claim is None:
+        registry.defer_unclaimed_delivery(evt)
+        return
+    _notif_dispatch_event(sid, session, evt, text, claim)
 
 def _notification_poller_loop(stop_event: threading.Event, sid: str, session: dict) -> None:
     """Daemon thread (started by _init_session()) that drains the process-global completion_queue for this session
@@ -430,24 +480,20 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
         if now - last_kanban_poll >= _KANBAN_POLL_SECONDS:
             last_kanban_poll = now
             _notif_poll_kanban(sid, session)
-        try:
-            evt = queue.get(timeout=0.5)
-        except Exception:
-            continue
-        handle(evt, None)
-    # Drain remaining events after the stop signal so nothing is lost on shutdown; foreign and orphaned-delegation
-    # events are handed back to the shared queue afterwards.
-    deferred: list = []
-    while not queue.empty():
-        try:
-            evt = queue.get_nowait()
-        except Exception:
+        with process_registry.completion_routing_lock:
+            evt, action = _notif_reserve_event(sid, session, process_registry)
+        if evt is not None:
+            handle(evt, action)
+        if action in {"empty", "foreign", "busy"}:
+            time.sleep({"empty": 0.5, "foreign": 0.1, "busy": 0.25}[action])
+    # Bound the shutdown snapshot so foreign/busy requeues cannot spin indefinitely.
+    for _ in range(queue.qsize()):
+        with process_registry.completion_routing_lock:
+            evt, action = _notif_reserve_event(sid, session, process_registry, shutdown=True)
+        if evt is not None:
+            handle(evt, action)
+        if action in {"empty", "busy"}:
             break
-        if not handle(evt, deferred):
-            break
-    for evt in deferred:
-        queue.put(evt)
-
 
 def _async_delegation_display_metadata(evt: dict) -> dict:
     """Build display-only metadata before the completion event is formatted."""

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -84,9 +84,17 @@ delegate_task(
     Auth files: src/auth/login.py, src/auth/jwt.py, src/auth/middleware.py
     Test command: pytest tests/auth/ -v
     Focus on: SQL injection, JWT validation, password hashing, session management.
-    Fix issues found and verify tests pass."""
+    Fix issues found and verify tests pass.""",
+    result_delivery="inject",
 )
 ```
+
+`inject` is appropriate here because the review can change the parent's current
+implementation. Hermes does not wait for the reviewer: if the review is ready
+when the parent produces another tool-result batch, it is carried on that new
+result before the next model request. Otherwise it stays durable and arrives
+later through the normal `after_turn` path. Use the default `after_turn` for
+independent work whose result does not need to change the current turn.
 
 :::warning The Context Problem
 Subagents know **absolutely nothing** about your conversation. They start completely fresh. If you delegate "fix the bug we were discussing," the subagent has no idea what bug you mean. Always pass file paths, error messages, project structure, and constraints explicitly.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -8,7 +8,7 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 The `delegate_task` tool spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
 
-Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
+Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue. The model chooses how the result comes back with `result_delivery`: the backward-compatible default, `after_turn`, posts a separate synthetic turn; `inject` lets an auditor or dependency re-enter a still-running parent turn when that turn produces another tool-result boundary. An orchestrator subagent still waits for its own workers so it can synthesize their results before returning.
 
 ## Single Task
 
@@ -30,6 +30,49 @@ delegate_task(tasks=[
     {"goal": "Fix the build", "context": "Project root: /home/user/project"}
 ])
 ```
+
+## Result Delivery
+
+`delegate_task` is always asynchronous at the top level and never waits for a
+running child. `result_delivery` controls only when an already-completed result
+is shown to the parent model:
+
+- **`after_turn` (default):** at each available turn boundary, every completed
+  but undelivered child from the batch is grouped into one synthetic turn. It
+  never waits for unfinished siblings: if 1/3 is ready, that result is delivered;
+  if two more are ready at a later boundary, those two are grouped into the next
+  turn.
+
+:::note Ready-set invariant
+At one delivery boundary, one batch produces exactly one envelope containing
+all of its currently completed, undelivered child rows. The envelope is claimed
+and acknowledged atomically. Unfinished siblings are never waited on; children
+that finish later form the ready-set at a later boundary.
+:::
+
+- **`inject`:** intended for auditors, reviewers, and dependent work that can
+  change what the parent should do now. At a newly completed tool batch, ready
+  child evidence is appended to the last tool result from that batch before it
+  is sent to the provider. No user/system/developer message is manufactured and
+  previously sent history is never rewritten. Batch children do not wait for
+  slower siblings. If there is no later tool-result carrier, no follow-up model
+  budget, or the originating turn has ended, the durable event stays pending
+  and follows the normal `after_turn` path.
+
+```python
+delegate_task(
+    goal="Audit the patch for correctness and race conditions",
+    context="Project: /home/user/project; review the current uncommitted diff",
+    result_delivery="inject",
+)
+```
+
+Injection is best-effort and role-safe: Hermes enriches only a tool result made
+by the current, not-yet-sent batch. Multiple results already ready at that
+boundary share one carrier. It never adds an iteration, waits, polls, mutates a
+previously sent tool result, or reopens a provisional final answer. Results that
+miss this bounded carrier stay on the same durable rail and arrive later through
+`after_turn`.
 
 ## How Subagent Context Works
 
@@ -117,7 +160,7 @@ delegate_task(
 
 ## Batch Mode Details
 
-When a top-level agent provides a `tasks` array, Hermes returns one background handle, runs the subagents in parallel, and posts one consolidated result after every child finishes. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
+When a top-level agent provides a `tasks` array, Hermes returns one background handle and runs the subagents in parallel. With the default `after_turn` delivery, every ready child at an available turn boundary is grouped into one result turn; unfinished siblings do not block it and appear in a later ready-set. With `inject`, children ready at one tool boundary share that tool-result carrier; later children use a later carrier or fall through to `after_turn`. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
 
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
@@ -130,12 +173,19 @@ Synchronous single-task delegation from an orchestrator runs directly without th
 ### Durable background completions
 
 When a background delegation finishes, Hermes stores its completion event in
-the active profile's `state.db` before publishing it to the normal fresh-turn
-queue. If Hermes restarts after completion but before delivery, the pending
-event is restored and routed through the same ownership checks. Competing
-consumers use a durable claim, so only the consumer that successfully accepts
-the synthetic turn acknowledges delivery; failed attempts release the claim for
-retry.
+the active profile's `state.db` before publishing it to the shared completion
+queue. Both `inject` and `after_turn` batches use one execution record plus
+independently claimable child-delivery records. At an idle `after_turn` boundary,
+currently-ready child rows are folded into a transient grouped envelope; the
+envelope is not a second aggregate database row. Legacy aggregate records from
+older Hermes versions remain deliverable through the compatibility path. If
+Hermes restarts after completion but before delivery, pending events are
+restored and routed through the same ownership checks. Competing consumers use
+a durable claim, so only the consumer which durably commits the tool carrier,
+or which successfully appends the separate after-turn input, acknowledges each
+event. Failed attempts release the claim for retry; a restored row whose
+previous process still owns a live lease is rescheduled for the lease boundary
+without spinning the completion queue.
 
 This does not resume child execution after a crash. A delegation whose owner
 process disappears while it is still running is recorded as `unknown`, because

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -8,7 +8,7 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 The `delegate_task` tool spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
 
-Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
+Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue. The model chooses how the result comes back with `result_delivery`: the backward-compatible default, `after_turn`, posts a separate synthetic turn; `inject` lets an auditor or dependency re-enter a still-running parent turn when that turn produces another tool-result boundary. An orchestrator subagent still waits for its own workers so it can synthesize their results before returning.
 
 ## Single Task
 
@@ -30,6 +30,49 @@ delegate_task(tasks=[
     {"goal": "Fix the build", "context": "Project root: /home/user/project"}
 ])
 ```
+
+## Result Delivery
+
+`delegate_task` is always asynchronous at the top level and never waits for a
+running child. `result_delivery` controls only when an already-completed result
+is shown to the parent model:
+
+- **`after_turn` (default):** at each available turn boundary, every completed
+  but undelivered child from the batch is grouped into one synthetic turn. It
+  never waits for unfinished siblings: if 1/3 is ready, that result is delivered;
+  if two more are ready at a later boundary, those two are grouped into the next
+  turn.
+
+:::note Ready-set invariant
+At one delivery boundary, one batch produces exactly one envelope containing
+all of its currently completed, undelivered child rows. The envelope is claimed
+and acknowledged atomically. Unfinished siblings are never waited on; children
+that finish later form the ready-set at a later boundary.
+:::
+
+- **`inject`:** intended for auditors, reviewers, and dependent work that can
+  change what the parent should do now. At a newly completed tool batch, ready
+  child evidence is appended to the last tool result from that batch before it
+  is sent to the provider. No user/system/developer message is manufactured and
+  previously sent history is never rewritten. Batch children do not wait for
+  slower siblings. If there is no later tool-result carrier, no follow-up model
+  budget, or the originating turn has ended, the durable event stays pending
+  and follows the normal `after_turn` path.
+
+```python
+delegate_task(
+    goal="Audit the patch for correctness and race conditions",
+    context="Project: /home/user/project; review the current uncommitted diff",
+    result_delivery="inject",
+)
+```
+
+Injection is best-effort and role-safe: Hermes enriches only a tool result made
+by the current, not-yet-sent batch. Multiple results already ready at that
+boundary share one carrier. It never adds an iteration, waits, polls, mutates a
+previously sent tool result, or reopens a provisional final answer. Results that
+miss this bounded carrier stay on the same durable rail and arrive later through
+`after_turn`.
 
 ## How Subagent Context Works
 
@@ -115,7 +158,7 @@ delegate_task(
 
 ## Batch Mode Details
 
-When a top-level agent provides a `tasks` array, Hermes returns one background handle, runs the subagents in parallel, and posts one consolidated result after every child finishes. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
+When a top-level agent provides a `tasks` array, Hermes returns one background handle and runs the subagents in parallel. With the default `after_turn` delivery, every ready child at an available turn boundary is grouped into one result turn; unfinished siblings do not block it and appear in a later ready-set. With `inject`, children ready at one tool boundary share that tool-result carrier; later children use a later carrier or fall through to `after_turn`. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
 
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
@@ -128,12 +171,19 @@ Synchronous single-task delegation from an orchestrator runs directly without th
 ### Durable background completions
 
 When a background delegation finishes, Hermes stores its completion event in
-the active profile's `state.db` before publishing it to the normal fresh-turn
-queue. If Hermes restarts after completion but before delivery, the pending
-event is restored and routed through the same ownership checks. Competing
-consumers use a durable claim, so only the consumer that successfully accepts
-the synthetic turn acknowledges delivery; failed attempts release the claim for
-retry.
+the active profile's `state.db` before publishing it to the shared completion
+queue. Both `inject` and `after_turn` batches use one execution record plus
+independently claimable child-delivery records. At an idle `after_turn` boundary,
+currently-ready child rows are folded into a transient grouped envelope; the
+envelope is not a second aggregate database row. Legacy aggregate records from
+older Hermes versions remain deliverable through the compatibility path. If
+Hermes restarts after completion but before delivery, pending events are
+restored and routed through the same ownership checks. Competing consumers use
+a durable claim, so only the consumer which durably commits the tool carrier,
+or which successfully appends the separate after-turn input, acknowledges each
+event. Failed attempts release the claim for retry; a restored row whose
+previous process still owns a live lease is rescheduled for the lease boundary
+without spinning the completion queue.
 
 This does not resume child execution after a crash. A delegation whose owner
 process disappears while it is still running is recorded as `unknown`, because


### PR DESCRIPTION
> [!IMPORTANT]
> This is the final behavior layer of a three-PR stack. It is cumulative over #76228 and #76229 because a fork branch cannot be used as the base of an upstream PR. The behavior owned by this PR is implemented by `554957424`, the review-hardening fix `ef3696708`, and the focused upstream-adaptation commit `ab2417bb4`; the stack map below separates the review boundaries.

## What this improves

Hermes can already run background subagents in parallel, but parallel execution is only useful when the result arrives while it can still affect the work that depends on it. Today, a reviewer, auditor, or prerequisite can finish during a long foreground turn yet remain invisible until that turn is over. By then the parent may already have made the edit, committed the change, or produced the final answer the child was meant to check.

This PR makes an explicitly dependent result visible at the next **existing safe continuation boundary**, while the parent still has an opportunity to use it. It turns background review from a post-hoc notification into actionable feedback without making the parent wait.

A concrete sequence is:

1. the parent delegates a review or prerequisite and marks that delegation `inject`;
2. the parent continues reversible discovery or tool work instead of blocking on the child;
3. the child finishes before a later provider continuation;
4. its marked evidence is included in that continuation;
5. the parent can change the next tool call, avoid a bad edit, or investigate a blocker before finalizing.

Under `after_turn`, step 4 happens only after the foreground workflow has ended. The bytes may eventually be identical, but their causal value is not: an audit received after the decision can only trigger rework, while the same audit received before the next decision can prevent the mistake.

The practical benefits are:

- **useful parallelism:** the parent does not have to choose between waiting for a reviewer and making the reviewer irrelevant;
- **less avoidable rework:** a ready blocker can stop or redirect unfinished work instead of reopening it in a later turn;
- **lower end-to-end latency:** the result uses a continuation the agent was already going to make, rather than requiring a manufactured reconciliation call;
- **better delegation UX:** the parent can choose whether a result is time-sensitive or simply useful after the turn, without learning a new workflow;
- **larger gains on long agentic turns:** the more tool calls and reversible decisions occur before finalization, the more valuable an already-ready dependency becomes.

## Zero-setup dependency awareness

Most delegated dependencies in Hermes are ad hoc: review this edit, verify this assumption, inspect this failure, or check this plan. They are too small to justify user-managed project state or a separate orchestration setup, but timing still matters because the answer may invalidate what the parent is doing now.

Without a lightweight timing signal, the parent has two bad choices:

- wait for the child and give up background parallelism; or
- keep working and accept that the child may become useful only as a post-mortem.

This PR removes that false choice inside the existing `delegate_task` UX. The parent marks the result as time-sensitive where it creates the work; Hermes then uses the existing delivery machinery to expose it at a useful boundary when possible. There is no new user-facing system to configure, no separate queue to operate, and no persistent planning workflow to maintain.

The contract is bounded best effort, not a barrier:

> If an opted-in result is ready at an existing safe continuation boundary, expose it before the next decision. Otherwise do not wait; preserve ordinary after-turn delivery.

## Why this is a net improvement across model quality

Using timely evidence does not require a perfect planner; reacting to new tool evidence is already a core part of an agentic continuation. Straightforward results such as “this API assumption is false,” “the test fails at this boundary,” or “this edit violates the requested scope” can help any model that can use ordinary tool output. More capable models gain even more because they can synthesize nuanced independent review into their next decision instead of merely reading a post-mortem.

The upside is concrete:

- when the parent uses the evidence well, it can prevent an incorrect edit, commit, tool call, or final answer before the cost is incurred;
- when the evidence would not help, `after_turn` remains the default and the parent need not opt in;
- if the safe boundary never appears, Hermes adds no wait or extra iteration and falls back to the existing path;
- the child report is clearly marked and arrives alongside tool evidence that the model already has to interpret on that continuation.

A weaker model may still over-focus on injected evidence, spend effort reconciling an unimportant detail, or drift toward the child's framing. That is a quality-of-reasoning risk around one explicitly selected dependency, not a failure of delivery, history, or recovery. The downside is bounded by opt-in use and an unchanged default; the upside can avoid work that has already become wrong.

In other words, this PR adds a missing causal opportunity; it does not guarantee model judgment. Keeping all results after-turn because some models may use feedback poorly would also prevent stronger models—and weaker models in straightforward cases—from using timely, correct feedback at all. The safe policy is therefore opt-in current-turn eligibility with an unchanged default and durable fallback, not removing the opportunity globally.

## Safe continuation shape

A ready dependent result is carried on the last **new, unsent tool result** of a complete tool-call batch. It is attached before that tail is first persisted. The next request therefore keeps the ordinary continuation shape:

```text
assistant(tool_calls) → tool(tool output + clearly marked background evidence) → assistant
```

There is no additional conversation message, no claimed user authorship, no rewritten history, and no manufactured model iteration. If that existing boundary does not occur before the foreground turn ends, the same durable event remains pending for the normal `after_turn` path.

## One delivery rail, better result timing

This is a UX improvement to the existing `delegate_task` flow, not a new task-management abstraction. `result_delivery` only records whether a delegation result is time-sensitive for the active work or can wait for the normal between-turn delivery:

```text
active dependency/review  → eligible at the next safe current-turn boundary
independent work          → eligible at the normal between-turn boundary
```

Both use the same:

- subagent execution;
- durable child-event identity;
- completion queue;
- claim and lease protocol;
- formatting;
- crash recovery;
- parent session/turn binding;
- exactly-once settlement;
- late-delivery path.

The state machine remains shared:

```text
pending → claimed → delivered
             ↘ released → pending
```

For an `inject` event, the active loop merely gets the first bounded opportunity to claim it. If that opportunity is absent, late, lost, or rolled back, the event is still the same pending row consumed by `after_turn`. There is no second queue, ledger, recovery scanner, or settlement protocol.

## Synthetic user vs. tool-boundary carrier

The old #74378 implementation did this after a tool block:

```text
append a new message:
    role = user
    content = delegation result
```

Even where a provider accepts `tool → user → assistant`, that representation is wrong for Hermes: the user did not send the message, and the active turn did not end. It also forced the loop to handle a synthetic turn, provisional finalization, reconciliation grace, and provider-specific tail behavior.

This PR does something narrower:

1. wait for a complete tool-call batch that already requires another model continuation;
2. inspect only the new, not-yet-persisted tool-result tail;
3. append a clearly delimited block beginning with:

   ```text
   [DELEGATION RESULT READY — background evidence for the current task;
   not a new user request]
   ```

4. persist that tool tail;
5. acknowledge the durable child row only after the transcript commit succeeds.

The provider necessarily receives the evidence inside tool-result content. The marker explicitly distinguishes that framework-added evidence from the bytes produced by the invoked tool and identifies its purpose. This reuses the same deliberate Hermes boundary as `/steer`, which already appends clearly marked external input to the last tool result so the next assistant continuation can observe it without inserting a role. Tool output in Hermes can already contain framework-added truncation, guardrail, and steering context; this adds another explicitly identified framework block at that established seam.

The restriction is intentional: if there is no complete tool batch, this PR does not fabricate a carrier. The event stays on `after_turn`.

## How this addresses the #74378 close review

The close review identified real problems in that implementation. This redesign does not ask maintainers to relax those invariants.

| Close-review concern | What is true after this redesign |
|---|---|
| synthetic `role:"user"` inside an active turn | eliminated; no delegation message is created |
| provider-dependent handling of a new user role after tool results | no such transition exists; the provider sees its ordinary tool continuation |
| prompt-cache integrity | no system or previously sent message is modified; no new synthetic user segment is added; only an unsent tail is finalized before its first request |
| roughly ten hooks plus provisional-final/grace lifecycle | provisional finalization and grace calls are gone; active-loop work is localized to the existing post-tool persistence checkpoint plus common rollback |
| TUI/active-loop competition | #76229 gives all consumers one routing reservation and the same durable claim API |
| the existing queue “already delivers the benefit” | it delivers the output, but only after the decision; it does not preserve the already-available review/dependency window |

The provider/cache concerns around the old shape were compatibility risks, not evidence that every major provider necessarily rejected it or that an already-cached prefix was rewritten. The decisive issue was Hermes' own turn/authorship invariant. The new carrier removes that issue rather than arguing for an exception.

The remaining product question is therefore precise:

> Should a completed, explicitly dependent child be allowed to affect unfinished parent work at an already-existing safe tool boundary?

It is no longer a question about permitting synthetic user turns.

## Bounded semantic risk and unchanged baseline

The model-quality risk is deliberately contained at the policy surface:

- `after_turn` remains the default and the interpretation of legacy or missing values;
- `inject` is explicit delegation metadata, chosen only when the result may change unfinished work;
- missed boundaries automatically preserve `after_turn` delivery;
- Hermes does not wait, poll, add a grace call, or extend the iteration budget;
- this PR adds no model-strength presets, user settings, mandatory `/goal`, or routing heuristics.

Existing goals, tool limits, iteration limits, compaction, and persistence still shape long-running agents, but they are surrounding capabilities—not scope added by this PR.

## Bounded carrier storage

Delegation evidence uses the existing tool-result budget instead of bypassing it:

- the final provider-visible text on the carrier is limited by the smaller of the configured default per-result cap and aggregate turn budget;
- if the full formatted child report does not fit, `maybe_persist_tool_result(...)` stores that report in the active environment and the carrier receives the ordinary `<persisted-output>` path plus bounded preview;
- if full-report storage is unavailable or cannot fit its pointer safely, the event is not claimed or truncated: it remains pending with its delivery-attempt count unchanged for the normal `after_turn` rail.

This keeps the child goal/context/summary available without allowing a large formatter result to inflate the next provider request after ordinary tool-output budgeting has already run.

## Failure ordering

Carrier settlement is deliberately persistence-first:

1. format the ready report and fit it inline or spill the complete formatter output through bounded tool-result storage;
2. claim the ready child row;
3. append evidence only to the new complete tool tail and register its pending claim ownership;
4. durably persist that append-only transcript tail;
5. acknowledge the child row.

If any operation after content mutation fails—including pending-claim registration or heartbeat startup—the exact original target structure is restored and every acquired durable claim is released/requeued. If persistence fails, the same rollback path removes the carrier before the event returns to pending. If the carrier was persisted, its durable event identity prevents restart recovery from presenting it twice. Private claim/display metadata is stripped before provider serialization.

## Stack and review boundaries

| PR | Owned commit | Responsibility | Standalone effect |
|---|---|---|---|
| #76228 | `21a283276` | durable child identity and settlement | recovery foundation; visibility unchanged |
| #76229 | `aa4038d03` | ready-set routing at existing between-turn consumers | faster/default `after_turn`; no active-loop behavior |
| **#76230** | `554957424` + `ef3696708` + `ab2417bb4` | opt-in tool-boundary eligibility, bounded carrier, and transactional rollback | ready dependencies may affect unfinished work without bypassing tool-result storage |

Reviewing the cumulative branch commit-by-commit gives three ownership cuts. After the foundations merge, this PR can be rebased to show only `554957424`, its focused hardening commit `ef3696708`, and the upstream-adaptation commit `ab2417bb4`.

## Compatibility

- default and legacy behavior: `after_turn`;
- `/background`: unchanged;
- no completed tool batch: no same-turn carrier;
- late/failed/lost carrier opportunity: same durable event remains for `after_turn`;
- Chat Completions, Anthropic, Gemini, and Responses retain their native tool-result role shape;
- OpenRouter/custom Chat Completions do not require a brand allowlist because no provider-specific message role is introduced;
- no new config or UI surface.

## Verification

- review-hardening matrix on `ef3696708`: **214 passed, 0 failed** across carrier/ledger/storage, production compressor, CLI, gateway, TUI lifecycle, and executor paths;
- a 250,000-character child summary is stored through canonical tool-result spill while the final carrier remains within a 10,000-character result budget;
- unavailable spill leaves the full event `pending`, unmodified, and at delivery attempt `0`;
- fault injection after content mutation but before pending-claim ownership proves exact target restoration plus durable release/requeue;
- a bounded carrier is loaded back from `SessionDB`, processed by the production `ContextCompressor`, and retained in the sanitized provider payload;
- carrier/ledger/CLI/gateway/TUI affected matrix: **662 passed, 0 failed**;
- combined carrier + subagent model/reasoning/provider integration: **814 passed, 0 persistent failures**; one unrelated TUI concurrent-write flake passed the full-file retry and a fresh targeted rerun;
- provider contract tests cover Chat Completions, Anthropic, Gemini, and Responses tool-result serialization;
- tests prove no synthetic delegation-user message and no mutation of prior message/system-prompt bytes;
- private carrier/claim metadata is absent from provider payloads;
- full GitHub CI on `ef3696708`: **28 successful, 9 skipped, 1 neutral, 0 failures**; PR `mergeable_state: clean`;
- Ruff, `py_compile`, and `git diff --check`: **passed**;
- current head (rebased): `ab2417bb40cf116e8ef5da12984c34fee79074fb`.

## Related

- Supersedes the carrier representation in #74378 without reopening or force-pushing the maintainer-closed PR.
- #76228 and #76229 are the independently reviewable foundations requested in the close review.

## Coordination graph

- **Issue interlock:** Fixes #85648
- **Stack siblings:** #76228 and #76229
- **Dependency edges:** depends on both foundations; no PR depends on this optional final layer
- **Collision constraints:** #75117, #65824, #61719/#73351, #70899, and #82519 overlap parts of delegation/gateway/TUI routing. This PR owns only opt-in current-turn eligibility and bounded tool-tail carriage; it does not own origin persistence, timeout redaction, notification ownership, UI observability, or Slack profile context
- **Merge order:** #76228 → #76229 → #76230. Review the three commits owned by this layer only after the foundations are accepted
- **Closed predecessor:** supersedes the synthetic-user carrier representation in #74378 while preserving the maintainer invariants from its close review

## Hermes triage dashboard graph

Live dashboard neighbourhood: https://hermes-triage.gottz.de/?node=76230&complex=e394e6179542bacbd5e7dbdc5adc9dfb

```mermaid
flowchart LR
    classDef focus fill:#fef3c7,stroke:#b45309,stroke-width:3px,color:#451a03
    classDef issue fill:#ede9fe,stroke:#6d28d9,color:#2e1065
    classDef open fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a
    classDef closed fill:#e5e7eb,stroke:#6b7280,color:#1f2937
    P76230["PR #76230 (open)"]
    I85648(["issue #85648 (open)"])
    P58690["PR #58690 (closed)"]
    P60863["PR #60863 (merged)"]
    P61332["PR #61332 (open)"]
    P62608["PR #62608 (open)"]
    P63866["PR #63866 (closed)"]
    P65860["PR #65860 (open)"]
    P70133["PR #70133 (merged)"]
    P72596["PR #72596 (open)"]
    P74378["PR #74378 (closed)"]
    P76229["PR #76229 (open)"]
    P76230 -->|related| I85648
    P76230 -->|closes| I85648
    P74378 -.->|duplicate of 0.76| P76230
    P76229 -.->|duplicate of 0.67| P76230
    P58690 -.->|duplicate of 0.66| P76230
    P63866 -.->|duplicate of 0.66| P76230
    P60863 -.->|duplicate of 0.66| P76230
    P65860 -.->|duplicate of 0.65| P76230
    P72596 -.->|duplicate of 0.65| P76230
    P61332 -.->|duplicate of 0.65| P76230
    P70133 -.->|duplicate of 0.65| P76230
    P62608 -.->|duplicate of 0.64| P76230
    class P76230 focus
    click P76230 "https://github.com/NousResearch/hermes-agent/pull/76230"
    class I85648 issue
    click I85648 "https://github.com/NousResearch/hermes-agent/issues/85648"
    class P58690 closed
    click P58690 "https://github.com/NousResearch/hermes-agent/pull/58690"
    class P60863 merged
    click P60863 "https://github.com/NousResearch/hermes-agent/pull/60863"
    class P61332 open
    click P61332 "https://github.com/NousResearch/hermes-agent/pull/61332"
    class P62608 open
    click P62608 "https://github.com/NousResearch/hermes-agent/pull/62608"
    class P63866 closed
    click P63866 "https://github.com/NousResearch/hermes-agent/pull/63866"
    class P65860 open
    click P65860 "https://github.com/NousResearch/hermes-agent/pull/65860"
    class P70133 merged
    click P70133 "https://github.com/NousResearch/hermes-agent/pull/70133"
    class P72596 open
    click P72596 "https://github.com/NousResearch/hermes-agent/pull/72596"
    class P74378 closed
    click P74378 "https://github.com/NousResearch/hermes-agent/pull/74378"
    class P76229 open
    click P76229 "https://github.com/NousResearch/hermes-agent/pull/76229"
```

Dashboard interpretation:

- solid edges are structural GitHub links (`closes` / `related`);
- dashed edges are embedding-discovery candidates and show the dashboard score;
- the fold thresholds reported by the dashboard are embedding `0.88` and file overlap `0.75`;
- a dashed `duplicate of` edge below the fold threshold is a similarity lead for review, **not** an accepted duplicate or merge-order edge;
- the gold node is this PR; purple nodes are issues; blue/gray nodes are open/closed neighbouring PRs.

This graph is additive to the hand-audited coordination block above: the dashboard supplies discovery neighbourhoods, while the declared dependency, collision, ownership, and merge-order edges remain the reviewed coordination contract.

