### PR TITLE
fix: preserve and autoplay gateway TTS across updates

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -18,6 +18,8 @@ from pathlib import Path
 import logging
 import os
 import random
+import shutil
+import subprocess
 import threading
 import time
 from dataclasses import dataclass
@@ -51,6 +53,62 @@ from tools.tool_result_storage import (
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
+
+# Gateway-owned TTS playback.  The model-facing MEDIA tag is only a delivery
+# hint on some platforms; it is not a speaker action in the desktop/TUI path.
+# Keep the player process here, immediately after the TTS tool returns, so
+# speech delivery cannot be forgotten by the model.
+_tts_playback_lock = threading.Lock()
+_tts_playback_process: subprocess.Popen | None = None
+
+
+def _autoplay_tts_result(function_name: str, result: Any) -> None:
+    """Play a successful ``text_to_speech`` result through the local speakers.
+
+    This is intentionally in the executor rather than the prompt/skill layer.
+    It handles both sequential and concurrent tool execution and uses argv
+    execution (not a shell string), so a generated path cannot become a shell
+    injection.  A new turn replaces stale playback to prevent overlapping
+    voices.
+    """
+    global _tts_playback_process
+    if function_name != "text_to_speech":
+        return
+    try:
+        payload = json.loads(result) if isinstance(result, str) else result
+        if not isinstance(payload, dict) or payload.get("success") is not True:
+            return
+        file_path = payload.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            logger.warning("TTS succeeded without a playable file_path")
+            return
+        path = Path(file_path).expanduser()
+        if not path.is_file() or path.stat().st_size <= 0:
+            logger.warning("TTS playback skipped; audio file is missing or empty: %s", path)
+            return
+        afplay = shutil.which("afplay")
+        if not afplay:
+            logger.warning("TTS playback skipped; afplay is not available")
+            return
+        with _tts_playback_lock:
+            if _tts_playback_process is not None and _tts_playback_process.poll() is None:
+                _tts_playback_process.terminate()
+                try:
+                    _tts_playback_process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    _tts_playback_process.kill()
+            _tts_playback_process = subprocess.Popen(
+                [afplay, str(path)],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        logger.info("TTS autoplay started: %s (pid=%s)", path, _tts_playback_process.pid)
+    except Exception:
+        # Playback must never turn a successful TTS tool call into a failed
+        # model turn; log the failure and leave the generated file intact.
+        logger.exception("Gateway TTS autoplay failed")
 
 
 def _ensure_file_checkpoint(
@@ -839,6 +897,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     authorization_gate=authorization_gate,
                 )
                 result = managed.result
+                _autoplay_tts_result(function_name, result)
                 function_args = managed.args
                 middleware_trace = managed.middleware_trace
                 blocked = managed.blocked
@@ -1800,6 +1859,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
 
+        _autoplay_tts_result(function_name, function_result)
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result

--- a/cli.py
+++ b/cli.py
@@ -12169,7 +12169,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tts_text = prepare_spoken_text(text, max_chars=4000)
             except Exception:
                 # Legacy fallback pipeline — keep voice replies best-effort.
-                tts_text = text[:4000] if len(text) > 4000 else text
+                tts_text = text[:10000] if len(text) > 10000 else text
                 tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)   # fenced code blocks
                 tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)  # [text](url) -> text
                 tts_text = re.sub(r'https?://\S+', '', tts_text)      # URLs

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4084,7 +4084,7 @@ class BasePlatformAdapter(ABC):
         except Exception:
             # Keep auto-TTS best-effort if the normalizer ever fails.
             text = re.sub(r'<think[\s>].*?</think>', ' ', text, flags=re.DOTALL)
-            return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+            return re.sub(r'[*_`#\[\]()]', '', text)[:10000].strip()
 
     async def play_tts(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18298,7 +18298,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = _strip_markdown_for_tts(text[:10000])
             if not tts_text:
                 return
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3516,26 +3516,38 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True, encoding="utf-8", errors="replace",
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # ff-only failed — local and remote have diverged.  Never
+                # reset --hard here: that silently destroys local commits,
+                # including durable user fixes.  Rebase the local commits onto
+                # the fetched upstream instead.  The working tree was already
+                # stashed above, so this path is safe for both committed and
+                # uncommitted local customisations.
                 print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    "  ⚠ Fast-forward not possible (history diverged), preserving local commits via rebase..."
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                rebase_result = subprocess.run(
+                    git_cmd + ["rebase", f"origin/{branch}"],
                     cwd=_m().PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                if rebase_result.returncode != 0:
+                    subprocess.run(
+                        git_cmd + ["rebase", "--abort"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                        check=False,
+                    )
+                    print(f"✗ Local commits conflict with origin/{branch}; rebase aborted safely.")
+                    if rebase_result.stderr.strip():
+                        print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  No local commits were discarded. Resolve the conflict manually, "
+                        "then re-run `hermes update`."
                     )
                     sys.exit(1)
+                print("  ✓ Local commits preserved and rebased onto upstream.")
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -981,7 +981,7 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
             tts_text = prepare_spoken_text(text, max_chars=4000)
         except Exception:
             # Legacy fallback pipeline — keep speak_text best-effort.
-            tts_text = text[:4000] if len(text) > 4000 else text
+            tts_text = text[:10000] if len(text) > 10000 else text
             tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)             # fenced code blocks
             tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)    # [text](url) → text
             tts_text = re.sub(r'https?://\S+', '', tts_text)                # bare URLs

--- a/tests/agent/test_tool_executor_tts_autoplay.py
+++ b/tests/agent/test_tool_executor_tts_autoplay.py
@@ -1,0 +1,62 @@
+"""Regression tests for gateway-owned TTS autoplay."""
+
+import json
+
+import agent.tool_executor as executor
+
+
+def test_successful_tts_result_starts_afplay(monkeypatch, tmp_path):
+    audio = tmp_path / "reply.mp3"
+    audio.write_bytes(b"audio")
+    calls = []
+
+    class FakeProcess:
+        pid = 123
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(executor.shutil, "which", lambda name: "/usr/bin/afplay")
+    monkeypatch.setattr(
+        executor.subprocess,
+        "Popen",
+        lambda argv, **kwargs: calls.append((argv, kwargs)) or FakeProcess(),
+    )
+    executor._tts_playback_process = None
+
+    executor._autoplay_tts_result(
+        "text_to_speech",
+        json.dumps({"success": True, "file_path": str(audio)}),
+    )
+
+    assert calls == [
+        (
+            ["/usr/bin/afplay", str(audio)],
+            {
+                "stdin": executor.subprocess.DEVNULL,
+                "stdout": executor.subprocess.DEVNULL,
+                "stderr": executor.subprocess.DEVNULL,
+                "start_new_session": True,
+            },
+        )
+    ]
+
+
+def test_unsuccessful_tts_result_does_not_play(monkeypatch):
+    called = []
+    monkeypatch.setattr(executor.subprocess, "Popen", lambda *a, **k: called.append((a, k)))
+
+    executor._autoplay_tts_result(
+        "text_to_speech", json.dumps({"success": False, "error": "provider down"})
+    )
+
+    assert called == []
+
+
+def test_other_tools_do_not_play(monkeypatch):
+    called = []
+    monkeypatch.setattr(executor.subprocess, "Popen", lambda *a, **k: called.append((a, k)))
+
+    executor._autoplay_tts_result("read_file", "not tts")
+
+    assert called == []

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -163,13 +163,12 @@ def _make_update_side_effect(
 
 
 # ---------------------------------------------------------------------------
-# reset --hard failure — don't attempt stash restore
+# Diverged history → preserve local commits with rebase
 # ---------------------------------------------------------------------------
 
-def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, capsys):
-    """When reset --hard fails, stash restore is skipped with a helpful message."""
+def test_cmd_update_rebases_and_preserves_local_commits(monkeypatch, tmp_path, capsys):
+    """Divergence must rebase local commits, never reset them away."""
     _setup_update_mocks(monkeypatch, tmp_path)
-    # Re-enable stash so it actually returns a ref
     monkeypatch.setattr(
         hermes_main, "_stash_local_changes_if_needed",
         lambda *a, **kw: "abc123deadbeef",
@@ -180,17 +179,17 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
         lambda *a, **kw: restore_calls.append(1) or True,
     )
 
-    side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    with pytest.raises(SystemExit, match="1"):
-        hermes_main.cmd_update(SimpleNamespace())
+    hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash restore should NOT have been called
-    assert len(restore_calls) == 0
+    assert any("rebase" in call and "origin/main" in call for call in recorded)
+    assert not any("reset" in call and "--hard" in call for call in recorded)
+    assert len(restore_calls) == 1
 
     out = capsys.readouterr().out
-    assert "preserved in stash" in out
+    assert "preserved and rebased" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1705,7 +1705,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 )
                 with _playback_lock:
                     _active_playback = proc
-                proc.wait(timeout=300)
+                proc.wait(timeout=7200)
                 rc = proc.returncode
                 with _playback_lock:
                     _active_playback = None


### PR DESCRIPTION
## Summary
- start local speaker playback in the tool executor immediately after successful `text_to_speech` results
- preserve local Hermes commits during update divergence by rebasing instead of resetting
- extend legacy voice text limits and long playback timeout
- add regression coverage for autoplay and update preservation

## Verification
- `scripts/run_tests.sh tests/agent/test_tool_executor_tts_autoplay.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/cli/test_update_command.py` — passed
- `scripts/run_tests.sh tests/tools/test_tts_max_text_length.py tests/tools/test_voice_cli_integration.py tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_base_auto_tts_output_format.py` — 51 passed
- `git diff --check` — passed

The upstream repository rejected direct pushes for this account, so this PR is opened from the contributor fork.