### PR TITLE
feat: show session cost in status bar (CLI + TUI)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5339,7 +5339,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Session cost
         cost = getattr(agent, "session_estimated_cost_usd", 0) or 0
-        snapshot["cost_usd"] = cost if cost > 0 else 0
+        snapshot["cost_usd"] = cost
         snapshot["cost_status"] = getattr(agent, "session_cost_status", "unknown") or "unknown"
 
         compressor = getattr(agent, "context_compressor", None)
@@ -5896,7 +5896,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             cost_usd = snapshot.get("cost_usd", 0)
             cost_label = (
                 f"${cost_usd:.2f}"
-                if cost_usd > 0 and getattr(self, "show_cost", False)
+                if getattr(self, "show_cost", False)
                 else ""
             )
             cost_part = f" {cost_label}" if cost_label else ""
@@ -5997,7 +5997,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             cost_usd = snapshot.get("cost_usd", 0)
             cost_label = (
                 f"${cost_usd:.2f}"
-                if cost_usd > 0 and getattr(self, "show_cost", False)
+                if getattr(self, "show_cost", False)
                 else ""
             )
 

--- a/cli.py
+++ b/cli.py
@@ -4263,6 +4263,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
+        # show_cost: display $ cost in the status bar
+        self.show_cost = CLI_CONFIG["display"].get("show_cost", False)
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
@@ -5335,6 +5337,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
 
+        # Session cost
+        cost = getattr(agent, "session_estimated_cost_usd", 0) or 0
+        snapshot["cost_usd"] = cost if cost > 0 else 0
+        snapshot["cost_status"] = getattr(agent, "session_cost_status", "unknown") or "unknown"
+
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
             # last_prompt_tokens is parked at the -1 sentinel right after a
@@ -5886,8 +5893,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
+            cost_usd = snapshot.get("cost_usd", 0)
+            cost_label = (
+                f"${cost_usd:.2f}"
+                if cost_usd > 0 and getattr(self, "show_cost", False)
+                else ""
+            )
+            cost_part = f" {cost_label}" if cost_label else ""
             if width < 52:
-                text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{battery_prefix}⚕ {snapshot['model_short']}{cost_part} · {duration_label}"
                 if goal_segment:
                     text += f" · {goal_segment}"
                 if focus_label:
@@ -5913,6 +5927,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     parts.append(f"⛓ {bg_subagent_count}")
                 if goal_segment:
                     parts.append(goal_segment)
+                if cost_label:
+                    parts.append(cost_label)
                 parts.append(duration_label)
                 if focus_label:
                     parts.append(focus_label)
@@ -5944,6 +5960,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 parts.append(f"⛓ {bg_subagent_count}")
             if goal_segment:
                 parts.append(goal_segment)
+            if cost_label:
+                parts.append(cost_label)
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -5976,14 +5994,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_label = snapshot.get("battery_label") or ""
             battery_style = self._battery_status_style(snapshot.get("battery_category", "dim"))
             focus_label = snapshot.get("focus_label") or ""
+            cost_usd = snapshot.get("cost_usd", 0)
+            cost_label = (
+                f"${cost_usd:.2f}"
+                if cost_usd > 0 and getattr(self, "show_cost", False)
+                else ""
+            )
 
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                if cost_label:
+                    frags.append(("class:status-bar-dim", f" {cost_label}"))
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                ]
+                ])
                 if goal_segment:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-strong", goal_segment))
@@ -6023,6 +6051,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if goal_segment:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", goal_segment))
+                    if cost_label:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", cost_label))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -6072,6 +6103,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if goal_segment:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", goal_segment))
+                    if cost_label:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", cost_label))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4727,6 +4727,19 @@ def _get_usage(agent) -> dict:
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
+    # Session cost tracking — populated from the agent's running accumulator
+    if agent is not None:
+        cost = getattr(agent, "session_estimated_cost_usd", 0) or 0
+        if cost > 0:
+            # Respect display.show_cost config gate
+            try:
+                from hermes_cli.config import load_config
+                show = (load_config().get("display") or {}).get("show_cost", False)
+            except Exception:
+                show = False
+            if show:
+                usage["cost_usd"] = cost
+        usage["cost_status"] = getattr(agent, "session_cost_status", "unknown") or "unknown"
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4727,18 +4727,22 @@ def _get_usage(agent) -> dict:
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
-    # Session cost tracking — populated from the agent's running accumulator
+    # Session cost tracking — populated from the agent's running accumulator.
+    # When display.show_cost is enabled the usage contract always carries
+    # cost_usd (including zero) so the TUI can render $0.00 for a subscription
+    # session whose USD accumulator hasn't moved yet.  A separate show_cost flag
+    # lets the renderer gate on the user's opt-in independent of the numeric value.
     if agent is not None:
         cost = getattr(agent, "session_estimated_cost_usd", 0) or 0
-        if cost > 0:
-            # Respect display.show_cost config gate
-            try:
-                from hermes_cli.config import load_config
-                show = (load_config().get("display") or {}).get("show_cost", False)
-            except Exception:
-                show = False
-            if show:
-                usage["cost_usd"] = cost
+        # Respect display.show_cost config gate
+        try:
+            from hermes_cli.config import load_config
+            show = (load_config().get("display") or {}).get("show_cost", False)
+        except Exception:
+            show = False
+        if show:
+            usage["cost_usd"] = cost
+            usage["show_cost"] = True
         usage["cost_status"] = getattr(agent, "session_cost_status", "unknown") or "unknown"
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -467,3 +467,50 @@ describe('StatusRule idle-since read-out', () => {
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
   })
 })
+
+describe('StatusRule session cost display', () => {
+  it('renders $0.00 when show_cost is true and cost_usd is zero (subscription accumulator)', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, calls: 0, input: 0, output: 0, cost_usd: 0, show_cost: true }
+    })
+
+    expect(textContent(element)).toContain('$0.00')
+  })
+
+  it('renders the formatted cost when show_cost is true and cost_usd > 0', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, calls: 0, input: 0, output: 0, cost_usd: 5.23, show_cost: true }
+    })
+
+    expect(textContent(element)).toContain('$5.23')
+  })
+
+  it('uses one decimal place for cost >= 10', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, calls: 0, input: 0, output: 0, cost_usd: 125.5, show_cost: true }
+    })
+
+    expect(textContent(element)).toContain('$125.5')
+  })
+
+  it('omits the cost segment when show_cost is absent', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, calls: 0, input: 0, output: 0 }
+    })
+
+    expect(textContent(element)).not.toContain('$')
+  })
+
+  it('omits the cost segment when show_cost is false', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseProps.usage, calls: 0, input: 0, output: 0, cost_usd: 0, show_cost: false }
+    })
+
+    expect(textContent(element)).not.toContain('$')
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -554,6 +554,12 @@ export function StatusRule({
   const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
   const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
+  // Estimated cost for the session (USD). Hidden when zero or included in subscription.
+  const costLabel =
+    usage.cost_usd && usage.cost_usd > 0 && usage.cost_status !== 'included'
+      ? `$${usage.cost_usd < 10 ? usage.cost_usd.toFixed(2) : usage.cost_usd.toFixed(1)}`
+      : ''
+  const showCost = !!costLabel && fits(SEP + stringWidth(costLabel))
   const subagentCount = typeof usage.active_subagents === 'number' ? usage.active_subagents : 0
   const showSubagents = segs.subagents && subagentCount > 0 && fits(SEP + stringWidth(`⛓ ${subagentCount}`))
 
@@ -688,6 +694,12 @@ export function StatusRule({
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
             {bgCount} bg
+          </Text>
+        ) : null}
+        {showCost ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {costLabel}
           </Text>
         ) : null}
         {showSubagents ? (

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -554,11 +554,13 @@ export function StatusRule({
   const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
   const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
-  // Estimated cost for the session (USD). Hidden when zero or included in subscription.
-  const costLabel =
-    usage.cost_usd && usage.cost_usd > 0 && usage.cost_status !== 'included'
-      ? `$${usage.cost_usd < 10 ? usage.cost_usd.toFixed(2) : usage.cost_usd.toFixed(1)}`
-      : ''
+  // Estimated cost for the session (USD).  The gateway sets usage.show_cost
+  // when the user has opted in via display.show_cost; when that flag is set we
+  // render $0.00 for a subscription session whose USD accumulator hasn't moved
+  // yet, matching the classic CLI.
+  const costLabel = usage.show_cost
+    ? `$${(usage.cost_usd ?? 0) < 10 ? (usage.cost_usd ?? 0).toFixed(2) : (usage.cost_usd ?? 0).toFixed(1)}`
+    : ''
   const showCost = !!costLabel && fits(SEP + stringWidth(costLabel))
   const subagentCount = typeof usage.active_subagents === 'number' ? usage.active_subagents : 0
   const showSubagents = segs.subagents && subagentCount > 0 && fits(SEP + stringWidth(`⛓ ${subagentCount}`))

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -195,6 +195,7 @@ export interface Usage {
   input: number
   output: number
   reasoning?: number
+  show_cost?: boolean
   total: number
 }
 


### PR DESCRIPTION
## What

Adds session cost display to the status bar in both CLI and TUI, gated behind `display.show_cost` config (default false).

## Changes

- **CLI** (`cli.py`): adds `cost_usd` to status bar snapshot and all 3 width levels
- **TUI gateway** (`tui_gateway/server.py`): adds `cost_usd` to usage events
- **TUI component** (`ui-tui/src/components/appChrome.tsx`): adds `showCost` segment to StatusRule

## Fix included

The initial implementation only showed the cost when `cost_usd > 0`. Users with Nous subscription track cost in credits, not USD, so `session_estimated_cost_usd` stayed at 0 and the segment never appeared. The fix ensures the segment always shows when `show_cost=True`: `$0.00` if no USD cost, or the real value when present.

## Config

```bash
hermes config set display.show_cost true
```

## Testing

77/77 tests pass (test_cli_status_bar, test_cli_status_bar_goal, test_focus_view, test_cli_background_status_indicator, test_cli_skin_integration, test_cli_status_command).