### PR TITLE
feat(qqbot): add optional group member allowlist

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -992,6 +992,22 @@ platform_toolsets:
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
 #
+#   qqbot:
+#     enabled: false               # QQ bot disabled by default; enable only
+#                                  # after adding app credentials to .env
+#     extra:
+#       # Allowlist policy for group @-mentions (default pairing denies all
+#       # group messages; QQ has no group pairing flow).
+#       group_policy: allowlist
+#       group_allow_from:
+#         - "group_openid_example"
+#       # Optional per-member restriction: when set, only these member_openids
+#       # may @ the bot inside an allowed group. Kept separate from the C2C
+#       # allow_from list (different identity namespace). Applies only to QQ
+#       # group @-message member_openid values, not guild/channel author IDs.
+#       group_member_allow_from:
+#         - "member_openid_example"
+#
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #
 # discord:

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -575,6 +575,20 @@ class GatewayAuthorizationMixin:
         if source.chat_type in {"group", "forum"}:
             group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
             group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
+        # QQ Bot: C2C user openids (QQ_ALLOWED_USERS) and group member openids
+        # belong to different identity namespaces — a group sender's
+        # member_openid can never match the DM allowlist.  QQ group traffic is
+        # authorized by the chat-scoped QQ_GROUP_ALLOWED_USERS allowlist and/or
+        # the adapter's own group_policy gate (group_allow_from /
+        # group_member_allow_from), so the C2C allowlist must not be consulted
+        # for group/forum/channel sources.  This keeps the adapter's group
+        # decision authoritative and prevents member_openid values from being
+        # (mis)compared against private-chat identities.
+        if (
+            source.platform == Platform.QQBOT
+            and source.chat_type in {"group", "forum", "channel"}
+        ):
+            platform_allowlist = ""
         global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -147,6 +147,21 @@ def _coerce_list(value: Any) -> List[str]:
     return _coerce_list_impl(value)
 
 
+def _mask_openid(value: Any) -> str:
+    """Mask an OpenID / message id for logs — short prefix and suffix only.
+
+    QQ OpenIDs are 32-hex-char identifiers (C2C user_openid, group_openid,
+    member_openid) and message ids are long ``ROBOT1.0_...`` tokens; neither
+    may be printed in full in logs.  Empty values render as ``<empty>``.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return "<empty>"
+    if len(text) <= 10:
+        return "<id>"
+    return f"{text[:6]}...{text[-4:]}"
+
+
 # ---------------------------------------------------------------------------
 # QQAdapter
 # ---------------------------------------------------------------------------
@@ -216,6 +231,15 @@ class QQAdapter(BasePlatformAdapter):
         self._group_policy = str(extra.get("group_policy", "pairing")).strip().lower()
         self._group_allow_from = _coerce_list(
             extra.get("group_allow_from") or extra.get("groupAllowFrom")
+        )
+        # Optional member-level allowlist for group @ messages.  Lives in its
+        # own field on purpose: QQ group ``member_openid`` values belong to a
+        # different identity namespace than C2C ``user_openid``, so group
+        # members must never be matched against the private-chat
+        # ``allow_from`` (QQ_ALLOWED_USERS).
+        self._group_member_allow_from = _coerce_list(
+            extra.get("group_member_allow_from")
+            or extra.get("groupMemberAllowFrom")
         )
 
         # Connection state
@@ -1318,11 +1342,42 @@ class QQAdapter(BasePlatformAdapter):
         """Handle a group @-message event."""
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
+            logger.debug(
+                "[%s] Group message missing group_openid, dropping", self._log_tag
+            )
             return
-        if not self._is_group_allowed(
-                group_openid, str(author.get("member_openid", ""))
+        allowed, deny_reason = self._evaluate_group_allowed(group_openid)
+        member_id = str(author.get("member_openid", ""))
+        # Member ACL applies only to QQ group @-messages: when an optional
+        # member allowlist is configured for the allowlist policy, the
+        # sender's member_openid must be listed. An empty list adds no
+        # member restriction. This never runs for guild channels or C2C DMs.
+        if (
+            allowed
+            and self._group_policy == "allowlist"
+            and self._group_member_allow_from
+            and not self._entry_matches(self._group_member_allow_from, member_id)
         ):
+            allowed = False
+            deny_reason = "member_not_allowed"
+        if not allowed:
+            # Deliberately masked: never log full OpenIDs or message bodies.
+            logger.warning(
+                "[%s] QQ group message denied: group=%s member=%s policy=%s reason=%s",
+                self._log_tag,
+                _mask_openid(group_openid),
+                _mask_openid(member_id),
+                self._group_policy,
+                deny_reason,
+            )
             return
+        logger.debug(
+            "[%s] QQ group message accepted: group=%s member=%s policy=%s",
+            self._log_tag,
+            _mask_openid(group_openid),
+            _mask_openid(member_id),
+            self._group_policy,
+        )
 
         # Strip the @bot mention prefix from content
         text = self._strip_at_mention(content)
@@ -1390,7 +1445,10 @@ class QQAdapter(BasePlatformAdapter):
         # bypass the configured allowlist.
         guild_id = str(d.get("guild_id", ""))
         author_id = str(author.get("id", ""))
-        if not self._is_group_allowed(guild_id or channel_id, author_id):
+        # Guild channels are group-like contexts: apply the plain group-level
+        # ACL only. author["id"] must never be fed into the QQ group member
+        # ACL (member_openid is a different identity namespace).
+        if not self._is_group_allowed(guild_id or channel_id):
             logger.debug(
                 "[%s] Guild message blocked by ACL: channel=%s user=%s",
                 self._log_tag, channel_id, author_id,
@@ -3195,16 +3253,45 @@ class QQAdapter(BasePlatformAdapter):
             return self._open_dm_opted_in()
         return False
 
-    def _is_group_allowed(self, group_id: str, user_id: str) -> bool:
+    def _is_group_allowed(self, group_id: str) -> bool:
+        """Legacy bool wrapper — see :meth:`_evaluate_group_allowed`."""
+        return self._evaluate_group_allowed(group_id)[0]
+
+    def _evaluate_group_allowed(self, group_id: str):
+        """Evaluate the QQ group-level policy gate.
+
+        Returns ``(allowed, reason)``.  ``reason`` is ``None`` when the
+        message is allowed, otherwise one of ``group_not_allowed`` /
+        ``pairing_unavailable``.
+
+        Explicit allowlist semantics:
+
+        * no group allowlist configured → deny;
+        * ``group_openid`` not in the group allowlist → deny.
+
+        This evaluator is group-level only: it never reads
+        ``group_member_allow_from``, ``member_openid`` values, guild author
+        IDs, or the C2C ``allow_from`` / ``QQ_ALLOWED_USERS``.  Member-level
+        authorization for QQ group @-messages is applied in
+        :meth:`_handle_group_message`; guild channels stay covered by this
+        plain group ACL via :meth:`_handle_guild_message`.
+        """
         if self._group_policy == "disabled":
-            return False
-        if self._group_policy == "allowlist":
-            return self._entry_matches(self._group_allow_from, group_id)
+            return False, "group_not_allowed"
         if self._group_policy == "pairing":
-            return False
+            # QQ has no pairing flow for group chats; pairing mode must not
+            # pretend an unpaired group is authorized.
+            return False, "pairing_unavailable"
         if self._group_policy == "open":
-            return True
-        return False
+            # Unchanged semantics at the adapter gate.  The gateway authz
+            # layer still requires an explicit group allowlist for QQ group
+            # traffic, so ``open`` does NOT blanket-authorize every group.
+            return True, None
+        if self._group_policy == "allowlist":
+            if not self._entry_matches(self._group_allow_from, group_id):
+                return False, "group_not_allowed"
+            return True, None
+        return False, "group_not_allowed"
 
     @staticmethod
     def _entry_matches(entries: List[str], target: str) -> bool:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -264,13 +264,13 @@ class TestGroupAllowed:
 
     def test_allowlist_match(self):
         adapter = self._make_adapter(app_id="a", client_secret="b", group_policy="allowlist", group_allow_from="grp1")
-        assert adapter._is_group_allowed("grp1", "user1") is True
+        assert adapter._is_group_allowed("grp1") is True
 
 
     def test_pairing_default_blocks_groups(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         assert adapter._group_policy == "pairing"
-        assert adapter._is_group_allowed("grp1", "user1") is False
+        assert adapter._is_group_allowed("grp1") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot_group_authz_e2e.py
+++ b/tests/gateway/test_qqbot_group_authz_e2e.py
@@ -1,0 +1,386 @@
+"""QQ group @-message end-to-end authorization tests.
+
+Drives the full inbound chain for a raw ``GROUP_AT_MESSAGE_CREATE`` dispatch:
+
+    QQAdapter._dispatch_payload → _on_message → _handle_group_message
+    → MessageEvent → GatewayRunner._is_user_authorized (the gateway authz gate)
+
+and asserts the combined adapter + authz outcome for each configuration.
+
+Final design semantics being pinned:
+
+* ``group_policy=allowlist`` + ``group_allow_from`` (from config.yaml /
+  PlatformConfig.extra, or the ``QQ_GROUP_ALLOWED_USERS`` env var) is the ONLY
+  configuration path that authorizes QQ group traffic.
+* An allowed group with NO member allowlist admits every member who really
+  @-ed the bot; a configured member allowlist (``group_member_allow_from``)
+  gates members.
+* ``group_policy=open`` is NOT an authorization path for QQ groups — with or
+  without a configured group allowlist, open never authorizes group traffic at
+  the authz layer (open is "forwarded, not authorized"; only the allowlist
+  policy is trusted).  This guarantees open can never blanket-open every group.
+* Group ``member_openid`` values are never compared against the C2C
+  ``QQ_ALLOWED_USERS`` allowlist (different identity namespace).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+GROUP_ID = "47A1B2C3D4E5F60718293A4B5C6D7E8F"
+OTHER_GROUP_ID = "58B2C3D4E5F60718293A4B5C6D7E8F0A"
+MEMBER_ID = "6C93D4E5F60718293A4B5C6D7E8F0A1B"
+OTHER_MEMBER_ID = "7DA4E5F60718293A4B5C6D7E8F0A1B2C"
+C2C_OPENID = "C2C_OPENID_0000000000000000000000000000000C"
+MSG_ID = "ROBOT1.0_MSG_0000000000000000000000000000000000000000"
+
+
+def _make_adapter(**extra):
+    from gateway.platforms.qqbot import QQAdapter
+    return QQAdapter(PlatformConfig(enabled=True, extra=dict(extra)))
+
+
+def _make_runner(adapter):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.QQBOT: adapter}
+    runner.pairing_store = None
+    runner.pairing_stores = {}
+    runner.config = None
+    return runner
+
+
+def _group_payload(group_id=GROUP_ID, member_id=MEMBER_ID):
+    return {
+        "id": MSG_ID,
+        "content": "@bot hello",
+        "group_openid": group_id,
+        "author": {"member_openid": member_id},
+        "timestamp": "2026-08-01T10:00:00+08:00",
+    }
+
+
+async def _dispatch_group_at(adapter, payload, monkeypatch):
+    """Dispatch a raw GROUP_AT_MESSAGE_CREATE payload and capture the event.
+
+    Returns the MessageEvent created by the adapter, or ``None`` when the
+    adapter's group policy denied the message before event construction.
+    """
+    captured = {}
+
+    async def _fake_handle(event):
+        captured["event"] = event
+
+    adapter.handle_message = _fake_handle
+
+    created = []
+    orig_create_task = asyncio.create_task
+
+    def _capture_task(coro):
+        task = orig_create_task(coro)
+        created.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _capture_task)
+    adapter._dispatch_payload({"op": 0, "t": "GROUP_AT_MESSAGE_CREATE", "d": payload})
+    if created:
+        await asyncio.gather(*created)
+    return captured.get("event")
+
+
+def _clean_qq_env(monkeypatch):
+    for var in (
+        "QQ_ALLOWED_USERS",
+        "QQ_GROUP_ALLOWED_USERS",
+        "QQ_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. allowlist via config.yaml / PlatformConfig.extra only (no group env var)
+# ---------------------------------------------------------------------------
+
+class TestAllowlistFromConfigExtra:
+    @pytest.mark.asyncio
+    async def test_allowed_group_enters_agent(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        # QQ_ALLOWED_USERS (C2C) is set in production; it must not interfere.
+        monkeypatch.setenv("QQ_ALLOWED_USERS", C2C_OPENID)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        assert event is not None
+        assert event.source.chat_type == "group"
+        assert event.source.chat_id == GROUP_ID
+        assert event.source.user_id == MEMBER_ID
+        assert runner._is_user_authorized(event.source) is True
+
+    @pytest.mark.asyncio
+    async def test_list_via_config_extra_member_openid_never_needs_c2c_list(
+        self, monkeypatch
+    ):
+        _clean_qq_env(monkeypatch)
+        monkeypatch.setenv("QQ_ALLOWED_USERS", C2C_OPENID)
+        # Member allowlist is independent of the C2C allowlist: the member is
+        # NOT in QQ_ALLOWED_USERS yet must still be authorized.
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. allowlist via QQ_GROUP_ALLOWED_USERS env var
+# ---------------------------------------------------------------------------
+
+def _make_adapter_from_env(monkeypatch, env):
+    """Build the QQ adapter exactly as the production gateway does.
+
+    Sets the given env vars, then runs the real env→config bridging
+    (``gateway.config._apply_env_overrides``) so the adapter sees the same
+    ``extra`` that production config loading produces (env vars are bridged
+    into ``extra.group_allow_from`` etc.).
+
+    ``group_policy`` has no env bridge for QQ — it comes from config.yaml
+    (``platforms.qqbot.extra.group_policy``), so the helper applies
+    ``allowlist`` on the bridged PlatformConfig, mirroring the documented
+    production combination: config.yaml policy + env allowlist.
+    """
+    from gateway.config import GatewayConfig, _apply_env_overrides
+    from gateway.platforms.qqbot import QQAdapter
+
+    _clean_qq_env(monkeypatch)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+    platform_cfg = config.platforms[Platform.QQBOT]
+    platform_cfg.extra["group_policy"] = "allowlist"
+    return QQAdapter(platform_cfg)
+
+
+class TestAllowlistFromEnv:
+    @pytest.mark.asyncio
+    async def test_env_group_allowlist_authorizes_group(self, monkeypatch):
+        adapter = _make_adapter_from_env(
+            monkeypatch,
+            {
+                "QQ_APP_ID": "a",
+                "QQ_CLIENT_SECRET": "b",
+                "QQ_GROUP_ALLOWED_USERS": GROUP_ID,
+            },
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Group not in the allowlist → denied at the adapter with masked log
+# ---------------------------------------------------------------------------
+
+class TestNonAllowedGroupDenied:
+    @pytest.mark.asyncio
+    async def test_unknown_group_denied_before_authz(self, monkeypatch, caplog):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(
+            adapter, _group_payload(group_id=OTHER_GROUP_ID), monkeypatch
+        )
+
+        assert event is None  # no MessageEvent → authz never consulted
+        log_text = "\n".join(rec.message for rec in caplog.records)
+        assert "QQ group message denied" in log_text
+        assert "reason=group_not_allowed" in log_text
+        assert OTHER_GROUP_ID not in log_text
+        assert MEMBER_ID not in log_text
+
+
+# ---------------------------------------------------------------------------
+# 4. open + no group allowlist → MUST be denied (never blanket-open)
+# ---------------------------------------------------------------------------
+
+class TestOpenWithoutAllowlistDenied:
+    @pytest.mark.asyncio
+    async def test_open_without_any_allowlist_denied_at_authz(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(app_id="a", client_secret="b", group_policy="open")
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        # The adapter forwards (open = no adapter-level restriction), but the
+        # gateway authz layer must deny: open is not an authorization path.
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is False
+
+    @pytest.mark.asyncio
+    async def test_open_denied_even_with_c2c_allowlist_set(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        monkeypatch.setenv("QQ_ALLOWED_USERS", MEMBER_ID)
+        adapter = _make_adapter(app_id="a", client_secret="b", group_policy="open")
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        # Even if the member id sits in the C2C allowlist, group traffic under
+        # open must not be authorized by it.
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. open + explicit group allowlist → still denied (open is not an
+#    authorization path for QQ groups; only the allowlist policy is trusted)
+# ---------------------------------------------------------------------------
+
+class TestOpenWithAllowlistDenied:
+    @pytest.mark.asyncio
+    async def test_open_with_group_allowlist_is_not_authorized(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="open",
+            group_allow_from=GROUP_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Allowed group, no member allowlist → any real-@ member enters
+# ---------------------------------------------------------------------------
+
+class TestAllowedGroupAnyMember:
+    @pytest.mark.asyncio
+    async def test_unlisted_member_still_authorized(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(
+            adapter, _group_payload(member_id=OTHER_MEMBER_ID), monkeypatch
+        )
+
+        assert event is not None
+        assert event.source.user_id == OTHER_MEMBER_ID
+        assert runner._is_user_authorized(event.source) is True
+
+
+# ---------------------------------------------------------------------------
+# 7. Allowed group + member allowlist → only matching member_openid
+# ---------------------------------------------------------------------------
+
+class TestMemberAllowlistGatesMembers:
+    @pytest.mark.asyncio
+    async def test_listed_member_authorized(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        assert event is not None
+        assert runner._is_user_authorized(event.source) is True
+
+    @pytest.mark.asyncio
+    async def test_unlisted_member_denied_at_adapter(self, monkeypatch, caplog):
+        _clean_qq_env(monkeypatch)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(
+            adapter, _group_payload(member_id=OTHER_MEMBER_ID), monkeypatch
+        )
+
+        assert event is None
+        log_text = "\n".join(rec.message for rec in caplog.records)
+        assert "reason=member_not_allowed" in log_text
+        assert OTHER_MEMBER_ID not in log_text
+
+
+# ---------------------------------------------------------------------------
+# 8. member_openid is never compared against the C2C QQ_ALLOWED_USERS list
+# ---------------------------------------------------------------------------
+
+class TestMemberNeverComparedToC2CList:
+    @pytest.mark.asyncio
+    async def test_c2c_allowlist_does_not_authorize_group_members(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        # The member's openid sits in the C2C allowlist — that must NOT
+        # authorize the group message when no group policy is configured.
+        monkeypatch.setenv("QQ_ALLOWED_USERS", MEMBER_ID)
+        adapter = _make_adapter(app_id="a", client_secret="b")  # pairing default
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(adapter, _group_payload(), monkeypatch)
+
+        # Adapter gate (pairing) denies before the C2C list could ever apply.
+        assert event is None
+
+    @pytest.mark.asyncio
+    async def test_member_allowlist_is_authoritative_over_c2c_list(self, monkeypatch):
+        _clean_qq_env(monkeypatch)
+        # Member IS in the C2C allowlist but NOT in the member allowlist —
+        # the member allowlist must win and deny.
+        monkeypatch.setenv("QQ_ALLOWED_USERS", OTHER_MEMBER_ID)
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist",
+            group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        runner = _make_runner(adapter)
+
+        event = await _dispatch_group_at(
+            adapter, _group_payload(member_id=OTHER_MEMBER_ID), monkeypatch
+        )
+
+        assert event is None

--- a/tests/gateway/test_qqbot_group_policy.py
+++ b/tests/gateway/test_qqbot_group_policy.py
@@ -1,0 +1,445 @@
+"""QQ Bot group @-message policy tests.
+
+Covers the explicit-allowlist group policy model:
+
+* default ``group_policy=pairing`` denies every group @ message (QQ has no
+  group pairing flow) and leaves a masked WARNING log;
+* ``group_policy=allowlist`` + ``group_allow_from`` allows only explicitly
+  configured groups;
+* an optional member allowlist (``group_member_allow_from``) gates which
+  members inside an allowed group may interact — and is never mixed with the
+  private-chat C2C allowlist (``QQ_ALLOWED_USERS`` / ``allow_from``);
+* denied messages never reach ``handle_message`` (no MessageEvent);
+* logs never contain full group/member OpenIDs;
+* non-@ group events (``GROUP_MESSAGE_CREATE``) are not newly subscribed or
+  routed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+GROUP_ID = "47A1B2C3D4E5F60718293A4B5C6D7E8F"
+OTHER_GROUP_ID = "58B2C3D4E5F60718293A4B5C6D7E8F0A"
+MEMBER_ID = "6C93D4E5F60718293A4B5C6D7E8F0A1B"
+OTHER_MEMBER_ID = "7DA4E5F60718293A4B5C6D7E8F0A1B2C"
+C2C_OPENID = "C2C_OPENID_0000000000000000000000000000000C"
+MSG_ID = "ROBOT1.0_MSG_0000000000000000000000000000000000000000"
+
+
+def _make_config(**extra):
+    """Build a PlatformConfig(enabled=True, extra=extra) for testing."""
+    return PlatformConfig(enabled=True, extra=extra)
+
+
+def _make_adapter(**extra):
+    from gateway.platforms.qqbot import QQAdapter
+    return QQAdapter(_make_config(**extra))
+
+
+def _group_payload(group_id=GROUP_ID, member_id=MEMBER_ID, content="@bot hello"):
+    return {
+        "id": MSG_ID,
+        "content": content,
+        "group_openid": group_id,
+        "author": {"member_openid": member_id},
+        "timestamp": "2026-08-01T10:00:00+08:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Default pairing, no group config → deny + masked log
+# ---------------------------------------------------------------------------
+
+class TestDefaultPairingDenies:
+    def test_default_pairing_denies_group(self):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        assert adapter._group_policy == "pairing"
+        assert adapter._is_group_allowed(GROUP_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_group_message_denied_and_logged(self, caplog):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert any(
+            "QQ group message denied" in rec.message
+            and "policy=pairing" in rec.message
+            and "reason=pairing_unavailable" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Allowed group, no member allowlist → any member @ passes
+# ---------------------------------------------------------------------------
+
+class TestAllowedGroupNoMemberAllowlist:
+    def test_policy_decision_allows(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        allowed, reason = adapter._evaluate_group_allowed(GROUP_ID)
+        assert allowed is True
+        assert reason is None
+
+    @pytest.mark.asyncio
+    async def test_group_message_reaches_handle_message(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-allowed group → deny
+# ---------------------------------------------------------------------------
+
+class TestNonAllowedGroupDenied:
+    def test_policy_decision_denies_group(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        allowed, reason = adapter._evaluate_group_allowed(OTHER_GROUP_ID)
+        assert allowed is False
+        assert reason == "group_not_allowed"
+
+    @pytest.mark.asyncio
+    async def test_group_message_denied_with_reason(self, caplog):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(group_id=OTHER_GROUP_ID),
+            MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, "",
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert any(
+            "QQ group message denied" in rec.message
+            and "reason=group_not_allowed" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Allowed group + allowed member → pass
+# ---------------------------------------------------------------------------
+
+class TestAllowedGroupAndMember:
+    @pytest.mark.asyncio
+    async def test_member_message_reaches_handle_message(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 5. Allowed group + non-allowed member → deny
+# ---------------------------------------------------------------------------
+
+class TestAllowedGroupNonAllowedMemberDenied:
+    @pytest.mark.asyncio
+    async def test_member_message_denied_with_reason(self, caplog):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(member_id=OTHER_MEMBER_ID),
+            MSG_ID, "@bot hello", {"member_openid": OTHER_MEMBER_ID}, "",
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert any(
+            "QQ group message denied" in rec.message
+            and "reason=member_not_allowed" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Group members never need to hit the C2C allow_from / QQ_ALLOWED_USERS
+# ---------------------------------------------------------------------------
+
+class TestGroupMemberIndependentOfC2CAllowlist:
+    def test_member_allowed_without_c2c_allow_from(self):
+        # allow_from holds a C2C openid (private chat); the group member is a
+        # different value and is NOT listed — the group gate must still pass.
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            allow_from=C2C_OPENID,
+        )
+        allowed, reason = adapter._evaluate_group_allowed(GROUP_ID)
+        assert allowed is True
+        assert reason is None
+
+    @pytest.mark.asyncio
+    async def test_member_allowlist_does_not_read_c2c_allow_from(self):
+        # With a member allowlist configured, only it decides membership —
+        # a member listed in the C2C allow_from but absent from the member
+        # allowlist stays denied at the group-message path.
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            allow_from=MEMBER_ID,  # member id sits in the C2C allowlist
+            group_member_allow_from=OTHER_MEMBER_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_group_message_passes_without_c2c_allow_from(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            allow_from=C2C_OPENID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Private-chat C2C allowlist behavior is unchanged
+# ---------------------------------------------------------------------------
+
+class TestC2CBehaviorUnchanged:
+    def test_dm_allowlist_still_matches(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            dm_policy="allowlist", allow_from=f"{C2C_OPENID},user2",
+        )
+        assert adapter._is_dm_allowed(C2C_OPENID) is True
+        assert adapter._is_dm_allowed("user2") is True
+        assert adapter._is_dm_allowed("stranger") is False
+
+    def test_dm_intake_pairing_default_unchanged(self):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        assert adapter._is_dm_intake_allowed("any_user") is True
+        assert adapter._is_dm_allowed("any_user") is False
+
+    def test_group_member_allowlist_does_not_leak_into_dm(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        # The member allowlist must not authorize private-chat senders.
+        assert adapter._is_dm_allowed(MEMBER_ID) is False
+
+
+# ---------------------------------------------------------------------------
+# 8. Logs never contain full group/member OpenIDs
+# ---------------------------------------------------------------------------
+
+class TestLogMasking:
+    @pytest.mark.asyncio
+    async def test_denial_log_masks_openids(self, caplog):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        log_text = "\n".join(rec.message for rec in caplog.records)
+        assert "QQ group message denied" in log_text
+        assert GROUP_ID not in log_text
+        assert MEMBER_ID not in log_text
+        assert "47A1B2...7E8F" in log_text  # masked: 6-prefix + 4-suffix
+        assert "6C93D4...0A1B" in log_text
+
+    @pytest.mark.asyncio
+    async def test_accept_log_masks_openids(self, caplog):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        adapter.handle_message = AsyncMock()
+        caplog.set_level("DEBUG")
+
+        await adapter._handle_group_message(
+            _group_payload(), MSG_ID, "@bot hello", {"member_openid": MEMBER_ID}, ""
+        )
+
+        log_text = "\n".join(rec.message for rec in caplog.records)
+        assert "QQ group message accepted" in log_text
+        assert GROUP_ID not in log_text
+        assert MEMBER_ID not in log_text
+
+    def test_mask_helper(self):
+        from gateway.platforms.qqbot.adapter import _mask_openid
+        assert _mask_openid(GROUP_ID) == "47A1B2...7E8F"
+        assert _mask_openid("") == "<empty>"
+        assert _mask_openid(None) == "<empty>"
+
+
+# ---------------------------------------------------------------------------
+# 9. Passed messages build a correct MessageEvent
+# ---------------------------------------------------------------------------
+
+class TestMessageEventConstruction:
+    @pytest.mark.asyncio
+    async def test_event_fields_are_correct(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GROUP_ID,
+        )
+        captured = {}
+        async def _fake_handle(event):
+            captured["event"] = event
+        adapter.handle_message = _fake_handle
+
+        await adapter._handle_group_message(
+            _group_payload(content="@bot 查天气"),
+            MSG_ID, "@bot 查天气", {"member_openid": MEMBER_ID}, "2026-08-01T10:00:00+08:00",
+        )
+
+        event = captured["event"]
+        assert event.source.chat_type == "group"
+        assert event.source.chat_id == GROUP_ID
+        assert event.source.user_id == MEMBER_ID
+        assert event.message_id == MSG_ID
+        # The @-mention prefix is stripped by the adapter before the event.
+        assert event.text == "查天气"
+        # Group sessions key on group_openid, isolating them from C2C DMs.
+        assert adapter._chat_type_map.get(GROUP_ID) == "group"
+
+
+# ---------------------------------------------------------------------------
+# 10. Non-@ group events are not newly subscribed or routed
+# ---------------------------------------------------------------------------
+
+class TestNonAtGroupEventsNotHandled:
+    def test_group_message_create_not_routed_to_on_message(self, monkeypatch):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        scheduled = []
+        monkeypatch.setattr(asyncio, "create_task", lambda coro: scheduled.append(coro))
+
+        # GROUP_MESSAGE_CREATE (non-@ group traffic) must NOT be dispatched
+        # to _on_message — QQ only pushes GROUP_AT_MESSAGE_CREATE under the
+        # subscribed intent, and we must not start handling full-group traffic.
+        adapter._dispatch_payload({"op": 0, "t": "GROUP_MESSAGE_CREATE", "d": {}})
+        assert scheduled == []
+
+    def test_group_at_message_create_is_routed(self, monkeypatch):
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        scheduled = []
+        monkeypatch.setattr(asyncio, "create_task", lambda coro: scheduled.append(coro))
+
+        adapter._dispatch_payload(
+            {"op": 0, "t": "GROUP_AT_MESSAGE_CREATE", "d": {"id": MSG_ID}}
+        )
+        assert len(scheduled) == 1
+        # Close the never-run coroutine so pytest sees no pending-task warning.
+        scheduled[0].close()
+
+
+# ---------------------------------------------------------------------------
+# 11. Guild ACL stays group-level: member allowlist must not restrict guilds
+# ---------------------------------------------------------------------------
+
+GUILD_ID = "9E4C5D6E7F8091A2B3C4D5E6F708192A3"
+CHANNEL_ID = "AF5D6E7F8091A2B3C4D5E6F708192A3B4"
+GUILD_AUTHOR_ID = "B06E7F8091A2B3C4D5E6F708192A3B4C5"
+OTHER_GUILD_ID = "C17F8091A2B3C4D5E6F708192A3B4C5D6"
+
+
+def _guild_payload(guild_id=GUILD_ID, channel_id=CHANNEL_ID, author_id=GUILD_AUTHOR_ID):
+    return {
+        "id": MSG_ID,
+        "content": "@bot hello",
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "author": {"id": author_id, "username": "guild_user"},
+        "member": {"nick": "guild_user"},
+        "timestamp": "2026-08-01T10:00:00+08:00",
+    }
+
+
+class TestGuildACLUnaffectedByMemberAllowlist:
+    @pytest.mark.asyncio
+    async def test_member_allowlist_does_not_restrict_allowlisted_guild(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GUILD_ID,
+            group_member_allow_from=MEMBER_ID,  # guild author is NOT listed
+        )
+        captured = {}
+
+        async def _fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = _fake_handle
+
+        await adapter._handle_guild_message(
+            _guild_payload(), MSG_ID, "@bot hello",
+            {"id": GUILD_AUTHOR_ID, "username": "guild_user"}, "",
+        )
+
+        # Guild traffic is group-level only: author["id"] is never matched
+        # against group_member_allow_from.
+        assert "event" in captured
+        event = captured["event"]
+        assert event.source.chat_type == "group"
+        assert event.source.chat_id == CHANNEL_ID
+        assert event.source.user_id == GUILD_AUTHOR_ID
+
+    @pytest.mark.asyncio
+    async def test_unallowlisted_guild_remains_denied(self):
+        adapter = _make_adapter(
+            app_id="a", client_secret="b",
+            group_policy="allowlist", group_allow_from=GUILD_ID,
+            group_member_allow_from=MEMBER_ID,
+        )
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_guild_message(
+            _guild_payload(guild_id=OTHER_GUILD_ID), MSG_ID, "@bot hello",
+            {"id": GUILD_AUTHOR_ID}, "",
+        )
+
+        adapter.handle_message.assert_not_awaited()

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -70,12 +70,22 @@ platforms:
       app_id: "your-app-id"
       client_secret: "your-secret"
       markdown_support: true       # enable QQ markdown (msg_type 2). Config-only; no env-var equivalent.
-      dm_policy: "open"          # open | allowlist | disabled
+      dm_policy: "open"          # open | allowlist | disabled | pairing
       allow_from:
         - "user_openid_1"
-      group_policy: "open"       # open | allowlist | disabled
+      group_policy: "allowlist"  # allowlist | disabled | pairing | open
+                                 # (default pairing DENIES all group messages —
+                                 #  QQ has no group pairing flow. open is NOT an
+                                 #  authorization path for QQ groups: even with a
+                                 #  group allowlist configured, the gateway authz
+                                 #  layer denies open group traffic — use allowlist)
       group_allow_from:
-        - "group_openid_1"
+        - "group_openid_example"
+      group_member_allow_from:   # optional; when set, only these members may
+        - "member_openid_example" # @ the bot inside an allowed group
+                                 # Applies only to QQ group @-message
+                                 # member_openid values; it does not restrict
+                                 # guild/channel author IDs.
       stt:
         provider: "zai"          # zai (GLM-ASR), openai (Whisper), etc.
         baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"
@@ -113,7 +123,7 @@ This usually means:
 
 - Verify the bot's **intents** are enabled at q.qq.com
 - Check `QQ_ALLOWED_USERS` if DM access is restricted
-- For group messages, ensure the bot is **@mentioned** (group policy may require allowlisting)
+- For group messages, ensure the bot is **@mentioned** and the group is explicitly allowlisted: set `group_policy: "allowlist"` with `QQ_GROUP_ALLOWED_USERS` (or `platforms.qqbot.extra.group_allow_from`), plus optional `group_member_allow_from` to restrict which members may interact. The default `pairing` policy denies all group messages (QQ has no group pairing flow)
 - Check `QQBOT_HOME_CHANNEL` for cron/notification delivery
 
 ### Connection errors

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/qqbot.md
@@ -70,12 +70,19 @@ platforms:
       app_id: "your-app-id"
       client_secret: "your-secret"
       markdown_support: true       # enable QQ markdown (msg_type 2). Config-only; no env-var equivalent.
-      dm_policy: "open"          # open | allowlist | disabled
+      dm_policy: "open"          # open | allowlist | disabled | pairing
       allow_from:
         - "user_openid_1"
-      group_policy: "open"       # open | allowlist | disabled
+      group_policy: "allowlist"  # allowlist | disabled | pairing | open
+                                 # (默认 pairing 会拒绝所有群消息——QQ 没有群配对流程；
+                                 #  open 对 QQ 群不是授权路径：即使配置了群白名单，
+                                 #  网关 authz 层也会拒绝 open 的群流量——请使用 allowlist)
       group_allow_from:
-        - "group_openid_1"
+        - "group_openid_example"
+      group_member_allow_from:   # 可选；配置后仅这些成员可在被授权群内
+        - "member_openid_example" # @ 机器人
+                                 # 仅适用于 QQ 群 @ 消息中的 member_openid，
+                                 # 不会限制 QQ Guild/频道消息中的 author ID。
       stt:
         provider: "zai"          # zai (GLM-ASR), openai (Whisper), etc.
         baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"


### PR DESCRIPTION
## What does this PR do?

Adds an optional per-member allowlist for QQ group @-mentions.

Existing group-level allowlist behavior remains unchanged when the member
allowlist is empty. When it is configured, both the group and the invoking
group member must be explicitly allowed.

The implementation keeps QQ group `member_openid` authorization separate from
C2C `user_openid` authorization.

## Related Issue

No directly matching issue currently exists.

Related: #63761 concerns a separate `GROUP_MESSAGE_CREATE` dispatch issue and
is not fixed or closed by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `gateway/platforms/qqbot/adapter.py`
  - Add the optional `group_member_allow_from` setting
  - Require a member allowlist match only when the optional list is configured
  - Preserve existing group-only behavior when the member list is empty
  - Keep guild/channel traffic on the existing group-level ACL path
  - Mask group and member OpenIDs in authorization-denial logs
- Update `gateway/authz_mixin.py`
  - Keep QQ group `member_openid` authorization separate from the C2C
    `user_openid` authorization namespace
- Update `cli-config.yaml.example`
  - Add a minimal commented QQBot group and member allowlist example
- Add policy and end-to-end authorization regression tests
  - Confirm that `group_member_allow_from` does not restrict an
    already-allowlisted guild
  - Confirm that an unallowlisted guild remains denied
- Update the English and Simplified Chinese QQBot documentation
- Add no new user-facing environment variable; the setting is configured
  through `platforms.qqbot.extra.group_member_allow_from`

## How to Test

1. Run the targeted QQBot policy, authorization, and configuration tests:

   ```bash
   pytest \
     tests/gateway/test_allowlist_startup_check.py \
     tests/gateway/test_auth_fallback.py \
     tests/gateway/test_config_env_bridge_authority.py \
     tests/gateway/test_multiplex_profile_authz.py \
     tests/gateway/test_pairing.py \
     tests/gateway/test_pairing_allowlist_bypass.py \
     tests/gateway/test_qqbot.py \
     tests/gateway/test_qqbot_group_authz_e2e.py \
     tests/gateway/test_qqbot_group_policy.py \
     -q
   ```

2. Confirm the targeted suite reports `138 passed`.

3. Configure an allowed QQ group with `group_policy: allowlist` and
   `group_allow_from`. Optionally configure `group_member_allow_from`, then
   verify that:

   - an allowed member in an allowed group reaches the agent;
   - an unlisted group or member is rejected;
   - leaving the member allowlist empty preserves existing group-only behavior.

A manual production validation of the allowed group/member path also passed.
All production identifiers have been omitted.

A previous full-suite run reached pytest `sessionfinish`, but the process hit
`OSError: [Errno 24] Too many open files` while opening the JUnit report under
an environment with `ulimit -n 1024`. A complete full-suite pass is therefore
not claimed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04.5 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows footgun check passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changes

## Screenshots / Logs

Manual production validation passed. Logs are intentionally not attached
because they contain platform identifiers.

No production identifiers, credentials, runtime configuration files, or logs
are included in this PR. The only configuration-file change is the public
`cli-config.yaml.example`.