### PR TITLE
fix(nix): repair nix run build (#76264)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18742,48 +18742,6 @@
         "vite": "8.2.0",
         "vitest": "4.1.10"
       }
-    },
-    "web/node_modules/@nous-research/ui": {
-      "version": "0.18.2",
-      "license": "MIT",
-      "dependencies": {
-        "@nanostores/react": "^1.1.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "nanostores": "^1.3.0",
-        "radix-ui": "^1.4.0",
-        "sanitize-html": "^2.17.4",
-        "tailwind-merge": "^3.6.0",
-        "tw-animate-css": "^1.4.0",
-        "unicode-animations": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@observablehq/plot": "^0.6.17",
-        "@react-three/fiber": "^9.4.0",
-        "gsap": "^3.13.0",
-        "leva": "^0.10.1",
-        "motion": "^12.38.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "three": "^0.180.0"
-      },
-      "peerDependenciesMeta": {
-        "@observablehq/plot": {
-          "optional": true
-        },
-        "@react-three/fiber": {
-          "optional": true
-        },
-        "gsap": {
-          "optional": true
-        },
-        "leva": {
-          "optional": true
-        },
-        "three": {
-          "optional": true
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Closes #76264

## Problem

`nix run github:NousResearch/hermes-agent -- setup` fails with:

```
npm error code ENOTCACHED
npm error request to https://registry.npmjs.org/@nous-research%2fui failed: cache mode is 'only-if-cached' but no cached response is available.
```

The `hermes-tui` derivation's `npmConfigHook` (from `importNpmLock`) runs `npm install` fully offline. Any entry in `package-lock.json` that is missing `resolved`/`integrity` cannot be materialized from the Nix store, so npm falls back to the registry and fails with `ENOTCACHED`.

## Root cause

`package-lock.json` contained a **stale, orphaned entry**:

```
web/node_modules/@nous-research/ui  →  version 0.18.2  (no `resolved`, no `integrity`)
```

- All three workspaces that use `@nous-research/ui` (`web`, `apps/desktop`, `apps/bootstrap-installer`) declare **`0.16.0`**, which is already present at the root (`node_modules/@nous-research/ui`, with valid `resolved`/`integrity`).
- Nothing references `0.18.2` anymore — the entry is dead weight left behind by `515e88a80` ("fix(sec): pin exact npm package versions everywhere"), which pinned `web` from `0.18.2` down to `0.16.0` but regenerated the lockfile in a way that kept the orphan entry without integrity metadata.
- Because the entry had no `integrity`, `importNpmLock` could not download it into the offline store, and `npm install` during the Nix build tried the registry → `ENOTCACHED`.

`nix run github:NousResearch/hermes-agent/v2026.7.20` (v0.19.0) works because that tag's lockfile still had `resolved`/`integrity` on the 0.18.2 entry (and `web` still depended on it).

## Fix

Remove the orphaned `web/node_modules/@nous-research/ui` (0.18.2) entry from `package-lock.json`. Verified:

- `npm install --package-lock-only` keeps the lockfile consistent and does **not** re-add the entry (npm confirms the tree resolves).
- `npm install --dry-run` resolves all 1240 packages offline with no errors.
- A scripted check equivalent to the repo's `npm-lockfile-fix` finds **zero** entries missing `resolved`/`integrity` after the removal — so `importNpmLock` can materialize every package from the store.
