### PR TITLE
fix: recover vision_analyze path when model normalizes U+202F to ASCII space

### DIFF
--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -127,6 +127,27 @@ async def resolve_image_source(
     # every other path is read inside the sandbox via exec-read, so a host
     # path outside the caches never yields the host's bytes.
     host_target = _permitted_host_read_target(p, ctx)
+    # Unicode-space recovery: macOS screenshot names use U+202F (narrow
+    # no-break space) before AM/PM; models normalize it to ASCII space,
+    # causing exact-path misses.  If the exact path is absent but its
+    # parent directory exists, scan for a unique sibling whose name matches
+    # after collapsing all UNICODE_MAP entries to their ASCII equivalents.
+    # Refuses silently when zero or more than one sibling matches (no broad
+    # fuzzy guessing).
+    if host_target is not None and not host_target.is_file() and host_target.parent.is_dir():
+        try:
+            from tools.fuzzy_match import UNICODE_MAP as _UMAP
+            def _norm_spaces(name: str) -> str:
+                return "".join(_UMAP.get(c, c) for c in name)
+            _wanted = _norm_spaces(host_target.name)
+            _siblings = [
+                sib for sib in host_target.parent.iterdir()
+                if sib.is_file() and _norm_spaces(sib.name) == _wanted
+            ]
+            if len(_siblings) == 1:
+                host_target = _siblings[0]
+        except Exception:  # noqa: BLE001 — recovery best-effort
+            pass
     if host_target is not None and host_target.is_file():
         # Shared credential-read guard (agent.file_safety, #57698): refuse
         # secret-bearing files (.env, auth.json, ...) with an intentional,


### PR DESCRIPTION
Closes #76334

## Problem

macOS screenshot filenames contain U+202F (NARROW NO-BREAK SPACE) before `AM`/`PM`, e.g.:

    Screenshot 2026-08-01 at 3.45.12 PM.png
                                    ^^^^
                                    U+202F here

When models pass this path as a tool argument, they normalize U+202F to a regular ASCII space. The exact `Path.is_file()` check in `resolve_image_source` then fails — the file exists on disk but the lookup misses.

## Fix

After an exact-path miss, scan the parent directory for a unique sibling whose basename matches after collapsing all `UNICODE_MAP` entries (shared with `tools/fuzzy_match`) to their ASCII equivalents. Recovery only triggers when exactly one sibling matches zero or multiple matches fall through to the original error path (no broad fuzzy guessing).

Design constraints followed:
- Recovery runs only after an exact miss
- Match scoped to the same parent directory
- Multi-match refuses
- No change to URL / `data:` paths
- Unicode space set kept aligned with `tools/fuzzy_match.UNICODE_MAP`

## File changed

`tools/image_source.py` 21-line addition between `_permitted_host_read_target()` and the existing `host_target.is_file()` branch