### PR TITLE
fix: forward reasoning_effort "max" for Kimi K3 models only

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1861,6 +1861,42 @@ def _model_name_suggests_kimi(model: str) -> bool:
     return lower.startswith("kimi") or "moonshot" in lower
 
 
+_KIMI_K3_MODEL_RE = re.compile(r"(?:^|[^a-z0-9])k3(?:[^a-z0-9]|$)")
+
+
+def is_kimi_k3_model(model: str | None) -> bool:
+    """Return True for Kimi K3-family model identifiers.
+
+    Matches ``k3`` (Kimi Coding bare slug), ``k3-256k`` (Coding-plan
+    variant), ``kimi-k3``, ``kimi-k3-cot``, ``moonshotai/kimi-k3`` and
+    similar spellings, without matching K2.x names (``kimi-k2.6`` …).
+
+    K3 is the only Kimi family whose API documents top-level
+    ``reasoning_effort`` values ``low`` / ``high`` / ``max`` (server
+    default ``max``); K2.x uses the ``thinking`` toggle instead.
+    """
+    name = (model or "").strip().lower()
+    if not name:
+        return False
+    return _KIMI_K3_MODEL_RE.search(name) is not None
+
+
+def normalize_kimi_reasoning_effort(
+    model: str | None, effort: str | None
+) -> str | None:
+    """Map Hermes effort tiers to Kimi's family-specific wire values."""
+    normalized = (effort or "").strip().lower()
+    if not is_kimi_k3_model(model):
+        return normalized if normalized in {"low", "medium", "high"} else None
+    if normalized == "low":
+        return "low"
+    if normalized in {"medium", "high"}:
+        return "high"
+    if normalized in {"xhigh", "ultra", "max"}:
+        return "max"
+    return None
+
+
 def _model_name_suggests_minimax_m3(model: str) -> bool:
     """Return True if the model name looks like MiniMax M3.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -12,6 +12,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.model_metadata import is_kimi_k3_model, normalize_kimi_reasoning_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -389,7 +390,10 @@ class ChatCompletionsTransport(ProviderTransport):
         elif anthropic_max_out is not None:
             api_kwargs["max_tokens"] = anthropic_max_out
 
-        # Kimi: top-level reasoning_effort (unless thinking disabled)
+        # Kimi: top-level reasoning_effort (unless thinking disabled).
+        # K3 models additionally accept "max" (K3 documents low/high/max,
+        # server default max); K2.x stays on low/medium/high only.
+        _kimi_thinking_off = False
         if is_kimi:
             _kimi_thinking_off = bool(
                 reasoning_config
@@ -399,9 +403,11 @@ class ChatCompletionsTransport(ProviderTransport):
             if not _kimi_thinking_off:
                 _kimi_effort = "medium"
                 if reasoning_config and isinstance(reasoning_config, dict):
-                    _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in {"low", "medium", "high"}:
-                        _kimi_effort = _e
+                    _mapped_effort = normalize_kimi_reasoning_effort(
+                        model, reasoning_config.get("effort")
+                    )
+                    if _mapped_effort is not None:
+                        _kimi_effort = _mapped_effort
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
         # Tencent TokenHub: top-level reasoning_effort (unless thinking disabled)
@@ -458,8 +464,9 @@ class ChatCompletionsTransport(ProviderTransport):
                         {"id": "pareto-router", "min_coding_score": _pareto_score_f}
                     ]
 
-        # Kimi extra_body.thinking
-        if is_kimi:
+        # K3 effort and thinking controls are mutually exclusive. Preserve the
+        # historical thinking shape for non-K3 Kimi models.
+        if is_kimi and (_kimi_thinking_off or not is_kimi_k3_model(model)):
             _kimi_thinking_enabled = True
             if reasoning_config and isinstance(reasoning_config, dict):
                 if reasoning_config.get("enabled") is False:

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -14,6 +14,21 @@ from providers import register_provider
 from providers.base import OMIT_TEMPERATURE, ProviderProfile
 
 
+def _normalize_kimi_reasoning_effort(
+    model: str | None, effort: str | None
+) -> str | None:
+    """Delegate to the shared Kimi effort policy lazily.
+
+    Imported at call time: ``agent.model_metadata`` pulls in heavy agent
+    machinery that is still initializing while provider plugins load, so a
+    module-level import here creates a circular-import failure at plugin
+    discovery.
+    """
+    from agent.model_metadata import normalize_kimi_reasoning_effort
+
+    return normalize_kimi_reasoning_effort(model, effort)
+
+
 def _is_confirmed_kimi_coding_url(base_url: str) -> bool:
     """Return True only for Kimi Code's canonical HTTPS API surfaces."""
     try:
@@ -86,8 +101,12 @@ class KimiProfile(ProviderProfile):
 
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
-        effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        # K3 models additionally accept "max" (K3 documents low/high/max,
+        # server default max); K2.x stays on low/medium/high only.
+        effort = _normalize_kimi_reasoning_effort(
+            context.get("model"), reasoning_config.get("effort")
+        )
+        if effort is not None:
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -286,6 +286,28 @@ class TestDefaultContextLengths:
                     ) == 1_048_576
 
 
+class TestIsKimiK3Model:
+    """``is_kimi_k3_model`` gates K3-only wire behavior (reasoning_effort=max)."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["k3", "k3-256k", "kimi-k3", "kimi-k3-cot", "moonshotai/kimi-k3", "Kimi-K3", "kimi/kimi-k3-0711"],
+    )
+    def test_k3_family_matches(self, model):
+        from agent.model_metadata import is_kimi_k3_model
+
+        assert is_kimi_k3_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        ["kimi-k2.6", "kimi-k2-turbo-preview", "kimi-k2-thinking", "moonshotai/kimi-k2.6", None, "", "gpt-5.6"],
+    )
+    def test_non_k3_models_do_not_match(self, model):
+        from agent.model_metadata import is_kimi_k3_model
+
+        assert is_kimi_k3_model(model) is False
+
+
     def test_xai_oauth_grok_build_uses_xai_models_dev_context(self):
         """xAI OAuth should share the xAI provider metadata path.
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -537,3 +537,57 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
 
+
+class TestChatCompletionsKimiLegacyReasoningEffort:
+    """Legacy (profile-less) Kimi path: K3 forwards "max", K2.x clamps."""
+
+    def _build(self, transport, model, effort):
+        return transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            is_kimi=True,
+            reasoning_config={"enabled": True, "effort": effort},
+            base_url="https://api.kimi.com/coding",
+        )
+
+    @pytest.mark.parametrize("model", ["k3", "k3-256k", "kimi-k3", "moonshotai/kimi-k3"])
+    def test_k3_models_forward_max_effort(self, transport, model):
+        kw = self._build(transport, model, "max")
+        assert kw["reasoning_effort"] == "max"
+        assert "thinking" not in kw.get("extra_body", {})
+
+    @pytest.mark.parametrize("effort", ["xhigh", "ultra"])
+    def test_k3_models_map_stronger_efforts_to_max(self, transport, effort):
+        kw = self._build(transport, "k3", effort)
+        assert kw["reasoning_effort"] == "max"
+        assert "thinking" not in kw.get("extra_body", {})
+
+    def test_k3_maps_medium_to_supported_high(self, transport):
+        kw = self._build(transport, "k3", "medium")
+        assert kw["reasoning_effort"] == "high"
+        assert "thinking" not in kw.get("extra_body", {})
+
+    @pytest.mark.parametrize("model", ["kimi-k2.6", "kimi-k2-turbo-preview"])
+    def test_k2_models_clamp_max_to_medium(self, transport, model):
+        kw = self._build(transport, model, "max")
+        assert kw["reasoning_effort"] == "medium"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_documented_efforts_pass_for_all_kimi(self, transport, effort):
+        kw = self._build(transport, "kimi-k2.6", effort)
+        assert kw["reasoning_effort"] == effort
+
+    def test_thinking_disabled_omits_effort(self, transport):
+        kw = transport.build_kwargs(
+            model="k3-256k",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            is_kimi=True,
+            reasoning_config={"enabled": False},
+            base_url="https://api.kimi.com/coding",
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -77,6 +77,46 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
+    @pytest.mark.parametrize("model", ["k3", "k3-256k", "kimi-k3", "kimi/kimi-k3-0711"])
+    def test_k3_models_accept_max_effort(self, kimi_profile, model):
+        """K3's API documents reasoning_effort low/high/max — "max" must be
+        forwarded verbatim for K3-family models, not dropped to thinking."""
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "max"}
+        assert "thinking" not in extra_body
+
+    @pytest.mark.parametrize("model", ["kimi-k2-turbo-preview", "kimi-k2.6", None, ""])
+    def test_non_k3_models_reject_max_effort(self, kimi_profile, model):
+        """K2.x and unknown models stay on low/medium/high — "max" falls back
+        to the thinking toggle rather than sending an invalid effort."""
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "ultra"])
+    def test_k3_models_map_stronger_hermes_efforts_to_max(
+        self, kimi_profile, effort
+    ):
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="k3-256k",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_k3_maps_medium_to_supported_high(self, kimi_profile):
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"}, model="k3"
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
 
     @pytest.mark.parametrize(
         "reasoning_config",


### PR DESCRIPTION
## Summary
- Kimi K3 documents top-level `reasoning_effort` values `low` / `high` / `max` (server default `max`). Both Kimi reasoning paths in Hermes clamped efforts to `low`/`medium`/`high`: the `kimi-coding` provider profile dropped a configured `max` to the `thinking` toggle, and the legacy `is_kimi` transport branch silently rewrote it to `medium`.
- This PR adds a shared `is_kimi_k3_model()` family check in `agent/model_metadata.py` and gates `max` on it in both paths: K3 ids (`k3`, `k3-256k`, `kimi-k3`, `kimi-k3-cot`, `moonshotai/kimi-k3`, …) now forward `max` verbatim, while K2.x and unknown models keep the historical `low`/`medium`/`high` clamp.
- Related work: #69648 forwards `max` for all Kimi ids but does not gate by model family and also unguards the bare-`k3` discovery filter; #73682 builds a broader family-ceiling mechanism across providers. This PR stays scoped to the Kimi family and leaves the K3 endpoint discovery guard untouched.

## Validation
- [ ] Not run (explain why)
- [x] Minimal checks run
- [ ] Broader relevant tests run
- [x] Manual verification performed

## Test plan
- [x] `python3 -m pytest tests/plugins/model_providers/test_kimi_profile.py tests/agent/transports/test_chat_completions.py tests/agent/test_model_metadata.py -q` (142 passed, both orderings — guards the plugin-discovery import cycle)
- [x] `python3 -m pytest tests/test_model_tools.py -q` (20 passed)
- [x] Manual wire verification against `https://api.kimi.com/coding/v1/chat/completions` with `k3-256k` + `reasoning_effort: "max"` → HTTP 200 (config: `agent.reasoning_effort: max`, provider `kimi-coding`)
- New tests: K3 ids accept `max` on profile and legacy paths; `kimi-k2.6`/`kimi-k2-turbo-preview`/None keep the clamp (`max` → thinking toggle on the profile, `medium` on legacy); `xhigh`/`ultra` still rejected for K3; `is_kimi_k3_model` unit tests; plugin-discovery regression (importing `agent.model_metadata` before `model_tools` must not unregister `kimi-coding` — the helper is imported lazily inside the call to avoid the circular import).