### PR TITLE
fix(kanban): opening a board must not rewrite the board

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2525,30 +2525,32 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # had its claim_lock / claim_expires / worker_pid on the task row.
     # Synthesize a matching task_runs row so subsequent end-run / heartbeat
     # calls have something to write to. The adoption is wrapped in write_txn
-    # to serialize against any concurrent dispatcher, and the per-row UPDATE
-    # uses ``current_run_id IS NULL`` as a CAS guard so a racing claim can't
-    # produce an orphaned row if it interleaves with the backfill pass.
+    # to serialize against any concurrent dispatcher.
     #
-    # The *search* deliberately runs outside that transaction: this pass runs
-    # on every process's first open of a board, and on a board migrated long
-    # ago (i.e. nearly all of them) it was taking the write lock per process
-    # to adopt nothing. A claim landing between the search and the adoption is
-    # already handled by that CAS: the loser's run row is retired below.
+    # The preflight search outside that transaction is an optimization only:
+    # this pass runs on every process's first open of a board, and on a board
+    # migrated long ago (i.e. nearly all of them) it was taking the write lock
+    # per process to adopt nothing. A preflight hit can go stale before the
+    # lock is granted, so it decides only *whether* to open the transaction —
+    # the list that is actually adopted is re-read under the lock. That
+    # re-read is what carries correctness: ``release_stale_claims`` can move a
+    # legacy task running -> ready in between, and on such a task ``_end_run``
+    # leaves ``current_run_id`` NULL, so the CAS below would happily hang a
+    # live run on a task that is no longer running. An empty re-read means the
+    # window closed on us and the transaction simply writes nothing.
     runs_exist = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
-    if runs_exist:
-        inflight = conn.execute(
-            "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
-            "       max_runtime_seconds, last_heartbeat_at, started_at "
-            "FROM tasks "
-            "WHERE status = 'running' AND current_run_id IS NULL"
-        ).fetchall()
-    else:
-        inflight = []
-    if inflight:
+    legacy_inflight_sql = (
+        "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+        "       max_runtime_seconds, last_heartbeat_at, started_at "
+        "FROM tasks "
+        "WHERE status = 'running' AND current_run_id IS NULL"
+    )
+    preflight = conn.execute(legacy_inflight_sql).fetchall() if runs_exist else []
+    if preflight:
         with write_txn(conn):
-            for row in inflight:
+            for row in conn.execute(legacy_inflight_sql).fetchall():
                 started = row["started_at"] or int(time.time())
                 cur = conn.execute(
                     """
@@ -2566,11 +2568,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                         started,
                     ),
                 )
-                # CAS: only install the pointer if nothing else claimed
-                # the task between the search above and here — a live
-                # dispatcher can, since the search runs outside this
-                # transaction. If the CAS fails we've got an orphan run row
-                # — mark it reclaimed so it doesn't look in-flight.
+                # CAS: only install the pointer if nothing else claimed the
+                # task between the re-read above and here. Under the write
+                # lock nothing should, so this is belt-and-suspenders against
+                # a non-serializable interleave rather than the guard that
+                # carries the race. If it does fail we've got an orphan run
+                # row — mark it reclaimed so it doesn't look in-flight.
                 upd = conn.execute(
                     "UPDATE tasks SET current_run_id = ? "
                     "WHERE id = ? AND current_run_id IS NULL",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1381,7 +1381,7 @@ def _resolve_busy_timeout_ms() -> int:
     return DEFAULT_BUSY_TIMEOUT_MS
 
 
-def _sqlite_connect(path: Path) -> sqlite3.Connection:
+def _sqlite_connect(path: Path, *, read_only: bool = False) -> sqlite3.Connection:
     """Open a Kanban SQLite connection with consistent lock waiting.
 
     Uses ``connect_tracked`` so the live-connection registry knows this file
@@ -1389,14 +1389,25 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
     because an ``open()``/``close()`` would cancel this process's POSIX
     advisory locks on the database (see ``hermes_cli.sqlite_safe_read``).
     The registration is released automatically when the connection closes.
+
+    ``read_only`` opens via a ``mode=ro`` URI, for callers that only inspect
+    the file (see :func:`_guard_existing_db_is_healthy`). A read/write handle
+    checkpoints a hot WAL into the main DB and unlinks the sidecars when it
+    closes; ``mode=ro`` still replays that WAL for its own reads — SQLite
+    restricts the database file, not the WAL index — while leaving both files
+    byte-identical. ``path`` must be absolute here, as the URI form requires.
     """
     from hermes_cli.sqlite_safe_read import connect_tracked
 
     busy_timeout_ms = _resolve_busy_timeout_ms()
     conn = connect_tracked(
-        path,
+        f"{path.as_uri()}?mode=ro" if read_only else path,
+        # The URI spelling is not a filesystem path; hand the registry the
+        # real one so its key matches every other connection to this DB.
+        tracking_path=path if read_only else None,
         connect_fn=sqlite3.connect,
         isolation_level=None,
+        uri=read_only,
         timeout=busy_timeout_ms / 1000.0,
     )
     # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
@@ -1832,6 +1843,27 @@ _REPAIRABLE_INDEX_ERROR_PATTERNS = (
 )
 
 
+# How a read-only open refuses when it cannot build the WAL index: SQLite may
+# not replay a hot WAL through a handle it cannot write, and may not create
+# ``-shm`` in a directory it cannot write. Neither means the DB is damaged —
+# see _refused_because_read_only().
+_READ_ONLY_REFUSAL_MARKERS = (
+    "readonly",
+    "unable to open database file",
+)
+
+
+def _refused_because_read_only(exc: sqlite3.OperationalError) -> bool:
+    """Did the integrity probe fail *because* it was read-only, not find damage?
+
+    Told apart from a locked board (``database is locked``) by the message,
+    which is all the DB-API exposes — and from real damage by the class, since
+    a malformed image or a non-database raises plain ``sqlite3.DatabaseError``.
+    """
+    text = str(exc).lower()
+    return any(marker in text for marker in _READ_ONLY_REFUSAL_MARKERS)
+
+
 def _integrity_messages_ok(messages: list[str]) -> bool:
     """True iff ``PRAGMA integrity_check`` output is the single ``ok`` row."""
     return len(messages) == 1 and messages[0].strip().lower() == "ok"
@@ -1908,9 +1940,15 @@ def _attempt_index_reindex_repair(
 def _guard_existing_db_is_healthy(path: Path) -> None:
     """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
-    Opens the probe in read/write mode so SQLite can recover or
-    checkpoint a healthy WAL/hot-journal DB before we declare it
-    corrupt.
+    Opens the probe **read-only**. A read/write probe rewrites the very file
+    it is judging: on close it checkpoints the WAL into the main DB and
+    unlinks ``-wal``/``-shm``, so by the time a failed check reaches
+    :func:`_backup_corrupt_db` below the quarantined bytes are no longer the
+    bytes that arrived — and on a board that opened cleanly it means merely
+    *looking* at a board rewrites it. ``mode=ro`` still replays a hot WAL for
+    the probe's own reads, so the check sees exactly what it saw before; a
+    read-only open that cannot proceed at all stands aside for the read/write
+    open that follows (see :func:`_refused_because_read_only`).
 
     **Narrow auto-repair:** when the integrity failure consists *only* of
     index-scoped errors (``wrong # of entries in index <name>`` / ``row N
@@ -1956,7 +1994,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     reason: Optional[str] = None
     messages: list[str] = []
     try:
-        probe = _sqlite_connect(resolved)
+        probe = _sqlite_connect(resolved, read_only=True)
         try:
             messages = _run_integrity_check(probe)
         finally:
@@ -1966,7 +2004,14 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
                 f"integrity_check returned "
                 f"{messages[0] if messages else '<no row>'!r}"
             )
-    except sqlite3.OperationalError:
+    except sqlite3.OperationalError as exc:
+        if _refused_because_read_only(exc):
+            # Not this function's job: recovering a hot WAL, or a directory it
+            # may not create -shm in, belongs to the read/write open that
+            # follows. Standing aside leaves that open to fail loudly if the
+            # file really is unusable; condemning the board here would
+            # quarantine a healthy one.
+            return
         # Lock contention, busy, transient IO — not corruption. Let it propagate.
         raise
     except sqlite3.DatabaseError as exc:
@@ -2479,21 +2524,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
     # Synthesize a matching task_runs row so subsequent end-run / heartbeat
-    # calls have something to write to. Wrapped in write_txn to serialize
-    # against any concurrent dispatcher, and the per-row UPDATE uses
-    # ``current_run_id IS NULL`` as a CAS guard so a racing claim can't
+    # calls have something to write to. The adoption is wrapped in write_txn
+    # to serialize against any concurrent dispatcher, and the per-row UPDATE
+    # uses ``current_run_id IS NULL`` as a CAS guard so a racing claim can't
     # produce an orphaned row if it interleaves with the backfill pass.
+    #
+    # The *search* deliberately runs outside that transaction: this pass runs
+    # on every process's first open of a board, and on a board migrated long
+    # ago (i.e. nearly all of them) it was taking the write lock per process
+    # to adopt nothing. A claim landing between the search and the adoption is
+    # already handled by that CAS: the loser's run row is retired below.
     runs_exist = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
+        inflight = conn.execute(
+            "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+            "       max_runtime_seconds, last_heartbeat_at, started_at "
+            "FROM tasks "
+            "WHERE status = 'running' AND current_run_id IS NULL"
+        ).fetchall()
+    else:
+        inflight = []
+    if inflight:
         with write_txn(conn):
-            inflight = conn.execute(
-                "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
-                "       max_runtime_seconds, last_heartbeat_at, started_at "
-                "FROM tasks "
-                "WHERE status = 'running' AND current_run_id IS NULL"
-            ).fetchall()
             for row in inflight:
                 started = row["started_at"] or int(time.time())
                 cur = conn.execute(
@@ -2513,10 +2567,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     ),
                 )
                 # CAS: only install the pointer if nothing else claimed
-                # the task between our SELECT and here (shouldn't happen
-                # under the write_txn, but belt-and-suspenders). If the
-                # CAS fails we've got an orphan run_row — mark it
-                # reclaimed so it doesn't look in-flight.
+                # the task between the search above and here — a live
+                # dispatcher can, since the search runs outside this
+                # transaction. If the CAS fails we've got an orphan run row
+                # — mark it reclaimed so it doesn't look in-flight.
                 upd = conn.execute(
                     "UPDATE tasks SET current_run_id = ? "
                     "WHERE id = ? AND current_run_id IS NULL",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1462,6 +1462,69 @@ def test_first_open_of_a_migrated_board_opens_no_write_transaction(tmp_path):
     assert boundaries == [], f"first open opened a transaction: {boundaries}"
 
 
+def test_backfill_ignores_a_task_reclaimed_after_its_preflight(tmp_path):
+    """A preflight hit outside the lock may be stale by the time the lock lands.
+
+    ``release_stale_claims`` moves a legacy in-flight task running -> ready,
+    and on such a task ``_end_run`` finds no run to close, so
+    ``current_run_id`` stays NULL. If the backfill adopts the list it saw
+    *before* the write lock, its ``current_run_id IS NULL`` CAS still matches
+    and a live ``running`` run is hung on a task nobody is working on. Only a
+    re-read under the lock is serialized against the reclaim.
+
+    The reclaim is injected at the moment the backfill asks for its
+    transaction — i.e. after the preflight has already read the task as
+    running, which is exactly the window that matters.
+    """
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    now = int(time.time())
+    with kb.connect(db_path=db_path) as conn:
+        tid = kb.create_task(conn, title="legacy in flight", assignee="worker")
+        conn.execute(
+            "UPDATE tasks SET status='running', current_run_id=NULL, "
+            "claim_lock=?, claim_expires=?, worker_pid=?, started_at=? "
+            "WHERE id=?",
+            ("host:1", now + 60, 4242, now, tid),
+        )
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    reclaimed: list[str] = []
+    real_write_txn = kb.write_txn
+
+    def reclaiming_write_txn(conn):
+        backfill = sys._getframe(1).f_code.co_name == "_migrate_add_optional_columns"
+        if backfill and not reclaimed:
+            # What release_stale_claims commits: the claim is dropped and the
+            # task goes back to ready, while current_run_id stays NULL.
+            conn.execute(
+                "UPDATE tasks SET status='ready', claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL WHERE id=?",
+                (tid,),
+            )
+            reclaimed.append(tid)
+        return real_write_txn(conn)
+
+    with unittest.mock.patch.object(kb, "write_txn", reclaiming_write_txn):
+        kb.connect(db_path=db_path).close()
+
+    assert reclaimed, "the backfill never opened its transaction — nothing was raced"
+    with kb.connect(db_path=db_path) as conn:
+        task = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id=?", (tid,)
+        ).fetchone()
+        runs = conn.execute(
+            "SELECT status FROM task_runs WHERE task_id=?", (tid,)
+        ).fetchall()
+    assert task["status"] == "ready"
+    assert task["current_run_id"] is None, (
+        "the backfill adopted a task the reclaim had already released"
+    )
+    assert [r["status"] for r in runs] == [], (
+        "the backfill synthesized a run for a task that is no longer running"
+    )
+
+
 # ---------------------------------------------------------------------------
 # First-use tip for scratch workspaces
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1356,6 +1356,110 @@ def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     assert "still here" in titles
 
 
+def _crash_a_writer(db_path: Path) -> None:
+    """Leave the board with an uncheckpointed WAL, the way a killed worker does.
+
+    The child exits via ``os._exit`` so nothing closes the connection: the
+    committed frames stay in ``-wal`` instead of being checkpointed away.
+    """
+    source = (
+        "import os, pathlib, sys\n"
+        f"sys.path.insert(0, {str(Path(kb.__file__).parents[1])!r})\n"
+        "from hermes_cli import kanban_db as kb\n"
+        f"conn = kb.connect(db_path=pathlib.Path({str(db_path)!r}))\n"
+        "kb.create_task(conn, title='committed by the crashed writer')\n"
+        "os._exit(0)\n"
+    )
+    subprocess.run([sys.executable, "-c", source], check=True, capture_output=True)
+
+
+def test_integrity_probe_does_not_rewrite_the_db_it_judges(tmp_path):
+    """The probe is a read: it must leave both the DB and its WAL byte-identical.
+
+    A read/write probe checkpoints the WAL into the main DB and unlinks the
+    sidecars when it closes. Two things follow, and neither is acceptable for a
+    diagnostic: opening a board to look at it rewrites it, and the
+    ``.corrupt.<sha>.bak`` quarantine taken further down
+    :func:`kb._guard_existing_db_is_healthy` no longer holds the bytes that
+    arrived. ``mode=ro`` still replays the WAL for the probe's own reads, so the
+    check itself sees exactly what it saw before — asserted here by reading the
+    crashed writer's committed row back afterwards.
+    """
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    _crash_a_writer(db_path)
+    wal = db_path.with_name(db_path.name + "-wal")
+    assert wal.exists() and wal.stat().st_size > 0, "expected an uncheckpointed WAL"
+    before = (db_path.read_bytes(), wal.read_bytes())
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb._guard_existing_db_is_healthy(db_path)
+
+    assert db_path.read_bytes() == before[0], "the probe rewrote the main DB"
+    assert wal.exists(), "the probe unlinked the WAL"
+    assert wal.read_bytes() == before[1], "the probe rewrote the WAL"
+    with kb.connect(db_path=db_path) as conn:
+        titles = [t.title for t in kb.list_tasks(conn)]
+    assert "committed by the crashed writer" in titles
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX directory modes are not enforced on NTFS")
+@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0,
+                    reason="root ignores the directory mode this test relies on")
+def test_probe_stands_aside_when_it_may_not_read(tmp_path):
+    """A directory the probe cannot write is not a damaged board.
+
+    A read-only open needs ``-shm`` to build the WAL index, and with the
+    sidecars gone it would have to create one in a directory it may not write.
+    That is not corruption and must not be quarantined as such: the probe steps
+    aside for the read/write open that follows, which reports its own failure.
+    """
+    board = tmp_path / "board"
+    board.mkdir()
+    db_path = board / "kanban.db"
+    kb.init_db(db_path=db_path)
+    for sidecar in ("-wal", "-shm"):
+        db_path.with_name(db_path.name + sidecar).unlink(missing_ok=True)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    board.chmod(0o500)
+    try:
+        # Precondition: this is the shape the stand-aside branch exists for.
+        with pytest.raises(sqlite3.OperationalError):
+            kb._sqlite_connect(db_path.resolve(), read_only=True).execute(
+                "PRAGMA integrity_check")
+        kb._guard_existing_db_is_healthy(db_path)
+    finally:
+        board.chmod(0o700)
+    assert list(board.glob("*.corrupt.*")) == [], "a healthy board was quarantined"
+
+
+def test_first_open_of_a_migrated_board_opens_no_write_transaction(tmp_path):
+    """The in-flight-run backfill is a migration, and migrations are rare.
+
+    It runs on every process's first open of a board, and on a board with
+    nothing in flight — which is nearly all of them, nearly always — it was
+    taking the write lock to adopt nothing.
+    """
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    boundaries: list[str] = []
+    real_sqlite_connect = kb._sqlite_connect
+
+    def tracing_connect(path, **kwargs):
+        conn = real_sqlite_connect(path, **kwargs)
+        conn.set_trace_callback(
+            lambda sql: boundaries.append(sql.strip())
+            if sql.strip().upper().startswith("BEGIN") else None
+        )
+        return conn
+
+    with unittest.mock.patch.object(kb, "_sqlite_connect", tracing_connect):
+        kb.connect(db_path=db_path).close()
+
+    assert boundaries == [], f"first open opened a transaction: {boundaries}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1356,6 +1356,24 @@ def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     assert "still here" in titles
 
 
+def _skip_unless_board_is_wal(db_path: Path) -> None:
+    """Skip when this SQLite build left the board in a rollback journal.
+
+    ``hermes_state`` refuses to enable WAL on builds carrying the WAL-reset
+    corruption bug and falls back to ``journal_mode=DELETE`` (it says so once
+    per process in the log). Such a board has no ``-wal`` to preserve and no
+    ``-shm`` a read-only open could fail to create, so the WAL behaviour these
+    tests pin down simply isn't in play — that is a skip, not a failure.
+    """
+    probe = sqlite3.connect(db_path)
+    try:
+        mode = probe.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        probe.close()
+    if str(mode).lower() != "wal":
+        pytest.skip(f"board is in journal_mode={mode}, not WAL; nothing to assert")
+
+
 def _crash_a_writer(db_path: Path) -> None:
     """Leave the board with an uncheckpointed WAL, the way a killed worker does.
 
@@ -1387,6 +1405,7 @@ def test_integrity_probe_does_not_rewrite_the_db_it_judges(tmp_path):
     """
     db_path = tmp_path / "kanban.db"
     kb.init_db(db_path=db_path)
+    _skip_unless_board_is_wal(db_path)
     _crash_a_writer(db_path)
     wal = db_path.with_name(db_path.name + "-wal")
     assert wal.exists() and wal.stat().st_size > 0, "expected an uncheckpointed WAL"
@@ -1419,6 +1438,7 @@ def test_probe_stands_aside_when_it_may_not_read(tmp_path):
     board.mkdir()
     db_path = board / "kanban.db"
     kb.init_db(db_path=db_path)
+    _skip_unless_board_is_wal(db_path)
     for sidecar in ("-wal", "-shm"):
         db_path.with_name(db_path.name + sidecar).unlink(missing_ok=True)
     kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))


### PR DESCRIPTION
Two things write while merely *opening* a kanban board, and neither needs to.
Both are on the first-open path in `hermes_cli/kanban_db.py`, so both run in
every process that touches a board — workers, the gateway dispatcher, the
dashboard, and plain `hermes kanban list`.

## 1. The integrity probe rewrites the file it is judging

`_guard_existing_db_is_healthy` opens its probe read/write. A read/write
handle checkpoints the WAL into the main database and unlinks `-wal`/`-shm`
when it closes, so a diagnostic that is supposed to *look* at the board
rewrites it instead.

Measured by calling `_guard_existing_db_is_healthy` once on a board whose
writer was killed mid-run (`os._exit`, so its commits are still in `-wal`) —
on `main`:

```
before probe: main-db sha256=171cf0a1f592  -wal = 45352 bytes
after  probe: main-db sha256=8f70da0429c5  -wal = gone
rows readable after the probe: ['committed by the crashed writer']
```

and with this change, same board, same check, same rows:

```
before probe: main-db sha256=171cf0a1f592  -wal = 45352 bytes
after  probe: main-db sha256=171cf0a1f592  -wal = 45352 bytes
rows readable after the probe: ['committed by the crashed writer']
```

Two consequences of the current behaviour:

- **Reading a board mutates it.** Every process's first open rewrites the main
  DB file and removes the sidecars — including commands whose whole job is to
  read. On a board with a hot WAL that is also the only copy of the writer's
  last commits being moved around by a process that was only asked to check
  integrity.
- **The corruption quarantine loses its evidence.** The code below the probe
  is explicit that the backup comes first — *"Quarantine FIRST — both the
  repair path and the fail-closed path preserve the pre-touch bytes before
  anything mutates the file"* — but the probe's `close()` has already run WAL
  recovery and a checkpoint by then. So on a board that fails
  `integrity_check`, `.corrupt.<sha>.bak` holds post-checkpoint bytes, not the
  bytes the operator had, and the content-addressed name is computed over
  those. If a damaged WAL is what did the damage, the probe has folded it into
  the copy that exists to diagnose it.

The fix is `mode=ro` for that one probe. `mode=ro` restricts the *database
file*, not the WAL index, so a read-only handle still replays a hot WAL for
its own reads — the check sees exactly what it saw before. The new test pins
that by reading the crashed writer's committed row back after the probe.

Where a read-only open genuinely cannot proceed — no `-shm` yet and a
directory it may not create one in — the probe stands aside for the
read/write open that immediately follows, rather than condemning a healthy
board. Everything else is unchanged and covered: a malformed image and a
non-database still raise `DatabaseError` and are still refused and
quarantined, a locked board still propagates raw with no `.corrupt` backup,
and the narrow index-only REINDEX repair still runs against its own
read/write connection.

`repair_db` (`hermes kanban repair`) deliberately keeps its read/write probe:
it is an explicit repair command, and a read-only refusal there would need to
mean something different from "skip" — worth a follow-up, but not a quiet
change to make inside this one.

## 2. The in-flight-run backfill takes the write lock to adopt nothing

The one-shot backfill in `_migrate_add_optional_columns` — adopting `running`
cards that predate `task_runs` by synthesising a run row — opened its
`write_txn` before looking for candidates. That pass runs on every process's
first open of a board, so on any board migrated more than once (that is,
effectively all of them, effectively always) it was a `BEGIN IMMEDIATE` /
`COMMIT` per process to do nothing.

It searches first now, and opens the transaction only when there is something
to adopt. The adoption is unchanged; the race with a live dispatcher claiming
a card between the search and the adoption was already handled by the
`current_run_id IS NULL` compare-and-set that retires the loser's run row —
that CAS now carries the race instead of the transaction.

## Tests

Three new tests in `tests/hermes_cli/test_kanban_db.py`:

- `test_integrity_probe_does_not_rewrite_the_db_it_judges` — crashes a real
  writer in a child process (`os._exit`, so `-wal` stays hot), then compares
  the bytes of both files across the probe and reads the crashed writer's row
  back. Fails on `main` with *"the probe rewrote the main DB"*.
- `test_first_open_of_a_migrated_board_opens_no_write_transaction` — traces
  transaction boundaries during a first open. Fails on `main` with
  *"first open opened a transaction: ['BEGIN IMMEDIATE']"*.
- `test_probe_stands_aside_when_it_may_not_read` — a board in a directory the
  probe may not write is not a damaged board and must not be quarantined.
  Skipped on Windows and under root.

Run: `pytest tests/hermes_cli/test_kanban_db.py` — 32 passed, 1 pre-existing
failure in my sandbox (`test_resolve_hermes_argv_module_actually_runs`, which
shells out to `python -m hermes_cli.main` and hits missing optional
dependencies; it fails identically on unmodified `main`). Across the 44
kanban/sqlite/WAL test files the failure set is byte-identical before and
after this change.

## Not in this PR

Two adjacent observations from the same read, both left alone deliberately:

- A first open of a migrated board still issues writes after this change:
  `executescript(SCHEMA_SQL)`, the three unconditional event-kind rename
  `UPDATE`s (`ready`→`promoted`, `priority`→`reprioritized`,
  `spawn_auto_blocked`→`gave_up`), and `_rebuild_drifted_tables`. The renames
  in particular match zero rows on any board that has been opened once and
  could be gated by the same search-before-you-write shape used here. That
  would make "opening a board writes nothing" an actual invariant worth a
  test; it is a bigger change than this one and belongs to whoever owns the
  migration pass.
- Adopting in-flight runs is arguably not open-time work at all. A dispatcher
  tick would do it once for the whole host instead of once per process, and
  the open path would lose its last reason to know about `task_runs`.