### PR TITLE
fix(cli): skip branch-switch when pytest owns live checkout

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3740,6 +3740,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         current_branch = result.stdout.strip()
 
+        # If pytest owns this live checkout, skip the branch-switch entirely.
+        # A test that leaks into _cmd_update_impl (through a stale subprocess
+        # mock or a PROJECT_ROOT monkeypatch) would otherwise move the real
+        # HEAD and corrupt the running suite.  The sibling _write_marker_file
+        # path already uses this same guard.  See #76271.
+        if _m()._pytest_owns_live_checkout(_m().PROJECT_ROOT):
+            return
+
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
         # "always update against main" behavior; for any other target it's


### PR DESCRIPTION
## Root Cause

`_cmd_update_impl` in `hermes_cli/update_cmd.py` runs `git checkout` / `git checkout -B` against the live project root with no pytest guard. If a test in `tests/hermes_cli/` reaches `_cmd_update_impl` against the real `PROJECT_ROOT` (through a leaked `subprocess.run` mock, or a `PROJECT_ROOT` monkeypatch an earlier test left un-torn-down), the branch-switch recreates a local `main` and moves the real HEAD out from under the running suite. Every test that runs afterward then executes against the wrong tree, producing a large batch of failures that are really just the suite running on a corrupted checkout.

## Fix

Added a `_pytest_owns_live_checkout(PROJECT_ROOT)` guard before the branch-switch block, matching the same posture used by the sibling `_write_marker_file` path (line 1657). When pytest owns the live checkout, the function returns early without mutating the git state.

## Verification

The guard is a no-op in production (it only returns `True` when `PYTEST_CURRENT_TEST` is in the environment AND the root matches this module's own checkout). The `_write_marker_file` function at line 1657 already uses the identical guard, so this is a proven pattern.

## Reproduce

```bash
git rev-parse HEAD > /tmp/head_before
python -m pytest tests/hermes_cli/ -q
git rev-parse HEAD > /tmp/head_after
diff /tmp/head_before /tmp/head_after   # non-empty => HEAD moved during the suite
```

Fixes #76271