### PR TITLE
fix(cli): redact secrets in interrupt_debug.log writes (#75461)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13989,9 +13989,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             self._clear_active_overlays_for_interrupt()
                             # Debug: log to file (stdout may be devnull from redirect_stdout)
                             try:
+                                from agent.redact import redact_sensitive_text
                                 _dbg = _hermes_home / "interrupt_debug.log"
                                 with open(_dbg, "a", encoding="utf-8") as _f:
-                                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={str(interrupt_msg)[:60]!r}, "
+                                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg))[:60]!r}, "
                                              f"children={len(self.agent._active_children)}, "
                                              f"parent._interrupt={self.agent._interrupt_requested}\n")
                                     for _ci, _ch in enumerate(self.agent._active_children):
@@ -15317,9 +15318,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             # follow-ups, or a turn that finished in the race.
                             self._interrupt_queue.put(payload)
                             try:
+                                from agent.redact import redact_sensitive_text
                                 _dbg = _hermes_home / "interrupt_debug.log"
                                 with open(_dbg, "a", encoding="utf-8") as _f:
-                                    _f.write(f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={str(payload)[:60]!r}, "
+                                    _f.write(f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload))[:60]!r}, "
                                              f"agent_running={self._agent_running}\n")
                             except Exception:
                                 pass


### PR DESCRIPTION
## fix(cli): redact secrets in interrupt_debug.log writes

Fixes #75461

### Problem

`~/.hermes/interrupt_debug.log` records raw user input via `open(...).write()`, bypassing `RedactingFormatter`. When a user pastes a credential during setup (e.g. a Telegram bot token), the value is written to the debug log in plaintext and persists indefinitely.

The same message, in the same millisecond, reaches two files:
- `agent.log` — masked by `RedactingFormatter` 
- `interrupt_debug.log` — plaintext (vulnerability)

### Root Cause

Two write sites in `cli.py` (interrupt-fired path and queued-interrupt path) use raw `open().write()` instead of the logging module, so `RedactingFormatter` never sees the data.

### Fix

Apply `redact_sensitive_text()` (already used elsewhere in `cli.py` at line 10312) to both payloads before writing, matching the masking that `agent.log` already performs.

**Changes:** `cli.py` — 2 lines modified (import + wrap each payload), 2 lines added (imports).
