### PR TITLE
feat(approval): add approvals.noninteractive_mode for headless contexts

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1967,6 +1967,13 @@ DEFAULT_CONFIG = {
     #   deny    — block the command and let the agent find another way (default, safe)
     #   approve — auto-approve all dangerous commands in cron jobs
     #
+    # noninteractive_mode — the same choice for a run that is headless but NOT
+    # cron: a scripted invocation, hermes-agent embedded as a library, a test
+    # harness, a dispatched kanban worker. That path has always auto-approved
+    # everything below the hardline floor with nobody present to answer.
+    #   approve — keep that behaviour (default, so an upgrade changes nothing)
+    #   deny    — block instead; operators opt in
+    #
     # timeout — seconds to wait for the user's approve/deny before failing
     # closed (deny). Shared by the CLI prompt and gateway/messaging waits.
     # Messaging approvals arrive as a push notification the user may not see
@@ -1976,6 +1983,7 @@ DEFAULT_CONFIG = {
         "mode": "smart",
         "timeout": 300,
         "cron_mode": "deny",
+        "noninteractive_mode": "approve",
         # Operator-customizable policy text for smart approvals. When
         # non-empty, this is appended to the smart-approval guardian's
         # SYSTEM prompt (trusted channel) as additional rules — e.g.

--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -12,7 +12,7 @@ Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configurat
 | `terminal` | `backend` (local/docker/ssh/modal/daytona/singularity), `cwd`, `timeout` (180) |
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
 | `display` | `skin`, `interface` (cli/tui), `language`, `show_reasoning`, `show_cost`, `pet` |
-| `approvals` | `mode` (smart/manual/off), `timeout`, `cron_mode` |
+| `approvals` | `mode` (smart/manual/off), `timeout`, `cron_mode`, `noninteractive_mode` |
 | `stt` | `enabled`, `provider` (local/groq/openai/mistral/elevenlabs/deepinfra) |
 | `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts/gemini/piper/kittentts/deepinfra/xai) |
 | `memory` | `memory_enabled`, `user_profile_enabled`, `provider`, `write_approval` |

--- a/tests/tools/test_noninteractive_approval_mode.py
+++ b/tests/tools/test_noninteractive_approval_mode.py
@@ -1,0 +1,103 @@
+"""Tests for approvals.noninteractive_mode — fail-closed for headless contexts."""
+
+from unittest.mock import patch as mock_patch
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import (
+    _get_noninteractive_approval_mode,
+    check_dangerous_command,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_approval_state():
+    approval_module._permanent_approved.clear()
+    approval_module.clear_session("default")
+    yield
+    approval_module._permanent_approved.clear()
+    approval_module.clear_session("default")
+
+
+@pytest.fixture
+def headless(monkeypatch):
+    """No interactive CLI, no gateway, no cron — the fail-open branch."""
+    for var in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_CRON_SESSION",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _config(approvals):
+    return mock_patch("hermes_cli.config.load_config", return_value={"approvals": approvals})
+
+
+# ---------------------------------------------------------------------------
+# config parsing
+# ---------------------------------------------------------------------------
+
+class TestNoninteractiveApprovalModeParsing:
+    def test_default_is_approve(self):
+        """Absent config keeps today's behaviour — operators opt in to deny."""
+        with _config({}):
+            assert _get_noninteractive_approval_mode() == "approve"
+
+    def test_explicit_deny(self):
+        with _config({"noninteractive_mode": "deny"}):
+            assert _get_noninteractive_approval_mode() == "deny"
+
+    def test_explicit_approve(self):
+        with _config({"noninteractive_mode": "approve"}):
+            assert _get_noninteractive_approval_mode() == "approve"
+
+    @pytest.mark.parametrize("value", ["DENY", " deny ", "block", "closed", "no"])
+    def test_deny_synonyms_and_whitespace(self, value):
+        with _config({"noninteractive_mode": value}):
+            assert _get_noninteractive_approval_mode() == "deny"
+
+    def test_unrecognised_value_falls_back_to_approve(self):
+        """An unknown value must not silently start blocking a live deployment."""
+        with _config({"noninteractive_mode": "maybe"}):
+            assert _get_noninteractive_approval_mode() == "approve"
+
+    def test_unreadable_config_falls_back_to_approve(self):
+        with mock_patch("hermes_cli.config.load_config", side_effect=OSError("boom")):
+            assert _get_noninteractive_approval_mode() == "approve"
+
+
+# ---------------------------------------------------------------------------
+# effect on check_dangerous_command
+# ---------------------------------------------------------------------------
+
+class TestNoninteractiveGate:
+    def test_deny_blocks_a_dangerous_command(self, headless):
+        with _config({"noninteractive_mode": "deny"}):
+            result = check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is False
+        assert "noninteractive_mode" in result["message"]
+
+    def test_approve_preserves_existing_behaviour(self, headless):
+        with _config({"noninteractive_mode": "approve"}):
+            result = check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is True
+
+    def test_default_config_preserves_existing_behaviour(self, headless):
+        with _config({}):
+            result = check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is True
+
+    def test_harmless_command_is_unaffected(self, headless):
+        with _config({"noninteractive_mode": "deny"}):
+            result = check_dangerous_command("git status", "local")
+        assert result["approved"] is True
+
+    def test_cron_still_governed_by_cron_mode(self, headless, monkeypatch):
+        """noninteractive_mode must not override the cron branch."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        with _config({"noninteractive_mode": "deny", "cron_mode": "approve"}):
+            result = check_dangerous_command("git push --force origin main", "local")
+        assert result["approved"] is True

--- a/tests/tools/test_noninteractive_approval_mode.py
+++ b/tests/tools/test_noninteractive_approval_mode.py
@@ -101,3 +101,97 @@ class TestNoninteractiveGate:
         with _config({"noninteractive_mode": "deny", "cron_mode": "approve"}):
             result = check_dangerous_command("git push --force origin main", "local")
         assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# the consolidated guard — the path terminal execution actually takes
+# ---------------------------------------------------------------------------
+
+class TestConsolidatedGuard:
+    """`terminal_tool` routes through `check_all_command_guards`, not
+    `check_dangerous_command`. A policy that only covers the latter has no
+    effect on real terminal calls."""
+
+    def test_deny_blocks_through_the_consolidated_guard(self, headless):
+        from tools.approval import check_all_command_guards
+        with _config({"noninteractive_mode": "deny"}):
+            result = check_all_command_guards("git reset --hard HEAD~3", "local")
+        assert result["approved"] is False
+        assert "noninteractive_mode" in result["message"]
+
+    def test_approve_preserves_existing_behaviour_through_the_guard(self, headless):
+        from tools.approval import check_all_command_guards
+        with _config({"noninteractive_mode": "approve"}):
+            result = check_all_command_guards("git reset --hard HEAD~3", "local")
+        assert result["approved"] is True
+
+    def test_default_preserves_existing_behaviour_through_the_guard(self, headless):
+        from tools.approval import check_all_command_guards
+        with _config({}):
+            result = check_all_command_guards("git reset --hard HEAD~3", "local")
+        assert result["approved"] is True
+
+    def test_harmless_command_unaffected_through_the_guard(self, headless):
+        from tools.approval import check_all_command_guards
+        with _config({"noninteractive_mode": "deny"}):
+            result = check_all_command_guards("git status", "local")
+        assert result["approved"] is True
+
+    def test_cron_still_governed_by_cron_mode_through_the_guard(self, headless, monkeypatch):
+        from tools.approval import check_all_command_guards
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        with _config({"noninteractive_mode": "deny", "cron_mode": "approve"}):
+            result = check_all_command_guards("git reset --hard HEAD~3", "local")
+        assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# the real DEFAULT_CONFIG / deep-merge contract, not a mocked load_config
+# ---------------------------------------------------------------------------
+
+def _write_hermes_config(monkeypatch, tmp_path, config):
+    import yaml
+    home = tmp_path / "hermes-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """load_config memoises; each case must read its own file."""
+    import hermes_cli.config as cfg
+    for attr in ("_CONFIG_CACHE", "_config_cache"):
+        if hasattr(cfg, attr):
+            setattr(cfg, attr, None)
+    yield
+
+
+class TestDefaultConfigContract:
+    def test_key_has_a_canonical_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["approvals"]["noninteractive_mode"] == "approve"
+
+    def test_absent_from_user_config_deep_merges_to_approve(self, monkeypatch, tmp_path):
+        """A user file that sets only `mode` must still resolve the new key."""
+        _write_hermes_config(monkeypatch, tmp_path, {"approvals": {"mode": "manual"}})
+        assert _get_noninteractive_approval_mode() == "approve"
+
+    def test_user_config_overrides_the_default(self, monkeypatch, tmp_path):
+        _write_hermes_config(
+            monkeypatch, tmp_path, {"approvals": {"noninteractive_mode": "deny"}}
+        )
+        assert _get_noninteractive_approval_mode() == "deny"
+
+    def test_sibling_keys_survive_the_merge(self, monkeypatch, tmp_path):
+        """Setting the new key must not drop cron_mode's default."""
+        from hermes_cli.config import load_config
+
+        _write_hermes_config(
+            monkeypatch, tmp_path, {"approvals": {"noninteractive_mode": "deny"}}
+        )
+        approvals = load_config()["approvals"]
+        assert approvals["noninteractive_mode"] == "deny"
+        assert approvals["cron_mode"] == "deny"
+        assert approvals["timeout"] == 300

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3521,6 +3521,66 @@ def check_all_command_guards(command: str, env_type: str,
                             ),
                         }
                     # else: tirith_fail_open is True — allow as before
+        elif _get_noninteractive_approval_mode() == "deny":
+            # Non-cron and still nobody present: a scripted or headless run, a
+            # dispatched worker, hermes-agent embedded as a library. Same
+            # reasoning as the cron branch above, under its own key — and this
+            # is the branch that governs real terminal calls, since
+            # terminal_tool routes here rather than through
+            # check_dangerous_command.
+            is_dangerous, _pk, description = detect_dangerous_command(command)
+            if is_dangerous:
+                return {
+                    "approved": False,
+                    "message": (
+                        f"BLOCKED: Command flagged as dangerous ({description}) "
+                        "but no interactive user or gateway is present to "
+                        "approve it (approvals.noninteractive_mode: deny). "
+                        "Find an alternative approach, or run this where a "
+                        "human can answer."
+                    ),
+                }
+            # Content-level threats that the pattern detector does not match
+            # (homograph URLs, pipe-to-interpreter, terminal injection) are
+            # caught the same way cron catches them.
+            try:
+                from tools.tirith_security import check_command_security
+                _ni_tirith = check_command_security(command)
+                if _ni_tirith.get("action") in ("block", "warn"):
+                    return {
+                        "approved": False,
+                        "message": (
+                            f"BLOCKED: {_format_tirith_description(_ni_tirith)} "
+                            "but no interactive user or gateway is present to "
+                            "approve it (approvals.noninteractive_mode: deny). "
+                            "Find an alternative approach, or run this where a "
+                            "human can answer."
+                        ),
+                    }
+            except ImportError:
+                # Mirrors the cron branch: an operator who opted into
+                # tirith fail-closed must not be silently allowed here either.
+                _ni_fail_open = True
+                try:
+                    from hermes_cli.config import load_config as _load_cfg
+                    _sec = (_load_cfg() or {}).get("security", {}) or {}
+                    if _sec.get("tirith_enabled", True):
+                        _ni_fail_open = _sec.get("tirith_fail_open", True)
+                except Exception:
+                    pass
+                if not _ni_fail_open:
+                    return {
+                        "approved": False,
+                        "message": (
+                            "BLOCKED: the Tirith security scanner could not be "
+                            "imported and security.tirith_fail_open is false, "
+                            "so this command cannot be silently allowed — and "
+                            "no interactive user or gateway is present to "
+                            "approve it. Find an alternative approach, install "
+                            "tirith, or set approvals.noninteractive_mode: "
+                            "approve in config.yaml."
+                        ),
+                    }
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2672,6 +2672,31 @@ def _get_cron_approval_mode() -> str:
         return "deny"
 
 
+def _get_noninteractive_approval_mode() -> str:
+    """Read ``approvals.noninteractive_mode``. Returns 'deny' or 'approve'.
+
+    Governs the dangerous-command path in a non-interactive, non-gateway,
+    non-cron context: a scripted or headless run, hermes-agent embedded as a
+    library, a test harness, or a dispatched kanban worker. That path fails
+    OPEN -- everything below the hardline floor is auto-approved with nobody
+    present to answer -- and ``cron_mode`` covers only the cron case.
+
+    Defaults to 'approve', preserving existing behaviour: an operator opts in
+    to fail-closed rather than having a deployment change under them on
+    upgrade. Mirrors ``_get_cron_approval_mode``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        mode = str(cfg_get(config, "approvals", "noninteractive_mode",
+                           default="approve")).lower().strip()
+        if mode in {"deny", "block", "closed", "no"}:
+            return "deny"
+        return "approve"
+    except Exception:
+        return "approve"
+
+
 def _strip_shell_comments(command: str) -> str:
     """Strip shell-style comments from a command before LLM assessment.
 
@@ -3125,6 +3150,13 @@ def check_dangerous_command(command: str, env_type: str,
         ),
         autoapprove_log_prefix=(
             "AUTO-APPROVED dangerous command in non-interactive non-gateway context"
+        ),
+        fail_closed_when_no_human=(_get_noninteractive_approval_mode() == "deny"),
+        no_human_block_message=(
+            f"BLOCKED: Command flagged as dangerous ({description}) but no "
+            "interactive user or gateway is present to approve it "
+            "(approvals.noninteractive_mode: deny). Find an alternative approach, "
+            "or run this where a human can answer."
         ),
     )
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2135,6 +2135,25 @@ approvals:
 
 Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
 
+### Runs with nobody present
+
+Every mode above assumes someone can answer. Two keys cover the runs where nobody can:
+
+```yaml
+approvals:
+  cron_mode: deny                 # deny | approve — cron jobs
+  noninteractive_mode: approve    # deny | approve — other headless runs
+```
+
+| Key | Default | Applies to |
+|---|---|---|
+| `cron_mode` | `deny` | Scheduled jobs (`HERMES_CRON_SESSION`). |
+| `noninteractive_mode` | `approve` | Any other run with no interactive CLI and no gateway: a scripted invocation, hermes-agent embedded as a library, a test harness, a dispatched kanban worker. |
+
+`noninteractive_mode` defaults to `approve` because that is the historical behaviour — everything below the hardline floor is auto-approved when nobody is present. Set it to `deny` to block instead. It is opt-in so that upgrading does not start blocking a running deployment.
+
+Both are evaluated after the hardline floor and `approvals.deny`, which block regardless of either setting, and neither affects sessions where a user or gateway *is* reachable.
+
 :::warning
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.
 :::

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -34,6 +34,7 @@ approvals:
   mode: smart                     # smart | manual | off
   timeout: 300                    # seconds to wait for user response (default: 300)
   cron_mode: deny                 # deny | approve — what cron jobs do when they hit a dangerous command
+  noninteractive_mode: approve    # deny | approve — same, for scripted/headless runs
   mcp_reload_confirm: true        # /reload-mcp asks before invalidating the MCP tool cache
   destructive_slash_confirm: true # /clear, /new, /reset, /undo prompt before discarding state
 ```
@@ -45,6 +46,7 @@ The full set of keys:
 | `mode` | `smart` | Approval policy for dangerous shell commands — see the table below. |
 | `timeout` | `300` | Seconds Hermes waits for an approval reply before timing out. |
 | `cron_mode` | `deny` | How [cron jobs](./features/cron.md) behave headlessly when they trigger a dangerous-command prompt. `deny` blocks the command (the agent must find another path); `approve` auto-approves everything in cron context. |
+| `noninteractive_mode` | `approve` | What a **non-interactive, non-gateway, non-cron** run does when it hits a dangerous command — a scripted or headless invocation, hermes-agent embedded as a library, a test harness, or a dispatched worker. `approve` auto-approves everything below the hardline floor with nobody present (the historical behaviour, kept as the default so upgrades don't change a running deployment); `deny` blocks it. Cron is governed separately by `cron_mode`. |
 | `mcp_reload_confirm` | `true` | When true, `/reload-mcp` asks before rebuilding the MCP tool set. Rebuilding invalidates the provider prompt cache (tool schemas live in the system prompt), so the next message re-sends full input tokens. Users who click **Always Approve** flip this key to `false`. |
 | `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. TUI uses its own modal overlay (set `HERMES_TUI_NO_CONFIRM=1` to opt out there). |
 


### PR DESCRIPTION
## What does this PR do?

`check_dangerous_command` auto-approves flagged dangerous commands, with only a log warning, whenever the context is neither interactive CLI nor gateway nor cron:

```
AUTO-APPROVED dangerous command in non-interactive non-gateway context (pattern: %s): %s
```

`approvals.cron_mode` covers only the cron case, so any scripted or headless invocation — a test harness, CI, hermes-agent embedded as a library, a dispatched kanban worker — silently loses the dangerous-command gate. Everything below the hardline floor runs with nobody present to answer.

This adds `approvals.noninteractive_mode` (`deny` | `approve`), mirroring `cron_mode`, and wires it through the existing `fail_closed_when_no_human` parameter that `request_tool_approval` already opts into. No new mechanism — the fail-closed branch is already there and tested; it was simply unreachable from the dangerous-command path.

**It defaults to `approve`**, preserving current behaviour. An operator opts in to fail-closed rather than having a running deployment start blocking under them on upgrade. Unrecognised and unreadable config values fall back to `approve` for the same reason.

Worth noting explicitly: with the default, this PR changes nothing for anyone until they set the key.

## Related Issue

Addresses **part 1** of #60505 ("no config option to make this branch deny instead"), which proposes exactly this knob.

Not using a closing keyword deliberately: that issue has two parts, and part 2 (permanent allowlist evaluated before the cron branch) is untouched here — #61064 is open against it. This PR is orthogonal to that one; they touch nearby code but not the same lines.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py` — new `_get_noninteractive_approval_mode()` mirroring `_get_cron_approval_mode()`; `check_dangerous_command` now passes `fail_closed_when_no_human` and a `no_human_block_message` naming the key that caused the block.
- `tests/tools/test_noninteractive_approval_mode.py` — new, 15 tests.
- `website/docs/user-guide/security.md` — sample config and the key table.
- `skills/autonomous-ai-agents/hermes-agent/references/configuration.md` — `approvals` key summary.

## How to Test

1. With no config change, confirm nothing moves:
   ```bash
   pytest tests/tools/test_noninteractive_approval_mode.py -q
   ```
2. Opt in, then run headlessly with `HERMES_INTERACTIVE`, `HERMES_GATEWAY_SESSION` and `HERMES_CRON_SESSION` all unset:
   ```yaml
   approvals:
     noninteractive_mode: deny
   ```
   ```python
   from tools import approval
   approval.check_dangerous_command("git push --force origin main", "local")
   # {'approved': False, 'message': 'BLOCKED: ... (approvals.noninteractive_mode: deny) ...'}
   approval.check_dangerous_command("git status", "local")
   # {'approved': True, ...}
   ```
3. Confirm cron is still governed by `cron_mode` alone: set `HERMES_CRON_SESSION=1` with `noninteractive_mode: deny` and `cron_mode: approve`; the command is approved.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (found #61064 on part 2 of the same issue; scoped this to part 1 to avoid competing)
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass — 79 pass across the approval suite (`test_noninteractive_approval_mode`, `test_cron_approval_mode`, `test_approval_plugin_hooks`, `test_smart_approval_policy`, `test_request_tool_approval`, `test_approval_interrupt`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (Linux 6.12), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`security.md`, configuration reference, docstrings)
- [x] `cli-config.yaml.example` — N/A, it has no `approvals` block
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, config parsing and a branch condition; no platform-specific code
- [x] Tool descriptions/schemas — N/A, no tool behaviour change

## Logs

Headless context, `noninteractive_mode: deny`, same command under each setting:

```
--- noninteractive_mode: approve (current behaviour, default) ---
   allowed  git push --force origin main
--- noninteractive_mode: deny ---
   BLOCKED  git push --force origin main
   allowed  git status
```
