### PR TITLE
test(cron): isolate execution ledger from operator home

### DIFF
--- a/tests/cron/conftest.py
+++ b/tests/cron/conftest.py
@@ -1,17 +1,62 @@
 """Cron-test fixtures.
 
-Provides a default ``HERMES_MODEL`` for cron run_job tests so each one
-doesn't have to spell out a model. The global conftest blanks
-HERMES_MODEL hermetically; without this autouse fixture every cron test
-that exercises ``run_job`` would hit the fail-fast guard added in
-``cron/scheduler.py`` (see issue #23979) and have to be rewritten.
-
-Tests that specifically need ``HERMES_MODEL`` unset — model-resolution
-edge cases — call ``monkeypatch.delenv("HERMES_MODEL", raising=False)``
-inside the test, which overrides this fixture's value for that scope.
+Cron tests get a second storage-isolation boundary in addition to the global
+suite sandbox.  The extra boundary is intentional: ``cron.executions`` used
+to cache its SQLite path at import time, before per-test fixtures could move
+``HERMES_HOME``, and fixture execution rows consequently reached an operator's
+live ledger when pytest inherited that home.
 """
 
+from __future__ import annotations
+
+import atexit
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
 import pytest
+
+# An unconditional collection-time sandbox closes the case where pytest was
+# launched with HERMES_HOME already pointing at the operator's profile.  A
+# per-test fixture below narrows this further to one store per test.
+_CRON_COLLECTION_HOME = Path(tempfile.mkdtemp(prefix="hermes-cron-tests-"))
+os.environ["HERMES_HOME"] = str(_CRON_COLLECTION_HOME)
+atexit.register(shutil.rmtree, _CRON_COLLECTION_HOME, True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_execution_store(_hermetic_environment, monkeypatch, tmp_path):
+    """Route every cron test to its own ledger and reject live-store writes.
+
+    Importing here also repairs collection-order leakage: if a test module
+    imported ``cron.executions`` before fixtures ran, its cached constant is
+    repointed before the test body can write.  Wrapping the module's connection
+    boundary then fails closed if a test later repoints the constant back to an
+    operator store.
+    """
+    test_home = tmp_path / "cron_hermes_home"
+    test_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(test_home))
+
+    import cron.executions as executions
+
+    test_file = test_home / "cron" / "executions.db"
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", test_file)
+    original_connect = executions._connect
+
+    allowed_root = tmp_path.resolve()
+
+    def guarded_connect():
+        target = Path(executions.EXECUTIONS_FILE).expanduser().resolve()
+        if not target.is_relative_to(allowed_root):
+            raise RuntimeError(
+                "cron test execution-store guard: refusing to write outside the "
+                f"current test sandbox: {target}"
+            )
+        return original_connect()
+
+    monkeypatch.setattr(executions, "_connect", guarded_connect)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cron/test_execution_store_isolation.py
+++ b/tests/cron/test_execution_store_isolation.py
@@ -1,0 +1,42 @@
+"""Cron execution-ledger test isolation regressions."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+# Deliberately import during collection.  The cron fixture must repair modules
+# that cached their store before per-test fixtures ran.
+import cron.executions as executions
+
+
+def test_execution_store_follows_the_per_test_hermes_home():
+    expected = Path(os.environ["HERMES_HOME"]).resolve() / "cron" / "executions.db"
+
+    assert executions.EXECUTIONS_FILE == expected
+    record = executions.create_execution("isolation-probe", source="test")
+
+    assert record["job_id"] == "isolation-probe"
+    assert expected.exists()
+
+
+def test_execution_store_guard_rejects_the_default_operator_home(monkeypatch):
+    target = (Path.home() / ".hermes" / "cron" / "executions.db").resolve()
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", target)
+
+    with pytest.raises(RuntimeError, match="refusing to write outside"):
+        executions.create_execution("guard-probe", source="test")
+
+
+def test_execution_store_guard_rejects_any_path_outside_per_test_home(
+    monkeypatch, tmp_path
+):
+    target = tmp_path.parent / "profile-home" / "cron" / "executions.db"
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", target)
+
+    with pytest.raises(RuntimeError, match="refusing to write outside"):
+        executions.create_execution("profile-guard-probe", source="test")
+
+    assert not target.exists()


### PR DESCRIPTION
## Summary

- add a collection-time cron-test Hermes-home sandbox before cron modules can cache live paths
- route each cron test to a per-test execution ledger
- fail closed if any cron test attempts to open an execution database outside its pytest sandbox
- add regressions for import-order leakage, default operator-home writes, and arbitrary profile-home escapes

## Why

Cron-resilience tests historically wrote 931 fixture rows across 27 fixture IDs into a live operator `~/.hermes/cron/executions.db`. Global environment isolation alone was insufficient because `cron.executions.EXECUTIONS_FILE` can be cached during collection.

## Verification

- RED: focused isolation regression wrote to the inherited store before the fixture guard existed
- GREEN: `tests/cron/test_execution_ledger.py` + isolation regressions — 21 passed
- GREEN: full `tests/cron` suite — 376 passed across 35 files
- Ruff check/format — pass
- live ledger invariant: SHA-256 and row count remained byte-for-byte unchanged across both focused and full cron suites (`1000` rows before and after)

This changes test fixtures only; production cron execution behavior is unchanged.
