### PR TITLE
fix(agent): drop empty tool_calls in internal API loop (#6545)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2135,6 +2135,17 @@ def run_conversation(
                         tools_for_api=tools_for_api,
                     )
                 )
+                # Re-run the unconditional pre-API sanitizer on the re-derived
+                # list. _redecorate_prompt_cache_for_provider returns fresh
+                # shallow copies every retry attempt (fallback provider swap,
+                # MoA rebase, cache re-render), so the payload for THIS attempt
+                # must be re-verified before the wire: strict OpenAI-compatible
+                # providers (DeepSeek v4) reject ``tool_calls: []`` with HTTP
+                # 400 at any position, including mid-tool-loop retries (#6545,
+                # upstream of WebUI fix #5737). Idempotent and non-destructive
+                # on the already-clean list; populated tool_calls pass through
+                # unchanged.
+                api_messages = agent._sanitize_api_messages(api_messages)
                 if tools_for_api == agent.tools:
                     api_kwargs = agent._build_api_kwargs(api_messages)
                 else:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -351,6 +351,65 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_retry_loop_rederivation_resanitizes_empty_tool_calls():
+    """#6545 long tool-loop case: every retry attempt re-derives
+    api_messages through ``_redecorate_prompt_cache_for_provider`` (fresh
+    shallow copies that preserve the source list's ``tool_calls`` state).
+    The copies still carry an empty ``tool_calls: []`` array, so the retry
+    loop must re-run ``sanitize_api_messages`` before building kwargs —
+    otherwise a strict provider (DeepSeek v4) 400s the retry with
+    "Invalid 'messages[N].tool_calls': empty array" even though the
+    pre-loop sanitizer already ran once."""
+    from unittest.mock import MagicMock
+
+    from agent.agent_runtime_helpers import sanitize_api_messages
+    from agent.conversation_loop import _redecorate_prompt_cache_for_provider
+
+    agent = MagicMock()
+    agent._use_prompt_caching = False
+    agent.provider = "deepseek"
+    agent.tools = []
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "answer", "tool_calls": []},
+    ]
+    # Re-decoration per retry attempt: shallow copies, empty array preserved.
+    rederived, _prepared, *_tools = _redecorate_prompt_cache_for_provider(
+        agent, messages, tools_for_api=None,
+    )
+    assert any(
+        m.get("role") == "assistant" and m.get("tool_calls") == []
+        for m in rederived
+    )
+
+    # The retry loop re-runs the sanitizer before _build_api_kwargs → dropped,
+    # while content survives.
+    out = sanitize_api_messages(rederived)
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    assert "tool_calls" not in assistant
+    assert assistant["content"] == "answer"
+
+
+def test_retry_loop_resanitizes_before_build_kwargs():
+    """Ordering invariant: the conversation retry loop must re-run the
+    pre-API sanitizer on the re-derived ``api_messages`` BEFORE building
+    request kwargs, so every retry payload is clean (DeepSeek ``tool_calls:
+    []`` HTTP 400 class, #6545). Locked against regression by source order,
+    mirroring test_prompt_caching.py's ordering tests."""
+    import inspect
+
+    from agent import conversation_loop
+
+    src = inspect.getsource(conversation_loop)
+    anchor = src.index("while retry_count < max_retries:")
+    build = src.index("api_kwargs = agent._build_api_kwargs(api_messages)", anchor)
+    sanitize = src.rindex("_sanitize_api_messages(api_messages)", anchor, build)
+    assert sanitize < build, (
+        "retry loop must re-sanitize api_messages before building api_kwargs"
+    )
+
+
 
 
 


### PR DESCRIPTION
Closes #6545 (upstream Agent half; the WebUI issue tracks the full picture).

## What

The conversation retry loop re-derives `api_messages` on **every** retry attempt via
`_redecorate_prompt_cache_for_provider` (fallback provider swap, MoA rebase, cache
re-render all return fresh shallow copies). The pre-API sanitizer
(`sanitize_api_messages`, added in #58755) runs **once** before the loop, but the
payload for each individual attempt was not re-verified after re-derivation.

This PR re-runs `agent._sanitize_api_messages(api_messages)` inside the retry loop,
immediately after re-decoration and **before** `_build_api_kwargs`, so every retry
payload is guaranteed clean at the wire boundary.

## Why

DeepSeek V4 (and other strict OpenAI-compatible providers) reject an assistant
message carrying `tool_calls: []` with `HTTP 400: Invalid 'messages[N].tool_calls':
empty array`. The WebUI fix #5737 only covered the initial send path
(`api/streaming.py`); the agent library's internal tool-execution/retry loop bypassed
it. With this change the final payload of **every** attempt — primary, retry, and
fallback — passes through the sanitizer that drops empty/malformed `tool_calls`.

The sanitizer is idempotent and non-destructive on the already-clean list: it only
shallow-copies messages whose `tool_calls` are empty/malformed, and populated
`tool_calls` arrays pass through unchanged.

## Tests

- `test_retry_loop_rederivation_resanitizes_empty_tool_calls` — proves the
  re-derivation step preserves `tool_calls: []` (i.e. re-decoration is not a
  sanitizer) and that the loop's re-run of `sanitize_api_messages` drops it while
  preserving content (the long tool-loop case from #6545).
- `test_retry_loop_resanitizes_before_build_kwargs` — source-order invariant locking
  the re-sanitize to run before `_build_api_kwargs` inside the retry loop (mirrors
  `test_prompt_caching.py` ordering tests).

Local: `tests/run_agent/test_message_sequence_repair.py` (16 passed),
`tests/agent/test_prompt_caching.py` + related sanitizer suites (58 passed).
