### PR TITLE
feat(kanban): add board WIP limits (#76016)

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -218,10 +218,15 @@ export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/r
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
 
-export const createBoard = (slug: string, name: string, projectId?: string) =>
-  call<{ board: { slug: string } }>('/boards', {
+export const createBoard = (slug: string, name: string, projectId?: string, wipLimit?: number | null) =>
+  call<{ board: BoardMeta; current: string }>('/boards', {
     method: 'POST',
-    body: { slug, name, ...(projectId ? { project_id: projectId } : {}) }
+    body: {
+      slug,
+      name,
+      ...(projectId ? { project_id: projectId } : {}),
+      ...(wipLimit !== undefined ? { wip_limit: wipLimit } : {})
+    }
   })
 
 /** Rough auxiliary-model estimate for a task (tokens + complexity). Makes a

--- a/apps/desktop/src/plugins/kanban/board-switcher.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildBoardWipPatch, parseBoardWipLimit } from './board-switcher'
+
+describe('board WIP limit editor contract', () => {
+  it('accepts positive integers, treats blank as unlimited, and rejects invalid input', () => {
+    expect(parseBoardWipLimit(' 3 ')).toBe(3)
+    expect(parseBoardWipLimit('')).toBeNull()
+    expect(parseBoardWipLimit('0')).toBeUndefined()
+    expect(parseBoardWipLimit('1.5')).toBeUndefined()
+    expect(parseBoardWipLimit('true')).toBeUndefined()
+  })
+
+  it('preserves board name and project fields in the exact PATCH payload', () => {
+    expect(buildBoardWipPatch('  Board  ', 'project-1', 4)).toEqual({
+      name: 'Board',
+      project_id: 'project-1',
+      wip_limit: 4
+    })
+    expect(buildBoardWipPatch('Board', '', null)).toEqual({
+      name: 'Board',
+      project_id: '',
+      wip_limit: null
+    })
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -38,6 +38,22 @@ import { errText, FIELD_LABEL, useKanban } from './ui'
 
 const NO_PROJECT = '__none__'
 
+export function parseBoardWipLimit(value: string): number | null | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined
+  }
+  const parsed = Number(trimmed)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export function buildBoardWipPatch(name: string, project: string, wipLimit: number | null) {
+  return { name: name.trim(), project_id: project, wip_limit: wipLimit }
+}
+
 /** Board scope = a first-class Hermes project. Its primary repo becomes the
  *  board's default workspace root; new tasks inherit it as a worktree with a
  *  deterministic branch. "No project" falls back to scratch sandboxes. */
@@ -75,6 +91,8 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
   const qc = useQueryClient()
   const [name, setName] = useState('')
   const [project, setProject] = useState('')
+  const [wipLimitInput, setWipLimitInput] = useState('')
+  const wipLimit = parseBoardWipLimit(wipLimitInput)
 
   const slug = name
     .trim()
@@ -86,11 +104,12 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
     if (open) {
       setName('')
       setProject('')
+      setWipLimitInput('')
     }
   }, [open])
 
   const create = useMutation({
-    mutationFn: () => createBoard(slug, name.trim(), project || undefined),
+    mutationFn: () => createBoard(slug, name.trim(), project || undefined, wipLimit),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: result => {
       $boardSlug.set(result.board.slug)
@@ -111,19 +130,35 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
             <Input
               autoFocus
               onChange={event => setName(event.target.value)}
-              onKeyDown={event => event.key === 'Enter' && slug && !project && create.mutate()}
+              onKeyDown={event =>
+                event.key === 'Enter' && slug && !project && wipLimit !== undefined && create.mutate()
+              }
               placeholder={k.boardNamePlaceholder}
               value={name}
             />
             {slug && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(slug)}</span>}
           </label>
           <ProjectPicker onChange={setProject} value={project} />
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL}>{k.wipLimit}</span>
+            <Input
+              inputMode="numeric"
+              min="1"
+              onChange={event => setWipLimitInput(event.target.value)}
+              placeholder={k.wipLimitHint}
+              type="number"
+              value={wipLimitInput}
+            />
+            <span className="text-[0.6875rem] leading-relaxed text-(--ui-text-quaternary)">
+              {wipLimit === undefined ? k.wipLimitInvalid : k.wipLimitHint}
+            </span>
+          </label>
         </div>
         <DialogFooter>
           <Button onClick={onClose} variant="text">
             {k.cancel}
           </Button>
-          <Button disabled={!slug || create.isPending} onClick={() => create.mutate()}>
+          <Button disabled={!slug || create.isPending || wipLimit === undefined} onClick={() => create.mutate()}>
             {k.createBoard}
           </Button>
         </DialogFooter>
@@ -137,18 +172,21 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
   const qc = useQueryClient()
   const [name, setName] = useState('')
   const [project, setProject] = useState('')
+  const [wipLimitInput, setWipLimitInput] = useState('')
+  const wipLimit = parseBoardWipLimit(wipLimitInput)
 
   useEffect(() => {
     if (board) {
       setName(board.name || '')
       setProject(board.project_id || '')
+      setWipLimitInput(board.wip_limit == null ? '' : String(board.wip_limit))
     }
   }, [board])
 
   const save = useMutation({
     // Slug is immutable; send name + project_id ('' clears the scope, which
     // also drops the mirrored default_workdir on the backend).
-    mutationFn: () => updateBoard(board!.slug, { name: name.trim(), project_id: project }),
+    mutationFn: () => updateBoard(board!.slug, buildBoardWipPatch(name, project, wipLimit!)),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: BOARDS_KEY })
@@ -169,12 +207,26 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
             {board && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(board.slug)}</span>}
           </label>
           <ProjectPicker onChange={setProject} value={project} />
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL}>{k.wipLimit}</span>
+            <Input
+              inputMode="numeric"
+              min="1"
+              onChange={event => setWipLimitInput(event.target.value)}
+              placeholder={k.wipLimitHint}
+              type="number"
+              value={wipLimitInput}
+            />
+            <span className="text-[0.6875rem] leading-relaxed text-(--ui-text-quaternary)">
+              {wipLimit === undefined ? k.wipLimitInvalid : k.wipLimitHint}
+            </span>
+          </label>
         </div>
         <DialogFooter>
           <Button onClick={onClose} variant="text">
             {k.cancel}
           </Button>
-          <Button disabled={save.isPending} onClick={() => save.mutate()}>
+          <Button disabled={save.isPending || wipLimit === undefined} onClick={() => save.mutate()}>
             {k.save}
           </Button>
         </DialogFooter>

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -1074,6 +1074,8 @@ export function KanbanBoardPage() {
     queryKey: boardKey(slug, archived),
     refetchInterval: 60_000
   })
+  const { data: boards } = useQuery({ queryFn: fetchBoards, queryKey: BOARDS_KEY, staleTime: 30_000 })
+  const currentBoard = boards?.boards.find(meta => meta.slug === (slug || boards.current))
 
   const [openId, setOpenId] = useState<null | string>(null)
   const [addStatus, setAddStatus] = useState<null | string>(null)
@@ -1166,6 +1168,7 @@ export function KanbanBoardPage() {
   }, [board, search, tenant, assignee])
 
   const total = filtered?.columns.reduce((sum, col) => sum + col.tasks.length, 0) ?? 0
+  const runningCount = board?.columns.find(column => column.name === 'running')?.tasks.length ?? 0
 
   const moveMut = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) => patchTask(id, { status }),
@@ -1313,6 +1316,9 @@ export function KanbanBoardPage() {
         <h1 className="text-sm font-semibold text-foreground">{k.title}</h1>
         <span className="rounded-full bg-(--ui-bg-quaternary) px-1.5 py-px text-[0.625rem] tabular-nums text-(--ui-text-tertiary)">
           {total}
+        </span>
+        <span className="rounded-full bg-(--ui-bg-quaternary) px-1.5 py-px text-[0.625rem] tabular-nums text-(--ui-text-tertiary)">
+          {k.runningCount(runningCount, currentBoard?.wip_limit ?? null)}
         </span>
         {board && (
           <FilterMenu

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -172,6 +172,10 @@ type KanbanMessages = {
   projectHintPre: string
   projectHintCmd: string
   createBoard: string
+  wipLimit: string
+  wipLimitHint: string
+  wipLimitInvalid: string
+  runningCount: (running: number, limit: null | number) => string
   // orchestration
   orchestratorProfile: string
   defaultAssignee: string
@@ -360,6 +364,10 @@ const en: KanbanMessages = {
     'New tasks run in the project’s repo (a worktree per task); each task can still override its workspace at creation. Manage projects with ',
   projectHintCmd: 'hermes project',
   createBoard: 'Create board',
+  wipLimit: 'Automatic WIP limit',
+  wipLimitHint: 'Maximum tasks the dispatcher may run at once. Blank is unlimited.',
+  wipLimitInvalid: 'Enter a positive whole number or leave this blank.',
+  runningCount: (running, limit) => (limit === null ? `${running} running` : `${running}/${limit} running`),
   orchestratorProfile: 'Orchestrator profile',
   defaultAssignee: 'Default assignee',
   defaultParen: '(default)',
@@ -547,6 +555,10 @@ const ja: KanbanMessages = {
     '新しいタスクはプロジェクトのリポジトリで実行されます（タスクごとに worktree）。各タスクは作成時にワークスペースを上書きできます。プロジェクトの管理は ',
   projectHintCmd: 'hermes project',
   createBoard: 'ボードを作成',
+  wipLimit: '自動WIP上限',
+  wipLimitHint: 'ディスパッチャが同時に実行できる最大タスク数。空欄は無制限。',
+  wipLimitInvalid: '正の整数を入力するか、空欄にしてください。',
+  runningCount: (running, limit) => (limit === null ? `実行中 ${running}` : `実行中 ${running}/${limit}`),
   orchestratorProfile: 'オーケストレータープロフィール',
   defaultAssignee: 'デフォルトの担当',
   defaultParen: '（既定）',
@@ -732,6 +744,10 @@ const zh: KanbanMessages = {
     '新任务将在项目的仓库中运行（每个任务一个 worktree）；每个任务在创建时仍可覆盖其工作区。管理项目请使用 ',
   projectHintCmd: 'hermes project',
   createBoard: '创建面板',
+  wipLimit: '自动 WIP 上限',
+  wipLimitHint: '调度器可同时运行的最大任务数。留空表示无限制。',
+  wipLimitInvalid: '请输入正整数，或留空。',
+  runningCount: (running, limit) => (limit === null ? `运行中 ${running}` : `运行中 ${running}/${limit}`),
   orchestratorProfile: '编排者配置档',
   defaultAssignee: '默认负责人',
   defaultParen: '（默认）',
@@ -916,6 +932,10 @@ const zhHant: KanbanMessages = {
     '新任務將在專案的儲存庫中執行（每個任務一個 worktree）；每個任務在建立時仍可覆寫其工作區。管理專案請使用 ',
   projectHintCmd: 'hermes project',
   createBoard: '建立面板',
+  wipLimit: '自動 WIP 上限',
+  wipLimitHint: '排程器可同時執行的最大工作數。留空表示不設限。',
+  wipLimitInvalid: '請輸入正整數，或留空。',
+  runningCount: (running, limit) => (limit === null ? `執行中 ${running}` : `執行中 ${running}/${limit}`),
   orchestratorProfile: '編排者設定檔',
   defaultAssignee: '預設負責人',
   defaultParen: '（預設）',

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -132,6 +132,9 @@ export interface BoardMeta {
   /** First-class Project the board is scoped to (id) + resolved name. */
   project_id?: null | string
   project_name?: null | string
+  /** Maximum automatically dispatched running tasks; null means unlimited. */
+  wip_limit?: null | number
+  counts?: Record<string, number>
 }
 
 /** GET /projects — first-class Hermes projects available to scope a board. */

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1286,10 +1286,11 @@ class GatewayKanbanWatchersMixin:
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
-        def _ready_nonempty() -> bool:
-            """Cheap probe: is there at least one ready+assigned+unclaimed
-            task on ANY board whose assignee maps to a real Hermes profile
-            (i.e. one the dispatcher would actually spawn for)?
+        def _ready_nonempty(board: "Optional[str]" = None) -> bool:
+            """Cheap probe for ready work on one board, or across all boards.
+
+            The board argument keeps health accounting aligned with the
+            dispatch result that supplied an intentional WIP deferral.
 
             Tasks assigned to control-plane lanes (e.g. ``orion-cc``,
             ``orion-research``) are pulled by terminals via
@@ -1298,10 +1299,13 @@ class GatewayKanbanWatchersMixin:
             here keeps the stuck-warn fire only on real failures (broken
             PATH, missing venv, credential loss for a real Hermes profile).
             """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            if board is not None:
+                boards = [{"slug": board}]
+            else:
+                try:
+                    boards = _kb.list_boards(include_archived=False)
+                except Exception:
+                    boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
@@ -1442,11 +1446,9 @@ class GatewayKanbanWatchersMixin:
                 if _ad_enabled:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
                 results = await asyncio.to_thread(_tick_once)
-                any_spawned = False
-                any_wip_capped = False
+                health_failure = False
                 for slug, res in (results or []):
                     if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
@@ -1461,15 +1463,21 @@ class GatewayKanbanWatchersMixin:
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
                     if res is not None and getattr(res, "skipped_wip_capped", None):
-                        any_wip_capped = True
                         logger.info(
                             "kanban dispatcher [%s]: deferred=%d due to board WIP limit",
                             slug,
                             len(res.skipped_wip_capped),
                         )
+                    if res is not None:
+                        board_ready = await asyncio.to_thread(_ready_nonempty, slug)
+                        if (
+                            board_ready
+                            and not getattr(res, "spawned", None)
+                            and not getattr(res, "skipped_wip_capped", None)
+                        ):
+                            health_failure = True
                 # Health telemetry (aggregate across boards)
-                ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned and not any_wip_capped:
+                if health_failure:
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1443,6 +1443,7 @@ class GatewayKanbanWatchersMixin:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
+                any_wip_capped = False
                 for slug, res in (results or []):
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
@@ -1459,9 +1460,16 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
+                    if res is not None and getattr(res, "skipped_wip_capped", None):
+                        any_wip_capped = True
+                        logger.info(
+                            "kanban dispatcher [%s]: deferred=%d due to board WIP limit",
+                            slug,
+                            len(res.skipped_wip_capped),
+                        )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                if ready_pending and not any_spawned and not any_wip_capped:
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -56,6 +56,16 @@ def _fmt_task_line(t: kb.Task) -> str:
     return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
 
 
+def _positive_wip_limit(value: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("WIP limit must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("WIP limit must be a positive integer")
+    return parsed
+
+
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     return {
         "id": t.id,
@@ -290,6 +300,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Switch to the new board after creating it")
     b_create.add_argument("--default-workdir", default=None,
                           help="Default workspace path for tasks created on this board")
+    b_create.add_argument("--wip-limit", type=_positive_wip_limit, default=None,
+                          help="Maximum automatically running tasks (positive integer)")
 
     b_rm = boards_sub.add_parser(
         "rm", aliases=["remove", "delete"],
@@ -325,6 +337,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_set_wd.add_argument("slug")
     b_set_wd.add_argument("path", nargs="?", default=None,
                           help="Absolute path to use as default workdir. Omit to clear.")
+
+    b_set_wip = boards_sub.add_parser(
+        "set-wip-limit",
+        help="Set or clear the maximum automatically running tasks",
+    )
+    b_set_wip.add_argument("slug")
+    b_set_wip.add_argument("limit", nargs="?", type=_positive_wip_limit,
+                           help="Positive integer; omit to clear")
 
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
@@ -1154,6 +1174,7 @@ _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "use",
     "rename",
     "set-default-workdir",
+    "set-wip-limit",
 })
 
 
@@ -1201,6 +1222,8 @@ def _dispatch_boards(args: argparse.Namespace) -> int:
         return _cmd_boards_rename(args)
     if sub == "set-default-workdir":
         return _cmd_boards_set_default_workdir(args)
+    if sub == "set-wip-limit":
+        return _cmd_boards_set_wip_limit(args)
     print(f"kanban boards: unknown action {sub!r}", file=sys.stderr)
     return 2
 
@@ -1247,7 +1270,8 @@ def _cmd_boards_list(args: argparse.Namespace) -> int:
         name = b.get("name") or ""
         if b.get("archived"):
             name += " [archived]"
-        print(f"{marker:2s}  {b['slug']:24s}  {name:28s}  {counts_str}")
+        wip = b.get("wip_limit") or "unlimited"
+        print(f"{marker:2s}  {b['slug']:24s}  {name:28s}  WIP={wip}  {counts_str}")
     print()
     print(f"Current board: {current}")
     if len(boards) > 1:
@@ -1265,17 +1289,20 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
         print("kanban boards create: slug is required", file=sys.stderr)
         return 2
     already = kb.board_exists(normed) and normed != kb.DEFAULT_BOARD
-    meta = kb.create_board(
-        normed,
-        name=args.name,
-        description=args.description,
-        icon=args.icon,
-        color=args.color,
-        default_workdir=args.default_workdir,
-    )
+    create_kwargs = {
+        "name": args.name,
+        "description": args.description,
+        "icon": args.icon,
+        "color": args.color,
+        "default_workdir": args.default_workdir,
+    }
+    if getattr(args, "wip_limit", None) is not None:
+        create_kwargs["wip_limit"] = args.wip_limit
+    meta = kb.create_board(normed, **create_kwargs)
     verb = "already exists" if already else "created"
     print(f"Board {meta['slug']!r} {verb}.")
     print(f"  Display name: {meta.get('name', '')}")
+    print(f"  WIP limit:    {meta.get('wip_limit') or 'unlimited'}")
     print(f"  DB path:      {meta['db_path']}")
     if getattr(args, "switch", False):
         kb.set_current_board(meta["slug"])
@@ -1333,6 +1360,7 @@ def _cmd_boards_show(args: argparse.Namespace) -> int:
     total = sum(counts.values())
     print(f"Current board: {current}")
     print(f"  Display name: {meta.get('name', '')}")
+    print(f"  WIP limit:    {meta.get('wip_limit') or 'unlimited'}")
     if meta.get("description"):
         print(f"  Description:  {meta['description']}")
     print(f"  DB path:      {meta['db_path']}")
@@ -1373,6 +1401,24 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"Board {normed!r} default workdir set to {new_val!r}.")
     else:
         print(f"Board {normed!r} default workdir cleared.")
+    return 0
+
+
+def _cmd_boards_set_wip_limit(args: argparse.Namespace) -> int:
+    try:
+        normed = kb._normalize_board_slug(args.slug)
+    except ValueError as exc:
+        print(f"kanban boards set-wip-limit: {exc}", file=sys.stderr)
+        return 2
+    if not normed or not kb.board_exists(normed):
+        print(f"kanban boards set-wip-limit: board {args.slug!r} does not exist",
+              file=sys.stderr)
+        return 1
+    meta = kb.write_board_metadata(normed, wip_limit=args.limit)
+    if meta.get("wip_limit") is None:
+        print(f"Board {normed!r} WIP limit cleared.")
+    else:
+        print(f"Board {normed!r} WIP limit set to {meta['wip_limit']}.")
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1259,7 +1259,7 @@ def _cmd_boards_list(args: argparse.Namespace) -> int:
     if not boards:
         print("(no boards — create one with `hermes kanban boards create <slug>`)")
         return 0
-    print(f"{'':2s}  {'SLUG':24s}  {'NAME':28s}  COUNTS")
+    print(f"{'':2s}  {'SLUG':24s}  {'NAME':28s}  WIP LIMIT  COUNTS")
     for b in boards:
         marker = "●" if b["is_current"] else " "
         counts = b["counts"] or {}
@@ -2541,6 +2541,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_wip_capped": res.skipped_wip_capped,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2573,6 +2574,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
+    if res.skipped_wip_capped:
+        print(f"Deferred (board WIP limit): {', '.join(res.skipped_wip_capped)}")
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
             print(
@@ -2657,7 +2660,8 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
     def _on_tick(res):
         ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
         spawned_any = bool(res.spawned)
-        if ready_pending and not spawned_any:
+        wip_capped = bool(res.skipped_wip_capped)
+        if ready_pending and not spawned_any and not wip_capped:
             health_state["bad_ticks"] += 1
         else:
             health_state["bad_ticks"] = 0
@@ -2683,6 +2687,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
             or res.spawned or res.auto_blocked or res.stale
+            or res.skipped_wip_capped
         )
         if did_work:
             print(
@@ -2690,7 +2695,8 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
                 f"timed_out={len(res.timed_out)} stale={len(res.stale)} "
                 f"promoted={res.promoted} spawned={len(res.spawned)} "
-                f"auto_blocked={len(res.auto_blocked)}",
+                f"auto_blocked={len(res.auto_blocked)} "
+                f"wip_capped={len(res.skipped_wip_capped)}",
                 flush=True,
             )
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8277,7 +8277,8 @@ def _dispatch_once_locked(
     except (TypeError, ValueError):
         resolved_board = None
     resolved_board = resolved_board or get_current_board()
-    board_wip_limit = read_board_metadata(resolved_board).get("wip_limit")
+    dispatch_board = resolved_board
+    board_wip_limit = read_board_metadata(dispatch_board).get("wip_limit")
     if board_wip_limit is not None:
         if (isinstance(max_in_progress, int) and not isinstance(max_in_progress, bool)
                 and max_in_progress > 0):
@@ -8295,7 +8296,7 @@ def _dispatch_once_locked(
     # they sit in status='running' until the worker calls
     # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_spawn is not None or effective_max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -8311,10 +8312,8 @@ def _dispatch_once_locked(
     # enough running tasks, skip spawning this tick so workers can finish.
     wip_running_count = 0
     if effective_max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        wip_running_count = int(in_progress)
+        in_progress = running_count
+        wip_running_count = in_progress
         if in_progress >= effective_max_in_progress:
             if board_wip_limit is not None and in_progress >= board_wip_limit:
                 result.skipped_wip_capped.extend(row["id"] for row in ready_rows)
@@ -8471,6 +8470,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8486,9 +8486,11 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=dispatch_board
+                )
             else:
-                workspace = resolve_workspace(claimed, board=board)
+                workspace = resolve_workspace(claimed, board=dispatch_board)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -8511,7 +8513,7 @@ def _dispatch_once_locked(
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
+                    pid = _spawn(claimed, str(workspace), board=dispatch_board)
                 else:
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
@@ -8571,6 +8573,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8578,9 +8581,11 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=dispatch_board
+                )
             else:
-                workspace = resolve_workspace(claimed, board=board)
+                workspace = resolve_workspace(claimed, board=dispatch_board)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -8606,7 +8611,7 @@ def _dispatch_once_locked(
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
+                    pid = _spawn(claimed, str(workspace), board=dispatch_board)
                 else:
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6749,7 +6749,7 @@ class DispatchResult:
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
     skipped_wip_capped: list[str] = field(default_factory=list)
-    """Ready task ids deferred because the board WIP limit is full."""
+    """Automatic task ids deferred because the board WIP limit is full."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -8303,6 +8303,14 @@ def _dispatch_once_locked(
             ).fetchone()[0]
         )
 
+    # max_spawn is a total concurrency cap shared by both automatic queues.
+    # Compose the board/installation cap before inspecting either queue so a
+    # review-only tick cannot bypass the effective cap.
+    if effective_max_in_progress is not None and (
+        max_spawn is None or max_spawn > effective_max_in_progress
+    ):
+        max_spawn = effective_max_in_progress
+
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
@@ -8310,18 +8318,13 @@ def _dispatch_once_locked(
     ).fetchall()
     # Honour the installation and board WIP caps: if the board already has
     # enough running tasks, skip spawning this tick so workers can finish.
-    wip_running_count = 0
+    wip_running_count = running_count if board_wip_limit is not None else 0
     if effective_max_in_progress is not None and ready_rows:
         in_progress = running_count
-        wip_running_count = in_progress
         if in_progress >= effective_max_in_progress:
             if board_wip_limit is not None and in_progress >= board_wip_limit:
                 result.skipped_wip_capped.extend(row["id"] for row in ready_rows)
             return result
-        # max_spawn is a total concurrency cap, so keep the existing running
-        # count in the loop's comparison instead of subtracting it twice.
-        if max_spawn is None or max_spawn > effective_max_in_progress:
-            max_spawn = effective_max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -8558,7 +8561,12 @@ def _dispatch_once_locked(
         "WHERE status = 'review' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    for row in review_rows:
+    for row_index, row in enumerate(review_rows):
+        if board_wip_limit is not None and wip_running_count + spawned >= board_wip_limit:
+            result.skipped_wip_capped.extend(
+                remaining_row["id"] for remaining_row in review_rows[row_index:]
+            )
+            break
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
         if not row["assignee"]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8272,7 +8272,11 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
-    resolved_board = _normalize_board_slug(board) or get_current_board()
+    try:
+        resolved_board = _normalize_board_slug(board)
+    except (TypeError, ValueError):
+        resolved_board = None
+    resolved_board = resolved_board or get_current_board()
     board_wip_limit = read_board_metadata(resolved_board).get("wip_limit")
     if board_wip_limit is not None:
         if (isinstance(max_in_progress, int) and not isinstance(max_in_progress, bool)
@@ -8315,10 +8319,10 @@ def _dispatch_once_locked(
             if board_wip_limit is not None and in_progress >= board_wip_limit:
                 result.skipped_wip_capped.extend(row["id"] for row in ready_rows)
             return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = effective_max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        # max_spawn is a total concurrency cap, so keep the existing running
+        # count in the loop's comparison instead of subtracting it twice.
+        if max_spawn is None or max_spawn > effective_max_in_progress:
+            max_spawn = effective_max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -657,6 +657,16 @@ def _default_board_display_name(slug: str) -> str:
     return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
 
 
+_WIP_LIMIT_UNSET = object()
+
+
+def _normalize_wip_limit(value: Any) -> Optional[int]:
+    """Return a valid board WIP limit, treating hand-edited bad values as unset."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return None
+    return value
+
+
 def read_board_metadata(board: Optional[str] = None) -> dict:
     """Return ``board.json`` contents (or synthesized defaults).
 
@@ -680,6 +690,7 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "project_id": None,
         "created_at": None,
         "archived": False,
+        "wip_limit": None,
     }
     try:
         p = board_metadata_path(slug)
@@ -692,6 +703,7 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
                 meta.update(raw)
     except (OSError, json.JSONDecodeError):
         pass
+    meta["wip_limit"] = _normalize_wip_limit(meta.get("wip_limit"))
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
 
@@ -706,6 +718,7 @@ def write_board_metadata(
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
     project_id: Optional[str] = None,
+    wip_limit: object = _WIP_LIMIT_UNSET,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -715,6 +728,9 @@ def write_board_metadata(
     ``project_id``: ``None`` leaves it unchanged; empty string clears the
     project scope; a value sets it (not validated here — the caller resolves
     it against ``projects_db``).
+
+    ``wip_limit`` distinguishes omission from an explicit ``None`` clear.
+    Invalid non-null values raise before the metadata file is written.
     """
     _assert_not_delegated_child_mutation()
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
@@ -736,6 +752,10 @@ def write_board_metadata(
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
     if project_id is not None:
         meta["project_id"] = str(project_id) if project_id else None
+    if wip_limit is not _WIP_LIMIT_UNSET:
+        if wip_limit is not None and _normalize_wip_limit(wip_limit) is None:
+            raise ValueError("wip_limit must be a positive integer or null")
+        meta["wip_limit"] = _normalize_wip_limit(wip_limit)
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -757,6 +777,7 @@ def create_board(
     color: Optional[str] = None,
     default_workdir: Optional[str] = None,
     project_id: Optional[str] = None,
+    wip_limit: object = _WIP_LIMIT_UNSET,
 ) -> dict:
     """Create a new board directory + DB + metadata. Idempotent.
 
@@ -775,6 +796,7 @@ def create_board(
         color=color,
         default_workdir=default_workdir,
         project_id=project_id,
+        **({"wip_limit": wip_limit} if wip_limit is not _WIP_LIMIT_UNSET else {}),
     )
     # Touch the DB so list_boards() sees it immediately.
     init_db(board=normed)
@@ -6726,6 +6748,8 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_wip_capped: list[str] = field(default_factory=list)
+    """Ready task ids deferred because the board WIP limit is full."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -8248,6 +8272,17 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
+    resolved_board = _normalize_board_slug(board) or get_current_board()
+    board_wip_limit = read_board_metadata(resolved_board).get("wip_limit")
+    if board_wip_limit is not None:
+        if (isinstance(max_in_progress, int) and not isinstance(max_in_progress, bool)
+                and max_in_progress > 0):
+            effective_max_in_progress = min(max_in_progress, board_wip_limit)
+        else:
+            effective_max_in_progress = board_wip_limit
+    else:
+        effective_max_in_progress = max_in_progress
+
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
     # rationale; the short version is that a 60-second tick interval with a
@@ -8268,18 +8303,20 @@ def _dispatch_once_locked(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    # Honour kanban.max_in_progress: if the board already has enough running
-    # tasks, skip spawning this tick so slow workers (local LLMs,
-    # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
+    # Honour the installation and board WIP caps: if the board already has
+    # enough running tasks, skip spawning this tick so workers can finish.
+    wip_running_count = 0
+    if effective_max_in_progress is not None and ready_rows:
         in_progress = conn.execute(
             "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
         ).fetchone()[0]
-        if in_progress >= max_in_progress:
+        wip_running_count = int(in_progress)
+        if in_progress >= effective_max_in_progress:
+            if board_wip_limit is not None and in_progress >= board_wip_limit:
+                result.skipped_wip_capped.extend(row["id"] for row in ready_rows)
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
+        remaining = effective_max_in_progress - in_progress
         if max_spawn is None or max_spawn > remaining:
             max_spawn = remaining
     spawned = 0
@@ -8319,7 +8356,12 @@ def _dispatch_once_locked(
             # bucket it as nonspawnable if the profile genuinely isn't
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
-    for row in ready_rows:
+    for row_index, row in enumerate(ready_rows):
+        if board_wip_limit is not None and wip_running_count + spawned >= board_wip_limit:
+            result.skipped_wip_capped.extend(
+                remaining_row["id"] for remaining_row in ready_rows[row_index:]
+            )
+            break
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
         row_assignee = row["assignee"]

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2215,6 +2215,7 @@ class CreateBoardBody(BaseModel):
     # board's default_workdir mirrors the project's primary repo and new tasks
     # inherit the project (deterministic worktree + branch).
     project_id: Optional[str] = None
+    wip_limit: Any = None
     switch: bool = False
 
 
@@ -2229,6 +2230,26 @@ class RenameBoardBody(BaseModel):
     # Project scope (id or slug). ``None`` = leave unchanged; empty = clear;
     # a value = resolve + set (and mirror default_workdir to its primary repo).
     project_id: Optional[str] = None
+    wip_limit: Any = None
+
+
+def _payload_has_field(payload: BaseModel, name: str) -> bool:
+    """Support Pydantic v1 and v2 field-presence tracking for PATCH tri-state."""
+    fields_set = getattr(payload, "model_fields_set", None)
+    if fields_set is None:
+        fields_set = getattr(payload, "__fields_set__", set())
+    return name in fields_set
+
+
+def _validate_wip_limit(value: Any) -> Optional[int]:
+    if value is not None and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="wip_limit must be a positive integer or null",
+        )
+    return value
 
 
 def _resolve_project(ref: Optional[str]) -> tuple[Optional[str], Optional[str], Optional[str]]:
@@ -2363,6 +2384,7 @@ def _validate_workdir(raw: str) -> str:
 @router.post("/boards")
 def create_board_endpoint(payload: CreateBoardBody):
     """Create a new board. Idempotent — ``slug`` collision returns existing."""
+    wip_limit = _validate_wip_limit(payload.wip_limit)
     default_workdir = None
     if payload.default_workdir:
         default_workdir = _validate_workdir(payload.default_workdir)
@@ -2372,8 +2394,8 @@ def create_board_endpoint(payload: CreateBoardBody):
     if primary_path and not default_workdir:
         default_workdir = primary_path
     try:
-        meta = kanban_db.create_board(
-            payload.slug,
+        board_kwargs = dict(
+            slug=payload.slug,
             name=payload.name,
             description=payload.description,
             icon=payload.icon,
@@ -2381,6 +2403,9 @@ def create_board_endpoint(payload: CreateBoardBody):
             default_workdir=default_workdir,
             project_id=project_id,
         )
+        if _payload_has_field(payload, "wip_limit"):
+            board_kwargs["wip_limit"] = wip_limit
+        meta = kanban_db.create_board(**board_kwargs)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     if payload.switch:
@@ -2402,6 +2427,7 @@ def rename_board(slug: str, payload: RenameBoardBody):
         raise HTTPException(status_code=400, detail=str(exc))
     if not normed or not kanban_db.board_exists(normed):
         raise HTTPException(status_code=404, detail=f"board {slug!r} does not exist")
+    wip_limit = _validate_wip_limit(payload.wip_limit)
     # default_workdir: None = leave unchanged; "" = clear; path = validate + set.
     # write_board_metadata treats a falsy value as "clear", so pass "" through.
     default_workdir: Optional[str] = None
@@ -2419,8 +2445,8 @@ def rename_board(slug: str, payload: RenameBoardBody):
                 default_workdir = primary_path
         else:
             project_id = ""  # clear the scope
-    meta = kanban_db.write_board_metadata(
-        normed,
+    metadata_kwargs = dict(
+        board=normed,
         name=payload.name,
         description=payload.description,
         icon=payload.icon,
@@ -2428,6 +2454,9 @@ def rename_board(slug: str, payload: RenameBoardBody):
         default_workdir=default_workdir,
         project_id=project_id,
     )
+    if _payload_has_field(payload, "wip_limit"):
+        metadata_kwargs["wip_limit"] = wip_limit
+    meta = kanban_db.write_board_metadata(**metadata_kwargs)
     meta["default_workspace_kind"] = _default_workspace_kind(meta)
     _, meta["project_name"], _ = _resolve_project(meta.get("project_id"))
     return {"board": meta}

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1076,11 +1076,9 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     async def _to_thread(fn, *args, **kwargs):
         # PR salvage (#32857 commit 7): the dispatcher now reaps zombies at
         # the top of each tick via ``asyncio.to_thread(_kb.reap_worker_zombies)``
-        # BEFORE the per-board tick work. Each tick now issues 3 ``to_thread``
-        # calls (reaper + ``_tick_once`` + ``_ready_nonempty``) instead of 2,
+        # BEFORE the per-board tick work. Each tick also probes board health,
         # so this counter must reach 6 to allow the same 2 dispatch ticks the
-        # pre-reaper test expected at 4. Connect counts in the assertion below
-        # are unchanged.
+        # pre-reaper test expected at 4.
         calls["to_thread"] += 1
         result = fn(*args, **kwargs)
         if calls["to_thread"] >= 6:
@@ -1106,13 +1104,9 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kb.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # The first tick opens one dispatch connection and one board-health probe.
+    # The quarantined second tick performs only the health probe.
+    assert calls["connect"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -1406,5 +1400,4 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
 

--- a/tests/hermes_cli/test_kanban_wip_limit.py
+++ b/tests/hermes_cli/test_kanban_wip_limit.py
@@ -124,6 +124,38 @@ def test_review_only_dispatch_respects_board_limit(fresh_home):
         assert len(result.skipped_wip_capped) == 1
 
 
+def test_mixed_ready_and_review_dispatch_shares_board_limit(fresh_home):
+    kb.create_board("mixed", wip_limit=1)
+    with kb.connect(board="mixed") as conn:
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        review = kb.create_task(conn, title="review", assignee="default")
+        assert _set_status_direct(conn, review, "review")
+
+        result = kb.dispatch_once(
+            conn, board="mixed", spawn_fn=_spawn, max_spawn=8
+        )
+
+        assert [item[0] for item in result.spawned] == [ready]
+        assert kb.get_task(conn, review).status == "review"
+        assert result.skipped_wip_capped == [review]
+
+
+def test_narrower_caller_cap_limits_mixed_dispatch(fresh_home):
+    kb.create_board("caller-cap", wip_limit=3)
+    with kb.connect(board="caller-cap") as conn:
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        review = kb.create_task(conn, title="review", assignee="default")
+        assert _set_status_direct(conn, review, "review")
+
+        result = kb.dispatch_once(
+            conn, board="caller-cap", spawn_fn=_spawn, max_spawn=1
+        )
+
+        assert [item[0] for item in result.spawned] == [ready]
+        assert kb.get_task(conn, review).status == "review"
+        assert result.skipped_wip_capped == []
+
+
 def test_dispatch_honors_installation_cap_without_max_spawn(fresh_home):
     kb.create_board("installation")
     with kb.connect(board="installation") as conn:

--- a/tests/hermes_cli/test_kanban_wip_limit.py
+++ b/tests/hermes_cli/test_kanban_wip_limit.py
@@ -1,0 +1,122 @@
+"""Production-path coverage for board-scoped automatic WIP limits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    (home / "profiles" / "default").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in ("HERMES_KANBAN_HOME", "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
+        monkeypatch.delenv(var, raising=False)
+    import hermes_constants
+
+    hermes_constants._cached_default_hermes_root = None
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+def _parser():
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    return parser
+
+
+def _spawn(*_args, **_kwargs):
+    return 12345
+
+
+def test_metadata_set_omit_clear_and_invalid_persisted_values(fresh_home):
+    meta = kb.create_board("metadata", wip_limit=3)
+    assert meta["wip_limit"] == 3
+    kb.write_board_metadata("metadata", description="kept")
+    assert kb.read_board_metadata("metadata")["wip_limit"] == 3
+
+    cleared = kb.write_board_metadata("metadata", wip_limit=None)
+    assert cleared["wip_limit"] is None
+
+    path = kb.board_metadata_path("metadata")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["wip_limit"] = True
+    raw["unknown"] = "preserved"
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    read = kb.read_board_metadata("metadata")
+    assert read["wip_limit"] is None
+    assert read["unknown"] == "preserved"
+
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(ValueError):
+        kb.write_board_metadata("metadata", wip_limit=0)
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_explicit_dispatch_respects_board_limit_after_cleanup(fresh_home):
+    kb.create_board("capped", wip_limit=1)
+    with kb.connect(board="capped") as conn:
+        running = kb.create_task(conn, title="running", assignee="default")
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        assert kb.claim_task(conn, running, claimer="default") is not None
+        result = kb.dispatch_once(
+            conn, board="capped", spawn_fn=_spawn, dry_run=True, max_in_progress=4
+        )
+        assert result.spawned == []
+        assert ready in result.skipped_wip_capped
+        assert kb.get_task(conn, ready).status == "ready"
+
+
+def test_implicit_or_precedence_current_board(fresh_home, monkeypatch):
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    kb.create_board("current", wip_limit=2)
+    kb.set_current_board("current")
+    with kb.connect(board="current") as conn:
+        running = kb.create_task(conn, title="running", assignee="default")
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        assert kb.claim_task(conn, running, claimer="default") is not None
+
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=True, max_in_progress=4)
+        assert [item[0] for item in result.spawned] == [ready]
+
+    with kb.connect(board="current") as conn:
+        # The installation cap is narrower than the board cap and therefore
+        # prevents the ready task from being claimed.
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=True, max_in_progress=1)
+        assert result.spawned == []
+
+
+def test_cli_create_show_set_list_and_clear(fresh_home, capsys):
+    parser = _parser()
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "create", "cli-board", "--wip-limit", "2"
+    ])) == 0
+    assert kb.read_board_metadata("cli-board")["wip_limit"] == 2
+
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "set-wip-limit", "cli-board", "4"
+    ])) == 0
+    assert kb.read_board_metadata("cli-board")["wip_limit"] == 4
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "set-wip-limit", "cli-board"
+    ])) == 0
+    assert kb.read_board_metadata("cli-board")["wip_limit"] is None
+
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "list"
+    ])) == 0
+    assert "WIP=unlimited" in capsys.readouterr().out
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "show"
+    ])) == 0
+    assert "WIP limit:    unlimited" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["kanban", "boards", "set-wip-limit", "cli-board", "0"])

--- a/tests/hermes_cli/test_kanban_wip_limit.py
+++ b/tests/hermes_cli/test_kanban_wip_limit.py
@@ -93,6 +93,47 @@ def test_explicit_dispatch_composes_board_limit_with_existing_running_tasks(fres
         assert result.skipped_wip_capped == []
 
 
+def test_dispatch_honors_installation_cap_without_max_spawn(fresh_home):
+    kb.create_board("installation")
+    with kb.connect(board="installation") as conn:
+        running_ids = [
+            kb.create_task(conn, title=f"running-{index}", assignee="default")
+            for index in range(2)
+        ]
+        ready_ids = [
+            kb.create_task(conn, title=f"ready-{index}", assignee="default")
+            for index in range(3)
+        ]
+        for task_id in running_ids:
+            assert kb.claim_task(conn, task_id, claimer="default") is not None
+
+        result = kb.dispatch_once(
+            conn,
+            board="installation",
+            spawn_fn=_spawn,
+            dry_run=True,
+            max_in_progress=4,
+        )
+
+        assert [item[0] for item in result.spawned] == ready_ids[:2]
+
+
+def test_dry_run_reports_board_wip_deferrals(fresh_home):
+    kb.create_board("dry-run", wip_limit=2)
+    with kb.connect(board="dry-run") as conn:
+        ready_ids = [
+            kb.create_task(conn, title=f"ready-{index}", assignee="default")
+            for index in range(3)
+        ]
+
+        result = kb.dispatch_once(
+            conn, board="dry-run", spawn_fn=_spawn, dry_run=True, max_spawn=8
+        )
+
+        assert [item[0] for item in result.spawned] == ready_ids[:2]
+        assert result.skipped_wip_capped == ready_ids[2:]
+
+
 def test_dispatch_falls_back_after_malformed_board_selector(fresh_home, monkeypatch):
     kb.create_board("fallback", wip_limit=2)
     kb.set_current_board("fallback")
@@ -109,11 +150,19 @@ def test_dispatch_falls_back_after_malformed_board_selector(fresh_home, monkeypa
             ),
         )
 
-        result = kb.dispatch_once(
-            conn, board="malformed", spawn_fn=_spawn, dry_run=True
-        )
+        workspace = fresh_home / "workspace"
+        seen_board = {}
+
+        def resolve_workspace(_task, board=None):
+            seen_board["value"] = board
+            workspace.mkdir(exist_ok=True)
+            return workspace
+
+        monkeypatch.setattr(kb, "resolve_workspace", resolve_workspace)
+        result = kb.dispatch_once(conn, board="malformed", spawn_fn=_spawn)
 
         assert [item[0] for item in result.spawned] == [ready]
+        assert seen_board["value"] == "fallback"
 
 
 def test_implicit_or_precedence_current_board(fresh_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_wip_limit.py
+++ b/tests/hermes_cli/test_kanban_wip_limit.py
@@ -9,6 +9,7 @@ import pytest
 
 from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
+from plugins.kanban.dashboard.plugin_api import _set_status_direct
 
 
 @pytest.fixture
@@ -91,6 +92,36 @@ def test_explicit_dispatch_composes_board_limit_with_existing_running_tasks(fres
 
         assert [item[0] for item in result.spawned] == [ready]
         assert result.skipped_wip_capped == []
+
+
+def test_review_only_dispatch_respects_board_limit(fresh_home):
+    kb.create_board("review-only", wip_limit=1)
+    with kb.connect(board="review-only") as conn:
+        review_ids = [
+            kb.create_task(conn, title=f"review-{index}", assignee="default")
+            for index in range(2)
+        ]
+        for task_id in review_ids:
+            assert _set_status_direct(conn, task_id, "review")
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'ready'"
+        ).fetchone()[0] == 0
+
+        result = kb.dispatch_once(
+            conn, board="review-only", spawn_fn=_spawn, max_spawn=8
+        )
+
+        spawned_ids = [item[0] for item in result.spawned]
+        assert len(spawned_ids) == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'review'"
+        ).fetchone()[0] == 1
+        assert set(spawned_ids) | set(result.skipped_wip_capped) == set(review_ids)
+        assert len(result.skipped_wip_capped) == 1
 
 
 def test_dispatch_honors_installation_cap_without_max_spawn(fresh_home):

--- a/tests/hermes_cli/test_kanban_wip_limit.py
+++ b/tests/hermes_cli/test_kanban_wip_limit.py
@@ -74,6 +74,48 @@ def test_explicit_dispatch_respects_board_limit_after_cleanup(fresh_home):
         assert kb.get_task(conn, ready).status == "ready"
 
 
+def test_explicit_dispatch_composes_board_limit_with_existing_running_tasks(fresh_home):
+    kb.create_board("composed", wip_limit=3)
+    with kb.connect(board="composed") as conn:
+        running_ids = [
+            kb.create_task(conn, title=f"running-{index}", assignee="default")
+            for index in range(2)
+        ]
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        for task_id in running_ids:
+            assert kb.claim_task(conn, task_id, claimer="default") is not None
+
+        result = kb.dispatch_once(
+            conn, board="composed", spawn_fn=_spawn, dry_run=True, max_spawn=8
+        )
+
+        assert [item[0] for item in result.spawned] == [ready]
+        assert result.skipped_wip_capped == []
+
+
+def test_dispatch_falls_back_after_malformed_board_selector(fresh_home, monkeypatch):
+    kb.create_board("fallback", wip_limit=2)
+    kb.set_current_board("fallback")
+    with kb.connect(board="fallback") as conn:
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        normalize_board_slug = kb._normalize_board_slug
+        monkeypatch.setattr(
+            kb,
+            "_normalize_board_slug",
+            lambda slug: (
+                (_ for _ in ()).throw(ValueError("malformed"))
+                if slug == "malformed"
+                else normalize_board_slug(slug)
+            ),
+        )
+
+        result = kb.dispatch_once(
+            conn, board="malformed", spawn_fn=_spawn, dry_run=True
+        )
+
+        assert [item[0] for item in result.spawned] == [ready]
+
+
 def test_implicit_or_precedence_current_board(fresh_home, monkeypatch):
     monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
     kb.create_board("current", wip_limit=2)
@@ -104,6 +146,18 @@ def test_cli_create_show_set_list_and_clear(fresh_home, capsys):
         "kanban", "boards", "set-wip-limit", "cli-board", "4"
     ])) == 0
     assert kb.read_board_metadata("cli-board")["wip_limit"] == 4
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "list"
+    ])) == 0
+    assert "WIP=4" in capsys.readouterr().out
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "switch", "cli-board"
+    ])) == 0
+    capsys.readouterr()
+    assert kc.kanban_command(parser.parse_args([
+        "kanban", "boards", "show"
+    ])) == 0
+    assert "WIP limit:    4" in capsys.readouterr().out
     assert kc.kanban_command(parser.parse_args([
         "kanban", "boards", "set-wip-limit", "cli-board"
     ])) == 0

--- a/tests/plugins/test_kanban_wip_limit_api.py
+++ b/tests/plugins/test_kanban_wip_limit_api.py
@@ -1,0 +1,90 @@
+"""FastAPI board WIP-limit contract and dashboard dispatch-owner coverage."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_router():
+    plugin_file = Path(__file__).resolve().parents[2] / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_kanban_wip_test", plugin_file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    (home / "profiles" / "default").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    import hermes_constants
+
+    hermes_constants._cached_default_hermes_root = None
+    kb._INITIALIZED_PATHS.clear()
+    app = FastAPI()
+    app.include_router(_load_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def test_board_contract_set_preserve_clear_and_reject(client):
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "api-board", "name": "API", "wip_limit": 2},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["board"]["wip_limit"] == 2
+
+    response = client.patch(
+        "/api/plugins/kanban/boards/api-board", json={"name": "Renamed"}
+    )
+    assert response.status_code == 200
+    assert response.json()["board"]["wip_limit"] == 2
+
+    response = client.patch(
+        "/api/plugins/kanban/boards/api-board", json={"wip_limit": None}
+    )
+    assert response.status_code == 200
+    assert response.json()["board"]["wip_limit"] is None
+
+    for value in (0, -1, True, "2", 1.5):
+        response = client.patch(
+            "/api/plugins/kanban/boards/api-board", json={"wip_limit": value}
+        )
+        assert response.status_code == 422, (value, response.text)
+        assert kb.read_board_metadata("api-board")["name"] == "Renamed"
+        assert kb.read_board_metadata("api-board")["wip_limit"] is None
+
+    listed = client.get("/api/plugins/kanban/boards").json()
+    board = next(item for item in listed["boards"] if item["slug"] == "api-board")
+    assert board["wip_limit"] is None
+
+
+def test_dashboard_dispatch_uses_shared_board_cap(client):
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "nudge-board", "wip_limit": 1},
+    )
+    assert response.status_code == 200
+    with kb.connect(board="nudge-board") as conn:
+        running = kb.create_task(conn, title="running", assignee="default")
+        ready = kb.create_task(conn, title="ready", assignee="default")
+        assert kb.claim_task(conn, running, claimer="default") is not None
+
+    response = client.post("/api/plugins/kanban/dispatch?board=nudge-board")
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["spawned"] == []
+    assert ready in result["skipped_wip_capped"]

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -764,7 +764,7 @@ hermes kanban boards set-wip-limit feature-work 3
 hermes kanban boards set-wip-limit feature-work  # clear the board limit
 ```
 
-The board limit and `kanban.max_in_progress` compose by minimum. An unset or cleared value is unlimited for that layer. The limit applies only to new automatic `ready` → `running` claims; cleanup, readiness promotion, dependency and assignment checks, per-profile limits, existing workers, manual status changes, and `max_spawn` continue to operate. The board REST API accepts a positive integer, preserves the current value when `wip_limit` is omitted from `PATCH`, and clears it when the field is explicitly `null`. Class-of-Service task fields are a separate follow-up and are not part of board WIP limits.
+The board limit and `kanban.max_in_progress` compose by minimum. An unset or cleared value is unlimited for that layer. The limit applies only to new automatic `ready` → `running` and `review` → `running` claims; cleanup, readiness promotion, dependency and assignment checks, per-profile limits, existing workers, manual status changes, and `max_spawn` continue to operate. The board REST API accepts a positive integer, preserves the current value when `wip_limit` is omitted from `PATCH`, and clears it when the field is explicitly `null`. Class-of-Service task fields are a separate follow-up and are not part of board WIP limits.
 
 ```yaml
 kanban:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -756,6 +756,16 @@ All commands are also available as a slash command in the interactive CLI and in
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
+Boards can add a narrower automatic-dispatch cap with the optional `wip_limit` field in `board.json`. Set it when creating or editing a board:
+
+```bash
+hermes kanban boards create feature-work --wip-limit 2
+hermes kanban boards set-wip-limit feature-work 3
+hermes kanban boards set-wip-limit feature-work  # clear the board limit
+```
+
+The board limit and `kanban.max_in_progress` compose by minimum. An unset or cleared value is unlimited for that layer. The limit applies only to new automatic `ready` → `running` claims; cleanup, readiness promotion, dependency and assignment checks, per-profile limits, existing workers, manual status changes, and `max_spawn` continue to operate. The board REST API accepts a positive integer, preserves the current value when `wip_limit` is omitted from `PATCH`, and clears it when the field is explicitly `null`. Class-of-Service task fields are a separate follow-up and are not part of board WIP limits.
+
 ```yaml
 kanban:
   max_in_progress: 2


### PR DESCRIPTION
## Summary

Hermes Kanban has installation-wide concurrency caps, but a board cannot request a narrower automatic-running capacity. This adds an optional board `wip_limit`, applies it in the shared dispatcher path, and exposes set, clear, and display behavior through the CLI, REST API, and Desktop board settings.

The smaller value wins when the board and installation caps are both set. Lowering the value leaves running work alone and defers only new automatic claims.

## Changes

- `hermes_cli/kanban_db.py`: persist and validate `board.json.wip_limit`, resolve the effective cap, and report capped automatic claims.
- `hermes_cli/kanban.py`: add board create, set, clear, list, and show support.
- `gateway/kanban_watchers.py`: surface intentional WIP deferrals and keep them out of stuck-dispatcher health warnings.
- `plugins/kanban/dashboard/plugin_api.py`: add WIP to board CRUD while leaving dispatch routing thin.
- `apps/desktop/src/plugins/kanban/`: add the typed board field, localized editor, and running-count display.
- `website/docs/user-guide/features/kanban.md`: document the board setting, API tri-state behavior, and precedence.
- Focused Python and API tests cover persistence, dispatch, validation, and response payloads; Desktop helper tests cover request parsing and payload construction.

## Validation

| Scenario | Before | After |
|---|---|---|
| Board has no WIP value | Existing installation cap or unlimited behavior applies | Unchanged |
| Board has `wip_limit: 2` and two running tasks | Board setting does not exist | New automatic claims remain queued |
| Board has `wip_limit: 1`, no ready tasks, and multiple review tasks | Review dispatch bypasses the board cap | One review agent starts; remaining review tasks stay queued |
| Mixed ready and review queues with caller `max_spawn=1` | Queue-specific behavior is unbounded | The narrower caller cap limits total automatic claims |
| Board limit is 4 and installation cap is 2 | Installation cap limits dispatch to 2 | Unchanged; the smaller cap wins |
| PATCH omits `wip_limit` | Field does not exist | Existing board value is preserved |
| PATCH sends JSON `null` | Field does not exist | Board returns to unlimited |
| Desktop board settings | No WIP control | Positive integer sets; blank clears |
| Dispatcher health | WIP deferrals can look like a stuck queue | CLI, gateway, and legacy daemon expose or classify capped work explicitly |

## Test plan

- `pytest tests/hermes_cli/test_kanban_wip_limit.py tests/plugins/test_kanban_wip_limit_api.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_board_project_api.py -v`
- `cd apps/desktop && npx vitest run --project ui src/plugins/kanban/board-switcher.test.tsx`
- `cd apps/desktop && npm run typecheck && npm run lint`: not run

## Not in scope

Task-level Class-of-Service fields are a separate sibling slice. This change does not add per-column limits, alter task priority or ordering, reject manual status changes, terminate running workers, modify `max_in_progress_per_profile`, or edit generated dashboard assets.

## Upstream

Refs #76016.
