### PR TITLE
fix(cron): bound agent pressure without delaying scripts

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -48,7 +48,12 @@ from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
-from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
+from tools.budget_config import (
+    BudgetConfig,
+    DEFAULT_BUDGET,
+    budget_for_context_window,
+    budget_with_overrides,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,19 +81,36 @@ def _ensure_file_checkpoint(
 
 
 def _budget_for_agent(agent) -> BudgetConfig:
-    """Resolve a tool-result BudgetConfig scaled to the agent's context window.
+    """Resolve context-scaled tool budgets plus optional cron-only overrides.
 
     Large-context models keep the historical 100K/200K char defaults; small
     models (e.g. a 65K-token local model switched into mid-session) get a budget
     proportional to their window so a single large tool result can't push the
-    request past the model's limit (#23767). Falls back to the default budget
-    when the context length isn't resolvable.
+    request past the model's limit (#23767). Cron agents may further constrain
+    those values through ``cron.tool_result_budget``. Interactive agents never
+    read or apply the cron override.
     """
     try:
         ctx = getattr(getattr(agent, "context_compressor", None), "context_length", None)
-        return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
+        base = budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
-        return DEFAULT_BUDGET
+        base = DEFAULT_BUDGET
+
+    if getattr(agent, "platform", None) != "cron":
+        return base
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        cron_config = config.get("cron", {}) if isinstance(config, dict) else {}
+        overrides = (
+            cron_config.get("tool_result_budget", {})
+            if isinstance(cron_config, dict)
+            else {}
+        )
+        return budget_with_overrides(base, overrides)
+    except Exception:
+        return base
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -326,6 +326,9 @@ _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
 _running_lock = threading.Lock()
+_agent_admission_condition = threading.Condition()
+_agent_parallel_limit: Optional[int] = None
+_agent_jobs_running = 0
 
 # Job IDs the gateway shutdown path force-killed the tool subprocess of
 # while still in ``_running_job_ids`` (see ``mark_running_jobs_interrupted``
@@ -498,6 +501,53 @@ def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadP
         )
         _parallel_pool_max_workers = max_workers
     return _parallel_pool
+
+
+def _set_agent_parallel_limit(limit: Optional[int]) -> None:
+    global _agent_parallel_limit
+    with _agent_admission_condition:
+        _agent_parallel_limit = limit
+        _agent_admission_condition.notify_all()
+
+
+def _acquire_agent_slot() -> None:
+    global _agent_jobs_running
+    with _agent_admission_condition:
+        while (
+            _agent_parallel_limit is not None
+            and _agent_jobs_running >= _agent_parallel_limit
+        ):
+            _agent_admission_condition.wait()
+        _agent_jobs_running += 1
+
+
+def _release_agent_slot() -> None:
+    global _agent_jobs_running
+    with _agent_admission_condition:
+        _agent_jobs_running -= 1
+        _agent_admission_condition.notify_all()
+
+
+def _resolve_agent_parallel_limit(config: Optional[dict] = None) -> Optional[int]:
+    if config is None:
+        try:
+            config = load_config() or {}
+        except Exception:
+            config = {}
+    cron_cfg = config.get("cron", {}) if isinstance(config, dict) else {}
+    if not isinstance(cron_cfg, dict):
+        return None
+    value = cron_cfg.get("max_parallel_agent_jobs")
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (ValueError, TypeError):
+        logger.warning(
+            "Invalid cron.max_parallel_agent_jobs value; defaulting to unbounded"
+        )
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _get_sequential_pool() -> concurrent.futures.ThreadPoolExecutor:
@@ -3260,7 +3310,13 @@ def run_job(
                     prefill_messages = None
 
         # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 500
+        cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg.get("cron", {}), dict) else {}
+        max_iterations = (
+            cron_cfg.get("max_turns")
+            or agent_cfg.get("max_turns")
+            or _cfg.get("max_turns")
+            or 500
+        )
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -3875,7 +3931,7 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+def _run_one_job_body(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
@@ -4078,6 +4134,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         return False
 
 
+def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+    """Run one job with the configured agent-only admission limit."""
+    if job.get("no_agent"):
+        return _run_one_job_body(job, adapters=adapters, loop=loop, verbose=verbose)
+    _set_agent_parallel_limit(_resolve_agent_parallel_limit())
+    _acquire_agent_slot()
+    try:
+        return _run_one_job_body(job, adapters=adapters, loop=loop, verbose=verbose)
+    finally:
+        _release_agent_slot()
+
+
 def _notify_provider_jobs_changed() -> None:
     """Best-effort: tell the active scheduler provider the job set changed.
 
@@ -4162,6 +4230,16 @@ def tick(
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
         _max_workers: Optional[int] = None
+        _ucfg = {}
+        try:
+            _ucfg = load_config() or {}
+        except Exception:
+            pass
+        _cron_cfg = (
+            _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
+        )
+        if not isinstance(_cron_cfg, dict):
+            _cron_cfg = {}
         try:
             _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
             if _env_par:
@@ -4170,20 +4248,20 @@ def tick(
             logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
         if _max_workers is None:
             try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
+                _cfg_par = _cron_cfg.get("max_parallel_jobs")
                 if _cfg_par is not None:
                     _max_workers = int(_cfg_par) or None
             except Exception:
                 pass
 
+        _max_agent_workers = _resolve_agent_parallel_limit(_ucfg)
+
         if verbose:
             logger.info(
-                "Running %d job(s) in parallel (max_workers=%s)",
+                "Running %d job(s) in parallel (max_workers=%s, max_agent_workers=%s)",
                 len(due_jobs),
                 _max_workers if _max_workers else "unbounded",
+                _max_agent_workers if _max_agent_workers else "unbounded",
             )
 
         def _process_job(job: dict) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3317,6 +3317,7 @@ def run_job(
             or _cfg.get("max_turns")
             or 500
         )
+        cron_api_max_retries = cron_cfg.get("api_max_retries")
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -3562,6 +3563,15 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+        if cron_api_max_retries is not None:
+            try:
+                agent._api_max_retries = max(int(cron_api_max_retries), 1)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Job '%s': invalid cron.api_max_retries=%r; using agent default",
+                    job_id,
+                    cron_api_max_retries,
+                )
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2144,6 +2144,14 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Maximum number of LLM-backed cron jobs allowed to execute at once.
+        # Script-only no_agent jobs bypass this admission gate.
+        # null/0 = unbounded; 1 serializes model requests without delaying
+        # deterministic watchdogs and maintenance scripts.
+        "max_parallel_agent_jobs": None,
+        # Maximum tool-calling iterations for LLM-backed cron jobs. When unset,
+        # agent.max_turns remains the fallback for backward compatibility.
+        "max_turns": None,
         # Per-job output-file retention: save_job_output keeps the N most
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2152,6 +2152,14 @@ DEFAULT_CONFIG = {
         # Maximum tool-calling iterations for LLM-backed cron jobs. When unset,
         # agent.max_turns remains the fallback for backward compatibility.
         "max_turns": None,
+        # Optional cron-only artifact-spill budgets for tool results. These
+        # preserve full output on disk while limiting what returns to the model.
+        # null values retain the context-scaled interactive defaults.
+        "tool_result_budget": {
+            "max_result_chars": None,
+            "max_turn_chars": None,
+            "preview_chars": None,
+        },
         # Per-job output-file retention: save_job_output keeps the N most
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2152,6 +2152,10 @@ DEFAULT_CONFIG = {
         # Maximum tool-calling iterations for LLM-backed cron jobs. When unset,
         # agent.max_turns remains the fallback for backward compatibility.
         "max_turns": None,
+        # Total app-level model attempts per cron turn. 1 means a single
+        # attempt; provider routers may still rotate their own credential pool.
+        # null retains agent.api_max_retries for backward compatibility.
+        "api_max_retries": None,
         # Optional cron-only artifact-spill budgets for tool results. These
         # preserve full output on disk while limiting what returns to the model.
         # null values retain the context-scaled interactive defaults.

--- a/tests/agent/test_cron_tool_result_budget.py
+++ b/tests/agent/test_cron_tool_result_budget.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.tool_executor import _budget_for_agent
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def _agent(platform: str):
+    return SimpleNamespace(
+        platform=platform,
+        context_compressor=SimpleNamespace(context_length=32_768),
+    )
+
+
+def test_cron_agent_uses_cron_tool_result_budget():
+    config = {
+        "cron": {
+            "tool_result_budget": {
+                "max_result_chars": 8_000,
+                "max_turn_chars": 16_000,
+                "preview_chars": 1_500,
+            }
+        }
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        budget = _budget_for_agent(_agent("cron"))
+
+    assert budget.default_result_size == 8_000
+    assert budget.turn_budget == 16_000
+    assert budget.preview_size == 1_500
+
+
+def test_default_config_preserves_existing_budget_behavior():
+    assert DEFAULT_CONFIG["cron"]["tool_result_budget"] == {
+        "max_result_chars": None,
+        "max_turn_chars": None,
+        "preview_chars": None,
+    }
+
+
+def test_interactive_agent_ignores_cron_tool_result_budget():
+    with patch(
+        "hermes_cli.config.load_config",
+        side_effect=AssertionError("interactive path must not read cron overrides"),
+    ):
+        budget = _budget_for_agent(_agent("cli"))
+
+    assert budget.default_result_size == 19_660
+    assert budget.turn_budget == 39_321
+    assert budget.preview_size == 1_500

--- a/tests/agent/test_cron_tool_result_budget.py
+++ b/tests/agent/test_cron_tool_result_budget.py
@@ -32,6 +32,7 @@ def test_cron_agent_uses_cron_tool_result_budget():
 
 
 def test_default_config_preserves_existing_budget_behavior():
+    assert DEFAULT_CONFIG["cron"]["api_max_retries"] is None
     assert DEFAULT_CONFIG["cron"]["tool_result_budget"] == {
         "max_result_chars": None,
         "max_turn_chars": None,

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -116,6 +116,57 @@ class TestSyncMode:
         sched._shutdown_parallel_pool()
 
 
+class TestAgentAdmissionGate:
+    """Agent jobs can be serialized without delaying no_agent scripts."""
+
+    def test_agent_limit_serializes_agents_but_not_scripts(self, monkeypatch):
+        import cron.scheduler as sched
+
+        sched._parallel_pool = None
+        sched._parallel_pool_max_workers = None
+        sched._running_job_ids.clear()
+        sched._set_agent_parallel_limit(None)
+
+        jobs = [
+            {"id": "agent-a", "name": "Agent A", "prompt": "test", "deliver": "local"},
+            {"id": "agent-b", "name": "Agent B", "prompt": "test", "deliver": "local"},
+            {"id": "script", "name": "Script", "script": "true", "no_agent": True, "deliver": "local"},
+        ]
+        state_lock = threading.Lock()
+        script_ran = threading.Event()
+        running_agents = 0
+        max_running_agents = 0
+
+        def fake_run_job(job, *, defer_agent_teardown=None):
+            nonlocal running_agents, max_running_agents
+            if job.get("no_agent"):
+                script_ran.set()
+                return True, "out", "resp", None
+            with state_lock:
+                running_agents += 1
+                max_running_agents = max(max_running_agents, running_agents)
+            assert script_ran.wait(timeout=2)
+            time.sleep(0.05)
+            with state_lock:
+                running_agents -= 1
+            return True, "out", "resp", None
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
+        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "load_config", lambda: {"cron": {"max_parallel_agent_jobs": 1}})
+        monkeypatch.setattr(sched, "run_job", fake_run_job)
+        monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+        assert sched.tick(verbose=False) == 3
+        assert script_ran.is_set()
+        assert max_running_agents == 1
+
+        sched._set_agent_parallel_limit(None)
+        sched._shutdown_parallel_pool()
+
+
 class TestSequentialPool:
     """Sequential (workdir) jobs use the persistent cron-seq pool.
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -490,6 +490,20 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_cron_max_turns_overrides_interactive_agent_limit(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: test-model\nagent:\n  max_turns: 90\ncron:\n  max_turns: 10\n",
+            encoding="utf-8",
+        )
+        job = {"id": "bounded-job", "name": "bounded", "prompt": "hello"}
+
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.call_args.kwargs["max_iterations"] == 10
+
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):
@@ -1899,5 +1913,4 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -504,6 +504,20 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert mock_agent_cls.call_args.kwargs["max_iterations"] == 10
 
+    def test_cron_api_retries_override_interactive_agent_limit(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: test-model\nagent:\n  api_max_retries: 5\ncron:\n  api_max_retries: 1\n",
+            encoding="utf-8",
+        )
+        job = {"id": "single-attempt", "name": "single", "prompt": "hello"}
+
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.return_value._api_max_retries == 1
+
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):
@@ -1913,4 +1927,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -19,6 +19,7 @@ from tools.budget_config import (
     PINNED_THRESHOLDS,
     BudgetConfig,
     budget_for_context_window,
+    budget_with_overrides,
 )
 
 
@@ -147,6 +148,50 @@ class TestResolveThreshold:
         mock_registry.get_max_result_size.return_value = 100_000
         cfg = BudgetConfig()  # default_result_size == 100_000
         assert cfg.resolve_threshold("web_search") == 100_000
+
+
+class TestBudgetConfigOverrides:
+    def test_applies_positive_limits(self):
+        base = BudgetConfig()
+
+        resolved = budget_with_overrides(
+            base,
+            {
+                "max_result_chars": 8_000,
+                "max_turn_chars": 16_000,
+                "preview_chars": 1_500,
+            },
+        )
+
+        assert resolved.default_result_size == 8_000
+        assert resolved.turn_budget == 16_000
+        assert resolved.preview_size == 1_500
+
+    def test_invalid_values_preserve_base(self):
+        base = BudgetConfig(default_result_size=20_000, turn_budget=40_000)
+
+        resolved = budget_with_overrides(
+            base,
+            {
+                "max_result_chars": 0,
+                "max_turn_chars": "invalid",
+                "preview_chars": None,
+            },
+        )
+
+        assert resolved is base
+
+    def test_preview_cannot_exceed_result_or_turn_budget(self):
+        resolved = budget_with_overrides(
+            BudgetConfig(),
+            {
+                "max_result_chars": 1_000,
+                "max_turn_chars": 900,
+                "preview_chars": 2_000,
+            },
+        )
+
+        assert resolved.preview_size == 900
 
 
 # ---------------------------------------------------------------------------

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -4,7 +4,7 @@ Per-tool resolution: pinned > config overrides > registry > default.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict
 
 # Tools whose thresholds must never be overridden.
 # read_file=inf prevents infinite persist->read->persist loops.
@@ -112,3 +112,32 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
         turn_budget=per_turn,
         preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
     )
+
+
+def budget_with_overrides(
+    base: BudgetConfig,
+    overrides: Any,
+) -> BudgetConfig:
+    """Apply positive per-result, per-turn, and preview overrides to a budget."""
+    if not isinstance(overrides, dict):
+        return base
+
+    def _positive_int(key: str, fallback: int) -> int:
+        try:
+            value = int(overrides.get(key))
+        except (TypeError, ValueError):
+            return fallback
+        return value if value > 0 else fallback
+
+    result_size = _positive_int("max_result_chars", base.default_result_size)
+    turn_budget = _positive_int("max_turn_chars", base.turn_budget)
+    preview_size = _positive_int("preview_chars", base.preview_size)
+    preview_size = min(preview_size, result_size, turn_budget)
+
+    resolved = BudgetConfig(
+        default_result_size=result_size,
+        turn_budget=turn_budget,
+        preview_size=preview_size,
+        tool_overrides=base.tool_overrides,
+    )
+    return base if resolved == base else resolved


### PR DESCRIPTION
## Summary
- add `cron.max_turns` so unattended jobs can use a tighter tool-iteration budget than interactive sessions
- add `cron.max_parallel_agent_jobs` to serialize LLM-backed jobs while allowing `no_agent` scripts to keep running concurrently
- add `cron.api_max_retries` so cron can make one app-level attempt while provider routers retain credential-pool rotation
- add optional `cron.tool_result_budget` overrides that reuse the existing lossless artifact-spill path
- enforce agent admission in shared `run_one_job`, covering built-in and external scheduler providers

## Why
A profile with `agent.max_turns: 90`, `agent.api_max_retries: 5`, several due agent jobs, and the default 100K/200K tool-result budgets can create concurrent local-model requests, duplicate a failed request five times, and repeatedly resend large tool outputs. Setting `cron.max_parallel_jobs: 1` also serializes deterministic `no_agent` watchdogs. These cron-scoped controls isolate model pressure without changing interactive behavior or dropping full tool output.

## Compatibility
All settings default to `null` and preserve existing behavior:
- `cron.max_turns` falls back to `agent.max_turns`
- `cron.max_parallel_agent_jobs` treats null/0 as unbounded
- `cron.api_max_retries` falls back to `agent.api_max_retries`; `1` means one total app-level attempt
- `cron.tool_result_budget` falls back to context-scaled budgets
- full oversized outputs remain available through existing sandbox artifact files

## Validation
- canonical isolated runner: 113 scheduler, budget, spill, retry, and cron-integration tests passed
- Ruff passed on all changed Python files
- `git diff --check` passed
