### PR TITLE
docs(site): redirect /quickstart and /installation short paths

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -92,6 +92,16 @@ const config: Config = {
             from: '/guides/build-a-hermes-plugin',
             to: '/developer-guide/plugins',
           },
+          {
+            // Users guess these short paths from abbreviated links and hit
+            // raw 404s (consumer-onboarding audit finding #1, Aug 2026).
+            from: '/quickstart',
+            to: '/getting-started/quickstart',
+          },
+          {
+            from: '/installation',
+            to: '/getting-started/installation',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
`/docs/quickstart` and `/docs/installation` now redirect to their real pages instead of 404ing.

Users following abbreviated links guess these short paths and hit raw GitHub-Pages 404s — the pages live under `/docs/getting-started/` (consumer-onboarding audit finding #1).

## Changes
- `website/docusaurus.config.ts`: two entries in the existing `@docusaurus/plugin-client-redirects` block.

## Validation
Redirect entries follow the exact pattern of the two existing redirects in the same block; Docusaurus generates client-side redirect stubs at build time.

## Infographic

![short paths redirect](https://v3b.fal.media/files/b/0aa4a463/2k9T1PcsjeFuvhfugEx9O_e09U47aj.png)
