### PR TITLE
fix(state): prevent fd accumulation from short-lived thread-pool workers in SessionDB

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1916,7 +1916,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # hold a reference so short-lived reader threads' connections are
         # not GC'd without close() — that would leak tracked fds in
         # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        self._read_conns: "dict[int, sqlite3.Connection]" = {}
         self._read_conns_lock = threading.Lock()
         # Set when close() begins.  _get_read_conn checks this under the
         # lock so a reader that finishes opening after the drain finds the
@@ -2176,6 +2176,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2194,7 +2195,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn.close()
                     self._read_local.failed = True
                     return None
-                self._read_conns.add(conn)
+                self._read_conns[threading.get_ident()] = conn
         except sqlite3.Error:
             # Mark this thread failed so we don't retry the open on every
             # query; the locked writer connection still serves reads.
@@ -2203,6 +2204,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         self._read_local.conn = conn
         return conn
+
+
+    def _prune_dead_read_conns(self) -> int:
+        """Close and remove read connections whose owning threads are dead.
+
+        Closes each dead-thread connection *before* removing it from the
+        strong registry.  On close failure the entry is retained and logged
+        so the shutdown drain in close() gets another attempt.
+        """
+        active_thread_ids = {t.ident for t in threading.enumerate() if t.ident is not None}
+        pruned = 0
+        # Phase 1: collect dead entries under the lock (no I/O)
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                return 0
+            dead_entries = [
+                (tid, self._read_conns[tid])
+                for tid in list(self._read_conns)
+                if tid not in active_thread_ids
+            ]
+        # Phase 2: close OUTSIDE the lock, then pop on success
+        for tid, conn in dead_entries:
+            try:
+                conn.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close dead-thread read connection (tid=%s); "
+                    "retained for shutdown drain",
+                    tid,
+                )
+                continue  # Entry stays in _read_conns for close()-retry
+            # close succeeded → safe to remove from registry
+            with self._read_conns_lock:
+                # Re-check: concurrent _get_read_conn may have reused this tid
+                if self._read_conns.get(tid) is conn:
+                    del self._read_conns[tid]
+                    pruned += 1
+        return pruned
 
     @contextmanager
     def _read_ctx(self):
@@ -2214,6 +2253,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
+        if self._read_conns:
+            self._prune_dead_read_conns()
         conn = self._get_read_conn()
         if conn is not None:
             yield conn
@@ -2737,7 +2778,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # connection after the drain.
         with self._read_conns_lock:
             self._read_conns_closed = True
-            read_conns = list(self._read_conns)
+            read_conns = list(self._read_conns.values())
             self._read_conns.clear()
         for conn in read_conns:
             try:

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -167,3 +167,43 @@ def test_session_resume_reads_do_not_take_writer_lock(db):
         assert len(done["ancestor_prefix"]) == 2
     finally:
         db._lock.release()
+
+
+@pytest.mark.requires_wal
+def test_prune_fires_through_read_ctx_no_explicit_call(db):
+    """Prune fires through _read_ctx; callers never need to call it directly.
+
+    When a read operation goes through _read_ctx (the WAL read-path
+    context manager), dead-thread connections are pruned automatically.
+    Callers of get_session / search_messages / get_messages etc. get
+    prune-for-free without explicitly calling _prune_dead_read_conns.
+    """
+    import time
+
+    dead_tids = []
+
+    def open_and_die():
+        conn = db._get_read_conn()
+        assert conn is not None
+        dead_tids.append(threading.get_ident())
+
+    t = threading.Thread(target=open_and_die)
+    t.start()
+    t.join()
+
+    assert len(dead_tids) == 1
+    dead_tid = dead_tids[0]
+
+    # Verify dead_tid is in _read_conns before the read
+    with db._read_conns_lock:
+        assert dead_tid in db._read_conns, "dead thread entry missing before read"
+
+    # Any read through _read_ctx triggers prune — no explicit call needed
+    result = db.get_session("s1")
+    assert result["id"] == "s1"
+
+    # The dead thread's connection was pruned by _read_ctx
+    with db._read_conns_lock:
+        assert dead_tid not in db._read_conns, (
+            "dead thread entry leaked after read through _read_ctx"
+        )

--- a/tests/test_sessiondb_prune.py
+++ b/tests/test_sessiondb_prune.py
@@ -1,0 +1,155 @@
+"""Tests for SessionDB._prune_dead_read_conns and cross-thread close safety.
+
+Covers the three critical fixes from PR #76424:
+- check_same_thread=False in _get_read_conn
+- Two-phase prune (close-before-pop, I/O outside lock, retain on failure)
+- Cross-thread close without ProgrammingError
+"""
+
+import logging
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    yield d
+    d.close()
+
+
+# ── test_prune_dead_read_conns_success ────────────────────────────
+
+
+@pytest.mark.requires_wal
+def test_prune_dead_read_conns_success(db):
+    """Threads open read connections, then die — prune removes their entries.
+
+    After prune, only the main thread's read connection (if any) remains
+    in _read_conns.
+    """
+    main_tid = threading.get_ident()
+
+    def open_and_die(results: list):
+        conn = db._get_read_conn()
+        assert conn is not None
+        results.append(threading.get_ident())
+    # Open a read connection in the main thread so it has an entry
+    main_conn = db._get_read_conn()
+    assert main_conn is not None
+
+    results: list[int] = []
+    threads = []
+    for _ in range(4):
+        t = threading.Thread(target=open_and_die, args=(results,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # Threads are dead now — their tids should be in _read_conns
+    dead_tids = set(results)
+    with db._read_conns_lock:
+        pre_tids = set(db._read_conns.keys())
+    assert dead_tids.issubset(pre_tids), "dead thread entries missing before prune"
+
+    pruned = db._prune_dead_read_conns()
+    assert pruned == len(threads), f"expected {len(threads)} pruned, got {pruned}"
+
+    with db._read_conns_lock:
+        remaining = dict(db._read_conns)
+    assert main_tid in remaining, "main thread entry should be present"
+    assert main_tid not in dead_tids or True  # main_tid not in dead_tids by construction
+    # Check no dead tids remain
+    for tid in dead_tids:
+        assert tid not in remaining, f"dead tid {tid} leaked after prune"
+
+
+# ── test_prune_dead_read_conns_failed_close_retained ──────────────
+
+
+@pytest.mark.requires_wal
+def test_prune_dead_read_conns_failed_close_retained(db, monkeypatch, caplog):
+    """When conn.close() raises, the entry stays in _read_conns and a warning is logged."""
+
+    def open_conn():
+        db._get_read_conn()
+
+    t = threading.Thread(target=open_conn)
+    t.start()
+    t.join()
+
+    with db._read_conns_lock:
+        dead_tid = next(
+            tid for tid in db._read_conns if tid != threading.get_ident()
+        )
+        dead_conn = db._read_conns[dead_tid]
+
+    # Make close() fail on the dead thread's connection
+    original_close = dead_conn.close
+    close_failed = threading.Event()
+
+    def failing_close():
+        close_failed.set()
+        raise OSError("simulated close failure")
+
+    monkeypatch.setattr(dead_conn, "close", failing_close)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        pruned = db._prune_dead_read_conns()
+
+    assert pruned == 0, "nothing should be pruned when close fails"
+    assert close_failed.is_set(), "failing_close must have been called"
+
+    with db._read_conns_lock:
+        assert dead_tid in db._read_conns, "failed-close entry must be retained"
+        assert db._read_conns[dead_tid] is dead_conn, "retained entry must be same object"
+
+    assert any(
+        "Failed to close dead-thread read connection" in rec.message
+        for rec in caplog.records
+    ), "warning must be logged on close failure"
+
+    # Restore close so the cleanup path succeeds
+    monkeypatch.setattr(dead_conn, "close", original_close)
+
+
+# ── test_cross_thread_close_with_check_same_thread_false ──────────
+
+
+@pytest.mark.requires_wal
+def test_cross_thread_close_with_check_same_thread_false(db):
+    """Thread A opens a connection; Thread B closes it via prune — no ProgrammingError.
+
+    Without check_same_thread=False, sqlite3 raises ProgrammingError when a
+    connection is closed from a different thread than the one that opened it.
+    """
+    conn_holder: list = []
+    opened = threading.Event()
+
+    def thread_a():
+        conn_holder.append(db._get_read_conn())
+        opened.set()
+        # Don't close — simulate thread death so prune finds it
+
+    t = threading.Thread(target=thread_a)
+    t.start()
+    t.join()
+    assert opened.wait(5), "thread A must open a connection"
+
+    assert len(conn_holder) == 1
+    assert conn_holder[0] is not None
+
+    # Thread A is dead. Prune should close its connection from main thread
+    # without raising ProgrammingError.
+    pruned = db._prune_dead_read_conns()
+    assert pruned == 1, f"expected 1 pruned, got {pruned}"
+
+    with db._read_conns_lock:
+        assert threading.get_ident() in db._read_conns or len(db._read_conns) == 0


### PR DESCRIPTION
## Summary

`SessionDB._read_conns` is a `dict[int, Connection]` that adds connections in `_get_read_conn()` but only removes them in `close()`. On a long-running gateway or desktop agent, every short-lived thread-pool worker leaks one `sqlite3.Connection` + its `-wal`/`-shm` file descriptors.

## Fix

- **`_prune_dead_read_conns()`** — Reaps connections owned by finished threads at runtime
- **Cross-thread close** with `check_same_thread=False` for worker-owned connections
- **Safe prune ordering** — close before pop, preserving `sqlite_safe_read.py` tracking contract
- **James Meadlock's ownership concern** resolved: connection is closed first, then removed from `_read_conns`

## Verification

- [x] Cross-thread close support (`check_same_thread=False`)
- [x] Prune ordering matches `sqlite_safe_read.py` contract
- [x] monerostar tested on Windows: 12 before prune, 1 after ✅