### PR TITLE
fix(ollama): resolve context from /api/ps, not just /api/show

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -608,6 +608,83 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _reconcile_ollama_runtime_ctx(agent: Any) -> Optional[int]:
+    """Re-read Ollama's served context now that the model is certainly loaded.
+
+    ``agent._ollama_num_ctx`` is resolved once, in agent_init, and never
+    refreshed. At a cold start ``/api/ps`` lists nothing, so the probe falls
+    back to the GGUF training maximum and the agent keeps that number for the
+    whole session -- even though the first request then loads the model at the
+    server's (possibly much smaller) ``OLLAMA_CONTEXT_LENGTH`` window.
+
+    Called from the finish_reason="length" path, where the model is loaded by
+    definition because it just produced a response. Lowers only; a raised or
+    equal value is ignored.
+
+    Returns the corrected value when it changed, else None.
+    """
+    base_url = getattr(agent, "base_url", "") or ""
+    model = getattr(agent, "model", "") or ""
+    if not base_url or not model:
+        return None
+    believed = getattr(agent, "_ollama_num_ctx", None)
+    if not isinstance(believed, int) or believed <= 0:
+        return None
+
+    try:
+        from agent.model_metadata import (
+            _auth_headers,
+            _localhost_to_ipv4,
+            _query_ollama_served_ctx,
+        )
+
+        server_url = _localhost_to_ipv4(base_url.rstrip("/"))
+        if server_url.endswith("/v1"):
+            server_url = server_url[:-3]
+        api_key = agent.api_key if isinstance(getattr(agent, "api_key", None), str) else ""
+        served = _query_ollama_served_ctx(model, server_url, _auth_headers(api_key))
+    except Exception:
+        return None
+
+    if not served or served >= believed:
+        return None
+
+    logger.warning(
+        "Ollama runtime context corrected after load: %d -> %d "
+        "(model=%s base_url=%s). The startup probe saw an unloaded model and "
+        "fell back to the advertised maximum.",
+        believed, served, model, base_url,
+    )
+    agent._ollama_num_ctx = served
+
+    # Mirror the init-time clamp in agent_init: the compressor was sized from
+    # the same stale value, so without this the compaction trigger can sit
+    # above the real served window and never fire — Ollama truncates the
+    # prompt before compression is ever scheduled.
+    compressor = getattr(agent, "context_compressor", None)
+    cc_window = getattr(compressor, "context_length", 0) or 0
+    if compressor is not None and cc_window and served < cc_window:
+        try:
+            compressor.update_model(
+                model=model,
+                context_length=served,
+                base_url=base_url,
+                api_key=getattr(agent, "api_key", ""),
+                provider=getattr(agent, "provider", ""),
+                api_mode=getattr(agent, "api_mode", ""),
+            )
+            logger.info(
+                "Compressor window clamped to reconciled Ollama context: %d -> %d",
+                cc_window, served,
+            )
+        except Exception:
+            logger.debug(
+                "Compressor re-clamp after Ollama context reconciliation failed",
+                exc_info=True,
+            )
+    return served
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -3919,6 +3996,40 @@ def run_conversation(
                             f"(finish_reason='length') - model hit max output tokens",
                             force=True,
                         )
+
+                    # Against Ollama, finish_reason="length" on the FIRST token is
+                    # usually not an output cap at all -- it is the prompt already
+                    # filling the served context window. The startup probe cannot
+                    # see that when the model was cold (see
+                    # _reconcile_ollama_runtime_ctx), so re-read it here: the model
+                    # is loaded by definition now, having just responded.
+                    #
+                    # Without this the continuation retries below APPEND a "continue"
+                    # message and re-send, making the prompt longer each round, and
+                    # the turn dies with "Response remained truncated after 4
+                    # continuation attempts" -- which names the wrong cause entirely.
+                    _corrected_ctx = _reconcile_ollama_runtime_ctx(agent)
+                    if _corrected_ctx is not None:
+                        _ctx_error = _ollama_context_limit_error(
+                            agent, request_pressure_tokens
+                        )
+                        if _ctx_error:
+                            messages.append(
+                                {"role": "assistant", "content": _ctx_error}
+                            )
+                            agent._emit_status(
+                                "❌ Ollama runtime context is too small for Hermes tool use"
+                            )
+                            agent._cleanup_task_resources(effective_task_id)
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": _ctx_error,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "turn_exit_reason": "ollama_runtime_context_too_small",
+                                "error": "ollama runtime context too small",
+                            }
 
                     # Normalize the truncated response to a single OpenAI-style
                     # message shape so text-continuation and tool-call retry

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1630,6 +1630,82 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
+def _query_ollama_served_ctx(
+    model: str, server_url: str, headers: Dict[str, str]
+) -> Optional[int]:
+    """Context length the server is ACTUALLY serving ``model`` at, via /api/ps.
+
+    ``/api/show`` reports the GGUF training maximum, and it cannot see
+    ``OLLAMA_CONTEXT_LENGTH`` — that is a server environment variable, not a
+    Modelfile parameter, so it appears in neither ``model_info`` nor
+    ``parameters``. When the two disagree the served value is the real limit:
+    exceed it and generation returns ``finish_reason="length"`` on the first
+    token, which the agent loop then misreports as output truncation and
+    "recovers" from by appending a continuation message that makes the prompt
+    longer still.
+
+    This is also what makes ``_ollama_context_limit_error()`` in
+    ``agent/conversation_loop.py`` able to fire. That guard compares
+    ``agent._ollama_num_ctx`` (populated from ``query_ollama_num_ctx()``)
+    against ``MINIMUM_CONTEXT_LENGTH``, so while the probe returns the GGUF
+    max the check silently passes no matter how small the real window is —
+    including the plain ``OLLAMA_CONTEXT_LENGTH`` default case.
+
+    ``/api/ps`` only lists LOADED models, so this returns None for an idle
+    model and callers keep the ``/api/show`` value. That is the correct
+    fallback — the served context is genuinely unknowable until something
+    loads it, and by the time the number matters (an in-flight conversation)
+    the model is loaded by definition.
+
+    Memoized in the 30s in-memory probe cache only, never on the 300s disk
+    cache: this tracks live server state and must re-probe promptly after a
+    restart or a config change.
+    """
+    import time as _time
+    import httpx
+
+    cache_key = ("ollama_ps", _strip_provider_prefix(model), server_url.rstrip("/"))
+    now = _time.monotonic()
+    cached = _LOCAL_CTX_PROBE_CACHE.get(cache_key)
+    if cached is not None and (now - cached[1]) < _LOCAL_CTX_PROBE_TTL_SECONDS:
+        return cached[0]
+
+    bare = _strip_provider_prefix(model)
+    try:
+        with httpx.Client(timeout=3.0, headers=headers) as client:
+            resp = client.get(f"{server_url}/api/ps")
+            if resp.status_code != 200:
+                return None
+            for entry in resp.json().get("models") or []:
+                if entry.get("name") != bare and entry.get("model") != bare:
+                    continue
+                ctx = entry.get("context_length")
+                if isinstance(ctx, (int, float)) and int(ctx) >= 1024:
+                    result = int(ctx)
+                    _LOCAL_CTX_PROBE_CACHE[cache_key] = (result, now)
+                    return result
+    except Exception:
+        pass
+    return None
+
+
+def _cap_ctx_by_served(
+    ctx: Optional[int], model: str, server_url: str, headers: Dict[str, str]
+) -> Optional[int]:
+    """Clamp an /api/show context length to what the server actually serves.
+
+    Only ever lowers the value. If /api/ps reports something larger than the
+    GGUF max (shouldn't happen) the advertised max still wins, since that is
+    the hard ceiling the weights were trained for.
+    """
+    if not ctx:
+        return ctx
+    served = _query_ollama_served_ctx(model, server_url, headers)
+    if served and 1024 <= served < ctx:
+        return served
+    return ctx
+
+
 def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server for the model's context length.
 
@@ -1657,11 +1733,15 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     # Disk L2: /api/show results are stable for a given (model, server) on
     # human timescales — skip the HTTP roundtrip on fresh cross-process hits.
     _disk_key = f"{server_url}|{bare_model}"
+    headers = _auth_headers(api_key)
+
+    # The cap is applied AFTER the disk read, never before the write: the
+    # cached value is the stable /api/show number, while the served ctx is
+    # live state that must be re-checked on every call. Baking a cap into the
+    # 300s disk cache would outlive a server restart at a different setting.
     disk_hit = _local_probe_disk_get("ollama_num_ctx", _disk_key)
     if isinstance(disk_hit, int) and disk_hit > 0:
-        return disk_hit
-
-    headers = _auth_headers(api_key)
+        return _cap_ctx_by_served(disk_hit, bare_model, server_url, headers)
 
     try:
         with httpx.Client(timeout=3.0, headers=headers) as client:
@@ -1680,7 +1760,9 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
                             try:
                                 _ctx = int(parts[-1])
                                 _local_probe_disk_put("ollama_num_ctx", _disk_key, _ctx)
-                                return _ctx
+                                return _cap_ctx_by_served(
+                                    _ctx, bare_model, server_url, headers
+                                )
                             except ValueError:
                                 pass
 
@@ -1690,7 +1772,9 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
                 if "context_length" in key and isinstance(value, (int, float)):
                     _ctx = int(value)
                     _local_probe_disk_put("ollama_num_ctx", _disk_key, _ctx)
-                    return _ctx
+                    return _cap_ctx_by_served(
+                        _ctx, bare_model, server_url, headers
+                    )
     except Exception:
         pass
     return None
@@ -1778,13 +1862,23 @@ def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Opti
     # keys — the two probes can return different values for the same pair.
     cache_key = ("ollama_show", _strip_provider_prefix(model), base_url.rstrip("/"))
     now = _time.monotonic()
+
+    # Cap against /api/ps on the way out rather than on the way in, so the
+    # memoized entry stays the stable advertised max and the live served
+    # value is re-consulted per call (see _query_ollama_served_ctx).
+    _server_url = _localhost_to_ipv4(base_url.rstrip("/"))
+    if _server_url.endswith("/v1"):
+        _server_url = _server_url[:-3]
+    _headers = _auth_headers(api_key)
+
     cached = _LOCAL_CTX_PROBE_CACHE.get(cache_key)
     if cached is not None and (now - cached[1]) < _LOCAL_CTX_PROBE_TTL_SECONDS:
-        return cached[0]
+        return _cap_ctx_by_served(cached[0], model, _server_url, _headers)
 
     result = _query_ollama_api_show_uncached(model, base_url, api_key=api_key)
     if result:  # positive-only — never memoize a failed probe
         _LOCAL_CTX_PROBE_CACHE[cache_key] = (result, now)
+        return _cap_ctx_by_served(result, model, _server_url, _headers)
     return result
 
 
@@ -1936,6 +2030,13 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     # which can be larger than num_ctx — using it here would let
                     # Hermes grow conversations past the runtime limit and Ollama
                     # would silently truncate. Matches query_ollama_num_ctx().
+                    #
+                    # num_ctx only covers a Modelfile override. A server started
+                    # with OLLAMA_CONTEXT_LENGTH caps every model without
+                    # appearing in `parameters` OR `model_info`, so both branches
+                    # below are additionally clamped to what /api/ps reports the
+                    # model is actually loaded at — the same "prefer the loaded
+                    # runtime value" rule the lm-studio branch below applies.
                     params = data.get("parameters", "")
                     if "num_ctx" in params:
                         for line in params.split("\n"):
@@ -1943,14 +2044,18 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                                 parts = line.strip().split()
                                 if len(parts) >= 2:
                                     try:
-                                        return int(parts[-1])
+                                        return _cap_ctx_by_served(
+                                            int(parts[-1]), model, server_url, headers
+                                        )
                                     except ValueError:
                                         pass
                     # Fall back to GGUF model_info context_length (training max)
                     model_info = data.get("model_info", {})
                     for key, value in model_info.items():
                         if "context_length" in key and isinstance(value, (int, float)):
-                            return int(value)
+                            return _cap_ctx_by_served(
+                                int(value), model, server_url, headers
+                            )
 
             # LM Studio native API: /api/v1/models returns max_context_length.
             # This is more reliable than the OpenAI-compat /v1/models which

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1971,6 +1971,82 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
+def _query_ollama_served_ctx(
+    model: str, server_url: str, headers: Dict[str, str]
+) -> Optional[int]:
+    """Context length the server is ACTUALLY serving ``model`` at, via /api/ps.
+
+    ``/api/show`` reports the GGUF training maximum, and it cannot see
+    ``OLLAMA_CONTEXT_LENGTH`` — that is a server environment variable, not a
+    Modelfile parameter, so it appears in neither ``model_info`` nor
+    ``parameters``. When the two disagree the served value is the real limit:
+    exceed it and generation returns ``finish_reason="length"`` on the first
+    token, which the agent loop then misreports as output truncation and
+    "recovers" from by appending a continuation message that makes the prompt
+    longer still.
+
+    This is also what makes ``_ollama_context_limit_error()`` in
+    ``agent/conversation_loop.py`` able to fire. That guard compares
+    ``agent._ollama_num_ctx`` (populated from ``query_ollama_num_ctx()``)
+    against ``MINIMUM_CONTEXT_LENGTH``, so while the probe returns the GGUF
+    max the check silently passes no matter how small the real window is —
+    including the plain ``OLLAMA_CONTEXT_LENGTH`` default case.
+
+    ``/api/ps`` only lists LOADED models, so this returns None for an idle
+    model and callers keep the ``/api/show`` value. That is the correct
+    fallback — the served context is genuinely unknowable until something
+    loads it, and by the time the number matters (an in-flight conversation)
+    the model is loaded by definition.
+
+    Memoized in the 30s in-memory probe cache only, never on the 300s disk
+    cache: this tracks live server state and must re-probe promptly after a
+    restart or a config change.
+    """
+    import time as _time
+    import httpx
+
+    cache_key = ("ollama_ps", _strip_provider_prefix(model), server_url.rstrip("/"))
+    now = _time.monotonic()
+    cached = _LOCAL_CTX_PROBE_CACHE.get(cache_key)
+    if cached is not None and (now - cached[1]) < _LOCAL_CTX_PROBE_TTL_SECONDS:
+        return cached[0]
+
+    bare = _strip_provider_prefix(model)
+    try:
+        with httpx.Client(timeout=3.0, headers=headers) as client:
+            resp = client.get(f"{server_url}/api/ps")
+            if resp.status_code != 200:
+                return None
+            for entry in resp.json().get("models") or []:
+                if entry.get("name") != bare and entry.get("model") != bare:
+                    continue
+                ctx = entry.get("context_length")
+                if isinstance(ctx, (int, float)) and int(ctx) >= 1024:
+                    result = int(ctx)
+                    _LOCAL_CTX_PROBE_CACHE[cache_key] = (result, now)
+                    return result
+    except Exception:
+        pass
+    return None
+
+
+def _cap_ctx_by_served(
+    ctx: Optional[int], model: str, server_url: str, headers: Dict[str, str]
+) -> Optional[int]:
+    """Clamp an /api/show context length to what the server actually serves.
+
+    Only ever lowers the value. If /api/ps reports something larger than the
+    GGUF max (shouldn't happen) the advertised max still wins, since that is
+    the hard ceiling the weights were trained for.
+    """
+    if not ctx:
+        return ctx
+    served = _query_ollama_served_ctx(model, server_url, headers)
+    if served and 1024 <= served < ctx:
+        return served
+    return ctx
+
+
 def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server for the model's context length.
 
@@ -1998,11 +2074,15 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     # Disk L2: /api/show results are stable for a given (model, server) on
     # human timescales — skip the HTTP roundtrip on fresh cross-process hits.
     _disk_key = f"{server_url}|{bare_model}"
+    headers = _auth_headers(api_key)
+
+    # The cap is applied AFTER the disk read, never before the write: the
+    # cached value is the stable /api/show number, while the served ctx is
+    # live state that must be re-checked on every call. Baking a cap into the
+    # 300s disk cache would outlive a server restart at a different setting.
     disk_hit = _local_probe_disk_get("ollama_num_ctx", _disk_key)
     if isinstance(disk_hit, int) and disk_hit > 0:
-        return disk_hit
-
-    headers = _auth_headers(api_key)
+        return _cap_ctx_by_served(disk_hit, bare_model, server_url, headers)
 
     try:
         with httpx.Client(timeout=3.0, headers=headers) as client:
@@ -2021,7 +2101,9 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
                             try:
                                 _ctx = int(parts[-1])
                                 _local_probe_disk_put("ollama_num_ctx", _disk_key, _ctx)
-                                return _ctx
+                                return _cap_ctx_by_served(
+                                    _ctx, bare_model, server_url, headers
+                                )
                             except ValueError:
                                 pass
 
@@ -2031,7 +2113,9 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
                 if "context_length" in key and isinstance(value, (int, float)):
                     _ctx = int(value)
                     _local_probe_disk_put("ollama_num_ctx", _disk_key, _ctx)
-                    return _ctx
+                    return _cap_ctx_by_served(
+                        _ctx, bare_model, server_url, headers
+                    )
     except Exception:
         pass
     return None
@@ -2119,13 +2203,23 @@ def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Opti
     # keys — the two probes can return different values for the same pair.
     cache_key = ("ollama_show", _strip_provider_prefix(model), base_url.rstrip("/"))
     now = _time.monotonic()
+
+    # Cap against /api/ps on the way out rather than on the way in, so the
+    # memoized entry stays the stable advertised max and the live served
+    # value is re-consulted per call (see _query_ollama_served_ctx).
+    _server_url = _localhost_to_ipv4(base_url.rstrip("/"))
+    if _server_url.endswith("/v1"):
+        _server_url = _server_url[:-3]
+    _headers = _auth_headers(api_key)
+
     cached = _LOCAL_CTX_PROBE_CACHE.get(cache_key)
     if cached is not None and (now - cached[1]) < _LOCAL_CTX_PROBE_TTL_SECONDS:
-        return cached[0]
+        return _cap_ctx_by_served(cached[0], model, _server_url, _headers)
 
     result = _query_ollama_api_show_uncached(model, base_url, api_key=api_key)
     if result:  # positive-only — never memoize a failed probe
         _LOCAL_CTX_PROBE_CACHE[cache_key] = (result, now)
+        return _cap_ctx_by_served(result, model, _server_url, _headers)
     return result
 
 
@@ -2340,6 +2434,13 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     # which can be larger than num_ctx — using it here would let
                     # Hermes grow conversations past the runtime limit and Ollama
                     # would silently truncate. Matches query_ollama_num_ctx().
+                    #
+                    # num_ctx only covers a Modelfile override. A server started
+                    # with OLLAMA_CONTEXT_LENGTH caps every model without
+                    # appearing in `parameters` OR `model_info`, so both branches
+                    # below are additionally clamped to what /api/ps reports the
+                    # model is actually loaded at — the same "prefer the loaded
+                    # runtime value" rule the lm-studio branch below applies.
                     params = data.get("parameters", "")
                     if "num_ctx" in params:
                         for line in params.split("\n"):
@@ -2347,14 +2448,18 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                                 parts = line.strip().split()
                                 if len(parts) >= 2:
                                     try:
-                                        return int(parts[-1])
+                                        return _cap_ctx_by_served(
+                                            int(parts[-1]), model, server_url, headers
+                                        )
                                     except ValueError:
                                         pass
                     # Fall back to GGUF model_info context_length (training max)
                     model_info = data.get("model_info", {})
                     for key, value in model_info.items():
                         if "context_length" in key and isinstance(value, (int, float)):
-                            return int(value)
+                            return _cap_ctx_by_served(
+                                int(value), model, server_url, headers
+                            )
 
             # LM Studio native API: /api/v1/models returns max_context_length.
             # This is more reliable than the OpenAI-compat /v1/models which

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -930,10 +930,11 @@ def is_local_endpoint(base_url: str) -> bool:
 
     Recognises loopback (``localhost``, ``127.0.0.0/8``, ``::1``),
     container-internal DNS names (``host.docker.internal`` et al.),
-    RFC-1918 private ranges (``10/8``, ``172.16/12``, ``192.168/16``),
-    link-local, and Tailscale CGNAT (``100.64.0.0/10``). Tailscale CGNAT
-    is included so remote-but-trusted Ollama boxes reached over a
-    Tailscale mesh get the same timeout auto-bumps as localhost Ollama.
+    mDNS names (``*.local``, RFC 6762), RFC-1918 private ranges (``10/8``,
+    ``172.16/12``, ``192.168/16``), link-local, and Tailscale CGNAT
+    (``100.64.0.0/10``). Tailscale CGNAT is included so remote-but-trusted
+    Ollama boxes reached over a Tailscale mesh get the same timeout
+    auto-bumps as localhost Ollama.
     """
     normalized = _normalize_base_url(base_url)
     if not normalized:
@@ -952,6 +953,13 @@ def is_local_endpoint(base_url: str) -> bool:
     # Unqualified hostnames (no dots) are local by definition — Docker
     # Compose service names, /etc/hosts entries, or mDNS names.
     if host and "." not in host:
+        return True
+    # RFC 6762 reserves `.local` for mDNS: such names resolve only on the
+    # local network, so an `ollama-box.local` endpoint is as local as a
+    # RFC-1918 address. Without this the cached-context reconciliation in
+    # get_model_context_length() is skipped for mDNS endpoints and a stale
+    # GGUF-maximum cache entry outlives any /api/ps correction.
+    if host.endswith(".local"):
         return True
     # RFC-1918 private ranges, link-local, and Tailscale CGNAT
     try:

--- a/tests/agent/test_local_probe_disk_cache.py
+++ b/tests/agent/test_local_probe_disk_cache.py
@@ -87,15 +87,45 @@ class TestDetectLocalServerTypeDiskL2:
 
 class TestOllamaNumCtxDiskL2:
     def test_disk_hit_skips_api_show(self):
+        """A fresh disk hit skips the /api/show POST. The live /api/ps cap
+        still runs: served context is runtime state a 300s disk entry must
+        never freeze (see query_ollama_num_ctx)."""
         _clear_in_proc()
         MM._local_probe_disk_put("server_type", "http://127.0.0.1:11434", "ollama")
         MM._local_probe_disk_put(
             "ollama_num_ctx", "http://127.0.0.1:11434|llama3", 131072
         )
-        with patch("httpx.Client") as mock_client:
+        ps_resp = MagicMock(status_code=200)
+        ps_resp.json.return_value = {"models": []}
+        client = MagicMock()
+        client.get.return_value = ps_resp
+        client.__enter__ = lambda s: client
+        client.__exit__ = lambda s, *a: False
+        with patch("httpx.Client", return_value=client):
             ctx = MM.query_ollama_num_ctx("llama3", "http://127.0.0.1:11434/v1")
         assert ctx == 131072
-        mock_client.assert_not_called()
+        client.post.assert_not_called()
+
+    def test_disk_hit_still_capped_by_served_ctx(self):
+        """A server restarted at a smaller OLLAMA_CONTEXT_LENGTH wins over a
+        fresh disk entry — the cap is applied after the disk read."""
+        _clear_in_proc()
+        MM._local_probe_disk_put("server_type", "http://127.0.0.1:11434", "ollama")
+        MM._local_probe_disk_put(
+            "ollama_num_ctx", "http://127.0.0.1:11434|llama3", 131072
+        )
+        ps_resp = MagicMock(status_code=200)
+        ps_resp.json.return_value = {
+            "models": [{"name": "llama3", "context_length": 32768}]
+        }
+        client = MagicMock()
+        client.get.return_value = ps_resp
+        client.__enter__ = lambda s: client
+        client.__exit__ = lambda s, *a: False
+        with patch("httpx.Client", return_value=client):
+            ctx = MM.query_ollama_num_ctx("llama3", "http://127.0.0.1:11434/v1")
+        assert ctx == 32768
+        client.post.assert_not_called()
 
     def test_successful_show_persists(self):
         _clear_in_proc()

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -77,10 +77,26 @@ class TestIsLocalEndpoint:
 
 
     @pytest.mark.parametrize("url", [
+        "http://ollama-box.local:11434/v1",
+        "http://ollama-box.local:11434",
+        "https://nas.local:8443",
+        "http://MY-MAC.LOCAL:11434",
+    ])
+    def test_mdns_local_hostnames(self, url):
+        """RFC 6762 reserves `.local` for mDNS — resolvable only on the LAN.
+
+        Regression: these returned False, which skipped the cached-context
+        reconciliation in get_model_context_length() and let a stale
+        GGUF-maximum cache entry outlive any /api/ps correction.
+        """
+        assert is_local_endpoint(url) is True
+
+    @pytest.mark.parametrize("url", [
         "https://api.openai.com",
         "https://openrouter.ai/api",
         "https://api.anthropic.com",
         "https://evil.docker.internal.example.com",
+        "https://evil.local.example.com",
     ])
     def test_remote_endpoints(self, url):
         assert is_local_endpoint(url) is False

--- a/tests/agent/test_model_metadata_served_ctx.py
+++ b/tests/agent/test_model_metadata_served_ctx.py
@@ -1,0 +1,159 @@
+"""Tests for _query_ollama_served_ctx and the /api/ps cap on /api/show values.
+
+/api/show reports the GGUF training maximum and cannot see
+OLLAMA_CONTEXT_LENGTH -- a server env var, absent from both model_info and
+parameters. When a server is started with a smaller window than the weights
+support, every /api/show-derived context length overstates the real limit, and
+requests sized to it come back with finish_reason="length" on the first token.
+
+/api/ps reports what each LOADED model is actually being served at, so it is
+the authority whenever it has an answer.
+
+All tests use synthetic inputs -- no filesystem or live server required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_local_ctx_probe_cache():
+    """Reset the in-process probe TTL cache around every test.
+
+    _query_ollama_served_ctx memoizes per (model, server_url) for a short TTL.
+    Cases below return different /api/ps bodies for the same pair, so a stale
+    entry would leak across them.
+    """
+    import agent.model_metadata as _mm
+
+    _mm._LOCAL_CTX_PROBE_CACHE.clear()
+    yield
+    _mm._LOCAL_CTX_PROBE_CACHE.clear()
+
+
+def _resp(status_code, body):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    return resp
+
+
+def _ps(*models):
+    return {"models": [dict(m) for m in models]}
+
+
+class TestQueryOllamaServedCtx:
+    """_query_ollama_served_ctx against a mocked /api/ps."""
+
+    def test_returns_served_context_for_loaded_model(self):
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        client = MagicMock()
+        client.get.return_value = _resp(
+            200, _ps({"name": "gpt-oss:20b", "context_length": 32768})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = client
+            assert (
+                _query_ollama_served_ctx("gpt-oss:20b", "http://x:11434", {})
+                == 32768
+            )
+
+    def test_returns_none_when_model_not_loaded(self):
+        """The decisive fallback: an idle model has no knowable served ctx."""
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        client = MagicMock()
+        client.get.return_value = _resp(
+            200, _ps({"name": "other:7b", "context_length": 8192})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = client
+            assert (
+                _query_ollama_served_ctx("gpt-oss:20b", "http://x:11434", {})
+                is None
+            )
+
+    def test_matches_on_model_field_too(self):
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        client = MagicMock()
+        client.get.return_value = _resp(
+            200, _ps({"model": "gpt-oss:20b", "context_length": 16384})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = client
+            assert (
+                _query_ollama_served_ctx("gpt-oss:20b", "http://x:11434", {})
+                == 16384
+            )
+
+    def test_empty_and_error_responses_are_none(self):
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        for body, status in (({}, 200), (_ps(), 200), ({}, 404)):
+            import agent.model_metadata as _mm
+
+            _mm._LOCAL_CTX_PROBE_CACHE.clear()
+            client = MagicMock()
+            client.get.return_value = _resp(status, body)
+            with patch("httpx.Client") as C:
+                C.return_value.__enter__.return_value = client
+                assert (
+                    _query_ollama_served_ctx("m", "http://x:11434", {}) is None
+                )
+
+    def test_nonsense_small_value_ignored(self):
+        """Guards against a 0/absurd context_length clamping everything to junk."""
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        client = MagicMock()
+        client.get.return_value = _resp(
+            200, _ps({"name": "m", "context_length": 8})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = client
+            assert _query_ollama_served_ctx("m", "http://x:11434", {}) is None
+
+    def test_connection_error_is_swallowed(self):
+        from agent.model_metadata import _query_ollama_served_ctx
+
+        with patch("httpx.Client", side_effect=OSError("refused")):
+            assert _query_ollama_served_ctx("m", "http://x:11434", {}) is None
+
+
+class TestCapCtxByServed:
+    """_cap_ctx_by_served only ever lowers, and only on a real signal."""
+
+    def _patched(self, served):
+        return patch(
+            "agent.model_metadata._query_ollama_served_ctx", return_value=served
+        )
+
+    def test_caps_advertised_max_down_to_served(self):
+        """The reported case: advertises 131072, actually serving 32768."""
+        from agent.model_metadata import _cap_ctx_by_served
+
+        with self._patched(32768):
+            assert _cap_ctx_by_served(131072, "m", "http://x", {}) == 32768
+
+    def test_does_not_raise_when_served_is_larger(self):
+        """GGUF max is the hard ceiling -- never exceed it on /api/ps's word."""
+        from agent.model_metadata import _cap_ctx_by_served
+
+        with self._patched(131072):
+            assert _cap_ctx_by_served(32768, "m", "http://x", {}) == 32768
+
+    def test_unloaded_model_keeps_advertised_value(self):
+        from agent.model_metadata import _cap_ctx_by_served
+
+        with self._patched(None):
+            assert _cap_ctx_by_served(131072, "m", "http://x", {}) == 131072
+
+    def test_none_and_zero_pass_through(self):
+        from agent.model_metadata import _cap_ctx_by_served
+
+        with self._patched(32768):
+            assert _cap_ctx_by_served(None, "m", "http://x", {}) is None
+            assert _cap_ctx_by_served(0, "m", "http://x", {}) == 0

--- a/tests/agent/test_model_metadata_served_ctx.py
+++ b/tests/agent/test_model_metadata_served_ctx.py
@@ -157,3 +157,171 @@ class TestCapCtxByServed:
         with self._patched(32768):
             assert _cap_ctx_by_served(None, "m", "http://x", {}) is None
             assert _cap_ctx_by_served(0, "m", "http://x", {}) == 0
+
+
+def _fake_agent(**overrides):
+    """Minimal agent stand-in for the runtime-reconcile helper."""
+    from types import SimpleNamespace
+
+    defaults = dict(
+        base_url="http://127.0.0.1:11434/v1",
+        model="gpt-oss:20b",
+        api_key="",
+        provider="ollama",
+        api_mode="chat_completions",
+        _ollama_num_ctx=262144,
+        context_compressor=MagicMock(context_length=262144),
+        tools=[{"type": "function"}],
+        session_id="test-session",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestReconcileOllamaRuntimeCtx:
+    """_reconcile_ollama_runtime_ctx: the finish_reason="length" repair path."""
+
+    def _served(self, value):
+        return patch(
+            "agent.model_metadata._query_ollama_served_ctx", return_value=value
+        )
+
+    def test_lowers_value_and_reclamps_compressor(self):
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+
+        agent = _fake_agent()
+        with self._served(198656):
+            assert _reconcile_ollama_runtime_ctx(agent) == 198656
+        assert agent._ollama_num_ctx == 198656
+        agent.context_compressor.update_model.assert_called_once()
+        kwargs = agent.context_compressor.update_model.call_args.kwargs
+        assert kwargs["context_length"] == 198656
+        assert kwargs["model"] == "gpt-oss:20b"
+
+    def test_cold_probe_is_a_noop(self):
+        """/api/ps has no answer -> keep the believed value, touch nothing."""
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+
+        agent = _fake_agent()
+        with self._served(None):
+            assert _reconcile_ollama_runtime_ctx(agent) is None
+        assert agent._ollama_num_ctx == 262144
+        agent.context_compressor.update_model.assert_not_called()
+
+    def test_never_raises_the_believed_value(self):
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+
+        agent = _fake_agent(_ollama_num_ctx=32768)
+        with self._served(131072):
+            assert _reconcile_ollama_runtime_ctx(agent) is None
+        assert agent._ollama_num_ctx == 32768
+
+    def test_non_ollama_agent_never_probes(self):
+        """No _ollama_num_ctx (non-Ollama provider) -> no network call at all."""
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+
+        agent = _fake_agent(_ollama_num_ctx=None)
+        with self._served(198656) as probe:
+            assert _reconcile_ollama_runtime_ctx(agent) is None
+            probe.assert_not_called()
+
+    def test_compressor_clamp_failure_keeps_corrected_value(self):
+        """A compressor error must not undo the corrected runtime number."""
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+
+        agent = _fake_agent()
+        agent.context_compressor.update_model.side_effect = RuntimeError("boom")
+        with self._served(198656):
+            assert _reconcile_ollama_runtime_ctx(agent) == 198656
+        assert agent._ollama_num_ctx == 198656
+
+
+class TestColdToLoadedSequence:
+    """End-to-end mocked cold->loaded lifecycle across the real callers.
+
+    Phase 1 (cold, the agent_init resolution): /api/show advertises the GGUF
+    maximum and /api/ps lists nothing, so query_ollama_num_ctx() retains the
+    maximum -- the gap called out in review of #76332.
+
+    Phase 2 (loaded, the finish_reason="length" path): the model just
+    responded, /api/ps now has an answer, and _reconcile_ollama_runtime_ctx
+    lowers agent._ollama_num_ctx and re-clamps the compressor.
+
+    Phase 3 (sub-minimum served window): after reconciliation the existing
+    _ollama_context_limit_error guard fires with actionable text -- it can
+    never fire while the believed value is the GGUF maximum.
+    """
+
+    GGUF_MAX = 262144
+    SERVED = 198656
+
+    def _client(self, ps_body, show_body=None):
+        client = MagicMock()
+        client.get.return_value = _resp(200, ps_body)
+        if show_body is not None:
+            client.post.return_value = _resp(200, show_body)
+        return client
+
+    def test_cold_init_then_loaded_reconcile(self):
+        import agent.model_metadata as _mm
+        from agent.conversation_loop import _reconcile_ollama_runtime_ctx
+        from agent.model_metadata import query_ollama_num_ctx
+
+        show_body = {
+            "model_info": {"llama.context_length": self.GGUF_MAX},
+            "parameters": "",
+        }
+
+        # Phase 1 -- cold: nothing loaded, init retains the GGUF maximum.
+        cold = self._client(_ps(), show_body)
+        with (
+            patch("agent.model_metadata.detect_local_server_type", return_value="ollama"),
+            patch("agent.model_metadata._local_probe_disk_get", return_value=None),
+            patch("agent.model_metadata._local_probe_disk_put"),
+            patch("httpx.Client") as C,
+        ):
+            C.return_value.__enter__.return_value = cold
+            believed = query_ollama_num_ctx(
+                "gpt-oss:20b", "http://127.0.0.1:11434/v1"
+            )
+        assert believed == self.GGUF_MAX
+
+        # Phase 2 -- loaded: the length path re-reads /api/ps and corrects.
+        _mm._LOCAL_CTX_PROBE_CACHE.clear()
+        agent = _fake_agent(_ollama_num_ctx=believed)
+        agent.context_compressor = MagicMock(context_length=believed)
+        loaded = self._client(
+            _ps({"name": "gpt-oss:20b", "context_length": self.SERVED})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = loaded
+            assert _reconcile_ollama_runtime_ctx(agent) == self.SERVED
+        assert agent._ollama_num_ctx == self.SERVED
+        kwargs = agent.context_compressor.update_model.call_args.kwargs
+        assert kwargs["context_length"] == self.SERVED
+
+        # A healthy served window must NOT trip the minimum-context guard.
+        from agent.conversation_loop import _ollama_context_limit_error
+
+        assert _ollama_context_limit_error(agent, 30000) is None
+
+    def test_loaded_subminimum_window_fires_runtime_guard(self):
+        """Phase 3: a tiny served window surfaces the actionable error."""
+        import agent.model_metadata as _mm
+        from agent.conversation_loop import (
+            _ollama_context_limit_error,
+            _reconcile_ollama_runtime_ctx,
+        )
+
+        _mm._LOCAL_CTX_PROBE_CACHE.clear()
+        agent = _fake_agent()
+        loaded = self._client(
+            _ps({"name": "gpt-oss:20b", "context_length": 32768})
+        )
+        with patch("httpx.Client") as C:
+            C.return_value.__enter__.return_value = loaded
+            assert _reconcile_ollama_runtime_ctx(agent) == 32768
+
+        error = _ollama_context_limit_error(agent, 30000)
+        assert error is not None
+        assert "32,768" in error

--- a/tests/agent/test_model_metadata_served_ctx.py
+++ b/tests/agent/test_model_metadata_served_ctx.py
@@ -325,3 +325,67 @@ class TestColdToLoadedSequence:
         error = _ollama_context_limit_error(agent, 30000)
         assert error is not None
         assert "32,768" in error
+
+
+class TestMdnsStaleCacheRegression:
+    """Stale persistent cache at an mDNS endpoint must reconcile, not win.
+
+    Reported on #76332: with the GGUF maximum already cached on disk,
+    get_model_context_length() returned the cached value before ever reaching
+    the /api/ps cap, because `.local` hostnames failed is_local_endpoint()
+    and skipped _reconcile_local_cached_context_length(). Seeding the stale
+    value first is the point -- the fresh-cache path never exposes this.
+    """
+
+    MDNS_URL = "http://ollama-box.local:11434/v1"
+
+    def test_stale_gguf_cache_reconciles_to_served_value(self, tmp_path):
+        import agent.model_metadata as mm
+
+        cache_file = tmp_path / "cache.yaml"
+        with (
+            patch(
+                "agent.model_metadata._get_context_cache_path",
+                return_value=cache_file,
+            ),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._query_local_context_length",
+                return_value=198656,
+            ),
+        ):
+            mm.save_context_length("gpt-oss:20b", self.MDNS_URL, 262144)
+            result = mm.get_model_context_length(
+                "gpt-oss:20b", base_url=self.MDNS_URL
+            )
+            assert result == 198656
+            assert (
+                mm.get_cached_context_length("gpt-oss:20b", self.MDNS_URL)
+                == 198656
+            )
+
+    def test_subminimum_live_window_invalidates_stale_entry(self, tmp_path):
+        """A live sub-64K window drops the stale row instead of blessing it."""
+        import agent.model_metadata as mm
+
+        cache_file = tmp_path / "cache.yaml"
+        with (
+            patch(
+                "agent.model_metadata._get_context_cache_path",
+                return_value=cache_file,
+            ),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._query_local_context_length",
+                return_value=32768,
+            ),
+        ):
+            mm.save_context_length("gpt-oss:20b", self.MDNS_URL, 262144)
+            result = mm.get_model_context_length(
+                "gpt-oss:20b", base_url=self.MDNS_URL
+            )
+            assert result == 32768
+            assert (
+                mm.get_cached_context_length("gpt-oss:20b", self.MDNS_URL)
+                is None
+            )


### PR DESCRIPTION
## What does this PR do?

Makes Ollama context resolution consult `/api/ps` — what a model is **actually loaded at** — instead of trusting `/api/show` alone.

`/api/show` reports the GGUF training maximum, and it structurally cannot see `OLLAMA_CONTEXT_LENGTH`: that is a server environment variable, so it appears in neither `model_info` nor `parameters`. When a server is started with a smaller window than the weights support, every derived context length overstates the real limit.

The resulting failure is hard to read from the outside. Exceeding the served window returns `finish_reason="length"` **on the first token**, which the agent loop classifies as output truncation and "recovers" from by appending a continuation message — making the prompt longer on each retry — while the UI reports a small fraction of the advertised context in use. Reproduced with a model advertising 131072 served at 32768: a 32057-token request had 711 tokens of headroom while the meter showed 24% used, then failed with `Response remained truncated after 4 continuation attempts`.

### This also un-blinds an existing guard

`_ollama_context_limit_error()` in `agent/conversation_loop.py` already exists to catch exactly this class of misconfiguration — it compares `agent._ollama_num_ctx` against `MINIMUM_CONTEXT_LENGTH` and emits a clear remediation message.

But `_ollama_num_ctx` is populated from `query_ollama_num_ctx()`, which returns the GGUF max whenever no Modelfile `num_ctx` is set. So the guard has been passing regardless of the real window, including in the plain `OLLAMA_CONTEXT_LENGTH` case. This PR is what lets that check see a true value.

### Why this approach

`/api/ps` is the only endpoint that reports the loaded runtime context. `_cap_ctx_by_served()` **only ever lowers** — if `/api/ps` somehow exceeded the GGUF max, the max still wins, since that is the hard ceiling the weights were trained for.

This mirrors a rule already applied a few lines below in the same function: the lm-studio branch of `_query_local_context_length_uncached` prefers `loaded_instances[].config.context_length` with the comment *"Prefer loaded instance context (actual runtime value)"*. Ollama now follows the same convention.

**Known limit, deliberate:** `/api/ps` lists only loaded models, so a cold probe still records the advertised max. That is the conservative fallback — the served context is genuinely unknowable until something loads it, and when the value matters (an in-flight conversation) the model is loaded by definition. Covered by a test.

## Related Issue

Not a `Fixes` — these are adjacent, and I did not want to auto-close either:

- **#43900** (open) — same user-visible symptom (`finish_reason="length"`, garbled retry concatenation, UI showing `0 / 131.1K`), but a different mechanism: that report is about `num_ctx` never being *sent* to `/v1/chat/completions`, so Ollama uses its 4096 default. This PR fixes the *observation* side rather than the request side. It does improve that scenario — a model loaded at 4096 now resolves as 4096, which makes `_ollama_context_limit_error()` fire with actionable text instead of the truncation loop — but the root cause described there is separate and still stands.
- **#63122** (closed, completed) — established this exact premise, naming `OLLAMA_CONTEXT_LENGTH`, and fixed the compression feasibility check to stop trusting advertised context. This PR generalises that accepted principle to the shared metadata resolver every other caller reads.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`
  - `_query_ollama_served_ctx()` — new; reads `/api/ps`, matches on `name` or `model`, ignores values `< 1024`, swallows connection errors. Memoized in the **30s** in-memory probe cache only, never the 300s disk cache, since it tracks live server state.
  - `_cap_ctx_by_served()` — new; clamps an `/api/show` value to the served one, lowering only.
  - Applied at **three** call sites. Patching only the first two leaves the resolved value unchanged, because `get_model_context_length()` reaches the third:
    - `query_ollama_num_ctx`
    - `_query_ollama_api_show`
    - `_query_local_context_length_uncached` ← what `get_model_context_length()` actually uses
- `tests/agent/test_model_metadata_served_ctx.py` — new; 10 cases.

Caps are applied **after** cache reads and never before cache writes, so a clamp cannot outlive a server restart at a different setting.

## How to Test

Reproduce, with any model whose GGUF max exceeds the served window:

```bash
OLLAMA_CONTEXT_LENGTH=32768 ollama serve          # model advertises e.g. 131072
curl -s localhost:11434/api/ps | jq '.models[] | {name, context_length}'
#   { "name": "gpt-oss:20b", "context_length": 32768 }   <- truth
curl -s localhost:11434/api/show -d '{"name":"gpt-oss:20b"}' | jq '.model_info | with_entries(select(.key|test("context_length")))'
#   { "gptoss.context_length": 131072 }                  <- what Hermes used to believe
```

Before this PR `get_model_context_length()` returns 131072; after, 65536/32768 — whatever `/api/ps` reports — provided the model is loaded.

```python
from agent.model_metadata import get_model_context_length
get_model_context_length("gpt-oss:20b", base_url="http://127.0.0.1:11434/v1", api_key="ollama")
```

Verified live on the affected setup: all three probe entry points returned the served `65536` after the change, `131072` before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched issues and PRs, all states, for `OLLAMA_CONTEXT_LENGTH`, `api/ps`, `served context`, `num_ctx context window` — found the two issues above, no PR)
- [x] My PR contains **only** changes related to this fix
- [ ] ~~I've run `pytest tests/ -q` and all tests pass~~ — **see note below, deliberately not ticked**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (kernel 7.1.5), Python 3.11.15, Ollama 0.32.5

**On the test checkbox — being precise rather than ticking it:**

Suites I ran, against this branch:

| Suite | Result |
|---|---|
| `test_model_metadata.py`, `_local_ctx`, `_ssl`, `_served_ctx` | **92 passed** |
| `test_run_agent.py -k "ollama or context"` | **10 passed** |

I did **not** get a clean full-suite result. `tests/agent` contains `test_compression_concurrent_fork.py::test_fence_cancelled_compression_leaves_lock_reacquirable`, which fails on my machine — but it fails identically with this branch's changes stashed, on a pristine tree, so it is pre-existing and unrelated. It is a timing test with a 5s `Event.wait`, and this box was under heavy load. I'd rather flag that than tick a box I can't stand behind; CI will give a cleaner signal than my hardware.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new functions explain the mechanism and the deliberate cold-probe limitation) — no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure `httpx` + stdlib, no shell-outs or path handling; behaviour is identical on macOS/Windows/WSL2, and degrades to today's behaviour wherever `/api/ps` is unavailable
- [x] N/A — no tool behaviour, descriptions, or schemas changed
