### PR TITLE
fix(copilot): skip token resolution when all sources are suppressed

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -72,12 +72,39 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
     return True, "OK"
 
 
+def _copilot_fully_suppressed() -> bool:
+    """True when every copilot credential source is user-suppressed.
+
+    ``hermes auth remove copilot`` marks ``gh_cli`` plus every
+    ``env:<VAR>`` source as suppressed.  When all of them are, skip token
+    resolution entirely so we never hit the network for a token exchange
+    the user has explicitly disabled (the exchange can stall the event
+    loop for seconds when the GitHub endpoint is unreachable).
+    """
+    try:
+        from hermes_cli.auth import is_source_suppressed
+    except Exception:
+        return False
+    if not is_source_suppressed("copilot", "gh_cli"):
+        return False
+    for env_var in COPILOT_ENV_VARS:
+        if not is_source_suppressed("copilot", f"env:{env_var}"):
+            return False
+    return True
+
+
 def resolve_copilot_token() -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
     Raises ValueError if only a classic PAT is available.
     """
+    # Respect user suppression (`hermes auth remove copilot`): skip
+    # resolution when every source is suppressed so no exchange network
+    # call is made on the caller's behalf.
+    if _copilot_fully_suppressed():
+        return "", ""
+
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
         val = os.getenv(env_var, "").strip()

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -41,6 +41,45 @@ class TestResolveToken:
                 resolve_copilot_token()
 
 
+class TestSuppressedResolution:
+    """`hermes auth remove copilot` must stop token resolution entirely.
+
+    Regression: previously the suppression marker was checked only *after*
+    token resolution, so a suppressed copilot source still triggered a
+    network token exchange on every credential-pool refresh — which could
+    stall the backend event loop for seconds when the GitHub exchange
+    endpoint was unreachable (issue observed with `gh auth token` fallback).
+    """
+
+    def test_fully_suppressed_skips_resolution_without_network(self, monkeypatch):
+        from hermes_cli.copilot_auth import resolve_copilot_token
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.auth.is_source_suppressed", return_value=True):
+            with patch(
+                "hermes_cli.copilot_auth._try_gh_cli_token",
+                side_effect=AssertionError("must not touch gh CLI when suppressed"),
+            ):
+                token, source = resolve_copilot_token()
+        assert token == ""
+        assert source == ""
+
+    def test_partial_suppression_still_resolves_env_token(self, monkeypatch):
+        from hermes_cli.copilot_auth import resolve_copilot_token
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "github_pat_supp_env_ok")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        def fake_suppressed(provider, source):
+            return provider == "copilot" and source == "gh_cli"
+
+        with patch("hermes_cli.auth.is_source_suppressed", side_effect=fake_suppressed):
+            token, source = resolve_copilot_token()
+        assert token == "github_pat_supp_env_ok"
+        assert source == "COPILOT_GITHUB_TOKEN"
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 


### PR DESCRIPTION
# Summary

Fix a bug where `hermes auth remove copilot` did not actually stop Copilot token resolution: the suppression check ran **after** token resolution, so a suppressed copilot source still fell back to `gh auth token` and hit GitHub's token-exchange endpoint on every credential-pool refresh. When that endpoint is slow or unreachable, the synchronous call stalls the backend event loop for 10–30s, which surfaces as desktop UI timeouts ("Timed out connecting to Hermes backend after 15000ms") and repeated "Copilot token exchange degraded to RAW token" warnings.

# Changes

- `hermes_cli/copilot_auth.py`: `resolve_copilot_token()` now checks `_copilot_fully_suppressed()` first and returns `("", "")` when every copilot source (`gh_cli` plus all of `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`) is suppressed — no `gh` CLI call, no network exchange. One guard at the resolution entry point covers all callers (credential-pool seeding, model catalog resolution, model switching, run_agent, auxiliary_client).
- `tests/hermes_cli/test_copilot_auth.py`: added `TestSuppressedResolution` with 2 regression tests — (1) fully suppressed → zero network (gh CLI mock raises if touched); (2) partial suppression → env token still resolves normally.

# Repro

1. `gh` CLI is logged in on the machine (`gh auth token` works)
2. Run `hermes auth remove copilot` (or any copilot source is present)
3. On backend startup / credential-pool refresh, Copilot token exchange is attempted repeatedly (roughly every 1–10s)
4. When `api.github.com` is slow or unreachable, the event loop stalls and the desktop settings page times out on save

After the fix: suppression takes effect immediately, `resolve_copilot_token()` returns empty, no network calls are made, and the event loop stays responsive.

# Known boundary

This fixes the "user explicitly disabled Copilot but it still runs" bug class. A separate, pre-existing behavior is intentionally **not** touched: when a user has **not** run `hermes auth remove copilot` and a logged-in `gh` CLI auto-discovers a Copilot token, a failing exchange is retried (with backoff) and can stall the loop while the GitHub endpoint is unreachable. That failure-retry policy is out of scope for this change — the fix here only guarantees that suppression actually suppresses.

# Tests

- `tests/hermes_cli/test_copilot_auth.py`: 2 new regression tests, all pass (23 passed)
- `tests/hermes_cli/test_copilot_token_exchange.py`: pass
- `tests/hermes_cli/test_api_key_providers.py`: pass
- `tests/agent/test_credential_pool.py`: 54 passed

<details>
<summary>中文版</summary>

# 概要

修复 `hermes auth remove copilot` 后 Copilot token 仍被解析并触发网络 exchange 的问题。suppression 标记检查被放在 token 解析**之后**，导致已禁用的 copilot 来源仍会走 `gh auth token` 回退并请求 GitHub token-exchange 接口；当该接口慢或不可达时，同步调用会卡住后端事件循环 10~30 秒，表现为桌面端 UI 超时（"Timed out connecting to Hermes backend after 15000ms"）并反复出现 "Copilot token exchange degraded to RAW token" 警告。

# 具体改动

- `hermes_cli/copilot_auth.py`：`resolve_copilot_token()` 开头新增 `_copilot_fully_suppressed()` 检查——当 copilot 的所有来源（`gh_cli` + `COPILOT_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN` 全部 env）都被 suppression 标记时，直接返回空，不碰 gh CLI、不发任何网络请求。一处修改覆盖所有调用方（凭据池 seed、模型目录解析、模型切换、run_agent、auxiliary_client）。
- `tests/hermes_cli/test_copilot_auth.py`：新增 `TestSuppressedResolution` 回归测试——① 全部来源 suppressed 时零网络（mock gh CLI 抛错验证不被调用）；② 仅部分 suppressed 时 env token 仍正常解析。

# 复现

1. 机器上 `gh` CLI 已登录（`gh auth token` 可用）
2. 执行 `hermes auth remove copilot`（或配置中存在 copilot 来源）
3. 后端启动/凭据池刷新时，仍每秒~每 10 秒尝试 Copilot token exchange
4. 当 `api.github.com` 不可达或慢时，事件循环卡死，桌面端保存设置超时

修复后：suppression 生效，`resolve_copilot_token()` 返回空，无网络调用，事件循环正常。

# 已知边界

本修复解决的是「用户明确禁用 Copilot 后仍被触发」这一类 bug。另一个**预先存在**的行为有意不在本次改动范围：当用户**未执行** `hermes auth remove copilot` 且已登录的 gh CLI 自动发现了 Copilot token 时，失败的 exchange 会带退避重试，在 GitHub 端点不可达期间可能卡住事件循环。该失败重试策略不属于本次改动——本次修复只保证「禁用即真正禁用」。

# 测试

- `tests/hermes_cli/test_copilot_auth.py`：新增 2 个测试，全部通过（23 passed）
- `tests/hermes_cli/test_copilot_token_exchange.py`：通过
- `tests/hermes_cli/test_api_key_providers.py`：通过
- `tests/agent/test_credential_pool.py`：54 passed
</details>
