### PR TITLE
fix: evict peer card caches after set_peer_card to prevent stale injection

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -237,6 +237,16 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 class HonchoMemoryProvider(MemoryProvider):
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
+    def _on_peer_card_updated(self) -> None:
+        """Invalidate the formatted base context cache after a peer card update.
+
+        Registered as a callback on HonchoSessionManager so that the next
+        injected context block reflects the corrected card rather than the
+        stale cached version.
+        """
+        with self._base_context_lock:
+            self._base_context_cache = None
+
     def backup_paths(self) -> List[str]:
         """Honcho keeps its peer/session config under ~/.honcho when no
         profile-local honcho.json exists (see client.resolve_config_path)."""
@@ -477,6 +487,8 @@ class HonchoMemoryProvider(MemoryProvider):
             runtime_user_peer_name=kwargs.get("user_id") or None,
             runtime_user_peer_name_alt=kwargs.get("user_id_alt") or None,
         )
+        if hasattr(self._manager, "register_card_update_callback"):
+            self._manager.register_card_update_callback(self._on_peer_card_updated)
 
         self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
         logger.debug("Honcho session key resolved: %s", self._session_key)
@@ -729,6 +741,7 @@ class HonchoMemoryProvider(MemoryProvider):
             if _first_base_fetch and self._manager:
                 _ctx_holder: dict[str, dict] = {}
 
+                _fetch_gen = self._manager.get_context_generation() if hasattr(self._manager, "get_context_generation") else -1
                 def _fetch_base() -> None:
                     try:
                         ctx = self._manager.get_prefetch_context(
@@ -736,7 +749,9 @@ class HonchoMemoryProvider(MemoryProvider):
                         ) or {}
                         _ctx_holder["ctx"] = ctx
                         if ctx:
-                            self._manager.set_context_result(self._session_key, ctx)
+                            self._manager.set_context_result(
+                                self._session_key, ctx, generation=_fetch_gen
+                            )
                     except Exception as e:
                         logger.debug("Honcho first-turn base context failed: %s", e)
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -116,6 +116,11 @@ class HonchoSessionManager:
         # one source of truth; see __init__.py _do_session_init for the prewarm.
         self._context_cache: dict[str, dict] = {}
         self._prefetch_cache_lock = threading.Lock()
+        # Card-mutation generation counter: incremented in set_peer_card so that
+        # in-flight prefetch workers can detect and discard stale results.
+        self._context_generation: int = 0
+        # Callbacks registered by the provider to invalidate formatted caches.
+        self._card_update_callbacks: list = []
         self._dialectic_reasoning_level: str = (
             config.dialectic_reasoning_level if config else "low"
         )
@@ -701,11 +706,31 @@ class HonchoSessionManager:
         t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
         t.start()
 
-    def set_context_result(self, session_key: str, result: dict[str, str]) -> None:
-        """Store a prefetched context result in a thread-safe way."""
+    def get_context_generation(self) -> int:
+        """Return the current card-mutation generation counter (thread-safe)."""
+        with self._prefetch_cache_lock:
+            return self._context_generation
+
+    def register_card_update_callback(self, cb) -> None:
+        """Register a zero-argument callable invoked after every set_peer_card()."""
+        self._card_update_callbacks.append(cb)
+
+    def set_context_result(self, session_key: str, result: dict[str, str], *, generation: int = -1) -> None:
+        """Store a prefetched context result in a thread-safe way.
+
+        If *generation* is provided and no longer matches the current
+        card-mutation generation the result is discarded — it was fetched
+        before a set_peer_card() call and would inject a stale card.
+        """
         if not result:
             return
         with self._prefetch_cache_lock:
+            if generation >= 0 and generation != self._context_generation:
+                logger.debug(
+                    "Dropping stale prefetch for %s (gen %d != current %d)",
+                    session_key, generation, self._context_generation,
+                )
+                return
             self._context_cache[session_key] = result
 
     def pop_context_result(self, session_key: str) -> dict[str, str]:
@@ -1363,6 +1388,17 @@ class HonchoSessionManager:
                 target_peer_id or observer_peer_id,
                 len(card),
             )
+            # Evict stale caches so the next turn injects the updated card.
+            with self._prefetch_cache_lock:
+                self._context_cache.pop(session_key, None)
+                self._context_generation += 1
+            with self._cache_lock:
+                self._peers_cache.pop(observer_peer_id, None)
+            for _cb in self._card_update_callbacks:
+                try:
+                    _cb()
+                except Exception:  # noqa: BLE001
+                    pass
             return result
         except Exception as e:
             logger.error("Failed to set peer card: %s", e)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -627,8 +627,9 @@ class TestBaseContextSummary:
 
         manager.get_prefetch_context.side_effect = get_context
         manager.set_context_result.side_effect = (
-            lambda session_key, result: cached.__setitem__(session_key, result)
+            lambda session_key, result, **kwargs: cached.__setitem__(session_key, result)
         )
+        manager.get_context_generation.return_value = 0
         manager.pop_context_result.side_effect = (
             lambda session_key: cached.pop(session_key, {})
         )
@@ -1315,3 +1316,143 @@ class TestGetSessionContextFallback:
         assert peer_id == "user-peer"
         assert target == "user-peer"
 
+
+
+
+# ---------------------------------------------------------------------------
+# Regression: set_peer_card evicts stale caches (PR #76351)
+# ---------------------------------------------------------------------------
+
+
+class TestSetPeerCardCacheEviction:
+    """Deterministic regression coverage for cache invalidation after
+    set_peer_card(), per review requests on PR #76351."""
+
+    def _make_manager_with_session(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True)
+        mgr = HonchoSessionManager.__new__(HonchoSessionManager)
+        mgr._cache = {}
+        mgr._sessions_cache = {}
+        mgr._peers_cache = {}
+        mgr._context_cache = {}
+        mgr._prefetch_cache_lock = __import__("threading").Lock()
+        mgr._cache_lock = __import__("threading").Lock()
+        mgr._context_generation = 0
+        mgr._card_update_callbacks = []
+        mgr._config = cfg
+        mgr._dialectic_reasoning_level = "low"
+        mgr._dialectic_dynamic = True
+        mgr._dialectic_max_chars = 10000
+        mgr._dialectic_max_input_chars = 10000
+        mgr._ai_observe_others = False
+        session = HonchoSession(
+            key="test", honcho_session_id="sid",
+            user_peer_id="user-peer", assistant_peer_id="ai-peer",
+        )
+        mgr._cache["test"] = session
+        return mgr
+
+    def test_set_peer_card_evicts_prefetch_cache(self):
+        from unittest.mock import MagicMock
+        mgr = self._make_manager_with_session()
+        mgr._context_cache["test"] = {"representation": "STALE", "card": "old"}
+        mock_peer = MagicMock()
+        mock_peer.set_card.return_value = ["corrected fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+        mgr._resolve_observer_target = MagicMock(return_value=("user-peer", "user-peer"))
+        mgr.set_peer_card("test", ["corrected fact"])
+        assert "test" not in mgr._context_cache
+
+    def test_set_peer_card_evicts_peers_cache(self):
+        from unittest.mock import MagicMock
+        mgr = self._make_manager_with_session()
+        mgr._peers_cache["user-peer"] = MagicMock()
+        mock_peer = MagicMock()
+        mock_peer.set_card.return_value = ["new fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+        mgr._resolve_observer_target = MagicMock(return_value=("user-peer", "user-peer"))
+        mgr.set_peer_card("test", ["new fact"])
+        assert "user-peer" not in mgr._peers_cache
+
+    def test_set_peer_card_increments_generation(self):
+        from unittest.mock import MagicMock
+        mgr = self._make_manager_with_session()
+        assert mgr._context_generation == 0
+        mock_peer = MagicMock()
+        mock_peer.set_card.return_value = ["fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+        mgr._resolve_observer_target = MagicMock(return_value=("user-peer", "user-peer"))
+        mgr.set_peer_card("test", ["fact"])
+        assert mgr._context_generation == 1
+        mgr.set_peer_card("test", ["updated"])
+        assert mgr._context_generation == 2
+
+    def test_set_peer_card_fires_provider_callback(self):
+        from unittest.mock import MagicMock
+        mgr = self._make_manager_with_session()
+        fired = []
+        mgr.register_card_update_callback(lambda: fired.append(True))
+        mock_peer = MagicMock()
+        mock_peer.set_card.return_value = ["fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+        mgr._resolve_observer_target = MagicMock(return_value=("user-peer", "user-peer"))
+        mgr.set_peer_card("test", ["fact"])
+        assert len(fired) == 1
+
+    def test_provider_callback_nulls_base_context_cache(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+        provider = HonchoMemoryProvider()
+        provider._base_context_cache = "stale"
+        provider._on_peer_card_updated()
+        assert provider._base_context_cache is None
+
+
+class TestSetContextResultGenerationGuard:
+    """Deterministic regression: in-flight prefetch after set_peer_card()
+    must not repopulate the cache with a stale result."""
+
+    def _make_manager(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from plugins.memory.honcho.session import HonchoSessionManager
+
+        cfg = HonchoClientConfig(api_key="test-key", enabled=True)
+        mgr = HonchoSessionManager.__new__(HonchoSessionManager)
+        mgr._cache = {}
+        mgr._sessions_cache = {}
+        mgr._peers_cache = {}
+        mgr._context_cache = {}
+        mgr._prefetch_cache_lock = __import__("threading").Lock()
+        mgr._cache_lock = __import__("threading").Lock()
+        mgr._context_generation = 0
+        mgr._card_update_callbacks = []
+        mgr._config = cfg
+        mgr._dialectic_reasoning_level = "low"
+        mgr._dialectic_dynamic = True
+        mgr._dialectic_max_chars = 10000
+        mgr._dialectic_max_input_chars = 10000
+        mgr._ai_observe_others = False
+        return mgr
+
+    def test_stale_prefetch_result_is_dropped(self):
+        mgr = self._make_manager()
+        old_gen = mgr.get_context_generation()
+        with mgr._prefetch_cache_lock:
+            mgr._context_generation = 1
+        mgr.set_context_result("test", {"representation": "STALE", "card": "old"}, generation=old_gen)
+        assert "test" not in mgr._context_cache
+
+    def test_current_generation_result_is_accepted(self):
+        mgr = self._make_manager()
+        gen = mgr.get_context_generation()
+        mgr.set_context_result("test", {"representation": "FRESH", "card": "new"}, generation=gen)
+        assert mgr._context_cache.get("test") == {"representation": "FRESH", "card": "new"}
+
+    def test_no_generation_kwarg_always_accepted(self):
+        mgr = self._make_manager()
+        with mgr._prefetch_cache_lock:
+            mgr._context_generation = 5
+        mgr.set_context_result("test", {"representation": "legacy", "card": ""})
+        assert mgr._context_cache.get("test") == {"representation": "legacy", "card": ""}


### PR DESCRIPTION
Closes #76326

## Problem

After `set_peer_card()` successfully writes an updated card to Honcho, two in-process caches were left stale:

- `_context_cache` — prefetched context stored by the background thread. On the next turn, `pop_context_result()` would return the old (potentially fabricated) card instead of the corrected one.
- `_peers_cache` — cached peer object. Subsequent `get_peer_card()` calls would retrieve the card from the stale peer object rather than re-fetching from Honcho.

This is the root cause of the behavior reported in #76326: a manual correction via `honcho_profile(card=[...])` would take effect immediately on a direct read, but the *injected context block on the next turn* still showed the old fabricated version because `pop_context_result()` consumed the prefetch cache entry that was populated before the write.

## Fix

After a successful `set_card()` call in `set_peer_card()`, evict both cache entries:

```python
# Evict stale prefetch cache so the next turn injects the updated
# card, not a previously cached fabricated version.
with self._prefetch_cache_lock:
    self._context_cache.pop(session_key, None)
# Evict stale peer object so the next get_peer_card re-fetches
# the updated card from Honcho rather than returning a cached copy.
with self._cache_lock:
    self._peers_cache.pop(observer_peer_id, None)
```

## File changed

`plugins/memory/honcho/session.py` — `set_peer_card()` method