### PR TITLE
fix(telegram): stop stamping hard-break markers onto block-level lines

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -539,7 +539,14 @@ _RICH_PROTECTED_REGION_RE = re.compile(
 # rich truncation stopping precisely at a heading and at a paragraph→list
 # boundary, both lines this function previously stamped with "  \n").
 _RICH_ATX_HEADING_LINE_RE = re.compile(r'^[ \t]{0,3}#{1,6}(?:[ \t]|$)')
-_RICH_LIST_ITEM_LINE_RE = re.compile(r'^[ \t]{0,3}(?:[-*+][ \t]|\d{1,9}[.)][ \t])')
+_RICH_BULLET_ITEM_LINE_RE = re.compile(r'^[ \t]{0,3}[-*+][ \t]')
+# Ordered-list markers follow CommonMark's paragraph-interrupt rule: after
+# prose, only a ``1.``/``1)`` marker opens a list — ``2024. Major rewrite`` is
+# paragraph text, NOT a block boundary, so it must keep its hard break. A
+# non-1 marker is a boundary only when the PREVIOUS line is itself an ordered
+# item (an existing list continuing: ``1. a\n2. b``).
+_RICH_ORDERED_ITEM_LINE_RE = re.compile(r'^[ \t]{0,3}\d{1,9}[.)][ \t]')
+_RICH_ORDERED_START_LINE_RE = re.compile(r'^[ \t]{0,3}1[.)][ \t]')
 _RICH_QUOTE_LINE_RE = re.compile(r'^[ \t]{0,3}>')
 
 
@@ -558,8 +565,11 @@ def _rich_normalize_linebreaks(text: str) -> str:
     - fenced code blocks and GFM pipe-table interiors (native rendering — a
       hard break in a row separator would corrupt the table);
     - newlines adjacent to block constructs: after an ATX heading line,
-      before a heading / list item / table / fenced code, and before a
-      blockquote opener when not already inside the quote.  Those newlines
+      before a heading / bullet item / table / fenced code, before an
+      ordered-list marker that actually opens or continues a list (per
+      CommonMark's interrupt rule ``2024. prose`` after a paragraph is
+      text, not a list), and before a blockquote opener when not already
+      inside the quote.  Those newlines
       are hard block boundaries already, so the marker adds nothing — and a
       trailing hard break welded onto a block opener is malformed Markdown
       that rich-message client renderers handle inconsistently (#69444).
@@ -589,7 +599,12 @@ def _rich_normalize_linebreaks(text: str) -> str:
         next_line = text[m.end():next_nl if next_nl != -1 else len(text)]
         if _RICH_ATX_HEADING_LINE_RE.match(cur_line):
             return m.group(0)
-        if _RICH_ATX_HEADING_LINE_RE.match(next_line) or _RICH_LIST_ITEM_LINE_RE.match(next_line):
+        if _RICH_ATX_HEADING_LINE_RE.match(next_line) or _RICH_BULLET_ITEM_LINE_RE.match(next_line):
+            return m.group(0)
+        if _RICH_ORDERED_ITEM_LINE_RE.match(next_line) and (
+            _RICH_ORDERED_START_LINE_RE.match(next_line)
+            or _RICH_ORDERED_ITEM_LINE_RE.match(cur_line)
+        ):
             return m.group(0)
         if _RICH_QUOTE_LINE_RE.match(next_line) and not _RICH_QUOTE_LINE_RE.match(cur_line):
             return m.group(0)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -530,6 +530,19 @@ _RICH_PROTECTED_REGION_RE = re.compile(
 )
 
 
+# Block-construct line shapes for the hard-break skip below. A single newline
+# adjacent to one of these is already a hard BLOCK boundary in Markdown, so a
+# hard-break marker there is meaningless at best (CommonMark strips trailing
+# spaces from ATX headings; list items are separate blocks natively) and
+# malformed at worst — a ``<br>`` welded onto a block opener is exactly the
+# kind of ambiguous structure client renderers disagree on (#69444 documented
+# rich truncation stopping precisely at a heading and at a paragraph→list
+# boundary, both lines this function previously stamped with "  \n").
+_RICH_ATX_HEADING_LINE_RE = re.compile(r'^[ \t]{0,3}#{1,6}(?:[ \t]|$)')
+_RICH_LIST_ITEM_LINE_RE = re.compile(r'^[ \t]{0,3}(?:[-*+][ \t]|\d{1,9}[.)][ \t])')
+_RICH_QUOTE_LINE_RE = re.compile(r'^[ \t]{0,3}>')
+
+
 def _rich_normalize_linebreaks(text: str) -> str:
     """Convert single ``\\n`` to Markdown hard breaks for the rich-message path.
 
@@ -539,26 +552,50 @@ def _rich_normalize_linebreaks(text: str) -> str:
     paragraph.  Adding two trailing spaces before each single newline
     forces a hard line break (``<br>``) in the rendered output.
 
-    Paragraph breaks (``\\n\\n``), fenced code blocks, and GFM pipe-table
-    blocks are left untouched: tables render natively in the rich path and a
-    hard break injected into a row separator would corrupt the table.
+    Injection is limited to prose-to-prose newlines. Left untouched:
+
+    - paragraph breaks (``\\n\\n``);
+    - fenced code blocks and GFM pipe-table interiors (native rendering — a
+      hard break in a row separator would corrupt the table);
+    - newlines adjacent to block constructs: after an ATX heading line,
+      before a heading / list item / table / fenced code, and before a
+      blockquote opener when not already inside the quote.  Those newlines
+      are hard block boundaries already, so the marker adds nothing — and a
+      trailing hard break welded onto a block opener is malformed Markdown
+      that rich-message client renderers handle inconsistently (#69444).
+
+    Blockquote interiors keep their hard breaks: ``> a\\n> b`` soft-wraps
+    into one line without them, so there the marker is load-bearing.
+    Lazy list-item continuations (``- item\\ncontinued``) likewise keep
+    theirs to preserve the visible line break inside the item.
     """
     if not text or '\n' not in text:
         return text
 
-    out: list[str] = []
-    # Split off protected regions (fenced code OR table blocks) and only inject
-    # hard breaks in the prose between them. Boundary newlines are handled by
-    # the original single-\n regex, which sees each prose run as a whole string.
-    pos = 0
-    for m in _RICH_PROTECTED_REGION_RE.finditer(text):
-        prose = text[pos:m.start()]
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
-        out.append(m.group(0))  # protected region kept verbatim
-        pos = m.end()
-    tail = text[pos:]
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))
-    return ''.join(out)
+    # Spans of fenced code / table blocks: newline matches inside them are
+    # kept verbatim, and a newline that ENTERS one (its end is a span start)
+    # is a block boundary — no marker.
+    protected = [(m.start(), m.end()) for m in _RICH_PROTECTED_REGION_RE.finditer(text)]
+
+    def _repl(m: "re.Match[str]") -> str:
+        i = m.start()
+        if any(s <= i < e for s, e in protected):
+            return m.group(0)  # inside a fence/table — keep verbatim
+        if any(s == m.end() for s, _e in protected):
+            return m.group(0)  # next line opens a fence/table block
+        line_start = text.rfind('\n', 0, i) + 1
+        cur_line = text[line_start:i]
+        next_nl = text.find('\n', m.end())
+        next_line = text[m.end():next_nl if next_nl != -1 else len(text)]
+        if _RICH_ATX_HEADING_LINE_RE.match(cur_line):
+            return m.group(0)
+        if _RICH_ATX_HEADING_LINE_RE.match(next_line) or _RICH_LIST_ITEM_LINE_RE.match(next_line):
+            return m.group(0)
+        if _RICH_QUOTE_LINE_RE.match(next_line) and not _RICH_QUOTE_LINE_RE.match(cur_line):
+            return m.group(0)
+        return '  \n'
+
+    return re.sub(r'(?<!\n)\n(?!\n)', _repl, text)
 
 
 # Watchdog bound for `await updater.stop()`. When the underlying TCP socket is

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -543,6 +543,19 @@ _RICH_PROTECTED_REGION_RE = re.compile(
 )
 
 
+# Block-construct line shapes for the hard-break skip below. A single newline
+# adjacent to one of these is already a hard BLOCK boundary in Markdown, so a
+# hard-break marker there is meaningless at best (CommonMark strips trailing
+# spaces from ATX headings; list items are separate blocks natively) and
+# malformed at worst — a ``<br>`` welded onto a block opener is exactly the
+# kind of ambiguous structure client renderers disagree on (#69444 documented
+# rich truncation stopping precisely at a heading and at a paragraph→list
+# boundary, both lines this function previously stamped with "  \n").
+_RICH_ATX_HEADING_LINE_RE = re.compile(r'^[ \t]{0,3}#{1,6}(?:[ \t]|$)')
+_RICH_LIST_ITEM_LINE_RE = re.compile(r'^[ \t]{0,3}(?:[-*+][ \t]|\d{1,9}[.)][ \t])')
+_RICH_QUOTE_LINE_RE = re.compile(r'^[ \t]{0,3}>')
+
+
 def _rich_normalize_linebreaks(text: str) -> str:
     """Convert single ``\\n`` to Markdown hard breaks for the rich-message path.
 
@@ -552,26 +565,50 @@ def _rich_normalize_linebreaks(text: str) -> str:
     paragraph.  Adding two trailing spaces before each single newline
     forces a hard line break (``<br>``) in the rendered output.
 
-    Paragraph breaks (``\\n\\n``), fenced code blocks, and GFM pipe-table
-    blocks are left untouched: tables render natively in the rich path and a
-    hard break injected into a row separator would corrupt the table.
+    Injection is limited to prose-to-prose newlines. Left untouched:
+
+    - paragraph breaks (``\\n\\n``);
+    - fenced code blocks and GFM pipe-table interiors (native rendering — a
+      hard break in a row separator would corrupt the table);
+    - newlines adjacent to block constructs: after an ATX heading line,
+      before a heading / list item / table / fenced code, and before a
+      blockquote opener when not already inside the quote.  Those newlines
+      are hard block boundaries already, so the marker adds nothing — and a
+      trailing hard break welded onto a block opener is malformed Markdown
+      that rich-message client renderers handle inconsistently (#69444).
+
+    Blockquote interiors keep their hard breaks: ``> a\\n> b`` soft-wraps
+    into one line without them, so there the marker is load-bearing.
+    Lazy list-item continuations (``- item\\ncontinued``) likewise keep
+    theirs to preserve the visible line break inside the item.
     """
     if not text or '\n' not in text:
         return text
 
-    out: list[str] = []
-    # Split off protected regions (fenced code OR table blocks) and only inject
-    # hard breaks in the prose between them. Boundary newlines are handled by
-    # the original single-\n regex, which sees each prose run as a whole string.
-    pos = 0
-    for m in _RICH_PROTECTED_REGION_RE.finditer(text):
-        prose = text[pos:m.start()]
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
-        out.append(m.group(0))  # protected region kept verbatim
-        pos = m.end()
-    tail = text[pos:]
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))
-    return ''.join(out)
+    # Spans of fenced code / table blocks: newline matches inside them are
+    # kept verbatim, and a newline that ENTERS one (its end is a span start)
+    # is a block boundary — no marker.
+    protected = [(m.start(), m.end()) for m in _RICH_PROTECTED_REGION_RE.finditer(text)]
+
+    def _repl(m: "re.Match[str]") -> str:
+        i = m.start()
+        if any(s <= i < e for s, e in protected):
+            return m.group(0)  # inside a fence/table — keep verbatim
+        if any(s == m.end() for s, _e in protected):
+            return m.group(0)  # next line opens a fence/table block
+        line_start = text.rfind('\n', 0, i) + 1
+        cur_line = text[line_start:i]
+        next_nl = text.find('\n', m.end())
+        next_line = text[m.end():next_nl if next_nl != -1 else len(text)]
+        if _RICH_ATX_HEADING_LINE_RE.match(cur_line):
+            return m.group(0)
+        if _RICH_ATX_HEADING_LINE_RE.match(next_line) or _RICH_LIST_ITEM_LINE_RE.match(next_line):
+            return m.group(0)
+        if _RICH_QUOTE_LINE_RE.match(next_line) and not _RICH_QUOTE_LINE_RE.match(cur_line):
+            return m.group(0)
+        return '  \n'
+
+    return re.sub(r'(?<!\n)\n(?!\n)', _repl, text)
 
 
 # Watchdog bound for `await updater.stop()`. When the underlying TCP socket is

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -76,3 +76,94 @@ class TestRichMessageTableProtection:
         assert "  \n" not in md
         assert md == content
 
+
+
+class TestRichBlockConstructProtection:
+    """Hard-break markers must not be stamped onto/around block constructs.
+
+    A single newline adjacent to a heading, list item, blockquote opener,
+    table, or fence is already a hard block boundary; "  \\n" there is
+    meaningless in CommonMark and malformed in lenient parsers. #69444's
+    truncation repro stopped exactly at a heading and at a paragraph→list
+    boundary — the two shapes stamped by the old unconditional injection.
+    """
+
+    def test_heading_line_gets_no_trailing_hard_break(self, adapter):
+        content = "## What RevenueOS has that Buzz does not\nFirst paragraph."
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content  # heading→prose newline untouched
+
+    def test_prose_to_heading_gets_no_hard_break(self, adapter):
+        content = "Intro text\n### Next heading"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+
+    def test_paragraph_to_list_boundary_gets_no_hard_break(self, adapter):
+        content = "RevenueOS answers:\n- point one\n- point two"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content  # list opener and item→item newlines untouched
+
+    def test_ordered_list_boundary_gets_no_hard_break(self, adapter):
+        content = "Steps:\n1. first\n2. second"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+
+    def test_lazy_list_continuation_keeps_hard_break(self, adapter):
+        # A plain-text line after a list item is a lazy continuation that
+        # would soft-wrap into the item — the marker is load-bearing there.
+        content = "- item one\ncontinued text\n- item two"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "- item one  \ncontinued text\n- item two"
+
+    def test_blockquote_interior_keeps_hard_breaks(self, adapter):
+        # "> a\n> b" soft-wraps into one line without markers.
+        content = "> first line\n> second line"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "> first line  \n> second line"
+
+    def test_prose_to_blockquote_gets_no_hard_break(self, adapter):
+        content = "Intro text\n> a quote"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+
+    def test_prose_to_table_gets_no_hard_break_weld(self, adapter):
+        content = "Scores:\n| A | B |\n|---|---|\n| 1 | 2 |"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content  # no "  " stamped before the header row
+
+    def test_prose_to_fence_gets_no_hard_break_weld(self, adapter):
+        content = "Example:\n```py\nx = 1\n```"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content
+
+    def test_plain_prose_lines_still_get_hard_breaks(self, adapter):
+        content = "Line 1\nLine 2\nLine 3"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "Line 1  \nLine 2  \nLine 3"
+
+    def test_hashtag_line_is_not_treated_as_heading(self, adapter):
+        # "#tag" (no space) is not an ATX heading — still prose.
+        content = "#hashtag one\nplain line"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "#hashtag one  \nplain line"
+
+    def test_69444_repro_shape_stays_clean(self, adapter):
+        content = (
+            "## What RevenueOS has that Buzz does not\n"
+            "First differentiator paragraph.\n"
+            "RevenueOS answers:\n"
+            "- point one\n"
+            "- point two\n\n"
+            "> An important quote\n"
+            "> second quote line\n\n"
+            "### Next heading\n"
+            "More text."
+        )
+        md = adapter._rich_message_payload(content)["markdown"]
+        # The ONLY hard break left is the prose→prose one after the first
+        # paragraph; every block-adjacent newline stays bare.
+        assert "## What RevenueOS has that Buzz does not\n" in md
+        assert "First differentiator paragraph.  \nRevenueOS answers:\n" in md
+        assert "RevenueOS answers:\n- point one\n- point two\n\n" in md
+        assert "> An important quote  \n> second quote line\n\n" in md
+        assert "### Next heading\nMore text." in md

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -167,3 +167,33 @@ class TestRichBlockConstructProtection:
         assert "RevenueOS answers:\n- point one\n- point two\n\n" in md
         assert "> An important quote  \n> second quote line\n\n" in md
         assert "### Next heading\nMore text." in md
+
+
+class TestOrderedListInterruptRule:
+    """Non-``1.`` numeric markers after prose are paragraph text, not lists.
+
+    CommonMark's interrupt rule: an ordered list can only interrupt a
+    paragraph when it starts with 1. ``Version history:\\n2024. Major
+    rewrite`` is prose and must KEEP its hard break — suppressing it
+    reintroduces the soft-wrap bug the normalizer exists to prevent.
+    """
+
+    def test_year_line_after_prose_keeps_hard_break(self, adapter):
+        content = "Version history:\n2024. Major rewrite"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "Version history:  \n2024. Major rewrite"
+
+    def test_non_one_paren_marker_after_prose_keeps_hard_break(self, adapter):
+        content = "Note:\n2) second point only"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "Note:  \n2) second point only"
+
+    def test_one_marker_after_prose_still_opens_list(self, adapter):
+        content = "Steps:\n1. first\n2. second"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content  # 1. interrupts; 2. continues the open list
+
+    def test_non_one_marker_continuing_list_stays_bare(self, adapter):
+        content = "1. first\n2. second\n3. third"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == content  # every marker follows an ordered item


### PR DESCRIPTION
## Summary
- `_rich_normalize_linebreaks()` no longer injects Markdown hard-break markers (`"  \n"`) onto or around block-level lines: ATX heading lines, paragraph→list boundaries, list-item boundaries, blockquote openers, and newlines entering a table/fence.
- Injection remains wherever the marker is load-bearing: prose→prose newlines, blockquote interiors (`> a\n> b` soft-wraps into one line without it), and lazy list-item continuations.

## Why
The rich-message path normalizes single newlines to hard breaks so multi-line content (e.g. slash-command lists) doesn't collapse into one paragraph (#46070). But the injection was unconditional over all prose, and its protected-region list (fenced code, then tables in a96693239) grew one reactive exemption at a time. Unprotected block constructs still get stamped:

```
## What RevenueOS has that Buzz does not  \n     ← hard-break marker ON the heading line
RevenueOS answers:  \n- point one  \n- point two  ← paragraph welded to the list opener
Scores:  \n| A | B |                              ← marker welded to a table header
```

A newline adjacent to a block construct is already a hard block boundary. The marker there is meaningless in strict CommonMark (trailing heading spaces are stripped; list items are separate blocks natively) and **malformed in lenient parsers** — a `<br>` fused to a block opener is precisely the kind of ambiguous structure that different client renderers resolve differently.

**Possible connection to #69444** (stated as motivation, not a proven fix): the documented rich-message truncation stopped *exactly* at a heading ("What RevenueOS has that Buzz does not") and at a paragraph→list boundary ("RevenueOS answers:") — the two line shapes this function stamps — and the same content renders with an expandable "show more" on iOS while macOS desktop cuts off, i.e. renderers diverging on the same accepted document. Emitting clean markdown at block boundaries removes Hermes's contribution to that ambiguity; the configurable cutoff in #69445 remains the defense for long documents generally. The two changes are complementary and independent.

This is the third block construct requiring exemption from the injection, so the fix makes the skip **structural** (block-opener line shapes) instead of adding another one-off protected region.

## Behavior notes
- Strict-CommonMark rendering is unchanged for every skipped case (the markers were semantically dead there).
- Blockquote interiors and lazy list continuations keep their markers — removing those would change rendering.
- `#hashtag` (no space) is not treated as a heading; prose lines starting with a year like `2024. ` follow CommonMark's own ordered-list ambiguity.

## Test Plan
- 12 new regression tests in `tests/gateway/test_telegram_rich_newlines.py` covering every construct, plus a full #69444-shaped document asserting exactly which newlines keep markers.
- Mutation-verified in both directions: removing the block-line skip rules fails 7 tests; removing the span-entering guard fails the 2 table/fence weld tests.
- All 4 pre-existing newline tests unchanged and passing (slash-command lists still get their hard breaks).
- Full rich-path suites: `test_telegram_rich_newlines.py`, `test_telegram_rich_messages.py`, `test_telegram_format.py`, `test_telegram_send_draft_format.py`, `test_telegram_final_delivery.py` — 89 passed.