### PR TITLE
fix(update): guard the auto-branch-switch against the live checkout under pytest

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3746,6 +3746,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # the same thing — get HEAD onto the requested branch first, then
         # fast-forward.
         if current_branch != branch:
+            # Never mutate the real HEAD when running under pytest against the
+            # live checkout. The branch-switch below runs `git checkout` (and a
+            # `checkout -B <branch> origin/<branch>` fallback) against the live
+            # PROJECT_ROOT; in a detached-HEAD test checkout current_branch is
+            # always "HEAD" != branch, so without this guard a stray test that
+            # reaches _cmd_update_impl recreates local `main` and moves HEAD —
+            # hijacking the gate worktree. Same posture as the guarded
+            # marker-write path (_write_marker_file) at PROJECT_ROOT.
+            if _m()._pytest_owns_live_checkout(_m().PROJECT_ROOT):
+                logger.debug(
+                    "Skipping update branch-switch under pytest (live checkout); "
+                    "would have switched %s -> %s",
+                    current_branch,
+                    branch,
+                )
+                return
             label = (
                 "detached HEAD"
                 if current_branch == "HEAD"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -424,6 +424,18 @@ class TestCmdUpdateBranchFlag:
     target without monkey-patching the implementation.
     """
 
+    @pytest.fixture(autouse=True)
+    def _exercise_branch_switch_against_mocked_git(self):
+        """These tests deliberately exercise the real branch-switch path with a
+        fully-mocked ``subprocess.run`` — no real git runs. The live-checkout
+        guard (added for the live-HEAD-hijack fix) would otherwise short-
+        circuit the switch because PROJECT_ROOT == the running checkout under
+        pytest. Tell the guard this is a controlled exercise, not the live-
+        checkout hazard, so the switch logic under test actually executes.
+        """
+        with patch("hermes_cli.main._pytest_owns_live_checkout", return_value=False):
+            yield
+
     def _branch_side_effect(self, current_branch, target_branch, *, checkout_fails=False, track_fails=False, commit_count="0"):
         """Mock side-effect that knows about checkout/track behavior.
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -103,6 +103,63 @@ def test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol(mon
     assert callable(hermes_constants.apply_subprocess_home_env)
 
 
+# ---------------------------------------------------------------------------
+# Gate-hijack guard: the update branch-switch must NEVER run `git checkout`
+# against the live checkout under pytest (recreates local main + moves HEAD).
+# Root cause: the update branch-switch in _cmd_update_impl
+# ran unguarded against PROJECT_ROOT; in a detached-HEAD test checkout
+# current_branch=="HEAD" != target, so it fired `checkout -B main origin/main`,
+# hijacking the gate worktree. Guard mirrors the marker-write path.
+# ---------------------------------------------------------------------------
+
+def test_update_branch_switch_guarded_under_pytest_live_checkout(monkeypatch, tmp_path, capsys):
+    """When _pytest_owns_live_checkout is True, the branch-switch must skip —
+    NO `git checkout` subprocess may touch the live repo HEAD."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    # Simulate the hazard condition: running under pytest AND PROJECT_ROOT is
+    # the live checkout (guard True). In production the guard's own root-equality
+    # check gates this; here we force it so the test doesn't depend on cwd.
+    monkeypatch.setattr(hermes_main, "_pytest_owns_live_checkout", lambda root: True)
+
+    # current_branch reports detached HEAD ("HEAD"), target defaults to main,
+    # so current_branch != branch and the switch path is entered.
+    side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    # Should return cleanly (early-exit), issuing zero checkout calls.
+    hermes_main.cmd_update(SimpleNamespace())
+
+    checkout_calls = [
+        cmd for cmd in recorded
+        if any("checkout" in str(c) for c in cmd)
+    ]
+    assert checkout_calls == [], (
+        f"branch-switch must not run git checkout under the live-checkout guard; "
+        f"got {checkout_calls}"
+    )
+
+
+def test_update_branch_switch_still_fires_when_not_live_checkout(monkeypatch, tmp_path):
+    """Belt-and-suspenders: the guard must NOT over-block. When PROJECT_ROOT is
+    a sandboxed tmp repo (guard False), the real switch still runs as before —
+    the fix protects the live checkout only, not legitimate sandboxed exercises.
+    """
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_pytest_owns_live_checkout", lambda root: False)
+
+    side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    checkout_calls = [
+        cmd for cmd in recorded
+        if any("checkout" in str(c) for c in cmd)
+    ]
+    assert checkout_calls, "sandboxed (guard-False) run should still perform the branch switch"
+
+
 
 
 

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -135,6 +135,13 @@ def _run_update_until_guard(args):
         return_value=[(101, "python.exe", "python.exe -m hermes_cli.main serve")],
     ), patch.object(
         cli_main, "PROJECT_ROOT", _RootSentinel()
+    ), patch.object(
+        # Hard backstop for the live-HEAD-hijack hazard: the
+        # branch-switch source guard always refuses under this test, so even if
+        # a leaky polluter earlier in the run lets execution slip past the venv
+        # guard and reach the branch-switch, it can never mutate the real repo
+        # HEAD. Keeps this test from being hostage to cross-test isolation.
+        cli_main, "_pytest_owns_live_checkout", return_value=True
     ):
         try:
             cli_main._cmd_update_impl(args, gateway_mode=False)


### PR DESCRIPTION
## Summary

`hermes update`'s auto-branch-switch in `_cmd_update_impl` (`hermes_cli/update_cmd.py`) runs `git checkout` against the live project checkout with no pytest guard. The sibling marker-write path (`_write_marker_file`) already guards its live-tree mutation with `_pytest_owns_live_checkout(...)` (`hermes_cli/_early_recovery.py`); the branch-switch did not. This PR closes that gap.

Fixes #76271.

## The bug

On a detached-HEAD test checkout `current_branch == "HEAD"` is never equal to the update target, so the branch-switch block always runs:

1. `git checkout <branch>` fails (no local branch of that name).
2. The fallback `git checkout -B <branch> origin/<branch>` recreates the local branch and moves HEAD onto it.

Any test that reaches `_cmd_update_impl` against the real `PROJECT_ROOT` (through a leaked `subprocess.run` mock, or a `PROJECT_ROOT` monkeypatch an earlier test left un-torn-down) therefore hijacks the live checkout, and every test that runs afterward executes against the wrong tree.

This is a gap between a stated invariant and the code: every other live-mutation path in the update command already consults `_pytest_owns_live_checkout(...)` before touching the real tree. The branch-switch is the one path that skipped it.

## The fix

Wrap the branch-switch in the existing guard, matching the marker-write path exactly:

```python
if current_branch != branch:
    if _m()._pytest_owns_live_checkout(_m().PROJECT_ROOT):
        logger.debug(
            "Skipping update branch-switch under pytest (live checkout); "
            "would have switched %s -> %s", current_branch, branch,
        )
        return
    # ... existing checkout logic ...
```

The guard's root-equality check (`root == Path(__file__).resolve().parent.parent`) means tests that sandbox `PROJECT_ROOT` to a tmp dir are unaffected and still exercise the switch normally, so the fix does not over-block legitimate coverage.

The block has a third `git checkout` (the "switch back to your original branch" restore, gated by `if current_branch not in {branch, "HEAD"}`). It is covered by construction: reaching it requires `current_branch != branch`, which is exactly the condition under which the new early-return fires when the guard is True. When the guard is False the run is sandboxed to a tmp `PROJECT_ROOT`, so that checkout is harmless.

## Tests

- `test_update_autostash`: red-green pair. The branch-switch issues zero `git checkout` calls and early-returns when the guard is True, and still fires when the guard is False (sandboxed run), proving the guard does not over-block. The guard-True test fails without the source fix.
- `test_update_venv_health`: a guard-True backstop makes the victim test polluter-immune regardless of run order.
- `test_cmd_update` (`TestCmdUpdateBranchFlag`): the class legitimately exercises the switch against fully-mocked git, so a class fixture sets the guard False (a controlled exercise, not the live-checkout hazard).

## Reproduce (before the fix)

```bash
git rev-parse HEAD > /tmp/head_before
python -m pytest tests/hermes_cli/ -q
git rev-parse HEAD > /tmp/head_after
diff /tmp/head_before /tmp/head_after   # non-empty => HEAD moved during the suite
```
