### PR TITLE
fix(gateway): bypass system proxy for Weixin ilinkai connections

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -123,7 +123,7 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     some system CA stores (notably Homebrew's OpenSSL on macOS Apple Silicon).
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
     verification. Otherwise fall back to aiohttp's default (which honors
-    ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+    ``SSL_CERT_FILE`` env var via ``trust_env=False``).
 
     Uses a tight ``keepalive_timeout=2`` (default aiohttp: 30s) so idle
     connections drain promptly behind proxies like Cloudflare Warp that
@@ -1030,7 +1030,7 @@ async def qr_login(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError("aiohttp is required for Weixin QR login")
 
-    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
+    async with aiohttp.ClientSession(trust_env=False, connector=_make_ssl_connector()) as session:
         try:
             qr_resp = await _api_get(
                 session,
@@ -1300,13 +1300,13 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+        self._poll_session = aiohttp.ClientSession(trust_env=False, connector=_make_ssl_connector())
         # Disable aiohttp's built-in ClientTimeout (total=None) to prevent
         # "Timeout context manager should be used inside a task" errors when
         # send() is invoked via asyncio.run_coroutine_threadsafe() from cron.
         # Timeout is managed externally via asyncio.wait_for() in _api_post/_api_get.
         _no_aiohttp_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
-        self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
+        self._send_session = aiohttp.ClientSession(trust_env=False, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -2355,7 +2355,7 @@ async def send_weixin_direct(
             "context_token_used": bool(context_token),
         }
 
-    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
+    async with aiohttp.ClientSession(trust_env=False, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(
                 enabled=True,


### PR DESCRIPTION
## Summary

Fixes recurring Weixin (WeChat) gateway disconnects on Windows by setting `trust_env=False` on all aiohttp sessions in the Weixin platform adapter.

## Root Cause

`trust_env=True` makes aiohttp honor the Windows system proxy settings. When the system proxy (e.g. Clash on port 7897) is enabled but not running — or times out — the gateway fails with:

```
[Weixin] poll error: Cannot connect to host 127.0.0.1:7897
```

The adapter then exits, silently dropping the Weixin platform until manually restarted.

## Fix

`ilinkai.weixin.qq.com` is directly reachable from most networks (verified 0.1s latency without proxy). This change sets `trust_env=False` on all aiohttp sessions in `gateway/platforms/weixin.py`:

- `qr_login` session
- `_poll_session` (inbound long-polling)
- `_send_session` (outbound replies)
- `send_weixin_direct` session

## Test Plan

- [x] Verified direct connectivity: `curl https://ilinkai.weixin.qq.com` → 404 in 0.11s
- [x] Gateway restart → `✓ weixin connected`
- [x] Inbound/outbound messages flowing after fix