### PR TITLE
fix(gateway): stop the auto voice reply from speaking MEDIA delivery directives

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19735,8 +19735,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         actual_paths: List[str] = []
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from gateway.platforms.base import _strip_media_directives
 
-            tts_text = _strip_markdown_for_tts(text)
+            # Delivery directives (MEDIA:<path>, [[audio_as_voice]]) are a wire
+            # contract with the platform adapter, not speech. The text path strips
+            # them before display; the voice path must strip them too, or the clip
+            # reads the raw file path aloud after the real sentence.
+            tts_text = _strip_markdown_for_tts(_strip_media_directives(text))
             if not tts_text:
                 return
 

--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -321,7 +321,9 @@ class GatewayVoiceMixin:
         try:
             from tools.tts_text_normalize import _strip_markdown_for_tts
             from tools.tts_tool import text_to_speech_tool
-            tts_text = _strip_markdown_for_tts(text)
+            from gateway.platforms.base import _strip_media_tag_directives
+            # Delivery directives belong to the adapter, never to the speech engine.
+            tts_text = _strip_markdown_for_tts(_strip_media_tag_directives(text))
             if not tts_text:
                 return
             # Platforms whose native voice bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS) get an

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -44,16 +44,62 @@ import queue
 import threading
 from typing import Any, Dict, Optional
 
-from gateway.platforms.base import AudioFormat, StreamingTTSHandle
+from gateway.platforms.base import (
+    AudioFormat,
+    StreamingTTSHandle,
+    _strip_media_directives,
+)
 
 logger = logging.getLogger("gateway.streaming_tts_consumer")
 
 _ABORT = object()
 _DONE = object()
 
+# Delivery directives are a contract with the platform adapter, never speech.
+# A partially arrived directive must not be forwarded to the chunker, so any
+# trailing text that could still grow into one is held back until the next
+# delta or the final flush.
+_DIRECTIVE_MARKERS = ("MEDIA:", "[[audio_as_voice]]", "[[as_document]]")
+
+
+def _directive_holdback_index(buf: str) -> int:
+    """Index from which ``buf`` must be withheld because a directive may be forming.
+
+    Returns ``len(buf)`` when nothing needs holding back.
+    """
+    if not buf:
+        return 0
+    candidates = [len(buf)]
+
+    # An opened MEDIA: whose path has not been terminated by a newline yet:
+    # the rest of the path is still arriving.
+    idx = buf.rfind("MEDIA:")
+    if idx != -1 and "\n" not in buf[idx:]:
+        candidates.append(idx)
+
+    # An opened [[ tag that has not closed yet.
+    idx = buf.rfind("[[")
+    if idx != -1 and "]]" not in buf[idx:]:
+        candidates.append(idx)
+
+    # A trailing fragment that is a proper prefix of a marker ("MED", "[[audio").
+    for marker in _DIRECTIVE_MARKERS:
+        for n in range(min(len(marker) - 1, len(buf)), 0, -1):
+            if buf.endswith(marker[:n]):
+                candidates.append(len(buf) - n)
+                break
+
+    return min(candidates)
+
 
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
+
+    # Class-level default so the attribute exists even on instances built via
+    # __new__ without __init__. on_delta() and finish() swallow exceptions
+    # broadly, so a missing attribute would not raise, it would silently drop
+    # every clause.
+    _directive_buf: str = ""
 
     def __init__(
         self,
@@ -105,6 +151,9 @@ class StreamingTTSConsumer:
         # Pre-allocate the strip-markdown helper lazily to avoid import cycles.
         self._strip_markdown = None
 
+        # Carry-over for a delivery directive split across deltas.
+        self._directive_buf = ""
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -153,12 +202,28 @@ class StreamingTTSConsumer:
     # Sync callback (agent worker thread)
     # ------------------------------------------------------------------
 
+    def _consume_directives(self, text: str, *, final: bool = False) -> str:
+        """Strip delivery directives from the delta stream before chunking.
+
+        Must run BEFORE the SentenceChunker: a directive path such as
+        ``song.mp3`` contains sentence boundaries, so chunking first would
+        cut the directive into fragments that no longer match and would then
+        be synthesised aloud.
+        """
+        buf = _strip_media_directives(self._directive_buf + text)
+        if final:
+            self._directive_buf = ""
+            return buf
+        hold = _directive_holdback_index(buf)
+        self._directive_buf = buf[hold:]
+        return buf[:hold]
+
     def on_delta(self, text: str) -> None:
         """Receive a text delta from the agent. Non-blocking."""
         if self._aborted or not self.active or self._finished:
             return
         try:
-            for clause in self._chunker.feed(text):
+            for clause in self._chunker.feed(self._consume_directives(text)):
                 self._queue.put_nowait(clause)
         except queue.Full:
             self._dropped = True
@@ -179,6 +244,12 @@ class StreamingTTSConsumer:
         if self._aborted or not self.active:
             return
         try:
+            # Release any held-back tail first: at end of text it can no
+            # longer grow into a directive.
+            tail = self._consume_directives("", final=True)
+            if tail:
+                for clause in self._chunker.feed(tail):
+                    self._queue.put_nowait(clause)
             for clause in self._chunker.flush():
                 self._queue.put_nowait(clause)
         except queue.Full:

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -16,7 +16,7 @@ import queue
 import threading
 from typing import Any, Dict, Optional
 
-from gateway.platforms.base import AudioFormat, StreamingTTSHandle
+from gateway.platforms.base import AudioFormat, StreamingTTSHandle, _strip_media_tag_directives
 
 logger = logging.getLogger("gateway.streaming_tts_consumer")
 
@@ -24,8 +24,48 @@ _ABORT = object()
 _DONE = object()
 
 
+# Delivery directives are a contract with the platform adapter, never speech.
+# A partially arrived directive must not be forwarded to the chunker, so any
+# trailing text that could still grow into one is held back until the next
+# delta or the final flush.
+_DIRECTIVE_MARKERS = ("MEDIA:", "[[audio_as_voice]]", "[[as_document]]")
+
+
+def _directive_holdback_index(buf: str) -> int:
+    """Index from which ``buf`` must be withheld because a directive may be forming.
+
+    Returns ``len(buf)`` when nothing needs holding back.
+    """
+    if not buf:
+        return 0
+    candidates = [len(buf)]
+
+    # An opened MEDIA: whose path has not been terminated by a newline yet:
+    # the rest of the path is still arriving.
+    idx = buf.rfind("MEDIA:")
+    if idx != -1 and "\n" not in buf[idx:]:
+        candidates.append(idx)
+
+    # An opened [[ tag that has not closed yet.
+    idx = buf.rfind("[[")
+    if idx != -1 and "]]" not in buf[idx:]:
+        candidates.append(idx)
+
+    # A trailing fragment that is a proper prefix of a marker ("MED", "[[audio").
+    for marker in _DIRECTIVE_MARKERS:
+        for n in range(min(len(marker) - 1, len(buf)), 0, -1):
+            if buf.endswith(marker[:n]):
+                candidates.append(len(buf) - n)
+                break
+
+    return min(candidates)
+
+
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
+
+    # Keep the holdback available to lightweight consumers built via __new__.
+    _directive_buf: str = ""
 
     def __init__(self, adapter: Any, chat_id: str, tts_config: Dict[str, Any],
                  loop: asyncio.AbstractEventLoop, *, metadata: Optional[Dict[str, Any]] = None,
@@ -45,6 +85,7 @@ class StreamingTTSConsumer:
         self._task: Optional[asyncio.Task] = None  # drain task, created once by start()
         self._completed = self._partial = self._aborted = False
         self._finished = self._dropped = self._suppress_whole_file = False
+        self._directive_buf = ""
         self._lock, self._strip_markdown = threading.Lock(), None  # stripper lazily imported
 
     active = property(lambda self: self._streamer is not None)  # usable streaming provider
@@ -66,11 +107,27 @@ class StreamingTTSConsumer:
             if log_errors:
                 logger.debug("streaming TTS on_delta error", exc_info=True)
 
+    def _consume_directives(self, text: str, *, final: bool = False) -> str:
+        """Strip delivery directives from the delta stream before chunking.
+
+        Must run BEFORE the SentenceChunker: a directive path such as
+        ``song.mp3`` contains sentence boundaries, so chunking first would
+        cut the directive into fragments that no longer match and would then
+        be synthesised aloud.
+        """
+        buf = _strip_media_tag_directives(self._directive_buf + text)
+        if final:
+            self._directive_buf = ""
+            return buf
+        hold = _directive_holdback_index(buf)
+        self._directive_buf = buf[hold:]
+        return buf[:hold]
+
     def on_delta(self, text: str) -> None:
         """Receive a text delta from the agent. Non-blocking."""
         if self._aborted or not self.active or self._finished:
             return
-        self._enqueue_clauses(self._chunker.feed(text), "streaming TTS queue full, dropping clause",
+        self._enqueue_clauses(self._chunker.feed(self._consume_directives(text)), "streaming TTS queue full, dropping clause",
                               log_errors=True)
 
     def finish(self) -> None:
@@ -81,6 +138,11 @@ class StreamingTTSConsumer:
         self._finished = True
         if self._aborted or not self.active:
             return
+        tail = self._consume_directives("", final=True)
+        if tail:
+            self._enqueue_clauses(self._chunker.feed(tail),
+                                  "streaming TTS queue full while flushing directive tail",
+                                  log_errors=False)
         self._enqueue_clauses(self._chunker.flush(), "streaming TTS queue full while flushing tail",
                               log_errors=False)
         # The load-bearing _DONE sentinel must never be lost: evict clauses until it fits.

--- a/tests/gateway/test_auto_voice_media_strip.py
+++ b/tests/gateway/test_auto_voice_media_strip.py
@@ -1,0 +1,293 @@
+"""Delivery directives must never be spoken, on either TTS path.
+
+A response that attaches a file carries a ``MEDIA:<path>`` line, and optionally
+an ``[[audio_as_voice]]`` or ``[[as_document]]`` flag. Those are a delivery
+contract with the platform adapter, not speech. The text delivery path already
+strips them via ``_strip_media_directives`` before display, but both TTS paths
+used to receive the raw text and synthesised the directive into the audio, so
+the clip read an absolute local file path aloud after the real sentence.
+
+Two independent paths are covered here:
+
+* whole file, ``GatewayRunner._send_voice_reply``
+* streaming, ``StreamingTTSConsumer``, which receives raw model deltas and is
+  the path that runs when streaming TTS is enabled
+
+All identifiers and paths below are synthetic fixtures.
+"""
+
+import asyncio
+import json
+import os
+import queue
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    AudioFormat,
+    MessageEvent,
+    MessageType,
+    StreamingTTSHandle,
+)
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.streaming_tts_consumer import (
+    StreamingTTSConsumer,
+    _directive_holdback_index,
+)
+
+FIXTURE_CHAT_ID = "-1000000000001"
+FIXTURE_USER_ID = "1000000002"
+FIXTURE_MEDIA = "/tmp/hermes-fixture/audio/clip-0001.mp3"
+FIXTURE_RESPONSE = "Here is the track you asked for.\n\nMEDIA:%s" % FIXTURE_MEDIA
+
+
+def _assert_no_directive(spoken):
+    assert "MEDIA:" not in spoken, "delivery directive leaked into speech: %r" % spoken
+    assert FIXTURE_MEDIA not in spoken, "file path spoken aloud: %r" % spoken
+    assert "clip-0001" not in spoken, "path fragment spoken aloud: %r" % spoken
+    assert "audio_as_voice" not in spoken, "delivery flag spoken aloud: %r" % spoken
+
+
+# ---------------------------------------------------------------------------
+# Whole-file path: GatewayRunner._send_voice_reply
+# ---------------------------------------------------------------------------
+
+
+def _make_event():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=FIXTURE_CHAT_ID,
+        user_id=FIXTURE_USER_ID,
+        chat_type="group",
+    )
+    return MessageEvent(
+        text="play it",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+def _runner_with_adapter(send_voice_mock):
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(
+        send_voice=send_voice_mock,
+        is_in_voice_channel=lambda *_a, **_k: False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+def _capture_tts(monkeypatch, seen):
+    """Record the exact text handed to the whole-file TTS engine."""
+
+    def _fake_text_to_speech_tool(*, text, output_path, **_kwargs):
+        seen.append(text)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fh:
+            fh.write(b"\x00" * 32)
+        return json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr(
+        "tools.tts_tool.text_to_speech_tool", _fake_text_to_speech_tool
+    )
+    # Identity markdown strip so these cases isolate the directive strip.
+    monkeypatch.setattr("tools.tts_tool._strip_markdown_for_tts", lambda text: text)
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_does_not_speak_media_directive(monkeypatch, tmp_path):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    seen = []
+    _capture_tts(monkeypatch, seen)
+
+    runner = _runner_with_adapter(AsyncMock())
+    await runner._send_voice_reply(_make_event(), FIXTURE_RESPONSE)
+
+    assert seen, "TTS was never invoked"
+    _assert_no_directive(seen[0])
+    assert "Here is the track you asked for." in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_strips_inline_delivery_flag(monkeypatch, tmp_path):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    seen = []
+    _capture_tts(monkeypatch, seen)
+
+    runner = _runner_with_adapter(AsyncMock())
+    await runner._send_voice_reply(
+        _make_event(), "Round five, here we go. [[audio_as_voice]]"
+    )
+
+    assert seen, "TTS was never invoked"
+    _assert_no_directive(seen[0])
+    assert "Round five" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# Split-delta holdback helper
+# ---------------------------------------------------------------------------
+
+
+class TestDirectiveHoldback:
+    """A directive half-arrived in a delta must never be forwarded."""
+
+    def test_plain_text_is_never_held_back(self):
+        text = "An ordinary sentence with no directives at all."
+        assert _directive_holdback_index(text) == len(text)
+
+    def test_empty_buffer(self):
+        assert _directive_holdback_index("") == 0
+
+    @pytest.mark.parametrize("frag", ["M", "ME", "MED", "MEDI", "MEDIA"])
+    def test_partial_media_marker_is_held(self, frag):
+        buf = "spoken words " + frag
+        assert _directive_holdback_index(buf) == len("spoken words ")
+
+    def test_open_media_path_is_held_until_newline(self):
+        buf = "spoken words MEDIA:/tmp/hermes-fixture/audio/clip"
+        assert _directive_holdback_index(buf) == len("spoken words ")
+
+    def test_terminated_media_line_is_not_held(self):
+        buf = "spoken words MEDIA:%s\nmore speech" % FIXTURE_MEDIA
+        assert _directive_holdback_index(buf) == len(buf)
+
+    def test_unclosed_double_bracket_is_held(self):
+        buf = "spoken words [[audio_as"
+        assert _directive_holdback_index(buf) == len("spoken words ")
+
+
+# ---------------------------------------------------------------------------
+# Streaming path: StreamingTTSConsumer
+# ---------------------------------------------------------------------------
+
+
+class RecordingStreamer:
+    """Streaming provider that records every text handed to it."""
+
+    sample_rate = 24000
+    channels = 1
+    sample_width = 2
+
+    def __init__(self):
+        self.spoken = []
+
+    def stream(self, text: str):
+        self.spoken.append(text)
+        yield b"\x00\x00"
+
+
+class RecordingAdapter:
+    name = "fake-voice"
+
+    def __init__(self):
+        self.chunks = []
+
+    async def write_streaming_tts(self, handle, chunk):
+        self.chunks.append(chunk)
+
+
+@pytest.fixture
+def streaming_consumer(monkeypatch):
+    """A consumer wired to a recording provider, with the drain loop bypassed."""
+    streamer = RecordingStreamer()
+    monkeypatch.setattr(
+        "tools.tts_streaming.resolve_streaming_provider",
+        lambda *_a, **_k: streamer,
+    )
+    loop = asyncio.new_event_loop()
+    try:
+        adapter = RecordingAdapter()
+        consumer = StreamingTTSConsumer(adapter, FIXTURE_CHAT_ID, {}, loop)
+        consumer._handle = StreamingTTSHandle(
+            chat_id=FIXTURE_CHAT_ID, audio_format=AudioFormat()
+        )
+        assert consumer.active is True
+        yield consumer, streamer
+    finally:
+        loop.close()
+
+
+def _drain_to_provider(consumer):
+    """Feed every queued clause through the real synthesis entry point."""
+    while True:
+        try:
+            clause = consumer._queue.get_nowait()
+        except queue.Empty:
+            return
+        if not isinstance(clause, str):
+            continue
+        asyncio.run(consumer._synthesise_and_write(clause))
+
+
+def test_streaming_directive_in_one_delta_never_reaches_provider(streaming_consumer):
+    consumer, streamer = streaming_consumer
+
+    consumer.on_delta("Here is the track you asked for. ")
+    consumer.on_delta("Enjoy the music tonight. \n\nMEDIA:%s\n" % FIXTURE_MEDIA)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Here is the track you asked for." in spoken
+
+
+def test_streaming_directive_split_across_deltas_never_reaches_provider(
+    streaming_consumer,
+):
+    """The model streams token by token, so a directive arrives in pieces."""
+    consumer, streamer = streaming_consumer
+
+    for delta in [
+        "Here is the track you asked for. ",
+        "Enjoy the music tonight. ",
+        "\n\nMED",
+        "IA:/tmp/hermes-",
+        "fixture/audio/",
+        "clip-0001",
+        ".mp3\n",
+    ]:
+        consumer.on_delta(delta)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Here is the track you asked for." in spoken
+    assert "Enjoy the music tonight." in spoken
+
+
+def test_streaming_inline_flag_split_across_deltas_never_reaches_provider(
+    streaming_consumer,
+):
+    consumer, streamer = streaming_consumer
+
+    for delta in ["Round five, here we go. ", "[[audio", "_as_voice]]"]:
+        consumer.on_delta(delta)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Round five" in spoken
+
+
+def test_streaming_ordinary_text_still_reaches_provider(streaming_consumer):
+    """The guard must not swallow normal speech."""
+    consumer, streamer = streaming_consumer
+
+    consumer.on_delta("The first sentence is here. ")
+    consumer.on_delta("The second sentence follows it. ")
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    assert "The first sentence is here." in spoken
+    assert "The second sentence follows it." in spoken

--- a/tests/gateway/test_auto_voice_media_strip.py
+++ b/tests/gateway/test_auto_voice_media_strip.py
@@ -1,0 +1,291 @@
+"""Delivery directives must never be spoken, on either TTS path.
+
+A response that attaches a file carries a ``MEDIA:<path>`` line, and optionally
+an ``[[audio_as_voice]]`` or ``[[as_document]]`` flag. Those are a delivery
+contract with the platform adapter, not speech. The text delivery path already
+strips them via ``_strip_media_directives`` before display, but both TTS paths
+used to receive the raw text and synthesised the directive into the audio, so
+the clip read an absolute local file path aloud after the real sentence.
+
+Two independent paths are covered here:
+
+* whole file, ``GatewayRunner._send_voice_reply``
+* streaming, ``StreamingTTSConsumer``, which receives raw model deltas and is
+  the path that runs when streaming TTS is enabled
+
+All identifiers and paths below are synthetic fixtures.
+"""
+
+import asyncio
+import json
+import os
+import queue
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    AudioFormat,
+    MessageEvent,
+    MessageType,
+    StreamingTTSHandle,
+)
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway import streaming_tts_consumer
+from gateway.streaming_tts_consumer import StreamingTTSConsumer
+
+FIXTURE_CHAT_ID = "-1000000000001"
+FIXTURE_USER_ID = "1000000002"
+FIXTURE_MEDIA = "/tmp/hermes-fixture/audio/clip-0001.mp3"
+FIXTURE_RESPONSE = "Here is the track you asked for.\n\nMEDIA:%s" % FIXTURE_MEDIA
+
+
+def _assert_no_directive(spoken):
+    assert "MEDIA:" not in spoken, "delivery directive leaked into speech: %r" % spoken
+    assert FIXTURE_MEDIA not in spoken, "file path spoken aloud: %r" % spoken
+    assert "clip-0001" not in spoken, "path fragment spoken aloud: %r" % spoken
+    assert "audio_as_voice" not in spoken, "delivery flag spoken aloud: %r" % spoken
+
+
+# ---------------------------------------------------------------------------
+# Whole-file path: GatewayRunner._send_voice_reply
+# ---------------------------------------------------------------------------
+
+
+def _make_event():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=FIXTURE_CHAT_ID,
+        user_id=FIXTURE_USER_ID,
+        chat_type="group",
+    )
+    return MessageEvent(
+        text="play it",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+def _runner_with_adapter(send_voice_mock):
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(
+        send_voice=send_voice_mock,
+        is_in_voice_channel=lambda *_a, **_k: False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+def _capture_tts(monkeypatch, seen):
+    """Record the exact text handed to the whole-file TTS engine."""
+
+    def _fake_text_to_speech_tool(*, text, output_path, **_kwargs):
+        seen.append(text)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fh:
+            fh.write(b"\x00" * 32)
+        return json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr(
+        "tools.tts_tool.text_to_speech_tool", _fake_text_to_speech_tool
+    )
+    # Identity markdown strip so these cases isolate the directive strip.
+    monkeypatch.setattr("tools.tts_text_normalize._strip_markdown_for_tts", lambda text: text)
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_does_not_speak_media_directive(monkeypatch, tmp_path):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    seen = []
+    _capture_tts(monkeypatch, seen)
+
+    runner = _runner_with_adapter(AsyncMock())
+    await runner._send_voice_reply(_make_event(), FIXTURE_RESPONSE)
+
+    assert seen, "TTS was never invoked"
+    _assert_no_directive(seen[0])
+    assert "Here is the track you asked for." in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_strips_inline_delivery_flag(monkeypatch, tmp_path):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    seen = []
+    _capture_tts(monkeypatch, seen)
+
+    runner = _runner_with_adapter(AsyncMock())
+    await runner._send_voice_reply(
+        _make_event(), "Round five, here we go. [[audio_as_voice]]"
+    )
+
+    assert seen, "TTS was never invoked"
+    _assert_no_directive(seen[0])
+    assert "Round five" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# Split-delta holdback helper
+# ---------------------------------------------------------------------------
+
+
+class TestDirectiveHoldback:
+    """A directive half-arrived in a delta must never be forwarded."""
+
+    def test_plain_text_is_never_held_back(self):
+        text = "An ordinary sentence with no directives at all."
+        assert streaming_tts_consumer._directive_holdback_index(text) == len(text)
+
+    def test_empty_buffer(self):
+        assert streaming_tts_consumer._directive_holdback_index("") == 0
+
+    @pytest.mark.parametrize("frag", ["M", "ME", "MED", "MEDI", "MEDIA"])
+    def test_partial_media_marker_is_held(self, frag):
+        buf = "spoken words " + frag
+        assert streaming_tts_consumer._directive_holdback_index(buf) == len("spoken words ")
+
+    def test_open_media_path_is_held_until_newline(self):
+        buf = "spoken words MEDIA:/tmp/hermes-fixture/audio/clip"
+        assert streaming_tts_consumer._directive_holdback_index(buf) == len("spoken words ")
+
+    def test_terminated_media_line_is_not_held(self):
+        buf = "spoken words MEDIA:%s\nmore speech" % FIXTURE_MEDIA
+        assert streaming_tts_consumer._directive_holdback_index(buf) == len(buf)
+
+    def test_unclosed_double_bracket_is_held(self):
+        buf = "spoken words [[audio_as"
+        assert streaming_tts_consumer._directive_holdback_index(buf) == len("spoken words ")
+
+
+# ---------------------------------------------------------------------------
+# Streaming path: StreamingTTSConsumer
+# ---------------------------------------------------------------------------
+
+
+class RecordingStreamer:
+    """Streaming provider that records every text handed to it."""
+
+    sample_rate = 24000
+    channels = 1
+    sample_width = 2
+
+    def __init__(self):
+        self.spoken = []
+
+    def stream(self, text: str):
+        self.spoken.append(text)
+        yield b"\x00\x00"
+
+
+class RecordingAdapter:
+    name = "fake-voice"
+
+    def __init__(self):
+        self.chunks = []
+
+    async def write_streaming_tts(self, handle, chunk):
+        self.chunks.append(chunk)
+
+
+@pytest.fixture
+def streaming_consumer(monkeypatch):
+    """A consumer wired to a recording provider, with the drain loop bypassed."""
+    streamer = RecordingStreamer()
+    monkeypatch.setattr(
+        "tools.tts_streaming.resolve_streaming_provider",
+        lambda *_a, **_k: streamer,
+    )
+    loop = asyncio.new_event_loop()
+    try:
+        adapter = RecordingAdapter()
+        consumer = StreamingTTSConsumer(adapter, FIXTURE_CHAT_ID, {}, loop)
+        consumer._handle = StreamingTTSHandle(
+            chat_id=FIXTURE_CHAT_ID, audio_format=AudioFormat()
+        )
+        assert consumer.active is True
+        yield consumer, streamer
+    finally:
+        loop.close()
+
+
+def _drain_to_provider(consumer):
+    """Feed every queued clause through the real synthesis entry point."""
+    while True:
+        try:
+            clause = consumer._queue.get_nowait()
+        except queue.Empty:
+            return
+        if not isinstance(clause, str):
+            continue
+        asyncio.run(consumer._synthesise_and_write(clause))
+
+
+def test_streaming_directive_in_one_delta_never_reaches_provider(streaming_consumer):
+    consumer, streamer = streaming_consumer
+
+    consumer.on_delta("Here is the track you asked for. ")
+    consumer.on_delta("Enjoy the music tonight. \n\nMEDIA:%s\n" % FIXTURE_MEDIA)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Here is the track you asked for." in spoken
+
+
+def test_streaming_directive_split_across_deltas_never_reaches_provider(
+    streaming_consumer,
+):
+    """The model streams token by token, so a directive arrives in pieces."""
+    consumer, streamer = streaming_consumer
+
+    for delta in [
+        "Here is the track you asked for. ",
+        "Enjoy the music tonight. ",
+        "\n\nMED",
+        "IA:/tmp/hermes-",
+        "fixture/audio/",
+        "clip-0001",
+        ".mp3\n",
+    ]:
+        consumer.on_delta(delta)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Here is the track you asked for." in spoken
+    assert "Enjoy the music tonight." in spoken
+
+
+def test_streaming_inline_flag_split_across_deltas_never_reaches_provider(
+    streaming_consumer,
+):
+    consumer, streamer = streaming_consumer
+
+    for delta in ["Round five, here we go. ", "[[audio", "_as_voice]]"]:
+        consumer.on_delta(delta)
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    _assert_no_directive(spoken)
+    assert "Round five" in spoken
+
+
+def test_streaming_ordinary_text_still_reaches_provider(streaming_consumer):
+    """The guard must not swallow normal speech."""
+    consumer, streamer = streaming_consumer
+
+    consumer.on_delta("The first sentence is here. ")
+    consumer.on_delta("The second sentence follows it. ")
+    consumer.finish()
+    _drain_to_provider(consumer)
+
+    spoken = " ".join(streamer.spoken)
+    assert "The first sentence is here." in spoken
+    assert "The second sentence follows it." in spoken


### PR DESCRIPTION
## What does this PR do?

`GatewayRunner._send_voice_reply` hands the raw assistant response to the TTS engine and strips only markdown:

```python
tts_text = _strip_markdown_for_tts(text[:4000])
```

A response that attaches a file also carries a `MEDIA:<path>` line, and optionally an `[[audio_as_voice]]` or `[[as_document]]` flag. Those are a delivery contract with the platform adapter, not speech. The text path already removes them with `_strip_media_directives` before display, so for one and the same response the visible message is clean while the generated voice note reads the absolute local file path aloud after the real sentence.

Observed on a live Telegram deployment. The gateway logged:

```
response ready: ... response=148 chars
[Telegram] Sending response (70 chars) to <chat_id>
[Telegram] Delivering 1 non-image MEDIA attachment(s)
```

The 70 characters are the visible text after the directive is stripped. The 148 characters are what was handed to TTS. Listeners heard the intended sentence followed by the spoken file path, which also discloses the install path and account name to everyone in the chat.

The fix routes the TTS input through the same `_strip_media_directives` helper the display path already uses, applied before the 4000 character truncation so a long directive cannot push real speech out of the window. Responses that contain no directives are unaffected, because that helper returns the text unchanged when none of the markers are present.

### Duplicate search

I searched open PRs before opening this one.

* **#57201** adds a group and forum scrub for local paths that survive into visible text. It runs on `text_content` immediately before the text send, so it never sees the TTS engine input. The two are complementary: that PR is a last line of defense for what is displayed, this one fixes what is spoken.
* **#75619** mechanically moves `_send_voice_reply` into a mixin. This change is one line plus one import inside that method, so it should carry over with the move. Happy to rebase if that lands first.
* **#14900**, **#24385** and **#31848** touch the voice reply path for codec, delivery timing and Slack extension points respectively, not directive handling.

## Related Issue

No existing issue; this was found in production. Happy to open one first if that is preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

* `gateway/run.py`: in `GatewayRunner._send_voice_reply`, apply `_strip_media_directives` to the response before `_strip_markdown_for_tts`, and before the 4000 character truncation.
* `tests/gateway/test_auto_voice_media_strip.py`: new regression test with two cases, a `MEDIA:<path>` attachment line and an inline `[[audio_as_voice]]` flag, asserting the directive never reaches the TTS engine while the real sentence survives.

## How to Test

1. On current `main`, add only the new test file and run `pytest tests/gateway/test_auto_voice_media_strip.py -q`. Both cases fail, and the assertion output shows the `MEDIA:` line and the `[[audio_as_voice]]` flag inside the text handed to TTS.
2. Apply the `gateway/run.py` change and run it again. Both pass.
3. End to end: put a chat in voice mode `all` and have the agent return a reply that attaches a file. Before the fix the voice note speaks the file path after the sentence. After it, only the sentence is spoken and the attachment still delivers normally.

**Test scope note:** I ran every voice, media, TTS and transcription suite in `tests/gateway` and `tests/tools` against current `main` with this change applied: **563 passed, 4 skipped**. I did not run the entire `tests/` tree on this host, which is a 1 GB VPS without test parallelism. The change is one line inside a single method and the suites above are the ones that exercise it. Happy to run anything else a reviewer wants.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see the test scope note above: targeted suites only, 563 passed / 4 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04.5 LTS, x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: N/A, no user facing behavior or config change, the fix restores the documented contract that delivery directives are internal
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A: pure string handling with no platform specific behavior, and the test uses `tmp_path` rather than hardcoded paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: N/A
