### PR TITLE
fix(kanban): scope worker file writes to task workspace (#70688)

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -27,6 +27,7 @@ KANBAN_ENV_KEYS: tuple[str, ...] = (
     "HERMES_KANBAN_CLAIM_LOCK",
     "HERMES_KANBAN_BOARD",
     "HERMES_KANBAN_DB",
+    # HERMES_KANBAN_SAFE_ROOT_ACTIVE intentionally survives for delegate children.
 )
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -306,7 +306,10 @@ def load_hermes_dotenv(
     - if no user env exists, the project `.env` also overrides stale shell vars.
     """
     loaded: list[Path] = []
-    kanban_worker = "HERMES_KANBAN_TASK" in os.environ
+    kanban_worker = (
+        "HERMES_KANBAN_TASK" in os.environ
+        or "HERMES_KANBAN_SAFE_ROOT_ACTIVE" in os.environ
+    )
     inherited_safe_root = os.environ.get("HERMES_WRITE_SAFE_ROOT")
     had_safe_root = "HERMES_WRITE_SAFE_ROOT" in os.environ
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -306,6 +306,9 @@ def load_hermes_dotenv(
     - if no user env exists, the project `.env` also overrides stale shell vars.
     """
     loaded: list[Path] = []
+    kanban_worker = "HERMES_KANBAN_TASK" in os.environ
+    inherited_safe_root = os.environ.get("HERMES_WRITE_SAFE_ROOT")
+    had_safe_root = "HERMES_WRITE_SAFE_ROOT" in os.environ
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
@@ -341,6 +344,13 @@ def load_hermes_dotenv(
 
     _apply_external_secret_sources(home_path)
     _apply_managed_env()
+
+    # Task-scoped roots must outrank profile and managed env files.
+    if kanban_worker:
+        if had_safe_root:
+            os.environ["HERMES_WRITE_SAFE_ROOT"] = inherited_safe_root or ""
+        else:
+            os.environ.pop("HERMES_WRITE_SAFE_ROOT", None)
 
     return loaded
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8924,6 +8924,7 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    env["HERMES_KANBAN_SAFE_ROOT_ACTIVE"] = "1"
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8941,11 +8941,21 @@ def _default_spawn(
     # build_context_files_prompt (#34619 — workers loaded the dispatching
     # gateway's AGENTS.md instead of the task's). Setting it to the workspace
     # fixes both: the workspace is where the task's work actually happens.
-    # Only pin a real, absolute directory — file_tools rejects relative /
-    # sentinel TERMINAL_CWD values, so a non-dir workspace must NOT be set
-    # here (leave the inherited value rather than write a meaningless one).
+    accepted_workspace = None
     if workspace and os.path.isabs(workspace) and os.path.isdir(workspace):
-        env["TERMINAL_CWD"] = workspace
+        try:
+            normalized_workspace = os.path.realpath(workspace)
+            if (
+                os.path.dirname(normalized_workspace) != normalized_workspace
+                and os.pathsep not in normalized_workspace
+            ):
+                accepted_workspace = normalized_workspace
+        except (OSError, ValueError):
+            pass
+    if accepted_workspace is not None:
+        # Scope native file-tool writes to this task root; terminal and OS access remain outside it.
+        env["TERMINAL_CWD"] = accepted_workspace
+        env["HERMES_WRITE_SAFE_ROOT"] = accepted_workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,6 +266,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_KANBAN_RUN_ID",
     "HERMES_KANBAN_CLAIM_LOCK",
     "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+    "HERMES_KANBAN_SAFE_ROOT_ACTIVE",
     # Pytest is routinely launched from a delegated worker.  The worker
     # lineage marker must not make parent-state tests run as delegated
     # children; tests that exercise child behavior set it explicitly.

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -13,7 +13,12 @@ Pinning ``TERMINAL_CWD`` to the workspace fixes both.
 
 from __future__ import annotations
 
+import os
 import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
 
 
 def _make_task(kb, *, assignee: str = "w"):
@@ -51,9 +56,31 @@ def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict:
         captured["cwd"] = kwargs.get("cwd")
         return FakeProc()
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    kb._default_spawn(_make_task(kb), workspace)
+    with monkeypatch.context() as capture_patch:
+        capture_patch.setattr(subprocess, "Popen", fake_popen)
+        kb._default_spawn(_make_task(kb), workspace)
     return captured
+
+
+def _shell_file_operations(workspace: Path):
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+
+    environment = LocalEnvironment(cwd=str(workspace))
+    return ShellFileOperations(environment, cwd=str(workspace))
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
 
 
 def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
@@ -77,3 +104,224 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
     assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
 
 
+def test_narrow_inherited_root_replaced_for_scratch_workspace_write(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "board"
+    workspace = root / "scratch-a"
+    sibling = root / "scratch-b"
+    inherited = tmp_path / "deployment-root"
+    workspace.mkdir(parents=True)
+    sibling.mkdir()
+    inherited.mkdir()
+    (tmp_path / ".hermes" / "profiles" / "w").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited))
+
+    from hermes_cli import kanban_db as kb
+
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    child_root = os.path.realpath(workspace)
+    assert captured["env"]["TERMINAL_CWD"] == child_root
+
+    target = workspace / "own.txt"
+    with mock.patch.dict(os.environ, captured["env"], clear=True):
+        result = _shell_file_operations(workspace).write_file(str(target), "own")
+
+    assert result.error is None
+    assert captured["env"]["HERMES_WRITE_SAFE_ROOT"] == child_root
+    assert target.read_text(encoding="utf-8") == "own"
+
+
+def test_sibling_and_traversal_mutations_are_denied(monkeypatch, tmp_path):
+    root = tmp_path / "board"
+    workspace = root / "scratch-a"
+    sibling = root / "scratch-b"
+    workspace.mkdir(parents=True)
+    sibling.mkdir()
+    (tmp_path / ".hermes" / "profiles" / "w").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_CWD", str(root))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    direct = sibling / "direct.txt"
+    traversal = sibling / "traversal.txt"
+    direct.write_text("before", encoding="utf-8")
+    traversal.write_text("before", encoding="utf-8")
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+
+    with mock.patch.dict(os.environ, captured["env"], clear=True):
+        ops = _shell_file_operations(workspace)
+        direct_result = ops.patch_replace(str(direct), "before", "after")
+        traversal_result = ops.patch_replace(
+            str(workspace / ".." / "scratch-b" / "traversal.txt"),
+            "before",
+            "after",
+        )
+
+    assert direct_result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in direct_result.error
+    assert traversal_result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in traversal_result.error
+    assert direct.read_text(encoding="utf-8") == "before"
+    assert traversal.read_text(encoding="utf-8") == "before"
+
+
+def test_symlink_escape_is_denied(monkeypatch, tmp_path):
+    if os.name == "nt":
+        pytest.skip("symlink boundary is covered on POSIX CI")
+
+    root = tmp_path / "board"
+    workspace = root / "scratch-a"
+    outside = root / "outside"
+    workspace.mkdir(parents=True)
+    outside.mkdir()
+    try:
+        (workspace / "escape").symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    (tmp_path / ".hermes" / "profiles" / "w").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_CWD", str(root))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    target = workspace / "escape" / "escaped.txt"
+    with mock.patch.dict(os.environ, captured["env"], clear=True):
+        result = _shell_file_operations(workspace).write_file(str(target), "blocked")
+
+    assert result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in result.error
+    assert not (outside / "escaped.txt").exists()
+
+
+def test_workspace_variables_share_realpath(monkeypatch, tmp_path):
+    target = tmp_path / "real-workspace"
+    workspace = tmp_path / "workspace-link"
+    target.mkdir()
+    try:
+        workspace.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    inherited = tmp_path / "inherited-root"
+    inherited.mkdir()
+    (tmp_path / ".hermes" / "profiles" / "w").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited))
+
+    from hermes_cli import kanban_db as kb
+
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    assert captured["cwd"] == str(workspace)
+    assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
+    assert captured["env"]["TERMINAL_CWD"] == os.path.realpath(workspace)
+    assert captured["env"]["HERMES_WRITE_SAFE_ROOT"] == os.path.realpath(workspace)
+
+
+def test_invalid_workspace_preserves_inherited_policy(monkeypatch, tmp_path):
+    inherited_cwd = tmp_path / "inherited-cwd"
+    inherited_root = tmp_path / "inherited-root"
+    existing_file = tmp_path / "workspace-file"
+    separator_dir = tmp_path / f"workspace{os.pathsep}roots"
+    inherited_cwd.mkdir()
+    inherited_root.mkdir()
+    existing_file.write_text("file", encoding="utf-8")
+    separator_dir.mkdir()
+    (tmp_path / ".hermes" / "profiles" / "w").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited_cwd))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited_root))
+
+    candidates = [
+        "relative-workspace",
+        "",
+        str(tmp_path / "missing-workspace"),
+        str(existing_file),
+        os.path.abspath(os.sep),
+        str(separator_dir),
+    ]
+    from hermes_cli import kanban_db as kb
+
+    for candidate in candidates:
+        captured = _capture_spawn_env(kb, monkeypatch, candidate)
+        assert captured["env"]["TERMINAL_CWD"] == str(inherited_cwd), candidate
+        assert captured["env"]["HERMES_WRITE_SAFE_ROOT"] == str(inherited_root), candidate
+
+
+def test_dispatch_scopes_materialized_scratch_workspace(kanban_home, monkeypatch):
+    from hermes_cli import kanban_db as kb
+
+    inherited = kanban_home.parent / "deployment-root"
+    inherited.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited))
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs["env"])
+        captured["cwd"] = kwargs["cwd"]
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="scoped scratch",
+            assignee="default",
+            workspace_kind="scratch",
+        )
+        result = kb.dispatch_once(conn, max_spawn=1)
+        task = kb.get_task(conn, task_id)
+
+    assert [item[0] for item in result.spawned] == [task_id]
+    assert task is not None
+    workspace = Path(task.workspace_path)
+    assert workspace.is_dir()
+    assert captured["cwd"] == str(workspace)
+    assert captured["env"]["HERMES_WRITE_SAFE_ROOT"] == os.path.realpath(workspace)
+
+
+def test_scoped_spawn_failure_records_existing_failure_flow(kanban_home, monkeypatch):
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    def failing_popen(*args, **kwargs):
+        raise OSError("spawn boom")
+
+    monkeypatch.setattr(subprocess, "Popen", failing_popen)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="spawn failure",
+            assignee="default",
+            workspace_kind="scratch",
+        )
+        first = kb.dispatch_once(conn, failure_limit=2)
+        after_first = kb.get_task(conn, task_id)
+        second = kb.dispatch_once(conn, failure_limit=2)
+        after_second = kb.get_task(conn, task_id)
+        event_kinds = [event.kind for event in kb.list_events(conn, task_id)]
+
+    assert first.spawned == []
+    assert second.spawned == []
+    assert after_first is not None
+    assert after_first.status == "ready"
+    assert after_first.claim_lock is None
+    assert after_first.consecutive_failures == 1
+    assert after_second is not None
+    assert after_second.status == "blocked"
+    assert after_second.claim_lock is None
+    assert after_second.consecutive_failures == 2
+    assert "spawn_failed" in event_kinds
+    assert "gave_up" in event_kinds

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -134,6 +134,35 @@ def test_narrow_inherited_root_replaced_for_scratch_workspace_write(
     assert target.read_text(encoding="utf-8") == "own"
 
 
+def test_task_safe_root_survives_profile_dotenv_override(monkeypatch, tmp_path):
+    root = tmp_path / "board"
+    workspace = root / "scratch-a"
+    inherited = tmp_path / "deployment-root"
+    workspace.mkdir(parents=True)
+    inherited.mkdir()
+    profile_home = tmp_path / ".hermes" / "profiles" / "w"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        f"HERMES_WRITE_SAFE_ROOT={inherited}\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    child_root = os.path.realpath(workspace)
+    with mock.patch.dict(os.environ, captured["env"], clear=True):
+        load_hermes_dotenv(hermes_home=captured["env"]["HERMES_HOME"])
+        target = workspace / "dotenv-own.txt"
+        result = _shell_file_operations(workspace).write_file(str(target), "own")
+
+    assert result.error is None
+    assert captured["env"]["HERMES_WRITE_SAFE_ROOT"] == child_root
+    assert target.read_text(encoding="utf-8") == "own"
+
+
 def test_sibling_and_traversal_mutations_are_denied(monkeypatch, tmp_path):
     root = tmp_path / "board"
     workspace = root / "scratch-a"

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -163,6 +163,41 @@ def test_task_safe_root_survives_profile_dotenv_override(monkeypatch, tmp_path):
     assert target.read_text(encoding="utf-8") == "own"
 
 
+def test_delegated_worker_safe_root_survives_profile_dotenv_override(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "board"
+    workspace = root / "scratch-a"
+    inherited = tmp_path / "deployment-root"
+    workspace.mkdir(parents=True)
+    inherited.mkdir()
+    profile_home = tmp_path / ".hermes" / "profiles" / "w"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        f"HERMES_WRITE_SAFE_ROOT={inherited}\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(inherited))
+
+    from agent.delegation_context import scrub_kanban_env
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    delegated_env = scrub_kanban_env(captured["env"])
+    child_root = os.path.realpath(workspace)
+    assert "HERMES_KANBAN_TASK" not in delegated_env
+    assert delegated_env["HERMES_KANBAN_SAFE_ROOT_ACTIVE"] == "1"
+    with mock.patch.dict(os.environ, delegated_env, clear=True):
+        load_hermes_dotenv(hermes_home=delegated_env["HERMES_HOME"])
+        target = workspace / "delegated-own.txt"
+        result = _shell_file_operations(workspace).write_file(str(target), "own")
+
+    assert result.error is None
+    assert target.read_text(encoding="utf-8") == "own"
+    assert delegated_env["HERMES_WRITE_SAFE_ROOT"] == child_root
+
+
 def test_sibling_and_traversal_mutations_are_denied(monkeypatch, tmp_path):
     root = tmp_path / "board"
     workspace = root / "scratch-a"

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -213,25 +213,44 @@ def test_sibling_and_traversal_mutations_are_denied(monkeypatch, tmp_path):
 
     direct = sibling / "direct.txt"
     traversal = sibling / "traversal.txt"
+    sibling_write = sibling / "sibling-write.txt"
+    sibling_delete = sibling / "sibling-delete.txt"
+    own_move = workspace / "own-move.txt"
+    moved = sibling / "moved.txt"
     direct.write_text("before", encoding="utf-8")
     traversal.write_text("before", encoding="utf-8")
+    sibling_delete.write_text("before", encoding="utf-8")
+    own_move.write_text("before", encoding="utf-8")
     captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
 
     with mock.patch.dict(os.environ, captured["env"], clear=True):
         ops = _shell_file_operations(workspace)
+        write_result = ops.write_file(str(sibling_write), "blocked")
         direct_result = ops.patch_replace(str(direct), "before", "after")
         traversal_result = ops.patch_replace(
             str(workspace / ".." / "scratch-b" / "traversal.txt"),
             "before",
             "after",
         )
+        delete_result = ops.delete_file(str(sibling_delete))
+        move_result = ops.move_file(str(own_move), str(moved))
 
+    assert write_result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in write_result.error
     assert direct_result.error is not None
     assert "outside HERMES_WRITE_SAFE_ROOT" in direct_result.error
     assert traversal_result.error is not None
     assert "outside HERMES_WRITE_SAFE_ROOT" in traversal_result.error
+    assert delete_result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in delete_result.error
+    assert move_result.error is not None
+    assert "outside HERMES_WRITE_SAFE_ROOT" in move_result.error
+    assert not sibling_write.exists()
     assert direct.read_text(encoding="utf-8") == "before"
     assert traversal.read_text(encoding="utf-8") == "before"
+    assert sibling_delete.read_text(encoding="utf-8") == "before"
+    assert own_move.read_text(encoding="utf-8") == "before"
+    assert not moved.exists()
 
 
 def test_symlink_escape_is_denied(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -104,6 +104,10 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
     assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
 
 
+def test_worker_lineage_marker_isolated_from_test_process():
+    assert os.environ.get("HERMES_KANBAN_SAFE_ROOT_ACTIVE") is None
+
+
 def test_narrow_inherited_root_replaced_for_scratch_workspace_write(
     monkeypatch, tmp_path
 ):

--- a/tests/hermes_cli/test_update_eol_churn.py
+++ b/tests/hermes_cli/test_update_eol_churn.py
@@ -59,6 +59,13 @@ def _managed_repo(tmp_path: Path, files: dict[str, bytes]) -> Path:
     for name in files:
         (repo / name).unlink()
     _git(repo, "checkout", "--", ".")
+    subprocess.run(
+        ["git", "-c", "core.autocrlf=false", "update-index", "--really-refresh"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
     return repo
 
 
@@ -177,6 +184,7 @@ def test_autocrlf_input_is_left_alone(tmp_path: Path) -> None:
     assert _autocrlf(repo) == "input"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows command-line limit regression")
 def test_churn_across_more_files_than_fit_in_one_argv(tmp_path: Path) -> None:
     """The pathspec goes over stdin, so a fully renormalized tree fits.
 

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -41,10 +41,14 @@ For Hermes profile lanes, the dispatcher's `_default_spawn` runs `hermes -p <ass
 | `HERMES_KANBAN_WORKSPACE` | absolute path to *this* task's workspace |
 | `HERMES_KANBAN_RUN_ID` | the current run's id (for the lifecycle gate) |
 | `HERMES_KANBAN_CLAIM_LOCK` | the claim lock string (`<host>:<pid>:<uuid>`) |
+| `HERMES_WRITE_SAFE_ROOT` | the normalized absolute task workspace used by native file tools |
+| `TERMINAL_CWD` | the same task workspace used as the worker process's current directory |
 | `HERMES_PROFILE` | the worker's own profile name (for `kanban_comment` author attribution) |
 | `HERMES_TENANT` | tenant namespace, if the task has one |
 
 For non-Hermes lanes (registered via a plugin), the plugin supplies its own `spawn_fn` callable that gets `task`, `workspace`, and `board` and returns an optional pid for crash detection.
+
+The default Hermes lane scopes native `write_file` and `patch` operations to the task workspace through `HERMES_WRITE_SAFE_ROOT`. This is defense in depth, not an operating-system sandbox: terminal commands and subprocesses can still write as the worker's OS user, so integrations that need a hard boundary must provide their own sandbox.
 
 ### 3. A lifecycle terminator
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -316,6 +316,8 @@ Do not ask the agent to `patch` `~/.hermes/cron/jobs.json` directly. Use the `cr
 Write guards apply to `write_file` and `patch` only. The `terminal` tool runs as the same OS user and can still `cat` or overwrite denied paths via shell commands. The denylist reduces accidental damage and gives models a clear stop signal; it does not sandbox a hostile or compromised agent.
 :::
 
+Kanban workers receive a task-scoped `HERMES_WRITE_SAFE_ROOT` and `TERMINAL_CWD`. The file-tool root limits native `write_file` and `patch` mutations to that task workspace; terminal commands and child processes retain the worker's OS privileges and are outside this boundary.
+
 ## User Authorization (Gateway)
 
 When running the messaging gateway, Hermes controls who can interact with the bot through a layered authorization system.


### PR DESCRIPTION
## Summary

Dispatcher-spawned Kanban workers inherit the deployment-wide `HERMES_WRITE_SAFE_ROOT` even though each worker already receives a task-specific workspace. A narrow deployment root blocks legitimate task writes, while an unset or common-parent root lets file tools modify sibling workspaces.

This change normalizes each valid task workspace once and uses it for both `TERMINAL_CWD` and the child process's `HERMES_WRITE_SAFE_ROOT`. The worker startup loader preserves that task-scoped root when profile or managed `.env` files load, including for delegated children after dispatcher-only metadata is scrubbed. Existing `agent.file_safety` enforcement then allows the worker's own files and rejects sibling, traversal, and symlink escapes.

The EOL regression keeps its 1,200-file argv-capacity assertion on Windows, refreshes Git's index stat data after checkout, and skips only that Windows-specific case on POSIX so the remaining EOL cases continue to run.

This remains a defense-in-depth file-tool constraint. Terminal commands and OS-level sandboxing are outside its scope.

## Changes

- `hermes_cli/kanban_db.py`: replace inherited worker write roots with the normalized task workspace while preserving inherited values for unusable workspace inputs.
- `hermes_cli/env_loader.py`: keep the task-scoped safe root ahead of profile, project, and managed environment-file overrides in worker processes.
- `agent/delegation_context.py`: preserve the worker-lineage marker when dispatcher-only Kanban metadata is scrubbed for delegated children.
- `tests/conftest.py`: clear the worker-lineage marker between test processes.
- `tests/hermes_cli/test_kanban_worker_terminal_cwd.py`: cover real own-workspace writes, startup environment loading, sibling and traversal denials, canonical paths, invalid inputs, scratch workspaces, and spawn-failure bookkeeping through production paths.
- `tests/hermes_cli/test_update_eol_churn.py`: refresh Git's index stat data in the CRLF fixture and gate the argv-capacity regression to Windows.
- `website/docs/user-guide/features/kanban-worker-lanes.md`: document the task-scoped native file-tool root.
- `website/docs/user-guide/security.md`: clarify the file-tool boundary.

## Validation

| Scenario | Before | After |
|---|---|---|
| Deployment root excludes the task workspace | Worker file tools reject writes in their assigned workspace | Worker file tools can write inside the assigned workspace |
| Profile environment file contains a deployment root | Worker startup replaces the task root with the profile value | Worker startup preserves the task root |
| Delegated child starts with dispatcher-only metadata scrubbed | Profile environment file replaces the inherited task root | The worker-lineage marker preserves the task root |
| Deployment root is unset or covers all task workspaces | Worker A can mutate worker B's workspace | Worker A receives a safe-root denial |
| Workspace path contains traversal or a symlink escape | Inherited broad policy can admit the resolved outside target | Existing `file_safety` realpath enforcement rejects it |
| Workspace cannot produce a safe task root | Inherited safe-root policy remains in place | Inherited safe-root policy remains in place |
| Worker process creation fails | Existing `spawn_failed` retry and circuit-breaker flow runs | Existing flow remains unchanged |
| POSIX collects the Windows argv-capacity regression | The fixture can fail before normalization | The Windows-specific case is skipped and the other EOL tests run |

## Test plan

- `pytest tests/hermes_cli/test_kanban_worker_terminal_cwd.py tests/hermes_cli/test_env_loader.py tests/tools/test_file_write_safety.py -q --timeout=120 -k "not CheckSensitivePathMacOSBypass and not patch_routes_through_atomic_write"`: 35 passed, 1 skipped, 7 deselected
- `pytest tests/hermes_cli/test_update_eol_churn.py -v`: Windows, 8 passed, 1 skipped
- `pytest tests/hermes_cli/test_update_eol_churn.py::test_churn_across_more_files_than_fit_in_one_argv -v`: Windows, 1 passed
- The regression composes `_default_spawn()` and `load_hermes_dotenv()` with real `ShellFileOperations` mutations.
- POSIX CI covers symlink escape behavior; the Windows argv-capacity case is skipped there because its contract is Windows-specific.

## Not in scope

- Confining terminal commands or arbitrary subprocess writes.
- Adding inherited deployment roots or profile `HERMES_HOME` to the task policy.
- Changing global `HERMES_WRITE_SAFE_ROOT` parsing or file-safety semantics.

The design and regression scenarios follow @powoct's [issue report](https://github.com/NousResearch/hermes-agent/issues/70688) and [scope clarification](https://github.com/NousResearch/hermes-agent/issues/70688#issuecomment-5150881506).

Closes #70688.
