### PR TITLE
fix(kanban): make manual promotion CAS-safe

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -133,6 +133,22 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _parse_nullable_id(value: str) -> Optional[int]:
+    """Parse a positive row id or an explicit SQL-NULL expectation."""
+    normalized = value.strip().casefold()
+    if normalized in {"none", "null"}:
+        return None
+    try:
+        parsed = int(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected a positive integer or 'none'"
+        ) from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer or 'none'")
+    return parsed
+
+
 def _check_dispatcher_presence(
     hermes_home: Optional[Path] = None,
 ) -> tuple[bool, str]:
@@ -680,6 +696,36 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--dry-run",
         action="store_true",
         help="Validate the promotion without mutating state",
+    )
+    p_promote.add_argument(
+        "--expect-status",
+        choices=sorted(kb.VALID_STATUSES),
+        default=None,
+        help="Promote only if the task still has this exact status",
+    )
+    p_promote.add_argument(
+        "--expect-current-run-id",
+        type=_parse_nullable_id,
+        default=kb.PROMOTE_EXPECTATION_UNSET,
+        metavar="ID|none",
+        help="Promote only if current_run_id matches (use 'none' for NULL)",
+    )
+    p_promote.add_argument(
+        "--expect-latest-run-id",
+        type=_parse_nullable_id,
+        default=kb.PROMOTE_EXPECTATION_UNSET,
+        metavar="ID|none",
+        help=(
+            "Promote only if the latest task run id matches "
+            "(use 'none' for no run)"
+        ),
+    )
+    p_promote.add_argument(
+        "--expect-latest-event-id",
+        type=_parse_nullable_id,
+        default=kb.PROMOTE_EXPECTATION_UNSET,
+        metavar="ID|none",
+        help="Promote only if the latest task event id matches",
     )
     p_promote.add_argument(
         "--json",
@@ -2359,6 +2405,22 @@ def _cmd_promote(args: argparse.Namespace) -> int:
                 reason=reason,
                 force=bool(args.force),
                 dry_run=bool(args.dry_run),
+                expected_status=getattr(args, "expect_status", None),
+                expected_current_run_id=getattr(
+                    args,
+                    "expect_current_run_id",
+                    kb.PROMOTE_EXPECTATION_UNSET,
+                ),
+                expected_latest_run_id=getattr(
+                    args,
+                    "expect_latest_run_id",
+                    kb.PROMOTE_EXPECTATION_UNSET,
+                ),
+                expected_latest_event_id=getattr(
+                    args,
+                    "expect_latest_event_id",
+                    kb.PROMOTE_EXPECTATION_UNSET,
+                ),
             )
             results.append({
                 "task_id": tid,
@@ -2366,7 +2428,9 @@ def _cmd_promote(args: argparse.Namespace) -> int:
                 "dry_run": bool(args.dry_run),
                 "forced": bool(args.force),
                 "reason": reason,
-                "error": err,
+                "error": str(err) if err is not None else None,
+                "code": getattr(err, "code", None),
+                "refusal_reason": str(err) if err is not None else None,
             })
 
     failed = [r for r in results if not r["promoted"]]

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2415,7 +2415,7 @@ def _cmd_promote(args: argparse.Namespace) -> int:
     )
 
     results: list[dict[str, object]] = []
-    if len(ids) > 1 and has_expectations:
+    if extra_ids and has_expectations:
         message = "CAS expectations require exactly one task"
         results = [
             {

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2395,43 +2395,66 @@ def _cmd_promote(args: argparse.Namespace) -> int:
             ids.append(tid)
             seen.add(tid)
 
+    expected_status = getattr(args, "expect_status", None)
+    expected_current_run_id = getattr(
+        args, "expect_current_run_id", kb.PROMOTE_EXPECTATION_UNSET
+    )
+    expected_latest_run_id = getattr(
+        args, "expect_latest_run_id", kb.PROMOTE_EXPECTATION_UNSET
+    )
+    expected_latest_event_id = getattr(
+        args, "expect_latest_event_id", kb.PROMOTE_EXPECTATION_UNSET
+    )
+    has_expectations = expected_status is not None or any(
+        value is not kb.PROMOTE_EXPECTATION_UNSET
+        for value in (
+            expected_current_run_id,
+            expected_latest_run_id,
+            expected_latest_event_id,
+        )
+    )
+
     results: list[dict[str, object]] = []
-    with kb.connect_closing() as conn:
-        for tid in ids:
-            ok, err = kb.promote_task(
-                conn,
-                tid,
-                actor=author,
-                reason=reason,
-                force=bool(args.force),
-                dry_run=bool(args.dry_run),
-                expected_status=getattr(args, "expect_status", None),
-                expected_current_run_id=getattr(
-                    args,
-                    "expect_current_run_id",
-                    kb.PROMOTE_EXPECTATION_UNSET,
-                ),
-                expected_latest_run_id=getattr(
-                    args,
-                    "expect_latest_run_id",
-                    kb.PROMOTE_EXPECTATION_UNSET,
-                ),
-                expected_latest_event_id=getattr(
-                    args,
-                    "expect_latest_event_id",
-                    kb.PROMOTE_EXPECTATION_UNSET,
-                ),
-            )
-            results.append({
+    if len(ids) > 1 and has_expectations:
+        message = "CAS expectations require exactly one task"
+        results = [
+            {
                 "task_id": tid,
-                "promoted": ok,
+                "promoted": False,
                 "dry_run": bool(args.dry_run),
                 "forced": bool(args.force),
                 "reason": reason,
-                "error": str(err) if err is not None else None,
-                "code": getattr(err, "code", None),
-                "refusal_reason": str(err) if err is not None else None,
-            })
+                "error": message,
+                "code": "cas_expectations_require_single_task",
+                "refusal_reason": message,
+            }
+            for tid in ids
+        ]
+    else:
+        with kb.connect_closing() as conn:
+            for tid in ids:
+                ok, err = kb.promote_task(
+                    conn,
+                    tid,
+                    actor=author,
+                    reason=reason,
+                    force=bool(args.force),
+                    dry_run=bool(args.dry_run),
+                    expected_status=expected_status,
+                    expected_current_run_id=expected_current_run_id,
+                    expected_latest_run_id=expected_latest_run_id,
+                    expected_latest_event_id=expected_latest_event_id,
+                )
+                results.append({
+                    "task_id": tid,
+                    "promoted": ok,
+                    "dry_run": bool(args.dry_run),
+                    "forced": bool(args.force),
+                    "reason": reason,
+                    "error": str(err) if err is not None else None,
+                    "code": getattr(err, "code", None),
+                    "refusal_reason": str(err) if err is not None else None,
+                })
 
     failed = [r for r in results if not r["promoted"]]
     if as_json:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5734,6 +5734,24 @@ def block_task(
 
 
 
+PROMOTE_EXPECTATION_UNSET = object()
+
+
+class PromoteRefusal(str):
+    """Backward-compatible promote error string with a stable refusal code."""
+
+    code: str
+
+    def __new__(cls, code: str, message: str) -> "PromoteRefusal":
+        refusal = super().__new__(cls, message)
+        refusal.code = code
+        return refusal
+
+
+def _promote_refusal(code: str, message: str) -> tuple[bool, PromoteRefusal]:
+    return False, PromoteRefusal(code, message)
+
+
 def promote_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5742,58 +5760,117 @@ def promote_task(
     reason: Optional[str] = None,
     force: bool = False,
     dry_run: bool = False,
-) -> tuple[bool, Optional[str]]:
-    """Manually promote a `todo` or `blocked` task to `ready`.
+    expected_status: Optional[str] = None,
+    expected_current_run_id: object = PROMOTE_EXPECTATION_UNSET,
+    expected_latest_run_id: object = PROMOTE_EXPECTATION_UNSET,
+    expected_latest_event_id: object = PROMOTE_EXPECTATION_UNSET,
+) -> tuple[bool, Optional[PromoteRefusal]]:
+    """Manually promote a ``todo`` or ``blocked`` task to ``ready``.
 
-    Mirrors the automatic promotion done by ``recompute_ready`` but
-    drives it from a deliberate operator action with an audit-trail
-    entry. Refuses to promote if any parent dep is not in a terminal
-    state (`done`/`archived`) unless ``force=True``. Does NOT change
-    assignee or claim state. Returns ``(True, None)`` on success and
-    ``(False, reason)`` if refused. ``dry_run=True`` validates the
-    promotion would succeed without mutating state.
+    Optional ``expected_*`` values bind an operator's read-only observation to
+    the mutation. An omitted keyword means no precondition; for run ids, ``None``
+    explicitly expects SQL NULL / no run. Every precondition, dependency check,
+    and the CAS update runs under one ``BEGIN IMMEDIATE`` transaction. ``force``
+    only bypasses dependency gating and never bypasses an expectation.
+
+    Returns the legacy ``(ok, error)`` pair. Refusal errors remain strings but
+    carry a stable ``.code`` attribute for machine-readable CLI output.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
-    if row is None:
-        return False, f"task {task_id} not found"
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return _promote_refusal("task_not_found", f"task {task_id} not found")
 
-    cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
-        return False, (
-            f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
+        cur_status = row["status"]
+        current_run_id = (
+            int(row["current_run_id"])
+            if row["current_run_id"] is not None
+            else None
         )
-
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
+        latest_run_row = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id = ? "
+            "ORDER BY started_at DESC, id DESC LIMIT 1",
             (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
-            return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
+        ).fetchone()
+        latest_run_id = int(latest_run_row["id"]) if latest_run_row else None
+        latest_event_row = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        latest_event_id = int(latest_event_row["id"]) if latest_event_row else None
+
+        if expected_status is not None and cur_status != expected_status:
+            return _promote_refusal(
+                "expected_status_mismatch",
+                f"expected status {expected_status!r}, found {cur_status!r}",
+            )
+        if (
+            expected_current_run_id is not PROMOTE_EXPECTATION_UNSET
+            and current_run_id != expected_current_run_id
+        ):
+            return _promote_refusal(
+                "expected_current_run_id_mismatch",
+                "expected current_run_id "
+                f"{expected_current_run_id!r}, found {current_run_id!r}",
+            )
+        if (
+            expected_latest_run_id is not PROMOTE_EXPECTATION_UNSET
+            and latest_run_id != expected_latest_run_id
+        ):
+            return _promote_refusal(
+                "expected_latest_run_id_mismatch",
+                "expected latest task run id "
+                f"{expected_latest_run_id!r}, found {latest_run_id!r}",
+            )
+        if (
+            expected_latest_event_id is not PROMOTE_EXPECTATION_UNSET
+            and latest_event_id != expected_latest_event_id
+        ):
+            return _promote_refusal(
+                "expected_latest_event_id_mismatch",
+                "expected latest task event id "
+                f"{expected_latest_event_id!r}, found {latest_event_id!r}",
             )
 
-    if dry_run:
-        return True, None
+        if cur_status not in ("todo", "blocked"):
+            return _promote_refusal(
+                "status_not_promotable",
+                f"task {task_id} is {cur_status!r}; promote only applies to "
+                "'todo' or 'blocked'",
+            )
 
-    with write_txn(conn):
+        if not force:
+            parents = conn.execute(
+                "SELECT t.id, t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            unsatisfied = [
+                p["id"]
+                for p in parents
+                if p["status"] not in ("done", "archived")
+            ]
+            if unsatisfied:
+                return _promote_refusal(
+                    "unsatisfied_dependencies",
+                    "unsatisfied parent dependencies: "
+                    f"{', '.join(unsatisfied)} (use --force to override)",
+                )
+
+        if dry_run:
+            return True, None
+
         upd = conn.execute(
-            "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
-            (task_id,),
+            "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = ?",
+            (task_id, cur_status),
         )
         if upd.rowcount != 1:
-            return False, f"task {task_id} status changed during promotion"
+            return _promote_refusal(
+                "promotion_conflict", f"task {task_id} changed during promotion"
+            )
         _append_event(
             conn,
             task_id,

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 
 import pytest
 
@@ -34,6 +39,12 @@ def kanban_home(tmp_path, monkeypatch):
 def conn(kanban_home):
     with kb.connect() as c:
         yield c
+
+
+def _task_status(conn, task_id):
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task.status
 
 
 def _stuck_todo(conn, *, parents_done=True, n_parents=1):
@@ -76,15 +87,26 @@ def test_promote_stuck_todo_succeeds(conn):
 
 
 def _promote_ns(task_id, *, ids=None, reason=None, force=False,
-                dry_run=False, as_json=False):
-    return argparse.Namespace(
-        task_id=task_id,
-        reason=list(reason or []),
-        ids=list(ids or []) or None,
-        force=force,
-        dry_run=dry_run,
-        json=as_json,
-    )
+                dry_run=False, as_json=False, **expectations):
+    values = {
+        "task_id": task_id,
+        "reason": list(reason or []),
+        "ids": list(ids or []) or None,
+        "force": force,
+        "dry_run": dry_run,
+        "json": as_json,
+        "expect_status": expectations.get("expect_status"),
+    }
+    values.update({
+        key: expectations[key]
+        for key in (
+            "expect_current_run_id",
+            "expect_latest_run_id",
+            "expect_latest_event_id",
+        )
+        if key in expectations
+    })
+    return argparse.Namespace(**values)
 
 
 def test_cli_promote_bulk_ids_promotes_all(kanban_home, capsys):
@@ -105,3 +127,261 @@ def test_cli_promote_bulk_ids_promotes_all(kanban_home, capsys):
             assert kb.get_task(conn, c).status == "ready"
 
 
+def _latest_event_id(conn, task_id):
+    row = conn.execute(
+        "SELECT id FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return int(row["id"]) if row else None
+
+
+def _insert_run(conn, task_id, *, active=False):
+    cur = conn.execute(
+        "INSERT INTO task_runs (task_id, status, started_at) VALUES (?, ?, ?)",
+        (task_id, "running" if active else "completed", 1),
+    )
+    run_id = int(cur.lastrowid)
+    if active:
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?", (run_id, task_id)
+        )
+    return run_id
+
+
+def test_promote_cas_success_binds_all_observed_state(conn):
+    child, _ = _stuck_todo(conn)
+    event_id = _latest_event_id(conn, child)
+
+    ok, err = kb.promote_task(
+        conn,
+        child,
+        actor="operator",
+        expected_status="todo",
+        expected_current_run_id=None,
+        expected_latest_run_id=None,
+        expected_latest_event_id=event_id,
+    )
+
+    assert (ok, err) == (True, None)
+    assert kb.get_task(conn, child).status == "ready"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_code"),
+    [
+        ("status", "expected_status_mismatch"),
+        ("current_run", "expected_current_run_id_mismatch"),
+        ("latest_run", "expected_latest_run_id_mismatch"),
+    ],
+)
+def test_promote_refuses_stale_task_or_run_observation(conn, mutation, expected_code):
+    child, _ = _stuck_todo(conn)
+    if mutation == "status":
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (child,))
+    elif mutation == "current_run":
+        _insert_run(conn, child, active=True)
+    else:
+        _insert_run(conn, child)
+
+    ok, refusal = kb.promote_task(
+        conn,
+        child,
+        actor="operator",
+        force=True,
+        expected_status="todo",
+        expected_current_run_id=None,
+        expected_latest_run_id=None,
+    )
+
+    assert ok is False
+    assert refusal is not None
+    assert refusal.code == expected_code
+    assert kb.get_task(conn, child).status != "ready"
+
+
+@pytest.mark.parametrize("mutation", ["comment", "link", "event"])
+def test_promote_refuses_stale_latest_event_after_task_activity(conn, mutation):
+    child, _ = _stuck_todo(conn)
+    observed_event = _latest_event_id(conn, child)
+    if mutation == "comment":
+        kb.add_comment(conn, child, "reviewer", "new evidence")
+    elif mutation == "link":
+        new_parent = kb.create_task(conn, title="late dependency")
+        kb.link_tasks(conn, new_parent, child)
+    else:
+        with kb.write_txn(conn):
+            kb._append_event(conn, child, "external_observation")
+
+    ok, refusal = kb.promote_task(
+        conn,
+        child,
+        actor="operator",
+        force=True,
+        expected_latest_event_id=observed_event,
+    )
+
+    assert ok is False
+    assert refusal is not None
+    assert refusal.code == "expected_latest_event_id_mismatch"
+    assert kb.get_task(conn, child).status != "ready"
+
+
+def test_promote_revalidates_dependency_committed_by_competing_writer(conn):
+    child, _ = _stuck_todo(conn)
+    late_parent = kb.create_task(conn, title="late dependency")
+    contender_started = Event()
+
+    def contend():
+        with kb.connect() as contender:
+            contender_started.set()
+            return kb.promote_task(contender, child, actor="operator")
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (late_parent, child),
+            )
+            future = pool.submit(contend)
+            assert contender_started.wait(timeout=2)
+        ok, refusal = future.result(timeout=5)
+
+    assert ok is False
+    assert refusal is not None
+    assert refusal.code == "unsatisfied_dependencies"
+    task = kb.get_task(conn, child)
+    assert task is not None and task.status == "todo"
+
+
+def test_promote_nullable_expectations_distinguish_null_from_omitted(conn):
+    null_child, _ = _stuck_todo(conn)
+    ok, err = kb.promote_task(
+        conn,
+        null_child,
+        actor="operator",
+        expected_current_run_id=None,
+        expected_latest_run_id=None,
+    )
+    assert (ok, err) == (True, None)
+
+    changed_child, _ = _stuck_todo(conn)
+    active_run = _insert_run(conn, changed_child, active=True)
+    ok, refusal = kb.promote_task(
+        conn,
+        changed_child,
+        actor="operator",
+        expected_current_run_id=None,
+    )
+    assert ok is False
+    assert refusal is not None
+    assert refusal.code == "expected_current_run_id_mismatch"
+
+    # Omitting both expectations preserves the legacy behavior.
+    ok, err = kb.promote_task(conn, changed_child, actor="operator")
+    assert (ok, err) == (True, None)
+    assert active_run is not None
+
+
+def test_promote_dry_run_has_zero_durable_effect(conn):
+    child, _ = _stuck_todo(conn)
+    before_events = _latest_event_id(conn, child)
+
+    ok, err = kb.promote_task(
+        conn,
+        child,
+        actor="operator",
+        dry_run=True,
+        expected_status="todo",
+        expected_current_run_id=None,
+        expected_latest_run_id=None,
+        expected_latest_event_id=before_events,
+    )
+
+    assert (ok, err) == (True, None)
+    assert kb.get_task(conn, child).status == "todo"
+    assert _latest_event_id(conn, child) == before_events
+
+
+def test_two_cas_contenders_only_one_promotes(kanban_home):
+    with kb.connect() as setup:
+        child, _ = _stuck_todo(setup)
+        event_id = _latest_event_id(setup, child)
+
+    def contend():
+        with kb.connect() as contender:
+            ok, refusal = kb.promote_task(
+                contender,
+                child,
+                actor="operator",
+                expected_status="todo",
+                expected_current_run_id=None,
+                expected_latest_run_id=None,
+                expected_latest_event_id=event_id,
+            )
+            return ok, getattr(refusal, "code", None)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: contend(), range(2)))
+
+    assert sorted(ok for ok, _ in results) == [False, True]
+    assert {code for ok, code in results if not ok} <= {
+        "expected_status_mismatch",
+        "expected_latest_event_id_mismatch",
+    }
+
+
+def _run_cli(home, *args):
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", *args],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def test_real_cli_promote_cas_success_and_machine_readable_refusal(kanban_home):
+    with kb.connect() as conn:
+        success_child, _ = _stuck_todo(conn)
+        success_event = _latest_event_id(conn, success_child)
+        stale_child, _ = _stuck_todo(conn)
+        stale_event = _latest_event_id(conn, stale_child)
+        kb.add_comment(conn, stale_child, "reviewer", "changed")
+
+    success = _run_cli(
+        kanban_home,
+        "promote",
+        success_child,
+        "--expect-status",
+        "todo",
+        "--expect-current-run-id",
+        "none",
+        "--expect-latest-run-id",
+        "none",
+        "--expect-latest-event-id",
+        str(success_event),
+        "--json",
+    )
+    assert success.returncode == 0, success.stderr
+    success_payload = json.loads(success.stdout)
+    assert success_payload["promoted"] is True
+    assert success_payload["code"] is None
+
+    refused = _run_cli(
+        kanban_home,
+        "promote",
+        stale_child,
+        "--force",
+        "--expect-latest-event-id",
+        str(stale_event),
+        "--json",
+    )
+    assert refused.returncode == 1
+    refusal_payload = json.loads(refused.stdout)
+    assert refusal_payload["promoted"] is False
+    assert refusal_payload["code"] == "expected_latest_event_id_mismatch"
+    assert refusal_payload["refusal_reason"]

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -153,6 +153,28 @@ def test_cli_promote_bulk_rejects_cas_before_any_mutation(kanban_home, capsys):
         assert _task_status(conn, second) == "todo"
 
 
+def test_cli_promote_rejects_duplicate_bulk_syntax_with_cas(kanban_home, capsys):
+    with kb.connect() as conn:
+        task, _ = _stuck_todo(conn)
+        event_id = _latest_event_id(conn, task)
+
+    rc = kb_cli._cmd_promote(
+        _promote_ns(
+            task,
+            ids=[task],
+            as_json=True,
+            expect_latest_event_id=event_id,
+        )
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["task_id"] == task
+    assert payload["code"] == "cas_expectations_require_single_task"
+    with kb.connect() as conn:
+        assert _task_status(conn, task) == "todo"
+
+
 def _latest_event_id(conn, task_id):
     row = conn.execute(
         "SELECT id FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -127,6 +127,32 @@ def test_cli_promote_bulk_ids_promotes_all(kanban_home, capsys):
             assert kb.get_task(conn, c).status == "ready"
 
 
+def test_cli_promote_bulk_rejects_cas_before_any_mutation(kanban_home, capsys):
+    with kb.connect() as conn:
+        first, _ = _stuck_todo(conn)
+        second, _ = _stuck_todo(conn)
+        first_event = _latest_event_id(conn, first)
+
+    rc = kb_cli._cmd_promote(
+        _promote_ns(
+            first,
+            ids=[second],
+            as_json=True,
+            expect_latest_event_id=first_event,
+        )
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["task_id"] for item in payload] == [first, second]
+    assert {
+        item["code"] for item in payload
+    } == {"cas_expectations_require_single_task"}
+    with kb.connect() as conn:
+        assert _task_status(conn, first) == "todo"
+        assert _task_status(conn, second) == "todo"
+
+
 def _latest_event_id(conn, task_id):
     row = conn.execute(
         "SELECT id FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",


### PR DESCRIPTION
## Summary

- adds optional compare-and-swap preconditions to `hermes kanban promote` for task status, current run, latest run, and latest event
- evaluates preconditions, dependency state, the status update, and the audit event inside one `BEGIN IMMEDIATE` transaction
- keeps legacy single and bulk promotion behavior when no expectations are supplied
- rejects task-specific CAS expectations with `--ids` before opening the board, including duplicate-ID bulk syntax
- exposes stable machine-readable refusal codes in JSON output

## Motivation

An operator can inspect a blocked/todo task and then manually promote it, but the current command cannot bind that read-only observation to the mutation. A concurrent run, event, status change, or dependency change can therefore invalidate the operator's evidence before promotion. The optional expectations make that recovery path fail closed without changing default behavior.

## Verification

- `./scripts/run_tests.sh tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py`
  - 43 passed, 0 failed
- `./.venv/bin/ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tests/hermes_cli/test_kanban_promote.py`
  - passed
- `git diff --check`
  - passed
- independent exact-head Security/Authority review: GO
- independent exact-head Correctness/Standards review: GO

A broader `tests/hermes_cli/` run was stopped at 78% after two unrelated environment-sensitive failures while all Kanban modules had passed:

- `test_gateway_platform_gating.py`: optional Slack plugin could not import `aiohttp`
- `test_doctor.py::test_doctor_reports_vercel_backend_diagnostics`: host did not expose the expected Vercel diagnostic

## Compatibility

- existing callers receive the same `(ok, error)` shape; refusal values remain strings and now additionally carry a stable `.code`
- omitted expectations preserve existing behavior
- explicit `none`/`null` remains distinct from an omitted nullable run expectation
- `--force` bypasses dependency gating only, never CAS expectations
