### PR TITLE
feat(dashboard): review pending skill writes

### DIFF
--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -391,6 +391,93 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
     return result
 
 
+@router.get("/api/skills/pending")
+async def get_pending_skill_writes(profile: Optional[str] = None):
+    """List staged skill writes without exposing their full payloads."""
+    from tools import write_approval as wa
+
+    with _profile_scope(profile):
+        pending = []
+        for record in wa.list_pending(wa.SKILLS):
+            payload = record.get("payload") or {}
+            if not isinstance(payload, dict):
+                payload = {}
+            pending.append(
+                {
+                    "id": record.get("id", ""),
+                    "action": record.get("action", payload.get("action", "")),
+                    "summary": record.get("summary", ""),
+                    "origin": record.get("origin", "foreground"),
+                    "created_at": record.get("created_at", 0),
+                    "name": payload.get("name", ""),
+                    "file_path": payload.get("file_path", ""),
+                }
+            )
+    return {"pending": pending}
+
+
+@router.get("/api/skills/pending/{pending_id}/diff")
+async def get_pending_skill_diff(pending_id: str, profile: Optional[str] = None):
+    """Return the full diff for one staged skill write."""
+    from tools import write_approval as wa
+
+    with _profile_scope(profile):
+        record = wa.get_pending(wa.SKILLS, pending_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Pending skill write not found.")
+        return {
+            "id": record.get("id", pending_id),
+            "summary": record.get("summary", ""),
+            "diff": wa.skill_pending_diff(record),
+        }
+
+
+@router.post("/api/skills/pending/{pending_id}/approve")
+async def approve_pending_skill_write(pending_id: str, profile: Optional[str] = None):
+    """Apply one staged skill write and remove it only after a successful write."""
+    import json
+
+    from tools import write_approval as wa
+    from tools.skill_manager_tool import apply_skill_pending
+
+    with _profile_scope(profile):
+        record = wa.get_pending(wa.SKILLS, pending_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Pending skill write not found.")
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Pending skill write has an invalid payload.")
+        try:
+            result = json.loads(apply_skill_pending(payload))
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Failed to apply skill write: {exc}") from exc
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=409,
+                detail=result.get("error", "The staged skill write can no longer be applied."),
+            )
+        if not wa.discard_pending(wa.SKILLS, pending_id):
+            raise HTTPException(
+                status_code=500,
+                detail="Skill write was applied but its pending record could not be cleared. Do not retry.",
+            )
+    _clear_skills_prompt_cache()
+    return {"ok": True, "id": pending_id}
+
+
+@router.delete("/api/skills/pending/{pending_id}")
+async def reject_pending_skill_write(pending_id: str, profile: Optional[str] = None):
+    """Discard one staged skill write without applying it."""
+    from tools import write_approval as wa
+
+    with _profile_scope(profile):
+        if not wa.get_pending(wa.SKILLS, pending_id):
+            raise HTTPException(status_code=404, detail="Pending skill write not found.")
+        if not wa.discard_pending(wa.SKILLS, pending_id):
+            raise HTTPException(status_code=500, detail="Failed to discard pending skill write.")
+    return {"ok": True, "id": pending_id}
+
+
 @router.get("/api/skills")
 async def get_skills(profile: Optional[str] = None):
     from tools.skills_tool import _find_all_skills

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -231,6 +231,20 @@ def test_invalid_cookie_returns_401_on_api(gated_app):
     assert r.status_code == 401
 
 
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/skills/pending"),
+        ("get", "/api/skills/pending/a1b2c3d4/diff"),
+        ("post", "/api/skills/pending/a1b2c3d4/approve"),
+        ("delete", "/api/skills/pending/a1b2c3d4"),
+    ],
+)
+def test_pending_skill_write_routes_require_dashboard_auth(gated_app, method, path):
+    response = getattr(gated_app, method)(path)
+
+    assert response.status_code == 401
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_skill_pending.py
+++ b/tests/hermes_cli/test_web_server_skill_pending.py
@@ -1,0 +1,210 @@
+"""Dashboard API tests for profile-scoped pending skill writes."""
+
+import json
+
+import pytest
+
+
+SKILL_MD = """---
+name: queued-skill
+description: a queued test skill
+---
+
+# Queued skill
+"""
+
+
+def _stage_skill_write(home, pending_id, *, summary, payload, origin="foreground"):
+    pending_dir = home / "pending" / "skills"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "id": pending_id,
+        "subsystem": "skills",
+        "action": payload["action"],
+        "summary": summary,
+        "origin": origin,
+        "created_at": 1_700_000_000.0,
+        "payload": payload,
+    }
+    (pending_dir / f"{pending_id}.json").write_text(
+        json.dumps(record), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    """Default and named profile homes, isolated like a real dashboard."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker_alpha"
+    for home in (default_home, worker_home):
+        (home / "skills").mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {"default": default_home, "worker_alpha": worker_home}
+
+
+@pytest.fixture
+def client(monkeypatch, isolated_profiles):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    dashboard = TestClient(app)
+    dashboard.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return dashboard
+
+
+def test_pending_list_is_profile_scoped_and_hides_payload(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["default"],
+        "a1b2c3d4",
+        summary="create default-only",
+        payload={"action": "create", "name": "default-only", "content": "private"},
+    )
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="create queued-skill",
+        origin="background_review",
+        payload={"action": "create", "name": "queued-skill", "content": SKILL_MD},
+    )
+
+    response = client.get("/api/skills/pending", params={"profile": "worker_alpha"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "pending": [
+            {
+                "id": "b1c2d3e4",
+                "action": "create",
+                "summary": "create queued-skill",
+                "origin": "background_review",
+                "created_at": 1_700_000_000.0,
+                "name": "queued-skill",
+                "file_path": "",
+            }
+        ]
+    }
+
+
+def test_pending_diff_uses_selected_profile(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="create queued-skill",
+        payload={"action": "create", "name": "queued-skill", "content": SKILL_MD},
+    )
+
+    response = client.get(
+        "/api/skills/pending/b1c2d3e4/diff", params={"profile": "worker_alpha"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "b1c2d3e4",
+        "summary": "create queued-skill",
+        "diff": SKILL_MD,
+    }
+
+
+def test_approve_applies_only_selected_profile_pending_write(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="create queued-skill",
+        payload={"action": "create", "name": "queued-skill", "content": SKILL_MD},
+    )
+
+    response = client.post(
+        "/api/skills/pending/b1c2d3e4/approve", params={"profile": "worker_alpha"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "id": "b1c2d3e4"}
+    assert (
+        isolated_profiles["worker_alpha"] / "skills" / "queued-skill" / "SKILL.md"
+    ).read_text(encoding="utf-8") == SKILL_MD
+    assert not (
+        isolated_profiles["worker_alpha"] / "pending" / "skills" / "b1c2d3e4.json"
+    ).exists()
+    assert not (
+        isolated_profiles["default"] / "skills" / "queued-skill"
+    ).exists()
+
+
+def test_reject_discards_only_selected_profile_pending_write(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="create queued-skill",
+        payload={"action": "create", "name": "queued-skill", "content": SKILL_MD},
+    )
+
+    response = client.delete(
+        "/api/skills/pending/b1c2d3e4", params={"profile": "worker_alpha"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "id": "b1c2d3e4"}
+    assert not (
+        isolated_profiles["worker_alpha"] / "pending" / "skills" / "b1c2d3e4.json"
+    ).exists()
+    assert not (
+        isolated_profiles["worker_alpha"] / "skills" / "queued-skill"
+    ).exists()
+
+
+def test_approve_cannot_cross_profile_boundary(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="create queued-skill",
+        payload={"action": "create", "name": "queued-skill", "content": SKILL_MD},
+    )
+
+    response = client.post(
+        "/api/skills/pending/b1c2d3e4/approve", params={"profile": "default"}
+    )
+
+    assert response.status_code == 404
+    assert (
+        isolated_profiles["worker_alpha"] / "pending" / "skills" / "b1c2d3e4.json"
+    ).exists()
+    assert not (
+        isolated_profiles["worker_alpha"] / "skills" / "queued-skill"
+    ).exists()
+
+
+def test_failed_approval_keeps_the_pending_write(client, isolated_profiles):
+    _stage_skill_write(
+        isolated_profiles["worker_alpha"],
+        "b1c2d3e4",
+        summary="patch a missing skill",
+        payload={
+            "action": "patch",
+            "name": "missing-skill",
+            "old_string": "old",
+            "new_string": "new",
+        },
+    )
+
+    response = client.post(
+        "/api/skills/pending/b1c2d3e4/approve", params={"profile": "worker_alpha"}
+    )
+
+    assert response.status_code == 409
+    assert (
+        isolated_profiles["worker_alpha"] / "pending" / "skills" / "b1c2d3e4.json"
+    ).exists()

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -288,6 +288,29 @@ class TestSkillGist:
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
 
 
+def test_skill_pending_diff_uses_the_fuzzy_patch_engine(hermes_home):
+    from tools import write_approval as wa
+
+    skill_dir = os.path.join(hermes_home, "skills", "demo")
+    os.makedirs(skill_dir)
+    with open(os.path.join(skill_dir, "SKILL.md"), "w", encoding="utf-8") as f:
+        f.write("---\nname: demo\ndescription: test\n---\n\nold value\n")
+
+    diff = wa.skill_pending_diff(
+        {
+            "payload": {
+                "action": "patch",
+                "name": "demo",
+                "old_string": "old    value",
+                "new_string": "new value",
+            }
+        }
+    )
+
+    assert "-old value\n" in diff
+    assert "+new value\n" in diff
+
+
 def test_pending_id_cannot_escape_its_subsystem_directory(hermes_home):
     from tools import write_approval as wa
 
@@ -299,3 +322,48 @@ def test_pending_id_cannot_escape_its_subsystem_directory(hermes_home):
     assert wa.get_pending(wa.SKILLS, "../outside") is None
     assert wa.discard_pending(wa.SKILLS, "../outside") is False
     assert escaped.exists()
+
+
+def test_pending_record_symlink_is_never_read_listed_or_deleted(hermes_home):
+    from tools import write_approval as wa
+
+    pending_id = "a1b2c3d4"
+    pending_dir = wa._pending_dir(wa.SKILLS)
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    outside = os.path.join(hermes_home, "outside.json")
+    with open(outside, "w", encoding="utf-8") as f:
+        json.dump({"id": pending_id, "subsystem": wa.SKILLS}, f)
+    link = pending_dir / f"{pending_id}.json"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    assert wa.get_pending(wa.SKILLS, pending_id) is None
+    assert wa.list_pending(wa.SKILLS) == []
+    assert wa.pending_count(wa.SKILLS) == 0
+    assert wa.discard_pending(wa.SKILLS, pending_id) is False
+    assert link.is_symlink()
+    assert os.path.exists(outside)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"id": "d4c3b2a1", "subsystem": "skills"},
+        {"id": "a1b2c3d4", "subsystem": "memory"},
+    ],
+)
+def test_pending_record_must_match_its_filename_and_subsystem(hermes_home, record):
+    from tools import write_approval as wa
+
+    pending_id = "a1b2c3d4"
+    pending_dir = wa._pending_dir(wa.SKILLS)
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    record_path = pending_dir / f"{pending_id}.json"
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+
+    assert wa.get_pending(wa.SKILLS, pending_id) is None
+    assert wa.list_pending(wa.SKILLS) == []
+    assert wa.discard_pending(wa.SKILLS, pending_id) is False
+    assert record_path.exists()

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -286,3 +286,16 @@ class TestSkillGist:
         assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
         assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
+
+
+def test_pending_id_cannot_escape_its_subsystem_directory(hermes_home):
+    from tools import write_approval as wa
+
+    escaped = wa._pending_dir(wa.SKILLS).parent / "outside.json"
+    wa._pending_dir(wa.SKILLS).mkdir(parents=True, exist_ok=True)
+    escaped.parent.mkdir(parents=True, exist_ok=True)
+    escaped.write_text('{"id": "outside"}', encoding="utf-8")
+
+    assert wa.get_pending(wa.SKILLS, "../outside") is None
+    assert wa.discard_pending(wa.SKILLS, "../outside") is False
+    assert escaped.exists()

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
+from tools.path_security import validate_within_dir
 
 logger = logging.getLogger(__name__)
 
@@ -114,12 +115,35 @@ def _pending_dir(subsystem: str) -> Path:
 
 
 def _pending_record_path(subsystem: str, pending_id: Any) -> Optional[Path]:
-    """Return a pending-record path only for generated, safe identifiers."""
+    """Return a regular pending-record path for a generated, safe identifier."""
     if subsystem not in _SUBSYSTEMS or not isinstance(pending_id, str):
         return None
     if _PENDING_ID_RE.fullmatch(pending_id) is None:
         return None
-    return _pending_dir(subsystem) / f"{pending_id}.json"
+    pending_dir = _pending_dir(subsystem)
+    path = pending_dir / f"{pending_id}.json"
+    try:
+        if path.is_symlink() or validate_within_dir(path, pending_dir):
+            return None
+    except (OSError, RuntimeError):
+        return None
+    return path
+
+
+def _read_pending_record(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
+    """Load only a well-formed record bound to its requested filename/store."""
+    path = _pending_record_path(subsystem, pending_id)
+    if path is None or not path.exists():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(record, dict):
+        return None
+    if record.get("id") != pending_id or record.get("subsystem") != subsystem:
+        return None
+    return record
 
 
 def stage_write(subsystem: str, payload: Dict[str, Any],
@@ -163,52 +187,43 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
 
 
 def list_pending(subsystem: str) -> List[Dict[str, Any]]:
-    """Return all pending records for ``subsystem``, oldest first."""
+    """Return all valid pending records for ``subsystem``, oldest first."""
     d = _pending_dir(subsystem)
     if not d.exists():
         return []
     records: List[Dict[str, Any]] = []
     for p in d.glob("*.json"):
-        try:
-            records.append(json.loads(p.read_text(encoding="utf-8")))
-        except Exception:
-            logger.warning("Skipping unreadable pending record: %s", p)
+        record = _read_pending_record(subsystem, p.stem)
+        if record is not None:
+            records.append(record)
     records.sort(key=lambda r: r.get("created_at", 0))
     return records
 
 
 def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
-    """Return a single pending record by id, or None."""
-    path = _pending_record_path(subsystem, pending_id)
-    if path is None or not path.exists():
-        return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
+    """Return a single valid pending record by id, or None."""
+    return _read_pending_record(subsystem, pending_id)
 
 
 def discard_pending(subsystem: str, pending_id: str) -> bool:
-    """Delete a pending record. Returns True if it existed."""
+    """Delete a valid pending record. Returns True if it existed."""
     path = _pending_record_path(subsystem, pending_id)
-    if path is None:
+    if path is None or _read_pending_record(subsystem, pending_id) is None:
         return False
     try:
-        if path.exists():
-            path.unlink()
-            return True
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
     except Exception as e:  # pragma: no cover
         logger.error("Failed to discard pending %s/%s: %s", subsystem, pending_id, e)
     return False
 
 
 def pending_count(subsystem: str) -> int:
-    """Cheap count of pending records (for notification badges)."""
-    d = _pending_dir(subsystem)
-    if not d.exists():
-        return 0
+    """Count valid pending records (for notification badges)."""
     try:
-        return sum(1 for _ in d.glob("*.json"))
+        return len(list_pending(subsystem))
     except Exception:
         return 0
 
@@ -486,7 +501,16 @@ def skill_pending_diff(record: Dict[str, Any]) -> str:
     elif action == "patch":
         old_s = payload.get("old_string") or ""
         new_s = payload.get("new_string") or ""
-        new = current.replace(old_s, new_s) if current else f"(patch {old_s!r} → {new_s!r})"
+        if current:
+            from tools.fuzzy_match import fuzzy_find_and_replace
+
+            new, _count, _strategy, match_error = fuzzy_find_and_replace(
+                current, old_s, new_s, payload.get("replace_all", False)
+            )
+            if match_error:
+                return f"(patch cannot be applied: {match_error})"
+        else:
+            new = f"(patch {old_s!r} → {new_s!r})"
     elif action == "write_file":
         new = payload.get("file_content") or ""
     elif action == "remove_file":

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from pathlib import Path
@@ -58,6 +59,7 @@ logger = logging.getLogger(__name__)
 MEMORY = "memory"
 SKILLS = "skills"
 _SUBSYSTEMS = (MEMORY, SKILLS)
+_PENDING_ID_RE = re.compile(r"^[0-9a-f]{8}$")
 
 # Config key (per subsystem). A single boolean: the approval gate is OFF by
 # default (writes flow freely, the pre-gate behaviour), and ON means stage /
@@ -109,6 +111,15 @@ def _normalize_enabled(value: Any) -> bool:
 
 def _pending_dir(subsystem: str) -> Path:
     return get_hermes_home() / "pending" / subsystem
+
+
+def _pending_record_path(subsystem: str, pending_id: Any) -> Optional[Path]:
+    """Return a pending-record path only for generated, safe identifiers."""
+    if subsystem not in _SUBSYSTEMS or not isinstance(pending_id, str):
+        return None
+    if _PENDING_ID_RE.fullmatch(pending_id) is None:
+        return None
+    return _pending_dir(subsystem) / f"{pending_id}.json"
 
 
 def stage_write(subsystem: str, payload: Dict[str, Any],
@@ -168,8 +179,8 @@ def list_pending(subsystem: str) -> List[Dict[str, Any]]:
 
 def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
     """Return a single pending record by id, or None."""
-    path = _pending_dir(subsystem) / f"{pending_id}.json"
-    if not path.exists():
+    path = _pending_record_path(subsystem, pending_id)
+    if path is None or not path.exists():
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -179,7 +190,9 @@ def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
 
 def discard_pending(subsystem: str, pending_id: str) -> bool:
     """Delete a pending record. Returns True if it existed."""
-    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    path = _pending_record_path(subsystem, pending_id)
+    if path is None:
+        return False
     try:
         if path.exists():
             path.unlink()

--- a/web/src/components/PendingSkillWrites.tsx
+++ b/web/src/components/PendingSkillWrites.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState } from "react";
+import { Check, ChevronDown, ChevronUp, FileDiff, RefreshCw, X } from "lucide-react";
+import { api } from "@/lib/api";
+import type { SkillPendingWrite } from "@/lib/api";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+
+interface PendingSkillWritesProps {
+  onApproved: () => void;
+  profile?: string;
+  showToast: (message: string, kind: "success" | "error") => void;
+}
+
+type PendingAction = {
+  kind: "approve" | "reject";
+  write: SkillPendingWrite;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+export function PendingSkillWrites({
+  onApproved,
+  profile,
+  showToast,
+}: PendingSkillWritesProps) {
+  const [pending, setPending] = useState<SkillPendingWrite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [diff, setDiff] = useState<{ id: string; text: string } | null>(null);
+  const [loadingDiffId, setLoadingDiffId] = useState<string | null>(null);
+  const [action, setAction] = useState<PendingAction | null>(null);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getPendingSkillWrites(profile)
+      .then((writes) => {
+        if (!cancelled) setPending(writes);
+      })
+      .catch((error) => {
+        if (!cancelled) showToast(`Pending skill writes: ${errorMessage(error)}`, "error");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profile, showToast]);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      setPending(await api.getPendingSkillWrites(profile));
+      setDiff(null);
+    } catch (error) {
+      showToast(`Pending skill writes: ${errorMessage(error)}`, "error");
+    } finally {
+      setRefreshing(false);
+    }
+  }, [profile, showToast]);
+
+  const toggleDiff = useCallback(
+    async (write: SkillPendingWrite) => {
+      if (diff?.id === write.id) {
+        setDiff(null);
+        return;
+      }
+      setLoadingDiffId(write.id);
+      try {
+        const result = await api.getPendingSkillDiff(write.id, profile);
+        setDiff({ id: write.id, text: result.diff });
+      } catch (error) {
+        showToast(`Skill diff: ${errorMessage(error)}`, "error");
+      } finally {
+        setLoadingDiffId(null);
+      }
+    },
+    [diff?.id, profile, showToast],
+  );
+
+  const submitAction = useCallback(async () => {
+    if (!action) return;
+    setApplying(true);
+    try {
+      if (action.kind === "approve") {
+        await api.approvePendingSkillWrite(action.write.id, profile);
+        onApproved();
+      } else {
+        await api.rejectPendingSkillWrite(action.write.id, profile);
+      }
+      setPending((writes) => writes.filter((write) => write.id !== action.write.id));
+      setDiff((current) => (current?.id === action.write.id ? null : current));
+      showToast(
+        `${action.kind === "approve" ? "Approved" : "Rejected"} ${action.write.id}`,
+        "success",
+      );
+      setAction(null);
+    } catch (error) {
+      showToast(`Skill write: ${errorMessage(error)}`, "error");
+    } finally {
+      setApplying(false);
+    }
+  }, [action, onApproved, profile, showToast]);
+
+  if (loading || pending.length === 0) return null;
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex-row items-center justify-between gap-3 py-3">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            Pending skill writes
+            <Badge>{pending.length}</Badge>
+          </CardTitle>
+          <Button
+            ghost
+            size="xs"
+            onClick={() => void refresh()}
+            disabled={refreshing}
+            aria-label="Refresh pending skill writes"
+            title="Refresh"
+          >
+            <RefreshCw className={refreshing ? "animate-spin" : ""} />
+          </Button>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <ul className="divide-y divide-border border-y border-border">
+            {pending.map((write) => {
+              const expanded = diff?.id === write.id;
+              const loadingDiff = loadingDiffId === write.id;
+              return (
+                <li key={write.id} className="py-3">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm text-foreground">{write.summary}</p>
+                      <p className="mt-0.5 font-mono-ui text-xs text-text-secondary">
+                        {write.id} · {write.action}
+                        {write.origin === "background_review" ? " · auto" : ""}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Button
+                        ghost
+                        size="sm"
+                        prefix={<FileDiff />}
+                        suffix={expanded ? <ChevronUp /> : <ChevronDown />}
+                        onClick={() => void toggleDiff(write)}
+                        disabled={loadingDiff}
+                        aria-expanded={expanded}
+                        aria-controls={`skill-diff-${write.id}`}
+                      >
+                        {expanded ? "Hide" : "Diff"}
+                      </Button>
+                      <Button
+                        outlined
+                        size="sm"
+                        prefix={<Check />}
+                        onClick={() => setAction({ kind: "approve", write })}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        destructive
+                        size="sm"
+                        prefix={<X />}
+                        onClick={() => setAction({ kind: "reject", write })}
+                      >
+                        Reject
+                      </Button>
+                    </div>
+                  </div>
+                  {expanded && (
+                    <pre
+                      id={`skill-diff-${write.id}`}
+                      className="mt-3 max-h-80 overflow-auto border border-border bg-muted/30 p-3 font-mono-ui text-xs leading-relaxed whitespace-pre-wrap break-all"
+                    >
+                      {diff.text}
+                    </pre>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={action !== null}
+        onCancel={() => !applying && setAction(null)}
+        onConfirm={() => void submitAction()}
+        title={action?.kind === "approve" ? "Approve skill write" : "Reject skill write"}
+        description={
+          action
+            ? `${action.kind === "approve" ? "Apply" : "Discard"} ${action.write.id}: ${action.write.summary}`
+            : undefined
+        }
+        confirmLabel={action?.kind === "approve" ? "Approve" : "Reject"}
+        destructive={action?.kind === "reject"}
+        loading={applying}
+      />
+    </>
+  );
+}

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -104,3 +104,37 @@ describe("api OAuth helpers", () => {
     }
   });
 });
+
+describe("api pending skill writes", () => {
+  it("uses the selected profile for review actions", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ pending: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getPendingSkillWrites("commissar-dansk");
+    await api.getPendingSkillDiff("a1b2c3d4", "commissar-dansk");
+    await api.approvePendingSkillWrite("a1b2c3d4", "commissar-dansk");
+    await api.rejectPendingSkillWrite("a1b2c3d4", "commissar-dansk");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/skills/pending?profile=commissar-dansk",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/skills/pending/a1b2c3d4/diff?profile=commissar-dansk",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/skills/pending/a1b2c3d4/approve?profile=commissar-dansk",
+      expect.objectContaining({ credentials: "include", method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "/api/skills/pending/a1b2c3d4?profile=commissar-dansk",
+      expect.objectContaining({ credentials: "include", method: "DELETE" }),
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -774,6 +774,24 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, content, profile: profile || undefined }),
     }),
+  getPendingSkillWrites: (profile?: string) =>
+    fetchJSON<{ pending: SkillPendingWrite[] }>(
+      `/api/skills/pending${profileQuery(profile)}`,
+    ).then(({ pending }) => pending),
+  getPendingSkillDiff: (id: string, profile?: string) =>
+    fetchJSON<SkillPendingDiff>(
+      `/api/skills/pending/${encodeURIComponent(id)}/diff${profileQuery(profile)}`,
+    ),
+  approvePendingSkillWrite: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean; id: string }>(
+      `/api/skills/pending/${encodeURIComponent(id)}/approve${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
+  rejectPendingSkillWrite: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean; id: string }>(
+      `/api/skills/pending/${encodeURIComponent(id)}${profileQuery(profile)}`,
+      { method: "DELETE" },
+    ),
   getToolsets: (profile?: string) =>
     fetchJSON<ToolsetInfo[]>(`/api/tools/toolsets${profileQuery(profile)}`),
   toggleToolset: (name: string, enabled: boolean, profile?: string) =>
@@ -2283,6 +2301,22 @@ export interface SkillWriteResult {
   message?: string;
   path?: string;
   error?: string;
+}
+
+export interface SkillPendingWrite {
+  id: string;
+  action: string;
+  summary: string;
+  origin: string;
+  created_at: number;
+  name: string;
+  file_path: string;
+}
+
+export interface SkillPendingDiff {
+  id: string;
+  summary: string;
+  diff: string;
 }
 
 export interface ToolsetInfo {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -42,6 +42,7 @@ import type {
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { ToolsetConfigDrawer } from "@/components/ToolsetConfigDrawer";
 import { SkillEditorDialog } from "@/components/SkillEditorDialog";
+import { PendingSkillWrites } from "@/components/PendingSkillWrites";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
@@ -152,6 +153,13 @@ export default function SkillsPage() {
     profile: selectedProfile,
   } = useProfileScope();
 
+  const refreshSkills = useCallback(() => {
+    api
+      .getSkills(selectedProfile || undefined)
+      .then(setSkills)
+      .catch(() => {});
+  }, [selectedProfile]);
+
   useEffect(() => {
     // Promise-chain shape: setState fires only inside async callbacks so the
     // effect body stays lint-clean (react-hooks/set-state-in-effect). On a
@@ -251,14 +259,9 @@ export default function SkillsPage() {
   const handleEditorSaved = useCallback(
     (skillName: string) => {
       showToast(`${skillName} saved ✓`, "success");
-      // Reload the list so a newly created skill (or an edited description)
-      // shows up immediately.
-      api
-        .getSkills(selectedProfile || undefined)
-        .then(setSkills)
-        .catch(() => {});
+      refreshSkills();
     },
-    [selectedProfile, showToast],
+    [refreshSkills, showToast],
   );
 
   /* ---- Derived data ---- */
@@ -381,6 +384,12 @@ export default function SkillsPage() {
     <div className="flex flex-col gap-4">
       <PluginSlot name="skills:top" />
       <Toast toast={toast} />
+      <PendingSkillWrites
+        key={selectedProfile || "__default__"}
+        profile={selectedProfile || undefined}
+        onApproved={refreshSkills}
+        showToast={showToast}
+      />
 
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
         <aside aria-label={t.skills.title} className="sm:w-56 sm:shrink-0">


### PR DESCRIPTION
## Summary
- add a compact pending-skill-writes panel to the Skills dashboard
- lazy-load the full diff and require a separate approve/reject confirmation
- reuse the native staged-write flow and selected-profile scope without bypassing `skills.write_approval`
- harden shared pending-record access: generated IDs only, no symlinks/out-of-root records, filename/subsystem binding, and fuzzy-engine-equivalent patch previews

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_web_server_skill_pending.py tests/hermes_cli/test_web_server_skills_profiles.py tests/hermes_cli/test_web_server_skill_editor.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/tools/test_write_approval.py -q` — 60 passed
- `npm test` — 145 passed; `npm run typecheck`; `npm run build`; `ruff check .`
- isolated dashboard API fixture: list, fuzzy diff, patch approval, create approval, and rejection/no-write
- browser-tested the dashboard panel: list, lazy diff, confirmation, approve/apply/remove, and reject/remove/no-write
- unauthenticated pending API regression coverage returns 401
