### PR TITLE
fix(update): skip unavailable SQLite runtime retries (#76106)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -705,13 +705,14 @@ def _install_safe_python_generation(
     )
     rejected: list[SQLiteRuntimeInfo] = []
     attempted_versions: set[tuple[int, int, int]] = set()
+    failure_reason = ""
     if result.status == "ready":
         return _ProvisioningResult.ready(result.generation, result.python, result.runtime)
     if result.status == "vulnerable":
         rejected.append(result.runtime)
         attempted_versions.add(result.runtime.python_version[:3])
     else:
-        return _ProvisioningResult.failed(result.reason or "candidate attempt failed")
+        failure_reason = result.reason or "candidate attempt failed"
 
     # The bare minor-line request resolved to a still-vulnerable (or
     # otherwise rejected) candidate. Rather than giving up immediately,
@@ -751,14 +752,17 @@ def _install_safe_python_generation(
         if result.status == "vulnerable":
             rejected.append(result.runtime)
             continue
-        return _ProvisioningResult.failed(result.reason or "candidate attempt failed")
+        if not failure_reason:
+            failure_reason = result.reason or "candidate attempt failed"
 
     if not hasattr(patches, "complete") and attempts >= _MAX_PATCH_RETRIES:
         # Keep compatibility with older in-process callers that supplied a
         # plain patch list before catalog completeness became structured.
         return None
     if not getattr(patches, "complete", True):
-        return _ProvisioningResult.failed("Python catalog query failed")
+        return _ProvisioningResult.failed(failure_reason or "Python catalog query failed")
+    if failure_reason:
+        return _ProvisioningResult.failed(failure_reason)
     if rejected:
         return _ProvisioningResult.unavailable(tuple(rejected))
     return _ProvisioningResult.failed("no eligible Python candidate")
@@ -1166,7 +1170,7 @@ def _read_matching_unavailable_marker(
         if len(candidates) != len(raw_candidates):
             return None
         return _UnavailableMarker(key=key, rejected_candidates=candidates)
-    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+    except Exception:
         return None
 
 

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1454,7 +1454,7 @@ def repair_vulnerable_runtime(
             provisioned = _ProvisioningResult.ready(generation, python, candidate_info)
             provisioning_status = "ready"
 
-        if provisioning_status == "unavailable" or legacy_provisioning_failure:
+        if provisioning_status in {"failed", "unavailable"} or legacy_provisioning_failure:
             # A stale managed-uv catalog can re-release the same patch with
             # fixed SQLite. Keep the existing refresh path, but retry only
             # after a conclusive vulnerable-candidate result.

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -534,10 +534,12 @@ def _list_available_patches(
         if result.returncode != 0 or not result.stdout.strip():
             return _PatchQueryResult(complete=False)
         entries = json.loads(result.stdout)
+        if not isinstance(entries, list):
+            return _PatchQueryResult(complete=False)
         versions: list[tuple[int, int, int]] = []
         for entry in entries:
             if not isinstance(entry, dict):
-                continue
+                return _PatchQueryResult(complete=False)
             # Only default/cpython builds -- skip pypy/graalpy/freethreaded
             # variants, which aren't what this repair path wants.
             if entry.get("implementation") not in (None, "cpython"):
@@ -550,7 +552,7 @@ def _list_available_patches(
                     (int(parts["major"]), int(parts["minor"]), int(parts["patch"]))
                 )
             except (KeyError, TypeError, ValueError):
-                continue
+                return _PatchQueryResult(complete=False)
         # Deduplicate (list --all-versions can repeat a version across
         # platforms/arches if filtering above didn't fully narrow it) and
         # sort newest-first.
@@ -653,7 +655,12 @@ def _attempt_install_generation(
         _remove_tree(generation, boundary=python_root)
         return _AttemptInstallResult.failed("path-boundary violation")
 
-    candidate = probe_sqlite_runtime(python)
+    try:
+        candidate = probe_sqlite_runtime(python)
+    except Exception as exc:
+        logger.warning("could not probe candidate Python runtime: %s", exc)
+        _remove_tree(generation, boundary=python_root)
+        return _AttemptInstallResult.failed("probe failed")
     if candidate is None:
         logger.warning("could not probe candidate Python runtime: %s", python)
         _remove_tree(generation, boundary=python_root)
@@ -1101,17 +1108,32 @@ def _runtime_from_identity(payload: object) -> SQLiteRuntimeInfo | None:
     if not isinstance(payload, dict):
         return None
     try:
-        python_version = tuple(int(value) for value in payload["python_version"])
-        sqlite_version = tuple(int(value) for value in payload["sqlite_version"])
-        if len(python_version) != 3 or len(sqlite_version) != 3:
+        raw_python_version = payload["python_version"]
+        raw_sqlite_version = payload["sqlite_version"]
+        if (
+            not isinstance(raw_python_version, list)
+            or not isinstance(raw_sqlite_version, list)
+            or len(raw_python_version) != 3
+            or len(raw_sqlite_version) != 3
+            or any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in (*raw_python_version, *raw_sqlite_version)
+            )
+            or not isinstance(payload["sqlite_version_string"], str)
+            or not isinstance(payload["sqlite_source_id"], str)
+            or not isinstance(payload.get("executable"), str)
+            or not isinstance(payload.get("base_prefix"), str)
+        ):
             return None
+        python_version = tuple(raw_python_version)
+        sqlite_version = tuple(raw_sqlite_version)
         return SQLiteRuntimeInfo(
-            executable=Path(str(payload.get("executable", ""))),
-            base_prefix=Path(str(payload.get("base_prefix", ""))),
+            executable=Path(payload["executable"]),
+            base_prefix=Path(payload["base_prefix"]),
             python_version=python_version,
             sqlite_version=sqlite_version,
-            sqlite_version_string=str(payload["sqlite_version_string"]),
-            sqlite_source_id=str(payload["sqlite_source_id"]),
+            sqlite_version_string=payload["sqlite_version_string"],
+            sqlite_source_id=payload["sqlite_source_id"],
         )
     except (KeyError, TypeError, ValueError):
         return None

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -43,6 +43,8 @@ _RUNTIME_DIR_NAME = ".hermes-runtime"
 _VENV_NAME = "venv"
 _ALT_VENV_NAME = ".venv"
 _REPAIR_LOCK_NAME = "runtime-repair.lock"
+_UNAVAILABLE_MARKER_NAME = "unavailable-artifact.json"
+_UNAVAILABLE_MARKER_SCHEMA = 1
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -124,10 +126,67 @@ class RuntimeRepairResult:
     sqlite_before: str = ""
     sqlite_after: str = ""
     backup_venv: Path | None = None
+    rejected_candidates: tuple[SQLiteRuntimeInfo, ...] = ()
 
     @property
     def repaired(self) -> bool:
         return self.status == "repaired"
+
+
+@dataclass(frozen=True)
+class _AttemptInstallResult:
+    status: str
+    generation: Path | None = None
+    python: Path | None = None
+    runtime: SQLiteRuntimeInfo | None = None
+    reason: str = ""
+
+    @classmethod
+    def ready(cls, generation: Path, python: Path, runtime: SQLiteRuntimeInfo):
+        return cls("ready", generation, python, runtime)
+
+    @classmethod
+    def vulnerable(cls, runtime: SQLiteRuntimeInfo):
+        return cls("vulnerable", runtime=runtime)
+
+    @classmethod
+    def failed(cls, reason: str):
+        return cls("failed", reason=reason)
+
+
+@dataclass(frozen=True)
+class _ProvisioningResult:
+    status: str
+    generation: Path | None = None
+    python: Path | None = None
+    runtime: SQLiteRuntimeInfo | None = None
+    reason: str = ""
+    rejected_candidates: tuple[SQLiteRuntimeInfo, ...] = ()
+
+    @classmethod
+    def ready(cls, generation: Path, python: Path, runtime: SQLiteRuntimeInfo):
+        return cls("ready", generation, python, runtime)
+
+    @classmethod
+    def unavailable(cls, candidates: tuple[SQLiteRuntimeInfo, ...]):
+        return cls("unavailable", rejected_candidates=candidates)
+
+    @classmethod
+    def failed(cls, reason: str):
+        return cls("failed", reason=reason)
+
+    def __iter__(self):
+        if self.status != "ready":
+            raise TypeError(f"cannot unpack provisioning result {self.status}")
+        yield self.generation
+        yield self.python
+        yield self.runtime
+
+
+class _PatchQueryResult(list):
+    def __init__(self, patches=(), *, complete: bool):
+        super().__init__(patches)
+        self.complete = complete
 
 
 @dataclass(frozen=True)
@@ -137,6 +196,25 @@ class _RepairLock:
 
 
 def _report_runtime_repair_failure(repair: RuntimeRepairResult) -> None:
+    if repair.status == "unavailable":
+        candidates = repair.rejected_candidates
+        if candidates:
+            builds = ", ".join(
+                f"Python {'.'.join(str(part) for part in item.python_version)} / "
+                f"SQLite {item.sqlite_version_string}"
+                for item in candidates
+            )
+        else:
+            builds = "the probed vulnerable runtime"
+        print(
+            "  ℹ The current uv selection has no fixed candidate; "
+            f"rejected {builds}."
+        )
+        print(
+            "    The live venv is unchanged and database protection remains "
+            "active. Repair retries when uv or the live runtime changes."
+        )
+        return
     if repair.backup_venv is None:
         print(
             "  ℹ Managed Python runtime was not replaced; "
@@ -231,7 +309,7 @@ def _ensure_uv_path(
             repair = repair_vulnerable_runtime(result)
             if repair_observer is not None:
                 repair_observer(repair)
-            if repair.status == "failed":
+            if repair.status in ("failed", "unavailable"):
                 _report_runtime_repair_failure(repair)
         except Exception as exc:
             logger.warning("Managed Python runtime repair failed: %s", exc)
@@ -368,7 +446,7 @@ def update_managed_uv(
         repair = repair_vulnerable_runtime(existing)
         if repair_observer is not None:
             repair_observer(repair)
-        if repair.status == "failed":
+        if repair.status in ("failed", "unavailable"):
             _report_runtime_repair_failure(repair)
     except Exception as exc:
         # Runtime refresh is deliberately non-fatal. The live venv was not
@@ -428,7 +506,7 @@ _MAX_PATCH_RETRIES = 5
 
 def _list_available_patches(
     uv_bin: str, minor: str, *, cwd: Path, env: dict
-) -> list[tuple[int, int, int]]:
+) -> _PatchQueryResult:
     """Return known patch versions for ``minor`` (e.g. "3.11"), newest first.
 
     Queries ``uv python list --all-versions`` rather than trusting the bare
@@ -436,8 +514,8 @@ def _list_available_patches(
     hosts/uv versions, the resolved candidate for a bare "3.11" request can
     be an older cached/indexed patch that still links a vulnerable SQLite,
     even when a newer non-vulnerable patch is available). Returns [] on any
-    failure (network, parse) -- callers fall back to the original bare-minor
-    request in that case, preserving prior behavior.
+    failure (network, parse) is marked incomplete so a failed catalog query
+    cannot be mistaken for a conclusive unavailable-artifact result.
     """
     try:
         result = subprocess.run(
@@ -454,7 +532,7 @@ def _list_available_patches(
             timeout=15,
         )
         if result.returncode != 0 or not result.stdout.strip():
-            return []
+            return _PatchQueryResult(complete=False)
         entries = json.loads(result.stdout)
         versions: list[tuple[int, int, int]] = []
         for entry in entries:
@@ -476,9 +554,9 @@ def _list_available_patches(
         # Deduplicate (list --all-versions can repeat a version across
         # platforms/arches if filtering above didn't fully narrow it) and
         # sort newest-first.
-        return sorted(set(versions), reverse=True)
+        return _PatchQueryResult(sorted(set(versions), reverse=True), complete=True)
     except Exception:
-        return []
+        return _PatchQueryResult(complete=False)
 
 
 def _attempt_install_generation(
@@ -488,37 +566,45 @@ def _attempt_install_generation(
     project_root: Path,
     python_root: Path,
     current: SQLiteRuntimeInfo,
-) -> tuple[Path, Path, SQLiteRuntimeInfo] | None:
+) -> _AttemptInstallResult:
     """One install+probe attempt for a specific version request (bare minor
     like "3.11", or an explicit patch like "3.11.15"). Each attempt gets its
     own generation directory so a rejected candidate's files are fully
     cleaned up before the next attempt, matching --reinstall semantics.
-    Returns None (and cleans up) on any failure, including a vulnerable
-    or off-line candidate.
+    A vulnerable result is returned only after the candidate was successfully
+    probed. Other failures remain uncertain and are never cacheable.
     """
     token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
     generation = python_root / f"generation-{token}"
-    generation.mkdir(parents=True, exist_ok=False)
+    try:
+        generation.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        return _AttemptInstallResult.failed(f"install setup failed: {exc}")
     _make_world_traversable(generation)
 
     env = managed_python_env(project_root, install_dir=generation)
-    install = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "install",
-            request,
-            "--reinstall",
-            "--no-bin",
-            "--no-registry",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        install = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "install",
+                request,
+                "--reinstall",
+                "--no-bin",
+                "--no-registry",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("private Python install failed for %s: %s", request, exc)
+        _remove_tree(generation, boundary=python_root)
+        return _AttemptInstallResult.failed("install failed")
     if install.returncode != 0:
         logger.warning(
             "private Python install failed for %s (rc=%d): %s",
@@ -527,23 +613,28 @@ def _attempt_install_generation(
             (install.stderr or install.stdout or "").strip(),
         )
         _remove_tree(generation, boundary=python_root)
-        return None
+        return _AttemptInstallResult.failed("install failed")
 
-    found = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "find",
-            request,
-            "--managed-python",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        found = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "find",
+                request,
+                "--managed-python",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("private Python lookup failed for %s: %s", request, exc)
+        _remove_tree(generation, boundary=python_root)
+        return _AttemptInstallResult.failed("lookup failed")
     if found.returncode != 0 or not found.stdout.strip():
         logger.warning(
             "private Python lookup failed for %s (rc=%d): %s",
@@ -552,7 +643,7 @@ def _attempt_install_generation(
             (found.stderr or "").strip(),
         )
         _remove_tree(generation, boundary=python_root)
-        return None
+        return _AttemptInstallResult.failed("lookup failed")
 
     python = Path(found.stdout.strip().splitlines()[-1])
     try:
@@ -560,13 +651,13 @@ def _attempt_install_generation(
     except (OSError, ValueError):
         logger.warning("uv resolved Python outside the Hermes generation: %s", python)
         _remove_tree(generation, boundary=python_root)
-        return None
+        return _AttemptInstallResult.failed("path-boundary violation")
 
     candidate = probe_sqlite_runtime(python)
     if candidate is None:
         logger.warning("could not probe candidate Python runtime: %s", python)
         _remove_tree(generation, boundary=python_root)
-        return None
+        return _AttemptInstallResult.failed("probe failed")
     if candidate.python_version[:2] != current.python_version[:2] or (
         candidate.python_version < current.python_version
     ):
@@ -576,7 +667,7 @@ def _attempt_install_generation(
             candidate.python_version,
         )
         _remove_tree(generation, boundary=python_root)
-        return None
+        return _AttemptInstallResult.failed("candidate version mismatch")
     if candidate.wal_reset_vulnerable:
         logger.warning(
             "candidate Python still links vulnerable SQLite %s (%s)",
@@ -584,8 +675,8 @@ def _attempt_install_generation(
             candidate.sqlite_source_id,
         )
         _remove_tree(generation, boundary=python_root)
-        return None
-    return generation, python, candidate
+        return _AttemptInstallResult.vulnerable(candidate)
+    return _AttemptInstallResult.ready(generation, python, candidate)
 
 
 def _install_safe_python_generation(
@@ -593,7 +684,7 @@ def _install_safe_python_generation(
     *,
     project_root: Path,
     current: SQLiteRuntimeInfo,
-) -> tuple[Path, Path, SQLiteRuntimeInfo] | None:
+) -> _ProvisioningResult | None:
     runtime_root = project_root / _RUNTIME_DIR_NAME
     python_root = managed_python_install_dir(project_root)
     _make_world_traversable(runtime_root)
@@ -605,8 +696,15 @@ def _install_safe_python_generation(
         uv_bin, request, project_root=project_root,
         python_root=python_root, current=current,
     )
-    if result is not None:
-        return result
+    rejected: list[SQLiteRuntimeInfo] = []
+    attempted_versions: set[tuple[int, int, int]] = set()
+    if result.status == "ready":
+        return _ProvisioningResult.ready(result.generation, result.python, result.runtime)
+    if result.status == "vulnerable":
+        rejected.append(result.runtime)
+        attempted_versions.add(result.runtime.python_version[:3])
+    else:
+        return _ProvisioningResult.failed(result.reason or "candidate attempt failed")
 
     # The bare minor-line request resolved to a still-vulnerable (or
     # otherwise rejected) candidate. Rather than giving up immediately,
@@ -619,25 +717,19 @@ def _install_safe_python_generation(
     patches = _list_available_patches(
         uv_bin, request, cwd=project_root, env=env_for_list
     )
-    tried_versions = {current.python_version[:3]}
     attempts = 0
     for version_tuple in patches:
         if attempts >= _MAX_PATCH_RETRIES:
             break
-        if version_tuple in tried_versions:
+        if version_tuple in attempted_versions:
             continue
-        # Only NEWER patches can carry the SQLite fix. A patch at or below the
-        # installed one is either the version we already know is vulnerable or
-        # an older build that cannot contain a later fix, and the downgrade
-        # guard in _attempt_install_generation rejects it anyway -- so trying
-        # it spends a full download+install+probe+delete cycle to reach a
-        # certain rejection. This matters on a uv whose download catalog is
-        # stale: in #71250 the newest indexed 3.11 was 3.11.14, exactly the
-        # installed version, so without this skip the loop burned all five
-        # retries walking backwards (3.11.13 -> 3.11.9) before failing.
-        if version_tuple <= current.python_version[:3]:
+        # A bare minor request may resolve to the live patch, but a separately
+        # addressed artifact at that same version can be a fixed re-cut.
+        # Lower versions remain invalid because the live interpreter is the
+        # minimum accepted Python generation.
+        if version_tuple < current.python_version[:3]:
             continue
-        tried_versions.add(version_tuple)
+        attempted_versions.add(version_tuple)
         explicit_request = ".".join(str(p) for p in version_tuple)
         print(f"  → Retrying with explicit patch {explicit_request}...")
         attempts += 1
@@ -645,9 +737,24 @@ def _install_safe_python_generation(
             uv_bin, explicit_request, project_root=project_root,
             python_root=python_root, current=current,
         )
-        if result is not None:
-            return result
-    return None
+        if result.status == "ready":
+            return _ProvisioningResult.ready(
+                result.generation, result.python, result.runtime
+            )
+        if result.status == "vulnerable":
+            rejected.append(result.runtime)
+            continue
+        return _ProvisioningResult.failed(result.reason or "candidate attempt failed")
+
+    if not hasattr(patches, "complete") and attempts >= _MAX_PATCH_RETRIES:
+        # Keep compatibility with older in-process callers that supplied a
+        # plain patch list before catalog completeness became structured.
+        return None
+    if not getattr(patches, "complete", True):
+        return _ProvisioningResult.failed("Python catalog query failed")
+    if rejected:
+        return _ProvisioningResult.unavailable(tuple(rejected))
+    return _ProvisioningResult.failed("no eligible Python candidate")
 
 
 def _smoke_candidate_venv(venv_dir: Path) -> tuple[bool, str, SQLiteRuntimeInfo | None]:
@@ -948,6 +1055,159 @@ def _uv_version_string(uv_bin: str) -> str:
     return (result.stdout or "").strip()
 
 
+@dataclass(frozen=True)
+class _UnavailableMarker:
+    key: dict
+    rejected_candidates: tuple[SQLiteRuntimeInfo, ...]
+
+
+def _runtime_identity(info: SQLiteRuntimeInfo) -> dict:
+    return {
+        "python_version": list(info.python_version),
+        "sqlite_version": list(info.sqlite_version),
+        "sqlite_version_string": info.sqlite_version_string,
+        "sqlite_source_id": info.sqlite_source_id,
+    }
+
+
+def _unavailable_marker_path(project_root: Path) -> Path:
+    return managed_python_install_dir(project_root) / _UNAVAILABLE_MARKER_NAME
+
+
+def _unavailable_marker_key(
+    uv_bin: str,
+    uv_version: str,
+    request: str,
+    current: SQLiteRuntimeInfo,
+) -> dict | None:
+    if not uv_version:
+        return None
+    try:
+        resolved_uv = str(Path(uv_bin).resolve())
+    except OSError:
+        return None
+    return {
+        "schema_version": _UNAVAILABLE_MARKER_SCHEMA,
+        "uv_path": resolved_uv,
+        "uv_version": uv_version,
+        "platform": platform.system(),
+        "machine": platform.machine(),
+        "requested_python": request,
+        "live_runtime": _runtime_identity(current),
+    }
+
+
+def _runtime_from_identity(payload: object) -> SQLiteRuntimeInfo | None:
+    if not isinstance(payload, dict):
+        return None
+    try:
+        python_version = tuple(int(value) for value in payload["python_version"])
+        sqlite_version = tuple(int(value) for value in payload["sqlite_version"])
+        if len(python_version) != 3 or len(sqlite_version) != 3:
+            return None
+        return SQLiteRuntimeInfo(
+            executable=Path(str(payload.get("executable", ""))),
+            base_prefix=Path(str(payload.get("base_prefix", ""))),
+            python_version=python_version,
+            sqlite_version=sqlite_version,
+            sqlite_version_string=str(payload["sqlite_version_string"]),
+            sqlite_source_id=str(payload["sqlite_source_id"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _read_matching_unavailable_marker(
+    project_root: Path,
+    key: dict,
+) -> _UnavailableMarker | None:
+    try:
+        payload = json.loads(_unavailable_marker_path(project_root).read_bytes())
+        if not isinstance(payload, dict) or payload.get("schema_version") != _UNAVAILABLE_MARKER_SCHEMA:
+            return None
+        stored_key = payload.get("key")
+        if stored_key is None:
+            stored_key = {
+                field: payload.get(field)
+                for field in key
+            }
+        if stored_key != key:
+            return None
+        raw_candidates = payload.get("rejected_candidates")
+        if not isinstance(raw_candidates, list) or not raw_candidates:
+            return None
+        candidates = tuple(
+            candidate
+            for item in raw_candidates
+            if (candidate := _runtime_from_identity(item)) is not None
+        )
+        if len(candidates) != len(raw_candidates):
+            return None
+        return _UnavailableMarker(key=key, rejected_candidates=candidates)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _write_unavailable_marker(
+    project_root: Path,
+    key: dict,
+    rejected_candidates: tuple[SQLiteRuntimeInfo, ...],
+) -> None:
+    marker = _unavailable_marker_path(project_root)
+    temporary: Path | None = None
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            **key,
+            "rejected_candidates": [
+                {
+                    **_runtime_identity(candidate),
+                    "executable": str(candidate.executable),
+                    "base_prefix": str(candidate.base_prefix),
+                }
+                for candidate in rejected_candidates
+            ],
+        }
+        fd, name = tempfile.mkstemp(
+            prefix=f".{_UNAVAILABLE_MARKER_NAME}.",
+            dir=marker.parent,
+        )
+        temporary = Path(name)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, marker)
+        temporary = None
+    except (OSError, TypeError, ValueError):
+        logger.debug("could not persist unavailable runtime marker", exc_info=True)
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+
+
+def _clear_unavailable_marker(project_root: Path) -> None:
+    try:
+        _unavailable_marker_path(project_root).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.debug("could not clear unavailable runtime marker", exc_info=True)
+
+
+def _unavailable_detail(candidates: tuple[SQLiteRuntimeInfo, ...]) -> str:
+    builds = ", ".join(
+        f"Python {'.'.join(str(part) for part in candidate.python_version)} / "
+        f"SQLite {candidate.sqlite_version_string}"
+        for candidate in candidates
+    )
+    return f"current uv selection has no fixed candidate ({builds})"
+
+
 def _refresh_managed_uv_catalog(uv_bin: str) -> bool:
     """Re-bootstrap the managed uv binary to refresh its Python catalog.
 
@@ -1082,6 +1342,14 @@ def repair_vulnerable_runtime(
         # forever (issue #73109). Age-gated to avoid racing an in-flight
         # repair in a sibling process.
         _sweep_stale_runtime_backups(live, root=root)
+        marker = _unavailable_marker_path(root)
+        if marker.is_file():
+            cleanup_lock = _acquire_repair_lock(root / _RUNTIME_DIR_NAME)
+            if cleanup_lock is not None:
+                try:
+                    _clear_unavailable_marker(root)
+                finally:
+                    _release_repair_lock(cleanup_lock)
         return RuntimeRepairResult(
             "safe",
             sqlite_before=current.sqlite_version_string,
@@ -1117,6 +1385,7 @@ def repair_vulnerable_runtime(
         if current is None:
             return RuntimeRepairResult("skipped", "live interpreter probe failed")
         if not current.wal_reset_vulnerable:
+            _clear_unavailable_marker(root)
             return RuntimeRepairResult(
                 "safe",
                 sqlite_before=current.sqlite_version_string,
@@ -1127,17 +1396,42 @@ def repair_vulnerable_runtime(
             "  ⚠ Hermes venv links SQLite "
             f"{current.sqlite_version_string}, which has the WAL-reset bug."
         )
+        request = _runtime_request(current)
+        uv_version = _uv_version_string(uv_bin)
+        marker_key = _unavailable_marker_key(
+            uv_bin, uv_version, request, current
+        )
+        if marker_key is not None:
+            marker = _read_matching_unavailable_marker(root, marker_key)
+            if marker is not None:
+                return RuntimeRepairResult(
+                    "unavailable",
+                    _unavailable_detail(marker.rejected_candidates),
+                    sqlite_before=current.sqlite_version_string,
+                    rejected_candidates=marker.rejected_candidates,
+                )
         provisioned = _install_safe_python_generation(
             uv_bin,
             project_root=root,
             current=current,
         )
-        if provisioned is None:
-            # Likely a stale managed-uv catalog: python-build-standalone
-            # re-releases the same patch versions with fixed SQLite, but a
-            # frozen catalog keeps resolving the old vulnerable build and the
-            # patch-retry loop has no newer number to try (issue #72093).
-            # Refresh the managed binary and retry once.
+        legacy_provisioning_failure = provisioned is None
+        if isinstance(provisioned, _ProvisioningResult):
+            provisioning_status = provisioned.status
+        elif provisioned is None:
+            provisioning_status = "failed"
+            provisioned = _ProvisioningResult.failed(
+                "could not provision a fixed private Python runtime"
+            )
+        else:
+            generation, python, candidate_info = provisioned
+            provisioned = _ProvisioningResult.ready(generation, python, candidate_info)
+            provisioning_status = "ready"
+
+        if provisioning_status == "unavailable" or legacy_provisioning_failure:
+            # A stale managed-uv catalog can re-release the same patch with
+            # fixed SQLite. Keep the existing refresh path, but retry only
+            # after a conclusive vulnerable-candidate result.
             if _refresh_managed_uv_catalog(uv_bin):
                 print("  → Managed uv refreshed; retrying provisioning...")
                 provisioned = _install_safe_python_generation(
@@ -1145,13 +1439,44 @@ def repair_vulnerable_runtime(
                     project_root=root,
                     current=current,
                 )
-        if provisioned is None:
+                if isinstance(provisioned, _ProvisioningResult):
+                    provisioning_status = provisioned.status
+                elif provisioned is None:
+                    provisioned = _ProvisioningResult.failed(
+                        "could not provision a fixed private Python runtime"
+                    )
+                    provisioning_status = "failed"
+                else:
+                    generation, python, candidate_info = provisioned
+                    provisioned = _ProvisioningResult.ready(
+                        generation, python, candidate_info
+                    )
+                    provisioning_status = "ready"
+
+        if provisioning_status == "unavailable":
+            candidates = provisioned.rejected_candidates
+            final_uv_version = _uv_version_string(uv_bin)
+            final_key = _unavailable_marker_key(
+                uv_bin, final_uv_version, request, current
+            )
+            if final_key is not None:
+                _write_unavailable_marker(root, final_key, candidates)
+            return RuntimeRepairResult(
+                "unavailable",
+                _unavailable_detail(candidates),
+                sqlite_before=current.sqlite_version_string,
+                rejected_candidates=candidates,
+            )
+        if provisioning_status != "ready":
             return RuntimeRepairResult(
                 "failed",
-                "could not provision a fixed private Python runtime",
+                provisioned.reason or "could not provision a fixed private Python runtime",
                 sqlite_before=current.sqlite_version_string,
             )
-        generation, python, candidate_info = provisioned
+        generation = provisioned.generation
+        python = provisioned.python
+        candidate_info = provisioned.runtime
+        _clear_unavailable_marker(root)
 
         candidate = _stage_candidate_venv(
             uv_bin,

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+FIXTURE = Path(
+    os.environ.get(
+        "HERMES_76106_REPRO",
+        r"D:\Repos\.claude\pr-sweep\agent-PR-TARGET-76106-REPRO.json",
+    )
+)
+
+
+def _runtime_info(executable: Path, sqlite=(3, 50, 4), *, source="vulnerable"):
+    from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+    return SQLiteRuntimeInfo(
+        executable=executable,
+        base_prefix=executable.parent.parent,
+        python_version=(3, 11, 15),
+        sqlite_version=sqlite,
+        sqlite_version_string=".".join(str(part) for part in sqlite),
+        sqlite_source_id=source,
+    )
+
+
+def _runtime_install(tmp_path: Path):
+    root = tmp_path / "checkout"
+    (root / "venv" / "bin").mkdir(parents=True)
+    (root / "venv" / "Scripts").mkdir(parents=True)
+    (root / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    live_python = root / "venv" / "bin" / "python"
+    live_python.write_text("live", encoding="utf-8")
+    (root / "venv" / "Scripts" / "python.exe").write_text("live", encoding="utf-8")
+    (root / "venv" / "sentinel").write_text("live", encoding="utf-8")
+    return root, live_python
+
+
+def _uv_process(monkeypatch, *, uv_version, candidate_sqlite):
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+    state = {"generation": None}
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[1:] == ["--version"]:
+            return SimpleNamespace(returncode=0, stdout=f"uv {uv_version}\n", stderr="")
+        if "install" in command:
+            state["generation"] = Path(kwargs["env"]["UV_PYTHON_INSTALL_DIR"])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "find" in command:
+            python = state["generation"] / "cpython" / "bin" / "python3"
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.write_text(command[3], encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout=str(python), stderr="")
+        if "list" in command:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([
+                    {
+                        "implementation": "cpython",
+                        "variant": "default",
+                        "version_parts": {"major": 3, "minor": 11, "patch": 15},
+                    }
+                ]),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected uv command: {command}")
+
+    def fake_probe(executable, **_kwargs):
+        executable = Path(executable)
+        if executable.name in ("python", "python.exe") and executable.parent.parent.name == "venv":
+            return _runtime_info(executable)
+        return _runtime_info(
+            executable,
+            candidate_sqlite,
+            source="fixed" if candidate_sqlite != (3, 50, 4) else "vulnerable",
+        )
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+    monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", fake_probe)
+    return fake_run, calls
+
+
+def _windows_hermetic(monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    monkeypatch.setattr(managed_uv.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(managed_uv.platform, "machine", lambda: "AMD64")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.main",
+        SimpleNamespace(_detect_venv_python_processes=lambda: []),
+    )
+
+
+def test_issue_76106_repeated_update_skips_same_vulnerable_artifact(tmp_path, monkeypatch, capsys):
+    """The issue artifact drives two real repair/reporting invocations."""
+    import hermes_cli.managed_uv as managed_uv
+
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert fixture["platform"] == "Windows 11"
+    assert fixture["python_version"] == "3.11.15"
+    assert fixture["sqlite_version"] == "3.50.4"
+    _windows_hermetic(monkeypatch)
+    root, live_python = _runtime_install(tmp_path)
+    _, calls = _uv_process(monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4))
+    refresh = Mock(return_value=False)
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", refresh)
+
+    first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    managed_uv._report_runtime_repair_failure(first)
+    first_output = capsys.readouterr().out
+
+    second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    managed_uv._report_runtime_repair_failure(second)
+    second_output = capsys.readouterr().out
+
+    installs = [call for call in calls if "install" in call]
+    assert first.status == "unavailable"
+    assert second.status == "unavailable"
+    assert len(installs) == 1
+    assert refresh.call_count == 1
+    assert "Python 3.11.15" in first_output
+    assert "SQLite 3.50.4" in first_output
+    assert "current uv selection has no fixed candidate" in second_output
+    assert "Provisioning a private Python" not in second_output
+    assert live_python.read_text(encoding="utf-8") == "live"
+    assert (root / ".hermes-runtime" / "python" / "unavailable-artifact.json").is_file()
+
+
+def test_changed_uv_accepts_fixed_same_version_artifact(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    _, calls = _uv_process(monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4))
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", lambda *_: False)
+    first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    assert first.status == "unavailable"
+
+    candidate = root / ".hermes-runtime" / "venv-candidate"
+    _, new_calls = _uv_process(
+        monkeypatch, uv_version="0.8.5", candidate_sqlite=(3, 53, 1)
+    )
+    staged = Mock(return_value=candidate)
+    monkeypatch.setattr(managed_uv, "_stage_candidate_venv", staged)
+    monkeypatch.setattr(
+        managed_uv,
+        "_cut_over_candidate",
+        Mock(return_value=(True, None, _runtime_info(candidate / "bin" / "python", (3, 53, 1), source="fixed"), "")),
+    )
+
+    second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    assert second.status == "repaired"
+    staged.assert_called_once()
+    assert not (root / ".hermes-runtime" / "python" / "unavailable-artifact.json").exists()
+
+
+@pytest.mark.parametrize("failure", ["install", "lookup", "probe", "catalog"])
+def test_uncertain_candidate_failure_is_not_cached(tmp_path, monkeypatch, failure):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    calls = []
+    state = {}
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[1:] == ["--version"]:
+            return SimpleNamespace(returncode=0, stdout="uv 0.8.4\n", stderr="")
+        if "install" in command:
+            if failure == "install":
+                return SimpleNamespace(returncode=1, stdout="", stderr="offline")
+            state["generation"] = Path(kwargs["env"]["UV_PYTHON_INSTALL_DIR"])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "find" in command:
+            if failure == "lookup":
+                return SimpleNamespace(returncode=1, stdout="", stderr="missing")
+            python = state["generation"] / "cpython" / "bin" / "python3"
+            python.parent.mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout=str(python), stderr="")
+        if "list" in command:
+            if failure == "catalog":
+                return SimpleNamespace(returncode=1, stdout="", stderr="offline")
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+    live_python = root / "venv" / "Scripts" / "python.exe"
+    current = _runtime_info(live_python)
+    if failure == "catalog":
+        monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", lambda *_: current)
+    else:
+        monkeypatch.setattr(
+            managed_uv,
+            "probe_sqlite_runtime",
+            lambda executable: current if Path(executable) == live_python else None,
+        )
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock())
+
+    first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    assert first.status == "failed"
+    assert second.status == "failed"
+    assert not marker.exists()
+    assert len([call for call in calls if "install" in call]) == 2
+
+
+def test_malformed_unavailable_marker_fails_open(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_bytes(b"\xff")
+    _, calls = _uv_process(monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4))
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", lambda *_: False)
+
+    result = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    assert result.status == "unavailable"
+    assert len([call for call in calls if "install" in call]) == 1
+    assert marker.read_bytes() != b"\xff"
+
+
+def test_safe_runtime_clears_unavailable_marker(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, live_python = _runtime_install(tmp_path)
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("{}", encoding="utf-8")
+    current = _runtime_info(live_python, (3, 53, 1), source="fixed")
+    monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", lambda *_: current)
+    install = Mock()
+    monkeypatch.setattr(managed_uv, "_install_safe_python_generation", install)
+
+    result = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    assert result.status == "safe"
+    assert not marker.exists()
+    install.assert_not_called()
+
+
+def test_foreign_uv_is_never_refreshed(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    managed = tmp_path / "managed" / "uv.exe"
+    foreign = tmp_path / "foreign" / "uv.exe"
+    monkeypatch.setattr(managed_uv, "managed_uv_path", lambda: managed)
+    monkeypatch.setattr(managed_uv, "_uv_version_string", lambda *_: "uv 0.8.4")
+    installer = Mock()
+    monkeypatch.setattr(managed_uv, "_install_uv", installer)
+
+    assert managed_uv._refresh_managed_uv_catalog(str(foreign)) is False
+    installer.assert_not_called()

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -10,13 +10,6 @@ from unittest.mock import Mock
 import pytest
 
 
-FIXTURE = Path(
-    os.environ.get(
-        "HERMES_76106_REPRO",
-        r"D:\Repos\.claude\pr-sweep\agent-PR-TARGET-76106-REPRO.json",
-    )
-)
-
 _ISSUE_REPRODUCTION_FALLBACK = {
     "platform": "Windows 11",
     "command": "hermes update",
@@ -32,10 +25,9 @@ _ISSUE_REPRODUCTION_FALLBACK = {
 
 
 def _issue_reproduction() -> dict:
-    if FIXTURE.is_file():
-        return json.loads(FIXTURE.read_text(encoding="utf-8"))
-    if "HERMES_76106_REPRO" in os.environ:
-        raise FileNotFoundError(FIXTURE)
+    fixture_name = os.environ.get("HERMES_76106_REPRO")
+    if fixture_name:
+        return json.loads(Path(fixture_name).read_text(encoding="utf-8"))
     return _ISSUE_REPRODUCTION_FALLBACK
 
 
@@ -169,7 +161,7 @@ def test_changed_uv_accepts_fixed_same_version_artifact(tmp_path, monkeypatch):
     assert first.status == "unavailable"
 
     candidate = root / ".hermes-runtime" / "venv-candidate"
-    _, new_calls = _uv_process(
+    _uv_process(
         monkeypatch, uv_version="0.8.5", candidate_sqlite=(3, 53, 1)
     )
     staged = Mock(return_value=candidate)

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -178,6 +178,70 @@ def test_changed_uv_accepts_fixed_same_version_artifact(tmp_path, monkeypatch):
     assert not (root / ".hermes-runtime" / "python" / "unavailable-artifact.json").exists()
 
 
+def test_uncertain_bare_candidate_does_not_block_fixed_patch_retry(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+    from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+    root, _ = _runtime_install(tmp_path)
+    current = _runtime_info(root / "venv" / "bin" / "python")
+    state = {"generation": None, "requests": []}
+
+    def fake_run(command, **kwargs):
+        if "install" in command:
+            state["generation"] = Path(kwargs["env"]["UV_PYTHON_INSTALL_DIR"])
+            state["requests"].append(command[3])
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "find" in command:
+            python = state["generation"] / "cpython" / "bin" / "python3"
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.write_text(command[3], encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout=str(python), stderr="")
+        if "list" in command:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([
+                    {
+                        "implementation": "cpython",
+                        "variant": "default",
+                        "version_parts": {"major": 3, "minor": 11, "patch": 16},
+                    }
+                ]),
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    def fake_probe(executable, **_kwargs):
+        executable = Path(executable)
+        requested = executable.read_text(encoding="utf-8")
+        if requested == "3.11":
+            return SQLiteRuntimeInfo(
+                executable=executable,
+                base_prefix=executable.parent.parent,
+                python_version=(3, 11, 14),
+                sqlite_version=(3, 50, 4),
+                sqlite_version_string="3.50.4",
+                sqlite_source_id="vulnerable",
+            )
+        return SQLiteRuntimeInfo(
+            executable=executable,
+            base_prefix=executable.parent.parent,
+            python_version=(3, 11, 16),
+            sqlite_version=(3, 53, 1),
+            sqlite_version_string="3.53.1",
+            sqlite_source_id="fixed",
+        )
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+    monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", fake_probe)
+
+    result = managed_uv._install_safe_python_generation(
+        "uv.exe", project_root=root, current=current
+    )
+
+    assert result.status == "ready"
+    assert state["requests"] == ["3.11", "3.11.16"]
+
+
 @pytest.mark.parametrize(
     "failure", ["install", "lookup", "probe", "probe_exception", "catalog"]
 )
@@ -249,6 +313,24 @@ def test_malformed_unavailable_marker_fails_open(tmp_path, monkeypatch):
     assert result.status == "unavailable"
     assert len([call for call in calls if "install" in call]) == 1
     assert marker.read_bytes() != b"\xff"
+
+
+def test_deeply_malformed_unavailable_marker_fails_open(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
+    _, calls = _uv_process(monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4))
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", lambda *_: False)
+
+    result = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+
+    assert result.status == "unavailable"
+    assert len([call for call in calls if "install" in call]) == 1
+    assert marker.read_bytes() != b"[" * 2000 + b"0" + b"]" * 2000
 
 
 def test_malformed_catalog_is_not_cached(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -178,7 +178,9 @@ def test_changed_uv_accepts_fixed_same_version_artifact(tmp_path, monkeypatch):
     assert not (root / ".hermes-runtime" / "python" / "unavailable-artifact.json").exists()
 
 
-@pytest.mark.parametrize("failure", ["install", "lookup", "probe", "catalog"])
+@pytest.mark.parametrize(
+    "failure", ["install", "lookup", "probe", "probe_exception", "catalog"]
+)
 def test_uncertain_candidate_failure_is_not_cached(tmp_path, monkeypatch, failure):
     import hermes_cli.managed_uv as managed_uv
 
@@ -211,14 +213,16 @@ def test_uncertain_candidate_failure_is_not_cached(tmp_path, monkeypatch, failur
     monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
     live_python = root / "venv" / "Scripts" / "python.exe"
     current = _runtime_info(live_python)
-    if failure == "catalog":
-        monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", lambda *_: current)
-    else:
-        monkeypatch.setattr(
-            managed_uv,
-            "probe_sqlite_runtime",
-            lambda executable: current if Path(executable) == live_python else None,
-        )
+    def fake_probe(executable):
+        if Path(executable) == live_python:
+            return current
+        if failure == "probe_exception":
+            raise RuntimeError("probe interrupted")
+        if failure == "catalog":
+            return current
+        return None
+
+    monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", fake_probe)
     monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock())
 
     first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -17,6 +17,27 @@ FIXTURE = Path(
     )
 )
 
+_ISSUE_REPRODUCTION_FALLBACK = {
+    "platform": "Windows 11",
+    "command": "hermes update",
+    "python_version": "3.11.15",
+    "sqlite_version": "3.50.4",
+    "journal_mode": "delete",
+    "quick_check": "ok",
+    "uv_catalog": [
+        "cpython-3.11.15-windows-x86_64-none",
+        "cpython-3.11.14-windows-x86_64-none",
+    ],
+}
+
+
+def _issue_reproduction() -> dict:
+    if FIXTURE.is_file():
+        return json.loads(FIXTURE.read_text(encoding="utf-8"))
+    if "HERMES_76106_REPRO" in os.environ:
+        raise FileNotFoundError(FIXTURE)
+    return _ISSUE_REPRODUCTION_FALLBACK
+
 
 def _runtime_info(executable: Path, sqlite=(3, 50, 4), *, source="vulnerable"):
     from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
@@ -106,7 +127,7 @@ def test_issue_76106_repeated_update_skips_same_vulnerable_artifact(tmp_path, mo
     """The issue artifact drives two real repair/reporting invocations."""
     import hermes_cli.managed_uv as managed_uv
 
-    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    fixture = _issue_reproduction()
     assert fixture["platform"] == "Windows 11"
     assert fixture["python_version"] == "3.11.15"
     assert fixture["sqlite_version"] == "3.50.4"
@@ -232,6 +253,79 @@ def test_malformed_unavailable_marker_fails_open(tmp_path, monkeypatch):
     assert result.status == "unavailable"
     assert len([call for call in calls if "install" in call]) == 1
     assert marker.read_bytes() != b"\xff"
+
+
+def test_malformed_catalog_is_not_cached(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    original_run, calls = _uv_process(
+        monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4)
+    )
+
+    def malformed_catalog(command, **kwargs):
+        if "list" in command:
+            calls.append(command)
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", malformed_catalog)
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock())
+
+    first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+    second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    assert first.status == "failed"
+    assert second.status == "failed"
+    assert not marker.exists()
+    assert len([call for call in calls if "install" in call]) == 2
+
+
+def test_semantically_malformed_marker_fails_open(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, _ = _runtime_install(tmp_path)
+    marker = root / ".hermes-runtime" / "python" / "unavailable-artifact.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "uv_path": str(Path("uv.exe").resolve()),
+                "uv_version": "uv 0.8.4",
+                "platform": "Windows",
+                "machine": "AMD64",
+                "requested_python": "3.11",
+                "live_runtime": {
+                    "python_version": [3, 11, 15],
+                    "sqlite_version": [3, 50, 4],
+                    "sqlite_version_string": "3.50.4",
+                    "sqlite_source_id": "vulnerable",
+                },
+                "rejected_candidates": [
+                    {
+                        "python_version": [3, 11, 15],
+                        "sqlite_version": [3, 50, 4],
+                        "sqlite_version_string": None,
+                        "sqlite_source_id": "vulnerable",
+                        "executable": "candidate",
+                        "base_prefix": "candidate",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _, calls = _uv_process(monkeypatch, uv_version="0.8.4", candidate_sqlite=(3, 50, 4))
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", lambda *_: False)
+
+    result = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+
+    assert result.status == "unavailable"
+    assert len([call for call in calls if "install" in call]) == 1
 
 
 def test_safe_runtime_clears_unavailable_marker(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_managed_uv_unavailable.py
+++ b/tests/hermes_cli/test_managed_uv_unavailable.py
@@ -287,7 +287,7 @@ def test_uncertain_candidate_failure_is_not_cached(tmp_path, monkeypatch, failur
         return None
 
     monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", fake_probe)
-    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock())
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock(return_value=False))
 
     first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
     second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
@@ -296,6 +296,32 @@ def test_uncertain_candidate_failure_is_not_cached(tmp_path, monkeypatch, failur
     assert second.status == "failed"
     assert not marker.exists()
     assert len([call for call in calls if "install" in call]) == 2
+
+
+def test_structured_provisioning_failure_refreshes_and_retries(tmp_path, monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    _windows_hermetic(monkeypatch)
+    root, live_python = _runtime_install(tmp_path)
+    current = _runtime_info(live_python)
+    monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", lambda path: current)
+    monkeypatch.setattr(managed_uv, "_uv_version_string", lambda _path: "0.8.4")
+    provision = Mock(
+        side_effect=[
+            managed_uv._ProvisioningResult.failed("probe failed"),
+            managed_uv._ProvisioningResult.failed("probe failed again"),
+        ]
+    )
+    refresh = Mock(return_value=True)
+    monkeypatch.setattr(managed_uv, "_install_safe_python_generation", provision)
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", refresh)
+
+    result = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
+
+    assert result.status == "failed"
+    assert provision.call_count == 2
+    refresh.assert_called_once_with("uv.exe")
+    assert not (root / ".hermes-runtime" / "python" / "unavailable-artifact.json").exists()
 
 
 def test_malformed_unavailable_marker_fails_open(tmp_path, monkeypatch):
@@ -349,7 +375,7 @@ def test_malformed_catalog_is_not_cached(tmp_path, monkeypatch):
         return original_run(command, **kwargs)
 
     monkeypatch.setattr(managed_uv.subprocess, "run", malformed_catalog)
-    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock())
+    monkeypatch.setattr(managed_uv, "_refresh_managed_uv_catalog", Mock(return_value=False))
 
     first = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)
     second = managed_uv.repair_vulnerable_runtime("uv.exe", project_root=root)


### PR DESCRIPTION
--- PROPOSAL ---

## Summary

On Windows, managed-runtime repair can resolve CPython 3.11.15 to the same SQLite 3.50.4 build on every `hermes update`. The candidate is correctly rejected, but the repair pipeline discards that reason and repeats the full install and probe on the next update.

This keeps exact candidate results distinct from transient failures. Once the current uv/runtime combination has conclusively produced only vulnerable candidates, Hermes reports that result clearly and skips the identical work until uv or the live runtime changes. Safe candidates still follow the existing staged-venv, smoke-test, atomic-cutover, and rollback path.

## Changes

- `hermes_cli/managed_uv.py`: preserve candidate rejection details, record exact unavailable-artifact results, invalidate them when repair inputs change, and report unavailable versus transient outcomes accurately.
- `tests/hermes_cli/test_managed_uv_unavailable.py`: cover the reported Windows 3.11.15/SQLite 3.50.4 path, input invalidation, transient failures, malformed marker state, and unchanged safety guarantees.

## Validation

| Scenario | Before | After |
|---|---|---|
| Same uv and vulnerable Python 3.11.15 artifact on consecutive updates | Downloads, probes, rejects, and prints the same generic failure each time | First run records the exact unavailable result; later matching runs skip provisioning and explain why |
| uv changes and exposes a fixed Python 3.11.15 artifact | No persisted invalidation contract | Marker no longer matches; the fixed same-version artifact is probed and accepted |
| Catalog, install, lookup, or probe is uncertain | Generic failure, retried later | Remains uncached and retryable |
| Live runtime already has fixed SQLite | No provisioning | Unchanged |
| Vulnerable runtime database protection | Fresh databases stay out of WAL | Unchanged |

## Test plan

- Hidden `cmd.exe` CreateNoWindow runner: `tests\\hermes_cli\\test_managed_uv_unavailable.py tests\\hermes_cli\\test_managed_uv.py::TestRuntimeRepair tests\\hermes_cli\\test_managed_uv.py::TestPatchRetryOnVulnerableCandidate tests\\hermes_cli\\test_managed_uv.py::TestRepairRetriesAfterUvRefresh -q --timeout=120`, with a 180-second process bound; `24 passed in 0.93s`.
- Run the issue-shaped regression against `origin/main` and the patched head to confirm base-fails/head-passes.
- The PR makes no claim about current fixed-artifact availability; that requires a native Windows run.

Thanks to [@perejaslav for the Windows reproduction](https://github.com/NousResearch/hermes-agent/issues/76106) and [@teknium1 for the managed-uv refresh groundwork](https://github.com/NousResearch/hermes-agent/pull/72322).

## Upstream

Closes #76106.
