### PR TITLE
feat(providers): add Mistral AI provider plugin

### DIFF
--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,0 +1,208 @@
+"""Mistral AI provider profile — production-grade.
+
+Wire-format quirks of https://api.mistral.ai/v1 that the generic ``custom``
+profile (and the earlier v1 of this plugin) get wrong:
+
+1. ``reasoning_effort`` accepts ONLY ``none`` or ``high``. A global Hermes
+   ``medium`` is rejected with HTTP 400 / code 3051.
+2. ``reasoning_effort`` is rejected ENTIRELY on models without the reasoning
+   capability — even ``none`` (HTTP 400 / code 3051, "reasoning_effort is not
+   enabled for this model"). Verified on codestral-latest, 2026-08. So the
+   field must only be emitted for known reasoning-capable families; for every
+   other model we stay silent and let the API apply its default.
+3. The ``extra_body.think`` flag (Ollama quirk emitted by the generic custom
+   profile) is rejected with HTTP 422 ``extra_forbidden`` — never emitted.
+4. With ``reasoning_effort=high`` the API returns ``message.content`` as a
+   *list* of parts (``{"type": "thinking", ...}`` then ``{"type": "text"}``);
+   with ``none`` (or the field omitted) it is a plain string. Hermes' stream
+   transport (``chat_completion_helpers``, v0.19.0) appends ``delta.content``
+   to a list and ``"".join()``s it — a list content chunk raises
+   ``TypeError: sequence item 0: expected str instance, list found``, which
+   surfaces as "Stream interrupted" / "Response remained truncated". Until
+   Hermes learns to flatten content-part arrays in streams, the profile
+   therefore NEVER emits ``reasoning_effort=high``: positive efforts are
+   mapped to *omit* (Mistral's server default — verified to return plain
+   string content), and only explicit disable maps to ``none``. Flip
+   ``_SEND_HIGH_REASONING`` to True after a Hermes upgrade that handles
+   list-content streams.
+5. Image input is accepted only by vision-capable models (HTTP 400 "Image
+   input is not enabled for this model" otherwise). ``supports_vision`` is
+   therefore True provider-wide; non-vision models fall back to the
+   auxiliary vision model via Hermes' image routing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+# Set to True once Hermes' chat-completions stream parser can flatten
+# Mistral's list-content deltas (see docstring point 4). While False,
+# positive reasoning efforts are omitted from the request instead of being
+# sent as "high" — which would crash the stream with a TypeError.
+_SEND_HIGH_REASONING: bool = False
+
+# Model families that expose the reasoning capability (verified against the
+# 2026-08 live catalog: capabilities.reasoning == true). For every other
+# model, sending reasoning_effort at all — even "none" — returns HTTP 400.
+# Prefix match so dated revisions (mistral-medium-2604, ...) and -latest
+# aliases are covered.
+_REASONING_PREFIXES: tuple[str, ...] = (
+    "mistral-small",
+    "mistral-medium",
+    "magistral",
+    "labs-leanstral",
+    "mistral-vibe-cli",
+)
+
+# Dated revisions of reasoning families that do NOT expose the reasoning
+# capability (verified against the 2026-08 catalog: no capabilities.reasoning).
+# The API rejects reasoning_effort on them with HTTP 400 / code 3051.
+_NON_REASONING_EXACT: frozenset[str] = frozenset(
+    {"mistral-medium-2505", "mistral-medium-2508"}
+)
+
+# Curated chat models for the /model picker when the live catalog fetch
+# fails. All support tool calling. Ordered by preference.
+FALLBACK_MODELS: tuple[str, ...] = (
+    "mistral-large-latest",
+    "mistral-small-latest",
+    "mistral-medium-latest",
+    "codestral-latest",
+    "devstral-latest",
+    "ministral-8b-latest",
+    "ministral-3b-latest",
+)
+
+
+def _model_supports_reasoning(model: str | None) -> bool:
+    """True when *model* is in a reasoning-capable Mistral family.
+
+    Unknown/out-of-catalog models return False on purpose: the safe default
+    is to never send ``reasoning_effort`` (it 400s on non-reasoning models),
+    so reasoning simply stays on the server default for those.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    if m in _NON_REASONING_EXACT:
+        return False
+    return any(m.startswith(prefix) for prefix in _REASONING_PREFIXES)
+
+
+class MistralProfile(ProviderProfile):
+    """Mistral AI — reasoning_effort in {none, high}, only on reasoning models."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not _model_supports_reasoning(model):
+            # Non-reasoning family (codestral, devstral, mistral-code-*,
+            # ministral, mistral-large, voxtral-small, ...): sending
+            # reasoning_effort — even "none" — is HTTP 400. Leave the wire
+            # format untouched and let the API use its default.
+            return extra_body, top_level
+
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            # No reasoning config at all — don't force anything.
+            return extra_body, top_level
+
+        enabled = reasoning_config.get("enabled", True)
+        if enabled is False:
+            top_level["reasoning_effort"] = "none"
+            return extra_body, top_level
+
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if effort in {"none", "false", "disabled"}:
+            top_level["reasoning_effort"] = "none"
+        elif effort and _SEND_HIGH_REASONING:
+            # Mistral supports only "high" as a positive level — map
+            # low/medium/high/xhigh all onto it. Disabled by default:
+            # Hermes' stream parser crashes on Mistral's list-content
+            # reasoning stream (see module docstring point 4).
+            top_level["reasoning_effort"] = "high"
+        # else: positive effort while _SEND_HIGH_REASONING is False → omit
+        # the field entirely; Mistral's server default returns plain
+        # string content, so the stream stays crash-free.
+
+        return extra_body, top_level
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Live catalog filtered to chat-capable models.
+
+        Mistral's /models endpoint also lists embeddings, OCR, moderation,
+        TTS and audio-transcription models. Only ``capabilities.completion_chat``
+        entries are usable through chat completions, so everything else is
+        filtered out of the picker.
+        """
+        effective_base = base_url or self.base_url
+        if not effective_base:
+            return None
+        url = effective_base.rstrip("/") + "/models"
+
+        import json
+        import urllib.request
+
+        from hermes_cli.urllib_security import open_credentialed_url
+
+        req = urllib.request.Request(url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with open_credentialed_url(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            items = data if isinstance(data, list) else data.get("data", [])
+            chat_models: list[str] = []
+            for m in items:
+                if not isinstance(m, dict) or "id" not in m:
+                    continue
+                caps = m.get("capabilities") or {}
+                if caps.get("completion_chat"):
+                    chat_models.append(m["id"])
+            return chat_models or None
+        except Exception as exc:
+            logger.debug("fetch_models(mistral): %s", exc)
+            return None
+
+    def default_vision_model(self) -> str | None:
+        """Best vision-capable chat model for auxiliary vision tasks."""
+        return "mistral-large-latest"
+
+
+mistral = MistralProfile(
+    name="mistral",
+    aliases=(),
+    env_vars=("MISTRAL_API_KEY",),
+    display_name="Mistral AI",
+    description="Mistral AI — native Mistral API",
+    signup_url="https://console.mistral.ai/",
+    fallback_models=FALLBACK_MODELS,
+    base_url="https://api.mistral.ai/v1",
+    default_aux_model="mistral-small-latest",
+    supports_vision=True,
+)
+
+register_provider(mistral)

--- a/plugins/model-providers/mistral/plugin.yaml
+++ b/plugins/model-providers/mistral/plugin.yaml
@@ -1,0 +1,5 @@
+name: mistral-provider
+kind: model-provider
+version: 1.0.0
+description: Mistral AI (api.mistral.ai) — reasoning gating, vision, live catalog
+author: merouaneagar

--- a/tests/providers/test_mistral_profile.py
+++ b/tests/providers/test_mistral_profile.py
@@ -1,0 +1,118 @@
+"""Tests du profile Mistral — style tests/providers/test_provider_profiles.py.
+
+Usage (depuis ~/.hermes/hermes-agent avec le venv):
+    ./venv/bin/python -m pytest ~/.hermes/plugins/model-providers/mistral/tests/ -v
+
+La découverte du registre providers scanne $HERMES_HOME/plugins/model-providers/
+au premier get_provider_profile(), donc le plugin utilisateur est chargé
+automatiquement — pas besoin d'import manuel.
+"""
+
+from providers import get_provider_profile
+
+
+def _profile():
+    p = get_provider_profile("mistral")
+    assert p is not None, "profile 'mistral' introuvable — le plugin utilisateur est-il découvert ?"
+    return p
+
+
+class TestMistralDiscovery:
+    """Identité du provider (conventions du README model-providers)."""
+
+    def test_registry_lookup(self):
+        p = _profile()
+        assert p.name == "mistral"
+        assert p.display_name == "Mistral AI"
+        assert p.signup_url  # console.mistral.ai
+        assert p.env_vars == ("MISTRAL_API_KEY",)
+        assert "api.mistral.ai" in p.base_url
+        assert p.default_aux_model == "mistral-small-latest"
+
+    def test_vision_flags(self):
+        p = _profile()
+        assert p.supports_vision is True
+        assert p.supports_vision_tool_messages is True
+
+    def test_vision_default(self):
+        p = _profile()
+        assert p.default_vision_model() == "mistral-large-latest"
+
+    def test_fallback_models_are_agentic_latest_aliases(self):
+        p = _profile()
+        assert p.fallback_models, "fallback_models ne doit pas etre vide"
+        # Règle du repo (base.py): seuls des modèles agentic (tool calling)
+        # doivent apparaître — les alias -latest sont tous tool-calling-capables.
+        for m in p.fallback_models:
+            assert m.endswith("latest"), f"{m} n'est pas un alias -latest"
+            assert m not in ("mistral-embed", "mistral-moderation-2603")
+
+
+class TestMistralReasoningMapping:
+    """build_api_kwargs_extras — contrat wire-format Mistral."""
+
+    def test_reasoning_disabled_sends_none(self):
+        p = _profile()
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="mistral-small-latest")
+        assert tl == {"reasoning_effort": "none"}
+        assert eb == {}
+
+    def test_positive_effort_is_omitted_not_high(self):
+        # Contrat v2: jamais `high` (crash stream Hermes sur content-liste).
+        p = _profile()
+        for effort in ("low", "medium", "high", "xhigh", "max", "ultra"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="mistral-small-latest")
+            assert tl == {}, f"effort={effort} ne doit envoyer aucun champ (omis)"
+            assert eb == {}
+
+    def test_effort_none_sends_none(self):
+        p = _profile()
+        for effort in ("none", "false", "disabled"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="mistral-small-latest")
+            assert tl == {"reasoning_effort": "none"}
+
+    def test_no_config_omits_everything(self):
+        p = _profile()
+        for rc in (None, {}):
+            eb, tl = p.build_api_kwargs_extras(reasoning_config=rc, model="mistral-small-latest")
+            assert tl == {} and eb == {}
+
+    def test_reasoning_families(self):
+        # Familles avec capability reasoning — le champ est géré.
+        p = _profile()
+        for model in ("mistral-small-latest", "mistral-small-2603",
+                      "mistral-medium-latest", "mistral-medium-2604", "mistral-medium-3",
+                      "magistral-small-latest", "labs-leanstral-1-5", "mistral-vibe-cli-fast"):
+            _, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": False}, model=model)
+            assert tl == {"reasoning_effort": "none"}, model
+
+    def test_non_reasoning_models_never_get_effort(self):
+        # 400 code 3051 sinon — vérifié empiriquement sur codestral-latest.
+        p = _profile()
+        for model in ("codestral-latest", "codestral-2508", "devstral-latest",
+                      "mistral-code-latest", "mistral-large-latest", "mistral-large-2512",
+                      "ministral-8b-latest", "ministral-3b-latest", "voxtral-small-latest",
+                      "mistral-medium-2505", "mistral-medium-2508"):
+            for rc in ({"enabled": False}, {"enabled": True, "effort": "high"}, None):
+                eb, tl = p.build_api_kwargs_extras(reasoning_config=rc, model=model)
+                assert tl == {}, f"{model} + {rc}: aucun reasoning_effort attendu, got {tl}"
+                assert eb == {}
+
+    def test_unknown_or_empty_model_is_safe(self):
+        p = _profile()
+        for model in (None, "", "future-model-xyz"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"}, model=model)
+            assert tl == {} and eb == {}
+
+    def test_never_emits_think_flag(self):
+        # Mistral rejette extra_body.think (422 extra_forbidden).
+        p = _profile()
+        for rc in ({"enabled": False}, {"enabled": True, "effort": "medium"}, None):
+            eb, _ = p.build_api_kwargs_extras(reasoning_config=rc, model="mistral-small-latest")
+            assert "think" not in eb and "thinking" not in eb


### PR DESCRIPTION
## Summary

Production-grade Mistral AI provider profile (api.mistral.ai) as a
bundled model-provider plugin, addressing long-standing requests
(#42357, #20859, #61160).

## Wire-format quirks handled

- reasoning_effort accepts ONLY none/high; a global Hermes medium is
  rejected (HTTP 400 / code 3051). Positive efforts are OMITTED
  rather than clamped to high: with high, Mistral streams
  delta.content as a JSON list (thinking + text parts), which crashes
  the Hermes 0.19 stream parser ("".join(content_parts) ->
  TypeError: sequence item 0: expected str instance, list found) --
  the "Stream interrupted" symptom.
- reasoning_effort is rejected entirely on models without the
  reasoning capability -- even none (HTTP 400 / code 3051). The
  profile gates per family with exact exclusions for
  mistral-medium-2505/2508.
- extra_body.think (Ollama quirk) is never emitted (HTTP 422).
- Vision only on vision-capable models; supports_vision=True
  provider-wide so Hermes routes images correctly.

## Included

- plugins/model-providers/mistral/__init__.py + plugin.yaml
- tests/providers/test_mistral_profile.py -- 12 tests (discovery,
  reasoning mapping contracts, never-emits-think)
- Validated E2E against the live API: 34 chat models (basic, stream,
  tools, reasoning, vision); 32/34 OK -- the 2 failures are
  account-gated (labs-leanstral-*, HTTP 403).

Closes #42357
