### PR TITLE
fix(matrix): ignore membership invites targeted at other users

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3796,9 +3796,18 @@ class MatrixAdapter(BasePlatformAdapter):
         # spurious "rejecting invite ... from unauthorized user <bridge
         # bot>" for every such invite, even though nothing was actually
         # offered to us and there's nothing to reject.
+        #
+        # The comparison goes through _is_self_sender() rather than a raw
+        # equality check: some homeservers normalize the localpart case
+        # differently at different API surfaces, so a byte-comparison here
+        # would discard a *genuine* invite whose state_key differs from our
+        # resolved mxid only by casing or surrounding whitespace. It also
+        # gives us the right fallback — when our own mxid hasn't resolved
+        # yet, _is_self_sender() returns True defensively, so we fall
+        # through to the authorization gate instead of silently swallowing
+        # an invite we cannot yet attribute.
         state_key = str(getattr(event, "state_key", "") or "")
-        our_mxid = str(getattr(self._client, "mxid", "") or "")
-        if our_mxid and state_key and state_key != our_mxid:
+        if state_key and not self._is_self_sender(state_key):
             return
 
         # Only auto-join when the inviter is authorized. Without this, any

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3786,6 +3786,21 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct = bool(getattr(content, "is_direct", False))
         inviter = str(getattr(event, "sender", ""))
 
+        # mautrix's MembershipEventDispatcher fires InternalEventType.INVITE
+        # for *any* m.room.member state event with membership=invite that
+        # appears in a synced room's timeline/state — not just invites
+        # targeting this bot. In shared/bridged rooms we've already joined,
+        # bridge bots routinely invite other ghost users (Discord/Signal
+        # puppets) into the room, and those state events land here too.
+        # Without checking state_key against our own mxid, we log a
+        # spurious "rejecting invite ... from unauthorized user <bridge
+        # bot>" for every such invite, even though nothing was actually
+        # offered to us and there's nothing to reject.
+        state_key = str(getattr(event, "state_key", "") or "")
+        our_mxid = str(getattr(self._client, "mxid", "") or "")
+        if our_mxid and state_key and state_key != our_mxid:
+            return
+
         # Only auto-join when the inviter is authorized. Without this, any
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3345,9 +3345,18 @@ class MatrixAdapter(BasePlatformAdapter):
         # spurious "rejecting invite ... from unauthorized user <bridge
         # bot>" for every such invite, even though nothing was actually
         # offered to us and there's nothing to reject.
+        #
+        # The comparison goes through _is_self_sender() rather than a raw
+        # equality check: some homeservers normalize the localpart case
+        # differently at different API surfaces, so a byte-comparison here
+        # would discard a *genuine* invite whose state_key differs from our
+        # resolved mxid only by casing or surrounding whitespace. It also
+        # gives us the right fallback — when our own mxid hasn't resolved
+        # yet, _is_self_sender() returns True defensively, so we fall
+        # through to the authorization gate instead of silently swallowing
+        # an invite we cannot yet attribute.
         state_key = str(getattr(event, "state_key", "") or "")
-        our_mxid = str(getattr(self._client, "mxid", "") or "")
-        if our_mxid and state_key and state_key != our_mxid:
+        if state_key and not self._is_self_sender(state_key):
             return
 
         # Only auto-join when the inviter is authorized. Without this, any

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3335,6 +3335,21 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct = bool(getattr(content, "is_direct", False))
         inviter = str(getattr(event, "sender", ""))
 
+        # mautrix's MembershipEventDispatcher fires InternalEventType.INVITE
+        # for *any* m.room.member state event with membership=invite that
+        # appears in a synced room's timeline/state — not just invites
+        # targeting this bot. In shared/bridged rooms we've already joined,
+        # bridge bots routinely invite other ghost users (Discord/Signal
+        # puppets) into the room, and those state events land here too.
+        # Without checking state_key against our own mxid, we log a
+        # spurious "rejecting invite ... from unauthorized user <bridge
+        # bot>" for every such invite, even though nothing was actually
+        # offered to us and there's nothing to reject.
+        state_key = str(getattr(event, "state_key", "") or "")
+        our_mxid = str(getattr(self._client, "mxid", "") or "")
+        if our_mxid and state_key and state_key != our_mxid:
+            return
+
         # Only auto-join when the inviter is authorized. Without this, any
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -44,12 +44,19 @@ def _make_invite_event(
     is_direct=True,
     state_key=None,
 ):
-    """Create a fake membership invite event."""
+    """Create a fake membership invite event.
+
+    ``state_key`` on an ``m.room.member`` event is the *invitee*, not the
+    sender. It therefore defaults to the bot's own MXID (the account
+    ``_make_adapter`` configures), matching the shape of a real invite
+    directed at us. Tests covering the bridge fan-out case pass an explicit
+    foreign ``state_key``.
+    """
     content = SimpleNamespace(is_direct=is_direct)
     return SimpleNamespace(
         room_id=room_id,
         sender=sender,
-        state_key=state_key if state_key is not None else sender,
+        state_key=state_key if state_key is not None else "@hermes:example.org",
         content=content,
     )
 
@@ -146,8 +153,8 @@ class TestOnInviteIgnoresForeignMemberEvents:
     @pytest.mark.asyncio
     async def test_foreign_invite_state_key_is_ignored_silently(self, caplog):
         adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
         adapter._client = MagicMock()
-        adapter._client.mxid = "@neo:sppun.com"
         adapter._join_room_by_id = AsyncMock(return_value=True)
         adapter._record_dm_room = AsyncMock()
 
@@ -166,8 +173,8 @@ class TestOnInviteIgnoresForeignMemberEvents:
     @pytest.mark.asyncio
     async def test_invite_targeting_us_still_runs_allowlist_gate(self, caplog):
         adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
         adapter._client = MagicMock()
-        adapter._client.mxid = "@neo:sppun.com"
         adapter._join_room_by_id = AsyncMock(return_value=True)
 
         event = _make_invite_event(
@@ -185,8 +192,8 @@ class TestOnInviteIgnoresForeignMemberEvents:
     @pytest.mark.asyncio
     async def test_real_invite_still_joins_when_authorized(self):
         adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
         adapter._client = MagicMock()
-        adapter._client.mxid = "@neo:sppun.com"
         adapter._join_room_by_id = AsyncMock(return_value=True)
         adapter._record_dm_room = AsyncMock()
 
@@ -202,10 +209,48 @@ class TestOnInviteIgnoresForeignMemberEvents:
         adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
 
     @pytest.mark.asyncio
-    async def test_missing_client_mxid_does_not_suppress_gate(self):
+    @pytest.mark.parametrize(
+        "state_key",
+        [
+            "@NEO:sppun.com",
+            "@Neo:SPPUN.com",
+            "  @neo:sppun.com  ",
+        ],
+    )
+    async def test_bot_targeted_invite_survives_mxid_normalization(
+        self, state_key, caplog
+    ):
+        """A genuine invite to us must not be discarded over casing/whitespace.
+
+        Homeservers have been observed returning the same bot localpart with
+        different casing at different API surfaces, which is why
+        ``_is_self_sender()`` trims and lowercases. A raw ``state_key !=
+        our_mxid`` comparison here would silently drop these invites instead
+        of running the authorization gate.
+        """
         adapter = _make_adapter()
+        adapter._user_id = "@neo:sppun.com"
         adapter._client = MagicMock()
-        adapter._client.mxid = ""
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key=state_key,
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+        assert "rejecting invite" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_own_mxid_does_not_suppress_gate(self):
+        adapter = _make_adapter()
+        adapter._user_id = ""
+        adapter._client = MagicMock()
         adapter._join_room_by_id = AsyncMock(return_value=True)
         adapter._record_dm_room = AsyncMock()
 
@@ -219,5 +264,25 @@ class TestOnInviteIgnoresForeignMemberEvents:
         await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
 
         adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_own_mxid_still_rejects_unauthorized_inviter(self, caplog):
+        """Unresolved mxid must fall through to the gate, not bypass it."""
+        adapter = _make_adapter()
+        adapter._user_id = ""
+        adapter._client = MagicMock()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!room:sppun.com",
+            sender="@stranger:evil.example",
+            state_key="@neo:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        assert "rejecting invite" in caplog.text
 
 

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -42,12 +42,14 @@ def _make_invite_event(
     room_id="!dm_room:example.org",
     sender="@alice:example.org",
     is_direct=True,
+    state_key=None,
 ):
-    """Create a fake invite event with is_direct in content."""
+    """Create a fake membership invite event."""
     content = SimpleNamespace(is_direct=is_direct)
     return SimpleNamespace(
         room_id=room_id,
         sender=sender,
+        state_key=state_key if state_key is not None else sender,
         content=content,
     )
 
@@ -138,5 +140,84 @@ class TestRecordDMRoom:
 
         adapter._client.set_account_data.assert_not_awaited()
         assert adapter._dm_rooms.get("!room:example.org") is True
+
+
+class TestOnInviteIgnoresForeignMemberEvents:
+    @pytest.mark.asyncio
+    async def test_foreign_invite_state_key_is_ignored_silently(self, caplog):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.mxid = "@neo:sppun.com"
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!shared:sppun.com",
+            sender="@discordbot:sppun.com",
+            state_key="@discord_1234:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        adapter._record_dm_room.assert_not_awaited()
+        assert "rejecting invite" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_invite_targeting_us_still_runs_allowlist_gate(self, caplog):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.mxid = "@neo:sppun.com"
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+
+        event = _make_invite_event(
+            room_id="!room:sppun.com",
+            sender="@stranger:evil.example",
+            state_key="@neo:sppun.com",
+            is_direct=False,
+        )
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_not_called()
+        assert "rejecting invite" in caplog.text
+        assert "@stranger:evil.example" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_real_invite_still_joins_when_authorized(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.mxid = "@neo:sppun.com"
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key="@neo:sppun.com",
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_client_mxid_does_not_suppress_gate(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.mxid = ""
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(
+            room_id="!dm:sppun.com",
+            sender="@alice:example.org",
+            state_key="@neo:sppun.com",
+            is_direct=True,
+        )
+        await adapter._on_invite(event)
+        await TestOnInviteRecordsDM._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm:sppun.com")
 
 


### PR DESCRIPTION
## Summary

- ignore `MembershipEventDispatcher` invite fan-out when `state_key` targets another MXID
- preserve existing fail-closed authorization handling when the invite target is unresolved or targets the bot
- prevent false unauthorized-invite warnings replayed during initial sync in bridged rooms

## Verification

- `python -m pytest tests/gateway/test_matrix_dm_invite_recording.py -q` — 8 passed
- `ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix_dm_invite_recording.py`
- `python -m py_compile plugins/platforms/matrix/adapter.py tests/gateway/test_matrix_dm_invite_recording.py`

Closes #76292