### PR TITLE
fix(website): restore TypeScript 6 typecheck

### DIFF
--- a/website/src/components/AutomationBlueprintsCatalog/index.tsx
+++ b/website/src/components/AutomationBlueprintsCatalog/index.tsx
@@ -25,7 +25,7 @@ interface Blueprint {
 
 const INDEX_URL = "/docs/api/automation-blueprints-index.json";
 
-function CopyButton({ text }: { text: string }): JSX.Element {
+function CopyButton({ text }: { text: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false);
   return (
     <button
@@ -44,7 +44,7 @@ function CopyButton({ text }: { text: string }): JSX.Element {
   );
 }
 
-function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
+function BlueprintCard({ blueprint }: { blueprint: Blueprint }): React.JSX.Element {
   return (
     <div className={styles.card}>
       <div className={styles.cardHead}>
@@ -78,7 +78,7 @@ function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
   );
 }
 
-export default function AutomationBlueprintsCatalog(): JSX.Element {
+export default function AutomationBlueprintsCatalog(): React.JSX.Element {
   const [blueprints, setBlueprints] = useState<Blueprint[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.JSX.Element {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,9 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
+  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Restores the website's TypeScript 6 typecheck with a focused compatibility update.

The website currently uses TypeScript 6.0.3, but `npm run typecheck` stops at the deprecated `baseUrl` diagnostic. Suppressing that TypeScript 6 migration diagnostic exposes four additional errors because two components still refer to the legacy global `JSX` namespace.

This PR sets the website resolution root so Docusaurus's inherited `@site/*` alias resolves from the website, acknowledges the TypeScript 6 deprecation window, and qualifies the four component return types through React's JSX namespace. It does not update dependencies, modify the lockfile, or broaden the website migration.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No issue exists for this focused repair.

Related pull requests:

- [Fix TypeScript typecheck error in UserStoriesCollage](https://github.com/NousResearch/hermes-agent/pull/43183) addresses one of the four `JSX` namespace errors, but not the remaining component errors or the TypeScript 6 `baseUrl` diagnostic.
- [Fix npm audit vulnerabilities in website](https://github.com/NousResearch/hermes-agent/pull/56849) includes equivalent compatibility changes as part of a much larger dependency and lockfile update. This PR isolates the compatibility repair to the three affected source/configuration files.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Add `baseUrl: "."` and `ignoreDeprecations: "6.0"` to `website/tsconfig.json`.
- Replace three legacy `JSX.Element` return annotations with `React.JSX.Element` in `website/src/components/AutomationBlueprintsCatalog/index.tsx`.
- Replace the legacy `JSX.Element` return annotation with `React.JSX.Element` in `website/src/components/UserStoriesCollage/index.tsx`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `cd website && npm ci`.
2. Run `python -m pip install ascii-guard==2.3.0 pyyaml==6.0.3`, then run `npm run typecheck` and confirm TypeScript exits successfully.
3. Run `npm run lint:diagrams && npm run build` and confirm both checks exit successfully.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Node.js 25.2.1, npm 11.6.2, TypeScript 6.0.3

The repository's parallel pytest runner completed with `23,854 passed / 17 failed / one retry-pass flake` on this branch and `23,853 passed / 18 failed / one retry-pass flake` on clean `main`. Both runs have the same 17 stable failures. `tests/test_tui_gateway_server.py` failed after retries only on clean `main`; the same file passed on retry on this branch. The website has no component test harness for these annotations, so the TypeScript compiler is the focused regression check: before this change it reports TS5101 and four TS2503 errors; after this change `npm run typecheck` exits successfully.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Before:

```text
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

After acknowledging that diagnostic, the compiler also reports four `TS2503: Cannot find namespace 'JSX'` errors in the two updated components.

After:

```text
> website@0.0.0 typecheck
> tsc -p . --noEmit

Process exited with code 0
```

Additional fresh website checks:

```text
npm run lint:diagrams: passed (383 files checked, 0 errors)
npm run build: passed
```

The production build retains existing non-fatal Docusaurus warnings for unresolved documentation links.
