### PR TITLE
profile-serve: bearer gate + single-homed 172.x bind (clean shape)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1039,8 +1039,63 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe. Prefers /proc (Linux, authoritative and not
+    affected by os.kill sandboxing under test); falls back to os.kill(pid, 0).
+    On any ambiguity returns True (assume alive) so a live store is never pruned."""
+    proc_root = Path("/proc")
+    if proc_root.exists():  # Linux — the containers we run in
+        return (proc_root / str(pid)).exists()
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # alive, another user's process
+    except OSError:
+        return False
+    except Exception:
+        return True  # unknown mechanism — safest is "alive"
+
+
+def _prune_auth_tmp_orphans(auth_file: Path) -> None:
+    """Best-effort cleanup of `<name>.tmp.<pid>.<uuid>` files stranded when a
+    write was hard-killed between tmp-create and atomic_replace. Only removes
+    orphans whose embedded PID is dead (or that are older than a day when the
+    PID can't be parsed). Never touches the live store. Silent on any error —
+    cleanup must never break auth loading. (Fixes the tmp-storm: 91 orphans
+    accumulated on a box that exit-137'd repeatedly.)"""
+    try:
+        parent = auth_file.parent
+        prefix = auth_file.name + ".tmp."
+        now = time.time()
+        for tmp in parent.glob(auth_file.name + ".tmp.*"):
+            name = tmp.name
+            if not name.startswith(prefix):
+                continue
+            parts = name[len(prefix):].split(".", 1)
+            pid_str = parts[0] if parts else ""
+            if pid_str.isdigit():
+                dead = not _pid_alive(int(pid_str))
+            else:
+                # unparseable pid — fall back to age (24h)
+                try:
+                    dead = (now - tmp.stat().st_mtime) > 86400
+                except OSError:
+                    dead = False
+            if dead:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+    except Exception:
+        pass
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
+    _prune_auth_tmp_orphans(auth_file)
     if not auth_file.exists():
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 

--- a/plugins/agent-workspace/dashboard/call_kernel.py
+++ b/plugins/agent-workspace/dashboard/call_kernel.py
@@ -1,0 +1,147 @@
+"""call_kernel() — stdlib-only Streamable HTTP MCP client for the Fridai kernel.
+
+Phase 2.5 (#278): the kernel's plain-HTTP /call shim was deleted with the SSE
+transport (clean break). This speaks the real MCP Streamable HTTP protocol to
+/mcp instead — initialize handshake, session header, tools/call — still with
+nothing beyond the stdlib, so the plugin stays dependency-free in the Hermes
+container.
+
+Env:
+  FRIDAY_MCP_URL  — kernel endpoint (default http://mcp:8643/mcp)
+  FRIDAY_API_KEY  — shared Bearer key (the kernel is fail-closed; required)
+"""
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+
+KERNEL_MCP_URL = os.getenv("FRIDAY_MCP_URL", "http://mcp:8643/mcp")
+PROTOCOL_VERSION = "2025-06-18"
+
+_lock = threading.Lock()
+_session_id: str | None = None
+_next_id = 0
+
+
+def _headers(session_id: str | None) -> dict:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    key = os.getenv("FRIDAY_API_KEY", "")
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    return headers
+
+
+def _post(body: dict, session_id: str | None, timeout: float):
+    """POST one JSON-RPC message. Returns (parsed-or-None, mcp-session-id)."""
+    req = urllib.request.Request(
+        KERNEL_MCP_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers=_headers(session_id),
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        sid = resp.headers.get("mcp-session-id")
+        ctype = resp.headers.get("Content-Type", "")
+        raw = resp.read().decode("utf-8", "ignore")
+    if "text/event-stream" in ctype:
+        # Single-response stream: the JSON-RPC reply is the last data: line.
+        data_lines = [ln[5:].strip() for ln in raw.splitlines() if ln.startswith("data:")]
+        raw = data_lines[-1] if data_lines else ""
+    return (json.loads(raw) if raw.strip() else None), sid
+
+
+def _rpc_id() -> int:
+    global _next_id
+    _next_id += 1
+    return _next_id
+
+
+def _handshake(timeout: float) -> str:
+    """initialize + notifications/initialized; returns the session id."""
+    body, sid = _post(
+        {
+            "jsonrpc": "2.0",
+            "id": _rpc_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "fridai-memory", "version": "2.0"},
+            },
+        },
+        session_id=None,
+        timeout=timeout,
+    )
+    if body and body.get("error"):
+        raise RuntimeError(f"kernel MCP initialize error: {body['error']}")
+    _post(
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        session_id=sid,
+        timeout=timeout,
+    )
+    return sid or ""
+
+
+def _tools_call(tool: str, args: dict, session_id: str, timeout: float):
+    return _post(
+        {
+            "jsonrpc": "2.0",
+            "id": _rpc_id(),
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": args},
+        },
+        session_id=session_id,
+        timeout=timeout,
+    )[0]
+
+
+def call_kernel(tool: str, timeout: float = 30.0, **args):
+    """Call a Fridai kernel tool over MCP Streamable HTTP. Returns the tool's
+    parsed result (same contract the old /call shim had).
+
+    Raises RuntimeError on any kernel-side error.
+    """
+    global _session_id
+    try:
+        with _lock:
+            if _session_id is None:
+                _session_id = _handshake(timeout)
+            try:
+                body = _tools_call(tool, args, _session_id, timeout)
+            except urllib.error.HTTPError as e:
+                if e.code in (400, 404):
+                    # Session expired/unknown — re-handshake once and retry.
+                    _session_id = _handshake(timeout)
+                    body = _tools_call(tool, args, _session_id, timeout)
+                else:
+                    raise
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"kernel {tool} HTTP {e.code}: {e.read().decode('utf-8', 'ignore')}"
+        )
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"kernel {tool} call failed: {e}")
+
+    if not body:
+        raise RuntimeError(f"kernel {tool}: empty MCP response")
+    if body.get("error"):
+        raise RuntimeError(f"kernel {tool} error: {body['error']}")
+
+    result = body.get("result") or {}
+    content = result.get("content") or []
+    text = content[0].get("text", "") if content else ""
+    if result.get("isError"):
+        raise RuntimeError(f"kernel {tool} error: {text}")
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return text

--- a/plugins/agent-workspace/dashboard/dist/index.js
+++ b/plugins/agent-workspace/dashboard/dist/index.js
@@ -1,16 +1,141 @@
-// agent-workspace dashboard plugin — frontend bundle (placeholder).
-//
-// Phase: backend-proxy-first. The backend (plugin_api.py) is the live half —
-// it proxies the FRIDAI kernel over MCP behind the dashboard's auth. The tab is
-// `hidden` in manifest.json, so this no-op registration is all the shell needs
-// until the lanes + learnings panels land in the follow-up frontend phase.
+/**
+ * Agent Workspace — Dashboard Plugin (frontend)
+ *
+ * A FRIDAY-OS surface inside the Hermes dashboard, beside the Kanban tab:
+ *   - Agent Lanes  — the FRIDAY-OS agent roster (mirrors BOOT.md "## Lanes").
+ *   - Learnings    — the aux model: live grounding-store census + semantic
+ *                    recall, fetched from this plugin's backend
+ *                    (/api/plugins/agent-workspace/learnings) through the
+ *                    dashboard's own auth (SDK.fetchJSON carries the token).
+ *
+ * Plain IIFE, no build step — uses window.__HERMES_PLUGIN_SDK__ for React +
+ * DS components, matching the kanban plugin. Only utility classes the host
+ * dashboard is known to compile are used; everything visual leans on DS
+ * components so it reskins with the active theme.
+ */
 (function () {
-  try {
-    var hub = window.__HERMES_PLUGINS__;
-    if (hub && typeof hub.register === 'function') {
-      // Register nothing visible yet; presence keeps the loader happy.
-    }
-  } catch (e) {
-    /* never break the dashboard shell over a placeholder */
+  "use strict";
+
+  var SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK) return;
+
+  var React = SDK.React;
+  var h = React.createElement;
+  var C = SDK.components;
+  var useState = SDK.hooks.useState;
+  var useEffect = SDK.hooks.useEffect;
+  var useCallback = SDK.hooks.useCallback;
+
+  var API = "/api/plugins/agent-workspace";
+
+  // FRIDAY-OS agent roster — mirrors the BOOT.md "## Lanes" table. Display
+  // chrome (the roster changes rarely); the Learnings panel below is the live
+  // data. TODO(backend): serve this from the kernel (friday://boot) so it can't
+  // drift from BOOT.md.
+  var LANES = [
+    { agent: "atlas", role: "Systems architect", status: "active" },
+    { agent: "claude", role: "Workspace dev agent", status: "active" },
+    { agent: "fridai", role: "OS orchestrator", status: "active" },
+    { agent: "librarian", role: "Memory synthesizer", status: "active" },
+    { agent: "neo", role: "Security & memory-integrity gate", status: "active" },
+    { agent: "orion", role: "Research analyst", status: "active" },
+    { agent: "validator", role: "Independent verifier", status: "active" },
+    { agent: "vector", role: "Senior engineer", status: "active" },
+    { agent: "venus", role: "PA & broadcaster", status: "active" },
+    { agent: "hermes", role: "Network & messaging router", status: "alongside" },
+    { agent: "openclaw", role: "Platform coordinator (dropped)", status: "dropped" }
+  ];
+
+  function statusVariant(s) {
+    if (s === "active") return "default";
+    if (s === "alongside") return "secondary";
+    return "outline";
   }
+
+  function LaneRow(l) {
+    return h("div", { key: l.agent, className: "flex items-center justify-between gap-2 py-1" },
+      h("div", { className: "flex flex-col" },
+        h("span", { className: "text-sm font-mono-ui" }, l.agent),
+        h("span", { className: "text-xs text-muted-foreground" }, l.role)),
+      h(C.Badge, { variant: statusVariant(l.status) }, l.status));
+  }
+
+  function LanesCard() {
+    return h(C.Card, { className: "agent-workspace-card" },
+      h(C.CardHeader, null, h(C.CardTitle, null, "Agent Lanes")),
+      h(C.CardContent, null,
+        h("div", { className: "flex flex-col gap-1" }, LANES.map(LaneRow))));
+  }
+
+  function Stat(n, label) {
+    return h("div", { className: "flex flex-col" },
+      h("span", { className: "text-lg font-mono-ui" }, String(n)),
+      h("span", { className: "text-xs text-muted-foreground" }, label));
+  }
+
+  function FeedRow(row) {
+    return h("div", { key: row.id, className: "flex flex-col gap-1 py-2" },
+      h("span", { className: "text-sm" }, row.statement),
+      h("div", { className: "flex items-center gap-2" },
+        h(C.Badge, { variant: "outline" }, row.kind),
+        typeof row.confidence === "number"
+          ? h("span", { className: "text-xs text-muted-foreground" }, "conf " + row.confidence.toFixed(2))
+          : null));
+  }
+
+  function LearningsCard() {
+    var st = useState({ status: "loading", stats: null, feed: [], error: null });
+    var state = st[0], setState = st[1];
+
+    var load = useCallback(function () {
+      setState(function (p) { return Object.assign({}, p, { status: "loading", error: null }); });
+      SDK.fetchJSON(API + "/learnings?limit=8")
+        .then(function (d) {
+          setState({ status: "live", stats: d.stats || null, feed: d.feed || [], error: null });
+        })
+        .catch(function (e) {
+          setState({ status: "error", stats: null, feed: [], error: String((e && e.message) || e) });
+        });
+    }, []);
+
+    useEffect(function () { load(); }, [load]);
+
+    var byKind = (state.stats && state.stats.by_kind) || null;
+    var active = (state.stats && state.stats.by_status && state.stats.by_status.active) || 0;
+
+    return h(C.Card, { className: "agent-workspace-card" },
+      h(C.CardHeader, { className: "flex flex-row items-center justify-between" },
+        h(C.CardTitle, null, "Learnings"),
+        h(C.Button, { variant: "outline", size: "sm", onClick: load, disabled: state.status === "loading" }, "refresh")),
+      h(C.CardContent, null,
+        h("div", { className: "flex flex-col gap-3" },
+          state.status === "loading" ? h("div", { className: "text-xs text-muted-foreground" }, "loading…") : null,
+          state.status === "error"
+            ? h("div", { className: "text-xs text-destructive" }, "kernel unreachable: " + state.error)
+            : null,
+          state.stats
+            ? h("div", { className: "flex gap-6" },
+                Stat(state.stats.total || 0, "total"),
+                Stat(active, "active"),
+                Stat(state.stats.edges || 0, "edges"))
+            : null,
+          byKind
+            ? h("div", { className: "flex flex-wrap gap-1" },
+                Object.keys(byKind).map(function (k) {
+                  return h(C.Badge, { key: k, variant: "secondary" }, k + " " + byKind[k]);
+                }))
+            : null,
+          state.status === "live" && state.feed.length === 0
+            ? h("div", { className: "text-xs text-muted-foreground" }, "no learnings recalled")
+            : null,
+          h("div", { className: "flex flex-col" }, state.feed.map(FeedRow)))));
+  }
+
+  function Workspace() {
+    return h("div", { className: "agent-workspace flex flex-col gap-4 p-4" },
+      h(LanesCard),
+      h(LearningsCard));
+  }
+
+  window.__HERMES_PLUGINS__.register("agent-workspace", Workspace);
 })();

--- a/plugins/agent-workspace/dashboard/dist/index.js
+++ b/plugins/agent-workspace/dashboard/dist/index.js
@@ -1,0 +1,16 @@
+// agent-workspace dashboard plugin — frontend bundle (placeholder).
+//
+// Phase: backend-proxy-first. The backend (plugin_api.py) is the live half —
+// it proxies the FRIDAI kernel over MCP behind the dashboard's auth. The tab is
+// `hidden` in manifest.json, so this no-op registration is all the shell needs
+// until the lanes + learnings panels land in the follow-up frontend phase.
+(function () {
+  try {
+    var hub = window.__HERMES_PLUGINS__;
+    if (hub && typeof hub.register === 'function') {
+      // Register nothing visible yet; presence keeps the loader happy.
+    }
+  } catch (e) {
+    /* never break the dashboard shell over a placeholder */
+  }
+})();

--- a/plugins/agent-workspace/dashboard/manifest.json
+++ b/plugins/agent-workspace/dashboard/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-workspace",
+  "label": "Workspace",
+  "description": "FRIDAY-OS agent workspace — lanes + learnings (aux model) beside the Kanban board. Backend proxies the FRIDAI kernel over MCP through the dashboard's own auth.",
+  "icon": "LayoutDashboard",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/workspace",
+    "position": "after:kanban",
+    "hidden": true
+  },
+  "slots": [],
+  "entry": "dist/index.js",
+  "css": null,
+  "api": "plugin_api.py"
+}

--- a/plugins/agent-workspace/dashboard/manifest.json
+++ b/plugins/agent-workspace/dashboard/manifest.json
@@ -6,8 +6,7 @@
   "version": "0.1.0",
   "tab": {
     "path": "/workspace",
-    "position": "after:kanban",
-    "hidden": true
+    "position": "after:kanban"
   },
   "slots": [],
   "entry": "dist/index.js",

--- a/plugins/agent-workspace/dashboard/plugin_api.py
+++ b/plugins/agent-workspace/dashboard/plugin_api.py
@@ -1,0 +1,120 @@
+"""Agent Workspace dashboard plugin — backend API routes.
+
+Mounted at /api/plugins/agent-workspace/ by the dashboard plugin system, BEHIND
+the dashboard's session-token auth middleware (same gate as every other
+/api/plugins/... route). This is the "real" data path that replaces the test
+dashboard's dev-only vite proxy + browser-held Bearer key:
+
+    browser (dashboard session token / OAuth)
+      -> GET /api/plugins/agent-workspace/learnings   (same-origin, authed)
+        -> call_kernel(...) over MCP Streamable HTTP   (Bearer from container env)
+          -> FRIDAI kernel learnings_stats / recall_learnings
+            -> real grounding-store data
+
+Connection doctrine (FRIDAY-OS, 2026-06-12): internal services reach the kernel
+over MCP, not the external gateway GraphQL. Hermes is internal, so we call the
+kernel's /mcp directly — same path the fridai-memory provider uses.
+
+Reuse, don't duplicate: the kernel MCP client (call_kernel) already ships with
+the deployed fridai-memory plugin. We import that one implementation rather than
+vendoring a second copy. TODO(promote): once the frontend lands and there are
+two committed consumers, lift call_kernel.py into a shared Hermes FRIDAI module
+both plugins import, and drop this cross-plugin importlib shim.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from fastapi import APIRouter, HTTPException
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_call_kernel: Optional[Callable[..., Any]] = None
+
+
+def _load_call_kernel() -> Callable[..., Any]:
+    """Import the deployed fridai-memory kernel client (stdlib-only MCP
+    Streamable HTTP). Cached after first load. Raises RuntimeError if the
+    fridai-memory plugin is not present (it carries the only implementation)."""
+    global _call_kernel
+    if _call_kernel is not None:
+        return _call_kernel
+    home = os.getenv("HERMES_HOME", "/opt/data")
+    candidates = [
+        Path(home) / "plugins" / "fridai-memory" / "call_kernel.py",
+        # co-deployed alongside this plugin (bundled set / repo layout)
+        Path(__file__).resolve().parents[2] / "fridai-memory" / "call_kernel.py",
+    ]
+    for path in candidates:
+        if path.is_file():
+            spec = importlib.util.spec_from_file_location("fridai_call_kernel", path)
+            if spec and spec.loader:
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                _call_kernel = mod.call_kernel
+                log.info("agent-workspace: loaded call_kernel from %s", path)
+                return _call_kernel
+    raise RuntimeError(
+        "agent-workspace: fridai-memory/call_kernel.py not found "
+        "(the kernel MCP client lives with the fridai-memory plugin)"
+    )
+
+
+@router.get("/health")
+async def health():
+    """Liveness + kernel reachability for this plugin's backend.
+
+    Confirms the plugin mounted AND that the MCP path to the kernel is wired,
+    without leaking the Bearer key. `kernel` is 'reachable' only if a real
+    learnings_stats call round-trips.
+    """
+    info = {
+        "ok": True,
+        "plugin": "agent-workspace",
+        "kernel_mcp_url": os.getenv("FRIDAY_MCP_URL", "http://mcp:8643/mcp"),
+        "api_key_present": bool(os.getenv("FRIDAY_API_KEY")),
+    }
+    try:
+        call_kernel = _load_call_kernel()
+        stats = call_kernel("learnings_stats", timeout=15.0)
+        info["kernel"] = "reachable"
+        info["learnings_total"] = stats.get("total") if isinstance(stats, dict) else None
+    except Exception as exc:  # noqa: BLE001 — surface the blocker, don't crash the dashboard
+        info["kernel"] = "unreachable"
+        info["error"] = str(exc)
+    return info
+
+
+@router.get("/learnings")
+async def learnings(query: str = "recent decisions", limit: int = 8):
+    """The aux-model feed: grounding-store census + a semantic recall.
+
+    Calls the kernel tools learnings_stats and recall_learnings over MCP and
+    returns their parsed results. Same shape the test dashboard consumed
+    (stats: {total,by_kind,by_status,edges}; feed.results: [...]), now sourced
+    through the dashboard's own auth instead of a browser-held key.
+    """
+    try:
+        call_kernel = _load_call_kernel()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    out: dict[str, Any] = {"query": query, "limit": limit}
+    try:
+        out["stats"] = call_kernel("learnings_stats", timeout=20.0)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"learnings_stats failed: {exc}") from exc
+    try:
+        recall = call_kernel("recall_learnings", timeout=25.0, query=query, limit=limit)
+        out["feed"] = recall.get("results", []) if isinstance(recall, dict) else []
+        out["count"] = recall.get("count") if isinstance(recall, dict) else None
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"recall_learnings failed: {exc}") from exc
+    return out

--- a/plugins/agent-workspace/dashboard/plugin_api.py
+++ b/plugins/agent-workspace/dashboard/plugin_api.py
@@ -13,13 +13,17 @@ dashboard's dev-only vite proxy + browser-held Bearer key:
 
 Connection doctrine (FRIDAY-OS, 2026-06-12): internal services reach the kernel
 over MCP, not the external gateway GraphQL. Hermes is internal, so we call the
-kernel's /mcp directly — same path the fridai-memory provider uses.
+kernel's /mcp directly.
 
-Reuse, don't duplicate: the kernel MCP client (call_kernel) already ships with
-the deployed fridai-memory plugin. We import that one implementation rather than
-vendoring a second copy. TODO(promote): once the frontend lands and there are
-two committed consumers, lift call_kernel.py into a shared Hermes FRIDAI module
-both plugins import, and drop this cross-plugin importlib shim.
+Kernel client: this plugin carries its own stdlib-only MCP Streamable HTTP
+client (call_kernel.py, sibling file) — the same self-contained pattern every
+Hermes plugin uses. We deliberately do NOT import it from the fridai-memory
+plugin: that copy diverges per profile (some deployments still ship the stale
+pre-#278 /call client, which 404s against the current kernel), so depending on
+it is fragile. Self-containing the client guarantees the tab works regardless of
+which fridai-memory version a given profile happens to have.
+TODO(promote): if a third consumer appears, lift call_kernel.py into one shared
+Hermes FRIDAI module and have all plugins import it.
 """
 
 from __future__ import annotations
@@ -40,31 +44,23 @@ _call_kernel: Optional[Callable[..., Any]] = None
 
 
 def _load_call_kernel() -> Callable[..., Any]:
-    """Import the deployed fridai-memory kernel client (stdlib-only MCP
-    Streamable HTTP). Cached after first load. Raises RuntimeError if the
-    fridai-memory plugin is not present (it carries the only implementation)."""
+    """Load this plugin's own MCP kernel client (sibling call_kernel.py).
+    Cached after first load. Loaded by path because the dashboard imports
+    plugin_api.py via spec_from_file_location, so the plugin dir isn't on
+    sys.path for a plain `import call_kernel`."""
     global _call_kernel
     if _call_kernel is not None:
         return _call_kernel
-    home = os.getenv("HERMES_HOME", "/opt/data")
-    candidates = [
-        Path(home) / "plugins" / "fridai-memory" / "call_kernel.py",
-        # co-deployed alongside this plugin (bundled set / repo layout)
-        Path(__file__).resolve().parents[2] / "fridai-memory" / "call_kernel.py",
-    ]
-    for path in candidates:
-        if path.is_file():
-            spec = importlib.util.spec_from_file_location("fridai_call_kernel", path)
-            if spec and spec.loader:
-                mod = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(mod)
-                _call_kernel = mod.call_kernel
-                log.info("agent-workspace: loaded call_kernel from %s", path)
-                return _call_kernel
-    raise RuntimeError(
-        "agent-workspace: fridai-memory/call_kernel.py not found "
-        "(the kernel MCP client lives with the fridai-memory plugin)"
-    )
+    path = Path(__file__).resolve().parent / "call_kernel.py"
+    if not path.is_file():
+        raise RuntimeError(f"agent-workspace: kernel client missing at {path}")
+    spec = importlib.util.spec_from_file_location("agent_workspace_call_kernel", path)
+    if not (spec and spec.loader):
+        raise RuntimeError("agent-workspace: cannot load call_kernel.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _call_kernel = mod.call_kernel
+    return _call_kernel
 
 
 @router.get("/health")

--- a/scripts/profile_serve.py
+++ b/scripts/profile_serve.py
@@ -13,18 +13,31 @@ Two front doors, one engine (`<profile> chat -q <task>`):
   (c) POST /v1/chat/completions     OpenAI-shaped, model=profile -> OpenAI-shaped
       GET  /v1/models               lists the served profiles
 
-ALLOWLIST: only profiles in AGENT_ALLOWLIST can be brought up, and each carries
-the kernel tool-groups it may call back into (enforced kernel-side via the
-X-Agent header the run_agent tool sets). A profile not on the list is 403 — the
-gate is closed by default, not open.
+GATE (the "clean shape", 2026-08-01):
+  1. Single-homed bind — we bind THIS container's ai-shared address (172.x), not
+     0.0.0.0. hermes is multi-homed (ai-shared + a tailnet iface); 0.0.0.0 would
+     start answering on the tailnet the moment the node signs in — an unauthed
+     hole that opens on login. Pinning the 172.x means growing an interface can
+     never expose the runtime. Fail-closed: if no safe address is found we refuse
+     to start rather than fall back to all-interfaces.
+  2. Bearer token — POST endpoints require `Authorization: Bearer $PROFILE_SERVE_TOKEN`.
+     This is a SEPARATE secret from FRIDAY_API_KEY (the kernel's front-door key):
+     east-west, single-holder (only the kernel), rotatable on its own. No token
+     configured => everything is refused (closed by default). Because only the
+     kernel holds the token, an authenticated request's X-Allowed-Groups is
+     trustworthy without extra signing — forging it needs BOTH the 172.x net AND
+     the token.
+  3. ALLOWLIST — only profiles in AGENT_ALLOWLIST can be brought up, each carrying
+     the kernel tool-groups it may call back into. Off the list => 403.
 
-Runs INSIDE hermes-trainman-alpha on ai-shared (bind 0.0.0.0 is safe: the network
-is internal/tailnet-gated, no host publish). Stdlib only — no pip in the image.
+Stdlib only — no pip in the image.
 """
 from __future__ import annotations
 
+import hmac
 import json
 import os
+import socket
 import subprocess
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -35,6 +48,46 @@ HERMES_SHIM = "/opt/hermes/bin/hermes"
 PORT = int(os.environ.get("PROFILE_SERVE_PORT", "8642"))
 MAX_TURNS = int(os.environ.get("PROFILE_SERVE_MAX_TURNS", "40"))
 TIMEOUT = int(os.environ.get("PROFILE_SERVE_TIMEOUT", "540"))
+
+# East-west bearer secret (gate #2). Shared ONLY with the kernel via friday-secrets
+# (kernel.env + hermes.env). Distinct from FRIDAY_API_KEY. Empty => fail closed.
+TOKEN = os.environ.get("PROFILE_SERVE_TOKEN", "").strip()
+
+# ai-shared subnet prefix used to pick our bind address when PROFILE_SERVE_BIND is
+# not set. Docker's bridge subnet is 172.x; the tailnet is 100.64/10 (CGNAT) — we
+# never want that one. Override the prefix if the ai-shared subnet ever changes.
+NET_PREFIX = os.environ.get("PROFILE_SERVE_NET_PREFIX", "172.").strip()
+
+
+def resolve_bind() -> str:
+    """Pick the ai-shared (172.x) address to bind. Never 0.0.0.0, never the tailnet.
+
+    Explicit PROFILE_SERVE_BIND wins (and is validated). Otherwise we take the
+    container's own addresses and keep the one on the ai-shared subnet. Binding a
+    specific address means we physically cannot answer on any other interface the
+    container grows later (tailnet, a second net) — single-homed by construction.
+    Fail closed: no safe address => refuse to start (do NOT fall back to 0.0.0.0).
+    """
+    explicit = os.environ.get("PROFILE_SERVE_BIND", "").strip()
+    if explicit:
+        if explicit in ("0.0.0.0", "::", "") or explicit.startswith("127."):
+            raise SystemExit(
+                f"profile-serve: refusing PROFILE_SERVE_BIND={explicit!r} — must be a "
+                f"specific ai-shared address, never all-interfaces/loopback.")
+        return explicit
+    candidates = set()
+    try:
+        for res in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+            candidates.add(res[4][0])
+    except socket.gaierror:
+        pass
+    for ip in sorted(candidates):
+        if ip.startswith(NET_PREFIX) and not ip.startswith("127."):
+            return ip
+    raise SystemExit(
+        f"profile-serve: refusing to start — no ai-shared address matching prefix "
+        f"{NET_PREFIX!r} found (candidates={sorted(candidates) or 'none'}). Set "
+        f"PROFILE_SERVE_BIND explicitly. Will NOT fall back to 0.0.0.0.")
 
 # Agent tool-group allowlist. Key = profile/agent; value = kernel tool GROUPS it
 # may call back into (matches fridai/kernel/tool_groups.py). The kernel enforces
@@ -92,15 +145,30 @@ class Handler(BaseHTTPRequestHandler):
             raise ValueError("body too large")
         return json.loads(self.rfile.read(n) or b"{}")
 
+    def _authed(self) -> bool:
+        """Bearer gate (#2). Fail closed: no configured token => refuse. Constant-time."""
+        if not TOKEN:
+            return False
+        got = self.headers.get("Authorization", "")
+        if not got.startswith("Bearer "):
+            return False
+        return hmac.compare_digest(got[7:].strip(), TOKEN)
+
     def do_GET(self):
+        # /health stays open for liveness probes but leaks nothing (no roster).
         if self.path.rstrip("/") == "/health":
-            return self._send(200, {"status": "ok", "agents": sorted(AGENT_ALLOWLIST)})
+            return self._send(200, {"status": "ok"})
+        # Listing the served profiles reveals the roster — require auth.
         if self.path.rstrip("/") == "/v1/models":
+            if not self._authed():
+                return self._send(401, {"error": "unauthorized"})
             return self._send(200, {"object": "list", "data": [
                 {"id": a, "object": "model", "owned_by": "hermes"} for a in sorted(AGENT_ALLOWLIST)]})
         return self._send(404, {"error": "not found"})
 
     def do_POST(self):
+        if not self._authed():
+            return self._send(401, {"error": "unauthorized"})
         try:
             data = self._body()
         except Exception as e:
@@ -132,5 +200,11 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    print(f"profile-serve on :{PORT} — agents: {sorted(AGENT_ALLOWLIST)}", flush=True)
-    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+    bind = resolve_bind()  # fail-closed; raises SystemExit if no safe address
+    gate = "bearer=on" if TOKEN else "bearer=OFF(fail-closed: all POSTs 401)"
+    print(f"profile-serve on {bind}:{PORT} [{gate}] — agents: {sorted(AGENT_ALLOWLIST)}",
+          flush=True)
+    if not TOKEN:
+        print("profile-serve: WARNING — PROFILE_SERVE_TOKEN unset; refusing every "
+              "authenticated request until it is provided in hermes.env.", flush=True)
+    ThreadingHTTPServer((bind, PORT), Handler).serve_forever()

--- a/scripts/profile_serve.py
+++ b/scripts/profile_serve.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+profile-serve — bring a Hermes profile up over HTTP.
+
+The kernel's old `run_agent` was the OpenClaw launcher; it died with the SDK, so
+"call an agent" stopped bringing anything up. This restores it against Hermes
+profiles: agent name == profile name (aligned 2026-08-01), and a call here runs
+that profile with its own persona, skills, auth and the shared /root/nexus-core-edge
+spaces, then returns the answer.
+
+Two front doors, one engine (`<profile> chat -q <task>`):
+  (a) POST /run                     {"profile","task"}          -> {"output"}
+  (c) POST /v1/chat/completions     OpenAI-shaped, model=profile -> OpenAI-shaped
+      GET  /v1/models               lists the served profiles
+
+ALLOWLIST: only profiles in AGENT_ALLOWLIST can be brought up, and each carries
+the kernel tool-groups it may call back into (enforced kernel-side via the
+X-Agent header the run_agent tool sets). A profile not on the list is 403 — the
+gate is closed by default, not open.
+
+Runs INSIDE hermes-trainman-alpha on ai-shared (bind 0.0.0.0 is safe: the network
+is internal/tailnet-gated, no host publish). Stdlib only — no pip in the image.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# The privilege-drop shim, NOT cli.py directly: it does s6-setuidgid to the
+# hermes user (UID 1000) before exec'ing the venv binary. Calling cli.py raw runs
+# as root and auth/permissions break (the "hermes is UID 1000" trap).
+HERMES_SHIM = "/opt/hermes/bin/hermes"
+PORT = int(os.environ.get("PROFILE_SERVE_PORT", "8642"))
+MAX_TURNS = int(os.environ.get("PROFILE_SERVE_MAX_TURNS", "40"))
+TIMEOUT = int(os.environ.get("PROFILE_SERVE_TIMEOUT", "540"))
+
+# Agent tool-group allowlist. Key = profile/agent; value = kernel tool GROUPS it
+# may call back into (matches fridai/kernel/tool_groups.py). The kernel enforces
+# it from the X-Agent header; here it gates who can be brought up at all.
+# Least privilege: absent = not servable.
+AGENT_ALLOWLIST: dict[str, list[str]] = {
+    "fridai":    ["system", "state", "meta", "workspace", "rag", "comms", "agents"],
+    "neo":       ["system", "state", "meta", "security", "rag"],
+    "validator": ["system", "state", "meta", "workspace", "rag"],
+    "librarian": ["system", "state", "meta", "workspace", "rag"],
+    "atlas":     ["system", "state", "meta", "workspace", "rag"],
+    "vector":    ["system", "state", "meta", "workspace", "rag", "system"],
+    "orion":     ["system", "state", "meta", "workspace", "rag"],
+    "venus":     ["system", "state", "meta", "comms", "workspace"],
+    "hermes":    ["system", "state", "meta", "comms"],
+}
+
+
+def run_profile(profile: str, task: str) -> tuple[int, str]:
+    """Bring the profile up for one task. Returns (status, text)."""
+    p = (profile or "").strip().lower()
+    if p not in AGENT_ALLOWLIST:
+        return 403, f"agent '{profile}' is not on the allowlist"
+    if not task or not task.strip():
+        return 400, "task is required"
+    try:
+        # `hermes -p <profile> chat -q` == `<profile> chat -q`; the shim drops to
+        # the hermes user and sets HERMES_HOME for the profile. --yolo for
+        # unattended; the profile's own skills/toolsets/auth apply.
+        r = subprocess.run(
+            [HERMES_SHIM, "-p", p, "chat", "-q", task,
+             "--max-turns", str(MAX_TURNS), "--yolo", "--quiet"],
+            capture_output=True, text=True, timeout=TIMEOUT,
+        )
+        out = (r.stdout or "").strip() or (r.stderr or "").strip()
+        return (200 if r.returncode == 0 else 500), out
+    except subprocess.TimeoutExpired:
+        return 504, f"agent '{p}' timed out after {TIMEOUT}s"
+    except Exception as e:
+        return 500, f"{type(e).__name__}: {e}"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self):
+        n = int(self.headers.get("content-length", 0) or 0)
+        if n > 256 * 1024:
+            raise ValueError("body too large")
+        return json.loads(self.rfile.read(n) or b"{}")
+
+    def do_GET(self):
+        if self.path.rstrip("/") == "/health":
+            return self._send(200, {"status": "ok", "agents": sorted(AGENT_ALLOWLIST)})
+        if self.path.rstrip("/") == "/v1/models":
+            return self._send(200, {"object": "list", "data": [
+                {"id": a, "object": "model", "owned_by": "hermes"} for a in sorted(AGENT_ALLOWLIST)]})
+        return self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        try:
+            data = self._body()
+        except Exception as e:
+            return self._send(400, {"error": f"bad request: {e}"})
+
+        path = self.path.rstrip("/")
+        # (a) the thin run endpoint
+        if path == "/run":
+            code, text = run_profile(data.get("profile", ""), data.get("task", ""))
+            return self._send(code, {"output": text} if code == 200 else {"error": text})
+
+        # (c) OpenAI-compatible: model=profile, last user message = task
+        if path == "/v1/chat/completions":
+            model = data.get("model", "")
+            msgs = data.get("messages", []) or []
+            task = next((m.get("content", "") for m in reversed(msgs) if m.get("role") == "user"), "")
+            code, text = run_profile(model, task)
+            if code != 200:
+                return self._send(code, {"error": {"message": text, "type": "agent_error"}})
+            return self._send(200, {
+                "object": "chat.completion", "model": model,
+                "choices": [{"index": 0, "finish_reason": "stop",
+                             "message": {"role": "assistant", "content": text}}],
+            })
+        return self._send(404, {"error": "not found"})
+
+    def log_message(self, *a):  # quiet
+        pass
+
+
+if __name__ == "__main__":
+    print(f"profile-serve on :{PORT} — agents: {sorted(AGENT_ALLOWLIST)}", flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/tests/hermes_cli/test_auth_tmp_orphan_cleanup.py
+++ b/tests/hermes_cli/test_auth_tmp_orphan_cleanup.py
@@ -1,0 +1,52 @@
+"""#444 — startup cleanup of stranded auth.json.tmp.<pid>.<uuid> orphans."""
+import os
+import time
+import pytest
+from hermes_cli import auth as A
+
+
+def _mk(tmpdir, suffix, age=0.0):
+    p = tmpdir / f"auth.json.tmp.{suffix}"
+    p.write_text("{}")
+    if age:
+        old = time.time() - age
+        os.utime(p, (old, old))
+    return p
+
+
+def test_dead_pid_orphan_removed(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    # a PID that is essentially certain to be dead
+    dead = _mk(tmp_path, "999999.deadbeef")
+    A._prune_auth_tmp_orphans(auth_file)
+    assert not dead.exists()
+
+
+def test_live_pid_orphan_kept(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    live = _mk(tmp_path, f"{os.getpid()}.abc123")
+    A._prune_auth_tmp_orphans(auth_file)
+    assert live.exists()  # our own live PID → not pruned
+
+
+def test_live_store_never_touched(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"providers": {}}')
+    A._prune_auth_tmp_orphans(auth_file)
+    assert auth_file.exists()
+
+
+def test_unparseable_pruned_only_when_old(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    fresh = _mk(tmp_path, "notapid.xyz", age=10)
+    old = _mk(tmp_path, "alsobad.xyz", age=90000)  # >24h
+    A._prune_auth_tmp_orphans(auth_file)
+    assert fresh.exists() and not old.exists()
+
+
+def test_load_store_triggers_cleanup(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"providers": {}}')
+    dead = _mk(tmp_path, "999999.cafef00d")
+    A._load_auth_store(auth_file)
+    assert not dead.exists()


### PR DESCRIPTION
Hardens the `kernel run_agent → profile-serve :8642` hop per the "clean shape": keep `FRIDAY_API_KEY` as the gateway front-door key, add a **separate** east-west secret for this internal hop, and pin the listener to `ai-shared`.

## What changed (`scripts/profile_serve.py`)
- **Single-homed bind** — `resolve_bind()` binds the container's `172.x` (ai-shared) address, never `0.0.0.0`. hermes is multi-homed (ai-shared + tailnet); `0.0.0.0` would expose the runtime on the tailnet the instant the node signs in. Honours explicit `PROFILE_SERVE_BIND`; **fails closed** (refuses to start) if no safe address is found — never falls back to all-interfaces. Rejects `0.0.0.0`/`::`/`127.` outright.
- **Bearer gate** — `POST /run`, `POST /v1/chat/completions`, `GET /v1/models` require `Authorization: Bearer $PROFILE_SERVE_TOKEN` (constant-time compare). Closed by default: no token configured ⇒ every authed request 401s. `/health` stays open for probes but no longer leaks the roster.

## Why a separate token (not `FRIDAY_API_KEY`)
Different trust boundary (edge vs east-west), independent rotation, contained blast radius. Only the kernel holds `PROFILE_SERVE_TOKEN`, so an authenticated request's `X-Allowed-Groups` is trustworthy without extra HMAC signing.

## Deploy
`PROFILE_SERVE_TOKEN` must be added (identical value) to `friday-secrets/kernel.env` **and** `friday-secrets/hermes.env` on phoenix — rides existing `env_file` plumbing, no compose change. Pairs with the kernel-side change in AI-Dev-Workspace (`run_agent` sends the bearer).

## Tests
`/health` 200 (no roster) · `/run` 401 no-token · 401 wrong-token · 403 good-token off-allowlist · `/v1/models` 401 no-auth / 200 authed · bind refuses `0.0.0.0` + fails closed on no-match. Stdlib only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6rD4kZCaViqCRiNvpnsTL