### PR TITLE
fix(compression): allow disabling engine preflight maintenance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1863,6 +1863,9 @@ def init_agent(
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
+    compression_preflight_enabled = is_truthy_value(
+        _compression_cfg.get("preflight_enabled"), default=True
+    )
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # Minimum REAL (actionable) user messages guaranteed to survive in the
@@ -2474,6 +2477,7 @@ def init_agent(
         except Exception:
             pass
     agent.compression_enabled = compression_enabled
+    agent.compression_preflight_enabled = compression_preflight_enabled
     agent.compression_in_place = compression_in_place
     # Apply micro-compaction settings to the compressor (feature is opt-in)
     _cc = getattr(agent, "context_compressor", None)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -959,11 +959,19 @@ def build_turn_context(
             _clear_warn = getattr(agent, "_clear_context_overflow_warn", None)
             if callable(_clear_warn):
                 _clear_warn()
-            # Engine maintenance only when NO skip-branch fired: a failure
+            # Engine maintenance only when enabled and NO skip-branch fired:
             # cooldown, deferred estimate, or codex-native route must keep
             # the engine hook un-consulted (#20316 contract — the cooldown
             # exists precisely because compression recently failed).
-            if _compression_cooldown or _preflight_deferred or _codex_native_auto:
+            _engine_preflight_enabled = getattr(
+                agent, "compression_preflight_enabled", True
+            )
+            if (
+                not _engine_preflight_enabled
+                or _compression_cooldown
+                or _preflight_deferred
+                or _codex_native_auto
+            ):
                 _engine_preflight = None
             else:
                 _engine_preflight = getattr(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -425,6 +425,11 @@ compression:
   # Set to false if you prefer to manage context manually or want errors on overflow
   enabled: true
 
+  # Allow context-engine plugins to request maintenance below the normal
+  # compression threshold (default: true). Set false to skip that engine hook
+  # while keeping threshold-triggered, manual, and idle compression available.
+  preflight_enabled: true
+
   # Opt-in compression progress notices on chat platforms (default: false).
   # By design, routine automatic compression is SILENT on human-facing chat
   # gateways (Telegram, Discord, Slack, ...) — it happens in the background

--- a/cli.py
+++ b/cli.py
@@ -467,6 +467,7 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
+            "preflight_enabled": True,  # Allow engine-requested sub-threshold maintenance
             "threshold": 0.50,    # Compress at 50% of model's context limit
             "min_tail_user_messages": 1,  # Real user messages guaranteed in the tail (1 = existing single anchor)
         },

--- a/docs/superpowers/specs/2026-08-02-engine-preflight-opt-out-design.md
+++ b/docs/superpowers/specs/2026-08-02-engine-preflight-opt-out-design.md
@@ -1,0 +1,110 @@
+# Engine Preflight Opt-Out Design
+
+## Problem
+
+Issue #76151 reports that an external context engine can request preflight
+maintenance far below Hermes' configured compression threshold. For engines
+such as `hermes-lcm`, that maintenance may block the start of a turn for several
+minutes and can repeat on later turns. Hermes currently calls
+`should_compress_preflight()` whenever the sub-threshold preflight path is
+eligible, with no host-level opt-out.
+
+The sub-threshold hook is intentional behavior introduced for #20316. Making it
+obey the ordinary compression threshold would break the context-engine contract
+and prevent incremental maintenance for every user. The fix therefore needs to
+be an explicit operator choice rather than a semantic change to the hook.
+
+## Goals
+
+- Add a `compression.preflight_enabled` boolean setting.
+- Preserve current behavior by defaulting the setting to `true`.
+- When set to `false`, skip only engine-driven sub-threshold preflight
+  maintenance.
+- Keep ordinary threshold-triggered compression, manual compression, idle
+  compaction, and other compression paths unchanged.
+- Document the setting in the example configuration.
+
+## Non-Goals
+
+- Changing `ContextEngine.should_compress_preflight()` or the LCM plugin's
+  internal maintenance policy.
+- Making engine preflight obey `compression.threshold`.
+- Adding timeouts, cancellation, cooldowns, or new retry policy.
+- Changing the default behavior for existing installations.
+
+## Considered Approaches
+
+### 1. Host-level boolean gate (selected)
+
+Parse `compression.preflight_enabled`, store the resolved value on the agent,
+and include it in the existing engine-preflight dispatch gate. This is small,
+backwards-compatible, applies to every context-engine plugin, and directly
+provides the requested opt-out.
+
+### 2. Force preflight to respect the ordinary threshold
+
+This would eliminate the reported early maintenance, but it reverses the
+explicit #20316 contract that permits engines to perform incremental work below
+the host threshold. It would silently disable valid behavior for all users and
+is therefore rejected.
+
+### 3. Add host-level timing or cooldown controls
+
+Timeout and cadence controls could reduce stalls while retaining maintenance,
+but they introduce cancellation and engine-state semantics beyond the issue's
+request. They are better handled separately after the plugin and host contracts
+are understood, so they are rejected for this PR.
+
+## Configuration Contract
+
+The new setting is:
+
+```yaml
+compression:
+  preflight_enabled: true
+```
+
+The canonical default config and legacy CLI defaults will both expose `true`.
+Runtime parsing will use the project's existing truthy-value convention and
+fall back to `true` when the key is absent or the compression section is
+partial. Adding the key does not require a config-version bump because the
+configuration loader deep-merges new keys.
+
+## Runtime Design
+
+Agent initialization resolves the setting once and stores it as
+`agent.compression_preflight_enabled`. The turn-start compression flow keeps all
+of its existing eligibility checks. In the sub-threshold `else` arm, Hermes
+consults `should_compress_preflight()` only when the new agent flag is true.
+
+With the flag false:
+
+- the engine hook is not called;
+- `_compress_context()` is not called by that engine-preflight arm;
+- no engine-preflight bookkeeping or status output changes;
+- the over-threshold `should_compress()` path remains available.
+
+The default is read through `getattr(..., True)` at the turn boundary so older
+or minimal agent test doubles remain compatible.
+
+## Testing
+
+Behavior tests will extend the existing engine-preflight suite:
+
+1. A false flag prevents a true-returning engine hook from being consulted and
+   prevents the engine-driven compression pass.
+2. A false flag does not prevent the ordinary over-threshold compression path.
+3. Existing default-enabled behavior continues to call the hook and retains
+   its current once-per-turn semantics.
+
+Configuration coverage will assert that agent initialization resolves the new
+setting to true by default and false when explicitly configured, using runtime
+behavior rather than reading source text. Tests will run through
+`scripts/run_tests.sh` as required by the repository.
+
+## Documentation and Compatibility
+
+`cli-config.yaml.example` will explain that disabling the option affects only
+engine-requested sub-threshold maintenance. The setting remains enabled by
+default, so existing users and context-engine plugins see no behavior change
+unless an operator opts out.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -539,6 +539,9 @@ DEFAULT_CONFIG = {
 
     "compression": {
         "enabled": True,
+        "preflight_enabled": True,  # allow context engines to request
+                                      # sub-threshold maintenance; default on
+                                      # preserves the existing plugin contract
         "progress_notices": False,    # opt-in (#52995): when True, routine compression
                                       # progress statuses (compacting/preflight/pre-API/
                                       # idle/retry) are delivered to chat gateway

--- a/tests/agent/test_compression_preflight_config.py
+++ b/tests/agent/test_compression_preflight_config.py
@@ -1,0 +1,60 @@
+"""Configuration coverage for engine-driven preflight maintenance."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from pathlib import Path
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _config(preflight_enabled=None) -> dict:
+    compression = {
+        "enabled": True,
+        "threshold": 0.50,
+        "target_ratio": 0.20,
+        "protect_first_n": 3,
+        "protect_last_n": 20,
+    }
+    if preflight_enabled is not None:
+        compression["preflight_enabled"] = preflight_enabled
+    return {
+        "compression": compression,
+        "prompt_caching": {"cache_ttl": "5m"},
+        "sessions": {},
+        "bedrock": {},
+    }
+
+
+def _make_agent(monkeypatch, tmp_path: Path, *, preflight_enabled=None):
+    from hermes_cli import config as config_mod
+
+    config = _config(preflight_enabled=preflight_enabled)
+    monkeypatch.setattr(config_mod, "load_config", lambda: config)
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: config)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    with contextlib.redirect_stdout(io.StringIO()):
+        return AIAgent(
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="test-key",
+            provider="openai-codex",
+            model="gpt-5.5",
+            enabled_toolsets=[],
+            disabled_toolsets=[],
+            quiet_mode=True,
+            skip_memory=True,
+            session_db=db,
+            session_id="preflight-config-test",
+        )
+
+
+def test_engine_preflight_defaults_enabled_when_unset(monkeypatch, tmp_path):
+    agent = _make_agent(monkeypatch, tmp_path)
+    assert agent.compression_preflight_enabled is True
+
+
+def test_engine_preflight_can_be_disabled(monkeypatch, tmp_path):
+    agent = _make_agent(monkeypatch, tmp_path, preflight_enabled=False)
+    assert agent.compression_preflight_enabled is False

--- a/tests/agent/test_engine_preflight_wire.py
+++ b/tests/agent/test_engine_preflight_wire.py
@@ -189,3 +189,35 @@ def test_builtin_compressor_default_sub_threshold_path_unchanged(tmp_path):
     agent._compress_context.assert_not_called()
     agent._emit_status.assert_not_called()
     assert ctx.preflight_compression_blocked is False
+
+
+def test_disabled_engine_preflight_does_not_block_threshold_compression():
+    """The opt-out affects only the engine's sub-threshold hook."""
+    hook = MagicMock(return_value=True)
+    comp = _stub_compressor(preflight=hook, threshold_tokens=100)
+    comp.should_compress = lambda _tokens=None: True
+    comp.context_length = 200_000
+    agent = _make_agent(comp)
+    agent.compression_preflight_enabled = False
+
+    with patch(
+        "agent.turn_context.estimate_request_tokens_rough", return_value=999_999
+    ):
+        _build(agent)
+
+    hook.assert_not_called()
+    agent._compress_context.assert_called()
+
+
+def test_disabled_engine_preflight_skips_sub_threshold_hook():
+    """An explicit opt-out skips engine-requested sub-threshold work."""
+    hook = MagicMock(return_value=True)
+    agent = _make_agent(_stub_compressor(preflight=hook))
+    agent.compression_preflight_enabled = False
+
+    ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    hook.assert_not_called()
+    agent._compress_context.assert_not_called()
+    assert ctx.preflight_compression_blocked is False


### PR DESCRIPTION
## What does this PR do?

This PR adds a backwards-compatible `compression.preflight_enabled` setting that lets operators disable context-engine-requested, sub-threshold preflight maintenance.

Engine preflight maintenance was intentionally wired into the turn-start path for context engines such as `hermes-lcm`, but Hermes currently has no host-level opt-out. An engine can therefore request an expensive `compress()` pass far below the configured compression threshold and block a turn for several minutes.

The new setting defaults to `true`, preserving the existing context-engine contract. Setting it to `false` skips only the engine-driven sub-threshold hook. Threshold-triggered compression, manual compression, and idle compaction remain unchanged.

## Related Issue

Fixes #76151

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `compression.preflight_enabled: true` to the canonical and legacy defaults in `hermes_cli/config_defaults.py` and `cli.py`.
- Parsed and attached the setting as `agent.compression_preflight_enabled` in `agent/agent_init.py`.
- Gated only the engine-driven sub-threshold hook in `agent/turn_context.py`, with a `getattr(..., True)` compatibility fallback for minimal or older agent objects.
- Documented the option in `cli-config.yaml.example`.
- Added config-to-agent coverage in `tests/agent/test_compression_preflight_config.py`.
- Added runtime coverage in `tests/agent/test_engine_preflight_wire.py` proving that the opt-out skips sub-threshold engine work without blocking normal threshold compression.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh tests/agent/test_compression_preflight_config.py tests/agent/test_engine_preflight_wire.py -q
   ```
2. Verify that all 7 focused tests pass.
3. Configure `compression.preflight_enabled: false` with a context engine that returns `true` from `should_compress_preflight()`; verify that the sub-threshold hook is skipped while over-threshold compression still runs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test result:

```text
7 tests passed, 0 failed
```

The full test suite was started but intentionally stopped before completion; this PR is being opened as a draft pending CI/full-suite validation.