### PR TITLE
fix(plugins): stop loading chronos via general PluginContext

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1345,17 +1345,18 @@ class PluginManager:
         #   - flat: ``plugins/disk-cleanup/plugin.yaml`` (standalone)
         #   - category: ``plugins/image_gen/openai/plugin.yaml`` (backend)
         #
-        # ``memory/``, ``context_engine/``, and ``model-providers/`` are
-        # skipped at the top level — they have their own discovery systems
-        # (plugins/memory/__init__.py, providers/__init__.py). ``platforms/``
-        # is a category holding platform adapters (scanned one level deeper
-        # below).
+        # ``memory/``, ``context_engine/``, ``model-providers/``, and
+        # ``cron_providers/`` are skipped at the top level — they have their
+        # own discovery systems (plugins/memory/__init__.py,
+        # providers/__init__.py, plugins/cron_providers/__init__.py).
+        # ``platforms/`` is a category holding platform adapters (scanned one
+        # level deeper below).
         repo_plugins = get_bundled_plugins_dir()
         logger.debug("Scanning bundled plugins: %s", repo_plugins)
         bundled = self._scan_directory(
             repo_plugins,
             source="bundled",
-            skip_names={"memory", "context_engine", "platforms", "model-providers"},
+            skip_names={"memory", "context_engine", "platforms", "model-providers", "cron_providers"},
         )
         logger.debug("  bundled (top-level): %d manifest(s)", len(bundled))
         manifests.extend(bundled)
@@ -1413,8 +1414,8 @@ class PluginManager:
                 logger.debug("Skipping disabled plugin '%s'", lookup_key)
                 continue
 
-            # Exclusive plugins (memory providers) have their own
-            # discovery/activation path. The general loader records the
+            # Exclusive plugins (memory / cron scheduler providers) have their
+            # own discovery/activation path. The general loader records the
             # manifest for introspection but does not load the module.
             if manifest.kind == "exclusive":
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
@@ -1628,6 +1629,20 @@ class PluginManager:
                             kind = "exclusive"
                             logger.debug(
                                 "Plugin %s: detected memory provider, "
+                                "treating as kind='exclusive'",
+                                key,
+                            )
+                        elif (
+                            "register_cron_scheduler" in source_text
+                            or "CronScheduler" in source_text
+                        ):
+                            # Cron scheduler provider (e.g. bundled Chronos).
+                            # Route to plugins/cron_providers discovery via
+                            # cron.provider — PluginContext has no
+                            # register_cron_scheduler (#62951).
+                            kind = "exclusive"
+                            logger.debug(
+                                "Plugin %s: detected cron scheduler provider, "
                                 "treating as kind='exclusive'",
                                 key,
                             )

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1063,7 +1063,7 @@ def _discover_all_plugins() -> list:
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
-        (repo_plugins, "bundled", {"memory", "context_engine"}),
+        (repo_plugins, "bundled", {"memory", "context_engine", "cron_providers"}),
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)

--- a/plugins/cron_providers/chronos/plugin.yaml
+++ b/plugins/cron_providers/chronos/plugin.yaml
@@ -1,4 +1,5 @@
 name: chronos
+kind: exclusive
 description: >-
   Chronos — NAS-mediated managed cron provider for scale-to-zero hosted agents.
   Delegates the "wake me at time T" trigger to Nous infrastructure so an idle

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -300,6 +300,61 @@ class TestPluginLoading:
         assert "exclusive" in (entry.error or "").lower()
 
 
+    def test_user_cron_scheduler_plugin_auto_coerced_to_exclusive(self, tmp_path, monkeypatch):
+        """User-installed cron scheduler plugins must NOT be loaded by the
+        general PluginManager — they belong to plugins/cron_providers.
+
+        Regression for #62951:
+            'PluginContext' object has no attribute 'register_cron_scheduler'
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "chronos-user"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "chronos-user"}))
+        (plugin_dir / "__init__.py").write_text(
+            "class FakeCron:\n"
+            "    pass\n"
+            "def register(ctx):\n"
+            "    ctx.register_cron_scheduler(FakeCron())\n"
+        )
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos-user"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "chronos-user" in mgr._plugins
+        entry = mgr._plugins["chronos-user"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "exclusive" in (entry.error or "").lower()
+
+    def test_bundled_cron_providers_skipped_by_general_loader(self, tmp_path, monkeypatch):
+        """Bundled plugins/cron_providers/* must not enter the general loader.
+
+        Chronos ships under that category and uses register_cron_scheduler,
+        which PluginContext does not expose (#62951).
+        """
+        hermes_home = tmp_path / "hermes_home_bundled"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos", "cron_providers/chronos"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "chronos" not in mgr._plugins
+        assert "cron_providers/chronos" not in mgr._plugins
+
+
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the bundled Chronos scheduler's startup failure:

```text
Failed to load plugin 'chronos': 'PluginContext' object has no attribute 'register_cron_scheduler'
```

Chronos is a cron scheduler provider with a dedicated discovery path under `plugins/cron_providers/`, selected through `cron.provider`. The generic plugin loader was also scanning that category and calling its `register()` function with the generic `PluginContext`, which intentionally does not expose category-specific scheduler registration.

This is the existing fix from #62960, replayed onto current `main` because that PR is now `CONFLICTING`. The original commit author, Jaret Bottoms, is preserved.

## Related Issue

Fixes #62951
Supersedes #62960 (same fix, rebased onto current `main` with contributor authorship preserved)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Exclude bundled `cron_providers/` from generic plugin discovery.
- Mark bundled Chronos `kind: exclusive` so its category loader owns activation.
- Auto-coerce legacy/user cron scheduler manifests that omit `kind` to `exclusive`; explicit manifest kinds remain authoritative.
- Keep `hermes plugins list` discovery aligned with runtime discovery.
- Add regression coverage for implicit user providers and bundled-category exclusion.

## How to Test

1. Enable Chronos in `plugins.enabled` while leaving `cron.provider` unset; generic plugin discovery must not call `register_cron_scheduler` on `PluginContext`.
2. Run:

```bash
uv run --locked --extra dev ruff check hermes_cli/plugins.py hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins.py
uv run --locked --extra dev pytest tests/hermes_cli/test_plugin_scanner_recursion.py tests/hermes_cli/test_plugins.py tests/plugins/test_chronos_cron.py tests/plugins/test_chronos_verify.py -q
uv run --locked --extra dev pytest tests/cron/test_scheduler_provider.py::test_discover_cron_schedulers_returns_list tests/cron/test_scheduler_provider.py::test_load_unknown_cron_scheduler_returns_none tests/cron/test_scheduler_provider.py::test_resolve_defaults_to_builtin -q
```

3. Results on Windows 10 / Python 3.12:
   - Ruff: passed
   - Plugin + Chronos regression suite: **63 passed**
   - Dedicated scheduler discovery/resolution: **3 passed**
   - Production gateway restart probe: Chronos generic-loader warning absent; Telegram, Discord, webhook, and API adapters reconnected.

The entire `pytest tests/ -q` matrix could not be collected under `--all-extras` on Windows because the optional Matrix extra (`python-olm`) requires a native `cmake`/libolm build. No project or dependency files were changed by that environment limitation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs; this preserves and updates the conflicting #62960 rather than independently reimplementing it
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (optional Matrix dependency build blocked collection on Windows; focused suites pass)
- [x] I've added tests for my changes
- [x] I've tested on Windows 10

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A — no architecture/workflow change
- [x] I've considered cross-platform impact; the change is `pathlib`-based discovery/config behavior with no platform-specific branch
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Verified against a live Windows gateway after restart:

```text
Gateway restarted: PID 108760 -> 75476
Chronos generic PluginContext failure: absent
Telegram / Discord / webhook / API server: connected
```
