### PR TITLE
fix(skills): prevent install from deleting category directories (#75983)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3707,6 +3707,28 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
+        # Guard against deleting a category directory that contains other
+        # skills.  When the install name collides with an existing category
+        # bucket (e.g. ``skills/research/`` holding 16 unrelated skills),
+        # an unconditional rmtree would destroy all of them.  (#75983)
+        #
+        # Only allow rmtree when the directory is a previously hub-installed
+        # skill (tracked in lock.json) — otherwise check for sibling skills.
+        lock = HubLockFile()
+        is_hub_skill = lock.get_installed(safe_skill_name) is not None
+        if install_dir.is_dir() and not is_hub_skill:
+            sibling_skills = [
+                p for p in install_dir.iterdir()
+                if p.is_dir() and (p / "SKILL.md").exists()
+            ]
+            if sibling_skills:
+                raise ValueError(
+                    f"Cannot install skill '{safe_skill_name}': "
+                    f"{install_dir} is a category directory containing "
+                    f"{len(sibling_skills)} other skill(s). "
+                    f"Use --category to install into a subdirectory, "
+                    f"or choose a different name."
+                )
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large


### PR DESCRIPTION
## fix(skills): prevent install from deleting category directories

Fixes #75983

### Problem

`hermes skills install <url> --name <name>` unconditionally calls `shutil.rmtree` on the target install directory before moving the new skill into place. When the skill name collides with an existing category bucket (e.g. `skills/research/` containing 16 unrelated skills), this silently destroys all of them — no warning, no confirmation, no backup.

### Root Cause

In `install_from_quarantine()` (`tools/skills_hub.py`):
```python
if install_dir.exists():
    shutil.rmtree(install_dir)  # unconditional — destroys category dirs
```

No check exists to distinguish a hub-installed skill directory from a category bucket containing multiple skills.

### Fix

Before calling `rmtree`, check if the target directory is a previously hub-installed skill (tracked in `lock.json`). If it is not, scan for sibling skills (subdirectories containing `SKILL.md`). If siblings exist, raise a `ValueError` with a clear message instead of deleting them.

The user can then:
- Use `--category` to install into a subdirectory
- Choose a different name that doesn't collide

**Changes:** `tools/skills_hub.py` — 22 lines added (guard block).
