### PR TITLE
fix(credential_pool): check copilot suppression before token exchange

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2363,17 +2363,33 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import (
+                COPILOT_ENV_VARS,
+                resolve_copilot_token,
+                get_copilot_api_token,
+            )
+            # All-sources suppression gate BEFORE any work — including the
+            # `gh auth token` subprocess spawn.  resolve_copilot_token()
+            # shells out (~30ms), and the exchange retries 3x with backoff
+            # (~13s worst case); a user who suppressed every copilot source
+            # (hermes auth remove copilot gh_cli) must not pay either on
+            # every pool load (model picker open, /model, agent startup).
+            # Enumerating the full source space here matches what
+            # credential_sources._remove_copilot_gh suppresses, so an
+            # all-suppressed check is stable.
+            copilot_sources = ["gh_cli"] + [f"env:{v}" for v in COPILOT_ENV_VARS]
+            if all(_is_suppressed(provider, s) for s in copilot_sources):
+                return changed, active_sources
             token, source = resolve_copilot_token()
             if token:
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
-                # Suppression gate BEFORE the network exchange.  The
-                # exchange retries 3x with backoff (~13s worst case), so a
-                # source the user already suppressed (hermes auth remove
-                # copilot gh_cli) must not burn that dead time on every pool
-                # load (model picker open, /model, agent startup) just to
-                # have the entry discarded afterwards.  This is the same
-                # early-gate pattern every other singleton branch uses.
+                # Per-source suppression gate (a user may suppress only the
+                # gh CLI path and keep an env var, or vice versa) BEFORE the
+                # network exchange.  The exchange retries 3x with backoff
+                # (~13s worst case), so a source the user already suppressed
+                # must not burn that dead time just to have the entry
+                # discarded afterwards.  Same early-gate pattern every other
+                # singleton branch uses.
                 if _is_suppressed(provider, source_name):
                     return changed, active_sources
                 api_token, enterprise_base_url = get_copilot_api_token(token)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2366,6 +2366,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
+                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
+                # Suppression gate BEFORE the network exchange.  The
+                # exchange retries 3x with backoff (~13s worst case), so a
+                # source the user already suppressed (hermes auth remove
+                # copilot gh_cli) must not burn that dead time on every pool
+                # load (model picker open, /model, agent startup) just to
+                # have the entry discarded afterwards.  This is the same
+                # early-gate pattern every other singleton branch uses.
+                if _is_suppressed(provider, source_name):
+                    return changed, active_sources
                 api_token, enterprise_base_url = get_copilot_api_token(token)
                 # Observability: get_copilot_api_token falls back to returning
                 # the RAW token when the exchange fails. A raw ~40-char token
@@ -2381,27 +2391,25 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "unavailable); enterprise-only models may 400 with "
                         "model_not_available_for_integrator until exchange recovers."
                     )
-                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
-                if not _is_suppressed(provider, source_name):
-                    active_sources.add(source_name)
-                    pconfig = PROVIDER_REGISTRY.get(provider)
-                    # Use enterprise base URL from token exchange if available,
-                    # otherwise fall back to the provider's default.
-                    effective_base_url = enterprise_base_url or (
-                        pconfig.inference_base_url if pconfig else ""
-                    )
-                    changed |= _upsert_entry(
-                        entries,
-                        provider,
-                        source_name,
-                        {
-                            "source": source_name,
-                            "auth_type": AUTH_TYPE_API_KEY,
-                            "access_token": api_token,
-                            "base_url": effective_base_url,
-                            "label": source,
-                        },
-                    )
+                active_sources.add(source_name)
+                pconfig = PROVIDER_REGISTRY.get(provider)
+                # Use enterprise base URL from token exchange if available,
+                # otherwise fall back to the provider's default.
+                effective_base_url = enterprise_base_url or (
+                    pconfig.inference_base_url if pconfig else ""
+                )
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    source_name,
+                    {
+                        "source": source_name,
+                        "auth_type": AUTH_TYPE_API_KEY,
+                        "access_token": api_token,
+                        "base_url": effective_base_url,
+                        "label": source,
+                    },
+                )
         except Exception as exc:
             logger.debug("Copilot token seed failed: %s", exc)
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1352,6 +1352,51 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
     assert entries[0].base_url == "https://api.githubcopilot.com"
 
 
+def test_load_pool_skips_exchange_for_suppressed_copilot(tmp_path, monkeypatch):
+    """A suppressed copilot source must NOT run the token exchange.
+
+    Regression test: the suppression gate used to sit AFTER
+    ``get_copilot_api_token`` (which retries 3x with backoff, ~13s worst
+    case), so every pool load — model picker open, /model, agent startup —
+    burned the full exchange dead time for a source the user had already
+    removed with ``hermes auth remove copilot gh_cli``.  The gate must run
+    BEFORE the network call.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {},
+            "suppressed_sources": {"copilot": ["gh_cli"]},
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_abc123", "gh auth token"),
+    )
+
+    exchange_called = False
+
+    def _boom(token):
+        nonlocal exchange_called
+        exchange_called = True
+        raise AssertionError("exchange must not run for a suppressed source")
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        _boom,
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not exchange_called
+    assert not pool.has_credentials()
+    assert pool.entries() == []
+
+
 
 
 def test_load_pool_seeds_qwen_oauth_via_cli_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

Opening the model picker (Desktop settings → model, TUI `/model`, or `hermes model`) took **~13s** on machines where Copilot is suppressed but a `gh` CLI token exists.

The copilot branch of `_seed_from_singletons` in `agent/credential_pool.py` ran the suppression gate **after** `get_copilot_api_token()`. That call performs the network token exchange with 3 retries and backoff (~13s worst case). A source the user already removed with `hermes auth remove copilot gh_cli` still burned the full exchange dead time on every pool load — model picker open, `/model`, agent startup — only to have the resulting entry discarded by the gate afterwards.

Reproduced with cProfile: `model.options` payload build = **12.87s**, of which 13.0s was `exchange_copilot_token` (4 × `time.sleep` = 9.0s + network timeouts). The user's `gh` token lacks the `copilot` scope, so the exchange always fails — every picker open paid the full retry ladder for a source that was already suppressed in `auth.json`.

## Fix

**commit 1 (`fix`)**: Move the `_is_suppressed()` gate **before** the network exchange, matching the early-gate pattern every other singleton branch (anthropic, qwen-oauth, minimax-oauth, …) already uses. Suppressed copilot sources now skip the exchange entirely.

**commit 2 (`perf`)**: When **all** copilot sources (gh_cli + every env variant) are suppressed, skip even `resolve_copilot_token()` — which shells out to `gh auth token` (~30ms) — so a fully-suppressed user pays neither the subprocess nor the exchange. The all-source enumeration mirrors exactly what `credential_sources._remove_copilot_gh` suppresses, so the check stays stable.

Measured after both commits: payload build **12.87s → ~0.26s** cold; `resolve_copilot_token()` no longer called at all for an all-suppressed user.

This also eliminates the recurring `Copilot token exchange degraded to RAW token` WARNING spam in `errors.log` on every pool load.

## Test

New regression test `test_load_pool_skips_exchange_for_suppressed_copilot` asserts `get_copilot_api_token` is never invoked when the source is suppressed. Full `tests/agent/test_credential_pool.py` suite: 55 passed (plus 21 in copilot auth/exchange files, 76 total green).
