### PR TITLE
feat(models): refresh OpenRouter + Nous curated catalogs (Aug 2026)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -60,16 +60,24 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Google
     ("google/gemini-3.1-pro-preview",          ""),
     ("google/gemini-3.6-flash",                ""),
+    ("google/gemini-3.5-flash",                ""),
+    ("google/gemini-3.5-flash-lite",           ""),
     # xAI
     ("x-ai/grok-4.5",                          ""),
+    ("x-ai/grok-build-0.1",                    ""),
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),
     ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
     ("qwen/qwen3.7-max",                       ""),
+    ("qwen/qwen3.7-plus",                      ""),
+    ("qwen/qwen3.7-flash",                     ""),
+    ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
     ("moonshotai/kimi-k3",                     "recommended"),
+    ("moonshotai/kimi-k2.6",                   ""),
+    ("moonshotai/kimi-k2.7-code",              ""),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
@@ -83,17 +91,22 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
+    ("nvidia/nemotron-3-ultra-550b-a55b",      ""),
+    # Thinking Machines
+    ("thinkingmachines/inkling",               ""),
+    # Meta
+    ("meta/muse-spark-1.1",                    ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
+    # Poolside
+    ("poolside/laguna-s-2.1",                  ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
-    ("openrouter/elephant-alpha",              "free"),
-    ("poolside/laguna-m.1:free",               "free"),
-    ("tencent/hy3:free",                       "free"),
+    ("poolside/laguna-s-2.1:free",             "free"),
+    ("inclusionai/ling-3.0-flash:free",        "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
-    ("inclusionai/ring-2.6-1t:free",           "free"),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
@@ -232,16 +245,24 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # Google
         "google/gemini-3.1-pro-preview",
         "google/gemini-3.6-flash",
+        "google/gemini-3.5-flash",
+        "google/gemini-3.5-flash-lite",
         # xAI
         "x-ai/grok-4.5",
+        "x-ai/grok-build-0.1",
         # DeepSeek
         "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-0731",
         # Qwen
         "qwen/qwen3.7-max",
+        "qwen/qwen3.7-plus",
+        "qwen/qwen3.7-flash",
+        "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
         "moonshotai/kimi-k3",
+        "moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k2.7-code",
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
@@ -255,8 +276,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "stepfun/step-3.7-flash",
         # NVIDIA
         "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia/nemotron-3-ultra-550b-a55b",
+        # Thinking Machines
+        "thinkingmachines/inkling",
+        # Meta
+        "meta/muse-spark-1.1",
         # Sakana
         "sakana/fugu-ultra",
+        # Poolside
+        "poolside/laguna-s-2.1",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-31T15:41:39Z",
+  "updated_at": "2026-08-01T16:02:19Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -85,7 +85,19 @@
           "description": ""
         },
         {
+          "id": "google/gemini-3.5-flash",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-3.5-flash-lite",
+          "description": ""
+        },
+        {
           "id": "x-ai/grok-4.5",
+          "description": ""
+        },
+        {
+          "id": "x-ai/grok-build-0.1",
           "description": ""
         },
         {
@@ -105,8 +117,28 @@
           "description": ""
         },
         {
+          "id": "qwen/qwen3.7-plus",
+          "description": ""
+        },
+        {
+          "id": "qwen/qwen3.7-flash",
+          "description": ""
+        },
+        {
+          "id": "qwen/qwen3.6-35b-a3b",
+          "description": ""
+        },
+        {
           "id": "moonshotai/kimi-k3",
           "description": "recommended"
+        },
+        {
+          "id": "moonshotai/kimi-k2.6",
+          "description": ""
+        },
+        {
+          "id": "moonshotai/kimi-k2.7-code",
+          "description": ""
         },
         {
           "id": "minimax/minimax-m3",
@@ -138,7 +170,23 @@
           "description": ""
         },
         {
+          "id": "nvidia/nemotron-3-ultra-550b-a55b",
+          "description": ""
+        },
+        {
+          "id": "thinkingmachines/inkling",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.1",
+          "description": ""
+        },
+        {
           "id": "sakana/fugu-ultra",
+          "description": ""
+        },
+        {
+          "id": "poolside/laguna-s-2.1",
           "description": ""
         },
         {
@@ -146,15 +194,11 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
-          "id": "openrouter/elephant-alpha",
+          "id": "poolside/laguna-s-2.1:free",
           "description": "free"
         },
         {
-          "id": "poolside/laguna-m.1:free",
-          "description": "free"
-        },
-        {
-          "id": "tencent/hy3:free",
+          "id": "inclusionai/ling-3.0-flash:free",
           "description": "free"
         },
         {
@@ -163,10 +207,6 @@
         },
         {
           "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
-          "description": "free"
-        },
-        {
-          "id": "inclusionai/ring-2.6-1t:free",
           "description": "free"
         }
       ]
@@ -226,7 +266,16 @@
           "id": "google/gemini-3.6-flash"
         },
         {
+          "id": "google/gemini-3.5-flash"
+        },
+        {
+          "id": "google/gemini-3.5-flash-lite"
+        },
+        {
           "id": "x-ai/grok-4.5"
+        },
+        {
+          "id": "x-ai/grok-build-0.1"
         },
         {
           "id": "deepseek/deepseek-v4-pro"
@@ -241,7 +290,22 @@
           "id": "qwen/qwen3.7-max"
         },
         {
+          "id": "qwen/qwen3.7-plus"
+        },
+        {
+          "id": "qwen/qwen3.7-flash"
+        },
+        {
+          "id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
           "id": "moonshotai/kimi-k3"
+        },
+        {
+          "id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "id": "moonshotai/kimi-k2.7-code"
         },
         {
           "id": "minimax/minimax-m3"
@@ -266,7 +330,19 @@
           "id": "nvidia/nemotron-3-super-120b-a12b"
         },
         {
+          "id": "nvidia/nemotron-3-ultra-550b-a55b"
+        },
+        {
+          "id": "thinkingmachines/inkling"
+        },
+        {
+          "id": "meta/muse-spark-1.1"
+        },
+        {
           "id": "sakana/fugu-ultra"
+        },
+        {
+          "id": "poolside/laguna-s-2.1"
         }
       ]
     }


### PR DESCRIPTION
Pulled the current OpenRouter /api/v1/models catalog (336 live models) and refreshed the curated picker lists against live pricing + tool-calling support.

**Adds** (all verified live with tool calling):
- Google: gemini-3.5-flash, gemini-3.5-flash-lite
- xAI: grok-build-0.1
- Qwen: qwen3.7-plus, qwen3.7-flash, qwen3.6-35b-a3b
- Moonshot: kimi-k2.6, kimi-k2.7-code
- NVIDIA: nemotron-3-ultra-550b-a55b
- Thinking Machines: inkling
- Meta: muse-spark-1.1
- Poolside: laguna-s-2.1 (+ free variant)
- inclusionai/ling-3.0-flash:free

**Removes** (no longer served by OpenRouter):
- openrouter/elephant-alpha, poolside/laguna-m.1:free, tencent/hy3:free, inclusionai/ring-2.6-1t:free

The GPT-5.6 family (sol/terra/luna + pro variants) and Claude Opus 5 are already in the list — kept as-is.

`model-catalog.json` regenerated via `scripts/build_model_catalog.py` (49 OpenRouter + 42 Nous entries). Tests: model_catalog, model_validation, gpt56_registration pass (the 5 test_api_key_providers failures reproduce on clean origin/main — pre-existing env issue).