### PR TITLE
fix(gateway): return MEDIA rejections to the session (#75065)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5716,6 +5716,19 @@ class BasePlatformAdapter(ABC):
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
 
+            pending_feedback = self._pending_messages.get(session_key)
+            if (
+                pending_feedback is not None
+                and (getattr(pending_feedback, "metadata", None) or {}).get(
+                    "media_delivery_feedback"
+                )
+            ):
+                runner = getattr(self, "gateway_runner", None)
+                queue_pending = getattr(runner, "_queue_or_replace_pending_event", None)
+                if callable(queue_pending):
+                    queue_pending(session_key, event)
+                    return
+
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
             # then process them immediately after the current task finishes.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4317,9 +4317,12 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
-        """Drop unsafe MEDIA paths and normalize accepted paths."""
+    def partition_media_delivery_paths(
+        media_files,
+    ) -> Tuple[List[Tuple[str, bool]], List[Tuple[str, bool]]]:
+        """Partition MEDIA paths into normalized accepted and rejected pairs."""
         safe_media: List[Tuple[str, bool]] = []
+        rejected_media: List[Tuple[str, bool]] = []
         for media_path, is_voice in media_files or []:
             raw = str(media_path)
             safe_path = validate_media_delivery_path(raw)
@@ -4327,6 +4330,13 @@ class BasePlatformAdapter(ABC):
                 safe_media.append((safe_path, bool(is_voice)))
             else:
                 logger.warning("Skipping unsafe MEDIA directive path: %s", _log_safe_path(raw))
+                rejected_media.append((raw, bool(is_voice)))
+        return safe_media, rejected_media
+
+    @staticmethod
+    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
+        """Drop unsafe MEDIA paths and normalize accepted paths."""
+        safe_media, _ = BasePlatformAdapter.partition_media_delivery_paths(media_files)
         return safe_media
 
     @staticmethod
@@ -5857,7 +5867,22 @@ class BasePlatformAdapter(ABC):
 
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                media_files, rejected_media = self.partition_media_delivery_paths(media_files)
+                runner = getattr(self, "gateway_runner", None)
+                if rejected_media and runner is not None:
+                    try:
+                        runner._queue_media_delivery_feedback(
+                            event,
+                            session_key,
+                            self,
+                            rejected_media,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "[%s] Could not queue MEDIA delivery feedback",
+                            self.name,
+                            exc_info=True,
+                        )
 
                 # Do NOT deduplicate MEDIA tags against prior turns here.
                 # The auto-append path in GatewayRunner._run_agent_inner already

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5475,6 +5475,16 @@ class BasePlatformAdapter(ABC):
         """
         await self._flush_text_debounce_now(session_key)
         pending_event = self._pending_messages.pop(session_key, None)
+        if pending_event is not None and (
+            getattr(pending_event, "metadata", None) or {}
+        ).get("media_delivery_feedback"):
+            runner = getattr(self, "gateway_runner", None)
+            promote = getattr(runner, "_promote_queued_event", None)
+            pending_event = (
+                promote(session_key, self, None)
+                if callable(promote)
+                else None
+            )
         self._release_session_guard(session_key, guard=command_guard)
         if pending_event is None:
             return

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5271,6 +5271,21 @@ class BasePlatformAdapter(ABC):
         existing_pending = self._pending_messages.get(session_key)
         if (
             existing_pending is not None
+            and (getattr(existing_pending, "metadata", None) or {}).get(
+                "media_delivery_feedback"
+            )
+        ):
+            state = store.pop(session_key, None)
+            if state is None:
+                return False
+            runner = getattr(self, "gateway_runner", None)
+            queue_pending = getattr(runner, "_queue_or_replace_pending_event", None)
+            if callable(queue_pending):
+                queue_pending(session_key, state.event)
+                return True
+            return False
+        if (
+            existing_pending is not None
             and not self._can_merge_text_debounce_events(existing_pending, state.event)
         ):
             return False
@@ -5869,7 +5884,7 @@ class BasePlatformAdapter(ABC):
                 media_files, response = self.extract_media(response)
                 media_files, rejected_media = self.partition_media_delivery_paths(media_files)
                 runner = getattr(self, "gateway_runner", None)
-                if rejected_media and runner is not None:
+                if rejected_media and runner is not None and not event.internal:
                     try:
                         runner._queue_media_delivery_feedback(
                             event,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7366,6 +7366,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             pending_slot[session_key] = queued_event
 
+    def _queue_media_delivery_feedback(
+        self,
+        event: "MessageEvent",
+        session_key: str,
+        adapter: Any,
+        rejected_media: List[Tuple[str, bool]],
+    ) -> None:
+        """Queue one bounded same-session turn for rejected MEDIA paths."""
+        if not rejected_media or event.metadata.get("media_delivery_feedback"):
+            return
+
+        paths = []
+        seen = set()
+        for media_path, _is_voice in rejected_media:
+            raw_path = str(media_path)
+            if raw_path in seen:
+                continue
+            seen.add(raw_path)
+            paths.append(json.dumps(raw_path, ensure_ascii=True))
+
+        feedback_text = (
+            "The gateway rejected the following MEDIA path(s) before upload, "
+            "so no attachment was sent:\n"
+            + "\n".join(f"- {path}" for path in paths)
+            + "\nMove, copy, translate, or regenerate the file at a host-visible "
+            "path under an allowed root, then retry with a new MEDIA directive. "
+            "If no valid path exists, report the delivery failure plainly."
+        )
+        feedback_event = MessageEvent(
+            text=feedback_text,
+            message_type=MessageType.TEXT,
+            source=event.source,
+            message_id=None,
+            auto_skill=event.auto_skill,
+            channel_prompt=event.channel_prompt,
+            channel_context=event.channel_context,
+            internal=True,
+            metadata={"media_delivery_feedback": True},
+        )
+        self._enqueue_fifo(session_key, feedback_event, adapter)
+
     def _promote_queued_event(
         self,
         session_key: str,
@@ -17303,7 +17344,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            response, event, _media_adapter, session_key=_quick_key,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -18402,6 +18443,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
+        session_key: Optional[str] = None,
     ) -> None:
         """Extract explicit MEDIA: tags from a response and deliver them.
 
@@ -18432,7 +18474,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
             media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            media_files, rejected_media = BasePlatformAdapter.partition_media_delivery_paths(media_files)
+            runner = getattr(adapter, "gateway_runner", None)
+            if rejected_media and runner is not None:
+                try:
+                    runner._queue_media_delivery_feedback(
+                        event,
+                        session_key or self._session_key_for_source(event.source),
+                        adapter,
+                        rejected_media,
+                    )
+                except Exception:
+                    logger.warning(
+                        "[%s] Could not queue streamed MEDIA delivery feedback",
+                        adapter.name,
+                        exc_info=True,
+                    )
             # Do NOT deduplicate explicit MEDIA tags against prior turns here
             # (#73771). This rescan is already EXPLICIT-ONLY (see docstring):
             # a MEDIA: directive in the final streamed reply is the model

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7388,12 +7388,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         feedback_text = (
             "The gateway rejected the following MEDIA path(s) before upload, "
-            "so no attachment was sent:\n"
+            "so the listed attachment(s) were not sent:\n"
             + "\n".join(f"- {path}" for path in paths)
             + "\nMove, copy, translate, or regenerate the file at a host-visible "
             "path under an allowed root, then retry with a new MEDIA directive. "
             "If no valid path exists, report the delivery failure plainly."
         )
+        feedback_metadata = dict(event.metadata or {})
+        feedback_metadata["media_delivery_feedback"] = True
         feedback_event = MessageEvent(
             text=feedback_text,
             message_type=MessageType.TEXT,
@@ -7403,7 +7405,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             channel_prompt=event.channel_prompt,
             channel_context=event.channel_context,
             internal=True,
-            metadata={"media_delivery_feedback": True},
+            metadata=feedback_metadata,
         )
         self._enqueue_fifo(session_key, feedback_event, adapter)
 
@@ -8359,6 +8361,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # semantics); everything else appends to the overflow tail.
         pending_slot = getattr(adapter, "_pending_messages", None)
         existing = pending_slot.get(session_key) if isinstance(pending_slot, dict) else None
+        if existing is not None and (
+            getattr(existing, "metadata", None) or {}
+        ).get("media_delivery_feedback"):
+            if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
+                logger.warning(
+                    "Dropping busy-mode follow-up for session %s — pending queue at cap (%d).",
+                    session_key,
+                    self._BUSY_QUEUE_MAX_PENDING,
+                )
+                return
+            self._enqueue_fifo(session_key, event, adapter)
+            return
         if existing is not None and (
             getattr(existing, "message_type", None) == MessageType.PHOTO
             or event.message_type == MessageType.PHOTO
@@ -17344,7 +17358,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter, session_key=_quick_key,
+                            response, event, _media_adapter, session_key=session_key,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -18476,7 +18490,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             media_files, cleaned = adapter.extract_media(response)
             media_files, rejected_media = BasePlatformAdapter.partition_media_delivery_paths(media_files)
             runner = getattr(adapter, "gateway_runner", None)
-            if rejected_media and runner is not None:
+            if rejected_media and runner is not None and not event.internal:
                 try:
                     runner._queue_media_delivery_feedback(
                         event,

--- a/tests/gateway/test_media_delivery_feedback.py
+++ b/tests/gateway/test_media_delivery_feedback.py
@@ -322,3 +322,32 @@ async def test_user_followup_after_feedback_keeps_turn_boundary(tmp_path, monkey
     queued = runner._sessions[session_key].conversation.queued_events
     assert len(queued) == 1
     assert queued[0].text == "follow-up"
+
+
+@pytest.mark.asyncio
+async def test_feedback_head_keeps_photo_followup_out_of_feedback_turn(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    runner._adapter_for_source = lambda source: adapter
+    session_key = build_session_key(_source())
+    runner._queue_media_delivery_feedback(
+        _event(),
+        session_key,
+        adapter,
+        [(str(rejected), False)],
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._busy_session_handler = AsyncMock(return_value=False)
+    adapter._message_handler = AsyncMock()
+    photo = _event("photo follow-up")
+    photo.message_type = MessageType.PHOTO
+
+    await adapter.handle_message(photo)
+
+    feedback_event = adapter._pending_messages[session_key]
+    assert feedback_event.metadata["media_delivery_feedback"] is True
+    queued = runner._sessions[session_key].conversation.queued_events
+    assert len(queued) == 1
+    assert queued[0] is photo

--- a/tests/gateway/test_media_delivery_feedback.py
+++ b/tests/gateway/test_media_delivery_feedback.py
@@ -1,0 +1,279 @@
+"""Regression coverage for rejected foreground MEDIA delivery."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _MediaFeedbackAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent_text: list[str] = []
+        self.sent_documents: list[str] = []
+        self.sent_voices: list[str] = []
+        self.sent_videos: list[str] = []
+        self.sent_images: list[list[tuple[str, str]]] = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content=None, **kwargs):
+        if content:
+            self.sent_text.append(content)
+        return SendResult(success=True, message_id=f"text-{len(self.sent_text)}")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+    async def send_document(self, chat_id, file_path, **kwargs):
+        self.sent_documents.append(file_path)
+        return SendResult(success=True, message_id="document")
+
+    async def send_voice(self, chat_id, audio_path, **kwargs):
+        self.sent_voices.append(audio_path)
+        return SendResult(success=True, message_id="voice")
+
+    async def send_video(self, chat_id, video_path, **kwargs):
+        self.sent_videos.append(video_path)
+        return SendResult(success=True, message_id="video")
+
+    async def send_multiple_images(self, chat_id, images, **kwargs):
+        self.sent_images.append(images)
+        return SendResult(success=True, message_id="images")
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="user-1",
+        chat_type="dm",
+    )
+
+
+def _event(text="request", *, metadata=None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="message-1",
+        channel_prompt="channel context",
+        auto_skill="skill-name",
+        metadata=metadata or {},
+    )
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._sessions = {}
+    runner._background_tasks = set()
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "thread-1"}
+    runner._reply_anchor_for_event = lambda event: None
+    return runner
+
+
+def _media_paths(tmp_path, monkeypatch):
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    safe = allowed_root / "safe.pdf"
+    safe.write_bytes(b"safe")
+    rejected = tmp_path / "container-output" / "report.pdf"
+    rejected.parent.mkdir()
+    rejected.write_bytes(b"rejected")
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (allowed_root,),
+    )
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+    return safe.resolve(), rejected.resolve()
+
+
+async def _drain_background_tasks(adapter):
+    await asyncio.sleep(0)
+    while adapter._background_tasks:
+        await asyncio.gather(*list(adapter._background_tasks))
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_rejected_nonstream_media_reenters_origin_session_and_recovers(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    events = []
+    responses = [
+        f"Here is the report.\nMEDIA:{rejected}",
+        "I could not deliver the report because the host rejected its path.",
+    ]
+
+    async def handler(event):
+        events.append(event)
+        return responses.pop(0)
+
+    adapter._message_handler = handler
+    await adapter._process_message_background(_event(), build_session_key(_source()))
+    await _drain_background_tasks(adapter)
+
+    assert len(events) == 2
+    assert events[1].internal is True
+    assert events[1].metadata["media_delivery_feedback"] is True
+    assert json.dumps(str(rejected), ensure_ascii=True) in events[1].text
+    assert "no attachment" in events[1].text.lower()
+    assert adapter.sent_text == [
+        "Here is the report.",
+        "I could not deliver the report because the host rejected its path.",
+    ]
+    assert adapter.sent_documents == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_streamed_media_queues_same_session_feedback(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    event = _event()
+
+    await GatewayRunner._deliver_media_from_response(
+        runner,
+        f"Already streamed text\nMEDIA:{rejected}",
+        event,
+        adapter,
+    )
+
+    pending = adapter.get_pending_message(build_session_key(event.source))
+    assert adapter.sent_documents == []
+    assert pending is not None
+    assert pending.internal is True
+    assert pending.metadata["media_delivery_feedback"] is True
+    assert "feedback-pending" not in pending.text
+
+
+@pytest.mark.asyncio
+async def test_safe_media_delivery_does_not_queue_feedback(tmp_path, monkeypatch):
+    safe, _ = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{safe}")
+    event = _event()
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.sent_documents == [str(safe)]
+    assert adapter._pending_messages == {}
+    assert runner._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_mixed_media_batch_delivers_safe_and_queues_one_feedback(tmp_path, monkeypatch):
+    safe, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    events = []
+
+    async def handler(event):
+        events.append(event)
+        if event.metadata.get("media_delivery_feedback"):
+            return "The report could not be recovered."
+        return f"Mixed result\nMEDIA:{safe}\nMEDIA:{rejected}"
+
+    adapter._message_handler = handler
+    await adapter._process_message_background(_event(), build_session_key(_source()))
+    await _drain_background_tasks(adapter)
+
+    assert adapter.sent_text == ["Mixed result", "The report could not be recovered."]
+    assert adapter.sent_documents == [str(safe)]
+    assert len(events) == 2
+    assert adapter._pending_messages == {}
+    assert events[1].metadata["media_delivery_feedback"] is True
+    assert events[1].text.count(json.dumps(str(rejected), ensure_ascii=True)) == 1
+
+
+def test_feedback_preserves_existing_fifo_order(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    event = _event()
+    session_key = build_session_key(event.source)
+    user_event = _event("follow-up")
+
+    runner._enqueue_fifo(session_key, user_event, adapter)
+    runner._queue_media_delivery_feedback(event, session_key, adapter, [(str(rejected), False)])
+
+    assert adapter._pending_messages[session_key] is user_event
+    queued = runner._sessions[session_key].conversation.queued_events
+    assert len(queued) == 1
+    assert queued[0].metadata["media_delivery_feedback"] is True
+    assert queued[0].source is event.source
+
+
+@pytest.mark.asyncio
+async def test_feedback_turn_rejection_does_not_requeue(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    feedback_event = _event(
+        metadata={"media_delivery_feedback": True},
+    )
+    adapter._message_handler = AsyncMock(
+        return_value=f"Retry failed\nMEDIA:{rejected}",
+    )
+
+    await adapter._process_message_background(
+        feedback_event,
+        build_session_key(feedback_event.source),
+    )
+
+    assert adapter.sent_text == ["Retry failed"]
+    assert adapter.sent_documents == []
+    assert adapter._pending_messages == {}
+    assert runner._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_post_validation_upload_failure_keeps_existing_user_notice(tmp_path, monkeypatch):
+    safe, _ = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=False, error="upload failed"),
+    )
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{safe}")
+
+    await adapter._process_message_background(_event(), build_session_key(_source()))
+
+    adapter.send_document.assert_awaited_once()
+    assert adapter.sent_text == ["⚠️ Couldn't deliver the file attachment (safe.pdf)."]
+    assert adapter._pending_messages == {}
+    assert runner._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_adapter_without_runner_preserves_filtering_and_delivery(tmp_path, monkeypatch):
+    safe, rejected = _media_paths(tmp_path, monkeypatch)
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = None
+    adapter._message_handler = AsyncMock(return_value=f"Safe\nMEDIA:{safe}\nMEDIA:{rejected}")
+
+    await adapter._process_message_background(_event(), build_session_key(_source()))
+
+    assert adapter.sent_text == ["Safe"]
+    assert adapter.sent_documents == [str(safe)]
+    assert adapter._pending_messages == {}

--- a/tests/gateway/test_media_delivery_feedback.py
+++ b/tests/gateway/test_media_delivery_feedback.py
@@ -351,3 +351,31 @@ async def test_feedback_head_keeps_photo_followup_out_of_feedback_turn(tmp_path,
     queued = runner._sessions[session_key].conversation.queued_events
     assert len(queued) == 1
     assert queued[0] is photo
+
+
+@pytest.mark.asyncio
+async def test_session_command_drops_stale_feedback_and_keeps_followup(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    session_key = build_session_key(_source())
+    command_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = command_guard
+
+    runner._queue_media_delivery_feedback(
+        _event(),
+        session_key,
+        adapter,
+        [(str(rejected), False)],
+    )
+    followup = _event("follow-up")
+    runner._enqueue_fifo(session_key, followup, adapter)
+
+    started = []
+    adapter._start_session_processing = lambda event, key: started.append((event, key)) or True
+
+    await adapter._drain_pending_after_session_command(session_key, command_guard)
+
+    assert started == [(followup, session_key)]
+    assert adapter._active_sessions == {}

--- a/tests/gateway/test_media_delivery_feedback.py
+++ b/tests/gateway/test_media_delivery_feedback.py
@@ -130,7 +130,7 @@ async def test_rejected_nonstream_media_reenters_origin_session_and_recovers(tmp
     assert events[1].internal is True
     assert events[1].metadata["media_delivery_feedback"] is True
     assert json.dumps(str(rejected), ensure_ascii=True) in events[1].text
-    assert "no attachment" in events[1].text.lower()
+    assert "listed attachment(s) were not sent" in events[1].text.lower()
     assert adapter.sent_text == [
         "Here is the report.",
         "I could not deliver the report because the host rejected its path.",
@@ -277,3 +277,48 @@ async def test_adapter_without_runner_preserves_filtering_and_delivery(tmp_path,
     assert adapter.sent_text == ["Safe"]
     assert adapter.sent_documents == [str(safe)]
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_internal_media_response_keeps_non_foreground_boundary(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    event = _event(metadata={"internal_source": "watch"})
+    event.internal = True
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{rejected}")
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+    await _drain_background_tasks(adapter)
+
+    assert adapter._message_handler.await_count == 1
+    assert adapter._pending_messages == {}
+    assert runner._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_user_followup_after_feedback_keeps_turn_boundary(tmp_path, monkeypatch):
+    _, rejected = _media_paths(tmp_path, monkeypatch)
+    runner = _runner()
+    adapter = _MediaFeedbackAdapter()
+    adapter.gateway_runner = runner
+    runner._adapter_for_source = lambda source: adapter
+    session_key = build_session_key(_source())
+    primary_event = _event()
+    runner._queue_media_delivery_feedback(
+        primary_event,
+        session_key,
+        adapter,
+        [(str(rejected), False)],
+    )
+    adapter._busy_text_mode = "queue"
+
+    await adapter._queue_text_debounce(session_key, _event("follow-up"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    feedback_event = adapter._pending_messages[session_key]
+    assert feedback_event.metadata["media_delivery_feedback"] is True
+    queued = runner._sessions[session_key].conversation.queued_events
+    assert len(queued) == 1
+    assert queued[0].text == "follow-up"


### PR DESCRIPTION
--- PROPOSAL ---

## Summary

The gateway currently removes an unsafe or host-invisible `MEDIA:<path>` before upload, delivers any remaining text, and leaves the agent session unaware that the attachment was omitted. This keeps the file-safety check intact but loses the information the agent needs to copy or regenerate the file at a deliverable path or report the failure honestly.

This change retains rejected explicit MEDIA candidates and queues one internal follow-up in the same session. The follow-up runs at a normal turn boundary, after the original response, so existing prompt caching, role alternation, text delivery, and safe attachment delivery remain unchanged.

## Changes

- `gateway/platforms/base.py`: partition accepted and rejected explicit MEDIA candidates while preserving the accepted-only compatibility helper.
- `gateway/run.py`: turn rejected foreground MEDIA candidates into one bounded, runner-owned same-session feedback event for normal and streamed responses.
- `tests/gateway/test_media_delivery_feedback.py`: cover recovery, streaming, mixed batches, FIFO ordering, recursion bounds, and unchanged upload-failure handling.

## Validation

| Scenario | Before | After |
|---|---|---|
| Unsafe container path in a normal response | Text arrives; attachment is omitted; only the gateway log records it | Text arrives; attachment remains blocked; the agent receives same-session feedback and can recover or report failure |
| Unsafe path in an already-streamed response | Attachment is omitted after the stream with no agent feedback | Stream remains unchanged; the agent receives one same-session feedback turn |
| Mixed safe and rejected attachments | Safe files upload; rejected files disappear from session context | Safe files upload unchanged; rejected files produce one feedback event |
| Safe attachment | Uploads normally | Unchanged |
| Accepted path whose platform upload fails | Existing user notice | Unchanged |

## Test plan

- Hidden `cmd.exe /v:on /d /s /c` runner, base: `tests/gateway/test_media_delivery_feedback.py::test_rejected_nonstream_media_reenters_origin_session_and_recovers` failed with `AssertionError: assert 1 == 2`; head: the same node passed with `1 passed in 1.21s`.
- Hidden `cmd.exe /v:on /d /s /c` runner: `tests/gateway/test_media_delivery_feedback.py tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation::test_filter_keeps_safe_media_and_drops_unsafe tests/gateway/test_tts_media_routing.py::test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_sender tests/gateway/test_tts_media_routing.py::test_streaming_delivery_blocks_media_path_outside_allowed_roots -q --timeout=120` — `15 passed in 0.97s`.

## Not in scope

The watch-pattern half remains in PR #75071. Direct tool-result or user notices remain with PRs #34178 and #31864, and missing post-stream files remain with PR #63837. This change doesn't alter bare local-file detection or failures that occur after validation accepts a path.

The session-feedback behavior follows [the original report](https://github.com/NousResearch/hermes-agent/issues/75065) and [GottZ's scope clarification](https://github.com/NousResearch/hermes-agent/issues/75065#issuecomment-5150580227).

## Upstream

Refs #75065.
