### PR TITLE
fix(memory): consistent time awareness across surfaces (#76307)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -520,7 +520,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
-    from hermes_time import now as _hermes_now
+    from hermes_time import now as _hermes_now, get_timezone as _hermes_tz
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable
     # for the full day.  Minute-precision changes invalidate prefix-cache KV
@@ -528,7 +528,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # session resume without a stored prompt).  The model can still query the
     # exact wall-clock time via tools when it actually needs it.
     # Credit: @iamfoz (PR #20451).
-    timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
+    #
+    # The timezone IS cache-safe: it only changes when the user's configured
+    # zone changes, landing on the next prompt rebuild.  Including it here
+    # gives every surface (CLI, TUI, gateway, cron, desktop) the same
+    # date+timezone awareness instead of depending on per-surface injection.
+    # (Issue #76307.)
+    _tz_label = getattr(_hermes_tz(), "key", None) or (now.tzname() or "UTC")
+    # Colons (e.g. fixed-offset labels like "UTC+05:30") would trip the
+    # date-only cache-stability pattern (HH:MM); strip them for the label.
+    _tz_label = _tz_label.replace(":", "")
+    timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')} ({_tz_label})"
     if agent.pass_session_id and agent.session_id:
         timestamp_line += f"\nSession ID: {agent.session_id}"
     if agent.model:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
@@ -160,7 +161,7 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         expected_profile,
         "SYSTEM_MESSAGE",
         "CONTEXT_FILES",
-        "Conversation started: Friday, January 02, 2026",
+        "Conversation started: Friday, January 02, 2026 (UTC)",
     ))
 
     with (
@@ -178,11 +179,75 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         ),
         patch("agent.file_safety._resolve_active_profile_name", return_value="default"),
         patch("hermes_time.now", return_value=datetime(2026, 1, 2)),
+        patch("hermes_time.get_timezone", return_value=None),
     ):
         prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
 
     assert prompt == expected
     assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:4])
+
+
+def test_timestamp_line_includes_configured_timezone():
+    """The cached timestamp line carries the configured IANA timezone so
+    every surface gets the same date+timezone awareness (issue #76307).
+
+    Timezone is cache-safe: it only changes on a prompt rebuild (session
+    start / compression), unlike minute-precision wall-clock time which the
+    codebase deliberately excludes (see test_datetime_is_date_only_not_minute_precision).
+    """
+    agent = _make_agent()
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch(
+            "hermes_time.now",
+            return_value=datetime(2026, 1, 2, 9, 30, tzinfo=ZoneInfo("America/Sao_Paulo")),
+        ),
+        patch("hermes_time.get_timezone", return_value=ZoneInfo("America/Sao_Paulo")),
+    ):
+        parts = build_system_prompt_parts(agent)
+
+    assert "Conversation started: Friday, January 02, 2026 (America/Sao_Paulo)" in parts["volatile"]
+
+
+def test_timestamp_timezone_label_never_contains_colon():
+    """Fixed-offset tz labels (e.g. "UTC+05:30") must not introduce an HH:MM
+    pattern into the cached prompt — the date-only cache-stability contract
+    (test_datetime_is_date_only_not_minute_precision) forbids colons."""
+    from datetime import timedelta, timezone as dt_timezone
+
+    agent = _make_agent()
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch(
+            "hermes_time.now",
+            return_value=datetime(
+                2026, 1, 2,
+                tzinfo=dt_timezone(timedelta(hours=5, minutes=30)),
+            ),
+        ),
+        patch("hermes_time.get_timezone", return_value=None),
+    ):
+        parts = build_system_prompt_parts(agent)
+
+    import re as _re
+
+    line = next(
+        l for l in parts["volatile"].splitlines()
+        if l.startswith("Conversation started:")
+    )
+    # The line legitimately contains "Conversation started:" — the contract
+    # is the HH:MM pattern (colon + digits), same as
+    # test_datetime_is_date_only_not_minute_precision.
+    assert not _re.search(r":\d", line)
+    # tzname of a fixed-offset zone without abbreviation is like "UTC+05:30";
+    # the label must have been sanitized to a colon-free form.
+    assert "Conversation started: Friday, January 02, 2026 (UTC+0530)" in parts["volatile"]
 
 
 class TestTelegramRichMessagesHint:

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -108,7 +108,7 @@ entry point is src/atlas/main.py. Always run `make lint` before
 committing.
 
 # Layer 9: Timestamp + session
-Current time: 2026-03-30T14:30:00-07:00
+Conversation started: Monday, March 30, 2026 (America/Los_Angeles)
 Session: abc123
 
 # Layer 10: Platform hint

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/prompt-assembly.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/prompt-assembly.md
@@ -108,7 +108,7 @@ entry point is src/atlas/main.py. Always run `make lint` before
 committing.
 
 # Layer 9: Timestamp + session
-Current time: 2026-03-30T14:30:00-07:00
+Conversation started: Monday, March 30, 2026 (America/Los_Angeles)
 Session: abc123
 
 # Layer 10: Platform hint


### PR DESCRIPTION
Closes #76307

## Scope
Consistent **time awareness** across every surface (CLI, TUI, gateway, cron, desktop) — the "skill/memory recall decay" half of the issue is intentionally left out of this PR (too broad; follow-up candidates welcome).

## Problem
- The system prompt only carried `Conversation started: <date>` — no timezone, and the wall-clock was never injected consistently; behavior depended on which surface the turn ran on.
- The prompt-assembly docs showed `Current time: <ISO> <tz>` (minute-precision), which the code deliberately does **not** emit (prefix-cache KV stability — codified in `test_datetime_is_date_only_not_minute_precision`).

## Fix
`agent/system_prompt.py::build_system_prompt_parts` — the single chokepoint every surface goes through — now appends the resolved timezone to the cached timestamp line:

```
Conversation started: Saturday, August 01, 2026 (America/Sao_Paulo)
```

- Timezone is **cache-safe**: it only changes when the configured zone changes, landing on the next prompt rebuild (session start / compression). No minute-precision wall-clock is introduced, preserving the date-only cache-stability contract.
- Label resolution: configured IANA key (`HERMES_TIMEZONE` / `config.yaml` `timezone`) → `now().tzname()` fallback → `UTC`.
- Fixed-offset labels with colons (e.g. `UTC+05:30`) are sanitized to `UTC+0530` so the HH:MM pattern never appears in the cached prompt.
- Docs (`prompt-assembly.md`, en + zh-Hans) Layer 9 updated to match the actual output, fixing the doc-vs-code inconsistency.

## Tests
- Updated `test_coding_prompt_preserves_legacy_workspace_order` for the new label (deterministic via patched `hermes_time.get_timezone`).
- Added `test_timestamp_line_includes_configured_timezone` (IANA key) and `test_timestamp_timezone_label_never_contains_colon` (offset-label sanitization).
- 66 tests pass across `test_system_prompt.py`, `test_run_agent.py::TestBuildAssistantMessage`, `test_system_prompt_restore.py`, `test_failover_identity.py`, `test_compression_persistence.py`, `test_timezone.py`, `test_context_breakdown.py`.