### PR TITLE
chore(contributors): map Seraphine Mac Studio email → Bartok9

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine local Mac Studio commits on Bartok9 Hermes PRs (Grok/Sera machine)


### PR DESCRIPTION
Maps `seraphine@Seraphines-Mac-Studio.local` so check-attribution passes on Bartok9 PRs with Seraphine-local tip commits.