### PR TITLE
fix(desktop): surface approval requests with in-app cue + toast

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10286,6 +10286,16 @@ const claimedAmbientCue = createEventDeduper()
 // The first caller within the window gets true; peers get false and stay quiet.
 ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
 
+ipcMain.handle('hermes:beep', () => {
+  // Renderer WebAudio is subject to autoplay policy: while the window is
+  // unfocused the AudioContext stays suspended and the cue is inaudible —
+  // exactly the case an approval/input alert must cover. shell.beep() plays
+  // the system alert sound from the main process, independent of focus.
+  shell.beep()
+
+  return true
+})
+
 ipcMain.handle('hermes:notify', (_event, payload) => {
   if (!Notification.isSupported()) {
     return false

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -8,6 +8,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
+  // Play the OS alert sound from main. Unlike renderer WebAudio, this is not
+  // subject to autoplay policy, so it works while the window is unfocused.
+  playSystemBeep: () => ipcRenderer.invoke('hermes:beep'),
   petOverlay: {
     // Main renderer → main process: window lifecycle + drag. `request` is
     // `{ bounds, screen }`; resolves with the screen bounds it actually used.

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -236,6 +236,8 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
+  /** Re-pull the stored session list from the backend (sidebar ↺ button). */
+  onRefreshSessions?: () => Promise<void> | void
   onManageCronJob: (jobId: string) => void
   onTriggerCronJob: (jobId: string) => void
 }
@@ -252,6 +254,7 @@ export function ChatSidebar({
   onBranchSession,
   onNewSessionInWorkspace,
   onNewSessionSplit,
+  onRefreshSessions,
   onManageCronJob,
   onTriggerCronJob
 }: ChatSidebarProps) {
@@ -1383,6 +1386,22 @@ export function ChatSidebar({
                             variant="ghost"
                           >
                             <Codicon name="add" size="0.75rem" />
+                          </Button>
+                        </Tip>
+                      ) : null}
+                      {onRefreshSessions ? (
+                        <Tip label={s.refreshSessions}>
+                          <Button
+                            aria-label={s.refreshSessions}
+                            className={HEADER_ACTION_BTN}
+                            onClick={event => {
+                              event.stopPropagation()
+                              void onRefreshSessions()
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                          >
+                            <Codicon name="refresh" size="0.75rem" />
                           </Button>
                         </Tip>
                       ) : null}

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -258,6 +258,49 @@ export function useBackgroundSync({
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
 
+  // Returning to the desktop window re-pulls the stored session list. The
+  // websocket only replays events emitted while this window was connected, so a
+  // session created on the phone/tablet while the desktop sat hidden never
+  // arrives as a stream event — the sidebar would stay stale until the next
+  // `sessions.changed` broadcast (or never, against an older backend). A
+  // focus/visibility refresh covers the "came back to the computer" case
+  // without running a foreground poll loop. Coalesced: refocus fires `focus`
+  // and `visibilitychange` together, and mashing ⌘⇥ should not spam the list
+  // endpoint.
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    let lastRunAt = 0
+
+    const refresh = () => {
+      const now = Date.now()
+
+      if (now - lastRunAt < 2_000) {
+        return
+      }
+
+      lastRunAt = now
+      void refreshSessions()
+      void refreshMessagingSessions()
+    }
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refresh()
+      }
+    }
+
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [gatewayState, refreshMessagingSessions, refreshSessions])
+
   // A reconnect loses renderer-only working/attention atoms while the backend
   // keeps the actual turns alive. Re-seed from the gateway's in-memory session
   // registry immediately, then re-pull on every sessions.changed broadcast; a

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -67,6 +67,7 @@ export function latestSidebarActions(actions: SidebarActions): SidebarActions {
     onNavigate: (...args) => actions.onNavigate(...args),
     onNewSessionInWorkspace: (...args) => actions.onNewSessionInWorkspace(...args),
     onNewSessionSplit: (...args) => actions.onNewSessionSplit(...args),
+    onRefreshSessions: latestOptional(() => actions.onRefreshSessions),
     onResumeSession: (...args) => actions.onResumeSession(...args),
     onTriggerCronJob: (...args) => actions.onTriggerCronJob(...args)
   }

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -21,6 +21,7 @@ export type SidebarActions = Pick<
   | 'onNavigate'
   | 'onNewSessionInWorkspace'
   | 'onNewSessionSplit'
+  | 'onRefreshSessions'
   | 'onResumeSession'
   | 'onTriggerCronJob'
 >

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -872,6 +872,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onNavigate: selectSidebarItem,
     onNewSessionInWorkspace: path => startSessionInWorkspace(path, { openTab: true }),
     onNewSessionSplit: dir => void openNewSessionTile(dir),
+    onRefreshSessions: () => void refreshSessions(),
     onPasteClipboardImage: opts => composer.pasteClipboardImage(opts),
     onPickFiles: () => void composer.pickContextPaths('file'),
     onPickFolders: () => void composer.pickContextPaths('folder'),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -10,7 +10,7 @@ import { burstVibeHearts } from '@/components/chat/vibe-hearts'
 import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
-import { playCompletionSound } from '@/lib/completion-sound'
+import { playApprovalSound, playCompletionSound } from '@/lib/completion-sound'
 import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
@@ -938,6 +938,20 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (sessionId) {
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
         }
+
+        // OS notifications can be silently swallowed by macOS (ad-hoc signed
+        // builds never enter the notification registry), so a blocked approval
+        // may otherwise go completely unnoticed while the user is in another
+        // session or another app. The WebAudio cue and the in-app toast need no
+        // macOS permission, so they are the reliable attention channel. The
+        // native notification is still dispatched for builds where it works.
+        playApprovalSound(sessionId ?? undefined)
+        notify({
+          durationMs: 0,
+          kind: 'warning',
+          message: command || description,
+          title: translateNow('notifications.native.approvalTitle')
+        })
 
         dispatchNativeNotification({
           actions: [

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -40,7 +40,7 @@ import { revealDesktopPane } from '@/store/pane-focus'
 import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
-import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { clearAllPrompts, clearApprovalRequest, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { recordAgentReaction } from '@/store/reactions-local'
 import {
   $currentCwd,
@@ -947,6 +947,19 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // native notification is still dispatched for builds where it works.
         playApprovalSound(sessionId ?? undefined)
         notify({
+          action: {
+            label: translateNow('notifications.native.runAction'),
+            onClick: () => {
+              // Resolve straight from the toast (like the inline bar's Run):
+              // the renderer might be showing another session, so the inline
+              // approve button may be nowhere on screen.
+              void $gateway.get()?.request<{ resolved?: boolean }>('approval.respond', {
+                choice: 'once',
+                session_id: sessionId ?? undefined
+              })
+              clearApprovalRequest(sessionId)
+            }
+          },
           durationMs: 0,
           kind: 'warning',
           message: command || description,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -42,6 +42,11 @@ declare global {
       // reply). Resolves true for the first window to claim a key, false for
       // peers — so N open windows don't all fire the same cue.
       claimAmbientCue: (key: string) => Promise<boolean>
+      // Play the OS alert sound from the main process. Renderer WebAudio is
+      // suspended while the window is unfocused (autoplay policy), so this is
+      // the reliable channel for attention cues the user must hear even when
+      // they are in another app or session.
+      playSystemBeep: () => Promise<boolean>
       // The pop-out pet overlay: a transparent always-on-top window hosting only
       // the mascot. The main renderer drives it (open/close/drag + state push);
       // the overlay sends control messages back (pop-in, composer submit).

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -148,6 +148,7 @@ export const ar = defineLocale({
       approvalTitle: 'مطلوب موافقة',
       approveAction: 'موافقة',
       rejectAction: 'رفض',
+      runAction: 'تشغيل',
       inputTitle: 'مطلوب إدخال',
       inputBody: 'ينتظر Hermes ردّك.',
       turnDoneTitle: 'أنهى Hermes',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1546,6 +1546,7 @@ export const ar = defineLocale({
     groupAriaUngrouped: 'الجلسات غير مجمعة',
     showProjects: 'عرض المشاريع',
     showSessions: 'عرض الجلسات',
+    refreshSessions: 'تحديث الجلسات',
     groupTitleGrouped: 'مجمعة حسب مساحة العمل',
     groupTitleUngrouped: 'كل الجلسات',
     allPinned: 'كل الجلسات مثبتة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -165,6 +165,7 @@ export const en: Translations = {
       approvalTitle: 'Approval needed',
       approveAction: 'Approve',
       rejectAction: 'Reject',
+      runAction: 'Run',
       inputTitle: 'Input needed',
       inputBody: 'Hermes is waiting for your response.',
       turnDoneTitle: 'Hermes finished',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1830,6 +1830,7 @@ export const en: Translations = {
     groupAriaUngrouped: 'Group sessions by workspace',
     showProjects: 'Show projects',
     showSessions: 'Show sessions',
+    refreshSessions: 'Refresh sessions',
     groupTitleGrouped: 'Ungroup sessions',
     groupTitleUngrouped: 'Group by workspace',
     allPinned: 'Everything here is pinned. Unpin a chat to show it in recents.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -166,6 +166,7 @@ export const ja = defineLocale({
       approvalTitle: '承認が必要です',
       approveAction: '承認',
       rejectAction: '拒否',
+      runAction: '実行',
       inputTitle: '入力が必要です',
       inputBody: 'Hermes が応答を待っています。',
       turnDoneTitle: 'Hermes が完了しました',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1671,6 +1671,7 @@ export const ja = defineLocale({
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',
     showProjects: 'プロジェクトを表示',
     showSessions: 'セッションを表示',
+    refreshSessions: 'セッションを再読み込み',
     groupTitleGrouped: 'セッションのグループ化を解除',
     groupTitleUngrouped: 'ワークスペースでグループ化',
     allPinned: 'ここにあるものはすべてピン留めされています。チャットのピン留めを解除すると最近のものに表示されます。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1532,6 +1532,7 @@ export interface Translations {
     groupAriaUngrouped: string
     showProjects: string
     showSessions: string
+    refreshSessions: string
     groupTitleGrouped: string
     groupTitleUngrouped: string
     allPinned: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -208,6 +208,7 @@ export interface Translations {
       approvalTitle: string
       approveAction: string
       rejectAction: string
+      runAction: string
       inputTitle: string
       inputBody: string
       turnDoneTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -161,6 +161,7 @@ export const zhHant = defineLocale({
       approvalTitle: '需要核准',
       approveAction: '核准',
       rejectAction: '拒絕',
+      runAction: '執行',
       inputTitle: '需要輸入',
       inputBody: 'Hermes 正在等待你的回應。',
       turnDoneTitle: 'Hermes 已完成',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1616,6 +1616,7 @@ export const zhHant = defineLocale({
     groupAriaUngrouped: '依工作區分組工作階段',
     showProjects: '顯示專案',
     showSessions: '顯示工作階段',
+    refreshSessions: '重新整理工作階段',
     groupTitleGrouped: '取消分組',
     groupTitleUngrouped: '依工作區分組',
     allPinned: '這裡的全部已釘選。取消釘選某個聊天即可在最近中顯示。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -161,6 +161,7 @@ export const zh: Translations = {
       approvalTitle: '需要批准',
       approveAction: '批准',
       rejectAction: '拒绝',
+      runAction: '运行',
       inputTitle: '需要输入',
       inputBody: 'Hermes 正在等待你的回应。',
       turnDoneTitle: 'Hermes 已完成',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2024,6 +2024,7 @@ export const zh: Translations = {
     groupAriaUngrouped: '按工作区分组会话',
     showProjects: '显示项目',
     showSessions: '显示会话',
+    refreshSessions: '刷新会话',
     groupTitleGrouped: '取消分组',
     groupTitleUngrouped: '按工作区分组',
     allPinned: '这里的全部已置顶。取消置顶某个对话即可在最近中显示。',

--- a/apps/desktop/src/lib/completion-sound.ts
+++ b/apps/desktop/src/lib/completion-sound.ts
@@ -471,6 +471,60 @@ export function playCompletionSound(dedupeKey?: string) {
   void ownsAmbientCue(`sound:${dedupeKey}`).then(owns => owns && play())
 }
 
+// Attention cue for approval/input requests — deliberately distinct from the
+// completion chime: three short high beeps on a rising figure. Runs through
+// the same warm signal chain as the completion variants, but the pattern reads
+// as "action needed" rather than "done". Unlike OS notifications, WebAudio
+// needs no macOS permission, so this is the reliable channel for surfacing a
+// blocked approval even when the system swallows native notifications (ad-hoc
+// signed builds, TCC, etc.).
+export function playApprovalSound(dedupeKey?: string) {
+  if ($hapticsMuted.get()) {
+    return
+  }
+
+  const play = () => {
+    const ac = getCtx()
+
+    if (!ac) {
+      return
+    }
+
+    const master = ac.createGain()
+    const tone = ac.createBiquadFilter()
+    tone.type = 'lowpass'
+    tone.frequency.setValueAtTime(3800, ac.currentTime)
+    tone.Q.setValueAtTime(0.32, ac.currentTime)
+    master.gain.setValueAtTime(0.48, ac.currentTime)
+    master.connect(tone)
+
+    const dry = ac.createGain()
+    dry.gain.setValueAtTime(0.88, ac.currentTime)
+    tone.connect(dry)
+    dry.connect(ac.destination)
+
+    const reverb = makeReverb(ac)
+    const wet = ac.createGain()
+    wet.gain.setValueAtTime(0.34, ac.currentTime)
+    tone.connect(reverb)
+    reverb.connect(wet)
+    wet.connect(ac.destination)
+
+    const t0 = ac.currentTime + 0.01
+
+    // Rising three-note attention figure (C6 → G5 → C6), tight and bright.
+    voice(ac, master, t0, { freq: C6, dur: 0.14, gain: 0.05, attack: 0.005, type: 'sine' })
+    voice(ac, master, t0 + 0.16, { freq: G5, dur: 0.14, gain: 0.042, attack: 0.005, type: 'sine' })
+    voice(ac, master, t0 + 0.32, { freq: C6, dur: 0.28, gain: 0.055, attack: 0.006, type: 'sine' })
+  }
+
+  if (!dedupeKey) {
+    return play()
+  }
+
+  void ownsAmbientCue(`approval:${dedupeKey}`).then(owns => owns && play())
+}
+
 interface AirPuffSpec {
   decay: number
   freq: number

--- a/apps/desktop/src/lib/completion-sound.ts
+++ b/apps/desktop/src/lib/completion-sound.ts
@@ -486,7 +486,13 @@ export function playApprovalSound(dedupeKey?: string) {
   const play = () => {
     const ac = getCtx()
 
-    if (!ac) {
+    // Renderer WebAudio is subject to autoplay policy: with the window
+    // unfocused (user in another app/session — exactly when an approval alert
+    // matters) the context stays suspended and resume() without a user gesture
+    // does not start it, so the cue would be inaudible. Fall back to the OS
+    // alert sound from the main process, which plays regardless of focus.
+    if (!ac || ac.state === 'suspended') {
+      void window.hermesDesktop?.playSystemBeep?.()
       return
     }
 


### PR DESCRIPTION
## Problem

macOS swallows native OS notifications from ad-hoc signed Electron builds (the app never enters the system notification registry), so an approval/input request can go completely unnoticed while the user is in another session or another app. The completion chime already worked because it is WebAudio in the renderer, not a system notification.

## Fix

- Add playApprovalSound(): a distinct rising three-note WebAudio cue (C6-G5-C6) on the same signal chain as the completion variants, with the same per-session ambient-cue dedupe.
- Fire it on approval.request, plus a persistent in-app warning toast, in addition to the existing (often-swallowed) native notification.

## Verification

- npm run check (typecheck x3, eslint, full UI test suite 3131 tests) passes.