### PR TITLE
fix(dingtalk): send plain-text messages as text type instead of markdown card

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -139,7 +139,20 @@ EXT_MAP = {
 
 # Detect markdown formatting — if absent, send as plain text (no title needed).
 _DINGTALK_MARKDOWN_RE = re.compile(
-    r"(^#{1,6}\s)|(^[\s]*[-*]\s)|(^[\s]*\d+\.\s)|(^[\s]*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    # Pipe table: any header line + separator line both starting with '|'.
+    r"(^\|.*\|\s*\n\|[-:|\s]+\|)"
+    r"|(^#{1,6}\s)"
+    r"|(^[\s]*[-*]\s)"
+    r"|(^[\s]*\d+\.\s)"
+    r"|(^[\s]*---+\s*$)"
+    r"|(```)"
+    r"|(`[^`\n]+`)"
+    r"|(\*\*[^*\n].+?\*\*)"
+    r"|(~~[^~\n].+?~~)"
+    r"|(<u>.+?</u>)"
+    r"|(\*[^*\n]+\*)"
+    r"|(\[[^\]]+\]\([^)]+\))"
+    r"|(^>\s)",
     re.MULTILINE,
 )
 

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -137,6 +137,12 @@ EXT_MAP = {
     "mp4": "video/mp4",
 }
 
+# Detect markdown formatting — if absent, send as plain text (no title needed).
+_DINGTALK_MARKDOWN_RE = re.compile(
+    r"(^#{1,6}\s)|(^[\s]*[-*]\s)|(^[\s]*\d+\.\s)|(^[\s]*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    re.MULTILINE,
+)
+
 
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured.
@@ -1036,10 +1042,20 @@ class DingTalkAdapter(BasePlatformAdapter):
         # Normalize markdown for DingTalk
         normalized = self._normalize_markdown(content[: self.MAX_MESSAGE_LENGTH])
 
-        payload = {
-            "msgtype": "markdown",
-            "markdown": {"title": "Hermes", "text": normalized},
-        }
+        # If the content is plain text (no markdown), send as text type
+        # so DingTalk doesn't force a card title on it — same approach as Feishu.
+        if _DINGTALK_MARKDOWN_RE.search(normalized):
+            _first_line = (normalized.split('\n')[0] or "").strip()
+            _title = _first_line[:30] if _first_line else "消息"
+            payload = {
+                "msgtype": "markdown",
+                "markdown": {"title": _title, "text": normalized},
+            }
+        else:
+            payload = {
+                "msgtype": "text",
+                "text": {"content": normalized},
+            }
 
         try:
             resp = await self._http_client.post(

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -163,9 +163,79 @@ class TestSend:
         call_args = mock_client.post.call_args
         assert call_args[0][0] == "https://dingtalk.example/webhook"
         payload = call_args[1]["json"]
+        # Plain text (no markdown) is sent as a text message, not a card.
+        assert payload["msgtype"] == "text"
+        assert payload["text"]["content"] == "Hello!"
+
+    @pytest.mark.asyncio
+    async def test_send_markdown_uses_markdown_card_with_derived_title(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+
+        result = await adapter.send(
+            "chat-123", "**Important** update",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"}
+        )
+        assert result.success is True
+        payload = mock_client.post.call_args[1]["json"]
         assert payload["msgtype"] == "markdown"
-        assert payload["markdown"]["title"] == "Hermes"
-        assert payload["markdown"]["text"] == "Hello!"
+        assert payload["markdown"]["title"] == "**Important** update"
+        assert payload["markdown"]["text"] == "**Important** update"
+
+    @pytest.mark.asyncio
+    async def test_send_table_only_markdown_uses_markdown_card(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+
+        table = "| Name | Score |\n|------|-------|\n| A    | 10    |"
+        result = await adapter.send(
+            "chat-123", table,
+            metadata={"session_webhook": "https://dingtalk.example/webhook"}
+        )
+        assert result.success is True
+        payload = mock_client.post.call_args[1]["json"]
+        # Pipe tables must be detected as markdown, not sent as plain text.
+        assert payload["msgtype"] == "markdown"
+        assert payload["markdown"]["text"] == table
+
+    @pytest.mark.asyncio
+    async def test_send_markdown_title_truncated_to_first_line(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+
+        content = "First line here\n\nSome **bold** body text below."
+        result = await adapter.send(
+            "chat-123", content,
+            metadata={"session_webhook": "https://dingtalk.example/webhook"}
+        )
+        assert result.success is True
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["msgtype"] == "markdown"
+        assert payload["markdown"]["title"] == "First line here"
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When Hermes replies to a DingTalk chat with a plain-text message (no markdown formatting), the adapter currently wraps it in a markdown card with a generic `Hermes` title. For simple text replies this looks noisy and clunky.

This PR detects whether the normalized content actually contains markdown formatting. If it does, it sends a markdown message as before; if not, it falls back to `msgtype='text'` so plain replies arrive as clean text — mirroring the approach already used by the Feishu adapter.

Additionally, when markdown IS used, the card title is now derived from the first line of the content (truncated to 30 chars) instead of a hardcoded `Hermes` label.

## Changes

- Add `_DINGTALK_MARKDOWN_RE` regex to detect markdown constructs (headings, lists, code blocks, bold/italic, links, blockquotes, etc.)
- In `send_message`, branch on whether the normalized content matches:
  - Markdown present → `msgtype: markdown` with a first-line-derived title
  - No markdown → `msgtype: text` with plain content

## Motivation

- Plain replies get a cleaner presentation in DingTalk (no forced card title)
- Card titles reflect actual content instead of a hardcoded `Hermes`
- Consistent behavior with the Feishu adapter's plain-text handling

## Testing

- Verified locally: plain-text replies arrive as `msgtype='text'`, markdown replies keep `msgtype='markdown'` with a content-derived title
- Syntax/import checks pass