### PR TITLE
fix(auth): transient read failures on auth.json must not be treated as corruption

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1367,7 +1367,11 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         raise
     except Exception as exc:
         # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
-        corrupt_path = auth_file.with_suffix(".json.corrupt")
+        # Timestamp the backup so a second corruption event (e.g. a stray
+        # write racing this read) can't silently clobber a prior backup that
+        # might still hold recoverable data.
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        corrupt_path = auth_file.with_name(f"{auth_file.name}.corrupt.{timestamp}")
         preserved = False
         try:
             import shutil

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -109,6 +109,25 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+# Internal-only key stamped onto an in-memory store dict that was created as
+# a *load-failure* fallback (genuine JSON/schema corruption after a
+# successful read) rather than an explicit user action (fresh install,
+# ``hermes auth logout``, etc.). ``_save_auth_store`` refuses to persist a
+# store carrying this marker while ``providers`` is still empty, so a load
+# failure alone can never flush an empty store over real on-disk credentials.
+# Any caller that legitimately mutates the store (adds/removes a provider,
+# writes credential_pool entries, ...) clears the marker before saving.
+_LOAD_FAILURE_MARKER = "__load_failure_fallback__"
+
+
+class AuthStoreWriteGuardError(RuntimeError):
+    """Raised when a write path tries to persist an unsafe empty auth store.
+
+    Specifically: an in-memory store that was only ever created as a
+    load-failure fallback (see ``_LOAD_FAILURE_MARKER``) and never received
+    a real provider or credential_pool entry from an explicit user action.
+    """
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1395,7 +1414,16 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
                 "A copy could NOT be preserved at %s",
                 auth_file, exc, corrupt_path,
             )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        # Mark this store as a load-failure fallback, not a user-created empty
+        # store. _save_auth_store() refuses to persist it while it is still
+        # empty, so a load failure alone can never flush and erase real
+        # on-disk credentials; only an explicit subsequent write (e.g. the
+        # user re-authenticating) clears the marker.
+        return {
+            "version": AUTH_STORE_VERSION,
+            "providers": {},
+            _LOAD_FAILURE_MARKER: True,
+        }
 
     if isinstance(raw, dict) and (
         isinstance(raw.get("providers"), dict)
@@ -1419,6 +1447,29 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+    # Invariant: a store that only exists because a *load* failed (genuine
+    # JSON/schema corruption; never a transient OSError, which raises before
+    # a store like this is ever constructed — see _load_auth_store) must
+    # never be flushed to disk while it is still empty. Doing so would take
+    # a real, merely-unparseable auth.json and permanently replace it with
+    # nothing. The marker is cleared implicitly the moment a caller adds a
+    # real provider or credential_pool entry, since the store is then no
+    # longer empty and this guard no longer applies.
+    if auth_store.get(_LOAD_FAILURE_MARKER) and not auth_store.get(
+        "providers"
+    ) and not auth_store.get("credential_pool"):
+        logger.error(
+            "auth: refusing to write an empty auth store that originated "
+            "from a load failure (target=%s); on-disk credentials, if any, "
+            "were left untouched",
+            target_path if target_path is not None else _auth_file_path(),
+        )
+        raise AuthStoreWriteGuardError(
+            "refusing to persist an empty auth store created as a load-"
+            "failure fallback; this would silently delete any existing "
+            "on-disk credentials"
+        )
+    auth_store.pop(_LOAD_FAILURE_MARKER, None)
     # target_path=None preserves the existing contract (write the active
     # store at _auth_file_path()). An explicit path lets callers persist a
     # specific store — e.g. the global-root write-through for rotating xAI

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1364,6 +1364,97 @@ def _auth_store_lock(
         yield
 
 
+_CORRUPT_AUTH_BACKUP_RETENTION = 10
+
+
+def _prune_corrupt_auth_backups(
+    parent: Path, base_name: str, keep: Optional[Path] = None,
+) -> None:
+    """Cap the number of retained ``auth.json.corrupt.<hash>.bak`` files.
+
+    Content-addressing dedupes identical corrupt bytes, but a store whose
+    bytes keep changing between corruption events (a partial repair, ongoing
+    damage, a fleet of profiles racing the same file) can still accumulate
+    backups without bound. After creating a new backup we keep only the
+    ``_CORRUPT_AUTH_BACKUP_RETENTION`` most recent by mtime and delete the
+    rest. ``keep`` (the just-created backup) is never pruned regardless of its
+    mtime, because ``shutil.copy2`` preserves the SOURCE file's timestamp,
+    which may well be older than existing backups.
+
+    Best effort: pruning failures must never mask the corruption the caller is
+    already reporting.
+    """
+    try:
+        backups = [
+            candidate
+            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
+            if candidate.is_file() and candidate != keep
+        ]
+    except OSError:
+        return
+    budget = _CORRUPT_AUTH_BACKUP_RETENTION - (1 if keep is not None else 0)
+    budget = max(budget, 0)
+    if len(backups) <= budget:
+        return
+
+    def _mtime(item: Path) -> float:
+        try:
+            return item.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    backups.sort(key=_mtime, reverse=True)
+    for stale in backups[budget:]:
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _backup_corrupt_auth_store(auth_file: Path) -> Optional[Path]:
+    """Copy a corrupt auth store to a content-addressed backup.
+
+    The filename is deterministic in the file's sha256, so repeated loads of
+    the same corrupt bytes reuse a single backup rather than minting a new
+    copy per read. Returns the backup path, or ``None`` when no copy could be
+    written (the caller then declines to advertise one).
+
+    Writes are confined to the store's own parent directory and the basename
+    is derived purely from ``auth_file.name`` plus a hex digest, so no
+    caller-supplied path segment can escape it.
+    """
+    try:
+        resolved = auth_file.resolve()
+        parent = resolved.parent
+        base_name = resolved.name
+
+        digest = hashlib.sha256()
+        with resolved.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        token = digest.hexdigest()[:16]
+
+        candidate = parent / f"{base_name}.corrupt.{token}.bak"
+        # Defensive: the constructed path must still sit inside parent.
+        if candidate.parent != parent:
+            return None
+        if candidate.exists():
+            # Same bytes already preserved — reuse it, write nothing.
+            return candidate
+        shutil.copy2(resolved, candidate)
+    except Exception:
+        logger.debug(
+            "auth: could not preserve a copy of the corrupt store for %s",
+            auth_file, exc_info=True,
+        )
+        return None
+
+    # A NEW backup landed on disk — enforce the retention cap so a
+    # mutating-corruption loop cannot accumulate quarantines forever.
+    _prune_corrupt_auth_backups(parent, base_name, keep=candidate)
+    return candidate
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1386,21 +1477,20 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         raise
     except Exception as exc:
         # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
-        # Timestamp the backup so a second corruption event (e.g. a stray
-        # write racing this read) can't silently clobber a prior backup that
-        # might still hold recoverable data.
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        corrupt_path = auth_file.with_name(f"{auth_file.name}.corrupt.{timestamp}")
-        preserved = False
-        try:
-            import shutil
-            shutil.copy2(auth_file, corrupt_path)
-            preserved = True
-        except Exception:
-            logger.debug(
-                "auth: could not preserve a copy of the corrupt store at %s",
-                corrupt_path, exc_info=True,
-            )
+        # Preserve a copy under a CONTENT-ADDRESSED name. This function leaves
+        # the corrupt auth.json in place, so every later load of the same bad
+        # bytes reaches this branch again; a unique-per-attempt (e.g.
+        # timestamped) name would therefore mint a fresh copy on every single
+        # read and amplify disk usage without bound. Hashing the bytes means
+        # repeated quarantines of UNCHANGED corruption reuse one backup, while
+        # bytes that actually change — a partial repair, further damage —
+        # still get their own preserved copy.
+        #
+        # Mirrors the retention design already used for corrupt kanban
+        # databases in hermes_cli/kanban_db.py (_backup_corrupt_db /
+        # _prune_corrupt_backups).
+        corrupt_path = _backup_corrupt_auth_store(auth_file)
+        preserved = corrupt_path is not None
         if preserved:
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
@@ -1411,8 +1501,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             # Do not advertise a backup that was never written.
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
-                "A copy could NOT be preserved at %s",
-                auth_file, exc, corrupt_path,
+                "A copy could NOT be preserved.",
+                auth_file, exc,
             )
         # Mark this store as a load-failure fallback, not a user-created empty
         # store. _save_auth_store() refuses to persist it while it is still

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1136,6 +1136,97 @@ def _auth_store_lock(
         yield
 
 
+_CORRUPT_AUTH_BACKUP_RETENTION = 10
+
+
+def _prune_corrupt_auth_backups(
+    parent: Path, base_name: str, keep: Optional[Path] = None,
+) -> None:
+    """Cap the number of retained ``auth.json.corrupt.<hash>.bak`` files.
+
+    Content-addressing dedupes identical corrupt bytes, but a store whose
+    bytes keep changing between corruption events (a partial repair, ongoing
+    damage, a fleet of profiles racing the same file) can still accumulate
+    backups without bound. After creating a new backup we keep only the
+    ``_CORRUPT_AUTH_BACKUP_RETENTION`` most recent by mtime and delete the
+    rest. ``keep`` (the just-created backup) is never pruned regardless of its
+    mtime, because ``shutil.copy2`` preserves the SOURCE file's timestamp,
+    which may well be older than existing backups.
+
+    Best effort: pruning failures must never mask the corruption the caller is
+    already reporting.
+    """
+    try:
+        backups = [
+            candidate
+            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
+            if candidate.is_file() and candidate != keep
+        ]
+    except OSError:
+        return
+    budget = _CORRUPT_AUTH_BACKUP_RETENTION - (1 if keep is not None else 0)
+    budget = max(budget, 0)
+    if len(backups) <= budget:
+        return
+
+    def _mtime(item: Path) -> float:
+        try:
+            return item.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    backups.sort(key=_mtime, reverse=True)
+    for stale in backups[budget:]:
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _backup_corrupt_auth_store(auth_file: Path) -> Optional[Path]:
+    """Copy a corrupt auth store to a content-addressed backup.
+
+    The filename is deterministic in the file's sha256, so repeated loads of
+    the same corrupt bytes reuse a single backup rather than minting a new
+    copy per read. Returns the backup path, or ``None`` when no copy could be
+    written (the caller then declines to advertise one).
+
+    Writes are confined to the store's own parent directory and the basename
+    is derived purely from ``auth_file.name`` plus a hex digest, so no
+    caller-supplied path segment can escape it.
+    """
+    try:
+        resolved = auth_file.resolve()
+        parent = resolved.parent
+        base_name = resolved.name
+
+        digest = hashlib.sha256()
+        with resolved.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        token = digest.hexdigest()[:16]
+
+        candidate = parent / f"{base_name}.corrupt.{token}.bak"
+        # Defensive: the constructed path must still sit inside parent.
+        if candidate.parent != parent:
+            return None
+        if candidate.exists():
+            # Same bytes already preserved — reuse it, write nothing.
+            return candidate
+        shutil.copy2(resolved, candidate)
+    except Exception:
+        logger.debug(
+            "auth: could not preserve a copy of the corrupt store for %s",
+            auth_file, exc_info=True,
+        )
+        return None
+
+    # A NEW backup landed on disk — enforce the retention cap so a
+    # mutating-corruption loop cannot accumulate quarantines forever.
+    _prune_corrupt_auth_backups(parent, base_name, keep=candidate)
+    return candidate
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1158,21 +1249,20 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         raise
     except Exception as exc:
         # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
-        # Timestamp the backup so a second corruption event (e.g. a stray
-        # write racing this read) can't silently clobber a prior backup that
-        # might still hold recoverable data.
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        corrupt_path = auth_file.with_name(f"{auth_file.name}.corrupt.{timestamp}")
-        preserved = False
-        try:
-            import shutil
-            shutil.copy2(auth_file, corrupt_path)
-            preserved = True
-        except Exception:
-            logger.debug(
-                "auth: could not preserve a copy of the corrupt store at %s",
-                corrupt_path, exc_info=True,
-            )
+        # Preserve a copy under a CONTENT-ADDRESSED name. This function leaves
+        # the corrupt auth.json in place, so every later load of the same bad
+        # bytes reaches this branch again; a unique-per-attempt (e.g.
+        # timestamped) name would therefore mint a fresh copy on every single
+        # read and amplify disk usage without bound. Hashing the bytes means
+        # repeated quarantines of UNCHANGED corruption reuse one backup, while
+        # bytes that actually change — a partial repair, further damage —
+        # still get their own preserved copy.
+        #
+        # Mirrors the retention design already used for corrupt kanban
+        # databases in hermes_cli/kanban_db.py (_backup_corrupt_db /
+        # _prune_corrupt_backups).
+        corrupt_path = _backup_corrupt_auth_store(auth_file)
+        preserved = corrupt_path is not None
         if preserved:
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
@@ -1183,8 +1273,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             # Do not advertise a backup that was never written.
             logger.warning(
                 "auth: failed to parse %s (%s), starting with empty store. "
-                "A copy could NOT be preserved at %s",
-                auth_file, exc, corrupt_path,
+                "A copy could NOT be preserved.",
+                auth_file, exc,
             )
         # Mark this store as a load-failure fallback, not a user-created empty
         # store. _save_auth_store() refuses to persist it while it is still

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -71,6 +71,25 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+# Internal-only key stamped onto an in-memory store dict that was created as
+# a *load-failure* fallback (genuine JSON/schema corruption after a
+# successful read) rather than an explicit user action (fresh install,
+# ``hermes auth logout``, etc.). ``_save_auth_store`` refuses to persist a
+# store carrying this marker while ``providers`` is still empty, so a load
+# failure alone can never flush an empty store over real on-disk credentials.
+# Any caller that legitimately mutates the store (adds/removes a provider,
+# writes credential_pool entries, ...) clears the marker before saving.
+_LOAD_FAILURE_MARKER = "__load_failure_fallback__"
+
+
+class AuthStoreWriteGuardError(RuntimeError):
+    """Raised when a write path tries to persist an unsafe empty auth store.
+
+    Specifically: an in-memory store that was only ever created as a
+    load-failure fallback (see ``_LOAD_FAILURE_MARKER``) and never received
+    a real provider or credential_pool entry from an explicit user action.
+    """
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1167,7 +1186,16 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
                 "A copy could NOT be preserved at %s",
                 auth_file, exc, corrupt_path,
             )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        # Mark this store as a load-failure fallback, not a user-created empty
+        # store. _save_auth_store() refuses to persist it while it is still
+        # empty, so a load failure alone can never flush and erase real
+        # on-disk credentials; only an explicit subsequent write (e.g. the
+        # user re-authenticating) clears the marker.
+        return {
+            "version": AUTH_STORE_VERSION,
+            "providers": {},
+            _LOAD_FAILURE_MARKER: True,
+        }
 
     if isinstance(raw, dict) and (
         isinstance(raw.get("providers"), dict)
@@ -1191,6 +1219,29 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+    # Invariant: a store that only exists because a *load* failed (genuine
+    # JSON/schema corruption; never a transient OSError, which raises before
+    # a store like this is ever constructed — see _load_auth_store) must
+    # never be flushed to disk while it is still empty. Doing so would take
+    # a real, merely-unparseable auth.json and permanently replace it with
+    # nothing. The marker is cleared implicitly the moment a caller adds a
+    # real provider or credential_pool entry, since the store is then no
+    # longer empty and this guard no longer applies.
+    if auth_store.get(_LOAD_FAILURE_MARKER) and not auth_store.get(
+        "providers"
+    ) and not auth_store.get("credential_pool"):
+        logger.error(
+            "auth: refusing to write an empty auth store that originated "
+            "from a load failure (target=%s); on-disk credentials, if any, "
+            "were left untouched",
+            target_path if target_path is not None else _auth_file_path(),
+        )
+        raise AuthStoreWriteGuardError(
+            "refusing to persist an empty auth store created as a load-"
+            "failure fallback; this would silently delete any existing "
+            "on-disk credentials"
+        )
+    auth_store.pop(_LOAD_FAILURE_MARKER, None)
     # target_path=None preserves the existing contract (write the active
     # store at _auth_file_path()). An explicit path lets callers persist a
     # specific store — e.g. the global-root write-through for rotating xAI

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1139,7 +1139,11 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         raise
     except Exception as exc:
         # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
-        corrupt_path = auth_file.with_suffix(".json.corrupt")
+        # Timestamp the backup so a second corruption event (e.g. a stray
+        # write racing this read) can't silently clobber a prior backup that
+        # might still hold recoverable data.
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        corrupt_path = auth_file.with_name(f"{auth_file.name}.corrupt.{timestamp}")
         preserved = False
         try:
             import shutil

--- a/tests/hermes_cli/test_auth_store_read_failure.py
+++ b/tests/hermes_cli/test_auth_store_read_failure.py
@@ -64,7 +64,7 @@ def test_read_failure_raises_and_leaves_the_store_alone(store_file, monkeypatch,
     )
 
 
-def test_unparseable_json_still_degrades_and_preserves_a_timestamped_copy(store_file):
+def test_unparseable_json_still_degrades_and_preserves_a_copy(store_file):
     store_file.write_text("{ not json", encoding="utf-8")
 
     result = auth._load_auth_store(store_file)
@@ -72,28 +72,72 @@ def test_unparseable_json_still_degrades_and_preserves_a_timestamped_copy(store_
     assert result["version"] == auth.AUTH_STORE_VERSION
     assert result["providers"] == {}
     matches = glob.glob(str(store_file) + ".corrupt.*")
-    assert len(matches) == 1, "genuine corruption must still be preserved, timestamped"
+    assert len(matches) == 1, "genuine corruption must still be preserved"
     corrupt = matches[0]
     assert not corrupt.endswith(".corrupt"), (
-        "backup filename must be timestamped, not the old fixed auth.json.corrupt"
+        "backup filename must be content-addressed, not the old fixed auth.json.corrupt"
     )
+    assert corrupt.endswith(".bak")
     with open(corrupt, encoding="utf-8") as fh:
         assert fh.read() == "{ not json"
 
 
-def test_second_corruption_event_does_not_clobber_first_backup(store_file):
+def test_repeated_loads_of_unchanged_corruption_reuse_one_backup(store_file):
+    """The corrupt file stays on disk, so this branch runs on every load.
+
+    A unique-per-attempt backup name would mint a new copy each time and
+    amplify disk usage without bound. Identical bytes must map to one backup.
+    """
+    store_file.write_text("{ not json", encoding="utf-8")
+
+    for _ in range(25):
+        auth._load_auth_store(store_file)
+
+    backups = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(backups) == 1, (
+        "repeated loads of UNCHANGED corrupt bytes must reuse a single "
+        f"content-addressed backup, got {len(backups)}"
+    )
+    with open(backups[0], encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_changed_corrupt_bytes_get_their_own_backup(store_file):
+    """Deduping must not lose genuinely different corrupt content."""
     store_file.write_text("{ not json one", encoding="utf-8")
     auth._load_auth_store(store_file)
-    first_backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
-    assert len(first_backups) == 1
+    assert len(glob.glob(str(store_file) + ".corrupt.*")) == 1
 
     store_file.write_text("{ not json two", encoding="utf-8")
     auth._load_auth_store(store_file)
-    second_backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
 
-    assert len(second_backups) == 2, "a second corruption must not overwrite the first backup"
-    with open(first_backups[0], encoding="utf-8") as fh:
-        assert fh.read() == "{ not json one", "the first backup's content must survive"
+    backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
+    assert len(backups) == 2, "changed corrupt bytes must be preserved separately"
+    contents = set()
+    for path in backups:
+        with open(path, encoding="utf-8") as fh:
+            contents.add(fh.read())
+    assert contents == {"{ not json one", "{ not json two"}
+
+
+def test_corrupt_backups_are_capped_by_retention(store_file, monkeypatch):
+    """A mutating-corruption loop must not accumulate backups forever."""
+    monkeypatch.setattr(auth, "_CORRUPT_AUTH_BACKUP_RETENTION", 5)
+
+    for i in range(20):
+        store_file.write_text(f"{{ not json {i}", encoding="utf-8")
+        auth._load_auth_store(store_file)
+
+    backups = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(backups) <= 5, (
+        f"retention cap must bound corrupt backups, got {len(backups)}"
+    )
+    # The most recent corruption must be among what we kept.
+    contents = set()
+    for path in backups:
+        with open(path, encoding="utf-8") as fh:
+            contents.add(fh.read())
+    assert "{ not json 19" in contents
 
 
 def test_healthy_store_is_returned_unchanged(store_file):

--- a/tests/hermes_cli/test_auth_store_read_failure.py
+++ b/tests/hermes_cli/test_auth_store_read_failure.py
@@ -6,11 +6,16 @@ roughly fifteen places, so an ``OSError`` (EMFILE under fd exhaustion, EACCES,
 EIO, a stalled mount) followed by any ``_save_auth_store`` rewrote auth.json
 with an empty provider set and destroyed every stored credential.
 
-Genuine corruption still degrades, still preserves a copy, and now only claims
-to have preserved one when the copy actually landed.
+Genuine corruption still degrades, still preserves a copy (now under a
+timestamped filename so a second corruption event can't clobber a prior
+backup), and still only claims to have preserved one when the copy actually
+landed. The resulting in-memory store is also stamped as a load-failure
+fallback so ``_save_auth_store`` refuses to ever flush it to disk while it
+is still empty.
 """
 
 import errno
+import glob
 import json
 import logging
 
@@ -54,25 +59,47 @@ def test_read_failure_raises_and_leaves_the_store_alone(store_file, monkeypatch,
         auth._load_auth_store(store_file)
 
     assert store_file.read_bytes() == before, "the store on disk was modified"
-    assert not store_file.with_suffix(".json.corrupt").exists(), (
+    assert not glob.glob(str(store_file) + ".corrupt*"), (
         "a read failure is not corruption and must not write a .corrupt sidecar"
     )
 
 
-def test_unparseable_json_still_degrades_and_preserves_a_copy(store_file):
+def test_unparseable_json_still_degrades_and_preserves_a_timestamped_copy(store_file):
     store_file.write_text("{ not json", encoding="utf-8")
 
     result = auth._load_auth_store(store_file)
 
-    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
-    corrupt = store_file.with_suffix(".json.corrupt")
-    assert corrupt.exists(), "genuine corruption must still be preserved"
-    assert corrupt.read_text(encoding="utf-8") == "{ not json"
+    assert result["version"] == auth.AUTH_STORE_VERSION
+    assert result["providers"] == {}
+    matches = glob.glob(str(store_file) + ".corrupt.*")
+    assert len(matches) == 1, "genuine corruption must still be preserved, timestamped"
+    corrupt = matches[0]
+    assert not corrupt.endswith(".corrupt"), (
+        "backup filename must be timestamped, not the old fixed auth.json.corrupt"
+    )
+    with open(corrupt, encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_second_corruption_event_does_not_clobber_first_backup(store_file):
+    store_file.write_text("{ not json one", encoding="utf-8")
+    auth._load_auth_store(store_file)
+    first_backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
+    assert len(first_backups) == 1
+
+    store_file.write_text("{ not json two", encoding="utf-8")
+    auth._load_auth_store(store_file)
+    second_backups = sorted(glob.glob(str(store_file) + ".corrupt.*"))
+
+    assert len(second_backups) == 2, "a second corruption must not overwrite the first backup"
+    with open(first_backups[0], encoding="utf-8") as fh:
+        assert fh.read() == "{ not json one", "the first backup's content must survive"
 
 
 def test_healthy_store_is_returned_unchanged(store_file):
     result = auth._load_auth_store(store_file)
     assert result["providers"]["nous"]["api_key"] == "secret"
+    assert auth._LOAD_FAILURE_MARKER not in result
 
 
 def test_log_does_not_claim_a_backup_that_was_not_written(
@@ -91,8 +118,55 @@ def test_log_does_not_claim_a_backup_that_was_not_written(
     with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
         result = auth._load_auth_store(store_file)
 
-    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
-    assert not store_file.with_suffix(".json.corrupt").exists()
+    assert result["providers"] == {}
+    assert not glob.glob(str(store_file) + ".corrupt*")
     text = caplog.text
     assert "could NOT be preserved" in text
     assert "Corrupt file preserved at" not in text
+
+
+def test_load_failure_store_cannot_be_flushed_to_disk(store_file):
+    """A load-failure fallback store must never reach _save_auth_store's write.
+
+    This is the guard that closes the actual data-loss bug: even if some
+    calling code did the old-style "load, then unconditionally save" thing
+    after a corruption-triggered fallback, the write itself must refuse.
+    """
+    store_file.write_text("{ not json", encoding="utf-8")
+    fallback_store = auth._load_auth_store(store_file)
+    assert fallback_store.get(auth._LOAD_FAILURE_MARKER) is True
+
+    with pytest.raises(auth.AuthStoreWriteGuardError):
+        auth._save_auth_store(fallback_store, target_path=store_file)
+
+    # The original (corrupt) content must remain completely untouched, and no
+    # new payload must have been written in its place.
+    with open(store_file, encoding="utf-8") as fh:
+        assert fh.read() == "{ not json"
+
+
+def test_load_failure_store_can_be_saved_once_populated(tmp_path):
+    """Once a caller adds a real provider, the guard no longer applies."""
+    store_file = tmp_path / "auth.json"
+    store_file.write_text("{ not json", encoding="utf-8")
+    fallback_store = auth._load_auth_store(store_file)
+
+    fallback_store["providers"]["nous"] = {"api_key": "new-secret"}
+    saved_path = auth._save_auth_store(fallback_store, target_path=store_file)
+
+    assert saved_path == store_file
+    on_disk = json.loads(store_file.read_text(encoding="utf-8"))
+    assert on_disk["providers"]["nous"]["api_key"] == "new-secret"
+    assert auth._LOAD_FAILURE_MARKER not in on_disk
+
+
+def test_save_of_ordinary_empty_store_is_still_allowed(tmp_path):
+    """A genuinely empty store from an explicit user action (no marker) still saves."""
+    store_file = tmp_path / "auth.json"
+    empty_store = {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+
+    saved_path = auth._save_auth_store(empty_store, target_path=store_file)
+
+    assert saved_path == store_file
+    on_disk = json.loads(store_file.read_text(encoding="utf-8"))
+    assert on_disk["providers"] == {}


### PR DESCRIPTION
## Problem

\`_load_auth_store()\` in \`hermes_cli/auth.py\` treated *any* exception raised
while reading/parsing \`~/.hermes/auth.json\` — including OS-level failures
like \`EMFILE\` (too many open files), \`EACCES\`, and \`EIO\` — as genuine file
corruption. On that path it moved the file aside to a fixed
\`auth.json.corrupt\` and returned an in-memory empty store
(\`{"providers": {}}\`).

This module performs read-modify-write in roughly fifteen call sites. Any one
of them hitting a *transient* OS error (e.g. brief fd exhaustion from an
unrelated part of the process) would silently swap in an empty store, and the
very next normal save on that code path would flush it to disk — permanently
deleting live OAuth credentials that were never actually corrupt. This was
observed in practice from a transient EMFILE misdiagnosed as corruption,
which wiped a real auth store.

## Fix

- **Distinguish OS-level read/open failures from content corruption.**
  \`OSError\` (and subclasses) raised while opening/reading the file now fails
  closed: it's logged loudly and re-raised so the caller can retry, and the
  on-disk file is left completely untouched. Only a failure that occurs
  *after* a successful read — i.e. \`json.JSONDecodeError\` or a bad
  schema/encoding — is treated as corruption and takes the
  backup-and-reset path.
- **Timestamped corruption backups.** The corrupt-file backup now goes to
  \`auth.json.corrupt.<timestamp>\` instead of a single fixed
  \`auth.json.corrupt\` path, so a second corruption event can't silently
  overwrite a prior backup that might still hold recoverable data.
- **Write-side invariant guard.** The in-memory empty store created as a
  load-failure fallback is now stamped with an internal marker.
  \`_save_auth_store()\` refuses to persist that store to disk while it's
  still empty (raising a new \`AuthStoreWriteGuardError\`), closing off any
  current or future code path that could flush a load-failure fallback over
  real on-disk credentials. The marker is cleared as soon as a caller adds a
  real provider/credential-pool entry (an explicit, legitimate mutation), so
  normal saves are unaffected.

## Tests

Added \`tests/hermes_cli/test_auth_store_read_failure.py\` coverage for:
- \`OSError(EMFILE)\`, \`EACCES\`, and \`EIO\` during read: raises, on-disk file
  is byte-for-byte unchanged, no \`.corrupt\` file is created.
- Genuinely corrupt JSON: still degrades to an empty store and still
  preserves a backup, now under a timestamped filename.
- A second corruption event does not clobber the first backup.
- A load-failure fallback store cannot be flushed via \`_save_auth_store()\`
  (raises \`AuthStoreWriteGuardError\`), the guard clears once the store is
  legitimately populated, and an ordinary (non-marked) empty store can still
  be saved normally.

All new and existing auth-store tests pass locally.

## Notes

No behavior changes to genuine corruption handling beyond the backup
filename; no new environment variables; no logging of credential values on
any of the new/changed paths.