### PR TITLE
feat(status): show named custom provider from config.yaml

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -649,6 +649,52 @@ class GatewaySlashCommandsMixin:
             if isinstance(configured_context, int) and configured_context > 0:
                 context_total = configured_context
 
+        # Named providers: / custom_providers: entries resolve to billing class
+        # "custom". Recover the config.yaml entry name so /status can show
+        # e.g. "openlux" instead of bare "custom".
+        try:
+            from hermes_cli.runtime_provider import resolve_custom_provider_display_name
+
+            runtime_provider = ""
+            raw_mc = session_row.get("model_config") if isinstance(session_row, dict) else None
+            model_config: Any = raw_mc
+            if isinstance(raw_mc, str) and raw_mc.strip():
+                try:
+                    import json
+
+                    model_config = json.loads(raw_mc)
+                except Exception:
+                    model_config = {}
+            if isinstance(model_config, dict):
+                gateway_runtime = model_config.get("gateway_runtime")
+                if isinstance(gateway_runtime, dict):
+                    runtime_provider = _clean_str(gateway_runtime.get("provider"))
+                    if not base_url:
+                        base_url = _clean_str(gateway_runtime.get("base_url"))
+
+            config_provider = ""
+            model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
+            if isinstance(model_cfg, dict):
+                config_provider = _clean_str(model_cfg.get("provider"))
+
+            # Prefer a durable named identity already stored on the session
+            # over bare billing "custom" when present.
+            seed_provider = provider_name
+            if runtime_provider and runtime_provider.lower() not in {"", "custom"}:
+                seed_provider = runtime_provider
+
+            provider_name = resolve_custom_provider_display_name(
+                seed_provider,
+                base_url=base_url or None,
+                config_provider=config_provider or None,
+                model=model_name or None,
+            )
+        except Exception:
+            logger.debug(
+                "custom provider display name recovery failed for /status",
+                exc_info=True,
+            )
+
         model_line = ""
         if model_name:
             if provider_name:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1046,8 +1046,9 @@ def resolve_custom_provider_display_name(
     This helper recovers the configured entry name from:
 
     1. An already-named identity (``custom:<name>`` or a direct ``providers:`` key)
-    2. ``base_url`` / ``model`` reverse-lookup against ``config.yaml`` entries
-    3. ``config_provider`` / active ``model.provider`` when it names a real entry
+    2. Session-scoped ``base_url`` / ``model`` reverse-lookup against ``config.yaml``
+    3. ``config_provider`` / active ``model.provider`` only when no session URL was
+       provided (routing recovery; must not override an explicit unmatched URL)
 
     When several catalog entries share one gateway URL (e.g. ``openlux-claude``
     and ``openlux-codex`` both pointing at the same host), a model catalog hit
@@ -1080,23 +1081,29 @@ def resolve_custom_provider_display_name(
     url = str(base_url or "").strip()
     model_id = str(model or "").strip()
 
-    # Shared-gateway disambiguation: prefer the entry that serves this model
-    # when its base_url also matches the session endpoint.
-    if url and model_id:
-        by_model = find_custom_provider_identity_by_model(model_id)
-        if by_model:
-            try:
-                entry = _get_named_custom_provider(by_model)
-            except Exception:
-                entry = None
-            if entry and _normalize_base_url_for_match(
-                entry.get("api") or entry.get("url") or entry.get("base_url")
-            ) == _normalize_base_url_for_match(url):
-                identity = by_model
-
-    if not identity:
+    if url:
+        # Session has an explicit endpoint. Only recover via that URL (and a
+        # model catalog entry that also owns the same URL). Never fall through
+        # to config.model.provider — an ad-hoc unmatched URL must stay "custom"
+        # even when the global default names a configured custom provider.
+        if model_id:
+            by_model = find_custom_provider_identity_by_model(model_id)
+            if by_model:
+                try:
+                    entry = _get_named_custom_provider(by_model)
+                except Exception:
+                    entry = None
+                if entry and _normalize_base_url_for_match(
+                    entry.get("api") or entry.get("url") or entry.get("base_url")
+                ) == _normalize_base_url_for_match(url):
+                    identity = by_model
+        if not identity:
+            identity = find_custom_provider_identity(url)
+    else:
+        # No session URL — model catalog and/or configured provider are fair
+        # game (same recovery sources as canonical_custom_identity).
         identity = canonical_custom_identity(
-            base_url=base_url,
+            base_url=None,
             config_provider=config_provider,
             model=model,
         )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1030,6 +1030,83 @@ def canonical_custom_identity(
     return None
 
 
+def resolve_custom_provider_display_name(
+    provider: Optional[str] = None,
+    *,
+    base_url: Optional[str] = None,
+    config_provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> str:
+    """Resolve a status/UI label for a provider, recovering named custom entries.
+
+    Named ``providers:`` / ``custom_providers:`` entries resolve at runtime to the
+    shared billing class ``"custom"``. Status surfaces that only print that
+    billing class look identical for every custom endpoint (``Model: x (custom)``).
+
+    This helper recovers the configured entry name from:
+
+    1. An already-named identity (``custom:<name>`` or a direct ``providers:`` key)
+    2. ``base_url`` / ``model`` reverse-lookup against ``config.yaml`` entries
+    3. ``config_provider`` / active ``model.provider`` when it names a real entry
+
+    When several catalog entries share one gateway URL (e.g. ``openlux-claude``
+    and ``openlux-codex`` both pointing at the same host), a model catalog hit
+    that also owns that URL wins over the first URL-only match so ``/status``
+    names the entry that actually serves the session model.
+
+    Returns the config entry name (e.g. ``openlux``) when recovered, otherwise the
+    original ``provider`` string unchanged (including bare ``custom`` for ad-hoc
+    endpoints with no matching config entry).
+    """
+    raw = str(provider or "").strip()
+    low = raw.lower()
+
+    # Already a durable custom:<name> menu key — surface the entry name.
+    if low.startswith("custom:") and len(raw) > 7:
+        return _normalize_custom_provider_name(raw.split(":", 1)[1])
+
+    # Direct named providers key (e.g. model.provider: openlux).
+    if low and low not in {"custom", "auto"}:
+        try:
+            if _get_named_custom_provider(raw) is not None:
+                return _normalize_custom_provider_name(raw)
+        except Exception:
+            pass
+        # Non-custom providers (anthropic, deepseek, …) stay as-is.
+        return raw
+
+    # Bare "custom" (or empty) — recover from config.yaml.
+    identity: Optional[str] = None
+    url = str(base_url or "").strip()
+    model_id = str(model or "").strip()
+
+    # Shared-gateway disambiguation: prefer the entry that serves this model
+    # when its base_url also matches the session endpoint.
+    if url and model_id:
+        by_model = find_custom_provider_identity_by_model(model_id)
+        if by_model:
+            try:
+                entry = _get_named_custom_provider(by_model)
+            except Exception:
+                entry = None
+            if entry and _normalize_base_url_for_match(
+                entry.get("api") or entry.get("url") or entry.get("base_url")
+            ) == _normalize_base_url_for_match(url):
+                identity = by_model
+
+    if not identity:
+        identity = canonical_custom_identity(
+            base_url=base_url,
+            config_provider=config_provider,
+            model=model,
+        )
+
+    if identity and identity.lower().startswith("custom:") and len(identity) > 7:
+        return _normalize_custom_provider_name(identity.split(":", 1)[1])
+
+    return raw or "custom"
+
+
 def _normalize_base_url_for_match(value) -> str:
     return str(value or "").strip().rstrip("/").lower()
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -83,21 +83,45 @@ def _effective_provider_label() -> str:
     except AuthError:
         effective = requested or "auto"
 
+    config_base_url = ""
+    config_model = ""
+    config_provider = ""
+    try:
+        model_cfg = load_config().get("model")
+        if isinstance(model_cfg, dict):
+            config_base_url = (model_cfg.get("base_url") or "").strip()
+            config_provider = (model_cfg.get("provider") or "").strip()
+            config_model = str(
+                model_cfg.get("default") or model_cfg.get("model") or ""
+            ).strip()
+    except Exception:
+        pass
+
     if effective == "openrouter":
         # A custom endpoint may be configured either in config.yaml
         # (model.base_url — the canonical location; the runtime treats
         # config.yaml as the single source of truth) or via the legacy
         # OPENAI_BASE_URL env var. Either way, labeling it "OpenRouter"
         # is misleading (#3296).
-        config_base_url = ""
-        try:
-            model_cfg = load_config().get("model")
-            if isinstance(model_cfg, dict):
-                config_base_url = (model_cfg.get("base_url") or "").strip()
-        except Exception:
-            pass
         if config_base_url or get_env_value("OPENAI_BASE_URL"):
             effective = "custom"
+
+    # Recover named providers:/custom_providers: entry names so CLI status
+    # shows "openlux" (etc.) instead of the generic "Custom endpoint" label.
+    try:
+        from hermes_cli.runtime_provider import resolve_custom_provider_display_name
+
+        seed = requested if (requested or "").strip().lower() not in {"", "auto"} else effective
+        display = resolve_custom_provider_display_name(
+            seed or effective,
+            base_url=config_base_url or get_env_value("OPENAI_BASE_URL") or None,
+            config_provider=config_provider or requested or None,
+            model=config_model or None,
+        )
+        if display:
+            effective = display
+    except Exception:
+        pass
 
     return provider_label(effective)
 

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -141,6 +141,103 @@ async def test_status_command_includes_live_agent_model_and_context():
     assert "**Lifetime tokens billed:** 1,250" in result
 
 
+
+@pytest.mark.asyncio
+async def test_status_command_recovers_named_custom_provider_from_session_row(monkeypatch):
+    """Session billing_provider=custom + matching providers: entry → named label."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-custom-named",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "gpt-5.6-terra",
+        "billing_provider": "custom",
+        "billing_base_url": "https://api.openlux.ai/v1",
+        "model_config": {
+            "gateway_runtime": {
+                "provider": "custom",
+                "base_url": "https://api.openlux.ai/v1",
+            }
+        },
+    }
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openlux",
+            "base_url": "https://api.openlux.ai/v1",
+        },
+        "providers": {
+            "openlux": {
+                "base_url": "https://api.openlux.ai/v1",
+                "models": ["gpt-5.6-sol", "gpt-5.6-terra"],
+            }
+        },
+    }
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: cfg)
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `gpt-5.6-terra` (openlux)" in result
+    assert "(custom)" not in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_keeps_custom_for_unmatched_session_url(monkeypatch):
+    """Ad-hoc custom URL must not be relabeled as global model.provider."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-custom-adhoc",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "gpt-5.6-sol",
+        "billing_provider": "custom",
+        "billing_base_url": "https://adhoc.example/v1",
+    }
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openlux",
+            "base_url": "https://api.openlux.ai/v1",
+        },
+        "providers": {
+            "openlux": {
+                "base_url": "https://api.openlux.ai/v1",
+                "models": ["gpt-5.6-sol"],
+            }
+        },
+    }
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: cfg)
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `gpt-5.6-sol` (custom)" in result
+    assert "(openlux)" not in result
+
+
 @pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())

--- a/tests/hermes_cli/test_custom_provider_display_name.py
+++ b/tests/hermes_cli/test_custom_provider_display_name.py
@@ -1,0 +1,150 @@
+"""Tests for resolve_custom_provider_display_name (status/UI labels).
+
+Named ``providers:`` / ``custom_providers:`` entries resolve to billing class
+``"custom"``. Status surfaces must recover the config.yaml entry name so
+``/status`` can show ``Model: gpt (openlux)`` instead of ``(custom)``.
+"""
+
+import hermes_cli.runtime_provider as rp
+
+
+def test_strips_custom_menu_key():
+    assert (
+        rp.resolve_custom_provider_display_name("custom:openlux") == "openlux"
+    )
+    assert (
+        rp.resolve_custom_provider_display_name("custom:My Local") == "my-local"
+    )
+
+
+def test_passthrough_builtin_providers():
+    assert rp.resolve_custom_provider_display_name("deepseek") == "deepseek"
+    assert rp.resolve_custom_provider_display_name("anthropic") == "anthropic"
+
+
+def test_recovers_providers_dict_by_base_url(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "openlux": {"base_url": "https://api.openlux.ai/v1"},
+                "onerouter": {"base_url": "https://www.onerouter.one/v1"},
+            }
+        },
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://api.openlux.ai/v1",
+        )
+        == "openlux"
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://www.onerouter.one/v1/",
+        )
+        == "onerouter"
+    )
+
+
+def test_recovers_legacy_custom_providers_list(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "MiMo v2.5 Pro", "base_url": "https://api.mimo.example/v1"}
+            ]
+        },
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://api.mimo.example/v1",
+        )
+        == "mimo-v2.5-pro"
+    )
+
+
+def test_shared_gateway_prefers_model_catalog_match(monkeypatch):
+    """Multiple providers on one URL: prefer the entry that serves the model."""
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "openlux-claude": {
+                    "base_url": "https://api.openlux.ai/v1",
+                    "models": ["claude-sonnet-5", "claude-opus-5"],
+                },
+                "openlux-codex": {
+                    "base_url": "https://api.openlux.ai/v1",
+                    "models": ["gpt-5.6-sol", "gpt-5.6-terra"],
+                },
+            }
+        },
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://api.openlux.ai/v1",
+            model="gpt-5.6-terra",
+        )
+        == "openlux-codex"
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://api.openlux.ai/v1",
+            model="claude-sonnet-5",
+        )
+        == "openlux-claude"
+    )
+
+
+def test_direct_named_provider_key(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "openlux": {"base_url": "https://api.openlux.ai/v1"},
+            }
+        },
+    )
+    assert rp.resolve_custom_provider_display_name("openlux") == "openlux"
+
+
+def test_unmatched_custom_stays_custom(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: {"providers": {}})
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://adhoc.example/v1",
+        )
+        == "custom"
+    )
+
+
+def test_recovers_by_model_when_base_url_missing(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "local-llm": {
+                    "base_url": "http://127.0.0.1:8000/v1",
+                    "default_model": "qwen3-coder",
+                }
+            }
+        },
+    )
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            model="qwen3-coder",
+        )
+        == "local-llm"
+    )

--- a/tests/hermes_cli/test_custom_provider_display_name.py
+++ b/tests/hermes_cli/test_custom_provider_display_name.py
@@ -128,6 +128,59 @@ def test_unmatched_custom_stays_custom(monkeypatch):
     )
 
 
+def test_unmatched_url_ignores_configured_provider(monkeypatch):
+    """Explicit ad-hoc session URL must not inherit global model.provider.
+
+    Regression for PR review: canonical_custom_identity falls back to
+    config_provider, which would mis-label an unmatched custom endpoint as
+    the unrelated named provider from config.yaml.
+    """
+    cfg = {
+        "model": {
+            "provider": "openlux",
+            "default": "gpt-5.6-sol",
+            "base_url": "https://api.openlux.ai/v1",
+        },
+        "providers": {
+            "openlux": {
+                "base_url": "https://api.openlux.ai/v1",
+                "models": ["gpt-5.6-sol"],
+            }
+        },
+    }
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            base_url="https://adhoc.example/v1",
+            config_provider="openlux",
+            model="gpt-5.6-sol",
+        )
+        == "custom"
+    )
+
+
+def test_no_url_may_use_configured_provider(monkeypatch):
+    """Without a session URL, config.model.provider remains a valid recovery."""
+    cfg = {
+        "model": {"provider": "openlux", "default": "gpt-5.6-sol"},
+        "providers": {
+            "openlux": {
+                "base_url": "https://api.openlux.ai/v1",
+                "models": ["gpt-5.6-sol"],
+            }
+        },
+    }
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    assert (
+        rp.resolve_custom_provider_display_name(
+            "custom",
+            config_provider="openlux",
+        )
+        == "openlux"
+    )
+
+
 def test_recovers_by_model_when_base_url_missing(monkeypatch):
     monkeypatch.setattr(
         rp,

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -51,6 +51,44 @@ def test_show_status_displays_configured_dict_model_and_provider_label(monkeypat
     assert "Provider:     Anthropic" in out
 
 
+def test_show_status_displays_named_custom_provider_from_config(monkeypatch, capsys, tmp_path):
+    """Bare custom + matching providers: entry should surface the config key."""
+    from hermes_cli import status as status_mod
+    import hermes_cli.runtime_provider as rp
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openlux",
+            "base_url": "https://api.openlux.ai/v1",
+        },
+        "providers": {
+            "openlux": {
+                "base_url": "https://api.openlux.ai/v1",
+                "models": ["gpt-5.6-sol"],
+            }
+        },
+    }
+    monkeypatch.setattr(status_mod, "load_config", lambda: cfg, raising=False)
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openlux", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "custom", raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "provider_label",
+        lambda provider: "Custom endpoint" if provider == "custom" else provider,
+        raising=False,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Model:        gpt-5.6-sol" in out
+    assert "Provider:     openlux" in out
+    assert "Custom endpoint" not in out
+
+
 def test_show_status_reports_empty_lmstudio_listing_as_reachable(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
 


### PR DESCRIPTION
## What does this PR do?

Named `providers:` / `custom_providers:` entries resolve at runtime to the shared billing class `"custom"`, so gateway `/status` and CLI `hermes status` print opaque labels like `Model: gpt-5.6-terra (custom)` / `Provider: Custom endpoint` even when the endpoint is clearly defined in `~/.hermes/config.yaml`.

This PR recovers the configured entry name from `config.yaml` (by `custom:<name>`, base URL, model catalog, or `model.provider`) and displays that name instead — e.g. `Model: gpt-5.6-terra (openlux)`.

The recovery is fully generic: any named custom provider in config works, not just specific gateways.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `resolve_custom_provider_display_name()` in `hermes_cli/runtime_provider.py` — reuses existing `canonical_custom_identity` / model+URL reverse-lookup against `providers:` and `custom_providers:`
- When several catalog entries share one gateway URL, prefer the entry whose model catalog contains the session model
- Wire into gateway `/status` (`gateway/slash_commands.py`) and CLI status (`hermes_cli/status.py`)
- Tests: `tests/hermes_cli/test_custom_provider_display_name.py` + status provider display case

## How to Test

1. Configure a named provider in `~/.hermes/config.yaml`:
   ```yaml
   providers:
     openlux:
       base_url: https://api.openlux.ai/v1
       key_env: HERMES_OPENLUX_API_KEY
       models: [gpt-5.6-sol]
   model:
     default: gpt-5.6-sol
     provider: openlux
     base_url: https://api.openlux.ai/v1
   ```
2. Restart gateway / start a session that uses that endpoint.
3. Run `/status` in chat — expect `Model: … (openlux)` instead of `(custom)`.
4. Run `hermes status` — expect `Provider: openlux` instead of `Custom endpoint`.
5. Ad-hoc custom endpoints with no matching config entry still show `custom` / `Custom endpoint`.

```bash
pytest tests/hermes_cli/test_custom_provider_display_name.py tests/hermes_cli/test_status_model_provider.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted pytest for the new/changed tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (display-only, no OS-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: `Model: gpt-5.6-terra (custom)`  
After: `Model: gpt-5.6-terra (openlux)` (name taken from the matching `providers:` key in config.yaml)


Made with [Cursor](https://cursor.com)