### PR TITLE
fix(desktop): add manual session refresh + refocus re-sync

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -236,6 +236,8 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
+  /** Re-pull the stored session list from the backend (sidebar ↺ button). */
+  onRefreshSessions?: () => Promise<void> | void
   onManageCronJob: (jobId: string) => void
   onTriggerCronJob: (jobId: string) => void
 }
@@ -252,6 +254,7 @@ export function ChatSidebar({
   onBranchSession,
   onNewSessionInWorkspace,
   onNewSessionSplit,
+  onRefreshSessions,
   onManageCronJob,
   onTriggerCronJob
 }: ChatSidebarProps) {
@@ -1383,6 +1386,22 @@ export function ChatSidebar({
                             variant="ghost"
                           >
                             <Codicon name="add" size="0.75rem" />
+                          </Button>
+                        </Tip>
+                      ) : null}
+                      {onRefreshSessions ? (
+                        <Tip label={s.refreshSessions}>
+                          <Button
+                            aria-label={s.refreshSessions}
+                            className={HEADER_ACTION_BTN}
+                            onClick={event => {
+                              event.stopPropagation()
+                              void onRefreshSessions()
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                          >
+                            <Codicon name="refresh" size="0.75rem" />
                           </Button>
                         </Tip>
                       ) : null}

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -258,6 +258,49 @@ export function useBackgroundSync({
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
 
+  // Returning to the desktop window re-pulls the stored session list. The
+  // websocket only replays events emitted while this window was connected, so a
+  // session created on the phone/tablet while the desktop sat hidden never
+  // arrives as a stream event — the sidebar would stay stale until the next
+  // `sessions.changed` broadcast (or never, against an older backend). A
+  // focus/visibility refresh covers the "came back to the computer" case
+  // without running a foreground poll loop. Coalesced: refocus fires `focus`
+  // and `visibilitychange` together, and mashing ⌘⇥ should not spam the list
+  // endpoint.
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    let lastRunAt = 0
+
+    const refresh = () => {
+      const now = Date.now()
+
+      if (now - lastRunAt < 2_000) {
+        return
+      }
+
+      lastRunAt = now
+      void refreshSessions()
+      void refreshMessagingSessions()
+    }
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refresh()
+      }
+    }
+
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [gatewayState, refreshMessagingSessions, refreshSessions])
+
   // A reconnect loses renderer-only working/attention atoms while the backend
   // keeps the actual turns alive. Re-seed from the gateway's in-memory session
   // registry immediately, then re-pull on every sessions.changed broadcast; a

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -67,6 +67,7 @@ export function latestSidebarActions(actions: SidebarActions): SidebarActions {
     onNavigate: (...args) => actions.onNavigate(...args),
     onNewSessionInWorkspace: (...args) => actions.onNewSessionInWorkspace(...args),
     onNewSessionSplit: (...args) => actions.onNewSessionSplit(...args),
+    onRefreshSessions: latestOptional(() => actions.onRefreshSessions),
     onResumeSession: (...args) => actions.onResumeSession(...args),
     onTriggerCronJob: (...args) => actions.onTriggerCronJob(...args)
   }

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -21,6 +21,7 @@ export type SidebarActions = Pick<
   | 'onNavigate'
   | 'onNewSessionInWorkspace'
   | 'onNewSessionSplit'
+  | 'onRefreshSessions'
   | 'onResumeSession'
   | 'onTriggerCronJob'
 >

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -872,6 +872,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onNavigate: selectSidebarItem,
     onNewSessionInWorkspace: path => startSessionInWorkspace(path, { openTab: true }),
     onNewSessionSplit: dir => void openNewSessionTile(dir),
+    onRefreshSessions: () => void refreshSessions(),
     onPasteClipboardImage: opts => composer.pasteClipboardImage(opts),
     onPickFiles: () => void composer.pickContextPaths('file'),
     onPickFolders: () => void composer.pickContextPaths('folder'),

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1546,6 +1546,7 @@ export const ar = defineLocale({
     groupAriaUngrouped: 'الجلسات غير مجمعة',
     showProjects: 'عرض المشاريع',
     showSessions: 'عرض الجلسات',
+    refreshSessions: 'تحديث الجلسات',
     groupTitleGrouped: 'مجمعة حسب مساحة العمل',
     groupTitleUngrouped: 'كل الجلسات',
     allPinned: 'كل الجلسات مثبتة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1830,6 +1830,7 @@ export const en: Translations = {
     groupAriaUngrouped: 'Group sessions by workspace',
     showProjects: 'Show projects',
     showSessions: 'Show sessions',
+    refreshSessions: 'Refresh sessions',
     groupTitleGrouped: 'Ungroup sessions',
     groupTitleUngrouped: 'Group by workspace',
     allPinned: 'Everything here is pinned. Unpin a chat to show it in recents.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1671,6 +1671,7 @@ export const ja = defineLocale({
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',
     showProjects: 'プロジェクトを表示',
     showSessions: 'セッションを表示',
+    refreshSessions: 'セッションを再読み込み',
     groupTitleGrouped: 'セッションのグループ化を解除',
     groupTitleUngrouped: 'ワークスペースでグループ化',
     allPinned: 'ここにあるものはすべてピン留めされています。チャットのピン留めを解除すると最近のものに表示されます。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1532,6 +1532,7 @@ export interface Translations {
     groupAriaUngrouped: string
     showProjects: string
     showSessions: string
+    refreshSessions: string
     groupTitleGrouped: string
     groupTitleUngrouped: string
     allPinned: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1616,6 +1616,7 @@ export const zhHant = defineLocale({
     groupAriaUngrouped: '依工作區分組工作階段',
     showProjects: '顯示專案',
     showSessions: '顯示工作階段',
+    refreshSessions: '重新整理工作階段',
     groupTitleGrouped: '取消分組',
     groupTitleUngrouped: '依工作區分組',
     allPinned: '這裡的全部已釘選。取消釘選某個聊天即可在最近中顯示。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2024,6 +2024,7 @@ export const zh: Translations = {
     groupAriaUngrouped: '按工作区分组会话',
     showProjects: '显示项目',
     showSessions: '显示会话',
+    refreshSessions: '刷新会话',
     groupTitleGrouped: '取消分组',
     groupTitleUngrouped: '按工作区分组',
     allPinned: '这里的全部已置顶。取消置顶某个对话即可在最近中显示。',


### PR DESCRIPTION
## Problem

The desktop sidebar session list only re-pulls when the websocket broadcasts sessions.changed (plus rare backstop polls for live statuses, not the list itself). A session created on a phone/tablet while the desktop window sat hidden never arrives as a stream event, so the sidebar stays stale until the app is relaunched. There was no way to force a refresh either.

## Fix

- **Manual refresh**: a refresh (refresh icon) action in the sessions section header calls refreshSessions() directly.
- **Refocus re-sync**: re-pull sessions + messaging sessions on window focus / visibilitychange (coalesced to 2s), so returning to the desktop picks up sessions created elsewhere.

Wired through SidebarActions (types / latest-actions / wiring) and i18n in all five locales (en, zh, zh-hant, ja, ar).

## Verification

- npm run check (typecheck x3, eslint, full UI test suite 3131 tests, desktop platform tests) passes.
- Built app: refresh button visible in sidebar; refocus triggers a list re-pull.