### PR TITLE
fix(update): detect EOL-only churn via numstat, not name-only

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3474,8 +3474,36 @@ def _normalize_managed_eol(git_cmd, repo_root):
             return None
         return {p for p in out.stdout.split("\0") if p}
 
+    def _real_dirty():
+        # Files with a *content* change once CRLF differences are ignored.
+        # NOTE: ``diff --name-only --ignore-cr-at-eol`` still LISTS CR-only
+        # files (the name list is computed from blob/stat differences before
+        # the CR filter is applied), so it cannot be used to isolate real
+        # edits. ``--numstat`` does honor the filter: a CR-only file produces
+        # no numstat record, while a genuinely-edited file does. Parse the
+        # paths out of numstat instead.
+        out = subprocess.run(
+            probe + ["-c", "core.quotepath=false",
+                     "diff", "--numstat", "--ignore-cr-at-eol"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if out.returncode != 0:
+            return None
+        paths = set()
+        for line in out.stdout.splitlines():
+            if not line.strip():
+                continue
+            # Format: "<added>\t<deleted>\t<path>". Rename detection is off in
+            # plain diff, so there is exactly one path field per record.
+            parts = line.split("\t", 2)
+            if len(parts) == 3 and parts[2]:
+                paths.add(parts[2])
+        return paths
+
     def _eol_only():
-        all_dirty, real_dirty = _dirty(), _dirty("--ignore-cr-at-eol")
+        all_dirty, real_dirty = _dirty(), _real_dirty()
         if all_dirty is None or real_dirty is None:
             return None
         return all_dirty - real_dirty


### PR DESCRIPTION
## Summary

`hermes update` on a managed Windows checkout now actually clears line-ending churn before pinning `core.autocrlf=false`, instead of pinning a still-dirty tree that breaks the next update.

Root cause: `_normalize_managed_eol` isolated EOL-only churn from real edits by diffing twice — all dirty files minus files still dirty under `--ignore-cr-at-eol`. But `git diff --name-only --ignore-cr-at-eol` computes its file list from blob/stat differences *before* the CR filter is applied, so it still lists CR-only files. On git 2.48.1 the two name-only sets are identical → `_eol_only()` is always empty → the checkout that would clear the churn is skipped, yet `autocrlf=false` is pinned anyway, leaving the whole CRLF tree dirty (the exact breakage this function exists to prevent).

## Changes

- `hermes_cli/update_cmd.py`: compute the real-edit set with `git diff --numstat --ignore-cr-at-eol` (numstat honors the CR filter — a CR-only file produces no record) instead of `--name-only`. Pin `core.quotepath=false` so non-ASCII paths parse.

## Validation

| | git 2.48.1 |
|---|---|
| Before | `_eol_only()` empty → tree left dirty, `autocrlf` pinned anyway |
| After | eol-only churn cleared, genuine edits preserved, pin applied only after tree reads clean |

- Verified at 1200 files: 1199 EOL-only files normalized to LF, one genuinely-edited file preserved (`REAL_EDIT` intact), only that file left dirty, `autocrlf=false` pinned.
- `scripts/run_tests.sh tests/hermes_cli/test_update_eol_churn.py` — 9/9 pass (was 1 failing on `test_churn_across_more_files_than_fit_in_one_argv`).

Pre-existing failure on `main` — the test failed deterministically on git 2.48.1; surfaced while landing unrelated file-tools PRs (#76394, #76399).

## Infographic

![EOL churn detection numstat vs name-only](https://v3b.fal.media/files/b/0aa4a3de/4F1YvdHDpWQzKGMjBv0wt_R6vEYBrD.png)
