### PR TITLE
fix(pricing): add regional Bedrock Kimi rates

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
+from urllib.parse import urlparse
 
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
 from utils import base_url_host_matches
@@ -971,6 +972,53 @@ for _alias, _canonical in {
 del _alias, _canonical
 
 
+# These Bedrock SKUs are region-priced, so they cannot safely share a generic
+# provider/model row.  Keep only prices published by AWS and return ``unknown``
+# for a supported region without a verified snapshot rather than silently
+# estimating at another region's rate.
+_BEDROCK_REGIONAL_PRICING: Dict[tuple[str, str], PricingEntry] = {
+    # Kimi K2.5 — AWS lists $0.60/$3.00 per 1M tokens in the three US regions.
+    **{
+        (region, "moonshotai.kimi-k2.5"): PricingEntry(
+            input_cost_per_million=Decimal("0.60"),
+            output_cost_per_million=Decimal("3.00"),
+            source="official_docs_snapshot",
+            source_url="https://aws.amazon.com/bedrock/pricing/",
+            pricing_version="bedrock-moonshot-pricing-2026-08",
+        )
+        for region in ("us-east-1", "us-east-2", "us-west-2")
+    },
+    # AWS lists these regions at $0.72/$3.60 per 1M tokens.
+    **{
+        (region, "moonshotai.kimi-k2.5"): PricingEntry(
+            input_cost_per_million=Decimal("0.72"),
+            output_cost_per_million=Decimal("3.60"),
+            source="official_docs_snapshot",
+            source_url="https://aws.amazon.com/bedrock/pricing/",
+            pricing_version="bedrock-moonshot-pricing-2026-08",
+        )
+        for region in (
+            "ap-northeast-1",
+            "ap-south-1",
+            "ap-southeast-3",
+            "eu-north-1",
+            "sa-east-1",
+        )
+    },
+    # Sydney's local list price, including the reporter's Mantle route.
+    (
+        "ap-southeast-2",
+        "moonshotai.kimi-k2.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.6180"),
+        output_cost_per_million=Decimal("3.0900"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-moonshot-pricing-2026-08",
+    ),
+}
+
+
 def _to_decimal(value: Any) -> Optional[Decimal]:
     if value is None:
         return None
@@ -985,6 +1033,15 @@ def _to_int(value: Any) -> int:
         return int(value or 0)
     except Exception:
         return 0
+
+
+def _is_bedrock_mantle_endpoint(base_url: str) -> bool:
+    """Return whether ``base_url`` is an AWS Bedrock Mantle endpoint."""
+    try:
+        hostname = (urlparse(base_url).hostname or "").lower()
+    except (TypeError, ValueError):
+        return False
+    return bool(re.fullmatch(r"bedrock-mantle\.[a-z0-9-]+\.api\.aws", hostname))
 
 
 def resolve_billing_route(
@@ -1007,6 +1064,8 @@ def resolve_billing_route(
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "nous" or base_url_host_matches(base_url or "", "inference-api.nousresearch.com"):
         return BillingRoute(provider="nous", model=model, base_url=base_url or _NOUS_DEFAULT_BASE_URL, billing_mode="official_models_api")
+    if provider_name == "bedrock" or _is_bedrock_mantle_endpoint(base_url or ""):
+        return BillingRoute(provider="bedrock", model=model, base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "anthropic":
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     # "openai-api" is the picker/registry slug for direct api.openai.com; it
@@ -1095,8 +1154,27 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return name
 
 
+def _bedrock_region_from_base_url(base_url: str) -> Optional[str]:
+    """Extract the region from a Bedrock Runtime or Mantle endpoint."""
+    try:
+        hostname = urlparse(base_url).hostname or ""
+    except (TypeError, ValueError):
+        return None
+    match = re.search(
+        r"(?:^|\.)bedrock-(?:runtime(?:-fips)?|mantle)\.([a-z0-9-]+)\.",
+        hostname,
+    )
+    return match.group(1) if match else None
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
+    if route.provider == "bedrock":
+        region = _bedrock_region_from_base_url(route.base_url)
+        if region:
+            entry = _BEDROCK_REGIONAL_PRICING.get((region, model))
+            if entry:
+                return entry
     # Direct lookup first
     entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))
     if entry:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -250,6 +250,27 @@ _OFFICIAL_DOCS_PRICING[("google", "gemini-2.5-pro")] = _snap(
     tier_threshold_tokens=200_000, input_cost_per_million_above=Decimal("2.50"),
     output_cost_per_million_above=Decimal("15.00"),
 )
+
+# Bedrock Kimi K2.5 has regional SKUs, so it cannot safely share a generic
+# provider/model row. Keep only AWS-published prices and leave a supported
+# region without a snapshot unknown rather than borrowing another region's rate.
+_BEDROCK_REGIONAL_PRICING: Dict[tuple[str, str], PricingEntry] = {
+    **{
+        (region, "moonshotai.kimi-k2.5"): _snap(
+            "0.60", "3.00", url=_BEDROCK_URL, version="bedrock-moonshot-pricing-2026-08",
+        )
+        for region in ("us-east-1", "us-east-2", "us-west-2")
+    },
+    **{
+        (region, "moonshotai.kimi-k2.5"): _snap(
+            "0.72", "3.60", url=_BEDROCK_URL, version="bedrock-moonshot-pricing-2026-08",
+        )
+        for region in ("ap-northeast-1", "ap-south-1", "ap-southeast-3", "eu-north-1", "sa-east-1")
+    },
+    ("ap-southeast-2", "moonshotai.kimi-k2.5"): _snap(
+        "0.6180", "3.0900", url=_BEDROCK_URL, version="bedrock-moonshot-pricing-2026-08",
+    ),
+}
 del _BEDROCK_URL, _ANTHROPIC_URL, _GOOGLE_URL, _OPUS, _SONNET
 
 # GPT-5.6 "-pro" high-effort variants bill at the base tier's per-token rates
@@ -303,6 +324,11 @@ _SNAPSHOT_PROVIDER_ALIASES = {
 _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google-ai-studio", "google-vertex", "vertex-ai"}
 
 
+def _is_bedrock_mantle_endpoint(base_url: str) -> bool:
+    """Return whether ``base_url`` is an AWS Bedrock Mantle endpoint."""
+    return bool(re.fullmatch(r"bedrock-mantle\.[a-z0-9-]+\.api\.aws", base_url_hostname(base_url)))
+
+
 def resolve_billing_route(
     model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None
 ) -> BillingRoute:
@@ -329,6 +355,8 @@ def resolve_billing_route(
         return BillingRoute(provider="openrouter", model=model, base_url=url, billing_mode="official_models_api")
     if provider_name == "nous" or host("inference-api.nousresearch.com"):
         return BillingRoute(provider="nous", model=model, base_url=base_url or _NOUS_DEFAULT_BASE_URL, billing_mode="official_models_api")
+    if provider_name == "bedrock" or _is_bedrock_mantle_endpoint(url):
+        return BillingRoute(provider="bedrock", model=model, base_url=url, billing_mode="official_docs_snapshot")
     snapshot_provider = _SNAPSHOT_PROVIDER_ALIASES.get(provider_name)
     if snapshot_provider is None:
         if (
@@ -370,6 +398,15 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return re.sub(r"(\d+)\.(\d+)", r"\1-\2", _strip_prefix(model.lower().strip(), ("anthropic/",)))
 
 
+def _bedrock_region_from_base_url(base_url: str) -> Optional[str]:
+    """Extract the region from a Bedrock Runtime or Mantle endpoint."""
+    match = re.search(
+        r"(?:^|\.)bedrock-(?:runtime(?:-fips)?|mantle)\.([a-z0-9-]+)\.",
+        base_url_hostname(base_url),
+    )
+    return match.group(1) if match else None
+
+
 # Anthropic dot-notation (opus-4.7) and Bedrock region-prefixed ids need
 # normalizing before a second lookup.
 _MODEL_NORMALIZERS = {"anthropic": _normalize_anthropic_model_name, "bedrock": _normalize_bedrock_model_name}
@@ -377,6 +414,12 @@ _MODEL_NORMALIZERS = {"anthropic": _normalize_anthropic_model_name, "bedrock": _
 
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
+    if route.provider == "bedrock":
+        region = _bedrock_region_from_base_url(route.base_url)
+        if region:
+            entry = _BEDROCK_REGIONAL_PRICING.get((region, model))
+            if entry:
+                return entry
     entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))
     if entry:
         return entry

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -237,6 +238,55 @@ def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     )
     assert result.status == "estimated"
     assert result.amount_usd is not None
+
+
+def test_bedrock_kimi_k25_pricing_uses_the_endpoint_region(monkeypatch):
+    """Kimi K2.5 has region-specific Bedrock prices, including Mantle.
+
+    The reporter's Sydney Mantle deployment must price at AWS's Sydney rate,
+    while a US Runtime endpoint uses the lower US rate.  A supported region
+    without a published snapshot stays unknown rather than borrowing one.
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    model = "moonshotai.kimi-k2.5"
+    sydney_mantle = "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+    us_runtime = "https://bedrock-runtime.us-east-1.amazonaws.com"
+
+    mantle_route = resolve_billing_route(
+        model,
+        provider="custom",
+        base_url=sydney_mantle,
+    )
+    assert mantle_route.provider == "bedrock"
+    assert mantle_route.billing_mode == "official_docs_snapshot"
+
+    sydney = get_pricing_entry(model, provider="custom", base_url=sydney_mantle)
+    us = get_pricing_entry(model, provider="bedrock", base_url=us_runtime)
+
+    assert sydney is not None
+    assert sydney.input_cost_per_million == Decimal("0.6180")
+    assert sydney.output_cost_per_million == Decimal("3.0900")
+    assert us is not None
+    assert us.input_cost_per_million == Decimal("0.60")
+    assert us.output_cost_per_million == Decimal("3.00")
+
+    result = estimate_usage_cost(
+        model,
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+        provider="custom",
+        base_url=sydney_mantle,
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd == Decimal("3.7080")
+
+    assert get_pricing_entry(
+        model,
+        provider="bedrock",
+        base_url="https://bedrock-runtime.ap-southeast-4.amazonaws.com",
+    ) is None
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -283,6 +283,55 @@ def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     assert result.amount_usd is not None
 
 
+def test_bedrock_kimi_k25_pricing_uses_the_endpoint_region(monkeypatch):
+    """Kimi K2.5 has region-specific Bedrock prices, including Mantle.
+
+    The reporter's Sydney Mantle deployment must price at AWS's Sydney rate,
+    while a US Runtime endpoint uses the lower US rate.  A supported region
+    without a published snapshot stays unknown rather than borrowing one.
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    model = "moonshotai.kimi-k2.5"
+    sydney_mantle = "https://bedrock-mantle.ap-southeast-2.api.aws/v1"
+    us_runtime = "https://bedrock-runtime.us-east-1.amazonaws.com"
+
+    mantle_route = resolve_billing_route(
+        model,
+        provider="custom",
+        base_url=sydney_mantle,
+    )
+    assert mantle_route.provider == "bedrock"
+    assert mantle_route.billing_mode == "official_docs_snapshot"
+
+    sydney = get_pricing_entry(model, provider="custom", base_url=sydney_mantle)
+    us = get_pricing_entry(model, provider="bedrock", base_url=us_runtime)
+
+    assert sydney is not None
+    assert sydney.input_cost_per_million == Decimal("0.6180")
+    assert sydney.output_cost_per_million == Decimal("3.0900")
+    assert us is not None
+    assert us.input_cost_per_million == Decimal("0.60")
+    assert us.output_cost_per_million == Decimal("3.00")
+
+    result = estimate_usage_cost(
+        model,
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+        provider="custom",
+        base_url=sydney_mantle,
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd == Decimal("3.7080")
+
+    assert get_pricing_entry(
+        model,
+        provider="bedrock",
+        base_url="https://bedrock-runtime.ap-southeast-4.amazonaws.com",
+    ) is None
+
+
 
 
 


### PR DESCRIPTION
## What changed and why

Per the reporter's Bedrock Mantle reproduction, add an embedded, AWS-sourced pricing snapshot for `moonshotai.kimi-k2.5`. The lookup derives the region from both Bedrock Runtime and Bedrock Mantle endpoint URLs, returning the correct Sydney, US, and other published regional rates. It deliberately leaves a supported region without a published row as unknown rather than estimating with another region's price.

This is independent of the config-based user overrides discussed in #22614 and its closed duplicate #40720; it fixes the provider-owned pricing gap in the concrete Bedrock route.

## How to test

- `pytest tests/agent/test_usage_pricing.py -q --timeout=60`
- The test verifies Sydney Mantle and US Runtime estimates, and that an unpriced region does not borrow another region's rate.

## What platforms tested on

- macOS (local Python test environment)

Fixes #19469

<!-- autocontrib:worker-id=issue-followup-5bb10df5 kind=pr-open -->