### PR TITLE
fix(desktop): show platform shortcut hints

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/ship-bar.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/ship-bar.tsx
@@ -9,6 +9,7 @@ import { SplitButton } from '@/components/ui/split-button'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { formatCombo } from '@/lib/keybinds/combo'
 import { notifyError } from '@/store/notifications'
 import {
   $reviewCommitDefault,
@@ -87,7 +88,7 @@ export function ReviewShipBar() {
               runCommit(commitDefault)
             }
           }}
-          placeholder={c.commitPlaceholder}
+          placeholder={c.commitPlaceholder(formatCombo('mod+enter'))}
           rows={1}
           size="sm"
           value={message}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -9,6 +9,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
+import { formatModifierToken } from '@/lib/keybinds/combo'
 import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import {
@@ -178,7 +179,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         triggerHaptic('open')
         toggleLayoutEditMode()
       },
-      title: t.titlebar.layoutEditorTitle
+      title: t.titlebar.layoutEditorTitle(formatModifierToken('mod'))
     },
     {
       active: hapticsMuted,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -174,7 +174,7 @@ export const ar = defineLocale({
     openStarmap: 'فتح خريطة الذاكرة',
     openKeybinds: 'اختصارات لوحة المفاتيح',
     layoutEditor: 'محرر التخطيط',
-    layoutEditorTitle: 'محرر التخطيط — انقر مع ⌘ لإعادة ضبط التخطيط'
+    layoutEditorTitle: modifier => `محرر التخطيط — انقر مع ${modifier} لإعادة ضبط التخطيط`
   },
   keybinds: {
     title: 'اختصارات لوحة المفاتيح',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1802,7 +1802,7 @@ export const ar = defineLocale({
       scopeLastTurn: 'آخر دور',
       commit: 'إيداع',
       commitAndPush: 'إيداع ودفع',
-      commitPlaceholder: 'رسالة (⌘↵ للإيداع)',
+      commitPlaceholder: shortcut => `رسالة (${shortcut} للإيداع)`,
       generateCommitMessage: 'توليد رسالة الإيداع',
       stopGenerating: 'إيقاف التوليد',
       createPr: 'إنشاء PR',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -204,7 +204,7 @@ export const en: Translations = {
     openStarmap: 'Open memory graph',
     openKeybinds: 'Keyboard shortcuts',
     layoutEditor: 'Layout editor',
-    layoutEditorTitle: 'Layout editor — ⌘-click resets the layout'
+    layoutEditorTitle: mod => `Layout editor — ${mod}-click resets the layout`
   },
 
   keybinds: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2127,7 +2127,7 @@ export const en: Translations = {
       scopeLastTurn: 'Last turn',
       commit: 'Commit',
       commitAndPush: 'Commit & Push',
-      commitPlaceholder: 'Message (⌘↵ to commit)',
+      commitPlaceholder: shortcut => `Message (${shortcut} to commit)`,
       generateCommitMessage: 'Generate commit message',
       stopGenerating: 'Stop generating',
       createPr: 'Create PR',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1964,7 +1964,7 @@ export const ja = defineLocale({
       scopeLastTurn: '前のターン',
       commit: 'コミット',
       commitAndPush: 'コミットしてプッシュ',
-      commitPlaceholder: 'メッセージ（⌘↵ でコミット）',
+      commitPlaceholder: shortcut => `メッセージ（${shortcut} でコミット）`,
       generateCommitMessage: 'コミットメッセージを生成',
       stopGenerating: '生成を停止',
       createPr: 'PR を作成',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -246,7 +246,7 @@ export interface Translations {
     openStarmap: string
     openKeybinds: string
     layoutEditor: string
-    layoutEditorTitle: string
+    layoutEditorTitle: (modifier: string) => string
   }
 
   keybinds: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1778,7 +1778,7 @@ export interface Translations {
       scopeLastTurn: string
       commit: string
       commitAndPush: string
-      commitPlaceholder: string
+      commitPlaceholder: (shortcut: string) => string
       generateCommitMessage: string
       stopGenerating: string
       createPr: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1905,7 +1905,7 @@ export const zhHant = defineLocale({
       scopeLastTurn: '上一輪',
       commit: '提交',
       commitAndPush: '提交並推送',
-      commitPlaceholder: '訊息（⌘↵ 提交）',
+      commitPlaceholder: shortcut => `訊息（${shortcut} 提交）`,
       generateCommitMessage: '產生提交訊息',
       stopGenerating: '停止產生',
       createPr: '建立 PR',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2320,7 +2320,7 @@ export const zh: Translations = {
       scopeLastTurn: '上一轮',
       commit: '提交',
       commitAndPush: '提交并推送',
-      commitPlaceholder: '信息（⌘↵ 提交）',
+      commitPlaceholder: shortcut => `信息（${shortcut} 提交）`,
       generateCommitMessage: '生成提交信息',
       stopGenerating: '停止生成',
       createPr: '创建 PR',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -199,7 +199,7 @@ export const zh: Translations = {
     openStarmap: '打开记忆图谱',
     openKeybinds: '键盘快捷键',
     layoutEditor: '布局编辑器',
-    layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局'
+    layoutEditorTitle: mod => `布局编辑器 — ${mod} 点击重置布局`
   },
 
   keybinds: {

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -104,19 +104,21 @@ describe('canonicalizeCombo', () => {
 
 describe('formatCombo — honest Control labels', () => {
   it('renders the Control glyph on macOS', async () => {
-    const { formatCombo } = await loadCombo('MacIntel')
+    const { formatCombo, formatModifierToken } = await loadCombo('MacIntel')
 
     expect(formatCombo('ctrl+tab')).toBe('⌃⇥')
     expect(formatCombo('ctrl+shift+tab')).toBe('⌃⇧⇥')
     expect(formatCombo('mod+enter')).toBe('⌘↵')
+    expect(formatModifierToken('mod')).toBe('⌘')
   })
 
   it.each(['Linux x86_64', 'Win32'])('renders "Ctrl+…" off macOS on %s (base key keeps its glyph)', async platform => {
-    const { formatCombo } = await loadCombo(platform)
+    const { formatCombo, formatModifierToken } = await loadCombo(platform)
 
     expect(formatCombo('ctrl+tab')).toBe('Ctrl+⇥')
     expect(formatCombo('ctrl+shift+tab')).toBe('Ctrl+Shift+⇥')
     expect(formatCombo('mod+enter')).toBe('Ctrl+↵')
+    expect(formatModifierToken('mod')).toBe('Ctrl')
   })
 })
 

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -108,13 +108,15 @@ describe('formatCombo — honest Control labels', () => {
 
     expect(formatCombo('ctrl+tab')).toBe('⌃⇥')
     expect(formatCombo('ctrl+shift+tab')).toBe('⌃⇧⇥')
+    expect(formatCombo('mod+enter')).toBe('⌘↵')
   })
 
-  it('renders "Ctrl+…" off macOS (base key keeps its glyph)', async () => {
-    const { formatCombo } = await loadCombo('Win32')
+  it.each(['Linux x86_64', 'Win32'])('renders "Ctrl+…" off macOS on %s (base key keeps its glyph)', async platform => {
+    const { formatCombo } = await loadCombo(platform)
 
     expect(formatCombo('ctrl+tab')).toBe('Ctrl+⇥')
     expect(formatCombo('ctrl+shift+tab')).toBe('Ctrl+Shift+⇥')
+    expect(formatCombo('mod+enter')).toBe('Ctrl+↵')
   })
 })
 

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -167,7 +167,7 @@ function labelForBase(base: string): string {
   return base.length === 1 ? base.toUpperCase() : base
 }
 
-function labelForMod(mod: string): string {
+export function formatModifierToken(mod: string): string {
   if (mod === 'mod') {
     return IS_MAC ? '⌘' : 'Ctrl'
   }
@@ -193,7 +193,7 @@ export function comboTokens(combo: string): string[] {
   const parts = combo.split('+')
   const base = parts.pop() ?? ''
 
-  return [...parts.map(labelForMod), labelForBase(base)]
+  return [...parts.map(formatModifierToken), labelForBase(base)]
 }
 
 // Human-readable label, e.g. "⌘⇧K" on macOS, "Ctrl+Shift+K" elsewhere.

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -4,8 +4,8 @@
  * header row (count, filter kebab, search, settings, new task — the board
  * SWITCHER lives in the titlebar, see board-switcher.tsx), columns in
  * BOARD_COLUMNS order, drag-to-move (optimistic, workflow-checked),
- * ⌘-click multi-select with a floating bulk bar, right-click actions, and
- * the detail drawer. Dispatch nudges ride every write (see api.ts).
+ * primary-modifier-click multi-select with a floating bulk bar, right-click
+ * actions, and the detail drawer. Dispatch nudges ride every write (see api.ts).
  */
 
 import {
@@ -30,6 +30,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   ErrorState,
+  formatModifierToken,
   host,
   Input,
   Loader,
@@ -308,7 +309,7 @@ function Card({
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => onToggleSelect(task.id)}>
           <Codicon name={selected ? 'close' : 'check-all'} size="0.85rem" />
-          {selected ? k.deselect : k.select}
+          {selected ? k.deselect : k.select(formatModifierToken('mod'))}
         </ContextMenuItem>
         <ContextMenuSeparator />
         {columns

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -29,7 +29,7 @@ type KanbanMessages = {
   noMatch: string
   noTasks: string
   open: string
-  select: string
+  select: (modifier: string) => string
   deselect: string
   moveTo: (label: string) => string
   delete: string
@@ -213,7 +213,7 @@ const en: KanbanMessages = {
   noMatch: 'No tasks match the filters',
   noTasks: 'No tasks on this board',
   open: 'Open',
-  select: 'Select (⌘-click)',
+  select: modifier => `Select (${modifier}-click)`,
   deselect: 'Deselect',
   moveTo: label => `Move to ${label}`,
   delete: 'Delete',
@@ -401,7 +401,7 @@ const ja: KanbanMessages = {
   noMatch: 'フィルタに一致するタスクはありません',
   noTasks: 'このボードにタスクはありません',
   open: '開く',
-  select: '選択（⌘クリック）',
+  select: modifier => `選択（${modifier}クリック）`,
   deselect: '選択解除',
   moveTo: label => `${label} へ移動`,
   delete: '削除',
@@ -588,7 +588,7 @@ const zh: KanbanMessages = {
   noMatch: '没有符合筛选条件的任务',
   noTasks: '此面板暂无任务',
   open: '打开',
-  select: '选择（⌘点击）',
+  select: modifier => `选择（${modifier}点击）`,
   deselect: '取消选择',
   moveTo: label => `移动到 ${label}`,
   delete: '删除',
@@ -772,7 +772,7 @@ const zhHant: KanbanMessages = {
   noMatch: '沒有符合篩選條件的任務',
   noTasks: '此面板尚無任務',
   open: '開啟',
-  select: '選取（⌘點擊）',
+  select: modifier => `選取（${modifier}點擊）`,
   deselect: '取消選取',
   moveTo: label => `移至 ${label}`,
   delete: '刪除',

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -224,6 +224,7 @@ export { triggerHaptic as haptic } from '@/lib/haptics'
 /** The app's lucide icon set (RefreshCw, LayoutDashboard, Activity, …). */
 export * as icons from '@/lib/icons'
 export { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
+export { formatModifierToken } from '@/lib/keybinds/combo'
 /** The app's deterministic identity color for a name (profiles, assignees,
  *  authors) + its translucent tag fill — so plugin-rendered identities read
  *  the same hue as everywhere else. */


### PR DESCRIPTION
## Summary

- make the Review pane's commit-message shortcut hint use the existing platform-aware keybind formatter
- make the Layout editor reset tooltip and Kanban card-selection label use the same platform-aware modifier labels
- preserve `⌘` hints on macOS while showing `Ctrl` on Linux and Windows
- cover macOS, Linux, and Windows formatting for both full shortcuts and modifier-only hints

## Problem

The commit-message placeholder, Layout editor reset tooltip, and Kanban card-selection label are hardcoded with macOS `⌘` hints. Their handlers already accept the primary platform modifier, so `Ctrl+Enter` commits, Ctrl-click resets the layout, and Ctrl-click selects Kanban cards on Linux and Windows even though the UI advertises only the macOS gestures.

## Solution

`ReviewShipBar` now formats the canonical `mod+enter` combo through the shared `formatCombo` helper and supplies that display string to the localized placeholder.

The Layout editor tooltip uses an exported modifier-token formatter from the same keybind utility and passes that label through its localized title. The combo formatter reuses that same modifier-token path, keeping platform detection and display labels in one place.

The same modifier formatter is exported through `@hermes/plugin-sdk` so the lint-fenced Kanban plugin can pass the correct platform label into its localized selection hint without duplicating platform detection. English, Japanese, Simplified Chinese, and Traditional Chinese Kanban strings interpolate that label.

Commit, layout-reset, and Kanban card-selection behavior are unchanged.

## Test plan

- `npm exec -- vitest run --project ui src/lib/keybinds/combo.test.ts src/store/review.test.ts src/i18n/plugin-i18n.test.tsx` — 57 passed
- `npm run test:ui` — 3,235 passed
- `npm run typecheck`
- exact-file ESLint for all changed TypeScript/TSX files
- `npm run build`
- `git diff --check`
