### PR TITLE
fix(mcp): catch OverflowError coercing infinite tool-call args to int

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -225,8 +225,13 @@ def _coerce_int(
     Returns default if value cannot be converted to int.
     """
     try:
+        # OverflowError (not ValueError) is what int() raises for a float
+        # infinity. MCP's JSON-RPC transport is plain json.loads(), which
+        # accepts bare Infinity/-Infinity/NaN by default (a non-standard but
+        # long-standing Python extension), so a client sending
+        # {"limit": Infinity} reaches this call with a literal inf float.
         coerced = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         coerced = default
     return max(minimum, min(coerced, maximum))
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -241,8 +241,13 @@ def _coerce_int(
     Returns default if value cannot be converted to int.
     """
     try:
+        # OverflowError (not ValueError) is what int() raises for a float
+        # infinity. MCP's JSON-RPC transport is plain json.loads(), which
+        # accepts bare Infinity/-Infinity/NaN by default (a non-standard but
+        # long-standing Python extension), so a client sending
+        # {"limit": Infinity} reaches this call with a literal inf float.
         coerced = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         coerced = default
     return max(minimum, min(coerced, maximum))
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -287,12 +287,14 @@ class TestHelpers:
         assert _coerce_int(-5, default=50, minimum=1, maximum=200) == 1
 
     def test_coerce_int_handles_infinity_and_nan(self):
-        """int() raises OverflowError (not ValueError) for a float infinity.
-        MCP's JSON-RPC transport is plain json.loads(), which accepts bare
-        Infinity/-Infinity/NaN by default, so a client sending
-        {"limit": Infinity} reaches this call with a literal inf float --
-        must fall back to default like any other unparseable value, not
-        raise past the tool boundary."""
+        """int() raises OverflowError (not ValueError) for a float infinity,
+        so the bare (TypeError, ValueError) guard violated this helper's
+        documented "returns default if value cannot be converted" contract.
+
+        Note: through the FastMCP SDK path, int-typed tool parameters are
+        currently shielded by pydantic's finite_number validation (see
+        TestE2ENonFiniteArguments), so this is defense-in-depth for direct
+        callers and any future dict/Any-typed parameter."""
         from mcp_serve import _coerce_int
 
         assert _coerce_int(float("inf"), default=50, minimum=1, maximum=200) == 50
@@ -537,6 +539,42 @@ def _event_loop():
     asyncio.set_event_loop(loop)
     yield loop
     loop.close()
+
+
+class TestE2ENonFiniteArguments:
+    """SDK-path verification of the non-finite argument story (both layers).
+
+    Empirically: a raw JSON-RPC envelope containing a bare ``Infinity`` token
+    IS accepted by the MCP SDK's pydantic envelope parsing and delivers a
+    literal ``float('inf')`` into the decoded ``arguments`` dict — but
+    FastMCP's per-tool argument validation then rejects it for int-typed
+    parameters with a clean ``finite_number`` error before the tool body
+    runs. ``_coerce_int()``'s OverflowError guard is therefore
+    defense-in-depth behind pydantic, not a live wire crash. These tests pin
+    down BOTH layers so a regression in either (SDK envelope tightening, or
+    argument validation loosening) becomes visible.
+    """
+
+    def test_envelope_parsing_admits_bare_infinity(self):
+        mcp_types = pytest.importorskip("mcp.types", reason="MCP SDK not installed")
+        raw = (
+            '{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+            '"params":{"name":"conversations_list","arguments":{"limit":Infinity}}}'
+        )
+        msg = mcp_types.JSONRPCMessage.model_validate_json(raw)
+        limit = msg.root.params["arguments"]["limit"]
+        assert limit == float("inf")  # non-finite crosses the envelope intact
+
+    def test_tool_argument_validation_rejects_infinity_before_tool_body(
+        self, mcp_server_e2e, _event_loop
+    ):
+        server, _ = mcp_server_e2e
+        with pytest.raises(Exception) as excinfo:
+            _run_tool(server, "conversations_list", {"limit": float("inf")})
+        # Rejected cleanly at argument validation — never an OverflowError
+        # escaping from the tool body.
+        assert not isinstance(excinfo.value, OverflowError)
+        assert "finite" in str(excinfo.value).lower()
 
 
 class TestE2EConversationsList:

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -286,6 +286,19 @@ class TestHelpers:
         assert _coerce_int(999, default=50, minimum=1, maximum=200) == 200
         assert _coerce_int(-5, default=50, minimum=1, maximum=200) == 1
 
+    def test_coerce_int_handles_infinity_and_nan(self):
+        """int() raises OverflowError (not ValueError) for a float infinity.
+        MCP's JSON-RPC transport is plain json.loads(), which accepts bare
+        Infinity/-Infinity/NaN by default, so a client sending
+        {"limit": Infinity} reaches this call with a literal inf float --
+        must fall back to default like any other unparseable value, not
+        raise past the tool boundary."""
+        from mcp_serve import _coerce_int
+
+        assert _coerce_int(float("inf"), default=50, minimum=1, maximum=200) == 50
+        assert _coerce_int(float("-inf"), default=50, minimum=1, maximum=200) == 50
+        assert _coerce_int(float("nan"), default=50, minimum=1, maximum=200) == 50
+
     def test_load_sessions_index_empty(self, sessions_dir, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -299,6 +299,19 @@ class TestHelpers:
         assert _coerce_int(999, default=50, minimum=1, maximum=200) == 200
         assert _coerce_int(-5, default=50, minimum=1, maximum=200) == 1
 
+    def test_coerce_int_handles_infinity_and_nan(self):
+        """int() raises OverflowError (not ValueError) for a float infinity.
+        MCP's JSON-RPC transport is plain json.loads(), which accepts bare
+        Infinity/-Infinity/NaN by default, so a client sending
+        {"limit": Infinity} reaches this call with a literal inf float --
+        must fall back to default like any other unparseable value, not
+        raise past the tool boundary."""
+        from mcp_serve import _coerce_int
+
+        assert _coerce_int(float("inf"), default=50, minimum=1, maximum=200) == 50
+        assert _coerce_int(float("-inf"), default=50, minimum=1, maximum=200) == 50
+        assert _coerce_int(float("nan"), default=50, minimum=1, maximum=200) == 50
+
     def test_load_sessions_index_empty(self, sessions_dir, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)


### PR DESCRIPTION
## Summary
- `mcp_serve.py:_coerce_int()` — the MCP tool boundary's guard against invalid types from external clients — now also catches `OverflowError`, alongside the existing `TypeError`/`ValueError`.
- Added SDK-path regression tests (`TestE2ENonFiniteArguments`) pinning down exactly where non-finite input is stopped today.

## Why
`int(value)` raises three different exception types depending on what goes wrong: `TypeError` for the wrong type, `ValueError` for an unparseable string or `float("nan")`, and — distinctly — `OverflowError` for `float("inf")`/`float("-inf")`. `_coerce_int()` only caught the first two, violating its documented "returns default if value cannot be converted" contract for the infinity case.

**Reachability (verified empirically through the real SDK path, per review):**
- The MCP SDK's pydantic envelope parsing **does** accept a bare `Infinity` token in JSON-RPC (`JSONRPCMessage.model_validate_json`) and delivers a literal `float('inf')` into the decoded `arguments` dict — non-finite input genuinely crosses the wire into the process.
- However, FastMCP's per-tool argument validation then rejects it for the current `int`-typed tool parameters with a clean `finite_number` validation error **before the tool body runs** — so on today's SDK path, `_coerce_int()` is shielded by pydantic and this is **defense-in-depth**, not a live remote crash. (An earlier revision of this description overstated that; corrected after testing the full FastMCP path.)

The guard still matters: it restores the helper's contract for direct callers, and for any future parameter typed `dict`/`Any` (or an SDK/validation change) where pydantic would no longer stand in front of it. Both layers are now regression-tested, so tightening of the SDK envelope or loosening of argument validation becomes visible immediately.

Six call sites in `mcp_serve.py` funnel through this one helper (`conversations_list`, `events_poll` cursor/limit/timeout params, etc.).

## Test Plan
- `TestE2ENonFiniteArguments::test_envelope_parsing_admits_bare_infinity` — proves `Infinity` crosses the envelope as a literal `inf` float.
- `TestE2ENonFiniteArguments::test_tool_argument_validation_rejects_infinity_before_tool_body` — proves FastMCP rejects it cleanly (no `OverflowError` escaping) on the real `_tool_manager.call_tool` path.
- `test_coerce_int_handles_infinity_and_nan` — direct-call contract test; fails with the exact uncaught `OverflowError` when the fix is reverted (mutation-tested).
- `uv run --extra dev pytest tests/test_mcp_serve.py -q` — 91 passed.