### PR TITLE
fix: gateway log-cleanup + OpenWrouter gpt-5.6 picker visibility

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,43 @@
+# Gauntlet Audit — Gateway/System Log Cleanup
+
+**Type:** audit-verify (post-fix continuous run)
+**Goal:** zero ERROR/WARNING noise in gateway + system logs; find every remaining issue.
+**Commit under review:** `247a2bdbd` (gateway env strip + skill-scan RLock) + follow-up deep root-cause fix (uncommitted at audit start).
+
+## Bar (falsifiable)
+
+| # | Criterion | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Zero `kanban dispatcher: tick failed` since 01:52 restart | ✅ | gateway.log: 0 errors on 08-01 after 01:52 (correct date-aware filter); last ever 01:50 pre-restart |
+| 2 | Zero `WARNING agent.skill_commands` "already claimed" after new serve backend | ✅ | agent.log: 0 after 04:19:18; last ever 04:18:47 = old process dying |
+| 3 | gateway/run.py marker strip correct, commented WHY | ✅ | strip at gateway startup; env verified `HERMES_DELEGATED_CHILD_CONTEXT = NOT SET` on new processes |
+| 4 | skill_commands.py RLock correct, no deadlock/recursion | ✅ | 4-thread concurrent scan test: 0 warnings, 342 commands consistent |
+| 5 | No new error/warning classes since restart | ✅ | only transient pre-existing "Synthetic event source unresolvable" (seen 07-30, startup wake noise) |
+| 6 | Targeted tests pass, no new failures | ✅ | 21 passed / 3 pre-existing inline-shell failures (identical on stashed baseline) |
+| 7 | Snapshot root-cause fix (base.py) verified | ✅ | snapshot exclusion suite: 3 passed; new serve backend spawned clean post-kill |
+| 8 | Live system clean across ALL surfaces incl. desktop sessions | ✅ | serve backend 10688 (pre-fix, started 07-31 17:57) killed 04:19; desktop auto-respawned 13900/12540; 0 warnings since |
+
+## Findings
+
+### F1 (fixed): Kanban dispatcher false-positive every 60s
+- **Root cause:** gateway inherited `HERMES_DELEGATED_CHILD_CONTEXT=1` from desktop session env snapshot; `kanban_db._assert_not_delegated_child_mutation` (line 159) fell back to env var when ContextVar unset, tripping on the gateway's own `connect()` → `_migrate_add_optional_columns()` write.
+- **Fix:** `gateway/run.py` strips stale marker at startup; **deep fix:** `tools/environments/base.py` excludes the marker from the shared bash snapshot (root of the leak).
+
+### F2 (fixed): ~200 "already claimed" skill warnings per boot
+- **Root cause:** concurrent startup scans raced (`seen_names` call-local, `_skill_commands` process-global, reset per scan); second scanner logged every skill as "claimed by itself".
+- **Fix:** `agent/skill_commands.py` RLock-serializes scans; atomic check-then-scan in `get_skill_commands()`.
+
+### F3 (found): stale-process recurrence
+- **Root cause:** serve backend PID 10688 (started 07-31 17:57, pre-fix) held old module in memory; every desktop session scanned through it → warnings recurred 03:52/04:07/04:09/04:12.
+- **Fix:** killed 10688/15764; desktop auto-respawned clean process (13900/12540); 0 warnings since.
+
+### F4 (environmental, not ours): 3 inline-shell test failures
+- `TestInlineShellExpansion` failures identical on stashed baseline; `agent/skill_preprocessing.py` inline-shell subprocess path, Windows-host-bound. Not a regression.
+
+## Critics (deleg_567afc37 — batch errored on owner exit; substance recovered from transcripts)
+- task-0 (code review): verified commit diff, consumers, ran stash baseline — confirmed 3 failures pre-existing.
+- task-1 (log evidence): confirmed gateway clean post-restart; attributed bursts to serve process; confirmed commit timestamp.
+- task-2 (root cause): confirmed serve tree pre-fix; mapped desktop supervision/respawn path.
+
+## Verdict: 10/10
+All bar items green after serve-backend restart. Both code layers fixed and committed; live system clean on every surface (gateway + desktop sessions).

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -22,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+# Guards scan_skill_commands() against concurrent startup scans (gateway
+# run loop, webhook platform, tool-registry scan all call it at boot).
+# Without it two threads race: seen_names is call-local while
+# _skill_commands is process-global and gets reset+repopulated, so the
+# second scanner logs "already claimed by itself" for every skill.
+_scan_lock = threading.RLock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -377,6 +384,17 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
+    with _scan_lock:
+        return _scan_skill_commands_locked()
+
+
+def _scan_skill_commands_locked() -> Dict[str, Dict[str, Any]]:
+    """Scan skill dirs and rebuild the slash-command map.
+
+    Caller MUST hold ``_scan_lock``. Kept separate from
+    ``scan_skill_commands`` so ``get_skill_commands`` can check-then-scan
+    atomically without recursive locking surprises.
+    """
     global _skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
@@ -474,11 +492,12 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536).
     """
-    if (
-        not _skill_commands
-        or _skill_commands_platform != _resolve_skill_commands_platform()
-    ):
-        scan_skill_commands()
+    with _scan_lock:
+        if (
+            not _skill_commands
+            or _skill_commands_platform != _resolve_skill_commands_platform()
+        ):
+            _scan_skill_commands_locked()
     return _skill_commands
 
 

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -101,11 +101,42 @@ export function setModelVisibilityOpen(open: boolean): void {
 
 /** The default-visible key set: the curated top-N per provider. Used both as
  *  the dropdown fallback and to seed the Edit Models dialog. */
+/** Models guaranteed visible in every provider's default set, regardless of
+ *  the backend's `featured_models` shortlist or a stale persisted visibility
+ *  store. Pinned here so a newly-released flagship (e.g. OpenAI's `gpt-5.6`
+ *  family) is always selectable the moment it lands in the curated catalog,
+ *  instead of being hidden behind a per-lab "newest N" cap until the user
+ *  manually re-shows it (#7efee3286 added the family to the catalog; this
+ *  guarantees it surfaces in the picker). */
+const PINNED_DEFAULT_MODELS: Record<string, string[]> = {
+  openrouter: [
+    'openai/gpt-5.6-luna',
+    'openai/gpt-5.6-luna-pro',
+    'openai/gpt-5.6-sol',
+    'openai/gpt-5.6-sol-pro',
+    'openai/gpt-5.6-terra',
+    'openai/gpt-5.6-terra-pro'
+  ]
+}
+
 export function defaultVisibleKeys(providers: readonly ModelOptionProvider[]): Set<string> {
   const keys = new Set<string>()
 
   for (const provider of providers) {
     expandProviderDefaults(provider, keys)
+  }
+
+  // Guarantee pinned flagships are visible even when a stale persisted
+  // visibility store or the featured shortlist would otherwise omit them.
+  for (const provider of providers) {
+    const pinned = PINNED_DEFAULT_MODELS[provider.slug]
+    if (!pinned) continue
+    const present = new Set(provider.models ?? [])
+    for (const model of pinned) {
+      if (present.has(model)) {
+        keys.add(modelVisibilityKey(provider.slug, model))
+      }
+    }
   }
 
   return keys

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1652,6 +1652,18 @@ def _clear_planned_restart_notification() -> None:
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
 
+# A gateway is never a delegate_task child, even when the process that
+# spawned it was one (e.g. a desktop session launched from a subagent, or
+# a terminal session that inherited the marker from a delegated context).
+# HERMES_DELEGATED_CHILD_CONTEXT is a lineage marker for subagent
+# subprocesses; inherited here it makes the kanban dispatcher's own
+# connect()/migration write_txn fail with "delegate_task child contexts
+# cannot mutate Kanban tasks or boards" on every tick. The gateway IS the
+# trusted dispatcher host, so strip the stale marker. The in-process
+# ContextVar guard still protects real delegated children (that signal is
+# per-execution-context and never survives a process boundary).
+os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+
 _ensure_ssl_certs()
 
 # Add parent directory to path

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -50,6 +50,7 @@ def test_export_snippet_shape():
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
     assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the dump,
@@ -60,6 +61,24 @@ def test_export_snippet_shape():
     assert snippet.lstrip().startswith("{ ")
     assert "|| true; }" in snippet
     assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")
+
+
+def test_delegated_child_marker_excluded_from_snapshot():
+    """The delegated-child lineage marker must never persist in the snapshot.
+
+    Regression for the gateway kanban dispatcher failure: a desktop session
+    snapshot captured HERMES_DELEGATED_CHILD_CONTEXT=1, every later session
+    sourced it as a stale "delegated child" flag, and the gateway's own
+    kanban connect()/migration write_txn then tripped
+    _assert_not_delegated_child_mutation on every tick.
+    """
+    rx = re.compile(_SNAPSHOT_EXCLUDED_ENV_REGEX)
+    line = 'declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"'
+    assert rx.search(line), "delegated-child marker should be excluded from the snapshot"
+
+    snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
+    # Unset happens before export -p, so the marker cannot appear in the dump.
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -400,8 +400,19 @@ def _cwd_marker(session_id: str) -> str:
 # with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
+#
+# HERMES_DELEGATED_CHILD_CONTEXT is excluded too: it is a Hermes-internal
+# lineage marker (set by agent.delegation_context.scrub_kanban_env on
+# subprocesses of delegate_task children), NOT user shell state. Persisting it
+# into the shared snapshot makes every LATER session source a stale
+# "delegated child" flag — a session that was never delegated then trips
+# kanban_db._assert_not_delegated_child_mutation and other delegated-child
+# guards (the gateway's own dispatcher failed every tick with exactly this
+# leak). Per-command Popen env scrubbing re-applies the marker when a
+# delegated child actually runs a command, so dropping it from the snapshot is
+# safe and matches the session-identity exclusion above.
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 
 
@@ -431,7 +442,7 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "HERMES_UI_SESSION_ID 2>/dev/null; "
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"


### PR DESCRIPTION
## Summary
- **gateway/run.py**: strip stale `HERMES_DELEGATED_CHILD_CONTEXT` marker on gateway startup (was poisoning the kanban dispatcher's `connect()` → `_migrate_add_optional_columns()` write guard, causing a false-positive `PermissionError` every 60s tick).
- **tools/environments/base.py**: exclude `HERMES_DELEGATED_CHILD_CONTEXT` from the shared bash session snapshot (the deep root cause — the marker leaked into `cache/terminal/hermes-snap-*.sh` and poisoned every later session). Regression test added.
- **agent/skill_commands.py**: `threading.RLock` around `scan_skill_commands()` / `get_skill_commands()` to stop concurrent-startup skill scans racing and logging ~200 "already claimed" warnings per boot.
- **apps/desktop/src/store/model-visibility.ts**: pin the OpenAI `gpt-5.6` family to the default-visible model set so `openai/gpt-5.6-luna` is always selectable on OpenWrouter even when a stale persisted visibility store or the per-lab "newest N" featured cap would otherwise hide it.

## Verification
- Gateway logs: 0 `kanban dispatcher: tick failed` since restart; 0 `WARNING agent.skill_commands` on any surface.
- Snapshot unit tests pass (3 passed, 3 skipped).
- Desktop `model-visibility` unit tests: 26/26 pass.
- Root cause traced end-to-end: the env marker leaked via the shared bash snapshot → gateway inherited it → kanban write guard tripped. Fixed at source + defense-in-depth.
- Desktop rebuilt, repackaged, and relaunched; gpt-5.6 family now guaranteed in the picker's default-visible set.

## Test plan
- [ ] Start gateway fresh → confirm no dispatcher errors in gateway.log
- [ ] Open desktop model picker → confirm `openai/gpt-5.6-luna` selectable under OpenWrouter
- [ ] `pytest tests/tools/test_snapshot_session_id_leak.py`