### PR TITLE
fix(cli): detect active gh authentication across versions

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2585,11 +2585,22 @@ def run_doctor(args):
         """Check if gh CLI is authenticated via token file or device flow."""
         try:
             result = subprocess.run(
-                ["gh", "auth", "status", "--json", "authenticated"],
-                capture_output=True, timeout=10,
+                ["gh", "auth", "status", "--json", "hosts", "--hostname", "github.com"],
+                capture_output=True, timeout=10, text=True,
             )
-            return result.returncode == 0
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+            if result.returncode != 0:
+                return False
+
+            import json
+
+            payload = json.loads(result.stdout or "{}")
+            hosts = payload.get("hosts", {})
+            github_accounts = hosts.get("github.com", [])
+            return any(
+                account.get("state") == "success"
+                for account in github_accounts
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError, AttributeError):
             return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2582,25 +2582,36 @@ def run_doctor(args):
     from hermes_cli.config import get_env_value
 
     def _gh_authenticated() -> bool:
-        """Check if gh CLI is authenticated via token file or device flow."""
+        """Check whether GitHub CLI has a usable active github.com account."""
+        json_command = [
+            "gh", "auth", "status", "--json", "hosts", "--hostname", "github.com",
+        ]
+        fallback_command = ["gh", "auth", "status", "--hostname", "github.com"]
         try:
             result = subprocess.run(
-                ["gh", "auth", "status", "--json", "hosts", "--hostname", "github.com"],
-                capture_output=True, timeout=10, text=True,
+                json_command,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
             )
-            if result.returncode != 0:
-                return False
+            if result.returncode == 0:
+                try:
+                    import json
 
-            import json
+                    accounts = json.loads(result.stdout or "{}").get("hosts", {}).get("github.com", [])
+                    return any(
+                        account.get("active") and account.get("state") == "success"
+                        for account in accounts
+                    )
+                except (ValueError, AttributeError):
+                    pass
 
-            payload = json.loads(result.stdout or "{}")
-            hosts = payload.get("hosts", {})
-            github_accounts = hosts.get("github.com", [])
-            return any(
-                account.get("state") == "success"
-                for account in github_accounts
+            # Older gh releases do not expose JSON auth status. Their text
+            # mode still returns a meaningful exit code for the selected host.
+            result = subprocess.run(
+                fallback_command,
+                capture_output=True, timeout=10,
             )
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError, AttributeError):
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -259,11 +259,39 @@ def _check_state_db(should_fix: bool, f: Finding) -> None:
 
 
 def _gh_authenticated() -> bool:
-    """Check if gh CLI is authenticated via token file or device flow."""
+    """Check whether GitHub CLI has a usable active github.com account."""
+    import json
+
+    json_command = [
+        "gh", "auth", "status", "--json", "hosts", "--hostname", "github.com",
+    ]
+    fallback_command = ["gh", "auth", "status", "--hostname", "github.com"]
     try:
-        result = subprocess.run(["gh", "auth", "status", "--json", "authenticated"], capture_output=True, timeout=10)
+        result = subprocess.run(
+            json_command,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+        )
+        if result.returncode == 0:
+            try:
+                accounts = json.loads(result.stdout).get("hosts", {}).get("github.com", [])
+                if isinstance(accounts, list):
+                    return any(
+                        isinstance(account, dict)
+                        and account.get("active") is True
+                        and account.get("state") == "success"
+                        for account in accounts
+                    )
+            except (ValueError, AttributeError):
+                pass
+
+        # Older gh releases do not expose JSON auth status. Their text
+        # mode still returns a meaningful exit code for the selected host.
+        result = subprocess.run(
+            fallback_command,
+            capture_output=True, timeout=10,
+        )
         return result.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         return False
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1100,8 +1100,9 @@ class TestGitHubTokenCheck:
         call_log = []
         def mock_run(cmd, **kwargs):
             call_log.append(cmd)
-            if cmd[:2] == ["gh", "auth"]:
-                result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            if cmd == ["gh", "auth", "status", "--json", "hosts", "--hostname", "github.com"]:
+                stdout = '{"hosts":{"github.com":[{"active":true,"state":"success"}]}}'
+                result = types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
             else:
                 result = types.SimpleNamespace(returncode=1, stdout="", stderr="")
             return result

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -912,6 +912,21 @@ class TestGitHubTokenCheck:
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         monkeypatch.setenv("HERMES_HOME", str(home))
 
+    def _run_with_mocked_subprocess(self, monkeypatch, tmp_path, mock_run):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        self._isolate_home(monkeypatch, home)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
     def test_no_token_and_not_gh_authenticated_shows_warn(self, monkeypatch, tmp_path):
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
@@ -931,42 +946,58 @@ class TestGitHubTokenCheck:
 
 
     def test_gh_authenticated_without_env_token_shows_ok(self, monkeypatch, tmp_path):
-        home = tmp_path / ".hermes"
-        home.mkdir(parents=True, exist_ok=True)
-        self._isolate_home(monkeypatch, home)
-        # No GITHUB_TOKEN or GH_TOKEN
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-
-        # Mock gh to return success
-        import shutil
-        real_which = shutil.which
-        def mock_which(cmd):
-            return "/usr/local/bin/gh" if cmd == "gh" else real_which(cmd)
-        monkeypatch.setattr(shutil, "which", mock_which)
-
+        json_probe = [
+            "gh", "auth", "status", "--json", "hosts", "--hostname", "github.com",
+        ]
         call_log = []
+
         def mock_run(cmd, **kwargs):
-            call_log.append((cmd, kwargs))
-            if cmd[:4] == ["gh", "auth", "status", "--json"]:
-                stdout = '{"hosts":{"github.com":[{"state":"success","active":true}]}}'
-                result = types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
-            else:
-                result = types.SimpleNamespace(returncode=1, stdout="", stderr="")
-            return result
+            call_log.append(cmd)
+            if cmd == json_probe:
+                stdout = '{"hosts":{"github.com":[{"active":true,"state":"success"}]}}'
+                return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="")
 
-        import subprocess
-        monkeypatch.setattr(subprocess, "run", mock_run)
+        out = self._run_with_mocked_subprocess(monkeypatch, tmp_path, mock_run)
 
-        from hermes_cli.doctor import run_doctor
-        import io, contextlib
+        assert json_probe in call_log, f"gh not called correctly: {call_log}"
+        assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
-        buf = io.StringIO()
-        with contextlib.redirect_stdout(buf):
-            run_doctor(Namespace(fix=False))
-        out = buf.getvalue()
+    def test_gh_active_account_auth_failure_shows_warn(self, monkeypatch, tmp_path):
+        json_probe = [
+            "gh", "auth", "status", "--json", "hosts", "--hostname", "github.com",
+        ]
+        call_log = []
 
-        assert any(c[0][:4] == ["gh", "auth", "status", "--json"] for c in call_log), f"gh not called: {call_log}"
+        def mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            stdout = '{"hosts":{"github.com":[{"active":true,"state":"failed"}]}}'
+            return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="auth failed")
+
+        out = self._run_with_mocked_subprocess(monkeypatch, tmp_path, mock_run)
+
+        gh_calls = [cmd for cmd in call_log if cmd[:3] == ["gh", "auth", "status"]]
+        assert gh_calls == [json_probe]
+        assert "No GITHUB_TOKEN" in out
+        assert "60 req/hr" in out
+
+    def test_gh_without_json_status_falls_back_to_text_mode(self, monkeypatch, tmp_path):
+        json_probe = [
+            "gh", "auth", "status", "--json", "hosts", "--hostname", "github.com",
+        ]
+        fallback_probe = ["gh", "auth", "status", "--hostname", "github.com"]
+        call_log = []
+
+        def mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd == fallback_probe:
+                return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="unknown flag: --json")
+
+        out = self._run_with_mocked_subprocess(monkeypatch, tmp_path, mock_run)
+
+        gh_calls = [cmd for cmd in call_log if cmd[:3] == ["gh", "auth", "status"]]
+        assert gh_calls == [json_probe, fallback_probe]
         assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -947,9 +947,10 @@ class TestGitHubTokenCheck:
 
         call_log = []
         def mock_run(cmd, **kwargs):
-            call_log.append(cmd)
-            if cmd[:2] == ["gh", "auth"]:
-                result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            call_log.append((cmd, kwargs))
+            if cmd[:4] == ["gh", "auth", "status", "--json"]:
+                stdout = '{"hosts":{"github.com":[{"state":"success","active":true}]}}'
+                result = types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
             else:
                 result = types.SimpleNamespace(returncode=1, stdout="", stderr="")
             return result
@@ -965,7 +966,7 @@ class TestGitHubTokenCheck:
             run_doctor(Namespace(fix=False))
         out = buf.getvalue()
 
-        assert "gh auth" in str(call_log) or any(c[0] == "gh" for c in call_log), f"gh not called: {call_log}"
+        assert any(c[0][:4] == ["gh", "auth", "status", "--json"] for c in call_log), f"gh not called: {call_log}"
         assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
 

--- a/tests/hermes_cli/test_doctor_gh_auth.py
+++ b/tests/hermes_cli/test_doctor_gh_auth.py
@@ -1,0 +1,95 @@
+"""GitHub auth probes must select a usable active account across gh versions."""
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.doctor_state import _gh_authenticated
+
+
+JSON_PROBE = ["gh", "auth", "status", "--json", "hosts", "--hostname", "github.com"]
+TEXT_PROBE = ["gh", "auth", "status", "--hostname", "github.com"]
+
+
+@pytest.mark.parametrize(
+    "accounts, expected",
+    [
+        ([{"active": True, "state": "success"}], True),
+        ([{"active": False, "state": "success"}], False),
+        ([{"active": True, "state": "failed"}], False),
+        ([{"state": "success"}], False),
+        ([{"active": "false", "state": "success"}], False),
+        ([{"active": True, "state": "failed"},
+          {"active": False, "state": "success"}], False),
+        ([{"active": False, "state": "failed"},
+          {"active": True, "state": "success"}], True),
+        ([None, 42, "account", [], {"active": True, "state": "success"}], True),
+        ([None, 42, "account", []], False),
+        ([], False),
+    ],
+)
+def test_json_requires_usable_active_account(monkeypatch, accounts, expected):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        assert kwargs["timeout"] == 10
+        assert kwargs["capture_output"] is True
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"hosts": {"github.com": accounts}}),
+        )
+
+    monkeypatch.setattr(subprocess, "run", run)
+    assert _gh_authenticated() is expected
+    # A valid JSON verdict must not be overridden by text-mode exit status.
+    assert calls == [JSON_PROBE]
+
+
+@pytest.mark.parametrize(
+    "first",
+    [
+        (1, "unknown flag: --json"),
+        (0, "not json"),
+        (0, ""),
+        (0, "null"),
+        (0, "42"),
+        (0, '"account"'),
+        (0, "[]"),
+        (0, '{"hosts": null}'),
+        (0, '{"hosts": []}'),
+        (0, '{"hosts": {"github.com": null}}'),
+        (0, '{"hosts": {"github.com": 42}}'),
+        (0, '{"hosts": {"github.com": "account"}}'),
+        (0, '{"hosts": {"github.com": {"active": true, "state": "success"}}}'),
+        FileNotFoundError(),
+        PermissionError(),
+        subprocess.TimeoutExpired(JSON_PROBE, 10),
+    ],
+)
+@pytest.mark.parametrize(
+    "fallback",
+    [0, 1, FileNotFoundError(), PermissionError(), subprocess.TimeoutExpired(TEXT_PROBE, 10)],
+)
+def test_unavailable_json_uses_bounded_nonfatal_legacy_probe(monkeypatch, first, fallback):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        assert kwargs["timeout"] == 10
+        assert kwargs["capture_output"] is True
+        if "--json" in cmd:
+            if isinstance(first, Exception):
+                raise first
+            return SimpleNamespace(returncode=first[0], stdout=first[1])
+        assert cmd == TEXT_PROBE
+        if isinstance(fallback, Exception):
+            raise fallback
+        return SimpleNamespace(returncode=fallback)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    expected = not isinstance(first, Exception) and fallback == 0
+    assert _gh_authenticated() is expected
+    assert calls == ([JSON_PROBE] if isinstance(first, Exception) else [JSON_PROBE, TEXT_PROBE])


### PR DESCRIPTION
## Summary

Refresh GitHub CLI auth detection onto main `79445a496c86a19332ad786494b8384d2167e2d0`, porting the fix into `hermes_cli/doctor_state.py` instead of restoring the old Doctor facade. Original authorship is preserved.

- Use `gh auth status --json hosts --hostname github.com`; require a genuinely active account with successful auth.
- Treat valid account verdicts as authoritative; inactive successes must not hide an active failure.
- Fall back to the bounded, hostname-scoped text probe when JSON is unsupported/malformed or its container shapes are invalid.
- Handle null/scalar account collections and non-object entries without crashing; missing executables, OS errors, and timeouts remain nonfatal.
- Preserve configured-token precedence and existing Doctor output.

## Verification — `65cec41057709b9cb12b8113f6bd6be1cbd09022`

`scripts/run_tests.sh tests/hermes_cli/test_doctor_gh_auth.py tests/hermes_cli/test_doctor.py -k 'GitHubTokenCheck or test_json_requires_usable_active_account or test_unavailable_json_uses_bounded_nonfatal_legacy_probe' --tb=short`

- **92 passed, 0 failed**, rerun on the exact committed head.
- New 90-case auth regression matrix fails against baseline production code, then passes on the candidate.
- Broader relevant Doctor suite: **225 passed, 1 failed**. The same unrelated `test_doctor_reports_vercel_backend_diagnostics` failure (missing `Vercel runtime` output) was reproduced on unmodified main: **135 passed, 1 failed**. Excluding only that baseline failure: **225 passed, 0 failed**. No unrelated Vercel change included.
- Targeted Ruff and `git diff HEAD^ HEAD --check` pass.

All local tests used the canonical hermetic, per-file runner. No full-repository green claim, merge, or production deployment. Hosted CI must run on this exact head before merge.
