### PR TITLE
fix(patch): anchor V4A Begin/End Patch markers to full lines

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -106,6 +106,61 @@ class TestParseMoveFile:
         assert ops[0].new_path == "new/path.py"
 
 
+class TestBoundaryMarkersInContent:
+    """Patch boundary markers inside content lines must not be treated as
+    real boundaries (docs about the patch format, nested patch text, etc.)."""
+
+    def test_end_patch_marker_in_add_content_does_not_truncate(self):
+        patch = """\
+*** Begin Patch
+*** Add File: notes.md
++doc line one
++*** End Patch
++content after the marker mention
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        contents = [l.content for l in ops[0].hunks[0].lines if l.prefix == "+"]
+        assert contents == [
+            "doc line one",
+            "*** End Patch",
+            "content after the marker mention",
+        ]
+
+    def test_begin_patch_marker_in_content_does_not_discard_operations(self):
+        patch = """\
+*** Begin Patch
+*** Add File: first.md
++first file content
+*** Add File: second.md
++*** Begin Patch
++second file content
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert [(op.operation, op.file_path) for op in ops] == [
+            (OperationType.ADD, "first.md"),
+            (OperationType.ADD, "second.md"),
+        ]
+
+    def test_context_line_end_patch_marker_does_not_truncate(self):
+        patch = """\
+*** Begin Patch
+*** Update File: guide.md
+@@ section @@
+ old line
+ *** End Patch
++new line
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        hunk_lines = [(l.prefix, l.content) for l in ops[0].hunks[0].lines]
+        assert (" ", "*** End Patch") in hunk_lines
+        assert ("+", "new line") in hunk_lines
+
+
 class TestParseInvalidPatch:
     def test_empty_patch_returns_empty_ops(self):
         ops, err = parse_v4a_patch("")

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -80,15 +80,19 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     """
     lines = patch_content.split('\n')
     operations: List[PatchOperation] = []
-    
-    # Find patch boundaries
+
+    # Find patch boundaries. Markers must occupy the whole line at column 0:
+    # content lines like "+*** End Patch" or " *** End Patch" (e.g. docs
+    # about the patch format) must not truncate the patch or reset the
+    # start boundary.
     start_idx = None
     end_idx = None
-    
+    begin_marker = re.compile(r'^\*\*\*\s*Begin\s+Patch\s*$')
+    end_marker = re.compile(r'^\*\*\*\s*End\s+Patch\s*$')
     for i, line in enumerate(lines):
-        if '*** Begin Patch' in line or '***Begin Patch' in line:
+        if begin_marker.match(line):
             start_idx = i
-        elif '*** End Patch' in line or '***End Patch' in line:
+        elif end_marker.match(line):
             end_idx = i
             break
     


### PR DESCRIPTION
## Summary

V4A patches no longer suffer silent data loss when the patch *content* mentions the boundary markers. `parse_v4a_patch` scanned for `*** Begin Patch` / `*** End Patch` with unanchored substring tests, so a content line like `+*** End Patch` (e.g. docs describing the V4A format, or nested patch text) was treated as the real boundary.

Salvage of #74458 by @spfcraze (authorship preserved via cherry-pick), clean onto current main.

Root cause: file-operation headers (`*** Update File:` etc.) already used anchored regexes, but the Begin/End markers used `'*** End Patch' in line` substring matching. A `+`/`-`/space-prefixed content line containing that string matched, truncating or discarding operations.

## Changes

- `tools/patch_parser.py`: boundary scan now matches `^\*\*\*\s*Begin\s+Patch\s*$` / `^\*\*\*\s*End\s+Patch\s*$` (whole line, column 0). The no-space `***Begin Patch` form is preserved.
- `tests/tools/test_patch_parser.py`: new `TestBoundaryMarkersInContent` — 3 regression tests.

## Validation

Live before/after against the real `parse_v4a_patch`:

| Scenario | Before (main) | After |
|---|---|---|
| `+*** End Patch` inside Add content | `['doc line one']` — 2 lines silently dropped, reports success | all 3 content lines preserved |
| `+*** Begin Patch` mid-content | 0 operations, no error (silent no-op) | 1 operation, content intact |
| `***Begin Patch` no-space markers | accepted | still accepted (no regression) |

`scripts/run_tests.sh tests/tools/test_patch_parser.py` — 26/26 pass.

Closes #74458.

## Infographic

![V4A patch markers anchored to full lines](https://v3b.fal.media/files/b/0aa4a238/wwonzL_z5xoaTctIGhe56_EpxMGS7z.png)
