### PR TITLE
feat(state): persist stable conversation identity

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3314,6 +3314,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "api_server",
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
+            model_config={"_branched_from": source_id},
             parent_session_id=source_id,
         )
         messages = await asyncio.to_thread(db.get_messages, source_id)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3309,12 +3309,25 @@ class APIServerAdapter(BasePlatformAdapter):
         # SessionDB's native parent_session_id/end_reason visibility model rather
         # than inventing a parallel fork store.
         await asyncio.to_thread(db.end_session, source_id, "branched")
+
+        source_model_config = source.get("model_config")
+        if isinstance(source_model_config, str):
+            try:
+                source_model_config = json.loads(source_model_config)
+            except (TypeError, ValueError):
+                source_model_config = {}
+        if not isinstance(source_model_config, dict):
+            source_model_config = {}
+
+        fork_model_config = dict(source_model_config)
+        fork_model_config["_branched_from"] = source_id
+
         await asyncio.to_thread(db.create_session,
             fork_id,
             "api_server",
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
-            model_config={"_branched_from": source_id},
+            model_config=fork_model_config,
             parent_session_id=source_id,
         )
         messages = await asyncio.to_thread(db.get_messages, source_id)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3173,14 +3173,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 import time as _time
                 conn.execute(
                     """INSERT INTO sessions (
-                       id, source, model, model_config, system_prompt, started_at
-                    ) VALUES (?, ?, ?, ?, ?, ?)""",
+                       id, source, model, model_config, system_prompt,
+                       conversation_id, started_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         source,
                         model_name,
                         json.dumps(model_config) if model_config else None,
                         system_prompt,
+                        session_id,
                         _time.time(),
                     ),
                 )

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -881,13 +881,14 @@ def _reconstruct_missing_sessions(
 
         cursor = destination.execute(
             "INSERT INTO sessions "
-            "(id, source, started_at, title, message_count) "
-            "VALUES (?, 'recovered', ?, ?, ?)",
+            "(id, source, started_at, title, message_count, conversation_id) "
+            "VALUES (?, 'recovered', ?, ?, ?, ?)",
             (
                 session_id,
                 started_at,
                 title,
                 int(message_count),
+                session_id,
             ),
         )
         if cursor.rowcount != 1:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2787,13 +2787,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         without a recoverable routing mapping (#59527).
         """
         def _do(conn):
+            conversation_id = session_id
+
+            if parent_session_id:
+                parent = conn.execute(
+                    """SELECT id, conversation_id, end_reason
+                       FROM sessions
+                       WHERE id = ?""",
+                    (parent_session_id,),
+                ).fetchone()
+
+                config = model_config if isinstance(model_config, dict) else {}
+
+                is_compression_continuation = (
+                    parent is not None
+                    and parent["end_reason"] == "compression"
+                    and config.get("_branched_from") is None
+                    and config.get("_delegate_from") is None
+                    and source != "tool"
+                )
+
+                if is_compression_continuation:
+                    conversation_id = (
+                        parent["conversation_id"] or parent["id"]
+                    )
+
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd,
-                   profile_name, git_repo_root, started_at
+                   model, model_config, system_prompt, parent_session_id,
+                   conversation_id, cwd, profile_name, git_repo_root, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -2803,6 +2828,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
                        thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
+                       conversation_id = COALESCE(sessions.conversation_id, excluded.conversation_id),
                        cwd = COALESCE(sessions.cwd, excluded.cwd),
                        profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
                        git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
@@ -2818,6 +2844,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
+                    conversation_id,
                     cwd,
                     profile_name,
                     git_repo_root,
@@ -3303,9 +3330,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"Compression lease lost before publication: {parent_session_id}"
                 )
             parent = conn.execute(
-                """SELECT ended_at, cwd, git_branch, git_repo_root,
-                          user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
+                """SELECT ended_at, conversation_id, cwd, git_branch,
+                          git_repo_root, user_id, session_key, chat_id,
+                          chat_type, thread_id, display_name, origin_json,
+                          profile_name
                    FROM sessions WHERE id = ?""",
                 (parent_session_id,),
             ).fetchone()
@@ -3319,10 +3347,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, model, model_config, system_prompt,
-                   parent_session_id, cwd, git_branch, git_repo_root,
-                   profile_name, user_id, session_key, chat_id, chat_type,
-                   thread_id, display_name, origin_json, started_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   parent_session_id, conversation_id, cwd, git_branch,
+                   git_repo_root, profile_name, user_id, session_key,
+                   chat_id, chat_type, thread_id, display_name,
+                   origin_json, started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     child_session_id,
                     source,
@@ -3330,6 +3359,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
+                    parent["conversation_id"] or parent_session_id,
                     cwd or parent["cwd"],
                     parent["git_branch"],
                     parent["git_repo_root"],

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -102,7 +102,7 @@ def _ephemeral_child_sql(alias: str = "s") -> str:
     )
 
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     model_config TEXT,
     system_prompt TEXT,
     parent_session_id TEXT,
+    conversation_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
     end_reason TEXT,

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -443,6 +443,9 @@ class SessionPortabilityMixin:
                 clean_session["parent_session_id"] = self._import_text_or_none(
                     clean_session.get("parent_session_id"), "parent_session_id"
                 )
+                clean_session["conversation_id"] = self._import_text_or_none(
+                    clean_session.get("conversation_id"), "conversation_id"
+                )
                 for field in session_text_fields:
                     clean_session[field] = self._import_text_or_none(
                         clean_session.get(field), field
@@ -518,7 +521,8 @@ class SessionPortabilityMixin:
                 conn.execute(
                     """INSERT INTO sessions (
                            id, source, user_id, model, model_config, system_prompt,
-                           parent_session_id, started_at, ended_at, end_reason,
+                           parent_session_id, conversation_id, started_at,
+                           ended_at, end_reason,
                            message_count, tool_call_count, input_tokens, output_tokens,
                            cache_read_tokens, cache_write_tokens, reasoning_tokens,
                            cwd, git_branch, git_repo_root,
@@ -528,8 +532,9 @@ class SessionPortabilityMixin:
                        )
                        VALUES (
                            :id, :source, :user_id, :model, :model_config,
-                           :system_prompt, NULL, :started_at, :ended_at,
-                           :end_reason, 0, 0, :input_tokens, :output_tokens,
+                           :system_prompt, NULL, :conversation_id,
+                           :started_at, :ended_at, :end_reason, 0, 0,
+                           :input_tokens, :output_tokens,
                            :cache_read_tokens, :cache_write_tokens,
                            :reasoning_tokens, :cwd, :git_branch, :git_repo_root,
                            :billing_provider, :billing_base_url, :billing_mode,
@@ -544,6 +549,7 @@ class SessionPortabilityMixin:
                         "model": raw.get("model"),
                         "model_config": raw.get("model_config"),
                         "system_prompt": raw.get("system_prompt"),
+                        "conversation_id": raw.get("conversation_id"),
                         "started_at": started_at,
                         "ended_at": self._float_or_none(raw.get("ended_at")),
                         "end_reason": raw.get("end_reason"),
@@ -642,6 +648,11 @@ class SessionPortabilityMixin:
                     # of a malformed imported lineage.
                     parent_by_child.pop(session_id, None)
                     detached += 1
+
+            # Legacy exports do not carry conversation_id. Run the same
+            # conservative classifier only after valid parent links have
+            # been restored. Explicit imported identities remain immutable.
+            self._backfill_conversation_ids(conn)
 
             return {
                 "ok": True,

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -410,6 +410,137 @@ class SessionSchemaMixin:
         finally:
             cursor.execute("PRAGMA foreign_keys=ON")
 
+    def _backfill_conversation_ids(
+        self,
+        cursor: sqlite3.Cursor,
+    ) -> None:
+        """Persist stable logical identities for historical session rows.
+
+        Only unambiguous compression continuations inherit an ancestor's
+        identity. Branches, delegates, tool sessions, missing parents,
+        ambiguous relations, and cycles retain their own physical session ID.
+
+        Existing non-NULL identities are immutable and are never replaced.
+        """
+        raw_rows = cursor.execute(
+            """SELECT id, source, parent_session_id, end_reason,
+                      model_config, conversation_id
+               FROM sessions"""
+        ).fetchall()
+
+        def _value(row, index, name):
+            if isinstance(row, sqlite3.Row):
+                return row[name]
+            return row[index]
+
+        sessions = {
+            _value(row, 0, "id"): {
+                "id": _value(row, 0, "id"),
+                "source": _value(row, 1, "source"),
+                "parent_session_id": _value(
+                    row,
+                    2,
+                    "parent_session_id",
+                ),
+                "end_reason": _value(row, 3, "end_reason"),
+                "model_config": _value(row, 4, "model_config"),
+                "conversation_id": _value(
+                    row,
+                    5,
+                    "conversation_id",
+                ),
+            }
+            for row in raw_rows
+        }
+
+        def _parse_config(value):
+            if not value:
+                return {}
+
+            if isinstance(value, dict):
+                return value
+
+            try:
+                parsed = json.loads(value)
+            except (TypeError, ValueError):
+                return {}
+
+            return parsed if isinstance(parsed, dict) else {}
+
+        def _resolve(session_id):
+            original_id = session_id
+            current_id = session_id
+            visited = set()
+
+            while True:
+                if current_id in visited:
+                    return original_id
+
+                visited.add(current_id)
+                child = sessions.get(current_id)
+
+                if child is None:
+                    return original_id
+
+                if (
+                    current_id != original_id
+                    and child["conversation_id"] is not None
+                ):
+                    return child["conversation_id"]
+
+                parent_id = child["parent_session_id"]
+
+                if not parent_id:
+                    return (
+                        child["conversation_id"]
+                        if child["conversation_id"] is not None
+                        else current_id
+                    )
+
+                parent = sessions.get(parent_id)
+
+                if parent is None:
+                    return (
+                        child["conversation_id"]
+                        if child["conversation_id"] is not None
+                        else current_id
+                    )
+
+                config = _parse_config(child["model_config"])
+
+                is_compression_continuation = (
+                    parent["end_reason"] == "compression"
+                    and config.get("_branched_from") is None
+                    and config.get("_delegate_from") is None
+                    and child["source"] != "tool"
+                )
+
+                if not is_compression_continuation:
+                    return (
+                        child["conversation_id"]
+                        if child["conversation_id"] is not None
+                        else current_id
+                    )
+
+                if parent["conversation_id"] is not None:
+                    return parent["conversation_id"]
+
+                current_id = parent_id
+
+        assignments = [
+            (_resolve(session_id), session_id)
+            for session_id, row in sessions.items()
+            if row["conversation_id"] is None
+        ]
+
+        cursor.executemany(
+            """UPDATE sessions
+               SET conversation_id = ?
+               WHERE id = ?
+                 AND conversation_id IS NULL""",
+            assignments,
+        )
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.
 
@@ -724,6 +855,12 @@ class SessionSchemaMixin:
                 if fts5_available and self._db_has_legacy_inline_fts(cursor):
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
+            if current_version < 24:
+                # v24: persist a stable logical conversation identity.
+                # Column creation is handled declaratively above; this
+                # versioned migration classifies existing rows conservatively.
+                self._backfill_conversation_ids(cursor)
+
             # The FTS storage layout is versioned independently of the main
             # schema (see the v23 note above). Stamp the current layout so the
             # main version can always advance: a fresh/optimized DB is at
@@ -762,6 +899,19 @@ class SessionSchemaMixin:
                     "UPDATE schema_version SET version = ?",
                     (SCHEMA_VERSION,),
                 )
+
+        # conversation_id is reconciled and historically backfilled above,
+        # so creating its index here avoids indexing every migration update.
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_id "
+                "ON sessions(conversation_id)"
+            )
+        except sqlite3.OperationalError as exc:
+            logger.debug(
+                "idx_sessions_conversation_id create skipped: %s",
+                exc,
+            )
 
         # Unique title index — always ensure it exists. Older databases may
         # contain duplicate aliases from before the constraint was enforced;

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -203,6 +203,10 @@ async def test_session_fork_persists_stable_branch_provenance(adapter, session_d
         "fork-provenance-source",
         "api_server",
         model="test-model",
+        model_config={
+            "max_iterations": 17,
+            "reasoning_config": {"effort": "high"},
+        },
     )
     session_db.append_message(source_id, "user", "Explore the first path")
     session_db.append_message(source_id, "assistant", "Initial answer")
@@ -228,6 +232,8 @@ async def test_session_fork_persists_stable_branch_provenance(adapter, session_d
         model_config = json.loads(model_config)
 
     assert model_config.get("_branched_from") == source_id
+    assert model_config["max_iterations"] == 17
+    assert model_config["reasoning_config"] == {"effort": "high"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -332,6 +332,7 @@ async def test_create_session_respects_browser_source_and_model_lock(adapter, se
     row = session_db.get_session("browser-lock-session")
     assert row["source"] == "hermes_browser"
     assert row["model"] == "x-ai/grok-4.5"
+    assert row["conversation_id"] == "browser-lock-session"
     import json as _json
     model_config = row.get("model_config")
     if isinstance(model_config, str):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -194,6 +194,42 @@ async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter
     assert any(m.get("tool_calls") for m in messages)
 
 
+@pytest.mark.asyncio
+async def test_session_fork_persists_stable_branch_provenance(adapter, session_db):
+    """API forks must retain the same durable branch marker as CLI /branch."""
+    import json
+
+    source_id = session_db.create_session(
+        "fork-provenance-source",
+        "api_server",
+        model="test-model",
+    )
+    session_db.append_message(source_id, "user", "Explore the first path")
+    session_db.append_message(source_id, "assistant", "Initial answer")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "fork-provenance-child",
+                "title": "Alternative path",
+            },
+        )
+        assert resp.status == 201, await resp.text()
+        payload = await resp.json()
+
+    fork_id = payload["session"]["id"]
+    row = session_db.get_session(fork_id)
+    assert row is not None
+
+    model_config = row.get("model_config") or {}
+    if isinstance(model_config, str):
+        model_config = json.loads(model_config)
+
+    assert model_config.get("_branched_from") == source_id
+
+
 # ---------------------------------------------------------------------------
 # Session-persisted model threading + provider-auth failure surfacing
 # (salvaged from PR #57947 by @FvanW and PR #59941 by @kaishi00)

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -449,7 +449,8 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
 
     with sqlite3.connect(str(output)) as verify:
         recovered_sessions = verify.execute(
-            "SELECT id, source, title, message_count FROM sessions ORDER BY id"
+            "SELECT id, source, title, message_count, conversation_id "
+            "FROM sessions ORDER BY id"
         ).fetchall()
         messages = verify.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
     assert messages == 120, f"expected all 120 messages retained, got {messages}"
@@ -458,6 +459,11 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
     # Fabricated sessions must be identifiable and carry collision-safe titles.
     assert {row[0] for row in recovered_sessions} == set(messages_per_session)
     assert {row[1] for row in recovered_sessions} == {"recovered"}
+    assert {
+        str(row[0]): row[4] for row in recovered_sessions
+    } == {
+        session_id: session_id for session_id in messages_per_session
+    }
     recovered_titles = [str(row[2]) for row in recovered_sessions]
     assert all(title.startswith("[recovered ") for title in recovered_titles)
     assert len(set(recovered_titles)) == len(recovered_titles)

--- a/tests/hermes_state/test_conversation_id.py
+++ b/tests/hermes_state/test_conversation_id.py
@@ -1,0 +1,464 @@
+"""Regression tests for persisted logical conversation identity."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_SQL, SCHEMA_VERSION
+
+
+def test_standalone_session_uses_its_own_id(tmp_path):
+    db = SessionDB(tmp_path / "standalone.db")
+    try:
+        db.create_session("standalone", source="cli")
+
+        row = db.get_session("standalone")
+        assert row is not None
+        assert row["conversation_id"] == "standalone"
+    finally:
+        db.close()
+
+
+def test_compression_continuation_inherits_parent_identity(tmp_path):
+    db = SessionDB(tmp_path / "compression.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+
+        db.create_session(
+            "tip",
+            source="cli",
+            parent_session_id="root",
+        )
+
+        assert db.get_session("root")["conversation_id"] == "root"
+        assert db.get_session("tip")["conversation_id"] == "root"
+    finally:
+        db.close()
+
+
+def test_branch_and_delegate_children_keep_their_own_identity(tmp_path):
+    db = SessionDB(tmp_path / "isolated-children.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+        db.create_session(
+            "delegate",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+
+        assert db.get_session("branch")["conversation_id"] == "branch"
+        assert db.get_session("delegate")["conversation_id"] == "delegate"
+    finally:
+        db.close()
+
+
+def test_tool_child_keeps_its_own_identity(tmp_path):
+    db = SessionDB(tmp_path / "tool-child.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+
+        db.create_session(
+            "tool-child",
+            source="tool",
+            parent_session_id="root",
+        )
+
+        assert db.get_session("tool-child")["conversation_id"] == "tool-child"
+    finally:
+        db.close()
+
+
+class _NoFtsExistingTableCursor(sqlite3.Cursor):
+    """Simulate an existing FTS database opened without FTS5 support."""
+
+    def execute(self, sql, parameters=()):
+        probe = sql.strip()
+        if "USING fts5" in probe:
+            raise sqlite3.OperationalError("no such module: fts5")
+        if probe in (
+            "SELECT * FROM messages_fts LIMIT 0",
+            "SELECT * FROM messages_fts_trigram LIMIT 0",
+        ):
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().execute(sql, parameters)
+
+    def executescript(self, sql_script):
+        if "USING fts5" in sql_script:
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().executescript(sql_script)
+
+
+class _NoFtsExistingTableConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(
+            factory or _NoFtsExistingTableCursor
+        )
+
+
+def _create_v23_database(db_path):
+    legacy_schema = SCHEMA_SQL.replace(
+        "    conversation_id TEXT,\n",
+        "",
+        1,
+    )
+    if legacy_schema == SCHEMA_SQL:
+        raise AssertionError(
+            "conversation_id was not removed from the legacy schema"
+        )
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript(legacy_schema)
+    conn.execute(
+        "INSERT INTO schema_version (version) VALUES (23)"
+    )
+    return conn
+
+
+def _insert_legacy_session(
+    conn,
+    session_id,
+    *,
+    source="cli",
+    parent_session_id=None,
+    end_reason=None,
+    model_config=None,
+):
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id,
+            source,
+            parent_session_id,
+            end_reason,
+            model_config,
+            started_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            source,
+            parent_session_id,
+            end_reason,
+            (
+                json.dumps(model_config)
+                if model_config is not None
+                else None
+            ),
+            1.0,
+        ),
+    )
+
+
+def test_v23_migration_backfills_conservative_conversation_ids(
+    tmp_path,
+):
+    db_path = tmp_path / "legacy-v23.db"
+    conn = _create_v23_database(db_path)
+
+    _insert_legacy_session(conn, "standalone")
+
+    _insert_legacy_session(
+        conn,
+        "root",
+        end_reason="compression",
+    )
+    _insert_legacy_session(
+        conn,
+        "mid",
+        parent_session_id="root",
+        end_reason="compression",
+    )
+    _insert_legacy_session(
+        conn,
+        "tip",
+        parent_session_id="mid",
+    )
+
+    _insert_legacy_session(
+        conn,
+        "branch",
+        parent_session_id="root",
+        model_config={"_branched_from": "root"},
+    )
+    _insert_legacy_session(
+        conn,
+        "delegate",
+        parent_session_id="root",
+        model_config={"_delegate_from": "root"},
+    )
+    _insert_legacy_session(
+        conn,
+        "tool-child",
+        source="tool",
+        parent_session_id="root",
+    )
+
+    _insert_legacy_session(
+        conn,
+        "ambiguous-parent",
+        end_reason="done",
+    )
+    _insert_legacy_session(
+        conn,
+        "ambiguous-child",
+        parent_session_id="ambiguous-parent",
+    )
+
+    _insert_legacy_session(
+        conn,
+        "orphan",
+        parent_session_id="missing-parent",
+    )
+
+    _insert_legacy_session(
+        conn,
+        "cycle-a",
+        parent_session_id="cycle-b",
+        end_reason="compression",
+    )
+    _insert_legacy_session(
+        conn,
+        "cycle-b",
+        parent_session_id="cycle-a",
+        end_reason="compression",
+    )
+
+    conn.commit()
+    conn.close()
+
+    db = SessionDB(db_path)
+    try:
+        expected = {
+            "standalone": "standalone",
+            "root": "root",
+            "mid": "root",
+            "tip": "root",
+            "branch": "branch",
+            "delegate": "delegate",
+            "tool-child": "tool-child",
+            "ambiguous-parent": "ambiguous-parent",
+            "ambiguous-child": "ambiguous-child",
+            "orphan": "orphan",
+            "cycle-a": "cycle-a",
+            "cycle-b": "cycle-b",
+        }
+
+        actual = {
+            session_id: db.get_session(session_id)["conversation_id"]
+            for session_id in expected
+        }
+
+        assert actual == expected
+
+        stored_version = db._conn.execute(
+            "SELECT version FROM schema_version LIMIT 1"
+        ).fetchone()[0]
+        assert stored_version == SCHEMA_VERSION
+
+        index = db._conn.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND name = 'idx_sessions_conversation_id'
+            """
+        ).fetchone()
+        assert index is not None
+    finally:
+        db.close()
+
+    reopened = SessionDB(db_path)
+    try:
+        reopened_values = {
+            session_id: reopened.get_session(session_id)[
+                "conversation_id"
+            ]
+            for session_id in expected
+        }
+        assert reopened_values == expected
+    finally:
+        reopened.close()
+
+
+def test_v23_migration_backfills_without_fts5(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "legacy-v23-no-fts.db"
+    conn = _create_v23_database(db_path)
+
+    _insert_legacy_session(
+        conn,
+        "no-fts-root",
+        end_reason="compression",
+    )
+    _insert_legacy_session(
+        conn,
+        "no-fts-tip",
+        parent_session_id="no-fts-root",
+    )
+
+    conn.commit()
+    conn.close()
+
+    real_connect = sqlite3.connect
+
+    def connect_without_fts(*args, **kwargs):
+        kwargs["factory"] = _NoFtsExistingTableConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(
+        sqlite3,
+        "connect",
+        connect_without_fts,
+    )
+
+    expected = {
+        "no-fts-root": "no-fts-root",
+        "no-fts-tip": "no-fts-root",
+    }
+
+    # Open twice to verify that the degraded-runtime migration is
+    # idempotent even though schema_version deliberately remains at 23.
+    for _ in range(2):
+        db = SessionDB(db_path)
+        try:
+            actual = {
+                session_id: db.get_session(session_id)[
+                    "conversation_id"
+                ]
+                for session_id in expected
+            }
+            assert actual == expected
+
+            stored_version = db._conn.execute(
+                "SELECT version FROM schema_version LIMIT 1"
+            ).fetchone()[0]
+            assert stored_version == 23
+
+            index = db._conn.execute(
+                """
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'index'
+                  AND name = 'idx_sessions_conversation_id'
+                """
+            ).fetchone()
+            assert index is not None
+        finally:
+            db.close()
+
+
+def test_export_import_preserves_conversation_identity(tmp_path):
+    source = SessionDB(tmp_path / "export-source.db")
+    try:
+        source.create_session("export-root", source="cli")
+        source.end_session("export-root", "compression")
+        source.create_session(
+            "export-tip",
+            source="cli",
+            parent_session_id="export-root",
+        )
+
+        exported = [
+            source.export_session("export-root"),
+            source.export_session("export-tip"),
+        ]
+
+        assert exported[0]["conversation_id"] == "export-root"
+        assert exported[1]["conversation_id"] == "export-root"
+    finally:
+        source.close()
+
+    target = SessionDB(tmp_path / "export-target.db")
+    try:
+        result = target.import_sessions(exported)
+
+        assert result["ok"] is True
+        assert result["imported"] == 2
+        assert target.get_session("export-root")[
+            "conversation_id"
+        ] == "export-root"
+        assert target.get_session("export-tip")[
+            "conversation_id"
+        ] == "export-root"
+    finally:
+        target.close()
+
+
+def test_legacy_import_backfills_identity_after_parent_restoration(
+    tmp_path,
+):
+    target = SessionDB(tmp_path / "legacy-import.db")
+    try:
+        result = target.import_sessions(
+            [
+                {
+                    "id": "legacy-root",
+                    "source": "cli",
+                    "end_reason": "compression",
+                    "messages": [],
+                },
+                {
+                    "id": "legacy-tip",
+                    "source": "cli",
+                    "parent_session_id": "legacy-root",
+                    "messages": [],
+                },
+            ]
+        )
+
+        assert result["ok"] is True
+        assert result["imported"] == 2
+        assert target.get_session("legacy-root")[
+            "conversation_id"
+        ] == "legacy-root"
+        assert target.get_session("legacy-tip")[
+            "conversation_id"
+        ] == "legacy-root"
+    finally:
+        target.close()
+
+
+def test_existing_conversation_identity_is_immutable_on_upsert(
+    tmp_path,
+):
+    db = SessionDB(tmp_path / "immutable-upsert.db")
+    try:
+        db.create_session("compression-parent", source="cli")
+        db.end_session("compression-parent", "compression")
+
+        db.create_session("stable-session", source="cli")
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET conversation_id = ? WHERE id = ?",
+                ("preserved-conversation", "stable-session"),
+            )
+        )
+
+        # A later idempotent creation computes a different candidate from the
+        # compression parent, but must not replace the stored logical identity.
+        db.create_session(
+            "stable-session",
+            source="cli",
+            parent_session_id="compression-parent",
+        )
+
+        row = db.get_session("stable-session")
+        assert row["conversation_id"] == "preserved-conversation"
+    finally:
+        db.close()

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -162,3 +162,33 @@ def test_compression_lease_blocks_non_owner_but_allows_owner_flush(
         compression_lock_holder="winner",
     )
     assert [m["content"] for m in db.get_messages("leased")] == ["winner flush"]
+
+
+def test_publish_compression_child_inherits_stable_conversation_identity(
+    db: SessionDB,
+) -> None:
+    db.create_session("conversation-root", source="webui")
+    db.end_session("conversation-root", "compression")
+
+    db.create_session(
+        "current-parent",
+        source="webui",
+        parent_session_id="conversation-root",
+    )
+
+    parent = db.get_session("current-parent")
+    assert parent is not None
+    assert parent["conversation_id"] == "conversation-root"
+
+    db.publish_compression_child(
+        parent_session_id="current-parent",
+        child_session_id="next-tip",
+        source="webui",
+        messages=[{"role": "user", "content": "compressed summary"}],
+        require_compression_lease=False,
+    )
+
+    child = db.get_session("next-tip")
+    assert child is not None
+    assert child["parent_session_id"] == "current-parent"
+    assert child["conversation_id"] == "conversation-root"


### PR DESCRIPTION
## Summary

Persist a canonical `conversation_id` on session rows so one logical user
conversation keeps a stable identity across physical compression rotations.

This separates:

- `session_id`: physical session or transcript segment
- `conversation_id`: stable logical conversation identity

## Dependency

This PR is stacked on and depends on:

- #76220 — `fix(api): persist branch provenance for forked sessions`

The dependency is required so API-created forks carry durable
`_branched_from` provenance and can remain isolated from compression
continuations.

Please do not merge this PR before #76220.

## Behavior

New sessions use their own session ID as their initial conversation identity.

A child inherits its parent's persisted identity only for a certain
compression continuation:

- the parent exists;
- the parent ended with `end_reason="compression"`;
- the child is not marked with `_branched_from`;
- the child is not marked with `_delegate_from`;
- the child is not a `source="tool"` session.

Branches, forks, delegates, tool sessions and ambiguous historical
relationships keep their own identity.

Existing non-NULL identities remain immutable during idempotent session
upserts.

## Schema and migration

- Adds nullable `sessions.conversation_id TEXT`
- Advances `SCHEMA_VERSION` to 24
- Adds `idx_sessions_conversation_id` after column reconciliation and backfill
- Performs a conservative, idempotent historical backfill
- Preserves existing non-NULL identities
- Handles missing parents and cycles defensively
- Keeps the migration operational when FTS5 is unavailable

Under the existing degraded-runtime policy, the data migration and index still
complete without FTS5 while `schema_version` remains at 23.

## Covered write paths

The implementation covers all durable direct session insertions:

- generic session creation and upsert
- atomic compression publication
- session import/export
- direct API session creation
- recovery placeholder reconstruction

The FTS write-health probe remains excluded because its transaction is always
rolled back and creates no durable session.

## Validation

Executed:

- `tests/test_hermes_state.py`
- `tests/hermes_state/test_conversation_id.py`
- `tests/state/test_compression_lineage_guard.py`
- `tests/gateway/test_session_api.py`
- `tests/hermes_cli/test_session_recovery.py`

Result:

    173 passed in 21.90s

Additional checks:

    Ruff: all checks passed
    git diff --check: passed
    git diff --cached --check: passed

## Commit lineage

Dependency commit:

    56ea2eb6594fe9a7844be2bd736a083f3ee6ec08

PR implementation commit:

    463b7fb81b3063ce7cd7be4a47970458252e633e
