### PR TITLE
fix(gateway): resolve session-scoped transcript ops against the session's own profile DB (supersedes #41234)

### DIFF
--- a/tests/tui_gateway/test_session_profile_db.py
+++ b/tests/tui_gateway/test_session_profile_db.py
@@ -1,0 +1,351 @@
+"""Session-scoped transcript ops must resolve against the session's own DB.
+
+App-global remote mode gives a session its own profile (``profile_home`` on
+the session dict, see ``session.create``), and that profile keeps its own
+``state.db``.  ``_get_db()`` is the *launch* profile's handle, so any
+session-scoped read or write that reaches for it operates on the wrong
+database: writes land in a foreign profile under this session's id, and reads
+come back empty because the row simply is not there.
+
+``_session_db(session)`` is the profile-aware resolver that already exists for
+exactly this (``tui_gateway/server.py``): the profile's ``state.db`` when
+``session['profile_home']`` is set, otherwise the shared launch handle.
+
+Every test here drives the real JSON-RPC entry point
+(``server.handle_request``).  Handler bodies live in ``tui_gateway/methods_*``
+but are rebound onto ``server.py``'s globals by
+``method_ctx.HandlerRegistry.install()``, so calling a handler function
+directly would bypass the path the gateway actually executes.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+SESSION_ID = "sid-profile"
+SESSION_KEY = "tui-profile-1"
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    # Mocks are scoped to the initial import only (see
+    # tests/tui_gateway/test_protocol.py for the rationale).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+
+    methods = dict(mod._methods)
+    yield mod
+    # Restore in place instead of clear+reload: importlib.reload re-registers
+    # atexit hooks and re-captures module-level paths against this test's
+    # soon-deleted tmpdir (see tests/tui_gateway/test_undo_command.py).
+    mod._methods.clear()
+    mod._methods.update(methods)
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+    mod._db = None
+
+
+@pytest.fixture()
+def launch_db(server, hermes_home):
+    """The launch profile's state.db, wired in as the ``_get_db()`` handle."""
+    db = SessionDB(db_path=hermes_home / "state.db")
+    server._db = db
+    return db
+
+
+@pytest.fixture()
+def profile_db(tmp_path):
+    """A second, non-launch profile's state.db."""
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    return profile_home, SessionDB(db_path=profile_home / "state.db")
+
+
+def _seed(db, turns=3, *, _capture_user_row_ids=None):
+    db.create_session(SESSION_KEY, source="tui")
+    for i in range(1, turns + 1):
+        uid = db.append_message(SESSION_KEY, "user", f"question {i}")
+        if _capture_user_row_ids is not None:
+            _capture_user_row_ids.append(uid)
+        db.append_message(SESSION_KEY, "assistant", f"answer {i}")
+    return db.get_messages_as_conversation(SESSION_KEY)
+
+
+def _register(server, history, *, profile_home=None):
+    # SimpleNamespace, not MagicMock: the usage snapshot compares attributes
+    # numerically, and auto-created mock attributes are not orderable.
+    agent = types.SimpleNamespace(
+        _memory_manager=MagicMock(),
+        _last_flushed_db_idx=len(history),
+        model="test-model",
+    )
+    session = {
+        "session_key": SESSION_KEY,
+        "history": list(history),
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "agent": agent,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 120,
+        # The cap slot is claimed on the first real turn; pre-claim it so the
+        # test exercises the transcript path rather than the lease allocator.
+        "active_session_lease": object(),
+    }
+    if profile_home is not None:
+        session["profile_home"] = str(profile_home)
+    server._sessions[SESSION_ID] = session
+    return session
+
+
+def _rpc(server, method, params):
+    return server.handle_request({"id": "1", "method": method, "params": params})
+
+
+def _texts(rows):
+    out = []
+    for row in rows:
+        content = row.get("content")
+        if isinstance(content, list):
+            content = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        out.append(str(content or ""))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# /undo — command.dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_undo_rewinds_the_profile_transcript(server, launch_db, profile_db):
+    """/undo on a profile session must read and rewind that profile's db.
+
+    ``list_recent_user_messages`` is session-id scoped, so against the launch
+    handle it finds nothing and /undo fails closed with 4018 — the command is
+    unusable for the entire session in app-global remote mode.
+    """
+    profile_home, pdb = profile_db
+    history = _seed(pdb)
+    _register(server, history, profile_home=profile_home)
+
+    resp = _rpc(
+        server,
+        "command.dispatch",
+        {"session_id": SESSION_ID, "name": "undo", "arg": ""},
+    )
+
+    assert not resp.get("error"), f"/undo failed: {resp.get('error')}"
+    result = resp["result"]
+    assert result["type"] == "prefill"
+    assert result["message"] == "question 3"
+    # The rewind is durable in the profile's own db, not the launch one.
+    assert _texts(pdb.get_messages_as_conversation(SESSION_KEY)) == [
+        "question 1",
+        "answer 1",
+        "question 2",
+        "answer 2",
+    ]
+    assert launch_db.get_messages_as_conversation(SESSION_KEY) == []
+
+
+def test_undo_still_uses_the_shared_handle_without_a_profile(server, launch_db):
+    """A launch-profile session keeps borrowing the shared ``_get_db()`` handle."""
+    history = _seed(launch_db)
+    _register(server, history)
+
+    resp = _rpc(
+        server,
+        "command.dispatch",
+        {"session_id": SESSION_ID, "name": "undo", "arg": ""},
+    )
+
+    assert not resp.get("error"), f"/undo failed: {resp.get('error')}"
+    assert resp["result"]["message"] == "question 3"
+    assert _texts(launch_db.get_messages_as_conversation(SESSION_KEY)) == [
+        "question 1",
+        "answer 1",
+        "question 2",
+        "answer 2",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# edit/resend truncation — prompt.submit
+# ---------------------------------------------------------------------------
+
+
+def _stop_after_truncate(server, monkeypatch):
+    """Return the RPC right after the truncate branch, before the agent turn.
+
+    Isolated turns hand the prompt to the compute host and return, which is
+    the natural exit closest to the code under test; stubbing the handoff keeps
+    the test on the transcript-persistence path instead of running a model.
+    """
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: True)
+    monkeypatch.setattr(
+        server,
+        "_submit_prompt_to_compute_host",
+        lambda rid, sid, session, text: server._ok(rid, {"status": "streaming"}),
+    )
+
+
+def test_truncation_persists_to_the_profile_db(server, launch_db, profile_db, monkeypatch):
+    """An edit/resend must truncate the profile's transcript, not the launch one."""
+    profile_home, pdb = profile_db
+    user_row_ids: list = []
+    history = _seed(pdb, _capture_user_row_ids=user_row_ids)
+    _register(server, history, profile_home=profile_home)
+    _stop_after_truncate(server, monkeypatch)
+
+    # Row-id addressed, not ordinal-only: current main refuses a bare ordinal
+    # for a durable session (truncate_before_row_id required). Target the 2nd
+    # user turn's durable row id; keep the matching ordinal as a cross-check.
+    resp = _rpc(
+        server,
+        "prompt.submit",
+        {
+            "session_id": SESSION_ID,
+            "text": "edited question 2",
+            "truncate_before_row_id": user_row_ids[1],
+            "truncate_before_user_ordinal": 1,
+            "confirm_truncate": True,
+        },
+    )
+
+    assert not resp.get("error"), f"prompt.submit failed: {resp.get('error')}"
+    # The undone turns are gone from the profile's own db, so session.resume
+    # (which opens the profile db correctly) cannot resurrect them.
+    assert _texts(pdb.get_messages_as_conversation(SESSION_KEY)) == [
+        "question 1",
+        "answer 1",
+    ]
+    # ...and nothing was copied into a foreign profile under this session id.
+    assert launch_db.get_messages_as_conversation(SESSION_KEY) == []
+
+
+def test_truncation_does_not_copy_rows_into_the_launch_profile(
+    server, launch_db, profile_db, monkeypatch
+):
+    """The launch profile must not receive a copy of a profile session's turns.
+
+    When the launch db happens to hold a row under the same session id, the
+    write through the launch handle succeeds instead of failing the foreign-key
+    check, so the truncated transcript is inserted into a profile the session
+    does not belong to.
+    """
+    profile_home, pdb = profile_db
+    user_row_ids: list = []
+    history = _seed(pdb, _capture_user_row_ids=user_row_ids)
+    launch_db.create_session(SESSION_KEY, source="unknown")
+    _register(server, history, profile_home=profile_home)
+    _stop_after_truncate(server, monkeypatch)
+
+    resp = _rpc(
+        server,
+        "prompt.submit",
+        {
+            "session_id": SESSION_ID,
+            "text": "edited question 2",
+            "truncate_before_row_id": user_row_ids[1],
+            "truncate_before_user_ordinal": 1,
+            "confirm_truncate": True,
+        },
+    )
+
+    assert not resp.get("error"), f"prompt.submit failed: {resp.get('error')}"
+    assert launch_db.get_messages_as_conversation(SESSION_KEY) == []
+    assert _texts(pdb.get_messages_as_conversation(SESSION_KEY)) == [
+        "question 1",
+        "answer 1",
+    ]
+
+
+def test_truncation_without_a_profile_uses_the_shared_handle(server, launch_db, monkeypatch):
+    user_row_ids: list = []
+    history = _seed(launch_db, _capture_user_row_ids=user_row_ids)
+    _register(server, history)
+    _stop_after_truncate(server, monkeypatch)
+
+    resp = _rpc(
+        server,
+        "prompt.submit",
+        {
+            "session_id": SESSION_ID,
+            "text": "edited question 2",
+            "truncate_before_row_id": user_row_ids[1],
+            "truncate_before_user_ordinal": 1,
+            "confirm_truncate": True,
+        },
+    )
+
+    assert not resp.get("error"), f"prompt.submit failed: {resp.get('error')}"
+    assert _texts(launch_db.get_messages_as_conversation(SESSION_KEY)) == [
+        "question 1",
+        "answer 1",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# /history and /context — slash.exec
+# ---------------------------------------------------------------------------
+
+
+def test_history_reads_the_profile_transcript(server, launch_db, profile_db):
+    """/history must render the profile session's own transcript."""
+    profile_home, pdb = profile_db
+    _seed(pdb)
+    # In-memory history is deliberately empty: the point of the db read is to
+    # rebuild the transcript for a session the process did not run itself.
+    _register(server, [], profile_home=profile_home)
+
+    resp = _rpc(server, "slash.exec", {"session_id": SESSION_ID, "command": "/history"})
+
+    assert not resp.get("error"), f"/history failed: {resp.get('error')}"
+    output = resp["result"]["output"]
+    assert "question 3" in output
+    assert "answer 3" in output
+
+
+def test_context_reads_the_profile_transcript(server, launch_db, profile_db, monkeypatch):
+    """/context must count the profile session's own messages."""
+    profile_home, pdb = profile_db
+    _seed(pdb)
+    _register(server, [], profile_home=profile_home)
+    # /context is an isolated-session read command, gated on the compute host.
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a, **k: True)
+
+    resp = _rpc(server, "slash.exec", {"session_id": SESSION_ID, "command": "/context"})
+
+    assert not resp.get("error"), f"/context failed: {resp.get('error')}"
+    output = resp["result"]["output"]
+    assert "Conversation: 6 messages" in output
+    assert "user: 3, assistant: 3" in output

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -641,48 +641,61 @@ def _(rid, params: dict) -> dict:
             # new exchange is appended on top of the "undone" turns — durable
             # zombie history on resume, and the edit/regenerate never sticks.
             # Fail closed: refuse the turn and leave memory/DB unchanged.
-            if (db := _get_db()) is not None:
-                try:
-                    # active_only=True: replace only the live (active=1) rows.
-                    # In-place compaction (#38763) keeps the pre-compaction
-                    # transcript as active=0/compacted=1 rows under this same
-                    # session key; a bare replace_messages() would DELETE that
-                    # durable archive on every edit/regenerate — the same bug
-                    # class #80216 fixed for /retry. On an uncompacted session
-                    # all rows are active=1, so this is behaviorally identical
-                    # to the full replace.
-                    # archive_dropped: a rewind overwrites turns the user may
-                    # not have meant to drop, and this write is the last step
-                    # before they are gone — three reported incidents ended
-                    # here with nothing to restore from (#70516, #80763,
-                    # #82756). Soft-archiving keeps them on disk (active=0) and
-                    # in the FTS index, so a mis-aimed cut is recoverable
-                    # instead of terminal. The live transcript is unchanged.
-                    # Fall back to session id when session_key is NULL — CLI-origin
-                    # sessions created before the session_key default fix have no
-                    # key, and replace_messages(None) triggers an FK violation.
-                    truncation_key = session.get("session_key") or sid
-                    db.replace_messages(
-                        truncation_key,
-                        truncated,
-                        active_only=True,
-                        archive_dropped=True,
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "prompt.submit: replace_messages failed for session %s "
-                        "(ordinal=%d); refusing turn so memory and DB stay "
-                        "aligned: %s",
-                        sid,
-                        ordinal,
-                        exc,
-                        exc_info=True,
-                    )
-                    return _err(
-                        rid,
-                        5008,
-                        f"failed to persist history truncation: {exc}",
-                    )
+            #
+            # _session_db, not _get_db(): the truncation has to land in the db
+            # that owns this session's row. A profile session (app-global
+            # remote mode) keeps its transcript in its own profile's state.db,
+            # so writing through the launch handle both loses the edit — resume
+            # reopens the profile db and resurrects the undone turns — and
+            # copies the transcript into a foreign profile under this session's
+            # id when that profile happens to hold a row for it. Fail-closed
+            # only holds if the handle we check is the one that owns the row.
+            with _session_db(session) as db:
+                if db is not None:
+                    try:
+                        # active_only=True: replace only the live (active=1)
+                        # rows. In-place compaction (#38763) keeps the
+                        # pre-compaction transcript as active=0/compacted=1
+                        # rows under this same session key; a bare
+                        # replace_messages() would DELETE that durable archive
+                        # on every edit/regenerate — the same bug class #80216
+                        # fixed for /retry. On an uncompacted session all rows
+                        # are active=1, so this is behaviorally identical to
+                        # the full replace.
+                        # archive_dropped: a rewind overwrites turns the user
+                        # may not have meant to drop, and this write is the
+                        # last step before they are gone — three reported
+                        # incidents ended here with nothing to restore from
+                        # (#70516, #80763, #82756). Soft-archiving keeps them
+                        # on disk (active=0) and in the FTS index, so a
+                        # mis-aimed cut is recoverable instead of terminal.
+                        # The live transcript is unchanged.
+                        # Fall back to session id when session_key is NULL —
+                        # CLI-origin sessions created before the session_key
+                        # default fix have no key, and replace_messages(None)
+                        # triggers an FK violation.
+                        truncation_key = session.get("session_key") or sid
+                        db.replace_messages(
+                            truncation_key,
+                            truncated,
+                            active_only=True,
+                            archive_dropped=True,
+                        )
+                    except Exception as exc:
+                        logger.error(
+                            "prompt.submit: replace_messages failed for session %s "
+                            "(ordinal=%d); refusing turn so memory and DB stay "
+                            "aligned: %s",
+                            sid,
+                            ordinal,
+                            exc,
+                            exc_info=True,
+                        )
+                        return _err(
+                            rid,
+                            5008,
+                            f"failed to persist history truncation: {exc}",
+                        )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
             if db is not None:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -877,50 +877,55 @@ def _(rid, params: dict) -> dict:
             return _err(
                 rid, 4009, "session busy — /interrupt the current turn before /undo"
             )
-        db = _get_db()
-        if db is None:
-            return _db_unavailable_error(rid, code=5008)
-        session_key = session.get("session_key", "")
-        if not session_key:
-            return _err(rid, 4001, "no session key for undo")
-        # Parse the optional count argument (e.g. "/undo 3" → 3).
-        n = 1
-        arg_str = (arg or "").strip()
-        if arg_str:
-            try:
-                n = int(arg_str.split()[0])
-            except (ValueError, IndexError):
-                return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
-        if n < 1:
+        # _session_db, not _get_db(): every read and write below is scoped by
+        # session id, and a profile session (app-global remote mode) keeps its
+        # rows in its own profile's state.db. Against the launch handle
+        # list_recent_user_messages finds nothing, so /undo fails closed with
+        # 4018 for the whole session instead of rewinding anything.
+        with _session_db(session) as db:
+            if db is None:
+                return _db_unavailable_error(rid, code=5008)
+            session_key = session.get("session_key", "")
+            if not session_key:
+                return _err(rid, 4001, "no session key for undo")
+            # Parse the optional count argument (e.g. "/undo 3" → 3).
             n = 1
-        try:
-            recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
-        except Exception as e:
-            return _err(rid, 5008, f"undo: failed to load history: {e}")
-        if not recents:
-            return _err(rid, 4018, "no user messages to undo")
-        # recents[0] is the most-recent user turn; pick the Nth-from-last.
-        # If N exceeds the number of user turns, back up to the oldest.
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = db.rewind_to_message(session_key, target_id)
-        except ValueError as e:
-            return _err(rid, 4004, f"undo: {e}")
-        except Exception as e:
-            return _err(rid, 5008, f"undo: {e}")
-        # Reload the active-only transcript into the in-memory session
-        # history so subsequent turns see the truncated view.
-        # repair_alternation: this reload feeds LIVE REPLAY — session["history"]
-        # is the working conversation for subsequent turns, and a rewind that
-        # lands on a durable user;user pair would otherwise re-fire the
-        # pre-request repair on every request from here on.
-        try:
-            active = db.get_messages_as_conversation(
-                session_key, repair_alternation=True, include_row_ids=True
-            )
-        except Exception:
-            active = []
+            arg_str = (arg or "").strip()
+            if arg_str:
+                try:
+                    n = int(arg_str.split()[0])
+                except (ValueError, IndexError):
+                    return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
+            if n < 1:
+                n = 1
+            try:
+                recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
+            except Exception as e:
+                return _err(rid, 5008, f"undo: failed to load history: {e}")
+            if not recents:
+                return _err(rid, 4018, "no user messages to undo")
+            # recents[0] is the most-recent user turn; pick the Nth-from-last.
+            # If N exceeds the number of user turns, back up to the oldest.
+            target_idx = min(n - 1, len(recents) - 1)
+            target_id = recents[target_idx]["id"]
+            try:
+                result = db.rewind_to_message(session_key, target_id)
+            except ValueError as e:
+                return _err(rid, 4004, f"undo: {e}")
+            except Exception as e:
+                return _err(rid, 5008, f"undo: {e}")
+            # Reload the active-only transcript into the in-memory session
+            # history so subsequent turns see the truncated view.
+            # repair_alternation: this reload feeds LIVE REPLAY — session["history"]
+            # is the working conversation for subsequent turns, and a rewind that
+            # lands on a durable user;user pair would otherwise re-fire the
+            # pre-request repair on every request from here on.
+            try:
+                active = db.get_messages_as_conversation(
+                    session_key, repair_alternation=True, include_row_ids=True
+                )
+            except Exception:
+                active = []
         with session["history_lock"]:
             session["history"] = list(active)
             session["history_version"] = int(session.get("history_version", 0)) + 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13597,14 +13597,17 @@ def _format_live_usage_output(session: dict) -> str:
 def _format_live_history_output(session: dict) -> str:
     with session["history_lock"]:
         history = list(session.get("history", []))
-    db = _get_db()
-    if db is not None and session.get("session_key"):
-        try:
-            history = db.get_messages_as_conversation(
-                session["session_key"], include_ancestors=True, include_row_ids=True
-            )
-        except Exception:
-            pass
+    # _session_db, not _get_db(): a profile session's transcript lives in its
+    # own profile's state.db, and this read is scoped by session id — through
+    # the launch handle it comes back empty and /history renders nothing.
+    with _session_db(session) as db:
+        if db is not None and session.get("session_key"):
+            try:
+                history = db.get_messages_as_conversation(
+                    session["session_key"], include_ancestors=True, include_row_ids=True
+                )
+            except Exception:
+                pass
     messages = _history_to_messages(history)
     if not messages:
         return "No conversation history yet."
@@ -13637,16 +13640,18 @@ def _format_live_prompt_output(session: dict) -> str:
 
 def _format_live_context_output(session: dict) -> str:
     messages = []
-    db = _get_db()
-    if db is not None and session.get("session_key"):
-        try:
-            messages = _history_to_messages(
-                db.get_messages_as_conversation(
-                    session["session_key"], include_ancestors=True, include_row_ids=True
+    # Same session-scoped read as /history — resolve it against the db that
+    # owns this session's rows, not the launch profile's handle.
+    with _session_db(session) as db:
+        if db is not None and session.get("session_key"):
+            try:
+                messages = _history_to_messages(
+                    db.get_messages_as_conversation(
+                        session["session_key"], include_ancestors=True, include_row_ids=True
+                    )
                 )
-            )
-        except Exception:
-            messages = []
+            except Exception:
+                messages = []
     if not messages:
         with session["history_lock"]:
             messages = _history_to_messages(list(session.get("history", [])))


### PR DESCRIPTION
## What does this PR do?

Session-scoped transcript reads and writes in the TUI gateway went through `_get_db()`, which is the **launch** profile's `SessionDB` handle. App-global remote mode gives a session its own profile (`session["profile_home"]`, "Profile-scoped HERMES_HOME for app-global remote mode"), and that profile keeps its transcript in its own `state.db` — so anything keyed on `session_key` that reaches for `_get_db()` addresses the wrong database.

`_session_db(session)` is the profile-aware resolver that already exists for exactly this, and is already used 176 lines above the first site in the same file (`methods_prompt.py:39`). Resolver precedence mirrored: **`_session_db(session)` → the profile's `state.db` when `session['profile_home']` is set, else the shared launch handle** (borrowed, left open, so non-profile sessions are byte-for-byte unaffected).

This replaces #41234, which reported the first of these sites but can no longer fix it — see *Related* below.

### Coverage — the full sweep of this root cause

`git grep -n "_get_db()" tui_gateway/` returns 26 call sites. All 26 were classified:

**Fixed here (4):**

| site | symptom |
|---|---|
| `methods_prompt.py:215` — `prompt.submit` truncate branch | edit/resend never sticks; can copy the transcript into a foreign profile |
| `methods_tools.py:845` — `command.dispatch` `/undo` | `/undo` fails closed with `4018` for the whole session |
| `server.py:12065` — `_format_live_history_output` | `/history` renders "No conversation history yet." |
| `server.py:12105` — `_format_live_context_output` | `/context` reports "Conversation is empty (no messages yet)." |

**Same root cause, deliberately left to their existing PRs — not touched here:**

- `server.py:7798` `_live_session_payload` — covered by open **#71834**.
- `server.py:9745` `maybe_auto_title` — covered by open **#61156**.

**Reasoned out (not the same defect):** `methods_session.py:327` and `server.py:2503` are already profile-aware; `server.py:2656` is inside the resolver; `server.py:3608/3647` already prefer the agent's own handle; `server.py:8541/8615` route notification *events* and degrade gracefully to `evt_key`; `server.py:5823/6310/6376/6378` are construction-time wiring where `session_db` is a caller-supplied parameter; `methods_tools.py:1216` (`insights.get`) is a genuinely cross-session N-day window; `methods_config.py:23/91/116/145` is the global config store.

Note the `session.undo` **RPC** (`methods_session.py:2283`) is a different handler from the `/undo` fixed here (`methods_tools.py:845` inside `command.dispatch`) — it is in-memory only and never touches the DB, so it is out of scope.

### Severity

1. **`/undo` is 100% broken for profile sessions.** `list_recent_user_messages` is session-id scoped (`hermes_state_search.py:714`), so against the launch handle it returns zero rows and the command returns `4018 "no user messages to undo"` before it ever reaches the rewind. Reproduced in the new test module — see the before/after table.
2. **The edit/resend silently never sticks.** `replace_messages` is destructive by default (`DELETE FROM messages WHERE session_id = ?` then reinsert). Against the launch db it either fails the foreign-key check and is swallowed by the surrounding `except Exception` (transcript truncation lost entirely), or — when the launch profile does hold a row under the same session id — **succeeds**, inserting this session's turns into a profile it does not belong to. Both branches are covered by tests.
3. Thanks to **@LuisGV212**, who independently reproduced (2) on current `main` with DB evidence on #41234: a named-profile session logged `prompt.submit: truncating session <id> history 7 -> 6 messages` and the launch profile's `messages` table received six copied rows under the same session id (`source=unknown`, `profile_name=NULL`, `message_count=6`).

## Related Issue

No filed issue. This supersedes PR **#41234** (`kernel-t1`), which reported site 1:

- It is **CONFLICTING / DIRTY**, last commit `2026-06-07`, never force-pushed since.
- `git apply --check` of its diff against current `main` fails on **both** files: commit `f67ca220a` moved `prompt.submit` out of `server.py` into `tui_gateway/methods_prompt.py`, and #41234 still patches `server.py@4381`. It cannot fix its own reported bug.
- It introduces `def _session_db(session) -> tuple[Any, bool]` at `server.py:488`, colliding by name with the existing `_session_db` **contextmanager** at `server.py:2638` with an incompatible protocol. This PR adds no helper and shadows no name — `server.py:2638` stays the sole definition.
- It covers one call site and misses the `/undo`, `/history` and `/context` siblings entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_prompt.py` — `prompt.submit` truncate branch now writes through `with _session_db(session) as db:`.
- `tui_gateway/methods_tools.py` — `/undo` in `command.dispatch` resolves its reads and its `rewind_to_message` write through `_session_db`. The `with` block spans only the db-using span (the `history_lock` block and everything after it stay at the original indent), so the profile handle is closed before the memory-provider hooks run.
- `tui_gateway/server.py` — `_format_live_history_output` and `_format_live_context_output` read through `_session_db`.
- `tests/tui_gateway/test_session_profile_db.py` — new module, 7 tests.

No import changes are needed in either `methods_*` module: `method_ctx.HandlerRegistry.install()` rebinds handler globals onto `server.py`, so `_session_db` resolves from `server.py`'s namespace (as `methods_prompt.py:39` and nine sites in `methods_session.py` already do). For the same reason every test drives the real RPC via `server.handle_request(...)` — calling a handler function directly would bypass the rebinding and miss the path the gateway executes.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tui_gateway/test_session_profile_db.py -v
```

Three-way demonstration, run locally against `origin/main` @ `87bc710`:

| tree | result |
|---|---|
| clean `main` | **5 failed**, 2 passed |
| `main` + #41234's single-site shape (`methods_prompt.py` only) | **3 failed**, 4 passed |
| this PR | **7 passed** |

The middle row is the point: fixing only the site #41234 named leaves `/undo`, `/history` and `/context` broken.

Per-test before/after on a session carrying `profile_home`:

| test | on `main` | with this PR |
|---|---|---|
| `test_undo_rewinds_the_profile_transcript` | `{'code': 4018, 'message': 'no user messages to undo'}` | prefill returned, profile db rewound |
| `test_truncation_persists_to_the_profile_db` | profile db still holds all 6 messages (`replace_messages failed: FOREIGN KEY constraint failed`, swallowed) | profile db truncated to 2 |
| `test_truncation_does_not_copy_rows_into_the_launch_profile` | launch db receives `['question 1', 'answer 1']` under the profile session's id | launch db stays empty |
| `test_history_reads_the_profile_transcript` | `No conversation history yet.` | transcript rendered |
| `test_context_reads_the_profile_transcript` | `Conversation is empty (no messages yet).` | `Conversation: 6 messages` |

The two remaining tests (`..._without_a_profile` / `..._still_uses_the_shared_handle`) are the no-regression guards for launch-profile sessions and pass in all three trees.

Adjacent suites: `tests/tui_gateway/` **328 passed**; `tests/test_tui_gateway_server.py` **500 passed, 1 failed** — `test_write_json_serializes_concurrent_writes`, which fails identically on clean `origin/main` (2/2 runs) and passes in isolation on both trees. Pre-existing flake, untouched by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the gateway-adjacent suites listed above, not the whole tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code; `_session_db` already handles path construction)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
