### PR TITLE
feat(memory): pass resolved agent cwd to memory provider initialize contract

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -41,6 +41,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -1929,6 +1930,7 @@ def init_agent(
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
                         "agent_context": "primary",
+                        "cwd": str(resolve_agent_cwd()),
                     }
                     if _init_kwargs["platform"] == "cli":
                         _init_kwargs["warning_callback"] = agent._emit_warning

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -40,6 +40,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -1683,6 +1684,7 @@ def init_agent(
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
                         "agent_context": "primary",
+                        "cwd": str(resolve_agent_cwd()),
                     }
                     if _init_kwargs["platform"] == "cli":
                         _init_kwargs["warning_callback"] = agent._emit_warning

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -142,6 +142,11 @@ class MemoryProvider(ABC):
           - hermes_home (str): The active HERMES_HOME directory path. Use this
             for profile-scoped storage instead of hardcoding ``~/.hermes``.
           - platform (str): "cli", "telegram", "discord", "cron", etc.
+          - cwd (str): The resolved agent working directory (session contextvar
+            → TERMINAL_CWD → process cwd, per ``agent.runtime_cwd``). Use this
+            instead of ``os.getcwd()``, which does not reflect the agent's
+            project directory on Desktop and gateway launches. Providers that
+            scope state per project should key on this value.
 
         kwargs may also include:
           - agent_context (str): "primary", "subagent", "cron", or "flush".

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -101,6 +101,42 @@ class TestMemoryManagerUserIdThreading:
 
 
 # ---------------------------------------------------------------------------
+# MemoryManager cwd threading tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryManagerCwdThreading:
+    """Verify cwd reaches providers via initialize_all."""
+
+    def test_cwd_passed_to_provider(self):
+        """initialize_all should forward cwd to providers."""
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        mgr.initialize_all(
+            session_id="sess-cwd-1",
+            platform="cli",
+            cwd="/projects/my-repo",
+        )
+
+        assert p._init_kwargs.get("cwd") == "/projects/my-repo"
+
+    def test_cwd_absent_when_not_provided(self):
+        """Without cwd in kwargs, providers should not receive it."""
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        mgr.initialize_all(
+            session_id="sess-cwd-2",
+            platform="cli",
+        )
+
+        assert "cwd" not in p._init_kwargs
+
+
+# ---------------------------------------------------------------------------
 # Mem0 provider user_id tests
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -100,6 +100,34 @@ class TestMemoryManagerUserIdThreading:
         assert p2._init_kwargs.get("platform") == "slack"
 
 
+class TestMemoryManagerCwdThreading:
+    """Verify the resolved agent cwd reaches providers via initialize_all."""
+
+    def test_initialize_all_forwards_cwd_kwarg(self):
+        """cwd passes through initialize_all to every provider."""
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        mgr.initialize_all(
+            session_id="sess-cwd",
+            platform="cli",
+            cwd="/tmp/project-a",
+        )
+
+        assert p._init_kwargs.get("cwd") == "/tmp/project-a"
+
+    def test_initialize_all_omits_cwd_when_absent(self):
+        """No cwd kwarg means providers receive no cwd key (no silent fallback)."""
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        mgr.initialize_all(session_id="sess-nocwd", platform="cli")
+
+        assert "cwd" not in p._init_kwargs
+
+
 # ---------------------------------------------------------------------------
 # Mem0 provider user_id tests
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -170,3 +170,41 @@ def test_core_tool_names_rejected_from_memory_routing_table():
     assert "honcho_search" in schema_names
 
 
+
+def test_aiagent_forwards_cwd_to_memory_provider(tmp_path, monkeypatch):
+    """AIAgent passes the resolved agent cwd to the provider's initialize kwargs.
+
+    The Desktop backend inherits the Electron launch cwd (the home directory
+    when no default project is configured), so providers must not rely on
+    os.getcwd(). TERMINAL_CWD is the controlled resolver input here: setting
+    it proves the value traveled resolve_agent_cwd() -> _init_kwargs ->
+    provider.initialize(), not an accidental os.getcwd() fallback.
+    """
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    provider = RecordingMemoryProvider()
+    cfg = {"memory": {"provider": "recording"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-cwd",
+            platform="feishu",
+        )
+
+    assert agent._memory_manager is not None
+    assert provider.init_session_id == "sess-cwd"
+    assert provider.init_kwargs["cwd"] == str(tmp_path)

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -94,6 +94,36 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert "status_callback" not in provider.init_kwargs
 
 
+def test_aiagent_forwards_cwd_to_memory_provider():
+    """AIAgent should pass resolve_agent_cwd() as cwd to memory providers (#76231)."""
+    provider = RecordingMemoryProvider()
+    cfg = {"memory": {"provider": "recording"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-cwd",
+            platform="cli",
+        )
+
+    assert agent._memory_manager is not None
+    assert "cwd" in provider.init_kwargs
+    assert provider.init_kwargs["cwd"]  # non-empty string
+
+
 class CoreShadowProvider:
     """Provider that tries to register tools shadowing built-in core tools."""
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -1,5 +1,6 @@
 """Regression tests for memory provider selection during AIAgent init."""
 
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -94,12 +95,13 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert "status_callback" not in provider.init_kwargs
 
 
-def test_aiagent_forwards_cwd_to_memory_provider():
+def test_aiagent_forwards_cwd_to_memory_provider(tmp_path):
     """AIAgent should pass resolve_agent_cwd() as cwd to memory providers (#76231)."""
     provider = RecordingMemoryProvider()
     cfg = {"memory": {"provider": "recording"}, "agent": {}}
 
     with (
+        patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}),
         patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
         patch("plugins.memory.load_memory_provider", return_value=provider),
         patch("agent.model_metadata.get_model_context_length", return_value=204_800),
@@ -120,8 +122,7 @@ def test_aiagent_forwards_cwd_to_memory_provider():
         )
 
     assert agent._memory_manager is not None
-    assert "cwd" in provider.init_kwargs
-    assert provider.init_kwargs["cwd"]  # non-empty string
+    assert provider.init_kwargs["cwd"] == str(tmp_path)
 
 
 class CoreShadowProvider:


### PR DESCRIPTION
## What does this PR do?

`MemoryProvider.initialize()` previously received no `cwd` field in `_init_kwargs`. Providers that want per-project state scoping had to fall back to `os.getcwd()`. That fallback does not reflect the agent's project directory on Desktop and gateway launches. The packaged Desktop backend inherits the Electron `resolveHermesCwd()` result, which resolves to the home directory when no default project directory is configured.

This PR adds `cwd=str(resolve_agent_cwd())` to `_init_kwargs` and documents `cwd` in the `MemoryProvider.initialize()` contract. `resolve_agent_cwd()` from `agent/runtime_cwd.py` is the single source of truth for the agent working directory. It checks the `_SESSION_CWD` contextvar, then `TERMINAL_CWD`, then `os.getcwd()`.

## Scope change from the original bug fix

This PR started as a bug fix for #76231, framed around the agentmemory provider. The reporter no longer uses agentmemory. On reflection, the underlying gap is broader than that one provider: `cwd` was never part of the documented `initialize()` kwargs contract. agentmemory consumed it by convention. Other providers with per-project scoping (Honcho maps sessions itself) have no official field to key on.

This PR is now a feature: make `cwd` an official, resolver-backed contract field so any provider can scope state per project. The code change is identical to the original fix. The documentation and tests now frame it as contract, not bug workaround.

## Changes Made

- `agent/agent_init.py`: import `resolve_agent_cwd` from `agent.runtime_cwd`; add `"cwd": str(resolve_agent_cwd())` to the `_init_kwargs` dict
- `agent/memory_provider.py`: document `cwd` in the `initialize()` kwargs contract (always included), with guidance to prefer it over `os.getcwd()`
- `tests/agent/test_memory_user_id.py`: add `TestMemoryManagerCwdThreading` with two tests: `cwd` forwards through `initialize_all`, and absent `cwd` forwards no key (no silent fallback)
- `tests/run_agent/test_memory_provider_init.py`: add `test_aiagent_forwards_cwd_to_memory_provider` — sets `TERMINAL_CWD` to `tmp_path` and asserts the provider receives exactly that value

## How to Test

1. Run the test suite:

```
scripts/run_tests.sh tests/agent/test_memory_user_id.py tests/run_agent/test_memory_provider_init.py -v
```

2. Manual verification (Desktop): start a Hermes Desktop session in a workspace directory. A provider that records `init_kwargs` should see `cwd` set to the workspace directory, not the home directory.

## Checklist

### Code

- [x]  I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x]  My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`, `fix(scope):`, etc.)
- [x]  I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x]  My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x]  I've run `pytest tests/ -q` and all tests pass (targeted suites: 17 passed)
- [x]  I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x]  I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x]  I've updated relevant documentation — the `MemoryProvider.initialize()` contract docstring in `agent/memory_provider.py`
- [x]  N/A - I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x]  N/A - I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x]  I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `resolve_agent_cwd()` and `TERMINAL_CWD` are platform-agnostic; no POSIX-only primitives introduced
- [x]  N/A - I've updated tool descriptions/schemas if I changed tool behavior - or N/A

Fixes #76231 (reclassified: the issue is proposed as a feature request — see the scope-change section above)
