### PR TITLE
feat(tools): batch file edits

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -407,10 +407,11 @@ def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
 def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List[str]:
     """Return the file paths a ``write_file`` or ``patch`` call is targeting.
 
-    For ``write_file`` and ``patch`` in replace mode this is just ``args["path"]``.
-    For ``patch`` in V4A patch mode we parse the patch content for
-    ``*** Update File:`` / ``*** Add File:`` / ``*** Delete File:`` headers so
-    the verifier can track each file in a multi-file patch separately.
+    For ``write_file`` and ``patch`` in replace/multi_edit mode this is just
+    ``args["path"]``.  For ``patch`` in V4A patch mode we parse the patch
+    content for ``*** Update File:`` / ``*** Add File:`` / ``*** Delete File:``
+    headers so the verifier can track each file in a multi-file patch
+    separately.
     """
     if tool_name not in _FILE_MUTATING_TOOLS:
         return []
@@ -419,7 +420,7 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
         return [str(p)] if p else []
     # tool_name == "patch"
     mode = args.get("mode") or "replace"
-    if mode == "replace":
+    if mode in ("replace", "multi_edit"):
         p = args.get("path")
         return [str(p)] if p else []
     if mode == "patch":

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -49,6 +49,13 @@ class TestExtractFileMutationTargets:
         assert _extract_file_mutation_targets("patch", args) == ["/tmp/a.md"]
 
 
+    def test_patch_multi_edit_mode_returns_path(self):
+        args = {"mode": "multi_edit", "path": "/tmp/a.md", "edits": [
+            {"old_string": "x", "new_string": "y"},
+        ]}
+        assert _extract_file_mutation_targets("patch", args) == ["/tmp/a.md"]
+
+
 
     def test_patch_v4a_multi_file(self):
         body = (

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -5,7 +5,7 @@ import re
 import pytest
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tools.file_operations import (
     _is_write_denied,
@@ -615,3 +615,160 @@ class TestAtomicWriteNewFilePermissions:
         assert result.error is None, f"write failed: {result.error}"
         assert dest.read_text() == "#!/bin/sh\necho updated\n"
         assert dest.stat().st_mode & 0o777 == 0o755
+
+class TestPatchMultiEdit:
+    """Tests for patch_multi_edit — sequential fuzzy edits on evolving
+    content, all per-edit results reported together, a single write and a
+    single syntax check at the end."""
+
+    @pytest.fixture()
+    def ops(self):
+        obj = ShellFileOperations.__new__(ShellFileOperations)
+        obj._command_cache = {}
+        return obj
+
+    ORIGINAL = "def foo():\n    return None\n"
+    MERGED = "def foo(x):\n    return x\n"
+
+    def _exec(self, original, merged):
+        """Side effect for _exec: first cat returns original, verify cat returns merged."""
+        cat_calls = {"n": 0}
+
+        def fake_exec(command, **kwargs):
+            if command.startswith("cat "):
+                cat_calls["n"] += 1
+                out = original if cat_calls["n"] == 1 else merged
+                return MagicMock(exit_code=0, stdout=out)
+            return MagicMock(exit_code=0, stdout="")
+
+        return fake_exec
+
+    def test_applies_edits_sequentially_and_reports_all(self, ops):
+        """Two edits applied in order; both reported; single write of merged
+        content; single lint check at the end."""
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, self.MERGED)), \
+             patch.object(ops, "write_file", return_value=MagicMock(
+                 error=None, lsp_diagnostics=None, lint={"success": True}
+             )) as write, \
+             patch.object(ops, "_check_lint_delta") as lint, \
+             patch.object(ops, "_unified_diff", return_value="--- a/x\n+++ b/x\n") as diff:
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                {"old_string": "def foo():", "new_string": "def foo(x):"},
+                {"old_string": "return None", "new_string": "return x"},
+            ])
+
+        assert result.success, f"expected success, got error={result.error}"
+        assert result.files_modified == ["/tmp/test/a.py"]
+        assert write.call_count == 1
+        assert write.call_args[0][1] == self.MERGED
+        assert [r["index"] for r in result.edit_results] == [0, 1]
+        assert [r["status"] for r in result.edit_results] == ["ok", "ok"]
+        lint.assert_not_called()
+        assert result.lint == {"success": True}
+        assert diff.call_count == 1
+
+    def test_partial_failure_reports_all_and_writes_successes(self, ops):
+        """Successful edits are committed in one atomic final write, but failed edits 
+        are reported and do not roll back successful edits."""
+        merged = "def foo(x):\n    return None\n"
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, merged)), \
+             patch.object(ops, "write_file", return_value=MagicMock(error=None, lsp_diagnostics=None)) as write, \
+             patch.object(ops, "_check_lint_delta", return_value=MagicMock(success=True, to_dict=lambda: {})), \
+             patch.object(ops, "_unified_diff", return_value=""):
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                {"old_string": "def foo():", "new_string": "def foo(x):"},
+                {"old_string": "MISSING STRING", "new_string": "x"},
+            ])
+
+        assert result.success
+        assert [r["status"] for r in result.edit_results] == ["ok", "error"]
+        assert write.call_count == 1
+        assert write.call_args[0][1] == merged
+
+    def test_all_edits_fail_no_write(self, ops):
+        """If no edit can be applied, nothing is written and an error is returned."""
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, self.ORIGINAL)), \
+             patch.object(ops, "write_file", return_value=MagicMock(error=None, lsp_diagnostics=None)) as write, \
+             patch.object(ops, "_check_lint_delta", return_value=MagicMock(success=True, to_dict=lambda: {})), \
+             patch.object(ops, "_unified_diff", return_value=""):
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                {"old_string": "NOPE 1", "new_string": "x"},
+                {"old_string": "NOPE 2", "new_string": "y"},
+            ])
+
+        assert result.error is not None
+        assert "None of the edits" in result.error
+        write.assert_not_called()
+        assert all(r["status"] == "error" for r in result.edit_results)
+
+    def test_empty_edits_rejected(self, ops):
+        """A missing/empty edits list is rejected without touching the file."""
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "write_file", return_value=MagicMock(error=None, lsp_diagnostics=None)) as write:
+            result = ops.patch_multi_edit("/tmp/test/a.py", [])
+
+        assert result.error is not None
+        assert "edits" in result.error
+        write.assert_not_called()
+
+    def test_malformed_edit_reported_but_valid_ones_still_apply(self, ops):
+        """A non-dict / missing-string edit is reported as an error while
+        valid edits still proceed and are written."""
+        merged = "def foo(x):\n    return None\n"
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, merged)), \
+             patch.object(ops, "write_file", return_value=MagicMock(error=None, lsp_diagnostics=None)) as write, \
+             patch.object(ops, "_check_lint_delta", return_value=MagicMock(success=True, to_dict=lambda: {})), \
+             patch.object(ops, "_unified_diff", return_value=""):
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                "not-a-dict",
+                {"old_string": "def foo():", "new_string": "def foo(x):"},
+            ])
+
+        assert result.success
+        assert [r["status"] for r in result.edit_results] == ["error", "ok"]
+        assert write.call_count == 1
+        assert write.call_args[0][1] == merged
+
+    def test_non_string_edit_reported_but_valid_ones_still_apply(self, ops):
+        """Invalid value types are isolated to their edit result."""
+        merged = "def foo(x):\n    return None\n"
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, merged)), \
+             patch.object(ops, "write_file", return_value=MagicMock(
+                 error=None, lsp_diagnostics=None, lint=None
+             )) as write, \
+             patch.object(ops, "_unified_diff", return_value=""):
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                {"old_string": 123, "new_string": "x"},
+                {"old_string": "def foo():", "new_string": "def foo(x):"},
+            ])
+
+        assert result.success
+        assert [r["status"] for r in result.edit_results] == ["error", "ok"]
+        assert "must both be strings" in result.edit_results[0]["error"]
+        assert write.call_args[0][1] == merged
+
+    def test_write_error_surfaces(self, ops):
+        """A write failure (write_file.error set) is surfaced, not swallowed."""
+        with patch("tools.file_operations.get_write_denied_error", return_value=None), \
+             patch.object(ops, "_expand_path", side_effect=lambda p: p), \
+             patch.object(ops, "_exec", side_effect=self._exec(self.ORIGINAL, self.MERGED)), \
+             patch.object(ops, "write_file", return_value=MagicMock(error="disk full", lsp_diagnostics=None)), \
+             patch.object(ops, "_unified_diff", return_value=""):
+            result = ops.patch_multi_edit("/tmp/test/a.py", [
+                {"old_string": "def foo():", "new_string": "def foo(x):"},
+                {"old_string": "return None", "new_string": "return x"},
+            ])
+
+        assert result.error is not None
+        assert "disk full" in result.error

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -158,6 +159,61 @@ class TestPatchHandler:
         result = json.loads(patch_tool(mode="patch", patch="*** Begin Patch\n..."))
         assert result["status"] == "ok"
         mock_ops.patch_v4a.assert_called_once()
+
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_multi_edit_mode_calls_patch_multi_edit(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {
+            "status": "ok",
+            "edit_results": [{"index": 0, "status": "ok"}],
+        }
+        mock_ops.patch_multi_edit.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        edits = [{"old_string": "foo", "new_string": "bar"}]
+        result = json.loads(patch_tool(mode="multi_edit", path="/tmp/f.py", edits=edits))
+        assert result["status"] == "ok"
+        _args = mock_ops.patch_multi_edit.call_args[0]
+        assert _args[1] == edits
+        assert str(Path(_args[0])).replace("\\", "/").endswith("tmp/f.py")
+
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_multi_edit_mode_requires_path(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="multi_edit", edits=[{"old_string": "a", "new_string": "b"}]
+        ))
+        assert "path required" in result["error"]
+
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_multi_edit_preserves_cross_platform_filename_characters(self, mock_get, tmp_path):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"success": True}
+        mock_ops.patch_multi_edit.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+
+        edits = [{"old_string": "foo", "new_string": "bar"}]
+        names = [
+            "file with spaces.py",
+            "café-東京.py",
+            "apostrophe's file.py",
+            "[draft] (final) $file.py",
+        ]
+        for name in names:
+            target = tmp_path / name
+            result = json.loads(patch_tool(mode="multi_edit", path=str(target), edits=edits))
+            assert result["success"] is True
+            actual_path, actual_edits = mock_ops.patch_multi_edit.call_args.args
+            assert Path(actual_path) == target.resolve()
+            assert actual_edits == edits
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -187,6 +187,38 @@ class TestPatchReplace:
         assert Path(path).read_text() == "line1\nREPLACED\nline3\n"
 
 
+# ── patch_multi_edit ────────────────────────────────────────────────────
+
+class TestPatchMultiEdit:
+    def test_real_roundtrip_with_cross_platform_filenames(self, ops, tmp_path):
+        """Exercise path quoting and the real atomic-write path end to end."""
+        names = [
+            "file with spaces.py",
+            "café-東京.py",
+            "apostrophe's file.py",
+            "[draft] (final) $file.py",
+        ]
+        original = "def greet():\n    return 'hello'\n"
+        expected = "def greet(name):\n    return f'hello {name}'\n"
+
+        for name in names:
+            target = tmp_path / name
+            target.write_text(original, encoding="utf-8")
+
+            result = ops.patch_multi_edit(str(target), [
+                {"old_string": "def greet():", "new_string": "def greet(name):"},
+                {
+                    "old_string": "return 'hello'",
+                    "new_string": "return f'hello {name}'",
+                },
+            ])
+
+            assert result.error is None, f"{name}: {result.error}"
+            assert result.success
+            assert [item["status"] for item in result.edit_results] == ["ok", "ok"]
+            assert target.read_text(encoding="utf-8") == expected
+
+
 # ── search ───────────────────────────────────────────────────────────────
 
 class TestSearch:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -345,9 +345,9 @@ _TOOL_STUBS = {
     ),
     "patch": (
         "patch",
-        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False',
-        '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile}',
+        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, edits: list = None, cross_profile: bool = False',
+        '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"), or sequential multi-edit on one file (mode="multi_edit", with a list of {old_string, new_string} edits). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
+        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "edits": edits, "cross_profile": cross_profile}',
     ),
     "terminal": (
         "terminal",

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -205,6 +205,7 @@ class PatchResult:
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
+    edit_results: Optional[List[Dict[str, Any]]] = None
     
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -222,6 +223,8 @@ class PatchResult:
             result["lsp_diagnostics"] = self.lsp_diagnostics
         if self.error:
             result["error"] = self.error
+        if self.edit_results:
+            result["edit_results"] = self.edit_results
         return result
 
 
@@ -463,6 +466,15 @@ class FileOperations(ABC):
     @abstractmethod
     def patch_v4a(self, patch_content: str) -> PatchResult:
         """Apply a V4A format patch."""
+        ...
+
+    @abstractmethod
+    def patch_multi_edit(self, path: str, edits: List[Dict[str, Any]]) -> PatchResult:
+        """Apply a list of ``{old_string, new_string}`` replacements to one file.
+
+        Each edit is applied sequentially against the running content using
+        fuzzy matching; all per-edit outcomes are reported together.
+        """
         ...
 
     @abstractmethod
@@ -1719,6 +1731,134 @@ class ShellFileOperations(FileOperations):
         result = apply_v4a_operations(operations, self)
         return result
     
+    def patch_multi_edit(self, path: str, edits: List[Dict[str, Any]]) -> PatchResult:
+        """Apply a list of ``{old_string, new_string}`` replacements to one file.
+
+        Each edit is applied sequentially against the *evolving* content
+        (edit N's ``old_string`` is matched against the result of edits
+        0..N-1), using the same fuzzy-matching chain as ``patch_replace``.
+        All per-edit outcomes are reported together in ``edit_results``;
+        a failed edit simply doesn't alter the content and the remaining
+        edits still run.
+
+        Write behavior: the merged content is written exactly once if at
+        least one edit succeeded. Successful edits are committed in one atomic 
+        final write, but failed edits are reported and do not roll back successful 
+        edits.
+
+        Args:
+            path: File path to modify
+            edits: List of ``{"old_string": str, "new_string": str}`` dicts.
+                Each ``old_string`` must be unique within the current content
+                at the time it is applied.
+
+        Returns:
+            PatchResult with the merged diff, per-edit ``edit_results``, and
+            a single lint result for the final content.
+        """
+        path = self._expand_path(path)
+
+        denied = get_write_denied_error(path)
+        if denied:
+            return PatchResult(error=denied)
+
+        if not edits or not isinstance(edits, list):
+            return PatchResult(error="edits list is required and must not be empty")
+
+        read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+        read_result = self._exec(read_cmd)
+
+        if read_result.exit_code != 0:
+            return PatchResult(error=f"Failed to read file: {path}")
+
+        content = read_result.stdout
+        # Strip a leading UTF-8 BOM before matching (see patch_replace for the
+        # rationale). write_file restores the marker on the way back out.
+        content, _ = _strip_bom(content)
+
+        from tools.fuzzy_match import fuzzy_find_and_replace
+
+        current = content
+        edit_results: List[Dict[str, Any]] = []
+        succeeded = 0
+
+        for i, edit in enumerate(edits):
+            if not isinstance(edit, dict):
+                edit_results.append({"index": i, "status": "error",
+                                     "error": "edit is not an object; expected {old_string, new_string}"})
+                continue
+            old_s = edit.get("old_string")
+            new_s = edit.get("new_string")
+            if old_s is None or new_s is None:
+                edit_results.append({"index": i, "status": "error",
+                                     "error": f"edit {i} requires both 'old_string' and 'new_string'"})
+                continue
+            if not isinstance(old_s, str) or not isinstance(new_s, str):
+                edit_results.append({
+                    "index": i,
+                    "status": "error",
+                    "error": f"edit {i} old_string and new_string must both be strings",
+                })
+                continue
+
+            new_current, match_count, strategy, error = fuzzy_find_and_replace(
+                current, old_s, new_s, False
+            )
+            if error or match_count == 0:
+                err_msg = error or f"Could not find match for old_string (edit {i}) in {path}"
+                try:
+                    from tools.fuzzy_match import format_no_match_hint
+                    err_msg += format_no_match_hint(err_msg, match_count, old_s, current)
+                except Exception:
+                    pass
+                edit_results.append({"index": i, "status": "error", "error": err_msg})
+                continue
+
+            current = new_current
+            succeeded += 1
+            edit_results.append({"index": i, "status": "ok", "strategy": strategy})
+
+        if succeeded == 0:
+            return PatchResult(error="None of the edits could be applied", edit_results=edit_results)
+
+        file_ending = _detect_line_ending(content)
+        if file_ending:
+            current = _normalize_line_endings(current, file_ending)
+
+        write_result = self.write_file(path, current)
+        if write_result.error:
+            return PatchResult(error=f"Failed to write changes: {write_result.error}",
+                               edit_results=edit_results)
+
+        verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+        verify_result = self._exec(verify_cmd)
+        if verify_result.exit_code != 0:
+            return PatchResult(error=f"Post-write verification failed: could not re-read {path}",
+                               edit_results=edit_results)
+
+        _verify_bomless, _ = _strip_bom(verify_result.stdout)
+        _verify_stdout_normalized = _verify_bomless.replace("\r\n", "\n").replace("\r", "\n")
+        _new_content_normalized = current.replace("\r\n", "\n").replace("\r", "\n")
+        if _verify_stdout_normalized != _new_content_normalized:
+            return PatchResult(error=(
+                f"Post-write verification failed for {path}: on-disk content "
+                f"differs from intended write "
+                f"(wrote {len(_new_content_normalized)} chars, read back "
+                f"{len(_verify_stdout_normalized)} chars after normalizing line endings). "
+                "The patch did not persist. Re-read the file and try again."
+            ), edit_results=edit_results)
+
+        diff = self._unified_diff(content, current, path)
+
+        return PatchResult(
+            success=True,
+            diff=diff,
+            files_modified=[path],
+            lint=write_result.lint,
+            lsp_diagnostics=write_result.lsp_diagnostics,
+            edit_results=edit_results,
+        )
+
     def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:
         """
         Run syntax check on a file after editing.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -9,6 +9,7 @@ import posixpath
 import sys
 import threading
 from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
@@ -1647,9 +1648,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
+               edits: List[Dict[str, Any]] = None,
                task_id: str = "default", cross_profile: bool = False,
                session_id: str | None = None) -> str:
-    """Patch a file using replace mode or V4A patch format.
+    """Patch a file using replace mode, V4A patch format, or multi-edit.
+
+    ``mode="replace"``: single find-and-replace (``old_string`` →
+    ``new_string``).
+    ``mode="patch"``: V4A multi-file patch content.
+    ``mode="multi_edit"``: apply a list of ``{"old_string", "new_string"}``
+    edits sequentially against one file's evolving content, reporting all
+    per-edit outcomes together and running a single syntax check at the end.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard for
     targets under another profile's skills/plugins/cron/memories
@@ -1769,6 +1778,10 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if not patch:
                     return tool_error("patch content required")
                 result = file_ops.patch_v4a(patch)
+            elif mode == "multi_edit":
+                if not path:
+                    return tool_error("path required")
+                result = file_ops.patch_multi_edit(_path_to_resolved.get(path) or path, edits or [])
             else:
                 return tool_error(f"Unknown mode: {mode}")
 
@@ -1976,20 +1989,25 @@ PATCH_SCHEMA = {
         "REPLACE MODE (mode='replace', default): find a unique string and replace it. "
         "REQUIRED PARAMETERS: mode, path, old_string, new_string.\n"
         "PATCH MODE (mode='patch'): apply V4A multi-file patches for bulk changes. "
-        "REQUIRED PARAMETERS: mode, patch."
+        "REQUIRED PARAMETERS: mode, patch.\n"
+        "MULTI_EDIT MODE (mode='multi_edit'): apply several find-and-replace edits to ONE file "
+        "in a single call. REQUIRED PARAMETERS: mode, path, edits (a list of "
+        "{old_string, new_string} objects). Each edit is applied sequentially against the "
+        "file's evolving content with fuzzy matching; all per-edit results are returned "
+        "together in 'edit_results', and a single syntax check runs once at the end."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "mode": {
                 "type": "string",
-                "enum": ["replace", "patch"],
-                "description": "Edit mode. 'replace' (default): requires path + old_string + new_string. 'patch': requires patch content only.",
+                "enum": ["replace", "patch", "multi_edit"],
+                "description": "Edit mode. 'replace' (default): requires path + old_string + new_string. 'patch': requires patch content only. 'multi_edit': requires path + a list of edits, applied sequentially to one file.",
                 "default": "replace",
             },
             "path": {
                 "type": "string",
-                "description": "REQUIRED when mode='replace'. File path to edit.",
+                "description": "REQUIRED when mode='replace' or mode='multi_edit'. File path to edit.",
             },
             "old_string": {
                 "type": "string",
@@ -2007,6 +2025,18 @@ PATCH_SCHEMA = {
             "patch": {
                 "type": "string",
                 "description": "REQUIRED when mode='patch'. V4A format patch content. Format:\n*** Begin Patch\n*** Update File: path/to/file\n@@ context hint @@\n context line\n-removed line\n+added line\n*** End Patch",
+            },
+            "edits": {
+                "type": "array",
+                "description": "REQUIRED when mode='multi_edit'. List of {old_string, new_string} objects to apply sequentially to one file. Each old_string must be unique in the file's content at the time it is applied. All per-edit outcomes are reported together in the result's 'edit_results' field.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "old_string": {"type": "string", "description": "Text to find. Must be unique in the current content."},
+                        "new_string": {"type": "string", "description": "Replacement text. Pass '' to delete the matched text."},
+                    },
+                    "required": ["old_string", "new_string"],
+                },
             },
             "cross_profile": {
                 "type": "boolean",
@@ -2075,7 +2105,8 @@ def _handle_patch(args, **kw):
     return patch_tool(
         mode=args.get("mode", "replace"), path=args.get("path"),
         old_string=args.get("old_string"), new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
+        replace_all=args.get("replace_all", False), patch=args.get("patch"),
+        edits=args.get("edits"), task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
     )


### PR DESCRIPTION
## What does this PR do?

Adding in the multi-edit feature so that multiple edits can be made across a file at once.  Focuses on fuzzy matching and per edit success and failure on the edits desired.  Includes tests and tool schema updates.

## Related Issue

Initial feature issue: https://github.com/NousResearch/hermes-agent/issues/518

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added new path_multi_edit function within `tools/file_operations.py`
- Related tests for new feature 
`tests/tools/test_file_operations.py`
  `tests/tools/test_file_tools.py`
   `tests/tools/test_file_tools_live.py`
   `tests/run_agent/test_file_mutation_verifier.py`     
-  Relevant schema updates to `agent/tool_dispatch_helpers.py` , `tools/code_execution_tool.py`, and `tools/file_operations.py`

## How to Test

The following are added tests to for the new multi-edit.

-    scripts/run_tests.sh tests/tools/test_file_operations.py -k PatchMultiEdit -q
-    scripts/run_tests.sh tests/tools/test_file_tools.py -k multi_edit -q
-    scripts/run_tests.sh tests/run_agent/test_file_mutation_verifier.py -k multi_edit -q
-    scripts/run_tests.sh tests/tools/test_file_tools_live.py -k PatchMultiEdit -q

Main test script includes tests as well

-    scripts/run_tests.sh  

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [[standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->