### PR TITLE
chore: add hermes audit symlink

### DIFF
--- a/hermes-audit
+++ b/hermes-audit
@@ -1,0 +1,1 @@
+/home/hermes/hermes-audit


### PR DESCRIPTION
## Summary
- Add repository symlink `hermes-audit` pointing to `/home/hermes/hermes-audit`.

## Verification
- Confirmed staged object is symlink mode `120000`.
- Commit pushed to `nrenault/hermes-agent:chore/hermes-audit-symlink` because direct push to `NousResearch/hermes-agent` is read-only for this account.
