### PR TITLE
feat(cli): add config validation command

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -11,6 +11,7 @@ This module provides:
 - hermes config get      - Print a resolved configuration value
 - hermes config set      - Set a specific value
 - hermes config unset    - Remove a user configuration value
+- hermes config validate - Validate config.yaml structure
 - hermes config wizard   - Re-run setup wizard
 """
 
@@ -5150,6 +5151,63 @@ def config_command(args):
     
     elif subcmd == "env-path":
         print(get_env_path())
+
+    elif subcmd == "validate":
+        config_path = Path(args.path) if getattr(args, "path", None) else get_config_path()
+        try:
+            with open(config_path, encoding="utf-8-sig") as config_file:
+                loaded_config = fast_safe_load(config_file)
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            print(
+                color(f"✗ Could not load config {config_path}: {exc}", Colors.RED),
+                file=sys.stderr,
+            )
+            return 1
+
+        if loaded_config is None:
+            config = {}
+        elif not isinstance(loaded_config, dict):
+            print(
+                color(
+                    f"✗ Configuration root must be a mapping in {config_path} "
+                    f"(got {type(loaded_config).__name__})",
+                    Colors.RED,
+                ),
+                file=sys.stderr,
+            )
+            return 1
+        else:
+            config = loaded_config
+
+        non_string_keys = [key for key in config if not isinstance(key, str)]
+        if non_string_keys:
+            print(
+                color(
+                    f"✗ Configuration top-level keys must be strings in {config_path} "
+                    f"(got {type(non_string_keys[0]).__name__})",
+                    Colors.RED,
+                ),
+                file=sys.stderr,
+            )
+            return 1
+
+        issues = validate_config_structure(config)
+        if not issues:
+            print(color(f"✓ Configuration structure is valid: {config_path}", Colors.GREEN))
+            return 0
+
+        print(f"Configuration issues in {config_path}:", file=sys.stderr)
+        had_error = False
+        for issue in issues:
+            if issue.severity == "error":
+                marker = color("✗", Colors.RED)
+                had_error = True
+            else:
+                marker = color("⚠", Colors.YELLOW)
+            print(f"  {marker} {issue.message}", file=sys.stderr)
+            for hint_line in issue.hint.splitlines():
+                print(color(f"    {hint_line}", Colors.DIM), file=sys.stderr)
+        return 1 if had_error else 0
     
     elif subcmd == "migrate":
         print()
@@ -5255,6 +5313,7 @@ def config_command(args):
         print("  hermes config set <key> <value>   Set a config value")
         print("  hermes config unset <key>        Remove a config value")
         print("  hermes config check     Check for missing/outdated config")
+        print("  hermes config validate [path]    Validate config.yaml structure")
         print("  hermes config migrate   Update config with new options")
         print("  hermes config path      Show config file path")
         print("  hermes config env-path  Show .env file path")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4870,7 +4870,7 @@ def cmd_config(args):
     """Configuration management."""
     from hermes_cli.config import config_command
 
-    config_command(args)
+    return config_command(args)
 
 
 def cmd_skin(args):

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -62,6 +62,16 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
     # config check
     config_subparsers.add_parser("check", help="Check for missing/outdated config")
 
+    # config validate
+    config_validate = config_subparsers.add_parser(
+        "validate", help="Validate config.yaml structure"
+    )
+    config_validate.add_argument(
+        "path",
+        nargs="?",
+        help="Path to config.yaml (defaults to the active profile's config.yaml)",
+    )
+
     # config migrate
     config_subparsers.add_parser("migrate", help="Update config with new options")
 

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -1,13 +1,21 @@
-"""Tests for config.yaml structure validation (validate_config_structure)."""
+"""Tests for config.yaml structure validation and its CLI command."""
 
+import argparse
+import os
+import subprocess
+import sys
+from argparse import Namespace
 
+import hermes_cli.config as config_mod
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     _EXTRA_KNOWN_ROOT_KEYS,
     _KNOWN_ROOT_KEYS,
+    config_command,
     validate_config_structure,
     ConfigIssue,
 )
+from hermes_cli.subcommands.config import build_config_parser
 
 
 class TestCustomProvidersValidation:
@@ -120,3 +128,231 @@ class TestUnknownTopLevelKeys:
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
 
+
+class TestConfigValidateParser:
+    """Parser coverage for ``hermes config validate [path]``."""
+
+    @staticmethod
+    def _parse(argv):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+
+        def handler(_args):
+            return None
+
+        build_config_parser(subparsers, cmd_config=handler)
+        return parser.parse_args(argv), handler
+
+    def test_explicit_path(self):
+        args, handler = self._parse(["config", "validate", "custom.yaml"])
+
+        assert args.func is handler
+        assert args.config_command == "validate"
+        assert args.path == "custom.yaml"
+
+    def test_default_path(self):
+        args, _ = self._parse(["config", "validate"])
+
+        assert args.config_command == "validate"
+        assert args.path is None
+
+
+class TestConfigValidateCommand:
+    """Behavior coverage for the config validation command handler."""
+
+    def test_valid_default_config_path_returns_zero(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model:\n  provider: openrouter\n", encoding="utf-8")
+        monkeypatch.setattr(config_mod, "get_config_path", lambda: config_path)
+
+        status = config_command(Namespace(config_command="validate", path=None))
+
+        assert status == 0
+        assert "Configuration structure is valid" in capsys.readouterr().out
+
+    def test_explicit_path_is_validated_instead_of_default(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        default_path = tmp_path / "default.yaml"
+        default_path.write_text("{}\n", encoding="utf-8")
+        explicit_path = tmp_path / "custom.yaml"
+        explicit_path.write_text(
+            "custom_providers:\n  name: broken\n  base_url: https://example.com\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(config_mod, "get_config_path", lambda: default_path)
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(explicit_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert str(explicit_path) in captured.err
+        assert "custom_providers is a dict" in captured.err
+        assert "Change to:" in captured.err
+
+    def test_missing_input_returns_one(self, tmp_path, capsys):
+        missing_path = tmp_path / "missing.yaml"
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(missing_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Could not load config" in captured.err
+        assert str(missing_path) in captured.err
+
+    def test_unreadable_input_returns_one(self, tmp_path, capsys):
+        directory_path = tmp_path / "config.yaml"
+        directory_path.mkdir()
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(directory_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Could not load config" in captured.err
+        assert str(directory_path) in captured.err
+
+    def test_warning_only_input_returns_zero(self, tmp_path, capsys):
+        config_path = tmp_path / "warning.yaml"
+        config_path.write_text(
+            "custom_providers:\n  - name: example\n    base_url: https://example.com\n",
+            encoding="utf-8",
+        )
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(config_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 0
+        assert captured.out == ""
+        assert "no 'model' section" in captured.err
+
+    def test_non_mapping_root_returns_one(self, tmp_path, capsys):
+        cases = [
+            ("[]\n", "list"),
+            ("false\n", "bool"),
+            ("0\n", "int"),
+            ('""\n', "str"),
+            ("- model\n", "list"),
+            ("plain text\n", "str"),
+        ]
+        config_path = tmp_path / "non-mapping.yaml"
+
+        for contents, root_type in cases:
+            config_path.write_text(contents, encoding="utf-8")
+
+            status = config_command(
+                Namespace(config_command="validate", path=str(config_path))
+            )
+
+            captured = capsys.readouterr()
+            assert status == 1
+            assert captured.out == ""
+            assert "root must be a mapping" in captured.err
+            assert root_type in captured.err
+
+    def test_non_string_top_level_key_returns_one(self, tmp_path, capsys):
+        cases = [
+            ("1: value\n", "int"),
+            ("true: value\n", "bool"),
+            ("null: value\n", "NoneType"),
+        ]
+        config_path = tmp_path / "non-string-key.yaml"
+
+        for contents, key_type in cases:
+            config_path.write_text(contents, encoding="utf-8")
+
+            status = config_command(
+                Namespace(config_command="validate", path=str(config_path))
+            )
+
+            captured = capsys.readouterr()
+            assert status == 1
+            assert captured.out == ""
+            assert "top-level keys must be strings" in captured.err
+            assert key_type in captured.err
+
+    def test_invalid_utf8_returns_one(self, tmp_path, capsys):
+        config_path = tmp_path / "invalid-utf8.yaml"
+        config_path.write_bytes(b"\xff")
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(config_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Could not load config" in captured.err
+
+    def test_utf8_bom_is_accepted(self, tmp_path, capsys):
+        config_path = tmp_path / "bom.yaml"
+        config_path.write_bytes(b"\xef\xbb\xbfmodel:\n  provider: openrouter\n")
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(config_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 0
+        assert "Configuration structure is valid" in captured.out
+        assert captured.err == ""
+
+    def test_malformed_yaml_returns_one(self, tmp_path, capsys):
+        config_path = tmp_path / "malformed.yaml"
+        config_path.write_text("model: [unterminated\n", encoding="utf-8")
+
+        status = config_command(
+            Namespace(config_command="validate", path=str(config_path))
+        )
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Could not load config" in captured.err
+
+    def test_process_exit_code_is_nonzero_for_invalid_structure(self, tmp_path):
+        config_path = tmp_path / "invalid.yaml"
+        config_path.write_text(
+            "custom_providers:\n  name: broken\n  base_url: https://example.com\n",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["NO_COLOR"] = "1"
+        isolated_home = tmp_path / "profiles" / "test"
+        isolated_home.mkdir(parents=True)
+        env["HERMES_HOME"] = str(isolated_home)
+        env.pop("HERMES_PROFILE", None)
+        env.pop("HERMES_CONFIG", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "config",
+                "validate",
+                str(config_path),
+            ],
+            capture_output=True,
+            check=False,
+            encoding="utf-8",
+            env=env,
+            text=True,
+            timeout=10,
+        )
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "custom_providers is a dict" in result.stderr


### PR DESCRIPTION
## What does this PR do?

Adds a read-only `hermes config validate [path]` command that exposes the existing configuration-structure validator through the CLI.

When no path is provided, the command validates the active profile's `config.yaml`. It accepts an explicit YAML path, reports load and structure problems on stderr, and returns a stable nonzero exit status for errors. Valid configurations and warning-only configurations return zero.

## Related Issue

Related to #27342

This PR is intentionally narrower than full schema enforcement: it exposes the structure validation that already exists without changing the schema or configuration loading behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `hermes config validate [path]` parser and help entries in `hermes_cli/subcommands/config.py` and `hermes_cli/config.py`.
- Validate the active profile config by default or an explicitly supplied YAML file, reusing `validate_config_structure()` unchanged.
- Return exit code 1 for unreadable input, malformed YAML, invalid root mappings, non-string top-level keys, and structural errors; return 0 for valid or warning-only input.
- Propagate the config command's return value through `hermes_cli/main.py`.
- Add focused CLI coverage in `tests/hermes_cli/test_config_validation.py`.

## How to Test

1. Run `hermes config validate --help` and confirm the optional `[path]` argument is documented.
2. Run `hermes config validate` with a valid active-profile config, then with an invalid one, and confirm the output and exit status.
3. Run `hermes config validate /path/to/config.yaml` for valid, malformed, missing, and structurally invalid files.
4. Run `pytest tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_subcommands_batch.py tests/hermes_cli/test_placeholder_usage.py tests/cli/test_cli_init.py -q`.
5. Run `ruff check hermes_cli/config.py hermes_cli/main.py hermes_cli/subcommands/config.py tests/hermes_cli/test_config_validation.py`.
6. Run `./scripts/run_tests.sh -j 8`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64, Python 3.11.14

The focused and adjacent CLI suite passes with 51 tests. The bounded repository-wide runner completed on both this branch and its parent commit. This branch added 13 passing tests and introduced no new failing files. The full-suite checkbox remains unchecked because the repository-wide suite is not fully green on either revision.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; argparse help documents the command and its path argument
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no agent tool behavior changed

## Screenshots / Logs

```text
Focused CLI suite: 51 passed, 0 failed
Repository-wide branch: 2519 files, 23694 passed, 62 failed
Repository-wide parent: 2519 files, 23680 passed, 63 failed
Delta: +13 added passing tests; no branch-only failing files
Ruff: All checks passed
Focused ty check: All checks passed
```
