### PR TITLE
fix(mem0): release prior Qdrant lock before re-initializing backend

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,2 @@
+dhruvkej9
+# PR #76281 mem0 reinit backend release

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -363,6 +363,14 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
+        # Release any prior backend before creating a new one. initialize()
+        # runs once per session in a long-lived gateway process; without this,
+        # the previous session's OSSBackend (and its QdrantLocal file lock on
+        # mem0_qdrant/.lock) is only released by GC, which is non-deterministic
+        # and intermittently fails the next init with "Storage folder ... already
+        # accessed by another instance of Qdrant client".
+        if self._backend is not None:
+            self._shutdown_backend()
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)

--- a/tests/plugins/memory/test_mem0_reinitialize.py
+++ b/tests/plugins/memory/test_mem0_reinitialize.py
@@ -1,0 +1,74 @@
+"""Regression test for releasing the prior Mem0 backend on re-initialize.
+
+The fix (plugins/memory/mem0/__init__.py) calls ``_shutdown_backend()``
+before building a new backend inside ``initialize()``. Without it, a prior
+session's OSSBackend (and its QdrantLocal file lock on mem0_qdrant/.lock)
+is only released by GC, which is non-deterministic and intermittently fails
+the next init with "Storage folder ... already accessed by another instance
+of Qdrant client".
+
+Reviewer ask: demonstrate repeated ``initialize()`` on the SAME provider
+instance and assert the first backend is closed before the second is built.
+"""
+
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class FakeBackend:
+    """Track close() so we can assert the old backend was released."""
+
+    def __init__(self, label):
+        self.label = label
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def __repr__(self):
+        return f"<FakeBackend {self.label}>"
+
+
+def test_repeated_initialize_releases_prior_backend(monkeypatch):
+    """initialize() twice on one provider closes backend #1 before #2."""
+    provider = Mem0MemoryProvider()
+
+    built = []
+
+    def fake_create_backend():
+        b = FakeBackend(len(built))
+        built.append(b)
+        return b
+
+    monkeypatch.setattr(provider, "_create_backend", fake_create_backend)
+
+    provider.initialize("session-1")
+    first = provider._backend
+    assert first is built[0]
+    assert first.closed is False
+
+    provider.initialize("session-2")
+    second = provider._backend
+
+    # The prior backend must have been closed before the new one was built.
+    assert first.closed is True
+    assert second is built[1]
+    assert second.closed is False
+    # Only the new (still-live) backend is held.
+    assert provider._backend is second
+
+
+def test_first_initialize_does_not_call_close(monkeypatch):
+    """The very first initialize() on a fresh provider never shuts anything down."""
+    provider = Mem0MemoryProvider()
+
+    def fake_create_backend():
+        return FakeBackend("fresh")
+
+    monkeypatch.setattr(provider, "_create_backend", fake_create_backend)
+
+    # A fresh provider starts with no backend, so initialize() must not touch
+    # _shutdown_backend / close(). Guard against the fix regressing into a
+    # close-on-first-run.
+    provider.initialize("session-1")
+    assert provider._backend.label == "fresh"
+    assert provider._backend.closed is False


### PR DESCRIPTION
## Problem

The mem0 memory provider's  runs once per session inside a long-lived gateway process and unconditionally overwrote `self._backend` with a fresh `OSSBackend` (fresh `Memory.from_config()` → fresh `QdrantLocal` client) on every call — **without releasing the previous backend**.

`_shutdown_backend` was only ever registered via `atexit`, so it ran once at full process exit, never between sessions. The previous session's `QdrantLocal` client — and its held file lock on `mem0_qdrant/.lock` — was only released once Python's GC happened to finalize the orphaned backend object. That's non-deterministic, producing **intermittent** lock failures under a single gateway process:

```
Mem0 backend failed to initialize (oss mode): Storage folder ... already accessed by another instance of Qdrant client.
```

## Fix

Before creating a new backend, explicitly close the prior one:

```python
if self._backend is not None:
    self._shutdown_backend()
self._backend = self._create_backend()
```

`_shutdown_backend()` already calls `self._backend.close()`, which tears down telemetry, the memory client, the vector store, and the underlying Qdrant client — deterministically releasing the file lock at every re-initialize.

## Notes

- The separately-floated `_create_backen` typo does **not** exist in the current tree / upstream `main` (line verifies as `_create_backend()`).
- `vector_store: qdrant <server>` (server mode) remains a valid independent mitigation, but this patch fixes the underlying lifecycle bug so local-file mode also works across repeated sessions.