### PR TITLE
fix(desktop): map SSH profiles to remote profiles (+ token-root anchor for non-default profiles)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -133,16 +133,38 @@ test('profileRemoteOverride tolerates a missing/!object profiles map', () => {
   assert.equal(profileRemoteOverride(null, 'coder'), null)
 })
 
-test('SSH remains separate from URL-shaped remote modes', () => {
+test('SSH remains separate from URL-shaped remote modes and preserves an explicit remote profile', () => {
   assert.equal(modeIsRemoteLike('ssh'), false)
-  const config = { profiles: { coder: { mode: 'ssh', host: 'alice@box:2222', keyPath: '/key' } } }
+
+  const config = {
+    profiles: { coder: { mode: 'ssh', host: 'alice@box:2222', keyPath: '/key', remoteProfile: 'default' } }
+  }
+
   assert.equal(profileRemoteOverride(config, 'coder'), null)
+
   assert.deepEqual(profileSshOverride(config, 'coder'), {
     mode: 'ssh',
     host: 'box',
     user: 'alice',
     port: 2222,
-    keyPath: '/key'
+    keyPath: '/key',
+    remoteProfile: 'default'
+  })
+})
+
+test('normalizeSshConfig rejects unsafe remote profile mappings', () => {
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: 'writer_2' }), {
+    mode: 'ssh',
+    host: 'box',
+    remoteProfile: 'writer_2'
+  })
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: 'bad profile' }), {
+    mode: 'ssh',
+    host: 'box'
+  })
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: '' }), {
+    mode: 'ssh',
+    host: 'box'
   })
 })
 

--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -166,6 +166,15 @@ test('normalizeSshConfig rejects unsafe remote profile mappings', () => {
     mode: 'ssh',
     host: 'box'
   })
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: 'root' }), {
+    mode: 'ssh',
+    host: 'box'
+  })
+  assert.deepEqual(normalizeSshConfig({ mode: 'ssh', host: 'box', remoteProfile: 'default' }), {
+    mode: 'ssh',
+    host: 'box',
+    remoteProfile: 'default'
+  })
 })
 
 test('normalizeSshConfig handles IPv6 and strict port bounds', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -281,6 +281,16 @@ function normalizeSshConfig(entry) {
     out.remoteHermesPath = remoteHermesPath
   }
 
+  // A Desktop profile can be a local routing label rather than the profile
+  // name used by the remote Hermes installation. Preserve an explicit mapping
+  // when it is a valid Hermes profile identifier; otherwise fall back to the
+  // historical same-name behavior in the caller.
+  const remoteProfile = String(entry.remoteProfile || '').trim()
+
+  if (/^[a-z0-9][a-z0-9_-]{0,63}$/.test(remoteProfile)) {
+    out.remoteProfile = remoteProfile
+  }
+
   return out
 }
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -45,6 +45,9 @@ const RT_COOKIE_VARIANTS = ['__Host-hermes_session_rt', '__Secure-hermes_session
 // cookies above. `privy-token` is the access token (the required signal);
 // variants cover the secured-prefix forms and the older `privy-session` name.
 const PRIVY_SESSION_COOKIE_VARIANTS = ['__Host-privy-token', '__Secure-privy-token', 'privy-token', 'privy-session']
+// Keep this aligned with hermes_cli.profiles.validate_profile_name(). `default`
+// is the built-in root alias; these names cannot be created as profiles.
+const RESERVED_REMOTE_PROFILES = new Set(['hermes', 'test', 'tmp', 'root', 'sudo'])
 
 function normalizeRemoteBaseUrl(rawUrl) {
   let value = String(rawUrl || '').trim()
@@ -287,7 +290,7 @@ function normalizeSshConfig(entry) {
   // historical same-name behavior in the caller.
   const remoteProfile = String(entry.remoteProfile || '').trim()
 
-  if (/^[a-z0-9][a-z0-9_-]{0,63}$/.test(remoteProfile)) {
+  if (/^[a-z0-9][a-z0-9_-]{0,63}$/.test(remoteProfile) && !RESERVED_REMOTE_PROFILES.has(remoteProfile)) {
     out.remoteProfile = remoteProfile
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6995,6 +6995,7 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
     sshPort: (ssh || savedSsh)?.port || null,
     sshKeyPath: (ssh || savedSsh)?.keyPath || '',
     sshRemoteHermesPath: (ssh || savedSsh)?.remoteHermesPath || '',
+    sshRemoteProfile: (ssh || savedSsh)?.remoteProfile || '',
     // The env override only forces the global/primary connection; a per-profile
     // scope is never overridden by HERMES_DESKTOP_REMOTE_URL.
     envOverride
@@ -7127,7 +7128,8 @@ function buildSshBlock(input: any, existingBlock: any = {}) {
     user: input.sshUser ?? existingBlock.user,
     port: input.sshPort ?? existingBlock.port,
     keyPath: input.sshKeyPath ?? existingBlock.keyPath,
-    remoteHermesPath: input.sshRemoteHermesPath ?? existingBlock.remoteHermesPath
+    remoteHermesPath: input.sshRemoteHermesPath ?? existingBlock.remoteHermesPath,
+    remoteProfile: input.sshRemoteProfile ?? existingBlock.remoteProfile
   })
 
   if (!merged) {
@@ -7416,7 +7418,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: connectionScopeKey(profile) || '',
+      profile: sshConfig.remoteProfile || connectionScopeKey(profile) || '',
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
+import { profileSshOverride } from './connection-config'
 import {
   buildSpawnCommand,
   cleanupStale,
@@ -418,6 +419,50 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
   assert.equal(result.token, 'the-served-token')
   assert.equal(result.baseUrl, 'http://127.0.0.1:50001')
   assert.equal(result.tokenFingerprint, fingerprintToken('the-served-token'))
+})
+
+test('managed SSH maps a local scope to a different non-default remote profile', async () => {
+  const localScope = 'work'
+  const sshConfig = profileSshOverride(
+    {
+      profiles: {
+        [localScope]: {
+          mode: 'ssh',
+          host: 'remote-box',
+          remoteProfile: 'writer_2'
+        }
+      }
+    },
+    localScope
+  )
+
+  assert.equal(sshConfig?.remoteProfile, 'writer_2')
+
+  const ssh = fakeSsh([
+    [/uname/, 'Linux\nx86_64'],
+    [/\[ -x/, 'OK'],
+    [/cat .*lock\.json/, ''],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [/python3 -c/, ''],
+    [/printf '%s\\n'/, ''],
+    [/setsid/, '778\n'],
+    [/kill -0 778/, 'ALIVE'],
+    [/cat .*\.log/, 'HERMES_BACKEND_READY port=52000\n']
+  ])
+
+  await connect(
+    connectDeps(ssh, {
+      profile: sshConfig?.remoteProfile,
+      adoptServedToken: async () => 'mapped-profile-token'
+    })
+  )
+
+  const spawn = ssh.calls.find(command => /setsid|nohup/.test(command)) || ''
+  assert.match(spawn, /--profile\b/)
+  assert.ok(spawn.includes('writer_2'))
+  assert.match(spawn, /serve\s+--isolated/)
+  assert.match(spawn, /\.hermes\/desktop-ssh\/[0-9a-f]{32}\/[0-9a-f]{16}\.token/)
+  assert.ok(!spawn.includes(' work'), 'the local Desktop scope must not become the remote profile')
 })
 
 test('connect() reuses a healthy dashboard when fingerprint + probe pass', async () => {

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -440,6 +440,33 @@ test('connect() reuses a healthy dashboard when fingerprint + probe pass', async
   assert.ok(!ssh.calls.some(c => /setsid/.test(c)), 'reuse path must not spawn a new dashboard')
 })
 
+test('connect() respawns when the requested remote profile differs from the lockfile profile', async () => {
+  const reuseToken = 'stored-token'
+  const lock = ownedLock({ profile: 'desktop-work', tokenFingerprint: fingerprintToken(reuseToken) })
+
+  const ssh = fakeSsh([
+    [/uname/, 'Linux\nx86_64'],
+    [/\[ -x/, 'OK'],
+    [/cat .*lock\.json/, JSON.stringify(lock)],
+    [/kill -0 333/, 'ALIVE'],
+    [/print\("OWNED"/, 'OWNED\n'],
+    [/kill 333/, ''],
+    [/--version/, 'Hermes Agent v0.18.2\n'],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [/python3 -c/, ''],
+    [/setsid/, '890\n'],
+    [/kill -0 890/, 'ALIVE'],
+    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=52050\n']
+  ])
+
+  const result = await connect(
+    connectDeps(ssh, { profile: 'default', reuseToken, adoptServedToken: async () => 'fresh' })
+  )
+
+  assert.equal(result.reused, false)
+  assert.ok(ssh.calls.some(c => /setsid/.test(c)), 'profile mismatch must spawn a fresh dashboard')
+})
+
 test('connect() respawns when the lockfile hermesPath differs from the resolved path', async () => {
   const reuseToken = 'stored-token'
   const lock = ownedLock({ hermesPath: '/old/stale/hermes', tokenFingerprint: fingerprintToken(reuseToken) })

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -423,6 +423,7 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
 
 test('managed SSH maps a local scope to a different non-default remote profile', async () => {
   const localScope = 'work'
+
   const sshConfig = profileSshOverride(
     {
       profiles: {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -713,6 +713,7 @@ async function connect(deps) {
       pidAlive &&
       owned &&
       lock.port > 0 &&
+      lock.profile === profile &&
       Boolean(reuseToken) &&
       lock.tokenFingerprint === fingerprintToken(reuseToken) &&
       lock.hermesPath === hermesPath &&

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -28,6 +28,7 @@ test('sshConfigFingerprint covers scope and every connection field', () => {
     port: 2222,
     keyPath: '/other',
     remoteHermesPath: '/other-hermes',
+    remoteProfile: 'default',
     effectiveConfigFingerprint: 'changed-config'
   })) {
     assert.notEqual(base, sshConfigFingerprint('', { ...config, [field]: value }))

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -8,6 +8,7 @@ function sshConfigFingerprint(scope, config) {
     config.port,
     config.keyPath,
     config.remoteHermesPath,
+    config.remoteProfile,
     config.effectiveConfigFingerprint
   ]
 

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
 
 import { test } from 'vitest'
 
@@ -9,6 +10,7 @@ import {
   helperCommand,
   powerShellCommand,
   psLiteral,
+  reusableWindowsLock,
   validLock
 } from './windows-remote-lifecycle'
 
@@ -112,6 +114,31 @@ test('Windows lock validation is scoped and exact', () => {
   // on it) but the reuse gate must reject it separately.
   assert.equal(validLock({ ...lock, port: 0 }, ownershipId), true)
   assert.equal(validLock({ ...lock, port: -1 }, ownershipId), false)
+})
+
+test('Windows SSH reuse requires the requested remote profile to match the lock', () => {
+  const token = 'stored-token'
+
+  const lock = {
+    schemaVersion: 2,
+    protocolVersion: 1,
+    ownershipId,
+    spawnNonce: '0123456789abcdef',
+    pid: 10,
+    creationTimeNs: '1784219690452757504',
+    port: 1234,
+    profile: 'default',
+    tokenFingerprint: crypto.createHash('sha256').update(token).digest('hex').slice(0, 32),
+    hermesPath: 'C:\\h\\hermes.exe',
+    hermesHome: 'C:\\h'
+  }
+
+  const state = { alive: true, owned: true }
+  const runtime = { hermesPath: lock.hermesPath, hermesHome: lock.hermesHome }
+
+  assert.equal(reusableWindowsLock(lock, state, 'default', token, runtime), true)
+  assert.equal(reusableWindowsLock(lock, state, 'desktop-work', token, runtime), false)
+  assert.equal(reusableWindowsLock({ ...lock, profile: '' }, state, '', token, runtime), true)
 })
 
 test('Windows integrated terminal uses encoded PowerShell and preserves cwd as literal data', () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -149,6 +149,19 @@ function validLock(lock, ownershipId) {
   )
 }
 
+function reusableWindowsLock(lock, state, profile, reuseToken, runtime) {
+  return Boolean(
+    state.alive &&
+    state.owned &&
+    lock.port > 0 &&
+    lock.profile === profile &&
+    reuseToken &&
+    lock.tokenFingerprint === fingerprintToken(reuseToken) &&
+    lock.hermesPath === runtime.hermesPath &&
+    lock.hermesHome === runtime.hermesHome
+  )
+}
+
 function assertCurrent(signal) {
   if (signal?.aborted) {
     const error: any = new Error('SSH bootstrap was cancelled.')
@@ -299,14 +312,7 @@ async function connectWindowsRemote(deps) {
       throw error
     }
 
-    const reusable =
-      state.alive &&
-      state.owned &&
-      lock.port > 0 &&
-      Boolean(reuseToken) &&
-      lock.tokenFingerprint === fingerprintToken(reuseToken) &&
-      lock.hermesPath === runtime.hermesPath &&
-      lock.hermesHome === runtime.hermesHome
+    const reusable = reusableWindowsLock(lock, state, profile, reuseToken, runtime)
 
     if (reusable) {
       const localPort = await pickLocalPort()
@@ -451,5 +457,6 @@ export {
   powerShellCommand,
   probeWindowsRemote,
   psLiteral,
+  reusableWindowsLock,
   validLock
 }

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProfileInfo } from '@/types/hermes'
 
 const getConnectionConfig = vi.fn()
+const saveConnectionConfig = vi.fn()
 const profiles = atom<ProfileInfo[]>([])
 
 vi.mock('@/store/profile', () => ({
@@ -45,9 +46,10 @@ beforeEach(() => {
     }
   ])
   getConnectionConfig.mockResolvedValue(localConnection)
+  saveConnectionConfig.mockResolvedValue(localConnection)
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getConnectionConfig }
+    value: { getConnectionConfig, saveConnectionConfig }
   })
 })
 
@@ -74,5 +76,44 @@ describe('GatewaySettings', () => {
     expect(
       screen.queryByText('Start a private Hermes backend on localhost. This is the default and works offline.')
     ).toBeNull()
+  })
+
+  it('shows and clears an SSH remote-profile mapping for a named Desktop profile', async () => {
+    getConnectionConfig.mockImplementation(async profile =>
+      profile === 'work'
+        ? {
+            ...localConnection,
+            mode: 'ssh',
+            profile: 'work',
+            sshHost: 'remote-box',
+            sshUser: 'alice',
+            sshPort: 22,
+            sshKeyPath: '',
+            sshRemoteHermesPath: '/opt/hermes/bin/hermes',
+            sshRemoteProfile: 'default'
+          }
+        : localConnection
+    )
+    saveConnectionConfig.mockReturnValue(new Promise(() => {}))
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'work' }))
+
+    await waitFor(() => expect(getConnectionConfig).toHaveBeenLastCalledWith('work'))
+    expect(await screen.findByText('Remote profile (optional)')).toBeTruthy()
+
+    const input = screen.getByPlaceholderText('work')
+
+    expect((input as HTMLInputElement).value).toBe('default')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save for next restart' }))
+
+    await waitFor(() =>
+      expect(saveConnectionConfig).toHaveBeenCalledWith(expect.objectContaining({
+        profile: 'work',
+        sshRemoteProfile: ''
+      }))
+    )
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -51,6 +51,7 @@ interface GatewaySettingsState {
   sshPort: number | null
   sshKeyPath: string
   sshRemoteHermesPath: string
+  sshRemoteProfile: string
 }
 
 const SSH_HOST_CUSTOM = '__custom__'
@@ -68,7 +69,8 @@ const EMPTY_STATE: GatewaySettingsState = {
   sshUser: '',
   sshPort: null,
   sshKeyPath: '',
-  sshRemoteHermesPath: ''
+  sshRemoteHermesPath: '',
+  sshRemoteProfile: ''
 }
 
 export function savedCloudConnectionUrl(config: Pick<GatewaySettingsState, 'mode' | 'remoteUrl'>): string {
@@ -413,7 +415,16 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     signingSeq.current += 1
     cloudConnectSeq.current += 1
     setLastTest(null)
-  }, [scope, state.mode, state.sshHost, state.sshUser, state.sshPort, state.sshKeyPath, state.sshRemoteHermesPath])
+  }, [
+    scope,
+    state.mode,
+    state.sshHost,
+    state.sshUser,
+    state.sshPort,
+    state.sshKeyPath,
+    state.sshRemoteHermesPath,
+    state.sshRemoteProfile
+  ])
 
   const oauthConnected = state.remoteOauthConnected
 
@@ -439,7 +450,10 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     sshUser: state.sshUser.trim() || undefined,
     sshPort: state.sshPort,
     sshKeyPath: state.sshKeyPath.trim() || undefined,
-    sshRemoteHermesPath: state.sshRemoteHermesPath.trim()
+    sshRemoteHermesPath: state.sshRemoteHermesPath.trim(),
+    // Preserve an intentional blank so an existing remote-profile mapping can
+    // be cleared instead of being mistaken for an omitted field.
+    sshRemoteProfile: state.sshRemoteProfile.trim()
   })
 
   const save = async (apply: boolean) => {
@@ -1424,6 +1438,20 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
             description={g.sshHermesPathDesc}
             title={g.sshHermesPathTitle}
           />
+          {scope !== null ? (
+            <ListRow
+              action={
+                <Input
+                  className={cn('h-8 font-mono', CONTROL_TEXT)}
+                  onChange={event => setState(current => ({ ...current, sshRemoteProfile: event.target.value }))}
+                  placeholder={scope}
+                  value={state.sshRemoteProfile}
+                />
+              }
+              description={g.sshRemoteProfileDesc}
+              title={g.sshRemoteProfileTitle}
+            />
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -27,6 +27,7 @@ function config(overrides: Partial<DesktopConnectionConfig> = {}): DesktopConnec
     sshPort: null,
     sshKeyPath: '',
     sshRemoteHermesPath: '',
+    sshRemoteProfile: '',
     ...overrides
   }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -525,6 +525,7 @@ export interface DesktopConnectionConfig {
   sshPort: number | null
   sshKeyPath: string
   sshRemoteHermesPath: string
+  sshRemoteProfile: string
 }
 
 export interface DesktopConnectionConfigInput {
@@ -543,6 +544,7 @@ export interface DesktopConnectionConfigInput {
   sshPort?: number | null
   sshKeyPath?: string
   sshRemoteHermesPath?: string
+  sshRemoteProfile?: string
 }
 
 export interface DesktopConnectionTestResult {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -713,6 +713,8 @@ export const en: Translations = {
       sshHermesPathTitle: 'Hermes path (optional)',
       sshHermesPathDesc: 'Full path to the remote hermes binary. Blank = auto-detect.',
       sshHermesPathPlaceholder: 'auto-detect',
+      sshRemoteProfileTitle: 'Remote profile (optional)',
+      sshRemoteProfileDesc: 'Profile name on the remote host. Blank = use the Desktop profile name.',
       sshTestConnection: 'Test SSH',
       sshConnect: 'Connect',
       sshButtonsHint: 'Save applies on the next launch. Connect reconnects now.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -782,6 +782,8 @@ export const ja = defineLocale({
       sshHermesPathTitle: 'Hermes パス（任意）',
       sshHermesPathDesc: 'リモートの hermes バイナリへのフルパス。空欄 = 自動検出。',
       sshHermesPathPlaceholder: '自動検出',
+      sshRemoteProfileTitle: 'リモートプロファイル（任意）',
+      sshRemoteProfileDesc: 'リモートホスト上のプロファイル名。空欄 = Desktop のプロファイル名を使用。',
       sshTestConnection: 'SSH をテスト',
       sshConnect: '接続',
       sshButtonsHint: '「保存」は次回起動時に適用され、「接続」は今すぐ再接続します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -606,6 +606,8 @@ export interface Translations {
       sshHermesPathTitle: string
       sshHermesPathDesc: string
       sshHermesPathPlaceholder: string
+      sshRemoteProfileTitle: string
+      sshRemoteProfileDesc: string
       sshTestConnection: string
       sshConnect: string
       sshButtonsHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -758,6 +758,8 @@ export const zhHant = defineLocale({
       sshHermesPathTitle: 'Hermes 路徑（選用）',
       sshHermesPathDesc: '遠端 hermes 執行檔的完整路徑。留空 = 自動偵測。',
       sshHermesPathPlaceholder: '自動偵測',
+      sshRemoteProfileTitle: '遠端設定檔（選用）',
+      sshRemoteProfileDesc: '遠端主機上的設定檔名稱。留空 = 使用 Desktop 設定檔名稱。',
       sshTestConnection: '測試 SSH',
       sshConnect: '連線',
       sshButtonsHint: '「儲存」會在下次啟動時生效，「連線」則立即重新連線。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -919,6 +919,8 @@ export const zh: Translations = {
       sshHermesPathTitle: 'Hermes 路径（可选）',
       sshHermesPathDesc: '远程 hermes 可执行文件的完整路径。留空 = 自动检测。',
       sshHermesPathPlaceholder: '自动检测',
+      sshRemoteProfileTitle: '远程配置文件（可选）',
+      sshRemoteProfileDesc: '远程主机上的配置文件名称。留空 = 使用 Desktop 配置文件名称。',
       sshTestConnection: '测试 SSH',
       sshConnect: '连接',
       sshButtonsHint: '“保存”将在下次启动时生效，“连接”则立即重新连接。',

--- a/contributors/emails/cad@arcabot.ai
+++ b/contributors/emails/cad@arcabot.ai
@@ -1,0 +1,1 @@
+arcabotai

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10047,13 +10047,19 @@ def _read_ssh_session_token_file(path: str) -> str:
 
     import stat as _stat
     from pathlib import Path as _Path
-    from hermes_constants import get_hermes_home as _get_hermes_home
 
     if not os.path.isabs(path):
         raise SystemExit("--ssh-session-token-file must be absolute")
 
     token_path = _Path(path)
-    token_root = _get_hermes_home() / "desktop-ssh"
+    # The Desktop client writes the token under $HOME/.hermes/desktop-ssh: a
+    # literal "~/.hermes/desktop-ssh" in apps/desktop/electron/remote-lifecycle.ts
+    # expanded against the account's $HOME, independent of HERMES_HOME and the
+    # active profile. Anchor validation to that same OS-home path, NOT to
+    # get_hermes_home(): a non-default sticky profile (or any HERMES_HOME pointing
+    # elsewhere, e.g. a Docker /opt/data root) re-homes get_hermes_home() and
+    # would otherwise reject every token the client legitimately wrote (#69551).
+    token_root = _Path.home() / ".hermes" / "desktop-ssh"
     try:
         relative = token_path.relative_to(token_root)
     except ValueError as exc:

--- a/hermes_cli/windows_ssh_runtime.py
+++ b/hermes_cli/windows_ssh_runtime.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root
 
 _HEX32 = re.compile(r"[0-9a-f]{32}\Z")
 _HEX16 = re.compile(r"[0-9a-f]{16}\Z")
@@ -49,7 +49,11 @@ def _nonce(value: str) -> str:
 
 
 def _root() -> Path:
-    return get_hermes_home() / "desktop-ssh"
+    # The helper uploads the token before the child applies `--profile`, while
+    # read_token() runs after profile activation. Anchor both processes to the
+    # machine root so a named profile cannot move the reader away from the
+    # helper's token, including custom HERMES_HOME layouts.
+    return get_default_hermes_root() / "desktop-ssh"
 
 
 def _directory(ownership_id: str) -> Path:
@@ -452,7 +456,7 @@ def dispatch(argv: list[str]) -> Any:
     operation = argv[0]
     if operation == "probe":
         import platform
-        return {"os": "Windows", "arch": platform.machine(), "hermesHome": str(get_hermes_home()), "python": sys.executable}
+        return {"os": "Windows", "arch": platform.machine(), "hermesHome": str(get_default_hermes_root()), "python": sys.executable}
     if operation == "upload-token" and len(argv) == 3:
         return upload_token(argv[1], argv[2], sys.stdin.buffer.read(65))
     if operation == "read-lock" and len(argv) == 2:

--- a/tests/hermes_cli/test_ssh_session_token_parser.py
+++ b/tests/hermes_cli/test_ssh_session_token_parser.py
@@ -32,11 +32,80 @@ def test_serve_help_advertises_secure_ssh_bootstrap_flags(capsys):
 
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX fixture uses mode bits; Windows read_token requires protected DACLs",
+)
+def test_token_file_is_read_and_unlinked_through_private_directory(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    hermes_home = home / ".hermes"
+    token_dir = hermes_home / "desktop-ssh" / ("a" * 32)
+    token_dir.mkdir(parents=True, mode=0o700)
+    token_path = token_dir / "0123456789abcdef.token"
+    token_path.write_text("b" * 64)
+    token_path.chmod(0o600)
+    override = set_hermes_home_override(hermes_home)
+    try:
+        assert _read_ssh_session_token_file(str(token_path)) == "b" * 64
+        assert not token_path.exists()
+    finally:
+        reset_hermes_home_override(override)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX desktop-ssh token path")
+def test_token_anchor_is_os_home_not_active_profile(tmp_path, monkeypatch):
+    """Regression for #69551: the Desktop client always writes the token under
+    ``$HOME/.hermes/desktop-ssh`` (a literal ``~/.hermes/desktop-ssh`` in
+    apps/desktop/electron/remote-lifecycle.ts, expanded against the account's
+    $HOME). A non-default sticky profile re-homes ``get_hermes_home()`` to
+    ``<root>/profiles/<name>``, and a Docker-style ``HERMES_HOME`` can point
+    elsewhere entirely — neither must move the validator off
+    ``$HOME/.hermes/desktop-ssh``, or the token is wrongly rejected."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    token_dir = home / ".hermes" / "desktop-ssh" / ("a" * 32)
+    token_dir.mkdir(parents=True, mode=0o700)
+    token_path = token_dir / "0123456789abcdef.token"
+
+    # A sticky profile and a custom (Docker) root both point get_hermes_home()
+    # away from $HOME/.hermes; the anchor must ignore both.
+    for elsewhere in (home / ".hermes" / "profiles" / "coder", tmp_path / "opt" / "data"):
+        token_path.write_text("b" * 64)
+        token_path.chmod(0o600)
+        override = set_hermes_home_override(elsewhere)
+        try:
+            assert _read_ssh_session_token_file(str(token_path)) == "b" * 64
+            assert not token_path.exists()
+        finally:
+            reset_hermes_home_override(override)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX desktop-ssh token path")
+def test_token_under_profile_desktop_ssh_is_rejected(tmp_path, monkeypatch):
+    """The client never writes under a profile-scoped desktop-ssh dir, so a token
+    placed there must be rejected even while that profile is active — proving the
+    anchor is the OS home, not the active profile (#69551)."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    profile_home = home / ".hermes" / "profiles" / "coder"
+    token_dir = profile_home / "desktop-ssh" / ("a" * 32)
+    token_dir.mkdir(parents=True, mode=0o700)
+    token_path = token_dir / "0123456789abcdef.token"
+    token_path.write_text("b" * 64)
+    token_path.chmod(0o600)
+    override = set_hermes_home_override(profile_home)
+    try:
+        with pytest.raises(SystemExit, match="desktop-ssh directory"):
+            _read_ssh_session_token_file(str(token_path))
+    finally:
+        reset_hermes_home_override(override)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink contract")
 def test_token_file_rejects_symlink(tmp_path, monkeypatch):
     home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
     token_dir = home / ".hermes" / "desktop-ssh" / ("a" * 32)
     token_dir.mkdir(parents=True, mode=0o700)
     target = tmp_path / "token"
@@ -54,3 +123,18 @@ def test_token_file_rejects_symlink(tmp_path, monkeypatch):
         reset_hermes_home_override(override)
 
 
+def test_token_file_rejects_parent_escape(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    token_root = home / ".hermes" / "desktop-ssh"
+    token_root.mkdir(parents=True, mode=0o700)
+    escaped = token_root.parent / "0123456789abcdef.token"
+    escaped.write_text("b" * 64)
+    escaped.chmod(0o600)
+    override = set_hermes_home_override(home / ".hermes")
+    try:
+        with pytest.raises(SystemExit, match="invalid runtime path"):
+            _read_ssh_session_token_file(str(token_root / ".." / escaped.name))
+        assert escaped.exists()
+    finally:
+        reset_hermes_home_override(override)

--- a/tests/hermes_cli/test_ssh_session_token_parser.py
+++ b/tests/hermes_cli/test_ssh_session_token_parser.py
@@ -138,3 +138,12 @@ def test_token_file_rejects_parent_escape(tmp_path, monkeypatch):
         assert escaped.exists()
     finally:
         reset_hermes_home_override(override)
+
+
+def test_windows_runtime_root_stays_at_machine_root_for_named_profile(tmp_path, monkeypatch):
+    from hermes_cli import windows_ssh_runtime
+
+    machine_root = tmp_path / "custom-hermes-root"
+    monkeypatch.setenv("HERMES_HOME", str(machine_root / "profiles" / "writer_2"))
+
+    assert windows_ssh_runtime._root() == machine_root / "desktop-ssh"


### PR DESCRIPTION
## Summary
Desktop SSH connections can now target a remote install whose profile name differs from the local connection's (#74776): an optional `remoteProfile` field on the SSH connection config + Gateway settings UI, with same-name behavior preserved by default and reserved names rejected.

This lands together with the fix that makes it actually work for named profiles: session-token validation on the backend was anchored to `get_hermes_home()`, which a non-default sticky profile re-homes — so the desktop client's tokens (written under the OS home's `~/.hermes/desktop-ssh` regardless of profile) were rejected for every profile except `default` (#69551). Validation is now anchored to the same OS-home path the client writes to. Without this companion fix the mapping feature only worked for `default` — the exact case it exists to go beyond.

Salvaged from #74779 by @arcabotai with authorship preserved (6 commits cherry-picked onto current main, including the token-root anchor by @Sora-bluesky — both credited). Applied clean; covers Unix + Windows lifecycles, bootstrap fingerprints, and a mapped non-default-profile regression test.

## Changes
- `apps/desktop/electron`: `remoteProfile` in connection-config + remote-lifecycle (Unix/Windows), identifier validation, bootstrap fingerprint inclusion, lockfile-mismatch respawn.
- `apps/desktop/src`: Gateway settings field.
- `hermes_cli/main.py`: SSH token root anchored to `$HOME/.hermes/desktop-ssh` (matches what the client writes).
- Tests: 179 desktop tests across 6 files + 7 backend token-parser tests incl. non-default-profile case.
- `contributors/emails/`: mappings for both contributors.

## Validation
| | Before | After |
|---|---|---|
| SSH connect, remote profile ≠ local name | broken (no mapping) | routed via remoteProfile |
| Token validation under non-default profile | rejected (#69551) | accepted |
| Desktop vitest (6 files) | — | 179/179 pass |
| tests/hermes_cli/test_ssh_session_token_parser.py | — | 7/7 pass |

## Infographic

![ssh profiles properly mapped](https://v3b.fal.media/files/b/0aa4a269/taUSOqYBnTAtwIR6l_Sb5_CFlSAK0m.png)
