### PR TITLE
fix: guard against list-valued keys in hermes config set (#76138)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4945,6 +4945,67 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # Guard against list-valued keys (#76138): ``hermes config set`` always
+    # writes a scalar, which corrupts list-typed settings (writes a quoted
+    # YAML string instead of a YAML sequence).  Check both the existing
+    # user-config value and the declared default — either being a list is
+    # enough to refuse (unless --force).
+    if not force and "." not in key:
+        _existing_for_list = user_config.get(key)
+        _default_for_list = _default_value_for_key(key)
+        _list_val = _existing_for_list if isinstance(_existing_for_list, list) else _default_for_list
+        if isinstance(_list_val, list):
+            print(
+                f"✗ '{key}' is a list-valued setting.  `hermes config set` writes a\n"
+                f"  scalar and would corrupt it (quoted string instead of YAML list).\n"
+                f"  Edit config.yaml directly, or use `hermes config edit`.",
+                file=sys.stderr,
+            )
+            print(
+                f"  Example — in config.yaml:\n"
+                f"    {key}:\n"
+                f"      - item1\n"
+                f"      - item2",
+                file=sys.stderr,
+            )
+            print(
+                f"  Or use --force to overwrite with a scalar anyway:",
+                file=sys.stderr,
+            )
+            print(
+                f"    hermes config set --force {key} {value!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    elif not force and "." in key:
+        # For dotted keys, walk user_config to find the parent's existing value.
+        _parts = key.split(".")
+        _parent = user_config
+        for _p in _parts[:-1]:
+            if isinstance(_parent, dict):
+                _parent = _parent.get(_p)
+            else:
+                _parent = None
+                break
+        _leaf_existing = _parent.get(_parts[-1]) if isinstance(_parent, dict) else None
+        _leaf_default = _default_value_for_key(key)
+        _list_val = _leaf_existing if isinstance(_leaf_existing, list) else _leaf_default
+        if isinstance(_list_val, list):
+            print(
+                f"✗ '{key}' is a list-valued setting.  `hermes config set` writes a\n"
+                f"  scalar and would corrupt it (quoted string instead of YAML list).\n"
+                f"  Edit config.yaml directly, or use `hermes config edit`.",
+                file=sys.stderr,
+            )
+            print(
+                f"  Or use --force to overwrite with a scalar anyway:",
+                file=sys.stderr,
+            )
+            print(
+                f"    hermes config set --force {key} {value!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical


### PR DESCRIPTION
## Problem

`hermes config set` always writes a scalar value. When the target key is list-typed (e.g. `toolsets`, `plugins.enabled`, `terminal.env_passthrough`), the command silently writes a quoted YAML string instead of a YAML sequence, corrupting the config.

```yaml
# What gets written (broken):
plugins:
  enabled: "[local_model_warning]"   # string, NOT a list

# What should exist:
plugins:
  enabled:
    - local_model_warning
```

The corrupted config silently breaks downstream consumers that iterate the value as a list.

## Fix

Add a pre-write guard in `set_config_value` that checks:
1. The existing value in user config
2. The declared default in `DEFAULT_CONFIG` via `_default_value_for_key()`

When either is a `list`, refuse the write with a clear error message:

```
✗ 'toolsets' is a list-valued setting.  `hermes config set` writes a
  scalar and would corrupt it (quoted string instead of YAML list).
  Edit config.yaml directly, or use `hermes config edit`.
```

The guard covers both bare keys and dotted keys. `--force` bypasses it for scripted use.

## Testing

- All 39 existing `config_set` tests pass
- The guard correctly rejects `hermes config set plugins.enabled foo` when the key is list-typed
- `--force` allows the write through

Closes #76138