### PR TITLE
fix(computer-use): preserve macOS TCC identity for YOLO daemon

### DIFF
--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -174,7 +174,7 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
     stopped = SimpleNamespace(returncode=0, stdout="", stderr="")
 
     daemon = cua_backend._EmbeddedCuaDaemon("cua-driver", "unrestricted")
-    with patch.object(
+    with patch.object(cua_backend.sys, "platform", "linux"), patch.object(
         cua_backend,
         "_resolve_mcp_invocation",
         return_value=("/opt/cua-driver", ["mcp"]),
@@ -195,6 +195,74 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
     assert env["CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"] == "1"
     assert proxy_command == "/opt/cua-driver"
     assert proxy_args == ["mcp", "--embedded", "--socket", daemon.socket_path]
+
+
+def test_macos_unrestricted_daemon_launches_via_app_bundle_for_tcc_identity():
+    """A raw Mach-O child has no bundle identity, so macOS ignores the
+    Accessibility and Screen Recording grants attached to CuaDriver.app."""
+    from tools.computer_use import cua_backend
+
+    process = Mock()
+    process.poll.return_value = None
+    process.stderr = []
+    status = SimpleNamespace(returncode=0, stdout="running", stderr="")
+
+    daemon = cua_backend._EmbeddedCuaDaemon("cua-driver", "unrestricted")
+    with patch.object(cua_backend.sys, "platform", "darwin"), patch.object(
+        cua_backend,
+        "_validated_macos_cua_app_path",
+        return_value="/Applications/CuaDriver.app",
+    ), patch.object(
+        cua_backend,
+        "_resolve_mcp_invocation",
+        return_value=("/Applications/CuaDriver.app/Contents/MacOS/cua-driver", ["mcp"]),
+    ), patch.object(cua_backend.subprocess, "Popen", return_value=process) as popen, patch.object(
+        cua_backend.subprocess, "run", return_value=status
+    ):
+        daemon.start()
+
+    command = popen.call_args.args[0]
+    assert command[:6] == [
+        "/usr/bin/open",
+        "-n",
+        "-g",
+        "-W",
+        "/Applications/CuaDriver.app",
+        "--args",
+    ]
+    assert command[6:8] == ["serve", "--embedded"]
+    assert "/Applications/CuaDriver.app/Contents/MacOS/cua-driver" not in command
+
+
+def test_macos_cua_app_validation_accepts_expected_signed_bundle():
+    from tools.computer_use import cua_backend
+
+    verified = SimpleNamespace(returncode=0, stdout="", stderr="")
+    details = SimpleNamespace(
+        returncode=0,
+        stdout="",
+        stderr="Identifier=com.trycua.driver\nTeamIdentifier=4YEC26S9KF\n",
+    )
+    with patch.object(
+        cua_backend.os.path,
+        "realpath",
+        return_value="/Applications/CuaDriver.app/Contents/MacOS/cua-driver",
+    ), patch.object(cua_backend.subprocess, "run", side_effect=[verified, details]):
+        assert (
+            cua_backend._validated_macos_cua_app_path("/usr/local/bin/cua-driver")
+            == "/Applications/CuaDriver.app"
+        )
+
+
+def test_macos_cua_app_validation_rejects_driver_outside_app_bundle():
+    from tools.computer_use import cua_backend
+
+    with patch.object(
+        cua_backend.os.path,
+        "realpath",
+        return_value="/tmp/cua-driver",
+    ), pytest.raises(RuntimeError, match="outside an app bundle"):
+        cua_backend._validated_macos_cua_app_path("/tmp/cua-driver")
 
 
 def test_standard_backend_does_not_spawn_an_embedded_daemon():

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -380,6 +380,53 @@ def _wsl_windows_path_to_posix(path: str) -> str:
     return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
 
 
+def _validated_macos_cua_app_path(driver_command: str) -> str:
+    """Return the signed CuaDriver.app containing *driver_command*.
+
+    Launching by display name would let LaunchServices select a different app
+    with the same name.  Derive the exact bundle from the already-resolved
+    driver command and fail closed unless its signature is valid and belongs to
+    the expected bundle identifier.
+    """
+    resolved = os.path.realpath(driver_command)
+    marker = f".app{os.sep}Contents{os.sep}MacOS{os.sep}"
+    marker_index = resolved.find(marker)
+    if marker_index < 0:
+        raise RuntimeError(
+            "macOS unrestricted computer use requires the signed "
+            "CuaDriver.app installation; resolved driver is outside an app bundle"
+        )
+    app_path = resolved[: marker_index + len(".app")]
+    verify = subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--deep", "--strict", app_path],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10.0,
+    )
+    details = subprocess.run(
+        ["/usr/bin/codesign", "-dv", app_path],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=10.0,
+    )
+    signature = f"{details.stdout}\n{details.stderr}"
+    if (
+        verify.returncode != 0
+        or details.returncode != 0
+        or "Identifier=com.trycua.driver" not in signature
+        or "TeamIdentifier=" not in signature
+        or "TeamIdentifier=not set" in signature
+    ):
+        raise RuntimeError(
+            "refusing to launch unrestricted CuaDriver: app signature or "
+            "bundle identity is invalid"
+        )
+    return app_path
+
+
 class _EmbeddedCuaDaemon:
     """Private host-owned daemon used for an explicit unrestricted session.
 
@@ -439,8 +486,7 @@ class _EmbeddedCuaDaemon:
             raise RuntimeError(cua_driver_install_hint())
         self._command, self._mcp_args = _resolve_mcp_invocation(self._driver_cmd)
         env = _sanitize_subprocess_env(self.child_env())
-        command = [
-            self._command,
+        daemon_args = [
             "serve",
             "--embedded",
             "--socket",
@@ -450,6 +496,25 @@ class _EmbeddedCuaDaemon:
             "unrestricted",
             "--dangerously-bypass-approvals",
         ]
+        # On macOS TCC grants are attached to the CuaDriver.app bundle identity,
+        # not merely to the signed Mach-O inside it.  Spawning the executable as
+        # a raw child leaves the process without a CFBundleIdentifier, so an
+        # unrestricted/private daemon cannot see windows even though System
+        # Settings says CuaDriver is approved.  LaunchServices supplies the app
+        # identity; -W keeps `open` alive as our lifecycle handle.
+        if sys.platform == "darwin":
+            app_path = _validated_macos_cua_app_path(self._command)
+            command = [
+                "/usr/bin/open",
+                "-n",
+                "-g",
+                "-W",
+                app_path,
+                "--args",
+                *daemon_args,
+            ]
+        else:
+            command = [self._command, *daemon_args]
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
- launch unrestricted/private CuaDriver daemons through the exact signed CuaDriver.app bundle on macOS
- validate the resolved bundle signature, identifier, and TeamIdentifier before LaunchServices startup
- preserve the existing raw-binary launch path on Linux and Windows

## Root cause
Hermes YOLO spawned the signed Mach-O directly with `cua-driver serve --embedded`. On macOS that process had no `CFBundleIdentifier`, so TCC ignored the existing Accessibility and Screen Recording grants for `com.trycua.driver`. The standard daemon remained healthy, which made `hermes computer-use doctor` misleadingly green while session captures returned 0x0.

## Verification
- `pytest tests/tools/test_computer_use_cua_0_10_permissions.py -q` — 12 passed
- live unrestricted backend capture — 723x1049, 312 AX elements
- private-socket health report — bundle identity, Accessibility, Screen Recording, and AX all pass
- repeated live `computer_use` captures succeed after Hermes restart