### PR TITLE
fix(tools): scrub signed delivery URL from plural result.samples (#75667)

### DIFF
--- a/tools/flux3_video_tool.py
+++ b/tools/flux3_video_tool.py
@@ -466,13 +466,27 @@ async def _save_if_ready(raw: str, save_to, started: float) -> str:
         return raw
 
     result = details.get("result")
-    url = result.get("sample") if isinstance(result, dict) else None
+    if not isinstance(result, dict):
+        return raw
+
+    # The signed URL may appear in the singular ``sample`` field or the
+    # plural ``samples`` list (both observed from the live BFL API).
+    url = result.get("sample")
+    if not isinstance(url, str) or not url.strip():
+        # Fall back to the plural form — pick the first non-empty entry.
+        samples = result.get("samples")
+        if isinstance(samples, list):
+            for s in samples:
+                if isinstance(s, str) and s.strip():
+                    url = s
+                    break
     if not isinstance(url, str) or not url.strip():
         return raw
 
     # Dropped whether or not the save succeeds. A retry re-polls, which mints a
     # fresh URL, so nothing is lost by not handing this one to the model.
     result.pop("sample", None)
+    result.pop("samples", None)
 
     try:
         target, size = await _download_video(url.strip(), save_to, started)


### PR DESCRIPTION
## fix(tools): scrub signed delivery URL from plural result.samples

Fixes #75667

### Problem

`_save_if_ready()` strips the singular `result.sample` field to keep bearer credentials out of the model context, but the live BFL API also returns a **plural** `result.samples` list containing the same signed URL. That list passes through untouched, so the credential lands in the model context and persisted transcript — exactly what the scrub exists to prevent.

### Root Cause

The scrub only handles `result.sample` (singular):
```python
url = result.get("sample") if isinstance(result, dict) else None
result.pop("sample", None)
```

The BFL API returns `result.samples` as a list with the same signed URL. This field is never checked or removed.

### Fix

- Fall back to `result.samples[0]` when `result.sample` is absent
- Pop both `sample` and `samples` after extracting the URL
- Add `isinstance(result, dict)` guard early for clarity

**Changes:** `tools/flux3_video_tool.py` — 15 lines added, 1 removed.
