### PR TITLE
fix(kanban): enforce scratch-artifact-guard in kanban_complete

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -642,6 +642,30 @@ def _handle_complete(args: dict, **kw) -> str:
             metadata = json.loads(meta_json)
         except json.JSONDecodeError:
             pass
+
+    # --- Scratch Artifact Guard (re-applied by ~/.hermes/profiles/operator/scripts/reapply_scratch_artifact_guard.py)
+    # The guard plugin's pre_tool_call hook is bypassed in quiet mode, so we
+    # enforce the same policy inside the kanban_complete tool handler itself.
+    # The actual policy lives in ~/.hermes/plugins/scratch-artifact-guard/guard.py.
+    try:
+        import importlib.util as _sag_iu, os as _sag_os
+        _sag_path = _sag_os.path.expanduser("~/.hermes/plugins/scratch-artifact-guard/guard.py")
+        if _sag_os.path.isfile(_sag_path):
+            _sag_spec = _sag_iu.spec_from_file_location("_hermes_sag_guard", _sag_path)
+            _sag_mod = _sag_iu.module_from_spec(_sag_spec)
+            _sag_spec.loader.exec_module(_sag_mod)
+            _sag_preview = None
+            _sag_text = (summary or result or "")
+            if isinstance(_sag_text, str):
+                _sag_preview = _sag_text.strip().splitlines()[0][:200]
+            _sag_block = _sag_mod.check_and_block(tid, _sag_preview)
+            if _sag_block:
+                return tool_error(_sag_block)
+    except Exception:
+        # Guard failures must never block a legitimate completion.
+        pass
+    # --- End Scratch Artifact Guard ---
+
     created_cards = args.get("created_cards")
     artifacts = args.get("artifacts")
     if created_cards is not None:


### PR DESCRIPTION
## Summary

The scratch-artifact-guard plugin's `pre_tool_call` hook is bypassed in quiet mode, allowing workers to complete kanban tasks with scratch artifact paths that should stay inside the workspace.

## Change

Adds an inline check inside `_handle_complete` (`tools/kanban_tools.py`) that dynamically loads the guard module from `~/.hermes/plugins/scratch-artifact-guard/guard.py` and calls its `check_and_block()` — the same policy the hook enforces. This closes the quiet-mode bypass gap.

- Guard failures are silently ignored (`except Exception: pass`) so a missing or broken guard never blocks a legitimate completion.
- The guard is loaded dynamically via `importlib` so the core does not hard-depend on the plugin.
- A reapply script comment marks the block for the plugin's self-healing mechanism.

## Testing

- Existing kanban tests continue to pass (guard is a no-op when the plugin is absent).
- With the guard plugin present, completions containing scratch-paths are blocked; completions without them proceed normally.

## Files changed

- `tools/kanban_tools.py` — +24 lines (inline guard check in `_handle_complete`)