### PR TITLE
fix(cli/web_server): add bounded graceful-shutdown timeout to prevent SIGTERM orphans

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -20226,6 +20226,13 @@ def start_server(
         # reaped via the WebSocketDisconnect → disconnect/reap path.
         ws_ping_interval=None if _is_loopback else 20.0,
         ws_ping_timeout=None if _is_loopback else 20.0,
+        # (#76244) Bounded graceful-shutdown window. Without this,
+        # uvicorn.Server.shutdown() does asyncio.wait_for(..., timeout=None)
+        # which waits forever on a lingering ASGI task. Electron Desktop
+        # sends a single SIGTERM on quit; uvicorn only force-exits on a
+        # second SIGINT. 3s is comfortably under the desktop's 5s SIGKILL
+        # budget while letting lifespan shutdown + cron_stop.set() run.
+        timeout_graceful_shutdown=3,
     )
     server = uvicorn.Server(config)
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -191,6 +191,33 @@ def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):
     )
 
 
+def test_start_server_bounded_graceful_shutdown_timeout(monkeypatch):
+    """On Desktop quit, Electron sends a single SIGTERM to the hermes serve
+    backend. Without ``timeout_graceful_shutdown``, uvicorn defaults to
+    ``None`` (unbounded) and ``Server.shutdown()`` does
+    ``asyncio.wait_for(..., timeout=None)`` — waiting forever on a lingering
+    ASGI task and producing an orphaned process (#76244).
+
+    Assert that the graceful-shutdown timeout is always set to a finite value
+    (≤ 3s is comfortably under the desktop's 5s SIGKILL budget).
+    """
+    captured = _stub_uvicorn(monkeypatch)
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert "timeout_graceful_shutdown" in captured, (
+        "start_server must pass timeout_graceful_shutdown to uvicorn.Config "
+        "to avoid unbounded waits on SIGTERM"
+    )
+    timeout = captured["timeout_graceful_shutdown"]
+    assert timeout is not None and timeout > 0, (
+        f"timeout_graceful_shutdown must be a positive number, got {timeout}"
+    )
+    assert timeout <= 5, (
+        f"timeout_graceful_shutdown={timeout} is too high for the desktop's "
+        "5s SIGKILL budget; recommend ≤3s"
+    )
+
+
 def test_start_server_keeps_bare_asyncio_run_on_posix(monkeypatch):
     """POSIX behavior must be byte-for-byte unchanged: serve via the plain
     ``asyncio.run(_serve())`` path, never the Windows loop-factory branch.


### PR DESCRIPTION
## Background

Fix #76244: hermes serve backend process gets stuck on SIGTERM when Electron Desktop quits, becoming an orphan process (reparented to PID 1), leaking RSS.

## Root Cause

uvicorn.Config in hermes_cli/web_server.py start_server does not set timeout_graceful_shutdown, defaulting to None (unbounded). Server.shutdown() calls asyncio.wait_for(..., timeout=None), which waits forever on a lingering ASGI task. Uvicorn only force-exits on a second SIGINT, but Electron Desktop sends only a single SIGTERM, so the process hangs indefinitely.

Process forensics on the orphaned PID confirmed: 0 listening/TCP sockets but ~12 non-daemon worker threads parked in queue.get(), main thread still in kevent -- the event loop never returns.

## Fix

Add timeout_graceful_shutdown=3 to the uvicorn.Config call, comfortably under the desktops 5s SIGKILL budget, so the process exits cleanly (lifespan shutdown + cron_stop.set() still run) instead of hanging until force-killed.

## Verification

- [x] All 6 tests in tests/test_web_server.py pass
- [x] Follows project AGENTS.md contribution standards
- [x] No breaking changes
- [x] Added regression test test_start_server_bounded_graceful_shutdown_timeout to ensure timeout is always a finite positive value

Closes #76244