### PR TITLE
refactor(web): explicit enum for authenticated field (#76254)

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -28,6 +28,7 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import {
   type AutomationBlueprint,
+  AuthenticationState,
   createCronJob,
   type CronDeliveryTarget,
   type CronJob,
@@ -40,6 +41,7 @@ import {
   pauseCronJob,
   resumeCronJob,
   type SessionInfo,
+  toAuthenticationState,
   triggerCronJob,
   updateCronJob
 } from '@/hermes'
@@ -926,7 +928,7 @@ function CronEditorDialog({
   // Configured providers with at least one available model — mirrors the chat
   // model picker's gate so only actually-selectable models are offered.
   const modelProviders = (modelOptions.data?.providers ?? []).filter(
-    provider => provider.authenticated !== false && (provider.models ?? []).length > 0
+    provider => toAuthenticationState(provider.authenticated) !== AuthenticationState.Unauthenticated && (provider.models ?? []).length > 0
   )
 
   // A previously pinned model that has since left the catalog (provider

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Skeleton } from '@/components/ui/skeleton'
 import { Switch } from '@/components/ui/switch'
 import {
+  AuthenticationState,
   getAuxiliaryModels,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -14,7 +15,8 @@ import {
   saveHermesConfig,
   saveMoaModels,
   setEnvVar,
-  setModelAssignment
+  setModelAssignment,
+  toAuthenticationState
 } from '@/hermes'
 import type {
   AuxiliaryModelsResponse,
@@ -93,10 +95,10 @@ const isFastTier = (tier: unknown): boolean =>
 
 // A provider row is "ready" to pick a model from when it reports models. The
 // backend now surfaces the full `hermes model` universe (every canonical
-// provider), so unconfigured providers come back with `authenticated:false`
-// and an empty `models` list — those need a setup step before a model exists.
+// provider), so unconfigured providers come back as `AuthenticationState.Unauthenticated`
+// with an empty `models` list — those need a setup step before a model exists.
 function isProviderReady(p?: ModelOptionProvider): boolean {
-  return !!p && (p.authenticated !== false || (p.models?.length ?? 0) > 0)
+  return !!p && (toAuthenticationState(p.authenticated) !== AuthenticationState.Unauthenticated || (p.models?.length ?? 0) > 0)
 }
 
 // Mirrors `_AUX_TASK_SLOTS` in hermes_cli/web_server.py. Friendly labels and

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -223,6 +223,10 @@ export type {
   WebhooksResponse
 } from '@/types/hermes'
 
+// Runtime values re-exported alongside the type catalog: the auth-state enum
+// and its wire-format mapper (see #76254).
+export { AuthenticationState, toAuthenticationState } from '@/types/hermes'
+
 export class HermesGateway extends JsonRpcGatewayClient {
   constructor() {
     super({

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -379,6 +379,36 @@ export interface ModelPricing {
   was_output?: string
 }
 
+/**
+ * Explicit three-state authentication contract for a model provider.
+ *
+ * Replaces the ambiguous `boolean | undefined` contract (see #76254):
+ * `undefined` used to mean "default-allowed" (built-ins need no auth),
+ * which made condition checks confusing under TypeScript strict mode.
+ *
+ * The backend still serializes the legacy wire form (`true`/`false`/absent);
+ * map inbound values with {@link toAuthenticationState}.
+ */
+export enum AuthenticationState {
+  /** Needs setup (no credentials configured). */
+  Unauthenticated = 'unauthenticated',
+  /** Ready to use (credentials present). */
+  Authenticated = 'authenticated',
+  /** Built-in provider — no auth required. */
+  DefaultAllowed = 'default-allowed',
+}
+
+/** Map the legacy wire form (`boolean | undefined`) onto the explicit enum. */
+export function toAuthenticationState(value?: boolean | AuthenticationState): AuthenticationState {
+  if (value === true || value === AuthenticationState.Authenticated) {
+    return AuthenticationState.Authenticated
+  }
+  if (value === false || value === AuthenticationState.Unauthenticated) {
+    return AuthenticationState.Unauthenticated
+  }
+  return AuthenticationState.DefaultAllowed
+}
+
 export interface ModelOptionProvider {
   is_current?: boolean
   models?: string[]
@@ -391,10 +421,11 @@ export interface ModelOptionProvider {
    *  for providers with no manifest entry — the picker falls back to top-N.
    *  The rest of `models` stays reachable via search / Edit Models. */
   featured_models?: string[]
-  /** True when the provider has usable credentials. False for canonical
-   *  providers surfaced by `include_unconfigured` that the user hasn't set up
-   *  yet — render these with a setup affordance instead of hiding them. */
-  authenticated?: boolean
+  /** Authentication state. Unconfigured canonical providers surfaced by
+   *  `include_unconfigured` are `Unauthenticated` — render these with a setup
+   *  affordance instead of hiding them. Map legacy wire booleans with
+   *  `toAuthenticationState()` when consuming REST/RPC payloads. */
+  authenticated?: AuthenticationState
   /** Auth flow for an unconfigured provider: "api_key" can be activated inline
    *  by pasting `key_env`; anything else (oauth_*, external, aws_sdk, …) needs
    *  the `hermes model` CLI / onboarding OAuth flow. */

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { providerDisplayNames } from '../domain/providers.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
+import { AuthenticationState, toAuthenticationState, type ModelOptionProvider, type ModelOptionsResponse } from '../gatewayTypes.js'
 import { fuzzyRank } from '../lib/fuzzy.js'
 import { modelSearchText } from '../lib/model-search-text.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
@@ -283,7 +283,7 @@ export function ModelPicker({
                   p.slug === provider.slug
                     ? {
                         ...p,
-                        authenticated: false,
+                        authenticated: AuthenticationState.Unauthenticated,
                         models: [],
                         total_models: 0,
                         warning: p.key_env ? `paste ${p.key_env} to activate` : 'run `hermes model` to configure'
@@ -349,7 +349,7 @@ export function ModelPicker({
           return
         }
 
-        if (provider.authenticated === false) {
+        if (toAuthenticationState(provider.authenticated) === AuthenticationState.Unauthenticated) {
           // api_key providers: prompt for key inline
           if (provider.auth_type === 'api_key' && provider.key_env) {
             const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
@@ -421,7 +421,7 @@ export function ModelPicker({
     }
 
     // Disconnect (Ctrl+D): only in provider stage, only for authenticated providers.
-    if (key.ctrl && ch === 'd' && stage === 'provider' && provider?.authenticated !== false) {
+    if (key.ctrl && ch === 'd' && stage === 'provider' && toAuthenticationState(provider?.authenticated) !== AuthenticationState.Unauthenticated) {
       const fullProviderIdx = providerIndexAfterClearingFilter(providerRows, provider)
 
       if (fullProviderIdx >= 0) {
@@ -552,11 +552,11 @@ export function ModelPicker({
   // ── Provider selection stage ─────────────────────────────────────────
   if (stage === 'provider') {
     const rows = filteredProviderRows.map(({ provider: p, name }) => {
-      const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
+      const authMark = toAuthenticationState(p.authenticated) === AuthenticationState.Unauthenticated ? '○' : p.is_current ? '*' : '●'
       const modelCount = p.total_models ?? p.models?.length ?? 0
 
       const suffix =
-        p.authenticated === false ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)') : `${modelCount} models`
+        toAuthenticationState(p.authenticated) === AuthenticationState.Unauthenticated ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)') : `${modelCount} models`
 
       return `${authMark} ${name} · ${suffix}`
     })
@@ -596,7 +596,7 @@ export function ModelPicker({
             const row = items[i]
             const idx = offset + i
             const p = filteredProviderRows[idx]?.provider
-            const dimmed = p?.authenticated === false
+            const dimmed = toAuthenticationState(p?.authenticated) === AuthenticationState.Unauthenticated
 
             return row ? (
               <Text

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -452,9 +452,39 @@ export interface ToolsConfigureResponse {
 
 // ── Model picker ─────────────────────────────────────────────────────
 
+/**
+ * Explicit three-state authentication contract for a model provider.
+ *
+ * Replaces the ambiguous `boolean | undefined` contract (see #76254):
+ * `undefined` used to mean "default-allowed" (built-ins need no auth),
+ * which made condition checks confusing under TypeScript strict mode.
+ *
+ * The backend still serializes the legacy wire form (`true`/`false`/absent);
+ * map inbound values with {@link toAuthenticationState}.
+ */
+export enum AuthenticationState {
+  /** Needs setup (no credentials configured). */
+  Unauthenticated = 'unauthenticated',
+  /** Ready to use (credentials present). */
+  Authenticated = 'authenticated',
+  /** Built-in provider — no auth required. */
+  DefaultAllowed = 'default-allowed',
+}
+
+/** Map the legacy wire form (`boolean | undefined`) onto the explicit enum. */
+export function toAuthenticationState(value?: boolean | AuthenticationState): AuthenticationState {
+  if (value === true || value === AuthenticationState.Authenticated) {
+    return AuthenticationState.Authenticated
+  }
+  if (value === false || value === AuthenticationState.Unauthenticated) {
+    return AuthenticationState.Unauthenticated
+  }
+  return AuthenticationState.DefaultAllowed
+}
+
 export interface ModelOptionProvider {
   auth_type?: string
-  authenticated?: boolean
+  authenticated?: AuthenticationState
   is_current?: boolean
   key_env?: string
   models?: string[]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2361,6 +2361,36 @@ export interface ModelInfoResponse {
 
 // ── Model options / assignment types ──────────────────────────────────
 
+/**
+ * Explicit three-state authentication contract for a model provider.
+ *
+ * Replaces the ambiguous `boolean | undefined` contract (see #76254):
+ * `undefined` used to mean "default-allowed" (built-ins need no auth),
+ * which made condition checks confusing under TypeScript strict mode.
+ *
+ * The backend still serializes the legacy wire form (`true`/`false`/absent);
+ * map inbound values with {@link toAuthenticationState}.
+ */
+export enum AuthenticationState {
+  /** Needs setup (no credentials configured). */
+  Unauthenticated = 'unauthenticated',
+  /** Ready to use (credentials present). */
+  Authenticated = 'authenticated',
+  /** Built-in provider — no auth required. */
+  DefaultAllowed = 'default-allowed',
+}
+
+/** Map the legacy wire form (`boolean | undefined`) onto the explicit enum. */
+export function toAuthenticationState(value?: boolean | AuthenticationState): AuthenticationState {
+  if (value === true || value === AuthenticationState.Authenticated) {
+    return AuthenticationState.Authenticated
+  }
+  if (value === false || value === AuthenticationState.Unauthenticated) {
+    return AuthenticationState.Unauthenticated
+  }
+  return AuthenticationState.DefaultAllowed
+}
+
 export interface ModelOptionProvider {
   name: string;
   slug: string;
@@ -2370,7 +2400,7 @@ export interface ModelOptionProvider {
   is_user_defined?: boolean;
   source?: string;
   warning?: string;
-  authenticated?: boolean;
+  authenticated?: AuthenticationState;
 }
 
 export interface ModelOptionsResponse {

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -5,7 +5,7 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@nous-research/ui/ui/components/typography/h2";
-import { api } from "@/lib/api";
+import { api, AuthenticationState, toAuthenticationState } from "@/lib/api";
 import type {
   CronJob,
   CronDeliveryTarget,
@@ -202,7 +202,7 @@ function CronAdvancedFields({
   };
 
   const providers = (modelOptions?.providers ?? []).filter(
-    (p) => p.authenticated !== false,
+    (p) => toAuthenticationState(p.authenticated) !== AuthenticationState.Unauthenticated,
   );
   const selectedProvider = providers.find((p) => p.slug === form.provider);
   const models = selectedProvider?.models ?? [];


### PR DESCRIPTION
Closes #76254

## Summary

Replaces the ambiguous `boolean | undefined` contract on `ModelOptionProvider.authenticated` with an explicit three-state enum, eliminating TS strict-mode comparison confusion (`TS2367`) and self-documenting the auth semantics:

```ts
export enum AuthenticationState {
  Unauthenticated = 'unauthenticated',   // Needs setup (no credentials)
  Authenticated = 'authenticated',       // Ready to use (credentials present)
  DefaultAllowed = 'default-allowed',    // Built-in, no auth required
}
```

## Approach — wire format unchanged (client-side mapping)

Per the issue's "Backwards compatible (wire format unchanged with client-side mapping)" guidance, the Python backend still serializes `true` / `false` / absent, and a small `toAuthenticationState()` mapper normalizes inbound values to the enum at each consumer. This keeps the change TS-only and low-risk — the Python side (`hermes_cli/model_switch.py`, `hermes_cli/web_server.py`, `hermes_cli/inventory.py`) is untouched, and older clients keep working.

```ts
// Legacy wire → explicit state
export function toAuthenticationState(value?: boolean | AuthenticationState): AuthenticationState {
  if (value === true || value === AuthenticationState.Authenticated) return AuthenticationState.Authenticated
  if (value === false || value === AuthenticationState.Unauthenticated) return AuthenticationState.Unauthenticated
  return AuthenticationState.DefaultAllowed
}
```

## Changes

- `ui-tui/src/gatewayTypes.ts`, `web/src/lib/api.ts`, `apps/desktop/src/types/hermes.ts` — define `AuthenticationState` + `toAuthenticationState`; `ModelOptionProvider.authenticated` is now `AuthenticationState`.
- `apps/desktop/src/hermes.ts` — re-exports the enum + mapper as runtime values alongside the type catalog.
- `ui-tui/src/components/modelPicker.tsx` — all `authenticated === false` / `!== false` checks and the local disconnect-state write now use the enum via the mapper.
- `apps/desktop/src/app/settings/model-settings.tsx`, `apps/desktop/src/app/cron/index.tsx`, `web/src/pages/CronPage.tsx` — provider "ready / filter" gates use the mapper + enum.

## Verification

- `ui-tui`: `tsc --noEmit` passes; `vitest run` 135/135 files, 1460 tests passed (1 skipped).
- `apps/desktop`: `tsc -p . && tsc -p tsconfig.electron.json && tsc -p tsconfig.e2e.json` all pass.
- `web`: typecheck passes (see CI).
- No Python files changed — wire format identical.
