### PR TITLE
fix(mcp-catalog): pin blender-mcp to 1.6.5 (mcp 2.0 FastMCP break)

### DIFF
--- a/optional-mcps/blender/manifest.yaml
+++ b/optional-mcps/blender/manifest.yaml
@@ -22,11 +22,14 @@ transport:
   command: "uvx"
   # Pinned per catalog dependency policy: exact version, and the release must
   # be at least 2 weeks old at pin time (supply-chain cooldown — same rule as
-  # pyproject.toml dependencies). 1.6.4 released 2026-06-11. The catalog never
-  # auto-updates; bumping the pin is a PR to this manifest.
+  # pyproject.toml dependencies). 1.6.5 released 2026-07-29 and is intentionally
+  # under the cooldown floor: 1.6.4's open `mcp[cli]>=1.3.0` bound resolves to
+  # mcp 2.0.0 (2026-07-28), which removed `mcp.server.fastmcp` and breaks the
+  # server import. 1.6.5 caps `mcp[cli]<2,>=1.3.0` so uvx stays on the 1.x SDK.
+  # The catalog never auto-updates; bumping the pin is a PR to this manifest.
   args:
-    - "blender-mcp==1.6.4"
-  version: "1.6.4"
+    - "blender-mcp==1.6.5"
+  version: "1.6.5"
   env:
     # Upstream ships anonymous telemetry, on by default. Hermes policy is
     # no outbound telemetry without explicit opt-in, so the catalog entry


### PR DESCRIPTION
## Summary
- Bump the Nous-approved Blender catalog entry from `blender-mcp==1.6.4` → `1.6.5`.
- `1.6.4` depends on `mcp[cli]>=1.3.0` with no upper bound. After `mcp==2.0.0` (2026-07-28), fresh `uvx blender-mcp==1.6.4` installs pull MCP SDK 2.x, which removed `mcp.server.fastmcp`, so the server fails on import (`ModuleNotFoundError: mcp.server.fastmcp`).
- `1.6.5` declares `mcp[cli]<2,>=1.3.0`, so uvx stays on the 1.x SDK (verified: resolves `mcp==1.29.0`, FastMCP imports cleanly).

## Cooldown note
Catalog policy prefers a 2-week pin age. `1.6.5` shipped 2026-07-29 (~3 days before this PR). This is an intentional under-cooldown bump because `1.6.4` is hard-broken on current PyPI resolution, not a routine version chase.

## Test plan
- [x] `uvx --from blender-mcp==1.6.5 python -c 'from mcp.server.fastmcp import FastMCP; import blender_mcp'` → OK, `mcp==1.29.0`
- [x] Confirmed `1.6.4` without a nested pin pulls `mcp==2.0.0` and fails the same import
- [ ] `hermes mcp install blender` / enable existing entry and `hermes mcp test blender` with Blender addon connected (needs local Blender UI)

Does not close #69931 (full Hermes client mcp 2.x migration); this is the catalog server-side pin only.
