### PR TITLE
feat(desktop): open stored sessions from deep links

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
+import { desktopDeepLinkAction } from '@/lib/deep-links'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -151,30 +152,30 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links either open an existing stored session without
+  // replacing occupied work, or stage a reviewable /blueprint command.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      const action = desktopDeepLinkAction(payload)
+
+      if (!action) {
         return
       }
 
-      const slots = Object.entries(payload.params || {})
-        .map(([k, v]) => {
-          const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
+      if (action.kind === 'session') {
+        openSession(action.sessionId, navigate, 'stack')
 
-          return `${k}=${sval}`
-        })
-        .join(' ')
+        return
+      }
 
-      const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
-      requestComposerInsert(command, { mode: 'block', target: 'main' })
+      requestComposerInsert(action.command, { mode: 'block', target: 'main' })
       requestComposerFocus('main')
     })
 
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the

--- a/apps/desktop/src/app/open-session.integration.test.ts
+++ b/apps/desktop/src/app/open-session.integration.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('openSession with the real pane store', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('preserves main and fronts a session opened with stack intent', async () => {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+    const session = await import('@/store/session')
+    const { watchSessionTiles } = await import('./chat/session-tile')
+    const { openSession } = await import('./open-session')
+
+    registry.register({
+      area: 'panes',
+      data: { placement: 'main', uncloseable: true },
+      id: 'workspace',
+      render: () => null,
+      title: 'chat'
+    })
+
+    watchSessionTiles()
+    tree.watchContributedPanes()
+    session.$selectedStoredSessionId.set('primary')
+    tree.declareDefaultTree(model.group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+
+    openSession('target', vi.fn(), 'stack')
+
+    expect(session.$selectedStoredSessionId.get()).toBe('primary')
+    expect(model.findGroupOfPane(tree.$layoutTree.get()!, 'session-tile:target')?.active).toBe('session-tile:target')
+  })
+})

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -132,6 +132,7 @@ describe('openSession', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'tab')
     expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(focusOpenSession).toHaveBeenCalledTimes(1)
     expect(navigate).not.toHaveBeenCalled()
   })
 
@@ -148,6 +149,17 @@ describe('openSession', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'stack')
     expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('stack fronts a newly opened tab so an external link reaches its conversation', () => {
+    $selectedStoredSessionId.set('s0')
+    focusOpenSession.mockReturnValueOnce(null).mockReturnValueOnce('tile')
+
+    openSession('s1', navigate, 'stack')
+
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(focusOpenSession).toHaveBeenNthCalledWith(2, 's1')
     expect(navigate).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -96,6 +96,7 @@ export function openSession(
   // IS fair game while it's only a blank draft, and an already-open blank draft
   // tab is spent before a new one is stacked.
   let spendBlankDraft = false
+  const frontNewTile = resolved === 'stack'
 
   if (resolved === 'stack') {
     spendBlankDraft = mainChatOccupied($activeSessionId.get(), $selectedStoredSessionId.get())
@@ -118,6 +119,10 @@ export function openSession(
     }
 
     openSessionTile(storedSessionId, 'center')
+
+    if (frontNewTile) {
+      focusOpenSession(storedSessionId)
+    }
 
     return
   }

--- a/apps/desktop/src/lib/deep-links.test.ts
+++ b/apps/desktop/src/lib/deep-links.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { desktopDeepLinkAction } from './deep-links'
+
+describe('desktopDeepLinkAction', () => {
+  it('opens a stored session from a hermes://session link', () => {
+    expect(
+      desktopDeepLinkAction({
+        kind: 'session',
+        name: '20260801_142533_1183a0',
+        params: {}
+      })
+    ).toEqual({ kind: 'session', sessionId: '20260801_142533_1183a0' })
+  })
+
+  it('preserves blueprint deep-link command construction', () => {
+    expect(
+      desktopDeepLinkAction({
+        kind: 'blueprint',
+        name: 'morning-brief',
+        params: { audience: 'Philippe LeBel', time: '08:00' }
+      })
+    ).toEqual({
+      kind: 'blueprint',
+      command: '/blueprint morning-brief audience="Philippe LeBel" time=08:00'
+    })
+  })
+
+  it('ignores empty and unknown deep links', () => {
+    expect(desktopDeepLinkAction(null)).toBeNull()
+    expect(desktopDeepLinkAction({ kind: 'session', name: '', params: {} })).toBeNull()
+    expect(desktopDeepLinkAction({ kind: 'unknown', name: 'value', params: {} })).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/deep-links.ts
+++ b/apps/desktop/src/lib/deep-links.ts
@@ -1,0 +1,38 @@
+export interface DesktopDeepLinkPayload {
+  kind: string
+  name: string
+  params: Record<string, string>
+}
+
+export type DesktopDeepLinkAction = { kind: 'blueprint'; command: string } | { kind: 'session'; sessionId: string }
+
+/**
+ * Convert an OS-level hermes:// payload into a narrow renderer action.
+ * Unknown link kinds stay inert instead of being interpreted as commands.
+ */
+export function desktopDeepLinkAction(payload?: DesktopDeepLinkPayload | null): DesktopDeepLinkAction | null {
+  if (!payload?.name) {
+    return null
+  }
+
+  if (payload.kind === 'session') {
+    return { kind: 'session', sessionId: payload.name }
+  }
+
+  if (payload.kind !== 'blueprint') {
+    return null
+  }
+
+  const slots = Object.entries(payload.params || {})
+    .map(([key, value]) => {
+      const serialized = /\s/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
+
+      return `${key}=${serialized}`
+    })
+    .join(' ')
+
+  return {
+    kind: 'blueprint',
+    command: `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
+  }
+}


### PR DESCRIPTION
## Summary
- parse `hermes://session/<stored-session-id>` payloads into a narrow renderer action
- route stored-session links through the existing stack-safe `openSession` path
- front newly created session tabs for external `stack` opens while preserving the occupied main conversation
- preserve ordinary background `tab` intent, window fallback, and existing blueprint deep-link behavior
- keep unknown or empty deep links inert

## Root cause addressed
A real dashboard click successfully launched Hermes and delivered the stored-session ID, but the stack-safe path only created a background session tile. The requested conversation therefore existed without becoming the visible pane. The follow-up fix explicitly fronts only newly created tiles opened with the external `stack` intent.

## Verification
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run check` — passed, including typecheck, lint, the complete UI suite, desktop platform tests, renderer/Electron builds, and macOS app/DMG packaging
- `npx vitest run src/app/open-session.test.ts src/app/open-session.integration.test.ts src/lib/deep-links.test.ts` — 28 passed
- permanent real pane-store regression verifies the occupied main conversation remains selected while the requested stored session becomes the active visible pane
- focused ESLint and Prettier checks — passed
- independent review — passed with no security concerns or logic errors
- staged static security scan and `git diff --check` — passed
- rebuilt local macOS app — strict deep-signature verification passed after local ad-hoc signing

## Notes
The stack intent avoids replacing occupied work when a deep link opens an existing stored conversation. A complete app restart is required to exercise the rebuilt renderer; end-to-end dashboard-click confirmation in the restarted app remains the final user-visible validation.
