### PR TITLE
fix(prompt): require source-first reasoning for judgment

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -353,7 +353,13 @@ TASK_COMPLETION_GUIDANCE = (
     "approach, ask the user). NEVER substitute plausible-looking fabricated "
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
-    "is always better than inventing a result."
+    "is always better than inventing a result.\n"
+    "When a task requires judgment over source material, read the complete relevant "
+    "source and understand it before drawing conclusions. Search is only for "
+    "navigation within material you already understand; do not replace reading with "
+    "grep, guessed phrases, a fixed vocabulary, or a lookup table. Put your reasoning "
+    "in front of the actual source and quote the evidence you read. Do not request "
+    "better-structured input merely to avoid reasoning over material already available."
 )
 
 # Universal parallel-tool-call guidance — applied to ALL models.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -31,6 +31,7 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    TASK_COMPLETION_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -53,6 +54,14 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_judgment_requires_reading_source_instead_of_enumerating_guesses(self):
+        guidance = TASK_COMPLETION_GUIDANCE.lower()
+        assert "read the complete relevant source" in guidance
+        assert "search is only for navigation" in guidance
+        assert all(term in guidance for term in ("grep", "fixed vocabulary", "lookup table"))
+        assert "quote the evidence you read" in guidance
+        assert "better-structured input" in guidance
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- require reading and understanding source material before judgment
- restrict search to navigation within already-understood material
- forbid grep/vocabulary/lookup-table substitution for reasoning tasks
- require evidence quotes and reject requests for structured-data escape hatches

## Test
- `python -m pytest tests/agent/test_prompt_builder.py::TestGuidanceConstants::test_judgment_requires_reading_source_instead_of_enumerating_guesses tests/run_agent/test_run_agent.py::TestTaskCompletionGuidance::test_default_injects_for_claude -q` (2 passed)
- `python -m pytest tests/agent/test_prompt_builder.py -q` (57 passed)