### PR TITLE
feat(kanban): add Class-of-Service fields (#76016)

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -158,6 +158,15 @@ export const fetchProjects = () => call<{ projects: KanbanProject[] }>('/project
 
 export const fetchOrchestration = () => call<OrchestrationSettings>('/orchestration')
 
+export const classOfServiceOptions = (board?: Pick<KanbanBoard, 'classes_of_service'>): string[] =>
+  board?.classes_of_service ?? []
+
+export const classOfServiceCreatePayload = (value: string): Record<string, string> =>
+  value ? { class_of_service: value } : {}
+
+export const classOfServicePatchPayload = (value: null | string): { class_of_service: null | string } =>
+  ({ class_of_service: value })
+
 // ── writes ────────────────────────────────────────────────────────────────────
 
 // Every board edit nudges the dispatcher (debounced, fire-and-forget) so the

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -67,6 +67,8 @@ import {
   boardKey,
   BOARDS_KEY,
   bulkTasks,
+  classOfServiceCreatePayload,
+  classOfServiceOptions,
   createTask,
   deleteTask,
   estimateNew,
@@ -78,6 +80,7 @@ import {
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
+import { classOfServiceLabel } from './i18n'
 import { OrchestrationPanel } from './orchestration'
 import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
 import {
@@ -160,7 +163,12 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
   const meta = columnMeta(task.status)
 
   return (
-    <div className="flex items-center gap-2 whitespace-nowrap text-[0.625rem] text-(--ui-text-tertiary)">
+      <div className="flex items-center gap-2 whitespace-nowrap text-[0.625rem] text-(--ui-text-tertiary)">
+      {task.class_of_service && (
+        <span className="rounded bg-(--ui-bg-tertiary) px-1.5 py-0.5 text-(--ui-text-secondary)">
+          {classOfServiceLabel(k, task.class_of_service)}
+        </span>
+      )}
       {arc === 'queued' && attached ? (
         // WHO is coming for the card. The arc only animates once the agent is
         // actually working; while queued, the named chip carries "attached".
@@ -533,10 +541,12 @@ function Field({ children, label }: { children: ReactNode; label: string }) {
 }
 
 function NewTaskDialog({
+  classesOfService,
   onClose,
   parents,
   target
 }: {
+  classesOfService: string[]
   onClose: () => void
   parents: Array<{ id: string; title: string }>
   target: null | string
@@ -564,6 +574,7 @@ function NewTaskDialog({
   const [bodyText, setBodyText] = useState('')
   const [assignee, setAssignee] = useState('')
   const [priority, setPriority] = useState('0')
+  const [classOfService, setClassOfService] = useState('')
   const [skills, setSkills] = useState('')
   const [workspaceKind, setWorkspaceKind] = useState<string>(boardDefaultKind)
   // Empty = inherit the board's default project dir (backend resolves it);
@@ -598,6 +609,7 @@ function NewTaskDialog({
       setBodyText('')
       setAssignee('')
       setPriority('0')
+      setClassOfService('')
       setSkills('')
       setWorkspaceKind(boardDefaultKind)
       setWorkspacePath('')
@@ -630,6 +642,7 @@ function NewTaskDialog({
       const { task, warning } = await createTask({
         assignee: assignee === PARKED ? undefined : assignee || resolvedDefault,
         body: bodyText.trim() || undefined,
+        ...classOfServiceCreatePayload(classOfService),
         goal_mode: goalMode,
         parents: parent ? [parent] : undefined,
         priority: Number(priority) || 0,
@@ -705,6 +718,22 @@ function NewTaskDialog({
               </Select>
             </Field>
           </div>
+
+          <Field label={k.classOfService}>
+            <Select onValueChange={value => setClassOfService(value === NO_PARENT ? '' : value)} value={classOfService || NO_PARENT}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_PARENT}>{k.unclassified}</SelectItem>
+                {classesOfService.map(value => (
+                  <SelectItem key={value} value={value}>
+                    {classOfServiceLabel(k, value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
 
           {workspaceKind !== 'scratch' && (
             <Field label={k.workspaceOverride}>
@@ -1406,8 +1435,19 @@ export function KanbanBoardPage() {
         />
       )}
 
-      <NewTaskDialog onClose={() => setAddStatus(null)} parents={parentOptions} target={addStatus} />
-      <TaskDrawer columns={columnNames} id={openId} onClose={() => setOpenId(null)} onOpen={setOpenId} />
+      <NewTaskDialog
+        classesOfService={classOfServiceOptions(board)}
+        onClose={() => setAddStatus(null)}
+        parents={parentOptions}
+        target={addStatus}
+      />
+      <TaskDrawer
+        classesOfService={classOfServiceOptions(board)}
+        columns={columnNames}
+        id={openId}
+        onClose={() => setOpenId(null)}
+        onOpen={setOpenId}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/plugins/kanban/class-of-service.test.tsx
+++ b/apps/desktop/src/plugins/kanban/class-of-service.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@hermes/plugin-sdk', () => ({
+  atom: (value: unknown) => ({ get: () => value, set: () => undefined, listen: () => () => undefined }),
+  queryClient: { invalidateQueries: () => Promise.resolve() },
+  usePluginI18n: () => () => ''
+}))
+
+import {
+  classOfServiceCreatePayload,
+  classOfServiceOptions,
+  classOfServicePatchPayload
+} from './api'
+import { classOfServiceLabel } from './i18n'
+
+describe('Class of Service desktop contract', () => {
+  it('uses backend-provided options and omits an unset create value', () => {
+    const values = ['expedite', 'fixed_date', 'intangible', 'standard']
+    expect(classOfServiceOptions({ classes_of_service: values })).toEqual(values)
+    expect(classOfServiceCreatePayload('')).toEqual({})
+    expect(classOfServiceCreatePayload('fixed_date')).toEqual({ class_of_service: 'fixed_date' })
+  })
+
+  it('sends exact update payloads and labels known plus future values', () => {
+    expect(classOfServicePatchPayload(null)).toEqual({ class_of_service: null })
+    expect(classOfServicePatchPayload('standard')).toEqual({ class_of_service: 'standard' })
+    const labels = {
+      classesOfService: {
+        expedite: 'Expedite',
+        fixed_date: 'Fixed date',
+        intangible: 'Intangible',
+        standard: 'Standard'
+      }
+    } as never
+    expect(classOfServiceLabel(labels, 'expedite')).toBe('Expedite')
+    expect(classOfServiceLabel(labels, 'future')).toBe('future')
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -20,6 +20,11 @@ import {
   host,
   Loader,
   LogView,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Textarea,
   Tip,
   useMutation,
@@ -32,6 +37,7 @@ import { type ReactNode, useEffect, useRef, useState } from 'react'
 import {
   $boardSlug,
   addComment,
+  classOfServicePatchPayload,
   deleteTask,
   estimateTask,
   fetchLog,
@@ -45,6 +51,7 @@ import {
   taskKey,
   uploadAttachment
 } from './api'
+import { classOfServiceLabel } from './i18n'
 import {
   type Diagnostic,
   type DiagnosticAction,
@@ -174,6 +181,40 @@ function MetaRow({ children, label }: { children: ReactNode; label: string }) {
       <span className="text-(--ui-text-quaternary)">{label}</span>
       <span className="min-w-0 truncate text-(--ui-text-secondary)">{children}</span>
     </>
+  )
+}
+
+const UNCLASSIFIED_CLASS_OF_SERVICE = '__unclassified__'
+
+function ClassOfServiceMenu({
+  current,
+  options,
+  onChange
+}: {
+  current?: null | string
+  options: string[]
+  onChange: (value: null | string) => void
+}) {
+  const k = useKanban()
+  const visibleOptions = current && !options.includes(current) ? [current, ...options] : options
+
+  return (
+    <Select
+      onValueChange={value => onChange(value === UNCLASSIFIED_CLASS_OF_SERVICE ? null : value)}
+      value={current || UNCLASSIFIED_CLASS_OF_SERVICE}
+    >
+      <SelectTrigger className="h-6 text-[0.71rem]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={UNCLASSIFIED_CLASS_OF_SERVICE}>{k.unclassified}</SelectItem>
+        {visibleOptions.map(value => (
+          <SelectItem key={value} value={value}>
+            {classOfServiceLabel(k, value)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }
 
@@ -537,11 +578,13 @@ function EstimateSection({ id }: { id: string }) {
 }
 
 export function TaskDrawer({
+  classesOfService,
   columns,
   id,
   onClose,
   onOpen
 }: {
+  classesOfService: string[]
   columns: string[]
   id: null | string
   onClose: () => void
@@ -763,6 +806,13 @@ export function TaskDrawer({
                 />
               </MetaRow>
               {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
+              <MetaRow label={k.metaClassOfService}>
+                <ClassOfServiceMenu
+                  current={task.class_of_service}
+                  onChange={value => void mutate(() => patchTask(task.id, classOfServicePatchPayload(value)))()}
+                  options={classesOfService}
+                />
+              </MetaRow>
               {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
               {task.workspace_path && (
                 <MetaRow label={k.workspace}>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -62,6 +62,9 @@ type KanbanMessages = {
   titlePlaceholder: string
   descPlaceholder: string
   priority: string
+  classOfService: string
+  unclassified: string
+  classesOfService: Record<'expedite' | 'fixed_date' | 'intangible' | 'standard', string>
   workspace: string
   boardDefaultSuffix: string
   workspaceOverride: string
@@ -115,6 +118,7 @@ type KanbanMessages = {
   someone: string
   // drawer — meta + sections
   metaPriority: string
+  metaClassOfService: string
   metaTenant: string
   metaCreatedBy: string
   metaCreated: string
@@ -247,6 +251,14 @@ const en: KanbanMessages = {
   titlePlaceholder: 'Title',
   descPlaceholder: 'Description (optional)',
   priority: 'Priority',
+  classOfService: 'Class of Service',
+  unclassified: 'Unclassified',
+  classesOfService: {
+    expedite: 'Expedite',
+    fixed_date: 'Fixed date',
+    intangible: 'Intangible',
+    standard: 'Standard'
+  },
   workspace: 'Workspace',
   boardDefaultSuffix: ' · board default',
   workspaceOverride: 'Workspace path (optional override)',
@@ -300,6 +312,7 @@ const en: KanbanMessages = {
   evtReprioritized: priority => `priority set to ${priority}`,
   someone: 'someone',
   metaPriority: 'Priority',
+  metaClassOfService: 'Class of Service',
   metaTenant: 'Tenant',
   metaCreatedBy: 'Created by',
   metaCreated: 'Created',
@@ -435,6 +448,14 @@ const ja: KanbanMessages = {
   titlePlaceholder: 'タイトル',
   descPlaceholder: '説明（任意）',
   priority: '優先度',
+  classOfService: 'サービスクラス',
+  unclassified: '未分類',
+  classesOfService: {
+    expedite: '緊急',
+    fixed_date: '期限固定',
+    intangible: '無形',
+    standard: '標準'
+  },
   workspace: 'ワークスペース',
   boardDefaultSuffix: '・ボード既定',
   workspaceOverride: 'ワークスペースパス（任意の上書き）',
@@ -487,6 +508,7 @@ const ja: KanbanMessages = {
   evtReprioritized: priority => `優先度を ${priority} に設定`,
   someone: '誰か',
   metaPriority: '優先度',
+  metaClassOfService: 'サービスクラス',
   metaTenant: 'テナント',
   metaCreatedBy: '作成者',
   metaCreated: '作成',
@@ -621,6 +643,14 @@ const zh: KanbanMessages = {
   titlePlaceholder: '标题',
   descPlaceholder: '描述（可选）',
   priority: '优先级',
+  classOfService: '服务类别',
+  unclassified: '未分类',
+  classesOfService: {
+    expedite: '加急',
+    fixed_date: '固定日期',
+    intangible: '无形',
+    standard: '标准'
+  },
   workspace: '工作区',
   boardDefaultSuffix: '・面板默认',
   workspaceOverride: '工作区路径（可选覆盖）',
@@ -673,6 +703,7 @@ const zh: KanbanMessages = {
   evtReprioritized: priority => `优先级设为 ${priority}`,
   someone: '某人',
   metaPriority: '优先级',
+  metaClassOfService: '服务类别',
   metaTenant: '租户',
   metaCreatedBy: '创建者',
   metaCreated: '创建于',
@@ -805,6 +836,14 @@ const zhHant: KanbanMessages = {
   titlePlaceholder: '標題',
   descPlaceholder: '描述（選填）',
   priority: '優先順序',
+  classOfService: '服務類別',
+  unclassified: '未分類',
+  classesOfService: {
+    expedite: '加急',
+    fixed_date: '固定日期',
+    intangible: '無形',
+    standard: '標準'
+  },
   workspace: '工作區',
   boardDefaultSuffix: '・面板預設',
   workspaceOverride: '工作區路徑（選填覆寫）',
@@ -857,6 +896,7 @@ const zhHant: KanbanMessages = {
   evtReprioritized: priority => `優先順序設為 ${priority}`,
   someone: '某人',
   metaPriority: '優先順序',
+  metaClassOfService: '服務類別',
   metaTenant: '租戶',
   metaCreatedBy: '建立者',
   metaCreated: '建立於',
@@ -967,5 +1007,7 @@ export function useKanban(): KanbanText {
 
 // Column labels/help live in i18n; unknown backend statuses fall back to the id.
 export const columnLabel = (k: KanbanText, name: string) => k.col[name as keyof KanbanText['col']]?.label ?? name
+export const classOfServiceLabel = (k: KanbanText, value: string) =>
+  k.classesOfService[value as keyof KanbanText['classesOfService']] ?? value
 export const columnHelp = (k: KanbanText, name: string) => k.col[name as keyof KanbanText['col']]?.help ?? ''
 export const lockedReason = (k: KanbanText, name: string) => k.locked[name as keyof KanbanText['locked']] ?? ''

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -10,6 +10,7 @@ export interface KanbanTask {
   status: string
   assignee?: null | string
   priority?: number
+  class_of_service?: null | string
   tenant?: null | string
   created_at?: number
   latest_summary?: null | string
@@ -32,6 +33,7 @@ export interface KanbanColumn {
 
 export interface KanbanBoard {
   columns: KanbanColumn[]
+  classes_of_service?: string[]
   tenants: string[]
   assignees: string[]
   latest_event_id: number

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -53,7 +53,8 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    class_of_service = f" [{t.class_of_service}]" if t.class_of_service else ""
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}{class_of_service}  {t.title}"
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -78,6 +79,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "class_of_service": t.class_of_service,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -344,6 +346,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "deterministic branch. See `hermes project list`.")
     p_create.add_argument("--tenant", default=None, help="Tenant namespace")
     p_create.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_create.add_argument(
+        "--class-of-service",
+        choices=kb.VALID_CLASSES_OF_SERVICE,
+        default=None,
+        help="Optional descriptive Class of Service",
+    )
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
@@ -494,6 +502,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Provider the model belongs to (worker is spawned with "
              "--provider <name>). Cleared together with the model.",
     )
+
+    p_set_class_of_service = sub.add_parser(
+        "set-class-of-service",
+        help="Set or clear a task's descriptive Class of Service",
+    )
+    p_set_class_of_service.add_argument("task_id")
+    p_set_class_of_service.add_argument(
+        "class_of_service",
+        nargs="?",
+        default=None,
+        help="One of " + ", ".join(kb.VALID_CLASSES_OF_SERVICE) + ", or 'none' to clear",
+    )
+    p_set_class_of_service.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- reclaim / reassign (recovery) ---
     p_reclaim = sub.add_parser(
@@ -1050,6 +1071,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "show":     _cmd_show,
             "assign":   _cmd_assign,
             "set-model": _cmd_set_model,
+            "set-class-of-service": _cmd_set_class_of_service,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
@@ -1516,6 +1538,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
+            class_of_service=getattr(args, "class_of_service", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
@@ -1524,7 +1547,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
-        print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+        suffix = f", class-of-service={task.class_of_service}" if task.class_of_service else ""
+        print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'}{suffix})")
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are
@@ -1692,6 +1716,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
     if task.model_override:
         _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
         print(f"  model:     {task.model_override}{_prov}")
+    if task.class_of_service:
+        print(f"  class-of-service: {task.class_of_service}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see
@@ -1820,6 +1846,29 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
     else:
         print(f"Cleared model override on {args.task_id} "
               "(worker uses its profile default)")
+    return 0
+
+
+def _cmd_set_class_of_service(args: argparse.Namespace) -> int:
+    value = args.class_of_service
+    if value is not None and value.lower() in {"none", "-", "null", ""}:
+        value = None
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.set_class_of_service(conn, args.task_id, value)
+            task = kb.get_task(conn, args.task_id) if ok else None
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    if not ok:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
+    elif value:
+        print(f"Set Class of Service on {args.task_id}: {value}")
+    else:
+        print(f"Cleared Class of Service on {args.task_id}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,7 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_CLASSES_OF_SERVICE = ("expedite", "fixed_date", "intangible", "standard")
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -133,6 +134,18 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+
+def validate_class_of_service(value: Optional[str]) -> Optional[str]:
+    """Return a supported class of service, or raise before a write occurs."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in VALID_CLASSES_OF_SERVICE:
+        raise ValueError(
+            "class_of_service must be one of "
+            f"{list(VALID_CLASSES_OF_SERVICE)} or None"
+        )
+    return value
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
@@ -929,6 +942,8 @@ class Task:
     # model (pre-existing behaviour). Solves the "model from provider A,
     # profile configured for provider B" mismatch class.
     provider_override: Optional[str] = None
+    # Descriptive task metadata. NULL means the task is unclassified.
+    class_of_service: Optional[str] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -1030,6 +1045,11 @@ class Task:
             provider_override=(
                 row["provider_override"]
                 if "provider_override" in keys and row["provider_override"]
+                else None
+            ),
+            class_of_service=(
+                row["class_of_service"]
+                if "class_of_service" in keys and row["class_of_service"]
                 else None
             ),
             max_retries=(
@@ -1200,6 +1220,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- worker resolves the model against the right backend instead of the
     -- profile's configured provider. NULL = profile provider.
     provider_override    TEXT,
+    -- Optional descriptive classification. The dispatcher never reads it.
+    class_of_service     TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -2388,6 +2410,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "provider_override", "provider_override TEXT"
         )
 
+    if "class_of_service" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "class_of_service", "class_of_service TEXT"
+        )
+
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
         # default) = classic single-shot worker, preserving the behaviour
@@ -2851,6 +2878,7 @@ def create_task(
     max_retries: Optional[int] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
+    class_of_service: Optional[str] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
@@ -2895,6 +2923,7 @@ def create_task(
     """
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
+    class_of_service = validate_class_of_service(class_of_service)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
@@ -3162,8 +3191,9 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
+                        class_of_service,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3185,6 +3215,7 @@ def create_task(
                         int(max_retries) if max_retries is not None else None,
                         model_override,
                         provider_override,
+                        class_of_service,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
@@ -3212,6 +3243,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "class_of_service": class_of_service,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -3423,6 +3455,37 @@ def set_model_override(
         _append_event(
             conn, task_id, "model_override_set",
             {"model": model, "provider": provider},
+        )
+        return True
+
+
+def set_class_of_service(
+    conn: sqlite3.Connection,
+    task_id: str,
+    value: Optional[str],
+) -> bool:
+    """Set or clear descriptive Class-of-Service metadata for one task."""
+    value = validate_class_of_service(value)
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT class_of_service FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not row:
+            return False
+        previous = row["class_of_service"]
+        if previous == value:
+            return True
+        conn.execute(
+            "UPDATE tasks SET class_of_service = ? WHERE id = ?", (value, task_id)
+        )
+        _append_event(
+            conn,
+            task_id,
+            "class_of_service_set",
+            {
+                "class_of_service": value,
+                "previous_class_of_service": previous,
+            },
         )
         return True
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -501,6 +501,7 @@ def get_board(
             "columns": [
                 {"name": name, "tasks": columns[name]} for name in columns.keys()
             ],
+            "classes_of_service": list(kanban_db.VALID_CLASSES_OF_SERVICE),
             "tenants": tenants,
             "assignees": assignees,
             "latest_event_id": int(latest_event_id),
@@ -610,6 +611,7 @@ class CreateTaskBody(BaseModel):
     goal_max_turns: Optional[int] = None
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
+    class_of_service: Optional[str] = None
     # Explicit project link; when omitted, create_task inherits the board's
     # scoped project (if any) so a project-scoped board anchors every task.
     project_id: Optional[str] = None
@@ -639,6 +641,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             goal_max_turns=payload.goal_max_turns,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
+            class_of_service=payload.class_of_service,
             project_id=payload.project_id,
             board=board,
         )
@@ -839,6 +842,8 @@ class UpdateTaskBody(BaseModel):
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     clear_model_override: bool = False
+    # ``None`` clears when the client explicitly includes this field.
+    class_of_service: Optional[str] = None
 
 
 @router.patch("/tasks/{task_id}")
@@ -849,6 +854,18 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+        fields_set = getattr(payload, "model_fields_set", None)
+        if fields_set is None:
+            fields_set = getattr(payload, "__fields_set__", set())
+        class_of_service_set = "class_of_service" in fields_set
+        try:
+            class_of_service = (
+                kanban_db.validate_class_of_service(payload.class_of_service)
+                if class_of_service_set else None
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
         # --- assignee ----------------------------------------------------
         if payload.assignee is not None:
@@ -930,6 +947,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     provider=payload.provider_override,
                 )
             except (ValueError, RuntimeError) as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            if not ok:
+                raise HTTPException(status_code=404, detail="task not found")
+
+        # --- Class of Service ----------------------------------------------
+        if class_of_service_set:
+            try:
+                ok = kanban_db.set_class_of_service(conn, task_id, class_of_service)
+            except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             if not ok:
                 raise HTTPException(status_code=404, detail="task not found")

--- a/tests/plugins/test_kanban_class_of_service.py
+++ b/tests/plugins/test_kanban_class_of_service.py
@@ -1,0 +1,171 @@
+"""Class-of-Service metadata stays validated, audited, and inert."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    connection = kb.connect()
+    yield connection
+    connection.close()
+
+
+def _load_plugin_router():
+    plugin_file = Path(__file__).resolve().parents[2] / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("kanban_class_of_service_test", plugin_file)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.router
+
+
+@pytest.fixture
+def client(kanban_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def test_contract_authority_is_shared_across_tool_and_api():
+    values = ["expedite", "fixed_date", "intangible", "standard"]
+    assert list(kb.VALID_CLASSES_OF_SERVICE) == values
+    assert kanban_tools.KANBAN_CREATE_SCHEMA["parameters"]["properties"]["class_of_service"]["enum"] == values
+
+
+def test_values_create_validate_and_preserve_rollback(conn):
+    for value in kb.VALID_CLASSES_OF_SERVICE:
+        task_id = kb.create_task(conn, title=value, class_of_service=value)
+        assert kb.get_task(conn, task_id).class_of_service == value
+
+    before_tasks = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    before_events = conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0]
+    with pytest.raises(ValueError):
+        kb.create_task(conn, title="invalid", class_of_service="rush")
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before_tasks
+    assert conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0] == before_events
+
+
+def test_legacy_persistence_migrates_as_unclassified(tmp_path):
+    path = tmp_path / "legacy.db"
+    legacy_schema = kb.SCHEMA_SQL.replace("    class_of_service     TEXT,\n", "")
+    raw = sqlite3.connect(path)
+    raw.executescript(legacy_schema)
+    raw.execute(
+        "INSERT INTO tasks (id, title, status, created_at, workspace_kind) VALUES (?, ?, ?, ?, ?)",
+        ("legacy", "legacy task", "ready", 1, "scratch"),
+    )
+    raw.commit()
+    raw.close()
+
+    with kb.connect(db_path=path) as connection:
+        assert kb.get_task(connection, "legacy").class_of_service is None
+        assert "class_of_service" in {row["name"] for row in connection.execute("PRAGMA table_info(tasks)")}
+
+
+def test_update_is_audited_idempotent_and_clearable(conn):
+    task_id = kb.create_task(conn, title="metadata")
+    assert kb.set_class_of_service(conn, task_id, "expedite")
+    assert kb.set_class_of_service(conn, task_id, "expedite")
+    assert kb.set_class_of_service(conn, task_id, None)
+    assert kb.get_task(conn, task_id).class_of_service is None
+    events = [event for event in kb.list_events(conn, task_id) if event.kind == "class_of_service_set"]
+    assert [event.payload["class_of_service"] for event in events] == ["expedite", None]
+    assert [event.payload["previous_class_of_service"] for event in events] == [None, "expedite"]
+
+
+def test_cli_create_set_json_and_show(kanban_home):
+    created = json.loads(kc.run_slash("create 'CLI task' --class-of-service standard --json"))
+    assert created["class_of_service"] == "standard"
+    task_id = created["id"]
+    cleared = json.loads(kc.run_slash(f"set-class-of-service {task_id} none --json"))
+    assert cleared["class_of_service"] is None
+    assert "class-of-service" not in kc.run_slash(f"show {task_id}")
+
+
+def test_tool_schema_and_summary_round_trip(kanban_home):
+    result = json.loads(kanban_tools._handle_create({
+        "title": "Tool task", "assignee": "worker", "class_of_service": "fixed_date",
+    }))
+    assert result["ok"] is True
+    with kb.connect() as connection:
+        task = kb.get_task(connection, result["task_id"])
+        assert kanban_tools._task_summary_dict(kb, connection, task)["class_of_service"] == "fixed_date"
+
+
+def test_api_create_patch_clear_invalid_and_board_options(client):
+    created = client.post("/api/plugins/kanban/tasks", json={
+        "title": "API task", "assignee": "worker", "priority": 2, "class_of_service": "intangible",
+    })
+    assert created.status_code == 200, created.text
+    task = created.json()["task"]
+    assert task["class_of_service"] == "intangible"
+
+    updated = client.patch(f"/api/plugins/kanban/tasks/{task['id']}", json={
+        "class_of_service": "standard", "priority": 4,
+    })
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["task"]["priority"] == 4
+    assert updated.json()["task"]["class_of_service"] == "standard"
+
+    omitted = client.patch(f"/api/plugins/kanban/tasks/{task['id']}", json={"priority": 5})
+    assert omitted.status_code == 200, omitted.text
+    assert omitted.json()["task"]["class_of_service"] == "standard"
+
+    rejected = client.patch(f"/api/plugins/kanban/tasks/{task['id']}", json={
+        "class_of_service": "rush", "priority": 9,
+    })
+    assert rejected.status_code == 400
+    assert client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()["task"]["priority"] == 5
+
+    cleared = client.patch(f"/api/plugins/kanban/tasks/{task['id']}", json={"class_of_service": None})
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["task"]["class_of_service"] is None
+    assert client.get("/api/plugins/kanban/board").json()["classes_of_service"] == list(kb.VALID_CLASSES_OF_SERVICE)
+
+
+def test_ordering_and_dispatch_ignore_class_of_service(conn, monkeypatch):
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    expedite = kb.create_task(conn, title="expedite", assignee="default", priority=1, class_of_service="expedite")
+    standard = kb.create_task(conn, title="standard", assignee="default", priority=9, class_of_service="standard")
+    task_ids = [task.id for task in kb.list_tasks(conn)]
+    assert task_ids.index(standard) < task_ids.index(expedite)
+    assert kb.get_task(conn, expedite).status == "ready"
+    assert kb.get_task(conn, standard).status == "ready"
+
+    before = {
+        task_id: (kb.get_task(conn, task_id).status, kb.get_task(conn, task_id).consecutive_failures)
+        for task_id in (expedite, standard)
+    }
+    result = kb.dispatch_once(
+        conn, spawn_fn=lambda *_args, **_kwargs: 123, dry_run=True, max_spawn=8
+    )
+    assert [item[0] for item in result.spawned] == [standard, expedite]
+    assert {
+        task_id: (kb.get_task(conn, task_id).status, kb.get_task(conn, task_id).consecutive_failures)
+        for task_id in (expedite, standard)
+    } == before

--- a/tests/plugins/test_kanban_class_of_service.py
+++ b/tests/plugins/test_kanban_class_of_service.py
@@ -52,8 +52,7 @@ def client(kanban_home):
 
 
 def test_contract_authority_is_shared_across_tool_and_api():
-    values = ["expedite", "fixed_date", "intangible", "standard"]
-    assert list(kb.VALID_CLASSES_OF_SERVICE) == values
+    values = list(kb.VALID_CLASSES_OF_SERVICE)
     assert kanban_tools.KANBAN_CREATE_SCHEMA["parameters"]["properties"]["class_of_service"]["enum"] == values
 
 
@@ -72,7 +71,16 @@ def test_values_create_validate_and_preserve_rollback(conn):
 
 def test_legacy_persistence_migrates_as_unclassified(tmp_path):
     path = tmp_path / "legacy.db"
-    legacy_schema = kb.SCHEMA_SQL.replace("    class_of_service     TEXT,\n", "")
+    schema_lines = kb.SCHEMA_SQL.splitlines(keepends=True)
+    class_of_service_lines = [
+        index
+        for index, line in enumerate(schema_lines)
+        if line.strip().split(maxsplit=1)[:1] == ["class_of_service"]
+    ]
+    assert len(class_of_service_lines) == 1
+    legacy_schema = "".join(
+        line for index, line in enumerate(schema_lines) if index != class_of_service_lines[0]
+    )
     raw = sqlite3.connect(path)
     raw.executescript(legacy_schema)
     raw.execute(
@@ -80,6 +88,9 @@ def test_legacy_persistence_migrates_as_unclassified(tmp_path):
         ("legacy", "legacy task", "ready", 1, "scratch"),
     )
     raw.commit()
+    assert "class_of_service" not in {
+        row[1] for row in raw.execute("PRAGMA table_info(tasks)")
+    }
     raw.close()
 
     with kb.connect(db_path=path) as connection:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -34,6 +34,7 @@ import os
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
+from hermes_cli import kanban_db as _kanban_db
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
@@ -466,6 +467,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
+        "class_of_service": task.class_of_service,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -512,6 +514,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "class_of_service": t.class_of_service,
                 }
 
             def _run_dict(r):
@@ -1265,6 +1268,7 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    class_of_service = args.get("class_of_service")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
     if isinstance(parents, str):
@@ -1308,6 +1312,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
+                class_of_service=class_of_service,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1324,6 +1329,7 @@ def _handle_create(args: dict, **kw) -> str:
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
+                class_of_service=new_task.class_of_service if new_task else None,
                 subscribed=subscribed,
             )
         finally:
@@ -1960,6 +1966,11 @@ KANBAN_CREATE_SCHEMA = {
                     "Dispatcher tiebreaker. Higher = picked sooner "
                     "when multiple ready tasks share an assignee."
                 ),
+            },
+            "class_of_service": {
+                "type": "string",
+                "enum": list(_kanban_db.VALID_CLASSES_OF_SERVICE),
+                "description": "Optional descriptive Class of Service. It does not affect dispatch or priority.",
             },
             "workspace_kind": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Kanban tasks currently carry priority and model/provider metadata, but no Class-of-Service classification. This adds an optional task field with `expedite`, `fixed_date`, `intangible`, and `standard`, preserves it through the database, CLI, existing Kanban tool, dashboard API, and Desktop, and keeps it descriptive only.

## Changes

- Add `class_of_service` persistence with additive migration and audited updates.
- Expose the field through task creation, update, list, show, tool, and dashboard contracts.
- Add a Desktop selector, card/detail display, and localized labels.
- Keep the value independent from priority, dispatch, retries, status, and WIP limits.

## Validation

| Scenario | Result |
|---|---|
| Existing task or caller omits the field | Stored value remains unset and existing behavior is preserved |
| Known value is supplied | The exact value round-trips through supported surfaces |
| Unknown value is supplied | The request fails before task or event mutation |
| Same value is applied again | No duplicate audit event is created |
| Field is cleared | Only Class of Service is cleared |
| Priority or dispatch runs after classification | Existing ordering and lifecycle behavior remain unchanged |

## Test plan

- `pytest tests/plugins/test_kanban_class_of_service.py -v`
- `cd apps/desktop && npx vitest run --project ui src/plugins/kanban/class-of-service.test.tsx`
- `cd apps/desktop && npm run typecheck && npm run lint`

The Desktop commands require the repository's Node dependencies.

## Not in scope

Class of Service does not alter queue ordering, priority, assignment, dispatch eligibility, retries, WIP limits, deadlines, or task status. Bulk editing and generated dashboard bundles remain unchanged.

## Upstream

Refs #76016.
