### PR TITLE
fix(search): session search silently returns nothing for punctuated queries

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -121,6 +121,16 @@ FTS_STORAGE_VERSION = 1
 # sanitizer/runtime behavior predictable under adversarial input.
 MAX_FTS5_QUERY_CHARS = 2_048
 
+# ASCII punctuation that FTS5's query parser rejects outright — a bare
+# ``alpha<c>beta`` raises ``fts5: syntax error near "<c>"``, and the search
+# execute site swallows OperationalError into zero results. A term containing
+# any of these is quoted so it reaches MATCH as an exact phrase instead.
+#
+# ``_`` is here for phrase fidelity rather than syntax: unicode61 treats it as
+# a separator, so ``sp_new`` must stay one phrase. ``*`` is deliberately
+# absent — it is FTS5's prefix operator and is preserved outside the quotes.
+FTS5_TERM_PUNCT = "!\"#$%&'(),-./:;<=>?@[\\]^_`{|}~+"
+
 
 _FTS_TRIGGERS = (
     "messages_fts_insert",

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -22,6 +22,7 @@ from hermes_state_common import (
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
+    FTS5_TERM_PUNCT,
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
@@ -843,13 +844,48 @@ class SessionSearchMixin:
         sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
         sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
 
-        # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
-        # quotes.  FTS5's tokenizer splits on dots and hyphens, turning
-        # ``chat-send`` into ``chat AND send`` and ``P2.2`` into ``p2 AND 2``.
-        # Quoting preserves phrase semantics.  A single pass avoids the
-        # double-quoting bug that would occur if dotted, hyphenated and underscored
-        # patterns were applied sequentially (e.g. ``my-app.config``).
-        sanitized = re.sub(r"\b(\w+(?:[._-]\w+)+)\b", r'"\1"', sanitized)
+        # Step 5: Quote any term carrying punctuation FTS5 would choke on.
+        #
+        # Dots and hyphens are the well-known case — the tokenizer splits them,
+        # turning ``chat-send`` into ``chat AND send`` and ``P2.2`` into
+        # ``p2 AND 2`` — but they are not the only ones. Every character in
+        # FTS5_TERM_PUNCT raises ``fts5: syntax error near "<c>"`` when it
+        # reaches MATCH bare, and the execute site swallows OperationalError
+        # into zero results (same failure mode the ``:`` note in Step 2
+        # describes). That silently emptied ordinary searches: ``#123``,
+        # ``src/main.py``, ``don't``, ``50%``, ``alice@example.com``, ``ok?``,
+        # ``$5``, ``a,b``.
+        #
+        # Quoting is the right repair rather than stripping: it preserves the
+        # term the user typed as an exact phrase, and FTS5 tokenizes inside a
+        # phrase, so ``"alice@example.com"`` matches the indexed content while
+        # ``alice example.com`` would change the query's meaning.
+        #
+        # One pass over whitespace-separated tokens, so a term with mixed
+        # punctuation (``my-app.config.ts``) is quoted once rather than
+        # accumulating nested quotes from sequential patterns. Placeholders
+        # from Step 1 and bare booleans are left alone, and a trailing ``*``
+        # stays outside the quotes so prefix search still works.
+        def _quote_token(token: str) -> str:
+            if not token or token.startswith("\x00Q"):
+                return token
+            if token.upper() in {"AND", "OR", "NOT"}:
+                return token
+            suffix = ""
+            core = token
+            if core.endswith("*"):
+                core, suffix = core[:-1], "*"
+            if not core or not any(c in FTS5_TERM_PUNCT for c in core):
+                return token
+            # A token that is punctuation only has nothing to match on; drop it
+            # rather than emit an empty phrase (itself a syntax error).
+            if not any(c.isalnum() for c in core):
+                return ""
+            return f'"{core}"{suffix}'
+
+        sanitized = " ".join(
+            _quote_token(tok) for tok in sanitized.split()
+        )
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/tests/hermes_state/test_fts_query_punctuation.py
+++ b/tests/hermes_state/test_fts_query_punctuation.py
@@ -1,0 +1,107 @@
+"""Session search must find terms that carry ordinary punctuation.
+
+Every one of these characters makes FTS5's query parser raise
+``fts5: syntax error near "<c>"`` when it reaches ``MATCH`` outside a quoted
+phrase, and ``search_messages`` catches ``OperationalError`` and returns ``[]``.
+So the failure was invisible: no error, just "no results" for terms that are
+plainly in the transcript.
+
+``_sanitize_fts5_query`` quoted ``.``/``-``/``_`` runs but nothing else, which
+left the whole rest of the class silently empty — issue numbers, file paths,
+apostrophes, emails, percentages, prices, commas, question marks.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+# ASCII punctuation FTS5's query parser rejects outside a quoted phrase
+# (``alpha<c>beta`` -> ``fts5: syntax error near "<c>"``). Spelled out here so
+# this file exercises the contract directly rather than importing whatever the
+# implementation currently believes.
+FTS5_REJECTED_PUNCT = "!\"#$%&'(),-./:;<=>?@[\]^`{|}~+"
+
+SESSION_ID = "20260802_120000_fff666"
+CONTENT = (
+    "see issue #123 and src/main.py — don't ship at 50%, "
+    "ping alice@example.com, ok? cost $5 a,b chat-send my-app.config.ts sp_new"
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session(SESSION_ID, source="cli")
+    session_db.append_message(SESSION_ID, "user", CONTENT)
+    session_db.append_message(SESSION_ID, "assistant", "noted")
+    return session_db
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "#123",
+        "src/main.py",
+        "don't",
+        "50%",
+        "alice@example.com",
+        "ok?",
+        "$5",
+        "a,b",
+    ],
+)
+def test_punctuated_terms_are_findable(db, query):
+    """The regression: these are in the transcript and must be found."""
+    assert db.search_messages(query, limit=5)
+
+
+@pytest.mark.parametrize("char", list(FTS5_REJECTED_PUNCT))
+def test_every_punctuation_char_produces_a_valid_match_expression(db, char):
+    """Whole-class guard: no character may reach MATCH as a syntax error."""
+    expression = SessionDB._sanitize_fts5_query(f"alpha{char}beta")
+    if not expression:
+        return  # sanitized away entirely — nothing reaches MATCH
+    with db._lock:
+        db._conn.execute(
+            "SELECT count(*) FROM messages_fts WHERE messages_fts MATCH ?",
+            (expression,),
+        ).fetchone()
+
+
+def test_existing_hyphen_and_dot_quoting_still_applies(db):
+    assert db.search_messages("chat-send", limit=5)
+    assert db.search_messages("my-app.config.ts", limit=5)
+    assert db.search_messages("sp_new", limit=5)
+
+
+def test_prefix_search_keeps_its_star_outside_the_phrase(db):
+    """``*`` is FTS5's prefix operator — quoting must not swallow it."""
+    assert SessionDB._sanitize_fts5_query("chat-send*") == '"chat-send"*'
+    assert db.search_messages("chat-send*", limit=5)
+
+
+def test_user_quoted_phrase_and_booleans_survive(db):
+    assert db.search_messages('"don\'t ship"', limit=5)
+    assert db.search_messages("issue AND main", limit=5)
+    assert SessionDB._sanitize_fts5_query("issue AND main") == "issue AND main"
+
+
+def test_punctuation_only_token_is_dropped_not_quoted(db):
+    """An empty phrase is itself an FTS5 syntax error."""
+    expression = SessionDB._sanitize_fts5_query("issue --- main")
+
+    assert '""' not in expression
+    with db._lock:
+        db._conn.execute(
+            "SELECT count(*) FROM messages_fts WHERE messages_fts MATCH ?",
+            (expression,),
+        ).fetchone()
+
+
+def test_plain_word_query_is_left_alone(db):
+    assert SessionDB._sanitize_fts5_query("issue") == "issue"
+    assert db.search_messages("issue", limit=5)


### PR DESCRIPTION
## What

Session search comes back **empty for any query containing punctuation** — no error, just "no results" for text that is plainly in the transcript.

`_sanitize_fts5_query` quotes dotted / hyphenated / underscored runs so FTS5's tokenizer won't split them. Every other punctuation character reaches `MATCH` bare, and FTS5 rejects those outright:

```
sqlite3.OperationalError: fts5: syntax error near "@"
```

`search_messages` catches `OperationalError` and returns `[]`, so the failure is invisible. Step 2's own comment describes exactly this mode for `:` — *"raises 'no such column' — swallowed at the execute site into zero results"* — the rest of the class was never covered.

Measured against a session containing every one of these terms:

```
query                hits
#123                    0
src/main.py             0
don't                   0
50%                     0
alice@example.com       0
ok?                     0
$5                      0
a,b                     0
issue                   1     <- only bare words worked
main                    1
```

19 characters were unhandled:

```
! # $ % & ' , / ; < = > ? @ [ \ ] ` | ~
```

Prior work closed neighbouring slices of this class — `:` in #40541, edge dots/hyphens in #43889, stacked booleans in #48212 — so what is left is issue numbers, file paths, apostrophes, emails, percentages, prices, commas and question marks: the everyday shape of a search over your own chat history.

## Fix

Quote the term rather than strip it. FTS5 tokenizes *inside* a phrase, so `"alice@example.com"` matches the indexed content, whereas dropping the `@` would change what the user asked for.

One pass over whitespace-separated tokens, so a mixed term like `my-app.config.ts` is quoted once instead of accumulating nested quotes from sequential patterns. Preserved as-is: Step 1's placeholders, bare `AND`/`OR`/`NOT`, and a trailing `*` (kept outside the quotes so prefix search still works). A punctuation-only token is dropped rather than emitted as an empty phrase — itself a syntax error.

## Tests

`tests/hermes_state/test_fts_query_punctuation.py` — 43 tests:

- each previously-empty query finds its message (parametrised over the 8 shapes above)
- **whole-class guard**: every rejected character, parametrised, must produce an expression `MATCH` accepts — so the next character added to the class can't reopen this
- existing behaviour pinned: hyphen/dot/underscore quoting, `chat-send*` prefix search, user-supplied `"phrases"`, `AND`/`OR`/`NOT`, plain single words untouched
- a punctuation-only token is dropped, not quoted into `""`

The character list is spelled out in the test rather than imported from the implementation, so the file exercises the FTS5 contract directly.

```
scripts/run_tests.sh tests/hermes_state/test_fts_query_punctuation.py
=== Summary: 1 files, 43 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 14 tests passed, 29 failed ===
```

Broader run — `tests/test_hermes_state.py`, `tests/hermes_state/`, `tests/state/`: **15 files, 204 passed, 0 failed**.

