### PR TITLE
fix(terminal): isolate delegated child snapshot state

### DIFF
--- a/contributors/emails/samdavies@live.co.uk
+++ b/contributors/emails/samdavies@live.co.uk
@@ -1,0 +1,2 @@
+SamDavies
+# PR #76360 — terminal snapshot isolation fix

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -196,17 +196,26 @@ def test_delegate_child_kanban_cli_cannot_delete_parent_board(
     env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
     try:
         with delegated_child_context():
-            result = env.execute(
+            child_result = env.execute(
                 _python_with_repo_path(code),
                 timeout=15,
             )
+        assert kb.board_exists("victim")
+        parent_result = env.execute(
+            _python_with_repo_path(code),
+            timeout=15,
+        )
     finally:
         env.cleanup()
 
-    assert result["returncode"] == 1
-    assert "delegate_task child contexts cannot mutate Kanban tasks" in result["output"]
-    assert kb.board_exists("victim")
-    assert kb.board_dir("victim").is_dir()
+    assert child_result["returncode"] == 1
+    assert (
+        "delegate_task child contexts cannot mutate Kanban tasks"
+        in child_result["output"]
+    )
+    assert parent_result["returncode"] == 0, parent_result["output"]
+    assert not kb.board_exists("victim")
+    assert not kb.board_dir("victim").exists()
 
 
 def test_delegate_child_attach_url_guard_leaves_no_row_or_file(monkeypatch, tmp_path):

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -10,9 +10,10 @@ stale value and its ``echo $HERMES_SESSION_ID`` reported a FOREIGN session's id
 — overriding the correct per-command Popen env injected by
 ``_inject_session_context_env``.
 
-The fix strips the per-session bridged vars (HERMES_SESSION_* / UI /
-CRON_AUTO_DELIVER_) from the snapshot at both dump sites in
-``tools/environments/base.py``; they are re-injected fresh on every command.
+The fix strips command-scoped Hermes authority vars (session/UI/delivery,
+Kanban ownership, and delegated-child lineage) from the snapshot at both dump
+sites in ``tools/environments/base.py``; they are re-injected fresh on every
+command.
 """
 
 import os
@@ -28,7 +29,7 @@ from tools.environments.base import (
 
 
 # ---------------------------------------------------------------------------
-# Unit: the exclusion regex matches exactly the bridged vars, nothing else.
+# Unit: the exclusion contract covers every Hermes-owned ephemeral class.
 # ---------------------------------------------------------------------------
 
 def test_regex_matches_bridged_session_vars():
@@ -40,6 +41,15 @@ def test_regex_matches_bridged_session_vars():
         line = f'declare -x {name}="whatever"'
         assert rx.search(line), f"{name} should be excluded from the snapshot"
 
+    for name in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_CLAIM_LOCK",
+        "HERMES_DELEGATED_CHILD_CONTEXT",
+    ):
+        line = f'declare -x {name}="whatever"'
+        assert rx.search(line), f"{name} should be excluded from the snapshot"
+
 
 def test_export_snippet_shape():
     snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
@@ -47,9 +57,15 @@ def test_export_snippet_shape():
     # Unset-by-name (not line-grep): multi-line declare values must not leave
     # continuation lines in the snapshot (issue #71296).
     assert "unset" in snippet
-    assert "${!HERMES_SESSION_*}" in snippet
-    assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
+    assert '"${!HERMES_SESSION_@}"' in snippet
+    assert '"${!HERMES_CRON_AUTO_DELIVER_@}"' in snippet
+    assert '"${!HERMES_KANBAN_@}"' in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
+    assert "builtin export -n" in snippet
+    assert snippet.index("builtin export -n") < snippet.index("builtin unset")
+    assert "builtin export -p" in snippet
+    assert '"$BASH" --noprofile --norc -p -c' in snippet
     assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the dump,
@@ -103,5 +119,48 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
         if os.path.exists(snap):
             with open(snap) as f:
                 assert "HERMES_SESSION_ID" not in f.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_preserves_parent_child_kanban_boundary(monkeypatch, tmp_path):
+    """A child cannot regain parent Kanban env or contaminate the parent."""
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "123")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    command = (
+        "printf '%s|%s\\n' "
+        '"${HERMES_KANBAN_TASK-unset}" '
+        '"${HERMES_DELEGATED_CHILD_CONTEXT-unset}"'
+    )
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        parent_before = env.execute(command)["output"]
+        readonly_result = env.execute(
+            "IFS=_; export HERMES_KANBAN_TASK=t_readonly; "
+            "readonly HERMES_KANBAN_TASK; "
+            "export HERMES_DELEGATED_CHILD_CONTEXT=readonly-child; "
+            "readonly HERMES_DELEGATED_CHILD_CONTEXT; "
+            "builtin() { :; }; export -f builtin; "
+            "BASH=/definitely/not/a/bash"
+        )
+        assert readonly_result["returncode"] == 0, readonly_result["output"]
+        with delegated_child_context():
+            child = env.execute(command)["output"]
+        parent_after = env.execute(command)["output"]
+
+        assert "t_parent|unset" in parent_before
+        assert "unset|1" in child
+        assert "t_parent|unset" in parent_after
+
+        snapshot = open(env._snapshot_path, encoding="utf-8").read()
+        assert "HERMES_KANBAN_" not in snapshot
+        assert "HERMES_DELEGATED_CHILD_CONTEXT" not in snapshot
     finally:
         env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -382,32 +382,43 @@ def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
 
 
-# Per-session variables that the gateway bridges freshly onto every command's
-# process environment (via tools/environments/local._inject_session_context_env,
-# reading gateway.session_context._VAR_MAP). They must NEVER be persisted into
-# the shared bash session snapshot: a single long-lived backend serves many
-# concurrent sessions (the messaging gateway, TUI, desktop/web dashboard all
-# collapse the terminal to one "default" environment), so ``export -p`` dumping
-# the FIRST session's HERMES_SESSION_ID into the snapshot makes every LATER
-# session ``source`` that stale value and see a FOREIGN session's identity —
-# overriding the correct per-command Popen env (issue: cross-session
-# HERMES_SESSION_ID leak via the shared snapshot). Stripping them from the
-# snapshot is safe because they are re-injected on every command; a snapshot
-# should only carry the user's own shell state (PATH, functions, exports they
-# set), not Hermes' per-turn session identity.
+# Hermes-owned variables that are injected freshly into each command's process
+# environment must NEVER be persisted into the shared bash session snapshot. A
+# single long-lived backend serves the parent and every ``delegate_task`` child
+# (plus many gateway/TUI/desktop sessions) through one "default" environment.
+# Persisting command-scoped metadata therefore crosses authority boundaries:
 #
-# Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
-# as the Python-side contract for the exclusion set; the dump path unsets by
-# name/prefix instead of grepping declare lines (see below / issue #71296).
+# * a session id from one turn can override the next turn's fresh identity;
+# * parent ``HERMES_KANBAN_*`` ownership can be restored inside a delegated
+#   child's scrubbed process; and
+# * a child's ``HERMES_DELEGATED_CHILD_CONTEXT`` marker can be restored inside
+#   the parent process after delegation returns.
+#
+# Session variables are bridged by
+# tools/environments/local._inject_session_context_env. Delegated-child and
+# Kanban variables are likewise derived from the current command context by
+# _make_run_env. Stripping all of them from the snapshot is safe because they
+# are re-injected on every command; a snapshot should carry only the user's own
+# shell state (PATH, functions, exports they set), not Hermes authority state.
+#
+# The session subset is kept in sync with gateway.session_context._VAR_MAP;
+# Kanban ownership and delegated-child lineage are the additional command-local
+# authority classes. Used by unit tests as the Python-side contract for the
+# exclusion set; the dump path unsets by name/prefix instead of grepping declare
+# lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|"
+    "HERMES_CRON_AUTO_DELIVER_|HERMES_KANBAN_|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 
 
-def _export_dump_excluding_session_vars(tmp_path: str) -> str:
-    """Return a shell snippet that dumps ``export -p`` to *tmp_path* minus the
-    per-session bridged vars (see ``_SNAPSHOT_EXCLUDED_ENV_REGEX``).
+def _export_dump_excluding_session_vars(
+    tmp_path: str,
+    *,
+    trusted_bash: str = '"$BASH"',
+) -> str:
+    """Return a shell snippet that dumps ``export -p`` to *tmp_path* minus
+    Hermes' command-scoped authority vars (see ``_SNAPSHOT_EXCLUDED_ENV_REGEX``).
 
     Unset the bridged vars in a subshell *before* ``export -p``. A line-based
     ``grep -vE`` filter is unsafe: bash 3.2 prints a value containing a newline
@@ -426,14 +437,32 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     The brace-group redirect is expanded in the current shell, keeping both
     expansions consistent.
     """
-    # ${!PREFIX*} is bash 3.2+ name-prefix expansion; empty matches are fine
-    # because ``unset`` with only missing names is ignored under 2>/dev/null.
+    # Quoted ${!PREFIX@} is bash 3.2+ name-prefix expansion that yields each
+    # matched name as a distinct word without consulting a command-poisoned
+    # IFS. Remove the export attribute before unsetting: ``unset`` cannot remove
+    # a readonly variable,
+    # while ``export -n`` can still keep that value out of ``export -p``. The
+    # two explicit markers keep the name list nonempty even when every prefix
+    # expansion is empty; bare ``export -n`` prints the whole environment.
+    # Run the dump in a fresh privileged Bash: ``-p`` ignores exported shell
+    # functions and BASH_ENV, so a model-defined function named ``builtin``,
+    # ``export``, or ``unset`` cannot shadow the sanitizer. ``trusted_bash`` is
+    # captured by _wrap_command before the model-authored command executes.
+    dump_script = (
+        'builtin export -n "${!HERMES_SESSION_@}" '
+        '"${!HERMES_CRON_AUTO_DELIVER_@}" "${!HERMES_KANBAN_@}" '
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT "
+        "2>/dev/null || true; "
+        'builtin unset "${!HERMES_SESSION_@}" '
+        '"${!HERMES_CRON_AUTO_DELIVER_@}" "${!HERMES_KANBAN_@}" '
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT "
+        "2>/dev/null || true; "
+        "builtin export -p"
+    )
     return (
-        "{ ( "
-        "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "HERMES_UI_SESSION_ID 2>/dev/null; "
-        "export -p; "
-        ") || true; } "
+        "{ "
+        f"{trusted_bash} --noprofile --norc -p -c {shlex.quote(dump_script)} "
+        "|| true; } "
         f"> {tmp_path}"
     )
 
@@ -681,6 +710,13 @@ class BaseEnvironment(ABC):
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
 
+        # Capture the actual Bash executable before the model-authored command
+        # runs. The readonly, session-unique name cannot be redirected to a
+        # model-supplied executable before the post-command snapshot dump.
+        _trusted_bash_var = f"__hermes_snapshot_bash_{self._session_id}"
+        parts.append(f'builtin readonly {_trusted_bash_var}="$BASH"')
+        _trusted_bash = f'"${{{_trusted_bash_var}}}"'
+
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
         quoted_cwd = self._quote_cwd_for_cd(cwd)
@@ -705,7 +741,7 @@ class BaseEnvironment(ABC):
         # _export_dump_excluding_session_vars.
         if self._snapshot_ready:
             parts.append(
-                f"{{ {_export_dump_excluding_session_vars(_snap_tmp)} "
+                f"{{ {_export_dump_excluding_session_vars(_snap_tmp, trusted_bash=_trusted_bash)} "
                 f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )


### PR DESCRIPTION
## Summary

- exclude `HERMES_KANBAN_*` ownership and `HERMES_DELEGATED_CHILD_CONTEXT` lineage from persistent terminal snapshots
- sanitize snapshot exports in a fresh privileged Bash so readonly vars, poisoned `IFS`, startup hooks, and exported shell functions cannot bypass the exclusion
- prove a shared parent → delegated child → parent terminal keeps the child read-only and restores parent mutation capability

## Root cause

Parent agents and `delegate_task` children collapse onto one persistent terminal environment. The child process environment was correctly scrubbed, but sourcing the shared snapshot restored the parent Kanban variables. The child then persisted its own delegated-child marker into that snapshot, so the parent’s next terminal command was misclassified as a child.

## Validation

- 63 focused environment/delegation tests passed
- `git diff --check`
- independent implementation review covered readonly exports, poisoned `IFS`, hostile exported functions, `BASH`/`BASH_ENV`, bootstrap/re-dump ordering, and parent mutation recovery

## Scope

This fixes shared-snapshot authority contamination. The prompt-level rule still forbids deliberately removing a child marker; environment lineage alone is not an OS-level hostile-process boundary.