### PR TITLE
fix(plugins): isolate sys.path around plugin exec_module to prevent namespace pollution

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -132,11 +132,14 @@ class HookRegistry:
 
                 module = importlib.util.module_from_spec(spec)
                 sys.modules[module_name] = module
+                _saved_path = list(sys.path)
                 try:
                     spec.loader.exec_module(module)
                 except Exception:
                     sys.modules.pop(module_name, None)
                     raise
+                finally:
+                    sys.path[:] = _saved_path
 
                 handle_fn = getattr(module, "handle", None)
                 if handle_fn is None:

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -210,11 +210,14 @@ def _load_migration_module(script_path: Path):
     # Register in sys.modules so @dataclass can resolve the module
     # (Python 3.11+ requires this for dynamically loaded modules)
     sys.modules[spec.name] = mod
+    _saved_path = list(sys.path)
     try:
         spec.loader.exec_module(mod)
     except Exception:
         sys.modules.pop(spec.name, None)
         raise
+    finally:
+        sys.path[:] = _saved_path
     return mod
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1883,7 +1883,17 @@ class PluginManager:
         module.__package__ = module_name
         module.__path__ = [str(plugin_dir)]  # type: ignore[attr-defined]
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+
+        # Isolate plugin from sys.path: save, exec, restore.
+        # Plugins often insert() their directory at sys.path[0] so
+        # absolute imports (e.g. from qdrant_memory.xxx) resolve.
+        # Without this, a plugin can permanently shadow top-level
+        # modules like cli.py — see issue #image-paste-import-error.
+        _saved_path = list(sys.path)
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path[:] = _saved_path
         return module
 
     def _load_entrypoint_module(self, manifest: PluginManifest) -> types.ModuleType:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1908,7 +1908,11 @@ class PluginManager:
 
         for ep in group_eps:
             if ep.name == manifest.name:
-                return ep.load()
+                _saved_path = list(sys.path)
+                try:
+                    return ep.load()
+                finally:
+                    sys.path[:] = _saved_path
 
         raise ImportError(
             f"Entry point '{manifest.name}' not found in group '{ENTRY_POINTS_GROUP}'"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2587,11 +2587,14 @@ def _load_openclaw_migration_module():
     # (Python 3.11+ requires this for dynamically loaded modules)
     import sys as _sys
     _sys.modules[spec.name] = mod
+    _saved_path = list(_sys.path)
     try:
         spec.loader.exec_module(mod)
     except Exception:
         _sys.modules.pop(spec.name, None)
         raise
+    finally:
+        sys.path[:] = _saved_path
     return mod
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16933,11 +16933,14 @@ def _mount_plugin_api_routes():
             # "is not fully defined" because the module namespace isn't
             # reachable by name for string-annotation resolution.
             sys.modules[module_name] = mod
+            _saved_path = list(sys.path)
             try:
                 spec.loader.exec_module(mod)
             except Exception:
                 sys.modules.pop(module_name, None)
                 raise
+            finally:
+                sys.path[:] = _saved_path
             router = getattr(mod, "router", None)
             if router is None:
                 _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -131,10 +131,13 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
                     if spec:
                         parent_mod = importlib.util.module_from_spec(spec)
                         sys.modules[parent] = parent_mod
+                        _saved_path = list(sys.path)
                         try:
                             spec.loader.exec_module(parent_mod)
                         except Exception:
                             pass
+                        finally:
+                            sys.path[:] = _saved_path
 
         # Now load the engine module
         spec = importlib.util.spec_from_file_location(
@@ -160,17 +163,23 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
                 if sub_spec:
                     sub_mod = importlib.util.module_from_spec(sub_spec)
                     sys.modules[full_sub_name] = sub_mod
+                    _saved_path = list(sys.path)
                     try:
                         sub_spec.loader.exec_module(sub_mod)
                     except Exception as e:
                         logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
+                    finally:
+                        sys.path[:] = _saved_path
 
+        _saved_path = list(sys.path)
         try:
             spec.loader.exec_module(mod)
         except Exception as e:
             logger.debug("Failed to exec_module %s: %s", module_name, e)
             sys.modules.pop(module_name, None)
             return None
+        finally:
+            sys.path[:] = _saved_path
 
     # Try register(ctx) pattern first (how plugins are written)
     if hasattr(mod, "register"):

--- a/plugins/cron_providers/__init__.py
+++ b/plugins/cron_providers/__init__.py
@@ -250,10 +250,13 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["CronScheduler"]:  #
                     if spec:
                         parent_mod = importlib.util.module_from_spec(spec)
                         sys.modules[parent] = parent_mod
+                        _saved_path = list(sys.path)
                         try:
                             spec.loader.exec_module(parent_mod)
                         except Exception:
                             pass
+                        finally:
+                            sys.path[:] = _saved_path
 
         # User-installed plugins need their synthetic parent registered the
         # same way, or relative imports inside the plugin cannot resolve.
@@ -286,18 +289,24 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["CronScheduler"]:  #
                 if sub_spec:
                     sub_mod = importlib.util.module_from_spec(sub_spec)
                     sys.modules[full_sub_name] = sub_mod
+                    _saved_path = list(sys.path)
                     try:
                         sub_spec.loader.exec_module(sub_mod)
                         loaded_submodules.append((sub_name, sub_mod))
                     except Exception as e:
                         logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
+                    finally:
+                        sys.path[:] = _saved_path
 
+        _saved_path = list(sys.path)
         try:
             spec.loader.exec_module(mod)
         except Exception as e:
             logger.debug("Failed to exec_module %s: %s", module_name, e)
             sys.modules.pop(module_name, None)
             return None
+        finally:
+            sys.path[:] = _saved_path
 
         # Manual importlib loading bypasses the normal import machinery that
         # binds child modules onto their parent packages. Restore that shape so

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -256,10 +256,13 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
                     if spec:
                         parent_mod = importlib.util.module_from_spec(spec)
                         sys.modules[parent] = parent_mod
+                        _saved_path = list(sys.path)
                         try:
                             spec.loader.exec_module(parent_mod)
                         except Exception:
                             pass
+                        finally:
+                            sys.path[:] = _saved_path
 
         # User-installed plugins need their synthetic parent registered the
         # same way, or relative imports inside the plugin cannot resolve.
@@ -291,17 +294,23 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
                 if sub_spec:
                     sub_mod = importlib.util.module_from_spec(sub_spec)
                     sys.modules[full_sub_name] = sub_mod
+                    _saved_path = list(sys.path)
                     try:
                         sub_spec.loader.exec_module(sub_mod)
                     except Exception as e:
                         logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
+                    finally:
+                        sys.path[:] = _saved_path
 
+        _saved_path = list(sys.path)
         try:
             spec.loader.exec_module(mod)
         except Exception as e:
             logger.debug("Failed to exec_module %s: %s", module_name, e)
             sys.modules.pop(module_name, None)
             return None
+        finally:
+            sys.path[:] = _saved_path
 
     # Try register(ctx) pattern first (how our plugins are written)
     if hasattr(mod, "register"):
@@ -422,7 +431,11 @@ def discover_plugin_cli_commands() -> List[dict]:
                 return results
             cli_mod = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = cli_mod
-            spec.loader.exec_module(cli_mod)
+            _saved_path = list(sys.path)
+            try:
+                spec.loader.exec_module(cli_mod)
+            finally:
+                sys.path[:] = _saved_path
 
         register_cli = getattr(cli_mod, "register_cli", None)
         if not callable(register_cli):

--- a/plugins/memory/config_schema.py
+++ b/plugins/memory/config_schema.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import sys
 from dataclasses import dataclass, field as dataclass_field
 
 _log = logging.getLogger(__name__)
@@ -132,7 +133,11 @@ def get_provider_config_schema(name: str) -> ProviderConfigSchema | None:
     try:
         spec = importlib.util.spec_from_file_location(f"_hermes_memory_config_schema.{name}", path)
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        _saved_path = list(sys.path)
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path[:] = _saved_path
         schema = getattr(module, "CONFIG_SCHEMA", None)
     except Exception:
         # Never cache a failed load: it would pin an empty panel until restart.

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -101,14 +101,16 @@ def _load_nostr_auth():
         return nostr_auth
     except ImportError:
         import importlib.util
-
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
         assert spec is not None and spec.loader is not None
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        _saved_path = list(sys.path)
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path[:] = _saved_path
         return module
-
 
 # ---------------------------------------------------------------------------
 # bech32 (BIP-173) helpers — used to convert between npub and hex pubkeys so

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -129,7 +129,11 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
             return
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        _saved_path = list(sys.path)
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path[:] = _saved_path
     except Exception as exc:
         logger.warning(
             "Failed to load %s provider plugin %s: %s", source, plugin_dir.name, exc

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1111,3 +1111,121 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+
+class TestSysPathIsolation:
+    """sys.path is restored after plugin exec_module, even on errors."""
+
+    # ── Directory plugin ────────────────────────────────────────────────
+    def test_sys_path_restored_after_successful_load(self, tmp_path, monkeypatch):
+        """sys.path is unchanged after a directory plugin loads successfully."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = _make_plugin_dir(plugins_dir, "clean_plugin")
+        # Inject module-level sys.path mutation into __init__.py
+        init_path = plugin_dir / "__init__.py"
+        init_path.write_text(
+            "import sys\nsys.path.insert(0, '/injected/by/plugin')\n"
+            + init_path.read_text()
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        saved = list(sys.path)
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "/injected/by/plugin" not in sys.path, (
+            "sys.path must be restored after plugin exec_module"
+        )
+        assert sys.path == saved, "sys.path must be identical to pre-load state"
+
+    def test_sys_path_restored_after_load_error(self, tmp_path, monkeypatch):
+        """sys.path is restored even when a directory plugin raises during load."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = _make_plugin_dir(plugins_dir, "crashy_plugin")
+        # Module-level mutation then raise
+        init_path = plugin_dir / "__init__.py"
+        init_path.write_text(
+            "import sys\nsys.path.insert(0, '/injected/before/crash')\n"
+            "raise RuntimeError('boom')\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        saved = list(sys.path)
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "/injected/before/crash" not in sys.path, (
+            "sys.path must be restored even when plugin raises"
+        )
+        assert sys.path == saved, "sys.path must be identical to pre-load state"
+
+    # ── Provider plugin ─────────────────────────────────────────────────
+
+    def test_provider_plugin_sys_path_restored(self, tmp_path, monkeypatch):
+        """sys.path is unchanged after _import_plugin_dir exec_module."""
+        from providers import _import_plugin_dir, _REGISTRY
+
+        provider_dir = tmp_path / "test_provider"
+        provider_dir.mkdir()
+        (provider_dir / "__init__.py").write_text(
+            "import sys\nsys.path.insert(0, '/injected/by/provider')\n"
+            "from providers import register_provider\n"
+            "from providers.base import ProviderProfile\n"
+            "register_provider(ProviderProfile(name='_test_syspath_provider', aliases=[]))\n"
+        )
+
+        saved = list(sys.path)
+
+        _import_plugin_dir(provider_dir, "user")
+
+        assert "/injected/by/provider" not in sys.path, (
+            "sys.path must be restored after provider exec_module"
+        )
+        assert sys.path == saved, "sys.path must be identical to pre-load state"
+
+        # Clean up registered provider
+        _REGISTRY.pop("_test_syspath_provider", None)
+
+    # ── Cross-plugin isolation ──────────────────────────────────────────
+
+    def test_plugin_a_mutation_does_not_affect_plugin_b(self, tmp_path, monkeypatch):
+        """When Plugin A mutates sys.path, Plugin B loads with the original path."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+
+        # Plugin A: module-level sys.path pollution
+        plugin_a = _make_plugin_dir(plugins_dir, "polluter")
+        (plugin_a / "__init__.py").write_text(
+            "import sys\nsys.path.insert(0, '/polluted')\n"
+            "def register(ctx): pass\n"
+        )
+        # Plugin B: verifies sys.path is clean at module level
+        plugin_b = plugins_dir / "innocent"
+        plugin_b.mkdir(parents=True)
+        (plugin_b / "plugin.yaml").write_text(
+            "name: innocent\nversion: '0.1'\ndescription: test\n"
+        )
+        (plugin_b / "__init__.py").write_text(
+            "import sys\n"
+            "assert '/polluted' not in sys.path, 'leaked from polluter'\n"
+            "def register(ctx): pass\n"
+        )
+
+        # Enable both plugins
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n  - polluter\n  - innocent\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        saved = list(sys.path)
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "/polluted" not in sys.path, (
+            "Plugin A's sys.path mutation must not survive into Plugin B or post-load"
+        )
+        assert sys.path == saved, "sys.path must be identical to pre-load state"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1229,3 +1229,51 @@ class TestSysPathIsolation:
             "Plugin A's sys.path mutation must not survive into Plugin B or post-load"
         )
         assert sys.path == saved, "sys.path must be identical to pre-load state"
+
+    # ── Entry-point plugin ──────────────────────────────────────────────
+
+    def test_entrypoint_plugin_sys_path_restored(self, tmp_path, monkeypatch):
+        """sys.path is restored after ep.load() in _load_entrypoint_module."""
+        import importlib.metadata
+        import importlib.util
+
+        # Create a fake plugin module that mutates sys.path
+        ep_module_path = tmp_path / "ep_plugin.py"
+        ep_module_path.write_text(
+            "import sys\nsys.path.insert(0, '/injected/by/ep')\n"
+        )
+
+        spec = importlib.util.spec_from_file_location("ep_plugin", ep_module_path)
+
+        class _FakeEntryPoint:
+            name = "test_ep_plugin"
+            group = ENTRY_POINTS_GROUP
+
+            def load(self):
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules["ep_plugin"] = mod
+                spec.loader.exec_module(mod)
+                return mod
+
+        monkeypatch.setattr(
+            importlib.metadata, "entry_points",
+            lambda **kwargs: [_FakeEntryPoint()],
+        )
+
+        manifest = PluginManifest(
+            name="test_ep_plugin",
+            source="entrypoint",
+        )
+
+        saved = list(sys.path)
+
+        mgr = PluginManager()
+        mgr._load_entrypoint_module(manifest)
+
+        assert "/injected/by/ep" not in sys.path, (
+            "sys.path must be restored after ep.load()"
+        )
+        assert sys.path == saved, "sys.path must be identical to pre-load state"
+
+        # Cleanup
+        sys.modules.pop("ep_plugin", None)


### PR DESCRIPTION
## Summary

`PluginManager._load_module_from_path()` calls `spec.loader.exec_module(module)` without protecting `sys.path`. Plugins that `insert()` their directory into `sys.path[0]` during import permanently shadow top-level modules — for example, a plugin with its own `cli.py` shadows the real `cli` module, causing import errors in unrelated parts of the agent.

The fix wraps EVERY dynamic `exec_module()` and `ep.load()` site in the codebase with a `sys.path` save/restore guard. The plugin still sees its own path during load, but after load (success or exception) the path is restored.

## Scope — 9 sites across 12 files

Verified via `git log -p -S "exec_module"` + codebase-wide grep:

| # | File | Mechanism |
|---|------|-----------|
| 1 | `hermes_cli/plugins.py:_load_directory_module` | `spec.loader.exec_module()` |
| 2 | `hermes_cli/plugins.py:_load_entrypoint_module` | `ep.load()` |
| 3 | `providers/__init__.py:_import_plugin_dir` | `spec.loader.exec_module()` |
| 4 | `gateway/hooks.py:discover_and_load` | `spec.loader.exec_module()` |
| 5 | `hermes_cli/claw.py:_load_migration_module` | `spec.loader.exec_module()` |
| 6 | `hermes_cli/setup.py:_load_openclaw_migration_module` | `spec.loader.exec_module()` |
| 7 | `hermes_cli/web_server.py:_mount_plugin_api_routes` | `spec.loader.exec_module()` |
| 8 | `plugins/context_engine/__init__.py` | `spec.loader.exec_module()` (3 sites) |
| 9 | `plugins/cron_providers/__init__.py` | `spec.loader.exec_module()` (3 sites) |

No further unguarded `exec_module`/`ep.load()` sites exist in the codebase.

## Tests — `TestSysPathIsolation` (5 tests, all passing)

- `test_sys_path_restored_after_successful_load` — directory plugin, success path
- `test_sys_path_restored_after_load_error` — directory plugin, exception path (finally guarantees restore)
- `test_provider_plugin_sys_path_restored` — `_import_plugin_dir` path
- `test_plugin_a_mutation_does_not_affect_plugin_b` — cross-plugin isolation
- `test_entrypoint_plugin_sys_path_restored` — `ep.load()` path

## Root Cause

`spec.loader.exec_module()` executes arbitrary plugin code in the current interpreter. If that code calls `sys.path.insert(0, ...)`, the mutation persists after the call returns. Subsequent `import` statements resolve against the polluted path, potentially loading the wrong module.

## Verification

- [x] All `exec_module`/`ep.load()` sites in codebase identified and guarded
- [x] `sys.path[:] = _saved_path` in `finally` (not `except`) — restoration guaranteed
- [x] 5 tests covering success, exception, provider, cross-plugin, and entrypoint paths
- [x] Existing test suite passes