### PR TITLE
fix(kanban): prevent archiving live tasks (#76196)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -692,6 +692,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
     p_archive.add_argument(
+        "--force",
+        action="store_true",
+        help="Archive even if the task is running with a live worker "
+             "(terminates the worker first)",
+    )
+    p_archive.add_argument(
         "--rm",
         dest="purge_ids",
         nargs="+",
@@ -2407,11 +2413,22 @@ def _cmd_archive(args: argparse.Namespace) -> int:
                     print(f"Deleted {tid}")
             return 0 if not failed else 1
         for tid in ids:
-            if not kb.archive_task(conn, tid):
-                failed.append(tid)
-                print(f"cannot archive {tid}", file=sys.stderr)
-            else:
+            if kb.archive_task(conn, tid, force=bool(args.force)):
                 print(f"Archived {tid}")
+            else:
+                failed.append(tid)
+                # Distinguish the live-worker refusal from a generic
+                # failure so the operator knows the --force escape hatch
+                # exists (#76196).
+                t = kb.get_task(conn, tid)
+                if t is not None and t.status == "running":
+                    print(
+                        f"cannot archive {tid}: task is running with a live "
+                        f"worker (use --force to terminate it and archive)",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(f"cannot archive {tid}", file=sys.stderr)
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4349,8 +4349,13 @@ def heartbeat_claim(
         if cur.rowcount == 1:
             run_id = _current_run_id(conn, task_id)
             if run_id is not None:
+                # ``ended_at IS NULL`` guard (same as elsewhere): never
+                # write a new expiry onto a run row that has already been
+                # closed (reclaimed/archived/crashed), even if the task
+                # row still looks running (#76196).
                 conn.execute(
-                    "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                    "UPDATE task_runs SET claim_expires = ? "
+                    "WHERE id = ? AND ended_at IS NULL",
                     (expires, run_id),
                 )
             return True
@@ -6194,7 +6199,49 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    force: bool = False,
+    signal_fn=None,
+) -> bool:
+    """Archive a task, refusing to orphan a live running worker.
+
+    A task whose worker process is still alive is **not** archived unless
+    ``force=True`` (CLI ``--force``): archiving it would null the claim
+    while the worker keeps running, so its terminal ``complete``/``block``
+    handoff would be silently discarded (#76196).
+
+    With ``force=True`` the worker is terminated first via the same
+    best-effort path the dispatcher uses for reclaims
+    (:func:`_terminate_reclaimed_worker`). If a host-local worker survives
+    termination the archive is refused rather than risking an orphaned
+    process — mirroring the reclaim guard. An ``archived_while_running``
+    event (worker pid + termination metadata) is recorded for auditability.
+    """
+    # Pre-flight check outside the write txn: never flip DB rows on a task
+    # whose worker process is still alive unless the operator forced it.
+    live_worker: Optional[int] = None
+    termination: Optional[dict[str, Any]] = None
+    row = conn.execute(
+        "SELECT status, worker_pid, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is not None and row["status"] == "running" and row["worker_pid"]:
+        pid = int(row["worker_pid"])
+        if _pid_alive(pid):
+            if not force:
+                return False
+            live_worker = pid
+            termination = _terminate_reclaimed_worker(
+                pid, row["claim_lock"], signal_fn=signal_fn,
+            )
+            if _worker_survived_termination(termination):
+                # Host-local worker we signalled is still alive; archiving
+                # now would orphan it. Keep the task running so the
+                # operator can retry (same guard as reclaim paths).
+                return False
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -6212,7 +6259,19 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        if live_worker is not None:
+            payload: Optional[dict[str, Any]] = {
+                "worker_pid": live_worker,
+                "forced": True,
+            }
+            if termination:
+                payload.update(termination)
+            _append_event(
+                conn, task_id, "archived_while_running",
+                payload, run_id=run_id,
+            )
+        else:
+            _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -886,6 +886,18 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     ok = _set_status_direct(conn, task_id, "ready")
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
+                if not ok:
+                    # A live worker makes archive refuse; surface why
+                    # instead of the generic transition error (#76196).
+                    current = kanban_db.get_task(conn, task_id)
+                    if current is not None and current.status == "running":
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "Cannot archive: task is running with a live "
+                                "worker (terminate/reclaim it first)"
+                            ),
+                        )
             elif s == "running":
                 raise HTTPException(
                     status_code=400,
@@ -1225,7 +1237,17 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     continue
                 if payload.archive:
                     if not kanban_db.archive_task(conn, tid):
-                        entry.update(ok=False, error="archive refused")
+                        # Live running workers refuse to archive; tell the
+                        # UI why instead of the generic refusal (#76196).
+                        entry.update(
+                            ok=False,
+                            error=(
+                                "archive refused: task is running with a "
+                                "live worker"
+                            )
+                            if task.status == "running"
+                            else "archive refused",
+                        )
                 if payload.status is not None and not payload.archive:
                     s = payload.status
                     if s == "done":

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -236,6 +236,112 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         assert payload["host_local"] is True
 
 
+def test_archive_refuses_running_task_with_live_worker(kanban_home, monkeypatch):
+    """Archiving a task whose worker process is still alive must be refused
+    unless ``--force`` is given; with force the worker is terminated first
+    and an ``archived_while_running`` event is recorded (#76196)."""
+    import json
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="live", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, tid, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, tid, 99999)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        # Without force the archive is refused and the task stays running.
+        assert kb.archive_task(conn, tid) is False
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["status"] == "running"
+
+        # With force the worker is terminated (signal_fn captures the kill)
+        # and the task is archived with an auditable event.
+        killed: list[int] = []
+        alive = {"state": True}
+
+        def fake_kill(pid: int, _sig: int) -> None:
+            killed.append(int(pid))
+            alive["state"] = False  # the signal killed the worker
+
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: alive["state"])
+        assert kb.archive_task(conn, tid, force=True, signal_fn=fake_kill) is True
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["status"] == "archived"
+        assert killed == [99999]
+        events = kb.list_events(conn, tid)
+        awr = [e for e in events if e.kind == "archived_while_running"]
+        assert len(awr) == 1
+        payload = awr[0].payload
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        assert payload["worker_pid"] == 99999
+        assert payload["forced"] is True
+
+
+def test_archive_force_refuses_when_worker_survives_termination(
+    kanban_home, monkeypatch,
+):
+    """Even with ``--force``, archiving must be refused when a host-local
+    worker survives termination — otherwise the archive would orphan a
+    still-running process (mirrors the reclaim guard, #76196)."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="survivor", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, tid, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, tid, 77777)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(
+            _kb,
+            "_terminate_reclaimed_worker",
+            lambda *a, **k: {
+                "prev_pid": 77777,
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": False,
+            },
+        )
+        assert kb.archive_task(conn, tid, force=True) is False
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["status"] == "running"
+
+
+def test_heartbeat_claim_skips_already_closed_run(kanban_home):
+    """``heartbeat_claim`` must not write a new expiry onto a run row that
+    has already been closed (``ended_at IS NULL`` guard, #76196)."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="hb", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host}:worker"
+        kb.claim_task(conn, tid, claimer=lock)
+        kb._set_worker_pid(conn, tid, 321)
+        run_id = _kb._current_run_id(conn, tid)
+        assert run_id is not None
+        # Close the run row as if it had already ended (reclaimed/crashed).
+        conn.execute(
+            "UPDATE task_runs SET ended_at = ?, status = 'done' WHERE id = ?",
+            (int(time.time()), run_id),
+        )
+        old_expires = conn.execute(
+            "SELECT claim_expires FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()[0]
+        assert kb.heartbeat_claim(conn, tid, claimer=lock) is True
+        new_expires = conn.execute(
+            "SELECT claim_expires FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()[0]
+        assert new_expires == old_expires
+
+
 
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -907,7 +907,18 @@ def _handle_heartbeat(args: dict, **kw) -> str:
             # default _claimer_id() covers locally-driven workers that
             # never went through the dispatcher path.
             claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
-            kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+            still_owner = kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+            if not still_owner:
+                # Claim was revoked (task reclaimed, reassigned, or
+                # archived out from under us). Keep heartbeating would be
+                # pointless — the worker no longer owns the task, so its
+                # terminal handoff would be discarded. Signal the agent to
+                # stop immediately (#76196).
+                return tool_error(
+                    f"claim revoked for {tid}: the task was reclaimed, "
+                    "reassigned, or archived by an operator — stop working "
+                    "on this task immediately (do not complete or block it)"
+                )
 
             ok = kb.heartbeat_worker(
                 conn,


### PR DESCRIPTION
Closes #76196

## Problem

`archive_task` archived a task that was `running` with a live claim and no
check for an active worker. It nulled the claim in the database but never
signalled the worker process, so the worker kept running against a task that
no longer belonged to it, and its terminal `complete`/`block` handoff was
silently discarded (work performed and paid for, then dropped).

## Changes

- **`archive_task(force=False)`** (hermes_cli/kanban_db.py): refuses to
  archive a task with `status='running'` and a live `worker_pid` unless
  `force=True`. With force, the worker is terminated first via the same
  best-effort path the dispatcher uses for reclaims
  (`_terminate_reclaimed_worker`, SIGTERM→SIGKILL). If a host-local worker
  survives termination, the archive is refused rather than orphaning it
  (mirrors the reclaim guard).
- **`archived_while_running` event**: emitted when a forced archive kills a
  live worker, carrying `worker_pid` + termination metadata so the loss is
  auditable.
- **CLI `hermes kanban archive --force`** (hermes_cli/kanban.py): the escape
  hatch, plus a specific error message when archive is refused due to a live
  worker.
- **Dashboard** (plugins/kanban/dashboard/plugin_api.py): single + bulk
  archive paths surface a specific "running with a live worker" error
  instead of a generic transition/refusal error.
- **`heartbeat_claim`** (hermes_cli/kanban_db.py): `task_runs` update now
  requires `ended_at IS NULL`, so it can no longer write a new expiry onto an
  already-closed run.
- **`kanban_heartbeat`** (tools/kanban_tools.py): treats
  `heartbeat_claim() == False` as a revoked claim and returns an explicit
  error telling the agent to stop immediately (do not complete/block) —
  previously the return value was discarded.

## Tests

Added to `tests/hermes_cli/test_kanban_db.py`:
- archive refused for a running task with a live worker (no force)
- force archives after terminating the worker, recording
  `archived_while_running`
- force refuses when a host-local worker survives termination
- `heartbeat_claim` skips already-closed run rows

All kanban suites pass: `test_kanban_db.py`, `test_kanban_tools.py`,
`test_kanban_core_functionality.py`, dashboard plugin tests, and
`test_atypical_scenarios.py`. `ruff check` clean on changed files.