### PR TITLE
fix(update): make npm recovery resumable on no-op retries

### DIFF
--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -17,8 +17,8 @@ Scope of the repair is deliberately narrow. Hermes only upgrades an npm that
 lives inside its **own** managed Node tree (``$HERMES_HOME/node``), installing
 in place with ``--prefix`` so ``bin/npm`` keeps resolving to the upgraded
 ``lib/node_modules/npm``. A system / nvm / brew / Nix npm belongs to the user
-and their other projects; for those we print the exact command and let the
-original failure stand.
+and their other projects; for those we print the actual/required toolchain and
+let the original failure stand.
 """
 
 from __future__ import annotations
@@ -36,6 +36,8 @@ from hermes_constants import get_hermes_home, with_hermes_node_path
 __all__ = [
     "is_ebadengine",
     "required_npm_range",
+    "actual_node_version",
+    "actual_npm_version",
     "managed_npm_prefix",
     "upgrade_managed_npm",
     "maybe_repair_npm_engine",
@@ -108,6 +110,18 @@ def actual_npm_version(output: str) -> str | None:
             continue
         if isinstance(parsed, dict) and parsed.get("npm"):
             return str(parsed["npm"]).strip()
+    return None
+
+
+def actual_node_version(output: str) -> str | None:
+    """Return the Node version npm reported as ``Actual`` in *output*."""
+    for match in _ACTUAL_RE.finditer(output or ""):
+        try:
+            parsed = json.loads(match.group(1))
+        except ValueError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("node"):
+            return str(parsed["node"]).strip().removeprefix("v")
     return None
 
 
@@ -237,14 +251,29 @@ def _probe_version(npm: str) -> str | None:
     return (result.stdout or "").strip() or None
 
 
-def _print_manual_fix(npm: str, npm_range: str, actual: str | None) -> None:
-    have = f"npm {actual} " if actual else "This npm "
+def _print_manual_fix(
+    npm: str,
+    npm_range: str,
+    actual_npm: str | None,
+    actual_node: str | None,
+) -> None:
+    current = ", ".join(
+        part
+        for part in (
+            f"Node {actual_node}" if actual_node else None,
+            f"npm {actual_npm}" if actual_npm else None,
+        )
+        if part
+    )
     print(
-        f"\n✗ {have}does not satisfy the range this project requires: {npm_range}\n"
-        f"  Resolved npm: {npm}\n"
-        "  Hermes only upgrades npm inside its own managed Node install, so this\n"
-        "  one is left alone. Upgrade it yourself with:\n"
-        f'      npm install -g npm@"{npm_range}"',
+        "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
+        + (f"  Current toolchain: {current}\n" if current else "")
+        + f"  Required npm: {npm_range}\n"
+        + f"  Resolved npm: {npm}\n"
+        + "  Hermes only upgrades npm inside its own managed Node install, so this\n"
+        + "  one is left alone. Use the version manager that owns this Node install\n"
+        + "  to select a compatible Node/npm pair, then re-run `hermes update`.\n"
+        + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )
 
@@ -270,7 +299,12 @@ def maybe_repair_npm_engine(
     prefix = managed_npm_prefix(npm)
     if prefix is None:
         if not quiet:
-            _print_manual_fix(npm, npm_range, actual_npm_version(output))
+            _print_manual_fix(
+                npm,
+                npm_range,
+                actual_npm_version(output),
+                actual_node_version(output),
+            )
         return False
 
     return upgrade_managed_npm(npm, npm_range, prefix=prefix, quiet=quiet)

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -266,7 +266,7 @@ def _print_manual_fix(
         )
         if part
     )
-    install_cmd = f"npm install -g {shlex.quote(f'npm@{npm_range}')}"
+    install_cmd = _manual_install_command(npm_range, windows=os.name == "nt")
     print(
         "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
         + (f"  Current toolchain: {current}\n" if current else "")
@@ -280,6 +280,14 @@ def _print_manual_fix(
         + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )
+
+
+def _manual_install_command(npm_range: str, *, windows: bool) -> str:
+    """Render the copy/paste remediation for the user's command shell."""
+    argv = ["npm", "install", "-g", f"npm@{npm_range}"]
+    if windows:
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)
 
 
 def maybe_repair_npm_engine(

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -265,14 +266,17 @@ def _print_manual_fix(
         )
         if part
     )
+    install_cmd = f"npm install -g {shlex.quote(f'npm@{npm_range}')}"
     print(
         "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
         + (f"  Current toolchain: {current}\n" if current else "")
         + f"  Required npm: {npm_range}\n"
         + f"  Resolved npm: {npm}\n"
         + "  Hermes only upgrades npm inside its own managed Node install, so this\n"
-        + "  one is left alone. Use the version manager that owns this Node install\n"
-        + "  to select a compatible Node/npm pair, then re-run `hermes update`.\n"
+        + "  one is left alone. Install a compatible npm release yourself with:\n"
+        + f"      {install_cmd}\n"
+        + "  If Node/npm are coupled by their version manager, select "
+        + "a compatible Node/npm pair instead. Then re-run the original command.\n"
         + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3860,8 +3860,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # not the helpers' return values: missing npm is a soft skip in
             # _update_node_dependencies(), and _build_web_ui() may serve a
             # stale dist after a failed build.
+            from hermes_constants import get_default_hermes_root
+
             node_failures = _update_node_dependencies()
-            node_refresh_pending = _npm_lockfile_changed(_m().PROJECT_ROOT)
+            node_refresh_pending = _npm_lockfile_changed(
+                get_default_hermes_root()
+            )
             web_refresh_pending = False
             if not node_failures and not node_refresh_pending:
                 _m()._build_web_ui(_m().PROJECT_ROOT / "web")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3856,10 +3856,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # "fix npm and re-run hermes update" recovery lands in this
             # commit_count == 0 branch. Re-check the manifest digest here and
             # rebuild a stale web bundle after the dependency refresh succeeds.
+            # Successful recovery is defined by the persisted digest/stamp,
+            # not the helpers' return values: missing npm is a soft skip in
+            # _update_node_dependencies(), and _build_web_ui() may serve a
+            # stale dist after a failed build.
             node_failures = _update_node_dependencies()
-            web_ok = False
-            if not node_failures:
-                web_ok = _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+            node_refresh_pending = _npm_lockfile_changed(_m().PROJECT_ROOT)
+            web_refresh_pending = False
+            if not node_failures and not node_refresh_pending:
+                _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+                web_refresh_pending = _m()._web_ui_build_needed(
+                    _m().PROJECT_ROOT / "web"
+                )
 
             healthy, detail = _venv_core_imports_healthy()
             if not healthy:
@@ -3901,7 +3909,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
-            elif node_failures or not web_ok:
+            elif node_failures or node_refresh_pending or web_refresh_pending:
                 print(
                     "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
                 )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3851,6 +3851,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # versions). Probe the venv's core imports and repair if broken —
             # otherwise "Already up to date!" gaslights the user while their
             # install stays bricked.
+            # The same is true for Node dependencies. A failed npm refresh has
+            # already moved HEAD to the fetched commit, so the documented
+            # "fix npm and re-run hermes update" recovery lands in this
+            # commit_count == 0 branch. Re-check the manifest digest here and
+            # rebuild a stale web bundle after the dependency refresh succeeds.
+            node_failures = _update_node_dependencies()
+            web_ok = False
+            if not node_failures:
+                web_ok = _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+
             healthy, detail = _venv_core_imports_healthy()
             if not healthy:
                 print("⚠ Checkout is current, but the venv is unhealthy:")
@@ -3891,6 +3901,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
+            elif node_failures or not web_ok:
+                print(
+                    "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
+                )
+                print("  Fix the npm error above and re-run `hermes update`.")
             else:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3913,12 +3913,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
-            elif node_failures or node_refresh_pending or web_refresh_pending:
+            if node_failures or node_refresh_pending or web_refresh_pending:
                 print(
                     "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
                 )
                 print("  Fix the npm error above and re-run `hermes update`.")
-            else:
+            elif healthy:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -256,13 +256,17 @@ class TestCmdUpdateBranchFallback:
         from hermes_cli import update_cmd
 
         mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        shared_hermes_root = PROJECT_ROOT / ".test-hermes-root"
         with patch.object(
             hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch(
+            "hermes_constants.get_default_hermes_root",
+            return_value=shared_hermes_root,
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=[]
         ) as refresh_node, patch.object(
             update_cmd, "_npm_lockfile_changed", return_value=False
-        ), patch.object(
+        ) as refresh_pending, patch.object(
             hm, "_build_web_ui", return_value=True
         ) as build_web, patch.object(
             hm, "_web_ui_build_needed", return_value=False
@@ -272,6 +276,7 @@ class TestCmdUpdateBranchFallback:
             cmd_update(mock_args)
 
         refresh_node.assert_called_once_with()
+        refresh_pending.assert_called_once_with(shared_hermes_root)
         build_web.assert_called_once_with(PROJECT_ROOT / "web")
         assert "Already up to date!" in capsys.readouterr().out
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -366,6 +366,43 @@ class TestCmdUpdateBranchFallback:
         assert "Already up to date!" not in out
         assert "Node.js dependency recovery is still incomplete" in out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_reports_node_failure_while_repairing_venv(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Python repair must not mask an independently incomplete Node refresh."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=["repo root"]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd,
+            "_venv_core_imports_healthy",
+            side_effect=[(False, "missing imports"), (True, "ok")],
+        ), patch(
+            "hermes_cli.managed_uv.ensure_uv", return_value="/managed/uv"
+        ), patch.object(
+            update_cmd, "venv_python_path", return_value=PROJECT_ROOT / "venv" / "python"
+        ), patch.object(
+            hm, "_install_python_dependencies_with_optional_fallback"
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Dependencies repaired!" in out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -215,6 +215,7 @@ class TestCmdUpdateBranchFallback:
         origin but behind NousResearch/hermes-agent silently misses updates.
         """
         from hermes_cli import main as hm
+        from hermes_cli import update_cmd
 
         mock_run.side_effect = _make_run_side_effect(
             branch="main", verify_ok=True, commit_count="0"
@@ -224,7 +225,17 @@ class TestCmdUpdateBranchFallback:
             hm,
             "_get_origin_url",
             return_value="https://github.com/example/hermes-agent.git",
-        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock, patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
+            hm, "_build_web_ui", return_value=True
+        ), patch.object(
+            hm, "_web_ui_build_needed", return_value=False
+        ), patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
             cmd_update(mock_args)
 
         expected_git_cmd = (
@@ -250,8 +261,12 @@ class TestCmdUpdateBranchFallback:
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=[]
         ) as refresh_node, patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
             hm, "_build_web_ui", return_value=True
         ) as build_web, patch.object(
+            hm, "_web_ui_build_needed", return_value=False
+        ), patch.object(
             update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
         ):
             cmd_update(mock_args)
@@ -274,6 +289,8 @@ class TestCmdUpdateBranchFallback:
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=["repo root"]
         ) as refresh_node, patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
             hm, "_build_web_ui"
         ) as build_web, patch.object(
             update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
@@ -286,6 +303,63 @@ class TestCmdUpdateBranchFallback:
         assert "Already up to date!" not in out
         assert "Node.js dependency recovery is still incomplete" in out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_treats_stale_manifest_digest_as_incomplete(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Missing npm is a soft skip, not successful stale dependency repair."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_checks_web_stamp_after_soft_build_success(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """A stale-dist fallback must not be reported as completed recovery."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
+            hm, "_build_web_ui", return_value=True
+        ) as build_web, patch.object(
+            hm, "_web_ui_build_needed", return_value=True
+        ), patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_called_once_with(PROJECT_ROOT / "web")
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -234,6 +234,58 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_repairs_stale_node_deps_and_web_ui(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """The documented recovery after a partial npm update must work even
+        when the failed pull already moved HEAD to the latest commit."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ) as refresh_node, patch.object(
+            hm, "_build_web_ui", return_value=True
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        refresh_node.assert_called_once_with()
+        build_web.assert_called_once_with(PROJECT_ROOT / "web")
+        assert "Already up to date!" in capsys.readouterr().out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_does_not_claim_success_when_node_repair_fails(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=["repo root"]
+        ) as refresh_node, patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        refresh_node.assert_called_once_with()
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.npm_engine import (
+    actual_node_version,
     actual_npm_version,
     is_ebadengine,
     managed_npm_prefix,
@@ -28,6 +29,13 @@ npm error engine Not compatible with your version of node/npm: hermes-agent@1.0.
 npm error notsup Not compatible with your version of node/npm: hermes-agent@1.0.0
 npm error notsup Required: {"node":">=20.0.0","npm":"<11.10.0 || >=12.0.0"}
 npm error notsup Actual:   {"npm":"11.10.0","node":"v22.23.1"}
+"""
+
+NODE25_EBADENGINE_OUTPUT = """
+npm error code EBADENGINE
+npm error engine Unsupported engine
+npm error notsup Required: {"node":">=20.0.0","npm":"<11.10.0 || >=12.0.0"}
+npm error notsup Actual:   {"node":"v25.9.0","npm":"11.12.1"}
 """
 
 LEGACY_EBADENGINE_OUTPUT = """
@@ -62,6 +70,7 @@ class TestDetection:
 
     def test_actual_version_is_reported_back(self):
         assert actual_npm_version(EBADENGINE_OUTPUT) == "11.10.0"
+        assert actual_node_version(EBADENGINE_OUTPUT) == "22.23.1"
 
     def test_no_range_for_non_engine_output(self):
         assert required_npm_range(ELOCK_OUTPUT) is None
@@ -194,11 +203,18 @@ class TestRepairDecision:
             raise AssertionError(f"must not run a subprocess for a foreign npm: {cmd}")
 
         monkeypatch.setattr(subprocess, "run", explode)
-        assert not maybe_repair_npm_engine(str(system_npm), EBADENGINE_OUTPUT)
+        assert not maybe_repair_npm_engine(
+            str(system_npm), NODE25_EBADENGINE_OUTPUT
+        )
 
-        # The user gets the exact command to run, since we refuse to run it.
+        # A foreign npm stays untouched, and the guidance describes a compatible
+        # Node/npm *pair* instead of suggesting npm 12 on an unsupported Node.
         err = capsys.readouterr().err
-        assert 'npm install -g npm@"<11.10.0 || >=12.0.0"' in err
+        assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
+        assert "Required npm: <11.10.0 || >=12.0.0" in err
+        assert "version manager that owns this Node install" in err
+        assert "re-run `hermes update`" in err
+        assert "npm install -g" not in err
 
     def test_non_engine_failure_never_upgrades(self, managed_npm, monkeypatch):
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -207,14 +207,16 @@ class TestRepairDecision:
             str(system_npm), NODE25_EBADENGINE_OUTPUT
         )
 
-        # A foreign npm stays untouched, and the guidance describes a compatible
-        # Node/npm *pair* instead of suggesting npm 12 on an unsupported Node.
+        # A foreign npm stays untouched. The guidance reports the current pair,
+        # preserves an actionable, shell-safe range command (npm resolves a
+        # Node-compatible release), and also covers coupled Node/npm managers.
         err = capsys.readouterr().err
         assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
         assert "Required npm: <11.10.0 || >=12.0.0" in err
-        assert "version manager that owns this Node install" in err
-        assert "re-run `hermes update`" in err
-        assert "npm install -g" not in err
+        assert "Install a compatible npm release" in err
+        assert "npm install -g 'npm@<11.10.0 || >=12.0.0'" in err
+        assert "select a compatible Node/npm pair instead" in err
+        assert "re-run the original command" in err
 
     def test_non_engine_failure_never_upgrades(self, managed_npm, monkeypatch):
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.npm_engine import (
+    _manual_install_command,
     actual_node_version,
     actual_npm_version,
     is_ebadengine,
@@ -91,6 +92,21 @@ class TestDetection:
             "npm error notsup Required: {not json}\n"
         )
         assert required_npm_range(broken) is None
+
+    @pytest.mark.parametrize(
+        ("windows", "expected"),
+        [
+            (False, "npm install -g 'npm@<11.10.0 || >=12.0.0'"),
+            (True, 'npm install -g "npm@<11.10.0 || >=12.0.0"'),
+        ],
+    )
+    def test_manual_install_command_quotes_range_for_target_shell(
+        self, windows, expected
+    ):
+        assert (
+            _manual_install_command("<11.10.0 || >=12.0.0", windows=windows)
+            == expected
+        )
 
 
 class TestManagedDetection:


### PR DESCRIPTION
## What does this PR do?

`hermes update` can fast-forward the checkout and then fail while refreshing Node dependencies. The failure deliberately leaves the npm manifest digest stale and tells the user to fix npm and re-run the updater. However, the zero-new-commit path only repaired Python dependencies, so the documented retry returned `Already up to date!` without retrying npm or rebuilding the Web UI.

This makes that recovery path resumable while preserving the existing ownership boundary: Hermes still never modifies Homebrew, nvm, Nix, or system npm installations.

For unmanaged npm failures, the diagnostic now reports the actual Node/npm pair and the required npm range. It keeps an actionable, shell-safe install command but asks for a *compatible* npm release rather than an upgrade: in an isolated Node 25.9.0/npm 11.12.1 probe, npm selected compatible npm 11.9.0 from the project range.

## Related Issue

Related to #75598. This does not close the broader Windows installer/update issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Re-run the manifest-digest-gated Node dependency refresh when `HEAD` already matches the fetched branch.
- Rebuild a stale Web UI only after Node dependency recovery succeeds.
- Do not print `Already up to date!` while Node/Web recovery is still incomplete.
- Keep unmanaged npm untouched, report its actual Node/npm pair, and render a compatible-range install command safely for POSIX shells and Windows `cmd.exe` without hard-coding an npm major.
- Add regressions for successful and failed zero-commit retries, simultaneous Python/Node recovery, and the Node 25/npm 11.12.1 diagnostic path.

## How to Test

1. Run the focused updater and npm-engine tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_npm_engine.py tests/hermes_cli/test_cmd_update.py -q
   ```
2. Run the broader updater surface:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_*update*.py tests/hermes_cli/test_npm_engine.py -q
   ```
3. Verify static checks:
   ```bash
   ruff check hermes_cli/npm_engine.py hermes_cli/update_cmd.py tests/hermes_cli/test_npm_engine.py tests/hermes_cli/test_cmd_update.py
   python -m compileall -q hermes_cli/npm_engine.py hermes_cli/update_cmd.py
   git diff --check
   ```

Observed locally:

- Focused tests: 45 passed.
- Broader updater tests: 181 passed; the five `test_update_eol_churn.py` failures reproduce unchanged on the exact base SHA on this macOS host.
- Isolated resolver probe: Node 25.9.0 + npm 11.12.1 selected npm 11.9.0 for `<11.10.0 || >=12.0.0>` with `engine-strict` both enabled and disabled; npm 11.9.0 supports Node `^20.17.0 || >=22.9.0`.
- Ruff, compileall, and `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this changes updater recovery behavior and terminal diagnostics.
