### PR TITLE
fix(web): surface SearXNG engine failures

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -23,12 +23,42 @@ Env var::
 from __future__ import annotations
 
 import logging
+import math
 import os
+import unicodedata
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+_MAX_UNRESPONSIVE_ENGINES = 10
+_MAX_UNRESPONSIVE_ENTRIES_TO_INSPECT = 100
+_MAX_ENGINE_NAME_LENGTH = 80
+_MAX_ENGINE_REASON_LENGTH = 200
+
+
+def _sanitize_diagnostic_text(value: Any, max_length: int) -> tuple[str, bool]:
+    """Return bounded, flattened diagnostic text plus a truncation indicator."""
+    if not isinstance(value, str):
+        return "", False
+    inspection_limit = max_length * 4
+    bounded = value[:inspection_limit]
+    printable = "".join(
+        " " if unicodedata.category(char).startswith("C") else char for char in bounded
+    )
+    normalized = " ".join(printable.split())
+    truncated = len(value) > inspection_limit or len(normalized) > max_length
+    return normalized[:max_length].rstrip(), truncated
+
+
+def _result_score(result: Dict[str, Any]) -> float:
+    """Return a sortable score without trusting the upstream value's type."""
+    try:
+        score = float(result.get("score", 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return score if math.isfinite(score) else 0.0
 
 
 def _searxng_url() -> str:
@@ -109,12 +139,85 @@ class SearXNGWebSearchProvider(WebSearchProvider):
                 "error": "Could not parse SearXNG response as JSON",
             }
 
-        raw_results = data.get("results", [])
+        if not isinstance(data, dict):
+            logger.warning("SearXNG returned an invalid top-level JSON payload")
+            return {
+                "success": False,
+                "error": "SearXNG returned an invalid JSON response",
+            }
+
+        if "results" not in data:
+            logger.warning("SearXNG response did not contain a results field")
+            return {
+                "success": False,
+                "error": "SearXNG returned an invalid response without results",
+            }
+
+        raw_results = data["results"]
+        if not isinstance(raw_results, list):
+            logger.warning("SearXNG returned an invalid results payload")
+            return {
+                "success": False,
+                "error": "SearXNG returned an invalid results payload",
+            }
+
+        unresponsive_engines = []
+        unresponsive_engines_truncated = False
+        unresponsive_engine_diagnostics_invalid = False
+        raw_unresponsive_engines = data.get("unresponsive_engines", [])
+        if isinstance(raw_unresponsive_engines, (list, tuple)):
+            if len(raw_unresponsive_engines) > _MAX_UNRESPONSIVE_ENTRIES_TO_INSPECT:
+                unresponsive_engines_truncated = True
+            for entry in raw_unresponsive_engines[
+                :_MAX_UNRESPONSIVE_ENTRIES_TO_INSPECT
+            ]:
+                if not isinstance(entry, (list, tuple)) or len(entry) < 2:
+                    unresponsive_engine_diagnostics_invalid = True
+                    continue
+                engine, reason = entry[:2]
+                engine, engine_truncated = _sanitize_diagnostic_text(
+                    engine, _MAX_ENGINE_NAME_LENGTH
+                )
+                reason, reason_truncated = _sanitize_diagnostic_text(
+                    reason, _MAX_ENGINE_REASON_LENGTH
+                )
+                if engine_truncated or reason_truncated:
+                    unresponsive_engines_truncated = True
+                if not engine or not reason:
+                    unresponsive_engine_diagnostics_invalid = True
+                    continue
+                if len(unresponsive_engines) < _MAX_UNRESPONSIVE_ENGINES:
+                    unresponsive_engines.append({
+                        "engine": engine,
+                        "reason": reason,
+                    })
+                else:
+                    unresponsive_engines_truncated = True
+        elif "unresponsive_engines" in data:
+            unresponsive_engine_diagnostics_invalid = True
+
+        valid_results = []
+        malformed_results = 0
+        for result in raw_results:
+            if not isinstance(result, dict):
+                malformed_results += 1
+                continue
+            url = result.get("url")
+            if not isinstance(url, str) or not url.strip():
+                malformed_results += 1
+                continue
+            valid_results.append(result)
+
+        if malformed_results:
+            logger.warning(
+                "SearXNG ignored %d malformed or URL-less result entries",
+                malformed_results,
+            )
 
         # SearXNG may return a score field; sort descending and cap to limit.
         sorted_results = sorted(
-            raw_results,
-            key=lambda r: float(r.get("score", 0)),
+            valid_results,
+            key=_result_score,
             reverse=True,
         )[:limit]
 
@@ -136,7 +239,55 @@ class SearXNGWebSearchProvider(WebSearchProvider):
             limit,
         )
 
-        return {"success": True, "data": {"web": web_results}}
+        result_data: Dict[str, Any] = {"web": web_results}
+        diagnostic_parts = [
+            f"{item['engine']} ({item['reason']})" for item in unresponsive_engines
+        ]
+        if unresponsive_engines_truncated:
+            diagnostic_parts.append("additional engine diagnostics omitted")
+        if unresponsive_engine_diagnostics_invalid:
+            diagnostic_parts.append("some engine diagnostics were invalid")
+
+        if diagnostic_parts:
+            diagnostic = "; ".join(diagnostic_parts)
+            if not web_results:
+                logger.warning(
+                    "SearXNG search failed with no usable results; %s",
+                    diagnostic,
+                )
+                return {
+                    "success": False,
+                    "error": f"SearXNG returned no usable results; {diagnostic}",
+                }
+
+            result_data.update({
+                "degraded": True,
+                "unresponsive_engines": unresponsive_engines,
+            })
+            if unresponsive_engines_truncated:
+                result_data["unresponsive_engines_truncated"] = True
+            if unresponsive_engine_diagnostics_invalid:
+                result_data["unresponsive_engine_diagnostics_invalid"] = True
+            logger.warning(
+                "SearXNG search returned degraded results; %s",
+                diagnostic,
+            )
+
+        if not web_results and malformed_results:
+            logger.warning(
+                "SearXNG search failed with no usable results; "
+                "%d malformed result entries",
+                malformed_results,
+            )
+            return {
+                "success": False,
+                "error": (
+                    "SearXNG returned no usable results because "
+                    f"{malformed_results} result entries were invalid"
+                ),
+            }
+
+        return {"success": True, "data": result_data}
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import unicodedata
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -92,6 +93,231 @@ class TestSearXNGSearchProviderSearch:
         assert result["data"]["web"][1]["title"] == "Mid"
         assert result["data"]["web"][2]["title"] == "Low"
 
+    def test_empty_results_with_unresponsive_engine_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [],
+            "unresponsive_engines": [["startpage", "Suspended: CAPTCHA"]],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "startpage" in result["error"]
+        assert "Suspended: CAPTCHA" in result["error"]
+        assert set(result) == {"success", "error"}
+
+    def test_usable_results_with_unresponsive_engine_are_degraded(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        response = {
+            **self._SAMPLE_RESPONSE,
+            "unresponsive_engines": [["startpage", "timeout"]],
+        }
+        mock_resp = self._make_mock_response(response)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=1)
+
+        assert result["success"] is True
+        assert [item["title"] for item in result["data"]["web"]] == ["Result A"]
+        assert result["data"]["degraded"] is True
+        assert result["data"]["unresponsive_engines"] == [
+            {"engine": "startpage", "reason": "timeout"},
+        ]
+
+    def test_empty_results_without_unresponsive_engines_remain_successful(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({"results": []})
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result == {"success": True, "data": {"web": []}}
+
+    def test_malformed_unresponsive_engines_fail_without_false_diagnostics(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [],
+            "unresponsive_engines": [
+                None,
+                "startpage: timeout",
+                ["startpage"],
+                ["", "timeout"],
+                ["startpage", ""],
+                [{"name": "startpage"}, "timeout"],
+                ["startpage", {"reason": "timeout"}],
+            ],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "diagnostic" in result["error"].lower()
+        assert "startpage" not in result["error"].lower()
+        assert set(result) == {"success", "error"}
+
+    def test_wrong_type_unresponsive_engines_fail_without_false_diagnostics(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [],
+            "unresponsive_engines": {"bing": "timeout"},
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "diagnostic" in result["error"].lower()
+        assert "bing" not in result["error"].lower()
+        assert set(result) == {"success", "error"}
+
+    def test_unresponsive_engine_diagnostics_are_sanitized_and_bounded(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [
+                {
+                    "title": "Usable",
+                    "url": "https://usable.example",
+                    "content": "",
+                    "score": 1,
+                }
+            ],
+            "unresponsive_engines": [
+                [
+                    f"engine-{index}\n\x1b[31m\u202e" + ("e" * 200),
+                    f"timeout-{index}\r\nFORGED" + ("r" * 500),
+                ]
+                for index in range(25)
+            ],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        diagnostics = result["data"]["unresponsive_engines"]
+        assert result["success"] is True
+        assert result["data"]["unresponsive_engines_truncated"] is True
+        assert len(diagnostics) == 10
+        assert all(len(item["engine"]) <= 80 for item in diagnostics)
+        assert all(len(item["reason"]) <= 200 for item in diagnostics)
+        assert all(
+            not unicodedata.category(char).startswith("C")
+            for item in diagnostics
+            for value in item.values()
+            for char in value
+        )
+        assert all("\n" not in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [[], {}, {"error": "backend unavailable"}, {"results": None}],
+    )
+    def test_malformed_response_payload_returns_failure(self, monkeypatch, payload):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response(payload)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "invalid" in result["error"].lower()
+        assert set(result) == {"success", "error"}
+
+    def test_malformed_result_items_do_not_count_as_usable(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [None, "bad", {}, {"url": ""}],
+            "unresponsive_engines": [["startpage", "timeout"]],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "startpage" in result["error"]
+        assert set(result) == {"success", "error"}
+
+    def test_malformed_scores_do_not_crash_or_outrank_finite_scores(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [
+                {"title": "Huge", "url": "https://huge.example", "score": 10**1000},
+                {"title": "NaN", "url": "https://nan.example", "score": "NaN"},
+                {
+                    "title": "Infinite",
+                    "url": "https://infinite.example",
+                    "score": "Infinity",
+                },
+                {"title": "Finite", "url": "https://finite.example", "score": 0.5},
+            ],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=4)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Finite"
+
+    def test_truncated_invalid_diagnostics_cannot_hide_engine_failure(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [],
+            "unresponsive_engines": [[None, None]] * 100
+            + [["bing", "timeout"]],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "diagnostic" in result["error"].lower()
+        assert set(result) == {"success", "error"}
+
+    def test_field_inspection_truncation_cannot_hide_engine_failure(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [],
+            "unresponsive_engines": [["\x00" * 320 + "bing", "timeout"]],
+        })
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "diagnostic" in result["error"].lower()
+        assert set(result) == {"success", "error"}
 
     def test_trailing_slash_stripped_from_url(self, monkeypatch):
         """Base URL trailing slash should not produce double-slash in endpoint."""


### PR DESCRIPTION
## Summary

- preserve SearXNG's `unresponsive_engines` diagnostics instead of silently discarding them
- return an explicit failure when there are no usable results and one or more engines are unresponsive
- keep partial results usable while marking them degraded and including structured engine/reason details
- preserve ordinary successful empty-result behavior when SearXNG reports no engine failures
- validate malformed response/result payloads and bound/sanitize upstream diagnostics before logging or returning them

## Production reproduction

A healthy SearXNG HTTP/JSON response returned:

```json
{
  "results": [],
  "unresponsive_engines": [["startpage", "Suspended: CAPTCHA"]]
}
```

The provider previously reduced that to `success=true` with `data.web=[]`, making an upstream engine outage indistinguishable from a legitimate no-hit query.

## Validation

- RED: initial contract tests exposed the silent-degradation failures; successive reviewer-driven adversarial tests then exposed the expected sanitization, payload-validation, score, and inspection-boundary failures before each hardening step
- `uv run --with pytest sh -c 'HERMES_PYTHON=$(command -v python) scripts/run_tests.sh tests/tools/test_web_providers_searxng.py'` — 28 passed via the repository test runner
- `uv run --with pytest python -m pytest -o addopts='' -q tests/tools/test_web_providers_*.py` — 74 passed
- `uv run --with ruff ruff check plugins/web/searxng/provider.py tests/tools/test_web_providers_searxng.py` — passed
- `uv run --with ruff ruff format --check plugins/web/searxng/provider.py` — passed
- `uv run --with pyright pyright plugins/web/searxng/provider.py` — 0 errors
- `python3 -m py_compile plugins/web/searxng/provider.py tests/tools/test_web_providers_searxng.py` — passed
- `git diff --check` — passed
- live self-hosted SearXNG smoke: usable results remained successful and exposed `degraded=true` plus structured CAPTCHA/rate-limit diagnostics

## Compatibility

- fully responsive searches retain the existing minimal response shape
- legitimate zero-hit responses without engine diagnostics remain successful
- complete failures preserve the documented `{"success": false, "error": str}` provider shape
- malformed or wrong-type nonempty `unresponsive_engines` payloads fail generically rather than fabricating diagnostics or returning success-empty
- diagnostic count/length is bounded, Unicode control/format characters are removed, and truncation is explicit
- malformed top-level/results payloads fail clearly; malformed or URL-less result entries cannot masquerade as usable hits
