### PR TITLE
fix: add creationflags to plugins subprocess calls (Windows console flash)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3814,6 +3814,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _probe_audio_duration_seconds(self, audio_path: str) -> Optional[float]:
         """Best-effort audio duration probe used to size playback timeouts."""
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         try:
             import importlib
             mutagen = importlib.import_module("mutagen")
@@ -3838,6 +3840,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 text=True,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if proc.returncode == 0:
                 raw = (proc.stdout or "").strip()

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -151,6 +151,8 @@ def _matrix_voice_metadata_for_file(path: Path) -> Dict[str, Any]:
     extraction is deliberately best-effort: media delivery must still work on
     systems without ffprobe/ffmpeg.
     """
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
     metadata: Dict[str, Any] = {}
 
     ffprobe = shutil.which("ffprobe")
@@ -171,6 +173,7 @@ def _matrix_voice_metadata_for_file(path: Path) -> Dict[str, Any]:
                 text=True,
                 timeout=10,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0:
                 duration = float((result.stdout or "").strip() or 0)
@@ -200,6 +203,7 @@ def _matrix_voice_metadata_for_file(path: Path) -> Dict[str, Any]:
                 capture_output=True,
                 timeout=15,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0 and result.stdout:
                 samples = array.array("h")
@@ -228,6 +232,8 @@ def _matrix_transcode_voice_to_ogg(path: str) -> Optional[str]:
     original file, matching the adapter's previous behaviour. Runs blocking
     subprocess work; call via ``asyncio.to_thread`` from async code.
     """
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
     ffmpeg = shutil.which("ffmpeg")
     if not ffmpeg:
         return None
@@ -261,6 +267,7 @@ def _matrix_transcode_voice_to_ogg(path: str) -> Optional[str]:
             capture_output=True,
             timeout=30,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode == 0 and os.path.getsize(ogg_path) > 0:
             return ogg_path

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -869,6 +869,7 @@ class SimplexAdapter(BasePlatformAdapter):
         """
         import subprocess
         import tempfile
+        from hermes_cli._subprocess_compat import windows_hide_flags
 
         p = Path(file_path)
         png_path = file_path
@@ -900,6 +901,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         check=True,
                         capture_output=True,
                         timeout=30,
+                        creationflags=windows_hide_flags(),
                     )
                 with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
                     tmp_path = tmp.name
@@ -916,6 +918,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     check=True,
                     capture_output=True,
                     timeout=30,
+                    creationflags=windows_hide_flags(),
                 )
                 with open(tmp_path, "rb") as f:
                     thumb_uri = (


### PR DESCRIPTION
## Summary

Three plugin adapters have non-interactive subprocess calls (ffprobe, ffmpeg, ImageMagick convert) missing CREATE_NO_WINDOW on Windows. Without it, each subprocess spawns a visible console window that flashes.

## Changes

| File | Calls | Tool |
|------|-------|------|
| plugins/platforms/matrix/adapter.py | 3 | ffprobe duration, ffmpeg PCM, ffmpeg Ogg/Opus |
| plugins/platforms/discord/adapter.py | 1 | ffprobe duration probe |
| plugins/platforms/simplex/adapter.py | 2 | ImageMagick convert (format + thumbnail) |

## Fix

Import windows_hide_flags() from hermes_cli._subprocess_compat (local import, same pattern as #65660) and pass creationflags=windows_hide_flags() to each subprocess.run() call. The helper returns 0x08000000 (CREATE_NO_WINDOW) on Windows and 0 elsewhere.

## Related

- Supersedes #65660 (closed, covered telegram/voice_mixer/raft but missed matrix, discord/adapter, simplex)