### PR TITLE
fix(gateway,photon): reject non-finite float config values

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -9,6 +9,7 @@ Handles loading and validating configuration for:
 """
 
 import logging
+import math
 import os
 import json
 from pathlib import Path
@@ -96,9 +97,16 @@ def _coerce_float(value: Any, default: float) -> float:
     if value is None:
         return default
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    # nan/inf parse without raising (YAML 1.1 even has bare .nan/.inf
+    # literals), but a nan then compares False against everything -- silently
+    # defeating threshold checks (e.g. `elapsed >= edit_interval` never
+    # firing) instead of falling back like any other malformed value.
+    if not math.isfinite(parsed):
+        return default
+    return parsed
 
 
 def _coerce_int(value: Any, default: int) -> int:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -9,6 +9,7 @@ Handles loading and validating configuration for:
 """
 
 import logging
+import math
 import os
 import json
 from pathlib import Path
@@ -141,9 +142,16 @@ def _coerce_float(value: Any, default: float) -> float:
     if value is None:
         return default
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    # nan/inf parse without raising (YAML 1.1 even has bare .nan/.inf
+    # literals), but a nan then compares False against everything -- silently
+    # defeating threshold checks (e.g. `elapsed >= edit_interval` never
+    # firing) instead of falling back like any other malformed value.
+    if not math.isfinite(parsed):
+        return default
+    return parsed
 
 
 def _coerce_int(value: Any, default: int) -> int:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -28,6 +28,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 import os
 import re
 import secrets
@@ -340,10 +341,21 @@ def sidecar_deps_installed() -> bool:
 
 
 def _coerce_float(value: Any, default: float) -> float:
+    """Coerce a probe interval/timeout, guarding against bad/non-finite values.
+
+    Both callers gate an ``> 0`` enabled check or feed an HTTP timeout, so
+    nan/inf (which parse via float() without raising -- YAML 1.1 even has
+    bare .nan/.inf literals) and negative values fall back to ``default``
+    instead of silently disabling the presence watchdog or producing a
+    permanently "inconclusive" probe.
+    """
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(parsed) or parsed < 0:
+        return default
+    return parsed
 
 
 def _coerce_int(value: Any, default: int) -> int:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -28,6 +28,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 import os
 import re
 import secrets
@@ -381,10 +382,21 @@ def sidecar_deps_installed() -> bool:
 
 
 def _coerce_float(value: Any, default: float) -> float:
+    """Coerce a probe interval/timeout, guarding against bad/non-finite values.
+
+    Both callers gate an ``> 0`` enabled check or feed an HTTP timeout, so
+    nan/inf (which parse via float() without raising -- YAML 1.1 even has
+    bare .nan/.inf literals) and negative values fall back to ``default``
+    instead of silently disabling the presence watchdog or producing a
+    permanently "inconclusive" probe.
+    """
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(parsed) or parsed < 0:
+        return default
+    return parsed
 
 
 def _coerce_int(value: Any, default: int) -> int:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -206,6 +206,22 @@ class TestStreamingConfig:
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 0.0
 
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    def test_from_dict_non_finite_numeric_values_fall_back_to_defaults(self, bad_value):
+        """float() parses nan/inf without raising, so a bare TypeError/ValueError
+        guard lets them through -- and nan then compares False against every
+        threshold check downstream (e.g. `elapsed >= edit_interval`), silently
+        defeating the edit-interval throttle instead of falling back like any
+        other malformed value."""
+        restored = StreamingConfig.from_dict(
+            {
+                "edit_interval": bad_value,
+                "fresh_final_after_seconds": bad_value,
+            }
+        )
+        assert restored.edit_interval == 0.8
+        assert restored.fresh_final_after_seconds == 0.0
+
 
 class TestGatewayConfigRoundtrip:
 

--- a/tests/plugins/platforms/photon/test_presence_watchdog.py
+++ b/tests/plugins/platforms/photon/test_presence_watchdog.py
@@ -38,6 +38,34 @@ def test_probe_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert a._probe_enabled is True
 
 
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf"), -5.0])
+def test_probe_interval_rejects_non_finite_and_negative(
+    monkeypatch: pytest.MonkeyPatch, bad_value: float
+) -> None:
+    """float() parses nan/inf without raising (YAML 1.1 even has bare .nan/
+    .inf literals). Unguarded, nan/negative would silently defeat the
+    ``_probe_interval > 0`` enabled check -- disabling the zombie-stream
+    watchdog with no error and no log -- instead of falling back to the
+    documented default like any other malformed value."""
+    a = _make_adapter(monkeypatch, probe_interval_seconds=bad_value)
+
+    assert a._probe_interval == 600.0
+    assert a._probe_enabled is True
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf"), -5.0])
+def test_probe_timeout_rejects_non_finite_and_negative(
+    monkeypatch: pytest.MonkeyPatch, bad_value: float
+) -> None:
+    """A bad probe_timeout isn't gated by _probe_enabled: it reaches the
+    sidecar HTTP call's ``timeout=`` kwarg directly. Falling back to the
+    default here avoids a permanently "inconclusive" probe (or a raised
+    timeout construction error) masking a genuinely hung sidecar."""
+    a = _make_adapter(monkeypatch, probe_timeout_seconds=bad_value)
+
+    assert a._probe_timeout == 10.0
+
+
 def test_note_activity_resets_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     a = _make_adapter(monkeypatch)
     a._probe_failures = 2


### PR DESCRIPTION
## Summary
- `gateway/config.py:_coerce_float` and `plugins/platforms/photon/adapter.py:_coerce_float` now reject `nan`/`inf` (and, for photon's interval/timeout semantics, negative values), falling back to their default instead of letting them through.

## Why
`float()` parses `"nan"`/`"inf"` without raising — YAML 1.1 even has bare `.nan`/`.inf` literals — so a plain `try/except (TypeError, ValueError)` guard lets non-finite values straight through. `weixin.py` and `whatsapp/adapter.py` already guard their own `_coerce_float_extra()` against exactly this (prior art in this same codebase); the Telegram adapter has the same gap, with a fix proposed in the still-open #69445. This PR covers the two remaining sibling coercers:

- **`gateway/config.py:_coerce_float`** feeds `StreamingConfig.edit_interval` / `fresh_final_after_seconds`. A NaN compares `False` against every threshold check downstream (e.g. `elapsed >= edit_interval`), so it silently defeats the edit-interval throttle instead of falling back — no crash, no error, the feature just stops working.
- **`plugins/platforms/photon/adapter.py:_coerce_float`** feeds the presence watchdog's `probe_interval`/`probe_timeout`. A NaN or negative interval silently disables the whole zombie-stream watchdog via the `_probe_interval > 0` enabled gate (no error, no log). A bad `probe_timeout` isn't gated at all — it reaches the sidecar HTTP call's `timeout=` kwarg directly, producing a permanently `"inconclusive"` probe verdict that masks a genuinely hung sidecar.

Neither of these crashes on startup — I traced both consumption paths — but a reliability feature silently going inert with zero indication is arguably worse to debug in production than a loud crash.

## Test Plan
- Added parametrized regression tests (`nan`/`inf`/`-inf`, plus a negative case for photon) to `tests/gateway/test_config.py::TestStreamingConfig` and `tests/plugins/platforms/photon/test_presence_watchdog.py`.
- Verified each new case fails when its guard is reverted (mutation-tested both fixes).
- `uv run --extra dev pytest tests/gateway/test_config.py tests/plugins/platforms/photon/ tests/gateway/test_stream_consumer*.py -q`
- `python3 -m py_compile gateway/config.py plugins/platforms/photon/adapter.py`