### PR TITLE
fix(cli): stop spurious TUI npm install on every launch in workspace checkouts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1660,6 +1660,60 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _npm_lock_dependency_closure(
+    packages: dict, workspace: str
+) -> set[str]:
+    """Return lockfile package paths reachable from an installed workspace."""
+    if workspace not in packages or not isinstance(packages[workspace], dict):
+        return set()
+
+    def resolve(package_path: str, dependency: str) -> str | None:
+        base = package_path.split("/") if package_path else []
+        while True:
+            candidate = "/".join(base + ["node_modules", dependency])
+            if candidate in packages:
+                return candidate
+            if not base:
+                return None
+            base.pop()
+
+    closure = {workspace}
+    pending = [workspace]
+    while pending:
+        package_path = pending.pop()
+        package = packages[package_path]
+        if not isinstance(package, dict):
+            continue
+        dependencies: set[str] = set()
+        for field in (
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+        ):
+            values = package.get(field)
+            if isinstance(values, dict):
+                dependencies.update(values)
+        for dependency in dependencies:
+            resolved = resolve(package_path, dependency)
+            if resolved is None:
+                continue
+            if resolved not in closure:
+                closure.add(resolved)
+                pending.append(resolved)
+            linked_package = packages[resolved]
+            linked_to = (
+                linked_package.get("resolved")
+                if isinstance(linked_package, dict) and linked_package.get("link")
+                else None
+            )
+            if linked_to in packages:
+                if linked_to not in closure:
+                    closure.add(linked_to)
+                    pending.append(linked_to)
+    return closure
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -1680,7 +1734,8 @@ def _tui_need_npm_install(root: Path) -> bool:
     already match, which used to trigger a spurious "Installing TUI
     dependencies" on every launch.
 
-    For each entry in the root lock's ``packages`` map:
+    For each entry in the root lock's ``packages`` map (or, in workspace mode,
+    the dependency closure reachable from ``ui-tui``):
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
@@ -1721,7 +1776,20 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
+    workspace_packages = (
+        _npm_lock_dependency_closure(
+            wanted, root.relative_to(ws_root).as_posix()
+        )
+        if ws_root != root
+        else None
+    )
+    if workspace_packages == set():
+        # A malformed lockfile without the workspace importer cannot safely
+        # establish a scoped closure, so retain strict missing-entry checks.
+        workspace_packages = None
     for name, pkg in wanted.items():
+        if workspace_packages is not None and name not in workspace_packages:
+            continue
         if not name:
             continue
 
@@ -1730,16 +1798,6 @@ def _tui_need_npm_install(root: Path) -> bool:
 
         if name not in installed:
             if pkg.get("optional") or pkg.get("peer"):
-                continue
-            if ws_root != root:
-                # Workspace mode: launch installs only the ui-tui subset
-                # (`npm install --workspace ui-tui`), so the hidden lockfile
-                # never contains the other workspaces' packages (desktop,
-                # web, bootstrap-installer). They are intentionally absent —
-                # treating them as missing forced a spurious reinstall on
-                # every launch (#45657). The @hermes/ink sentinel above still
-                # guards the critical TUI dependency, and entries that ARE
-                # installed but differ are still caught below.
                 continue
             return True
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1590,16 +1590,20 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer", "dev"})
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing
 (per-platform opt-outs).  ``peer`` is dropped from the hidden ``.package-lock.json``
 on dev-dependencies that are *also* declared as peers — the canonical
 ``package-lock.json`` records the dual role, but npm 9's actualized tree strips
-it.  Neither key represents a real skew between what was declared and what was
-installed, so we exclude them from the comparison in :func:`_tui_need_npm_install`
-to avoid false-positive reinstalls on every launch.
+it.  ``dev`` is recomputed against the installed subset: after a scoped
+``npm install --workspace ui-tui``, packages that are prod deps of *other*
+workspaces but only dev-reachable inside ui-tui get ``dev: true`` in the hidden
+lock while the full lock records no flag — a false-positive reinstall trigger
+on every launch (#45657).  Neither key represents a real skew between what was
+declared and what was installed, so we exclude them from the comparison in
+:func:`_tui_need_npm_install` to avoid false-positive reinstalls on every launch.
 """
 
 
@@ -1726,6 +1730,16 @@ def _tui_need_npm_install(root: Path) -> bool:
 
         if name not in installed:
             if pkg.get("optional") or pkg.get("peer"):
+                continue
+            if ws_root != root:
+                # Workspace mode: launch installs only the ui-tui subset
+                # (`npm install --workspace ui-tui`), so the hidden lockfile
+                # never contains the other workspaces' packages (desktop,
+                # web, bootstrap-installer). They are intentionally absent —
+                # treating them as missing forced a spurious reinstall on
+                # every launch (#45657). The @hermes/ink sentinel above still
+                # guards the critical TUI dependency, and entries that ARE
+                # installed but differ are still caught below.
                 continue
             return True
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -176,3 +176,130 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+# ── workspace-mode lockfile comparison (#45657) ─────────────────────
+
+
+import json
+
+
+def _write_lock(path: Path, packages: dict) -> None:
+    path.write_text(json.dumps({"packages": packages}), encoding="utf-8")
+
+
+def _make_workspace_checkout(tmp_path: Path) -> Path:
+    """Minimal npm-workspaces checkout: ui-tui/ has a package.json but no
+    lockfile, so _workspace_root(ui-tui) resolves to the repo root where the
+    single lockfile and hoisted node_modules/ live."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    return tui_dir
+
+
+_PKG = {
+    "version": "1.2.3",
+    "resolved": "https://registry.npmjs.org/dep/-/dep-1.2.3.tgz",
+    "integrity": "sha512-abc",
+}
+
+
+def test_workspace_mode_ignores_packages_from_other_workspaces(
+    tmp_path: Path, main_mod
+) -> None:
+    """#45657 primary trigger: launch installs only the ui-tui subset
+    (``npm install --workspace ui-tui``), so the hidden lockfile never
+    contains sibling-workspace entries (apps/desktop, web, …).  Treating
+    them as missing forced a spurious "Installing TUI dependencies…" +
+    no-op npm install on EVERY launch.  In workspace mode, entries absent
+    from the hidden lockfile must be skipped."""
+    tui_dir = _make_workspace_checkout(tmp_path)
+
+    full_packages = {
+        "": {"name": "monorepo"},
+        "ui-tui": {"version": "0.1.0", "license": "MIT"},
+        # Sibling workspaces and their deps: installed only by a full-root
+        # npm install, intentionally absent from the hidden lockfile.
+        "apps/desktop": {"version": "0.1.0", "license": "MIT"},
+        "apps/bootstrap-installer": {"version": "0.1.0"},
+        "node_modules/electron": dict(_PKG),
+        # ui-tui deps: installed, present in both locks.
+        "node_modules/@hermes/ink": {"resolved": "ui-tui/packages/hermes-ink", "link": True},
+        "node_modules/ink": dict(_PKG),
+    }
+    installed_packages = {
+        "": {"name": "monorepo"},
+        "ui-tui": {"version": "0.1.0", "license": "MIT"},
+        "node_modules/@hermes/ink": {"resolved": "ui-tui/packages/hermes-ink", "link": True},
+        "node_modules/ink": dict(_PKG),
+    }
+    _write_lock(tmp_path / "package-lock.json", full_packages)
+    _write_lock(tmp_path / "node_modules" / ".package-lock.json", installed_packages)
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_mode_ignores_dev_flag_skew(tmp_path: Path, main_mod) -> None:
+    """#45657 secondary trigger: npm recomputes ``dev`` against the installed
+    subset — a package that is a prod dep of an *uninstalled* workspace has
+    no ``dev`` flag in the root lock but gets ``dev: true`` in the hidden
+    actualized lock.  That annotation is not real skew."""
+    tui_dir = _make_workspace_checkout(tmp_path)
+
+    _write_lock(
+        tmp_path / "package-lock.json",
+        {"": {"name": "monorepo"}, "node_modules/zod": dict(_PKG)},
+    )
+    hidden_pkg = {**_PKG, "dev": True}
+    _write_lock(
+        tmp_path / "node_modules" / ".package-lock.json",
+        {"": {"name": "monorepo"}, "node_modules/zod": hidden_pkg},
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_mode_still_detects_real_skew(tmp_path: Path, main_mod) -> None:
+    """The skip must not blind the check: a ui-tui dependency whose version
+    actually moved (e.g. lockfile updated, node_modules stale) is present
+    in BOTH locks with differing fields and must still trigger reinstall."""
+    tui_dir = _make_workspace_checkout(tmp_path)
+
+    _write_lock(
+        tmp_path / "package-lock.json",
+        {"": {"name": "monorepo"}, "node_modules/ink": dict(_PKG)},
+    )
+    stale = dict(_PKG)
+    stale["version"] = "1.2.2"
+    stale["integrity"] = "sha512-old"
+    _write_lock(
+        tmp_path / "node_modules" / ".package-lock.json",
+        {"": {"name": "monorepo"}, "node_modules/ink": stale},
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_standalone_mode_still_reinstalls_for_missing_packages(
+    tmp_path: Path, main_mod
+) -> None:
+    """Non-workspace layouts (curl install: ui-tui has its own lockfile)
+    keep the strict behaviour — a package missing from the hidden lockfile
+    means an incomplete install and must trigger npm install."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    # Own lockfile → _workspace_root(tui_dir) == tui_dir (standalone mode).
+    _write_lock(
+        tui_dir / "package-lock.json",
+        {"": {"name": "ui-tui"}, "node_modules/ink": dict(_PKG)},
+    )
+    _touch_ink(tui_dir)
+    _write_lock(
+        tui_dir / "node_modules" / ".package-lock.json",
+        {"": {"name": "ui-tui"}},  # ink missing from the actualized tree
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -241,6 +241,53 @@ def test_workspace_mode_ignores_packages_from_other_workspaces(
     assert main_mod._tui_need_npm_install(tui_dir) is False
 
 
+def test_workspace_mode_detects_missing_direct_tui_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    """A missing package reachable from ui-tui must still trigger repair."""
+    tui_dir = _make_workspace_checkout(tmp_path)
+    _write_lock(
+        tmp_path / "package-lock.json",
+        {
+            "": {"name": "monorepo"},
+            "ui-tui": {"dependencies": {"ink": "1.2.3"}},
+            "node_modules/ink": dict(_PKG),
+        },
+    )
+    _write_lock(
+        tmp_path / "node_modules" / ".package-lock.json",
+        {"": {"name": "monorepo"}, "ui-tui": {"dependencies": {"ink": "1.2.3"}}},
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_workspace_mode_detects_missing_nested_tui_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    """A missing transitive package in the ui-tui closure must trigger repair."""
+    tui_dir = _make_workspace_checkout(tmp_path)
+    _write_lock(
+        tmp_path / "package-lock.json",
+        {
+            "": {"name": "monorepo"},
+            "ui-tui": {"dependencies": {"ink": "1.2.3"}},
+            "node_modules/ink": {"dependencies": {"nested": "1.0.0"}, **_PKG},
+            "node_modules/ink/node_modules/nested": dict(_PKG),
+        },
+    )
+    _write_lock(
+        tmp_path / "node_modules" / ".package-lock.json",
+        {
+            "": {"name": "monorepo"},
+            "ui-tui": {"dependencies": {"ink": "1.2.3"}},
+            "node_modules/ink": {"dependencies": {"nested": "1.0.0"}, **_PKG},
+        },
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_workspace_mode_ignores_dev_flag_skew(tmp_path: Path, main_mod) -> None:
     """#45657 secondary trigger: npm recomputes ``dev`` against the installed
     subset — a package that is a prod dep of an *uninstalled* workspace has


### PR DESCRIPTION
## What does this PR do?

Stops `_tui_need_npm_install` from forcing a no-op `npm install` — and the accompanying **"Installing TUI dependencies…"** message — on *every* launch of a workspace (git) checkout.

**Root cause.** The check compares the full monorepo `package-lock.json` (all workspaces: `ui-tui`, `apps/desktop`, `apps/bootstrap-installer`, `web`, …) against npm's hidden actualized lockfile `node_modules/.package-lock.json`. But launch deliberately installs only the ui-tui subset (`npm install --workspace ui-tui`, see #38772), so the hidden lockfile never contains the other workspaces' packages. On a real checkout:

- **574 of ~1500 lockfile entries are permanently "missing"** from the hidden lockfile (`apps/desktop`, `apps/bootstrap-installer`, Electron/web deps). Each one short-circuits the check to `return True`.
- **npm's `dev`-flag recompute adds spurious diffs on top**: packages that are prod deps of an *uninstalled* workspace but only dev-reachable inside ui-tui get `dev: true` in the hidden lock while the root lock records no flag (observed on `fast-deep-equal`, `ignore`, `zod`).

Every launch → check returns `True` → `npm install` runs → nothing changes → mismatch persists → repeat forever.

**Fix.** In workspace mode (`ws_root != root`), compute the package-lock dependency closure reachable from the `ui-tui` importer, following dependency/dev/optional/peer edges, nested `node_modules` resolution, and workspace links. Compare only that closure: sibling-workspace packages are excluded, while a missing direct or transitive TUI dependency still triggers repair. `dev` joins `ideallyInert`/`peer` in `_NPM_LOCK_RUNTIME_KEYS` as a non-deterministic npm annotation. Standalone layouts (curl install, own lockfile) retain strict whole-lock comparison. New-dependency sync after `git pull` remains covered by `hermes update` (`update_cmd._npm_lockfile_changed` → `_run_npm_install_deterministic`), which digests the lockfile plus every workspace manifest.

**Relation to existing PRs** (checked before opening, per the contributing guide):

- #45671 — replaces the comparison with an ink-version check and falls back to **mtime** comparison, re-introducing the false-positive class the content comparison was built to fix; discards per-package skew detection.
- #51417 — short-circuits to `False` whenever `dist/entry.js` exists, so genuine dependency drift after `hermes update` would no longer trigger a reinstall at launch.
- #52245 — fixes the comparison-noise side (intersection comparison, more runtime keys) but leaves the **primary trigger intact**: the missing-from-hidden-lock branch still `return True` on the first sibling-workspace package, so the every-launch reinstall persists on workspace checkouts.

This PR is the minimal change that addresses both observed triggers while preserving the existing comparison's detection power. It composes cleanly with #52245's intersection comparison if that lands first.

## Related Issue

Fixes #45657

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — add `_npm_lock_dependency_closure`; scope `_tui_need_npm_install` to the reachable `ui-tui` closure in workspace mode; retain strict missing checks inside that closure; add `dev` to `_NPM_LOCK_RUNTIME_KEYS`
- `tests/hermes_cli/test_tui_npm_install.py` — 4 regression tests (see below)

## How to Test

1. On a git checkout, launch the TUI twice (`hermes`). Before: "Installing TUI dependencies…" appears on *both* launches. After: only ever on the first (or never, if deps are already synced).
2. `pytest tests/hermes_cli/test_tui_npm_install.py -v` — 9 passed (3 existing + 6 new):
   - `test_workspace_mode_ignores_packages_from_other_workspaces` — the 574-missing-packages trigger
   - `test_workspace_mode_detects_missing_direct_tui_dependency` — a missing direct dependency still repairs
   - `test_workspace_mode_detects_missing_nested_tui_dependency` — a missing transitive dependency still repairs
   - `test_workspace_mode_ignores_dev_flag_skew` — the `dev: true` annotation trigger
   - `test_workspace_mode_still_detects_real_skew` — version bump in an installed dep still forces reinstall
   - `test_standalone_mode_still_reinstalls_for_missing_packages` — non-workspace layouts keep strict behaviour
3. RED-GREEN verified: the first two new tests fail against unpatched `main.py`, pass with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted module `pytest tests/hermes_cli/test_tui_npm_install.py -v` — 9 passed (full-repo `pytest tests/ -q` delegated to CI on this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon), npm workspaces checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure `pathlib`/JSON comparison logic, no OS-specific paths or subprocess behaviour; Termux flow untouched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Real-world verification on an affected checkout (macOS): before the fix, `_tui_need_npm_install(ui-tui)` returned `True` on every launch with 574 lockfile entries missing from the hidden lock + 3 `dev`-flag-only diffs; after the fix it returns `False`, launch goes straight to `node dist/entry.js`, and the message no longer appears.
