### PR TITLE
feat(delegation): add child-specific fast mode config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1254,6 +1254,9 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # reasoning_effort: "xhigh"                 # Optional reasoning level for subagents (empty = inherit parent)
+  # fast: true                                 # Opt supported subagent models into Fast/Priority processing only.
+  #                                           # Does not enable Fast Mode on the parent session.
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1606,6 +1606,8 @@ DEFAULT_CONFIG = {
                            # "codex_responses", or "anthropic_messages". Empty = auto-detect
                            # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
                            # explicitly for non-standard endpoints the heuristic can't detect.
+        "fast": False,      # opt supported child models into Fast/Priority processing;
+                            # false = do not add a child-specific tier override
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -960,6 +960,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Reasoning effort for delegated subagents",
         "options": ["", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"],
     },
+    "delegation.fast": {
+        "type": "boolean",
+        "description": "Use Fast/Priority processing for supported delegated subagent models",
+    },
     "updates.non_interactive_local_changes": {
         "type": "select",
         "description": (

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -75,6 +75,7 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["delegation"]["fast"] is False
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -79,6 +79,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("acp_args", props)
         self.assertNotIn("acp_command", props["tasks"]["items"]["properties"])
         self.assertNotIn("acp_args", props["tasks"]["items"]["properties"])
+        self.assertNotIn("fast", props)  # operator-controlled via delegation.fast
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
 class TestChildSystemPrompt(unittest.TestCase):
@@ -1099,6 +1100,285 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
+
+
+class TestDelegationFastMode(unittest.TestCase):
+    """Tests for the operator-controlled delegation.fast override."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_fast_config_forces_child_fast_without_changing_parent(self, MockAgent, mock_cfg):
+        """A normal Sol parent can run a Luna child at xhigh + fast."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "reasoning_effort": "xhigh",
+            "fast": True,
+        }
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.model = "gpt-5.6-sol"
+        parent.provider = "openai-codex"
+        parent.api_mode = "codex_responses"
+        parent.reasoning_config = {"enabled": True, "effort": "ultra"}
+        parent.service_tier = None
+        parent.request_overrides = {"custom": "keep"}
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model="gpt-5.6-luna",
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gpt-5.6-luna")
+        self.assertEqual(
+            call_kwargs["reasoning_config"],
+            {"enabled": True, "effort": "xhigh"},
+        )
+        self.assertEqual(call_kwargs["service_tier"], "priority")
+        self.assertEqual(
+            call_kwargs["request_overrides"],
+            {"custom": "keep", "service_tier": "priority"},
+        )
+        self.assertIsNone(parent.service_tier)
+        self.assertEqual(parent.request_overrides, {"custom": "keep"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_fast_config_overrides_provider_tier_without_mutating_it(self, MockAgent, mock_cfg):
+        """Fast wins over a provider's flex tier while preserving other overrides."""
+        mock_cfg.return_value = {"max_iterations": 50, "fast": True}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        provider_overrides = {
+            "extra_body": {"service_tier": "flex", "provider_option": "keep"},
+            "custom": "keep",
+        }
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model="gpt-5.6-luna",
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+            override_provider="openai-codex",
+            override_request_overrides=provider_overrides,
+        )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(
+            call_kwargs["request_overrides"],
+            {
+                "extra_body": {"provider_option": "keep"},
+                "custom": "keep",
+                "service_tier": "priority",
+            },
+        )
+        self.assertEqual(
+            provider_overrides,
+            {
+                "extra_body": {"service_tier": "flex", "provider_option": "keep"},
+                "custom": "keep",
+            },
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_fast_config_uses_anthropic_speed_override(self, MockAgent, mock_cfg):
+        """Anthropic Fast Mode uses speed=fast while retaining the durable marker."""
+        mock_cfg.return_value = {"max_iterations": 50, "fast": True}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.model = "claude-opus-4-6"
+        parent.provider = "anthropic"
+        parent.api_mode = "anthropic_messages"
+        parent.service_tier = None
+        parent.request_overrides = {"custom": "keep"}
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model="claude-opus-4-6",
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["service_tier"], "priority")
+        self.assertEqual(
+            call_kwargs["request_overrides"],
+            {"custom": "keep", "speed": "fast"},
+        )
+        self.assertIsNone(parent.service_tier)
+        self.assertEqual(parent.request_overrides, {"custom": "keep"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_fast_config_does_not_invent_overrides_for_unsupported_model(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "fast": True}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.request_overrides = {
+            "custom": "keep",
+            "service_tier": "priority",
+            "speed": "fast",
+            "extra_body": {
+                "service_tier": "priority",
+                "speed": "fast",
+                "nested": "keep",
+            },
+        }
+        original_parent_overrides = {
+            "custom": "keep",
+            "service_tier": "priority",
+            "speed": "fast",
+            "extra_body": {
+                "service_tier": "priority",
+                "speed": "fast",
+                "nested": "keep",
+            },
+        }
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model="google/gemini-3-flash-preview",
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertIsNone(call_kwargs.get("service_tier"))
+        self.assertEqual(
+            call_kwargs["request_overrides"],
+            {"custom": "keep", "extra_body": {"nested": "keep"}},
+        )
+        self.assertEqual(parent.request_overrides, original_parent_overrides)
+
+
+def test_fast_profile_config_reaches_child_request(tmp_path, monkeypatch):
+    """Exercise config.yaml -> real child construction -> provider wire kwargs."""
+    from agent.chat_completion_helpers import build_api_kwargs
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "delegation:\n"
+        "  model: gpt-5.6-luna\n"
+        "  reasoning_effort: xhigh\n"
+        "  fast: true\n",
+        encoding="utf-8",
+    )
+
+    parent = AIAgent(
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-key",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        model="gpt-5.6-sol",
+        max_iterations=1,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id="test-fast-profile-parent",
+        reasoning_config={"enabled": True, "effort": "ultra"},
+        request_overrides={},
+    )
+
+    config = _load_config()
+    credentials = _resolve_delegation_credentials(config, parent)
+    child = _build_child_agent(
+        task_index=0,
+        goal="test",
+        context=None,
+        toolsets=None,
+        model=credentials["model"],
+        max_iterations=config["max_iterations"],
+        parent_agent=parent,
+        task_count=1,
+        override_provider=credentials["provider"],
+        override_base_url=credentials["base_url"],
+        override_api_key=credentials["api_key"],
+        override_api_mode=credentials["api_mode"],
+        override_request_overrides=credentials["request_overrides"],
+    )
+    wire_kwargs = build_api_kwargs(
+        child,
+        [{"role": "user", "content": "ping"}],
+        [],
+    )
+
+    assert getattr(child, "model") == "gpt-5.6-luna"
+    assert getattr(child, "reasoning_config") == {"enabled": True, "effort": "xhigh"}
+    assert getattr(child, "service_tier") == "priority"
+    assert getattr(child, "request_overrides") == {"service_tier": "priority"}
+    assert wire_kwargs["service_tier"] == "priority"
+    assert getattr(parent, "model") == "gpt-5.6-sol"
+    assert getattr(parent, "reasoning_config") == {"enabled": True, "effort": "ultra"}
+    assert getattr(parent, "service_tier") is None
+
+
+def test_fast_profile_config_reaches_native_anthropic_wire(tmp_path, monkeypatch):
+    """Exercise delegate Fast Mode through the native Anthropic request shape."""
+    from agent.anthropic_adapter import _FAST_MODE_BETA
+    from agent.chat_completion_helpers import build_api_kwargs
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "delegation:\n  fast: true\n",
+        encoding="utf-8",
+    )
+    parent = AIAgent(
+        base_url="https://api.anthropic.com",
+        api_key="test-key",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model="claude-opus-4-6",
+        max_iterations=1,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id="test-fast-profile-anthropic-parent",
+        request_overrides={},
+    )
+
+    child = _build_child_agent(
+        task_index=0,
+        goal="test",
+        context=None,
+        toolsets=None,
+        model="claude-opus-4-6",
+        max_iterations=1,
+        parent_agent=parent,
+        task_count=1,
+    )
+    wire_kwargs = build_api_kwargs(
+        child,
+        [{"role": "user", "content": "ping"}],
+        [],
+    )
+
+    assert getattr(child, "request_overrides") == {"speed": "fast"}
+    assert wire_kwargs["extra_body"]["speed"] == "fast"
+    assert _FAST_MODE_BETA in wire_kwargs["extra_headers"]["anthropic-beta"]
+    assert getattr(parent, "request_overrides") == {}
 
 # =========================================================================
 # Dispatch helper, progress events, concurrency

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1498,6 +1498,51 @@ def _build_child_agent(
     if isinstance(child_max_tokens, int):
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
+    # Build the child's request overrides before construction so an operator can
+    # opt delegated agents into Fast/Priority processing independently of the
+    # parent session.  This is deliberately config-authoritative rather than a
+    # delegate_task argument: the parent model must not be able to select a more
+    # expensive service tier on its own.
+    child_request_overrides = (
+        dict(override_request_overrides or {})
+        if override_provider
+        else dict(getattr(parent_agent, "request_overrides", {}) or {})
+    )
+    child_service_tier = None
+    if is_truthy_value(delegation_cfg.get("fast"), default=False):
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        # A fast-enabled delegation request owns the child's tier choice. Strip
+        # inherited/session tier keys even when the child model is unsupported,
+        # so the warn-and-continue path actually runs at normal speed instead of
+        # leaking a parent Fast override onto an incompatible model.
+        child_request_overrides.pop("service_tier", None)
+        child_request_overrides.pop("speed", None)
+        extra_body = child_request_overrides.get("extra_body")
+        if isinstance(extra_body, dict):
+            child_extra_body = dict(extra_body)
+            child_extra_body.pop("service_tier", None)
+            child_extra_body.pop("speed", None)
+            if child_extra_body:
+                child_request_overrides["extra_body"] = child_extra_body
+            else:
+                child_request_overrides.pop("extra_body", None)
+
+        fast_overrides = resolve_fast_mode_overrides(effective_model)
+        if fast_overrides:
+            child_request_overrides.update(fast_overrides)
+            # service_tier is the durable generic marker Hermes uses for both
+            # OpenAI Priority Processing and Anthropic speed="fast" sessions.
+            child_service_tier = "priority"
+        else:
+            logger.warning(
+                "delegation.fast is enabled, but model %r does not support Fast Mode; "
+                "starting the subagent normally",
+                effective_model,
+            )
+    if child_service_tier:
+        child_optional_kwargs["service_tier"] = child_service_tier
+
     from agent.delegation_context import delegated_child_context
 
     with delegated_child_context():
@@ -1532,11 +1577,7 @@ def _build_child_agent(
             provider_sort=child_provider_sort,
             provider_require_parameters=child_provider_require_parameters,
             provider_data_collection=child_provider_data_collection,
-            request_overrides=(
-                dict(override_request_overrides or {})
-                if override_provider
-                else dict(getattr(parent_agent, "request_overrides", {}) or {})
-            ),
+            request_overrides=child_request_overrides,
             openrouter_min_coding_score=child_openrouter_min_coding_score,
             tool_progress_callback=child_progress_cb,
             iteration_budget=None,  # fresh budget per subagent

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2195,12 +2195,16 @@ delegation:
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
   # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
+  reasoning_effort: ""                     # Child reasoning level (empty = inherit parent)
+  fast: false                               # Opt supported child models into Fast/Priority processing; parent is unchanged
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Subagent Fast Mode:** Set `delegation.fast: true` to opt supported child models into provider Fast/Priority processing independently of the parent session. Hermes resolves the child model's wire parameter (`service_tier: priority` for eligible OpenAI models or `speed: fast` for eligible models on native Anthropic endpoints) after applying the delegation model/provider override. An unsupported child model logs a warning and starts normally. The setting is operator-controlled in `config.yaml`; it is not exposed as a `delegate_task` argument, so the model cannot opt itself into the paid tier. Leaving it `false` preserves the existing parent/session inheritance behavior.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -140,18 +140,20 @@ process disappears while it is still running is recorded as `unknown`, because
 Hermes cannot prove whether its external side effects happened. Pending and
 delivered records are bounded and profile-local.
 
-## Model Override
+## Model and Fast-Mode Override
 
 You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
 
 ```yaml
 # In ~/.hermes/config.yaml
 delegation:
-  model: "google/gemini-flash-2.0"    # Cheaper model for subagents
-  provider: "openrouter"              # Optional: route subagents to a different provider
+  model: "gpt-5.6-luna"        # Different model for subagents
+  provider: "openai-codex"     # Optional: route subagents to a different provider
+  reasoning_effort: "xhigh"    # Independent child reasoning level
+  fast: true                    # Fast/Priority processing for supported child models only
 ```
 
-If omitted, subagents use the same model as the parent.
+If omitted, subagents use the same model as the parent. `fast: true` applies only to delegated agents and does not change the parent session's Fast Mode. Hermes maps it to the provider-appropriate request setting for supported models and runs unsupported models normally with a warning. Fast/Priority processing can carry a provider billing premium.
 
 ## Inherited Tool Access
 
@@ -357,6 +359,8 @@ delegation:
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
+  reasoning_effort: "xhigh"                         # Optional child reasoning override
+  # fast: true                                       # Optional child-only Fast/Priority processing (supported models only)
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints
 
 # Or use a direct custom endpoint instead of provider:


### PR DESCRIPTION
## What does this PR do?

Adds an operator-controlled, delegate-only Fast Mode switch:

```yaml
delegation:
  fast: true
```

Today, Hermes can enable Fast/Priority processing for the main session, but there is no declarative way to opt only delegated work into the faster provider tier. That matters when the parent should remain a high-reasoning, normal-tier coordinator while a separately configured child model handles latency-sensitive work.

A representative configuration is:

```yaml
model:
  default: gpt-5.6-sol

agent:
  reasoning_effort: ultra

delegation:
  model: gpt-5.6-luna
  reasoning_effort: xhigh
  fast: true
```

The implementation deliberately reuses Hermes's existing `resolve_fast_mode_overrides()` policy rather than introducing a second latency mechanism:

- eligible OpenAI/Codex child models receive `service_tier: priority`;
- eligible child models on native Anthropic endpoints receive `speed: fast`;
- unsupported child models emit the existing warning and continue at normal speed;
- conflicting tier keys are removed from a copied child override dictionary before the Fast override is applied;
- the parent agent's model, reasoning config, service tier, request overrides, and provider overrides are never mutated.

`delegation.fast` defaults to `false`. The option is config/UI controlled and is intentionally **not** added to the model-facing `delegate_task` schema, so a delegate request cannot autonomously opt into paid priority processing. When disabled, existing delegate inheritance behavior is unchanged.

## Related Issue

No dedicated issue. Related to #61870, which addresses inheriting a parent session's Fast preference across child routing. This PR covers the orthogonal child-only case: the parent remains normal while `delegation.fast: true` opts the child in.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`
  - builds child-owned copies of request/provider overrides;
  - applies existing model-aware Fast Mode resolution only after the effective child model is known;
  - removes conflicting OpenAI/Anthropic tier fields before applying the resolved override;
  - passes the durable priority marker to the child without changing parent state.
- `hermes_cli/config_defaults.py`
  - adds the backward-compatible `delegation.fast: false` default without a config-version migration.
- `hermes_cli/web_server.py`
  - exposes the boolean in generated settings metadata with an explicit paid-processing description.
- `tests/tools/test_delegate.py`
  - covers child-only OpenAI priority mapping, Anthropic `speed: fast`, reasoning overrides, conflicting provider tiers, parent immutability, unsupported-model fallback, and real config-to-wire integration paths for both providers.
- `tests/hermes_cli/test_config.py`
  - verifies the default remains opt-in.
- `cli-config.yaml.example`
  - documents the setting and its operator-only semantics.
- `website/docs/user-guide/configuration.md`
  - adds the configuration reference.
- `website/docs/user-guide/features/delegation.md`
  - documents behavior, cost implications, inheritance compatibility, and the independent parent/child example.

## How to Test

1. Add the following to a temporary Hermes profile:

   ```yaml
   delegation:
     model: gpt-5.6-luna
     reasoning_effort: xhigh
     fast: true
   ```

2. Keep the parent session on a normal tier, delegate a task, and verify the child is constructed with `service_tier="priority"` plus `request_overrides={"service_tier": "priority"}` while parent state remains unchanged.
3. Repeat with a native Anthropic child and verify `request_overrides={"speed": "fast"}`. Repeat with an unsupported model and verify Hermes warns but still creates the child without a Fast override.
4. Run the canonical targeted suite:

   ```bash
   scripts/run_tests.sh \
     tests/tools/test_delegate.py \
     tests/hermes_cli/test_config.py \
     tests/cli/test_fast_command.py -q
   ```

   Result: **159 passed, 0 failed**.

### Additional verification

- Automated and manual real `AIAgent` parent/child construction through provider request-kwarg assembly against temporary `HERMES_HOME` directories: passed. OpenAI/Codex produced `service_tier: priority`; native Anthropic produced `extra_body.speed: fast` plus the Fast Mode beta header; parent state remained unchanged.
- Ruff on every modified Python file: passed.
- `git diff --check`: passed.
- `cli-config.yaml.example` YAML parse: passed.
- Added-line secret scan: clean.
- Docusaurus production build for English and Chinese: passed. The build reports the same existing unrelated Chinese broken-link/anchor warnings.
- Full `scripts/run_tests.sh` was also run. It reported 32 failures in 11 unrelated files. Every failure was reproduced against detached clean `origin/main` worktrees at `003af7f85c` (the Honcho cache-busting failure was confirmed in a second isolated baseline run after it passed once):
  - `tests/hermes_cli/test_update_eol_churn.py`
  - `tests/honcho_plugin/test_pin_peer_name.py`
  - `tests/plugins/memory/test_hindsight_provider.py`
  - `tests/tools/test_daytona_environment.py`
  - `tests/tools/test_modal_snapshot_isolation.py`
  - `tests/tools/test_termux_api_detection.py`
  - `tests/test_mcp_serve.py`
  - `tests/tools/test_web_tools_config.py`
  - `tests/hermes_cli/test_doctor.py`
  - `tests/agent/test_compression_concurrent_fork.py`
  - `tests/tools/test_process_registry.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the affected canonical suite passes; the full-suite failures are reproduced unchanged on clean `origin/main` above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Linux 6.8, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — config and mapping logic are platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the paid-tier switch is intentionally operator-only and not model-facing

## Screenshots / Logs

```text
manual construction-to-wire verification: passed
```

```text
=== Summary: 3 files, 159 tests passed, 0 failed ===
```
