### PR TITLE
fix(memory): honor sqlite ':memory:' in holographic store instead of resolving it to a CWD file

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -132,30 +132,55 @@ class MemoryStore:
         # resolve() (not just expanduser) so symlinked/relative paths to the
         # same file share ONE connection instead of silently reintroducing
         # the multi-writer contention this registry exists to prevent.
-        try:
-            self._key = str(self.db_path.resolve())
-        except OSError:
-            self._key = str(self.db_path)
-        with MemoryStore._shared_guard:
-            entry = MemoryStore._shared.get(self._key)
-            if entry is None:
-                conn = sqlite3.connect(
-                    self._key,
+        #
+        # EXCEPTION: sqlite's reserved ":memory:" name must reach
+        # sqlite3.connect verbatim — resolve() would turn it into a literal
+        # on-disk file in the CWD (shared by every ":memory:" caller in that
+        # directory, silently coupling tests/fixtures that asked for private
+        # in-memory DBs). In-memory stores are private by sqlite semantics:
+        # each instance gets its own connection and bypasses the registry.
+        if str(db_path) == ":memory:":
+            self._key = None
+            entry = {
+                "conn": sqlite3.connect(
+                    ":memory:",
                     check_same_thread=False,
                     timeout=10.0,
-                    # Autocommit: every statement is its own transaction, so a
-                    # write that raises mid-method can never leave a dangling
-                    # transaction (and its write lock) open. The explicit
-                    # commit() calls below become harmless no-ops.
                     isolation_level=None,
-                )
-                conn.row_factory = sqlite3.Row
-                entry = {"conn": conn, "lock": threading.RLock(), "refs": 0, "ready": False}
-                MemoryStore._shared[self._key] = entry
-            entry["refs"] += 1
+                ),
+                "lock": threading.RLock(),
+                "refs": 1,
+                "ready": False,
+            }
+            entry["conn"].row_factory = sqlite3.Row
             self._entry = entry
             self._conn = entry["conn"]
             self._lock = entry["lock"]
+        else:
+            try:
+                self._key = str(self.db_path.resolve())
+            except OSError:
+                self._key = str(self.db_path)
+            with MemoryStore._shared_guard:
+                entry = MemoryStore._shared.get(self._key)
+                if entry is None:
+                    conn = sqlite3.connect(
+                        self._key,
+                        check_same_thread=False,
+                        timeout=10.0,
+                        # Autocommit: every statement is its own transaction, so a
+                        # write that raises mid-method can never leave a dangling
+                        # transaction (and its write lock) open. The explicit
+                        # commit() calls below become harmless no-ops.
+                        isolation_level=None,
+                    )
+                    conn.row_factory = sqlite3.Row
+                    entry = {"conn": conn, "lock": threading.RLock(), "refs": 0, "ready": False}
+                    MemoryStore._shared[self._key] = entry
+                entry["refs"] += 1
+                self._entry = entry
+                self._conn = entry["conn"]
+                self._lock = entry["lock"]
 
         # Initialise the schema once per shared connection.
         with self._lock:

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -225,3 +225,50 @@ class TestProviderShutdown:
         assert provider._store is None
         assert MemoryStore._shared == {}
 
+
+
+class TestMemoryColonPath:
+    """MemoryStore(':memory:') must honor sqlite's reserved in-memory name.
+
+    Pre-fix, the shared-connection registry keyed on
+    ``Path(':memory:').resolve()`` — which turns the reserved name into a
+    literal on-disk file in the CWD, shared by every ':memory:' caller in
+    that directory (silently coupling fixtures that asked for private
+    in-memory DBs, and leaving garbage files behind). The fix bypasses the
+    registry for ':memory:' — each instance gets a private connection,
+    matching sqlite semantics (SessionDB in hermes_state.py already treats
+    ':memory:' verbatim).
+    """
+
+    def test_memory_store_creates_no_cwd_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        store = MemoryStore(":memory:")
+        store.add_fact("anything at all")
+        store.close()
+        assert not (tmp_path / ":memory:").exists(), (
+            "':memory:' was path-resolved into a literal on-disk file")
+
+    def test_memory_stores_are_isolated(self):
+        """Two ':memory:' stores must NOT share state — sqlite semantics
+        are one private database per connection."""
+        a = MemoryStore(":memory:")
+        b = MemoryStore(":memory:")
+        try:
+            a.add_fact("fact only in store A")
+            assert b.search_facts("fact only in store A") == []
+        finally:
+            a.close()
+            b.close()
+
+    def test_file_backed_stores_still_share_connection(self, tmp_path):
+        """Registry regression guard: same file path = one shared
+        connection, visible state across instances."""
+        path = tmp_path / "shared.db"
+        a = MemoryStore(path)
+        b = MemoryStore(path)
+        try:
+            a.add_fact("fact in the shared file")
+            assert len(b.search_facts("fact in the shared file")) == 1
+        finally:
+            a.close()
+            b.close()


### PR DESCRIPTION
## What does this PR do?

MemoryStore(':memory:') computed its shared-connection registry key as Path(':memory:').resolve(), turning sqlite's reserved in-memory name into a literal on-disk file in the current working directory. Every ':memory:' caller in the same directory silently shared one file-backed database — fixtures that asked for private in-memory stores were coupled through it, and the literal file was left behind in the repo. Bypass the registry for ':memory:' so each instance gets a private connection, matching sqlite semantics (SessionDB already treats the name verbatim).

## Related Issue

No direct issue — discovered via code review and reproduced live (see below).
Related PRs reviewed during the duplicate check (none covers this change):
- #43421 [closed] fix(memory): match entities by exact name, not LIKE wildcards
- #71655 [open] fix(auth): harden Windows atomic store races
- #66108 [open] fix(checkpoints): serialize shared store maintenance
- #71049 [open] fix(auth): protect Windows auth store during tests
- #65354 [open] fix(checkpoints): make store GC concurrency safe
- #65479 [open] fix(cron): support durable cron state store
- #74661 [open] fix(kanban): validate stored task skills before worker spawn
- #71654 [open] fix(pairing): fail closed on approved store read errors
- …and 29 more reviewed in the sweep

## Changes Made

- `fix/memory-store-memory-fix` — 2 file(s) changed vs base:
  - `plugins/memory/holographic/store.py`
  - `tests/plugins/memory/test_holographic_store.py`

plugins/memory/holographic/store.py: ':memory:' bypasses the shared-connection registry (private connection per instance, refs=1 so close() works unmodified). tests/plugins/memory/test_holographic_store.py: +3 tests — no ':memory:' file is created in the CWD (chdir'd tmp), two ':memory:' stores are state-isolated, and file-backed stores still share one registry connection (regression guard).

## How to Test

Reproduced during holographic-retrieval test work: a MemoryStore(':memory:', hrr_dim=128) run wrote 128-dim vectors into the shared CWD file; subsequent 1024-dim runs opened the same file and crashed in _rebuild_bank with numpy 'inhomogeneous shape' errors — cross-test contamination through a file that should never have existed. After the fix, no ':memory:' file is created and stores are isolated.

Validation completed (recorded by prp):
1. Sabotage check: pre-fix code fails the regression tests (2 failed), with the fix all pass (16 passed, 0 failed) — target `tests/plugins/memory/test_holographic_store.py`.
2. Suite `tests/plugins/memory/`: branch 231 passed / 0 failed vs baseline 228 passed / 0 failed — zero branch-only failures.
3. tests/plugins/memory/ fullcheck: 231 passed vs 228 baseline, zero branch-only failures. Sabotage revert-verified: the no-file and isolation tests fail pre-fix (file created; state leaks across instances), 16/16 pass with the fix. Full repo-wide suite NOT run locally for this PR (skipped by decision; CI owns full-suite validation).
4. Duplicate check: 37 potential matches reviewed — none covers this change.
5. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 14 passed, 2 failed
# head leg (with fix):
#   tests: 16 passed, 0 failed
```
