### PR TITLE
fix(skills): guard install_from_quarantine against category bucket wipe (#75983)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3707,6 +3707,26 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
+        # Guard against wiping a category bucket that contains other skills.
+        # If the directory is NOT a previously hub-installed skill, check
+        # whether it holds any SKILL.md files from other skills — if so,
+        # refuse to overwrite to prevent silent data loss (issue #75983).
+        lock = HubLockFile()
+        is_hub_installed = lock.get_installed(safe_skill_name) is not None
+        if not is_hub_installed:
+            # Check if this is a category directory containing other skills
+            other_skills = [
+                p for p in install_dir.rglob("SKILL.md")
+                if p.resolve() != (install_dir / "SKILL.md").resolve()
+            ]
+            if other_skills:
+                raise ValueError(
+                    f"Cannot install skill '{safe_skill_name}': "
+                    f"{install_dir} already exists and contains "
+                    f"{len(other_skills)} other skill(s). "
+                    f"Choose a different name with --name, or specify a "
+                    f"category with --category to avoid the collision."
+                )
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large


### PR DESCRIPTION
## Summary

Fixes #75983 — `hermes skills install` silently deletes an entire category directory when the skill name matches.

## Problem

Installing a skill whose name collides with an existing category bucket (e.g. `hermes skills install <url> --name research`) unconditionally calls `shutil.rmtree` on the target directory before moving the new skill in. If that directory is a category containing many unrelated skills, all of them are permanently destroyed — no warning, no confirmation, no backup.

## Fix

Added a safety check in `install_from_quarantine()` before the `rmtree` call:

1. Check if the target directory is a previously hub-installed skill (exists in `lock.json`) — if so, allow overwrite (legitimate reinstall).
2. If NOT hub-installed, scan for `SKILL.md` files from other skills inside the directory.
3. If other skills are found, raise `ValueError` with a clear message instead of deleting.

## Changes

- `tools/skills_hub.py`: Added category bucket detection guard in `install_from_quarantine()` before `shutil.rmtree()`

## Testing

- Existing `test_install_from_quarantine_rejects_symlinks` passes (no conflict)
- Manual scenario: creating a category directory with skills + installing same-name skill now raises `ValueError` instead of deleting
