### PR TITLE
Ship the example plugin off by default

### DIFF
--- a/apps/desktop/src/plugins/example/plugin.tsx
+++ b/apps/desktop/src/plugins/example/plugin.tsx
@@ -13,6 +13,9 @@
  *    and as a rebindable (default-unbound) action in the keybind panel;
  *  - plugin-local `atom` + `useValue` — module state, leaf subscription;
  *  - `haptic` / `host.notify` / `Tip` / `cn` — the design language.
+ *
+ * Ships OFF by default (`defaultEnabled: false`): it inventories in
+ * Settings ▸ Plugins and registers nothing until the user flips the switch.
  */
 
 import {
@@ -69,6 +72,7 @@ function ClickCounter() {
 const plugin: HermesPlugin = {
   id: 'example',
   name: 'Example Plugin',
+  defaultEnabled: false,
   register(ctx) {
     // Persisted count: hydrate once, write through on every change.
     $clicks.set(ctx.storage.get('clicks', 0))


### PR DESCRIPTION
## Summary
The bundled desktop **Example Plugin** was on by default, so every install got the statusbar click-counter chrome. It now ships `defaultEnabled: false`, same as kanban — still inventoriable in Settings ▸ Plugins, registers nothing until the user flips it on.

## Test plan
- [ ] Fresh profile / cleared plugin decisions: statusbar has no Example “click me” chip
- [ ] Settings ▸ Plugins lists **Example Plugin** as off
- [ ] Toggle on → chip + palette/keybind appear live; toggle off → gone
- [ ] Existing users who already enabled it keep it (explicit decision wins over default)