### PR TITLE
fix(cron): release dispatch guard on ledger failure

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4231,30 +4231,56 @@ def tick(
                 _running_job_ids.add(job_id)
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
-            dispatched_job = dict(job, execution_id=execution["id"])
-            _ctx = contextvars.copy_context()
-
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
-                try:
-                    return ctx.run(_process_job, j)
-                finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
-
+            execution = None
             try:
+                execution = create_execution(job_id, source="builtin")
+                dispatched_job = dict(job, execution_id=execution["id"])
+                _ctx = contextvars.copy_context()
+
+                def _run_and_release(j=dispatched_job, ctx=_ctx):
+                    try:
+                        return ctx.run(_process_job, j)
+                    finally:
+                        with _running_lock:
+                            _running_job_ids.discard(j["id"])
+
                 return pool.submit(_run_and_release)
-            except Exception as submit_err:
+            except BaseException as dispatch_err:
                 with _running_lock:
                     _running_job_ids.discard(job_id)
-                finish_execution(
-                    execution["id"],
-                    success=False,
-                    error=f"Executor dispatch failed: {submit_err}",
-                )
+
+                # If the durable attempt exists, make its terminal failure
+                # explicit. If creation itself failed there is no ledger row to
+                # update, so the error log is the only truthful surface.
+                if execution is not None:
+                    try:
+                        finish_execution(
+                            execution["id"],
+                            success=False,
+                            error=f"Executor dispatch failed: {dispatch_err}",
+                        )
+                    except Exception as record_err:
+                        logger.error(
+                            "Failed to finish execution record for job %s after dispatch failure: %s",
+                            job_id,
+                            record_err,
+                        )
+
+                if not isinstance(dispatch_err, Exception):
+                    raise
+
+                if execution is None:
+                    logger.error(
+                        "Job '%s' not dispatched — execution record could not be created: %s",
+                        job.get("name", job_id),
+                        dispatch_err,
+                        exc_info=True,
+                    )
+                    return None
+
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
-                if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):
+                if isinstance(dispatch_err, RuntimeError) and _interpreter_shutting_down(dispatch_err):
                     logger.warning(
                         "Job '%s' not dispatched — interpreter is shutting down",
                         job.get("name", job_id),
@@ -4263,7 +4289,7 @@ def tick(
                 logger.error(
                     "Job '%s' not dispatched: %s",
                     job.get("name", job_id),
-                    submit_err,
+                    dispatch_err,
                 )
                 return None
 

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -165,6 +165,53 @@ def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):
     assert [r["status"] for r in records] == ["unknown"]
 
 
+def test_execution_create_failure_releases_guard_and_job_refires(monkeypatch, caplog):
+    import concurrent.futures
+
+    import cron.scheduler as scheduler
+
+    class ImmediatePool:
+        def submit(self, callback):
+            future = concurrent.futures.Future()
+            try:
+                future.set_result(callback())
+            except BaseException as exc:
+                future.set_exception(exc)
+            return future
+
+    attempts = []
+
+    def create_execution(job_id, *, source):
+        attempts.append((job_id, source))
+        if len(attempts) == 1:
+            raise OSError("disk I/O error")
+        return {"id": "exec-after-recovery"}
+
+    job = {"id": "ledger-create-fail", "name": "ledger-create-fail"}
+    monkeypatch.setattr(scheduler, "create_execution", create_execution)
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_run", lambda _job_id: None)
+    monkeypatch.setattr(scheduler, "_get_parallel_pool", lambda _workers: ImmediatePool())
+    monkeypatch.setattr(scheduler, "run_one_job", lambda *_args, **_kwargs: True)
+    scheduler._running_job_ids.discard(job["id"])
+
+    try:
+        with caplog.at_level("ERROR", logger="cron.scheduler"):
+            assert scheduler.tick(verbose=False, sync=False) == 0
+
+        assert job["id"] not in scheduler.get_running_job_ids()
+        assert "execution record could not be created" in caplog.text
+        assert "disk I/O error" in caplog.text
+
+        assert scheduler.tick(verbose=False, sync=False) == 1
+        assert attempts == [
+            (job["id"], "builtin"),
+            (job["id"], "builtin"),
+        ]
+    finally:
+        scheduler._running_job_ids.discard(job["id"])
+
+
 def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch):
     import cron.scheduler as scheduler
 


### PR DESCRIPTION
## Summary
- release the in-memory cron dispatch guard when execution-ledger creation fails
- catch all pre-dispatch failures after guard acquisition while preserving terminal ledger records for attempts that were created
- log ledger-creation failures explicitly so the scheduler failure is visible even when no durable execution row can be written
- add a regression test proving a transient `create_execution` failure does not block a later tick

## Test plan
- `./scripts/run_tests.sh tests/cron -q` (374 passed)
- `python -m ruff check cron/scheduler.py tests/cron/test_execution_ledger.py`
- `python -m py_compile cron/scheduler.py tests/cron/test_execution_ledger.py`