### PR TITLE
fix(skills): improve diagnostics and skill packaging

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1349,7 +1349,9 @@ _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 # v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
 # org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3: entries gained folder_slug/declared_name identity aliases; older
+# snapshots (including matching v2 manifests) are discarded and rebuilt.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1478,10 +1478,17 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    # ``skill_name`` historically held the folder slug; keep it for backward
+    # compatibility with existing snapshot consumers. Expose unambiguous
+    # aliases so diagnostics can distinguish folder slug from declared name
+    # (e.g. folder ``audiocraft`` declaring ``audiocraft-audio-generation``).
+    declared_name = str(frontmatter.get("name", skill_name) or skill_name)
     entry = {
         "skill_name": skill_name,
+        "folder_slug": skill_name,
+        "declared_name": declared_name,
+        "frontmatter_name": declared_name,
         "category": category,
-        "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -857,6 +857,71 @@ def is_skill_description_truncated_for_prompt(frontmatter: Dict[str, Any]) -> bo
 
 # ── File iteration ────────────────────────────────────────────────────────
 
+# Canonical skill entry filename. Wrong-case variants (``skill.md``,
+# ``Skill.md``) are never loaded — discovery is intentionally case-sensitive
+# so macOS/Windows case-insensitive volumes cannot silently activate a package
+# that would be invisible on Linux.
+CANONICAL_SKILL_MD = "SKILL.md"
+
+
+def find_wrong_case_skill_md_files(skills_dir: Path) -> List[Path]:
+    """Return skill packages that use a non-canonical ``skill.md`` spelling.
+
+    Hermes only indexes the exact filename ``SKILL.md``. On case-insensitive
+    filesystems a lowercase ``skill.md`` looks installed but is undiscoverable
+    by ``iter_skill_index_files``. This helper surfaces those packages for
+    diagnostics — it never treats wrong-case names as loadable skills.
+    """
+    if not skills_dir or not Path(skills_dir).exists():
+        return []
+
+    skills_dir_str = str(skills_dir)
+    active_org = read_active_org_id(skills_dir)
+    org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
+    found: list[str] = []
+    for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+        has_canonical = CANONICAL_SKILL_MD in files
+        if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
+            dirs.remove(ORG_MIRROR_DIR_NAME)
+        elif root == org_root:
+            dirs[:] = [d for d in dirs if d == active_org]
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in EXCLUDED_SKILL_DIRS
+            and not (has_canonical and d in SKILL_SUPPORT_DIRS)
+        ]
+        # Skip support dirs even when only a wrong-case skill.md is present —
+        # those are progressive-disclosure payloads, not skill roots.
+        rel_parts = Path(root).relative_to(skills_dir).parts if root != skills_dir_str else ()
+        if any(part in SKILL_SUPPORT_DIRS for part in rel_parts):
+            continue
+        for name in files:
+            if name.lower() == "skill.md" and name != CANONICAL_SKILL_MD:
+                # Only warn when the canonical file is absent; a dual listing
+                # on a case-insensitive FS is the same inode and already loads.
+                if not has_canonical:
+                    found.append(os.path.join(root, name))
+    return [Path(p) for p in sorted(found)]
+
+
+def format_wrong_case_skill_md_warning(paths: List[Path], *, skills_dir: Optional[Path] = None) -> str:
+    """Human-readable warning for wrong-case skill.md packages (never loaded)."""
+    if not paths:
+        return ""
+    lines = [
+        "Warning: skill package(s) use non-canonical skill.md filename casing "
+        "and will NOT be loaded. Rename to exact SKILL.md (two-step rename on "
+        "case-insensitive filesystems):",
+    ]
+    for path in paths:
+        try:
+            display = path.relative_to(skills_dir) if skills_dir else path
+        except ValueError:
+            display = path
+        lines.append(f"  - {display}")
+    return "\n".join(lines)
+
 
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
@@ -866,6 +931,10 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     scripts) can contain arbitrary markdown and even archived package
     ``SKILL.md`` files, but they are progressive-disclosure data loaded through
     ``skill_view(..., file_path=...)`` rather than active skill roots.
+
+    Matching is case-sensitive: only the exact ``filename`` string is yielded.
+    Wrong-case ``skill.md`` packages are never silently loaded — use
+    ``find_wrong_case_skill_md_files`` for diagnostics.
 
     M2 org mirrors (``_org/``): TOKEN-GATED resolution. Only the active org's
     subdir (per the sync-client-written ``.active_org`` marker) is walked;

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -299,6 +299,49 @@ def collect_deprecated_env_vars(env_map: dict | None) -> list[tuple[str, str]]:
     return findings
 
 
+def report_missing_bundled_skills_check(missing_bundled: list[dict] | None = None) -> str:
+    """Emit doctor severity for bundled source/manifest vs install drift.
+
+    Returns the severity label used: ``ok_match``, ``ok_intentional``, or
+    ``warn_actionable``. When every absence is ``opt_out`` or
+    ``curator_suppressed``, emit healthy/informational output with provenance
+    counts — never a warning. Warn only when at least one absence is
+    unexpected (``manifest_tracked_absent``, ``source_present_never_installed``,
+    ``manifest_orphan_no_source``, or ``unknown``).
+    """
+    from tools.skills_sync import (
+        list_missing_bundled_skills,
+        partition_missing_bundled_skills,
+        provenance_counts,
+    )
+
+    if missing_bundled is None:
+        missing_bundled = list_missing_bundled_skills()
+    if not missing_bundled:
+        check_ok("Bundled skills installed match source/manifest baseline")
+        return "ok_match"
+
+    by_prov = provenance_counts(missing_bundled)
+    prov_summary = ", ".join(f"{k}={v}" for k, v in sorted(by_prov.items()))
+    _intentional, actionable = partition_missing_bundled_skills(missing_bundled)
+    if actionable:
+        check_warn(
+            f"{len(missing_bundled)} bundled skill(s) missing from install",
+            f"({prov_summary}; unexpected={len(actionable)}; see: hermes skills check)",
+        )
+        return "warn_actionable"
+
+    check_ok(
+        "Bundled skill absences are intentional",
+        f"({prov_summary}; see: hermes skills check)",
+    )
+    check_info(
+        f"{len(missing_bundled)} intentional absence(s) "
+        f"(opt_out / curator_suppressed) — no restore needed"
+    )
+    return "ok_intentional"
+
+
 def report_deprecated_config_and_env(
     raw_config: dict | None = None,
     env_map: dict | None = None,
@@ -2578,6 +2621,31 @@ def run_doctor(args):
             check_warn(f"{q_count} skill(s) in quarantine", "(pending review)")
     else:
         check_warn("Skills Hub directory not initialized", "(run: hermes skills list)")
+
+    # Wrong-case skill.md packages are never loaded (case-sensitive SKILL.md).
+    try:
+        from agent.skill_utils import find_wrong_case_skill_md_files
+
+        wrong_case = find_wrong_case_skill_md_files(HERMES_HOME / "skills")
+        if wrong_case:
+            sample = ", ".join(p.parent.name for p in wrong_case[:5])
+            more = f" (+{len(wrong_case) - 5} more)" if len(wrong_case) > 5 else ""
+            check_warn(
+                f"{len(wrong_case)} skill package(s) use wrong-case skill.md",
+                f"(not loaded — rename to SKILL.md: {sample}{more})",
+            )
+        else:
+            check_ok("No wrong-case skill.md packages")
+    except Exception as e:
+        check_warn("Could not scan for wrong-case skill.md", f"({e})")
+
+    # Manifest/source-present but installed-missing bundled skills.
+    # Warn only for unexpected absences; all-intentional (opt_out /
+    # curator_suppressed) is healthy with provenance counts.
+    try:
+        report_missing_bundled_skills_check()
+    except Exception as e:
+        check_warn("Could not check bundled skill install drift", f"({e})")
 
     from hermes_cli.config import get_env_value
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11015,7 +11015,11 @@ def cmd_tools(args):
 
         sys.exit(run_post_setup_command(args))
     else:
-        _require_tty("tools")
+        # ``--summary`` is a read-only non-interactive diagnostic; it must work
+        # without a TTY so audits/CI can capture tool configuration. The
+        # interactive curses UI still requires a terminal.
+        if not getattr(args, "summary", False):
+            _require_tty("tools")
         from hermes_cli.tools_config import tools_command
 
         tools_command(args)

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -143,13 +143,20 @@ def _compute_skills_breakdown(skills_block: str) -> List[Dict[str, Any]]:
     ) -> None:
         path = name_to_path.get(name)
         md_bytes: Optional[int] = None
+        folder_slug = ""
         if path is not None:
             try:
                 md_bytes = path.stat().st_size
             except OSError:
                 md_bytes = None
+            folder_slug = path.parent.name
+        # ``name`` is the index/declared name. Expose folder_slug separately so
+        # audits can distinguish folder ``audiocraft`` from declared
+        # ``audiocraft-audio-generation`` without breaking older consumers.
         entries.append({
             "name": name,
+            "declared_name": name,
+            "folder_slug": folder_slug,
             "index_line_bytes": attributed_bytes,
             "index_line_total_bytes": total_bytes,
             "index_line_shared_bytes": shared_bytes,
@@ -348,6 +355,9 @@ def render_breakdown(data: Dict[str, Any]) -> str:
             md = sk["skill_md_bytes"]
             md_str = f"{md:>8,} B" if md is not None else f"{'n/a':>10}"
             name = sk["name"]
+            folder_slug = sk.get("folder_slug") or ""
+            if folder_slug and folder_slug != name:
+                name = f"{name} (folder: {folder_slug})"
             if len(name) > 28:
                 name = name[:27] + "…"
             lines.append(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1247,6 +1247,30 @@ def do_uninstall(name: str, console: Optional[Console] = None,
         c.print(f"[bold red]Error:[/] {msg}\n")
 
 
+def do_clean_manifest(console: Optional[Console] = None) -> dict:
+    """Remove stale .bundled_manifest keys that have no bundled source."""
+    from tools.skills_sync import clean_stale_manifest_orphans
+
+    c = console or _console
+    result = clean_stale_manifest_orphans()
+    removed = result.get("removed") or []
+    kept = int(result.get("kept") or 0)
+    if not removed:
+        c.print(
+            f"[dim]No stale manifest orphans. Kept {kept} source-backed "
+            f"manifest entr{'y' if kept == 1 else 'ies'}.[/]\n"
+        )
+        return result
+    c.print(
+        f"[green]✓[/] Removed {len(removed)} stale manifest orphan(s); "
+        f"kept {kept} source-backed entr{'y' if kept == 1 else 'ies'}."
+    )
+    for name in removed:
+        c.print(f"  − {name}")
+    c.print()
+    return result
+
+
 def do_reset(name: str, restore: bool = False,
              console: Optional[Console] = None,
              skip_confirm: bool = False,
@@ -1835,6 +1859,8 @@ def skills_command(args) -> None:
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))
+    elif action == "clean-manifest":
+        do_clean_manifest()
     elif action == "list-modified":
         do_list_modified(as_json=getattr(args, "json", False))
     elif action == "diff":
@@ -1869,7 +1895,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|clean-manifest|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1039,29 +1039,98 @@ def do_list(source_filter: str = "all",
         summary += f" — {enabled_count} enabled, {disabled_count} disabled"
     summary += "[/]\n"
     c.print(summary)
+    _warn_wrong_case_skill_md(c)
+
+
+def _warn_wrong_case_skill_md(console: Optional[Console] = None) -> None:
+    """Warn about wrong-case skill.md packages without loading them."""
+    from agent.skill_utils import (
+        find_wrong_case_skill_md_files,
+        format_wrong_case_skill_md_warning,
+    )
+    from hermes_constants import get_skills_dir
+
+    c = console or _console
+    skills_dir = get_skills_dir()
+    wrong = find_wrong_case_skill_md_files(skills_dir)
+    if not wrong:
+        return
+    warning = format_wrong_case_skill_md_warning(wrong, skills_dir=skills_dir)
+    c.print(f"[yellow]{warning}[/]\n")
+
+
+def _report_missing_bundled_skills(
+    console: Optional[Console] = None,
+    *,
+    name: Optional[str] = None,
+) -> int:
+    """Print bundled source/manifest-present but installed-missing diagnostics.
+
+    Returns the number of missing entries reported.
+    """
+    from tools.skills_sync import list_missing_bundled_skills
+
+    c = console or _console
+    missing = list_missing_bundled_skills()
+    if name:
+        missing = [e for e in missing if e["name"] == name]
+    if not missing:
+        return 0
+
+    table = Table(title="Bundled Skills Missing From Install")
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Folder", style="dim")
+    table.add_column("Manifest", style="dim")
+    table.add_column("Source", style="dim")
+    table.add_column("Provenance", style="yellow")
+
+    for entry in missing:
+        folder = entry.get("folder_slug") or ""
+        declared = entry.get("name") or ""
+        folder_cell = folder if folder and folder != declared else ""
+        table.add_row(
+            declared,
+            folder_cell,
+            "yes" if entry.get("in_manifest") else "no",
+            "yes" if entry.get("in_source") else "no",
+            str(entry.get("provenance") or ""),
+        )
+
+    c.print(table)
+    from tools.skills_sync import format_missing_bundled_restore_guidance
+
+    c.print(f"[dim]{format_missing_bundled_restore_guidance(missing)}[/]\n")
+    return len(missing)
 
 
 def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> None:
-    """Check hub-installed skills for upstream updates."""
+    """Check hub updates and bundled install/manifest drift diagnostics."""
     from tools.skills_hub import check_for_skill_updates
 
     c = console or _console
     results = check_for_skill_updates(name=name)
     if not results:
         c.print("[dim]No hub-installed skills to check.[/]\n")
-        return
+    else:
+        table = Table(title="Skill Updates")
+        table.add_column("Name", style="bold cyan")
+        table.add_column("Source", style="dim")
+        table.add_column("Status", style="dim")
 
-    table = Table(title="Skill Updates")
-    table.add_column("Name", style="bold cyan")
-    table.add_column("Source", style="dim")
-    table.add_column("Status", style="dim")
+        for entry in results:
+            table.add_row(entry.get("name", ""), entry.get("source", ""), entry.get("status", ""))
 
-    for entry in results:
-        table.add_row(entry.get("name", ""), entry.get("source", ""), entry.get("status", ""))
+        c.print(table)
+        update_count = sum(1 for entry in results if entry.get("status") == "update_available")
+        c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
 
-    c.print(table)
-    update_count = sum(1 for entry in results if entry.get("status") == "update_available")
-    c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
+    # Existing-surface bundled drift diagnostic (manifest/source present,
+    # installed missing) with curator/seeding provenance when available.
+    missing_count = _report_missing_bundled_skills(c, name=name)
+    if missing_count == 0 and not name:
+        c.print("[dim]No bundled skills missing from the local install.[/]\n")
+
+    _warn_wrong_case_skill_md(c)
 
 
 def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> None:

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -188,6 +188,16 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Skip confirmation prompt when using --restore",
     )
 
+    skills_subparsers.add_parser(
+        "clean-manifest",
+        help="Remove stale .bundled_manifest keys with no bundled source",
+        description=(
+            "Drop orphaned entries from ~/.hermes/skills/.bundled_manifest whose "
+            "bundled source no longer exists. Source-backed tracking keys are never "
+            "removed — including skills that are merely missing from the local install."
+        ),
+    )
+
     skills_list_modified = skills_subparsers.add_parser(
         "list-modified",
         help="List bundled skills you've edited (which `hermes update` keeps)",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -125,7 +125,14 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     )
 
     skills_check = skills_subparsers.add_parser(
-        "check", help="Check installed hub skills for updates"
+        "check",
+        help="Check hub updates and bundled install/manifest drift",
+        description=(
+            "Check hub-installed skills for upstream updates, report bundled "
+            "skills that are present in source/manifest but missing from the "
+            "local install (with curator/seeding provenance), and warn about "
+            "wrong-case skill.md packages that are never loaded."
+        ),
     )
     skills_check.add_argument(
         "name", nargs="?", help="Specific skill to check (default: all)"

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -2,7 +2,7 @@
 name: research-paper-writing
 title: Research Paper Writing Pipeline
 description: "Write ML papers for NeurIPS/ICML/ICLR: design→submit."
-version: 1.1.0
+version: 1.2.0
 author: Orchestra Research
 license: MIT
 dependencies: [semanticscholar, arxiv, habanero, requests, scipy, numpy, matplotlib, SciencePlots]
@@ -46,7 +46,7 @@ This is **not a linear pipeline** — it is an iterative loop. Results trigger n
 
 ---
 
-## When To Use This Skill
+## When to Use
 
 Use this skill when:
 - **Starting a new research paper** from an existing codebase or idea
@@ -58,6 +58,35 @@ Use this skill when:
 - **Writing non-empirical papers** — theory, survey, benchmark, or position papers (see [Paper Types Beyond Empirical ML](#paper-types-beyond-empirical-ml))
 - **Designing human evaluations** for NLP, HCI, or alignment research
 - **Preparing post-acceptance deliverables** — posters, talks, code releases
+
+## Prerequisites
+
+- Python packages from frontmatter `dependencies` (semanticscholar, arxiv, habanero, scipy, numpy, matplotlib, SciencePlots).
+- A TeX distribution with `latexmk` for PDF builds.
+- Hermes toolsets: `terminal`, file tools (`read_file`/`write_file`/`patch`), and preferably `web` for literature lookup.
+- Optional related skills: `arxiv`, `plan`, `subagent-driven-development`.
+
+## How to Run
+
+1. Load this skill with `skill_view("research-paper-writing")`.
+2. Follow Phases 0–8 in order, looping back when results or reviews demand it.
+3. Load progressive references with `skill_view("research-paper-writing", file_path="references/<file>.md")` only when that phase needs them.
+
+## Quick Reference
+
+| Need | Where |
+|------|-------|
+| Citations / BibTeX | `references/citation-workflow.md` + `arxiv` skill |
+| Experiment design / stats | `references/experiment-patterns.md` |
+| Writing / figures | `references/writing-guide.md` |
+| LaTeX templates | `references/latex-and-templates.md` + `templates/` |
+| Venue checklists | `references/checklists.md` |
+| Non-empirical paper types | `references/paper-types.md` |
+| Hermes tool patterns | `references/hermes-integration.md` |
+
+## Procedure
+
+Execute the phase pipeline below (Setup → Literature → Design → Execution → Analysis → Drafting → Review → Submission → Post-acceptance). Treat it as an iterative loop, not a one-pass checklist.
 
 ## Core Philosophy
 
@@ -1151,386 +1180,9 @@ Model Card (Appendix):
 
 ### Using LaTeX Templates
 
-**Always copy the entire template directory first, then write within it.**
+Copy the full venue template directory from `templates/` before editing. Verify it compiles unchanged, then replace example content section by section.
 
-```
-Template Setup Checklist:
-- [ ] Step 1: Copy entire template directory to new project
-- [ ] Step 2: Verify template compiles as-is (before any changes)
-- [ ] Step 3: Read the template's example content to understand structure
-- [ ] Step 4: Replace example content section by section
-- [ ] Step 5: Use template macros (check preamble for \newcommand definitions)
-- [ ] Step 6: Clean up template artifacts only at the end
-```
-
-**Step 1: Copy the Full Template**
-
-```bash
-cp -r templates/neurips2025/ ~/papers/my-paper/
-cd ~/papers/my-paper/
-ls -la  # Should see: main.tex, neurips.sty, Makefile, etc.
-```
-
-Copy the ENTIRE directory, not just the .tex file. Templates include style files (.sty), bibliography styles (.bst), example content, and Makefiles.
-
-**Step 2: Verify Template Compiles First**
-
-Before making ANY changes:
-```bash
-latexmk -pdf main.tex
-# Or manual: pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex
-```
-
-If the unmodified template doesn't compile, fix that first (usually missing TeX packages — install via `tlmgr install <package>`).
-
-**Step 3: Keep Template Content as Reference**
-
-Don't immediately delete example content. Comment it out and use as formatting reference:
-```latex
-% Template example (keep for reference):
-% \begin{figure}[t]
-%   \centering
-%   \includegraphics[width=0.8\linewidth]{example-image}
-%   \caption{Template shows caption style}
-% \end{figure}
-
-% Your actual figure:
-\begin{figure}[t]
-  \centering
-  \includegraphics[width=0.8\linewidth]{your-figure.pdf}
-  \caption{Your caption following the same style.}
-\end{figure}
-```
-
-**Step 4: Replace Content Section by Section**
-
-Work through systematically: title/authors → abstract → introduction → methods → experiments → related work → conclusion → references → appendix. Compile after each section.
-
-**Step 5: Use Template Macros**
-
-```latex
-\newcommand{\method}{YourMethodName}  % Consistent method naming
-\newcommand{\eg}{e.g.,\xspace}        % Proper abbreviations
-\newcommand{\ie}{i.e.,\xspace}
-```
-
-### Template Pitfalls
-
-| Pitfall | Problem | Solution |
-|---------|---------|----------|
-| Copying only `.tex` file | Missing `.sty`, won't compile | Copy entire directory |
-| Modifying `.sty` files | Breaks conference formatting | Never edit style files |
-| Adding random packages | Conflicts, breaks template | Only add if necessary |
-| Deleting template content early | Lose formatting reference | Keep as comments until done |
-| Not compiling frequently | Errors accumulate | Compile after each section |
-| Raster PNGs for figures | Blurry in paper | Always use vector PDF via `savefig('fig.pdf')` |
-
-### Quick Template Reference
-
-| Conference | Main File | Style File | Page Limit |
-|------------|-----------|------------|------------|
-| NeurIPS 2025 | `main.tex` | `neurips.sty` | 9 pages |
-| ICML 2026 | `example_paper.tex` | `icml2026.sty` | 8 pages |
-| ICLR 2026 | `iclr2026_conference.tex` | `iclr2026_conference.sty` | 9 pages |
-| ACL 2025 | `acl_latex.tex` | `acl.sty` | 8 pages (long) |
-| AAAI 2026 | `aaai2026-unified-template.tex` | `aaai2026.sty` | 7 pages |
-| COLM 2025 | `colm2025_conference.tex` | `colm2025_conference.sty` | 9 pages |
-
-**Universal**: Double-blind, references don't count, appendices unlimited, LaTeX required.
-
-Templates in `templates/` directory. See [templates/README.md](templates/README.md) for compilation setup (VS Code, CLI, Overleaf, other IDEs).
-
-### Tables and Figures
-
-**Tables** — use `booktabs` for professional formatting:
-
-```latex
-\usepackage{booktabs}
-\begin{tabular}{lcc}
-\toprule
-Method & Accuracy $\uparrow$ & Latency $\downarrow$ \\
-\midrule
-Baseline & 85.2 & 45ms \\
-\textbf{Ours} & \textbf{92.1} & 38ms \\
-\bottomrule
-\end{tabular}
-```
-
-Rules:
-- Bold best value per metric
-- Include direction symbols ($\uparrow$ higher better, $\downarrow$ lower better)
-- Right-align numerical columns
-- Consistent decimal precision
-
-**Figures**:
-- **Vector graphics** (PDF, EPS) for all plots and diagrams — `plt.savefig('fig.pdf')`
-- **Raster** (PNG 600 DPI) only for photographs
-- **Colorblind-safe palettes** (Okabe-Ito or Paul Tol)
-- Verify **grayscale readability** (8% of men have color vision deficiency)
-- **No title inside figure** — the caption serves this function
-- **Self-contained captions** — reader should understand without main text
-
-### Conference Resubmission
-
-For converting between venues, see Phase 7 (Submission Preparation) — it covers the full conversion workflow, page-change table, and post-rejection guidance.
-
-### Professional LaTeX Preamble
-
-Add these packages to any paper for professional quality. They are compatible with all major conference style files:
-
-```latex
-% --- Professional Packages (add after conference style file) ---
-
-% Typography
-\usepackage{microtype}              % Microtypographic improvements (protrusion, expansion)
-                                     % Makes text noticeably more polished — always include
-
-% Tables
-\usepackage{booktabs}               % Professional table rules (\toprule, \midrule, \bottomrule)
-\usepackage{siunitx}                % Consistent number formatting, decimal alignment
-                                     % Usage: \num{12345} → 12,345; \SI{3.5}{GHz} → 3.5 GHz
-                                     % Table alignment: S column type for decimal-aligned numbers
-
-% Figures
-\usepackage{graphicx}               % Include graphics (\includegraphics)
-\usepackage{subcaption}             % Subfigures with (a), (b), (c) labels
-                                     % Usage: \begin{subfigure}{0.48\textwidth} ... \end{subfigure}
-
-% Diagrams and Algorithms
-\usepackage{tikz}                   % Programmable vector diagrams
-\usetikzlibrary{arrows.meta, positioning, shapes.geometric, calc, fit, backgrounds}
-\usepackage[ruled,vlined]{algorithm2e}  % Professional pseudocode
-                                     % Alternative: \usepackage{algorithmicx} if template bundles it
-
-% Cross-references
-\usepackage{cleveref}               % Smart references: \cref{fig:x} → "Figure 1"
-                                     % MUST be loaded AFTER hyperref
-                                     % Handles: figures, tables, sections, equations, algorithms
-
-% Math (usually included by conference .sty, but verify)
-\usepackage{amsmath,amssymb}        % AMS math environments and symbols
-\usepackage{mathtools}              % Extends amsmath (dcases, coloneqq, etc.)
-
-% Colors (for figures and diagrams)
-\usepackage{xcolor}                 % Color management
-% Okabe-Ito colorblind-safe palette:
-\definecolor{okblue}{HTML}{0072B2}
-\definecolor{okorange}{HTML}{E69F00}
-\definecolor{okgreen}{HTML}{009E73}
-\definecolor{okred}{HTML}{D55E00}
-\definecolor{okpurple}{HTML}{CC79A7}
-\definecolor{okcyan}{HTML}{56B4E9}
-\definecolor{okyellow}{HTML}{F0E442}
-```
-
-**Notes:**
-- `microtype` is the single highest-impact package for visual quality. It adjusts character spacing at a sub-pixel level. Always include it.
-- `siunitx` handles decimal alignment in tables via the `S` column type — eliminates manual spacing.
-- `cleveref` must be loaded **after** `hyperref`. Most conference .sty files load hyperref, so put cleveref last.
-- Check if the conference template already loads any of these (especially `algorithm`, `amsmath`, `graphicx`). Don't double-load.
-
-### siunitx Table Alignment
-
-`siunitx` makes number-heavy tables significantly more readable:
-
-```latex
-\begin{tabular}{l S[table-format=2.1] S[table-format=2.1] S[table-format=2.1]}
-\toprule
-Method & {Accuracy $\uparrow$} & {F1 $\uparrow$} & {Latency (ms) $\downarrow$} \\
-\midrule
-Baseline         & 85.2  & 83.7  & 45.3 \\
-Ablation (no X)  & 87.1  & 85.4  & 42.1 \\
-\textbf{Ours}    & \textbf{92.1} & \textbf{90.8} & \textbf{38.7} \\
-\bottomrule
-\end{tabular}
-```
-
-The `S` column type auto-aligns on the decimal point. Headers in `{}` escape the alignment.
-
-### Subfigures
-
-Standard pattern for side-by-side figures:
-
-```latex
-\begin{figure}[t]
-  \centering
-  \begin{subfigure}[b]{0.48\textwidth}
-    \centering
-    \includegraphics[width=\textwidth]{fig_results_a.pdf}
-    \caption{Results on Dataset A.}
-    \label{fig:results-a}
-  \end{subfigure}
-  \hfill
-  \begin{subfigure}[b]{0.48\textwidth}
-    \centering
-    \includegraphics[width=\textwidth]{fig_results_b.pdf}
-    \caption{Results on Dataset B.}
-    \label{fig:results-b}
-  \end{subfigure}
-  \caption{Comparison of our method across two datasets. (a) shows the scaling
-  behavior and (b) shows the ablation results. Both use 5 random seeds.}
-  \label{fig:results}
-\end{figure}
-```
-
-Use `\cref{fig:results}` → "Figure 1", `\cref{fig:results-a}` → "Figure 1a".
-
-### Pseudocode with algorithm2e
-
-```latex
-\begin{algorithm}[t]
-\caption{Iterative Refinement with Judge Panel}
-\label{alg:method}
-\KwIn{Task $T$, model $M$, judges $J_1 \ldots J_n$, convergence threshold $k$}
-\KwOut{Final output $A^*$}
-$A \gets M(T)$ \tcp*{Initial generation}
-$\text{streak} \gets 0$\;
-\While{$\text{streak} < k$}{
-  $C \gets \text{Critic}(A, T)$ \tcp*{Identify weaknesses}
-  $B \gets M(T, C)$ \tcp*{Revised version addressing critique}
-  $AB \gets \text{Synthesize}(A, B)$ \tcp*{Merge best elements}
-  \ForEach{judge $J_i$}{
-    $\text{rank}_i \gets J_i(\text{shuffle}(A, B, AB))$ \tcp*{Blind ranking}
-  }
-  $\text{winner} \gets \text{BordaCount}(\text{ranks})$\;
-  \eIf{$\text{winner} = A$}{
-    $\text{streak} \gets \text{streak} + 1$\;
-  }{
-    $A \gets \text{winner}$; $\text{streak} \gets 0$\;
-  }
-}
-\Return{$A$}\;
-\end{algorithm}
-```
-
-### TikZ Diagram Patterns
-
-TikZ is the standard for method diagrams in ML papers. Common patterns:
-
-**Pipeline/Flow Diagram** (most common in ML papers):
-
-```latex
-\begin{figure}[t]
-\centering
-\begin{tikzpicture}[
-  node distance=1.8cm,
-  box/.style={rectangle, draw, rounded corners, minimum height=1cm, 
-              minimum width=2cm, align=center, font=\small},
-  arrow/.style={-{Stealth[length=3mm]}, thick},
-]
-  \node[box, fill=okcyan!20] (input) {Input\\$x$};
-  \node[box, fill=okblue!20, right of=input] (encoder) {Encoder\\$f_\theta$};
-  \node[box, fill=okgreen!20, right of=encoder] (latent) {Latent\\$z$};
-  \node[box, fill=okorange!20, right of=latent] (decoder) {Decoder\\$g_\phi$};
-  \node[box, fill=okred!20, right of=decoder] (output) {Output\\$\hat{x}$};
-  
-  \draw[arrow] (input) -- (encoder);
-  \draw[arrow] (encoder) -- (latent);
-  \draw[arrow] (latent) -- (decoder);
-  \draw[arrow] (decoder) -- (output);
-\end{tikzpicture}
-\caption{Architecture overview. The encoder maps input $x$ to latent 
-representation $z$, which the decoder reconstructs.}
-\label{fig:architecture}
-\end{figure}
-```
-
-**Comparison/Matrix Diagram** (for showing method variants):
-
-```latex
-\begin{tikzpicture}[
-  cell/.style={rectangle, draw, minimum width=2.5cm, minimum height=1cm, 
-               align=center, font=\small},
-  header/.style={cell, fill=gray!20, font=\small\bfseries},
-]
-  % Headers
-  \node[header] at (0, 0) {Method};
-  \node[header] at (3, 0) {Converges?};
-  \node[header] at (6, 0) {Quality?};
-  % Rows
-  \node[cell] at (0, -1) {Single Pass};
-  \node[cell, fill=okgreen!15] at (3, -1) {N/A};
-  \node[cell, fill=okorange!15] at (6, -1) {Baseline};
-  \node[cell] at (0, -2) {Critique+Revise};
-  \node[cell, fill=okred!15] at (3, -2) {No};
-  \node[cell, fill=okred!15] at (6, -2) {Degrades};
-  \node[cell] at (0, -3) {Ours};
-  \node[cell, fill=okgreen!15] at (3, -3) {Yes ($k$=2)};
-  \node[cell, fill=okgreen!15] at (6, -3) {Improves};
-\end{tikzpicture}
-```
-
-**Iterative Loop Diagram** (for methods with feedback):
-
-```latex
-\begin{tikzpicture}[
-  node distance=2cm,
-  box/.style={rectangle, draw, rounded corners, minimum height=0.8cm, 
-              minimum width=1.8cm, align=center, font=\small},
-  arrow/.style={-{Stealth[length=3mm]}, thick},
-  label/.style={font=\scriptsize, midway, above},
-]
-  \node[box, fill=okblue!20] (gen) {Generator};
-  \node[box, fill=okred!20, right=2.5cm of gen] (critic) {Critic};
-  \node[box, fill=okgreen!20, below=1.5cm of $(gen)!0.5!(critic)$] (judge) {Judge Panel};
-  
-  \draw[arrow] (gen) -- node[label] {output $A$} (critic);
-  \draw[arrow] (critic) -- node[label, right] {critique $C$} (judge);
-  \draw[arrow] (judge) -| node[label, left, pos=0.3] {winner} (gen);
-\end{tikzpicture}
-```
-
-### latexdiff for Revision Tracking
-
-Essential for rebuttals — generates a marked-up PDF showing changes between versions:
-
-```bash
-# Install
-# macOS: brew install latexdiff (or comes with TeX Live)
-# Linux: sudo apt install latexdiff
-
-# Generate diff
-latexdiff paper_v1.tex paper_v2.tex > paper_diff.tex
-pdflatex paper_diff.tex
-
-# For multi-file projects (with \input{} or \include{})
-latexdiff --flatten paper_v1.tex paper_v2.tex > paper_diff.tex
-```
-
-This produces a PDF with deletions in red strikethrough and additions in blue — standard format for rebuttal supplements.
-
-### SciencePlots for matplotlib
-
-Install and use for publication-quality plots:
-
-```bash
-pip install SciencePlots
-```
-
-```python
-import matplotlib.pyplot as plt
-import scienceplots  # registers styles
-
-# Use science style (IEEE-like, clean)
-with plt.style.context(['science', 'no-latex']):
-    fig, ax = plt.subplots(figsize=(3.5, 2.5))  # Single-column width
-    ax.plot(x, y, label='Ours', color='#0072B2')
-    ax.plot(x, y2, label='Baseline', color='#D55E00', linestyle='--')
-    ax.set_xlabel('Training Steps')
-    ax.set_ylabel('Accuracy')
-    ax.legend()
-    fig.savefig('paper/fig_results.pdf', bbox_inches='tight')
-
-# Available styles: 'science', 'ieee', 'nature', 'science+ieee'
-# Add 'no-latex' if LaTeX is not installed on the machine generating plots
-```
-
-**Standard figure sizes** (two-column format):
-- Single column: `figsize=(3.5, 2.5)` — fits in one column
-- Double column: `figsize=(7.0, 3.0)` — spans both columns
-- Square: `figsize=(3.5, 3.5)` — for heatmaps, confusion matrices
-
----
+Full template setup, venue pitfalls, preamble macros, tables/figures, siunitx alignment, subfigures, algorithm2e, TikZ patterns, latexdiff, and SciencePlots sizing live in [references/latex-and-templates.md](references/latex-and-templates.md). Load with `skill_view("research-paper-writing", file_path="references/latex-and-templates.md")`.
 
 ## Phase 6: Self-Review & Revision
 
@@ -2062,57 +1714,7 @@ ACL venues have distinct submission types:
 
 The main pipeline above targets empirical ML papers. Other paper types require different structures and evidence standards. See [references/paper-types.md](references/paper-types.md) for detailed guidance on each type.
 
-### Theory Papers
-
-**Structure**: Introduction → Preliminaries (definitions, notation) → Main Results (theorems) → Proof Sketches → Discussion → Full Proofs (appendix)
-
-**Key differences from empirical papers:**
-- Contribution is a theorem, bound, or impossibility result — not experimental numbers
-- Methods section replaced by "Preliminaries" and "Main Results"
-- Proofs are the evidence, not experiments (though empirical validation of theory is welcome)
-- Proof sketches in main text, full proofs in appendix is standard practice
-- Experimental section is optional but strengthens the paper if it validates theoretical predictions
-
-**Proof writing principles:**
-- State theorems formally with all assumptions explicit
-- Provide intuition before formal proof ("The key insight is...")
-- Proof sketches should convey the main idea in 0.5-1 page
-- Use `\begin{proof}...\end{proof}` environments
-- Number assumptions and reference them in theorems: "Under Assumptions 1-3, ..."
-
-### Survey / Tutorial Papers
-
-**Structure**: Introduction → Taxonomy / Organization → Detailed Coverage → Open Problems → Conclusion
-
-**Key differences:**
-- Contribution is the organization, synthesis, and identification of open problems — not new methods
-- Must be comprehensive within scope (reviewers will check for missing references)
-- Requires a clear taxonomy or organizational framework
-- Value comes from connections between works that individual papers don't make
-- Best venues: TMLR (survey track), JMLR, Foundations and Trends in ML, ACM Computing Surveys
-
-### Benchmark Papers
-
-**Structure**: Introduction → Task Definition → Dataset Construction → Baseline Evaluation → Analysis → Intended Use & Limitations
-
-**Key differences:**
-- Contribution is the benchmark itself — it must fill a genuine evaluation gap
-- Dataset documentation is mandatory, not optional (see Datasheets, Step 5.11)
-- Must demonstrate the benchmark is challenging (baselines don't saturate it)
-- Must demonstrate the benchmark measures what you claim it measures (construct validity)
-- Best venues: NeurIPS Datasets & Benchmarks track, ACL (resource papers), LREC-COLING
-
-### Position Papers
-
-**Structure**: Introduction → Background → Thesis / Argument → Supporting Evidence → Counterarguments → Implications
-
-**Key differences:**
-- Contribution is an argument, not a result
-- Must engage seriously with counterarguments
-- Evidence can be empirical, theoretical, or logical analysis
-- Best venues: ICML (position track), workshops, TMLR
-
----
+Detailed structures for theory, survey/tutorial, benchmark, and position papers are in [references/paper-types.md](references/paper-types.md).
 
 ## Hermes Agent Integration
 
@@ -2152,126 +1754,8 @@ Compose this skill with other Hermes skills for specific phases:
 
 ### Tool Usage Patterns
 
-**Experiment monitoring** (most common):
-```
-terminal("ps aux | grep <pattern>")
-→ terminal("tail -30 <logfile>")
-→ terminal("ls results/")
-→ execute_code("analyze results JSON, compute metrics")
-→ terminal("git add -A && git commit -m '<descriptive message>' && git push")
-→ (final response auto-delivers "Experiment complete: <summary>"; for unattended runs, schedule via cron with a deliver: target)
-```
+Experiment monitoring, parallel section drafting, state management with `memory`/`todo`, cron monitoring, and communication patterns are in [references/hermes-integration.md](references/hermes-integration.md). Load with `skill_view("research-paper-writing", file_path="references/hermes-integration.md")`.
 
-**Parallel section drafting** (using delegation):
-```
-delegate_task("Draft the Methods section based on these experiment scripts and configs. 
-  Include: pseudocode, all hyperparameters, architectural details sufficient for 
-  reproduction. Write in LaTeX using the neurips2025 template conventions.")
-
-delegate_task("Draft the Related Work section. Use web_search and web_extract to 
-  find papers. Verify every citation via Semantic Scholar. Group by methodology.")
-
-delegate_task("Draft the Experiments section. Read all result files in results/. 
-  State which claim each experiment supports. Include error bars and significance.")
-```
-
-Each delegate runs as a **fresh subagent** with no shared context — provide all necessary information in the prompt. Collect outputs and integrate.
-
-**Citation verification** (using execute_code):
-```python
-# In execute_code:
-from semanticscholar import SemanticScholar
-import requests
-
-sch = SemanticScholar()
-results = sch.search_paper("attention mechanism transformers", limit=5)
-for paper in results:
-    doi = paper.externalIds.get('DOI', 'N/A')
-    if doi != 'N/A':
-        bibtex = requests.get(f"https://doi.org/{doi}", 
-                              headers={"Accept": "application/x-bibtex"}).text
-        print(bibtex)
-```
-
-### State Management with `memory` and `todo`
-
-**`memory` tool** — persist key decisions (bounded: ~2200 chars for MEMORY.md):
-
-```
-memory("add", "Paper: autoreason. Venue: NeurIPS 2025 (9 pages). 
-  Contribution: structured refinement works when generation-evaluation gap is wide.
-  Key results: Haiku 42/42, Sonnet 3/5, S4.6 constrained 2/3.
-  Status: Phase 5 — drafting Methods section.")
-```
-
-Update memory after major decisions or phase transitions. This persists across sessions.
-
-**`todo` tool** — track granular progress:
-
-```
-todo("add", "Design constrained task experiments for Sonnet 4.6")
-todo("add", "Run Haiku baseline comparison")
-todo("add", "Draft Methods section")
-todo("update", id=3, status="in_progress")
-todo("update", id=1, status="completed")
-```
-
-**Session startup protocol:**
-```
-1. todo("list")                           # Check current task list
-2. memory("read")                         # Recall key decisions
-3. terminal("git log --oneline -10")      # Check recent commits
-4. terminal("ps aux | grep python")       # Check running experiments
-5. terminal("ls results/ | tail -20")     # Check for new results
-6. Report status to user, ask for direction
-```
-
-### Cron Monitoring with `cronjob`
-
-Use the `cronjob` tool to schedule periodic experiment checks:
-
-```
-cronjob("create", {
-  "schedule": "*/30 * * * *",  # Every 30 minutes
-  "prompt": "Check experiment status:
-    1. ps aux | grep run_experiment
-    2. tail -30 logs/experiment_haiku.log
-    3. ls results/haiku_baselines/
-    4. If complete: read results, compute Borda scores, 
-       git add -A && git commit -m 'Add Haiku results' && git push
-    5. Report: table of results, key finding, next step
-    6. If nothing changed: respond with [SILENT]"
-})
-```
-
-**[SILENT] protocol**: When nothing has changed since the last check, respond with exactly `[SILENT]`. This suppresses notification delivery to the user. Only report when there are genuine changes worth knowing about.
-
-**Deadline tracking**:
-```
-cronjob("create", {
-  "schedule": "0 9 * * *",  # Daily at 9am
-  "prompt": "NeurIPS 2025 deadline: May 22. Today is {date}. 
-    Days remaining: {compute}. 
-    Check todo list — are we on track? 
-    If <7 days: warn user about remaining tasks."
-})
-```
-
-### Communication Patterns
-
-**When to notify the user** (via your direct/final response, or a cron `deliver:` target for unattended runs):
-- Experiment batch completed (with results table)
-- Unexpected finding or failure requiring decision
-- Draft section ready for review
-- Deadline approaching with incomplete tasks
-
-**When NOT to notify:**
-- Experiment still running, no new results → `[SILENT]`
-- Routine monitoring with no changes → `[SILENT]`
-- Intermediate steps that don't need attention
-
-**Report format** — always include structured data:
-```
 ## Experiment: <name>
 Status: Complete / Running / Failed
 
@@ -2324,7 +1808,7 @@ See [references/reviewer-guidelines.md](references/reviewer-guidelines.md) for d
 
 ---
 
-## Common Issues and Solutions
+## Pitfalls
 
 | Issue | Solution |
 |-------|----------|
@@ -2342,6 +1826,14 @@ See [references/reviewer-guidelines.md](references/reviewer-guidelines.md) for d
 | Results are negative/null | See Phase 4.3 on handling negative results. Consider workshops, TMLR, or reframing as analysis. |
 
 ---
+
+## Verification
+
+- Every citation resolves via Semantic Scholar / arXiv / CrossRef (no hallucinated refs).
+- Paper compiles with the target venue template (`latexmk -pdf`).
+- Contribution is stated in one sentence; every experiment maps to a claim.
+- Venue checklist in `references/checklists.md` is complete before submission.
+- Self-review ensemble (Phase 6) has been run and major weaknesses addressed.
 
 ## Reference Documents
 

--- a/skills/research/research-paper-writing/references/hermes-integration.md
+++ b/skills/research/research-paper-writing/references/hermes-integration.md
@@ -1,0 +1,126 @@
+# Hermes Agent Integration Patterns
+
+Progressive-disclosure reference for the research-paper-writing skill. Load with `skill_view("research-paper-writing", file_path="references/hermes-integration.md")`.
+
+### Tool Usage Patterns
+
+**Experiment monitoring** (most common):
+```
+terminal("ps aux | grep <pattern>")
+→ terminal("tail -30 <logfile>")
+→ terminal("ls results/")
+→ execute_code("analyze results JSON, compute metrics")
+→ terminal("git add -A && git commit -m '<descriptive message>' && git push")
+→ (final response auto-delivers "Experiment complete: <summary>"; for unattended runs, schedule via cron with a deliver: target)
+```
+
+**Parallel section drafting** (using delegation):
+```
+delegate_task("Draft the Methods section based on these experiment scripts and configs.
+  Include: pseudocode, all hyperparameters, architectural details sufficient for
+  reproduction. Write in LaTeX using the neurips2025 template conventions.")
+
+delegate_task("Draft the Related Work section. Use web_search and web_extract to
+  find papers. Verify every citation via Semantic Scholar. Group by methodology.")
+
+delegate_task("Draft the Experiments section. Read all result files in results/.
+  State which claim each experiment supports. Include error bars and significance.")
+```
+
+Each delegate runs as a **fresh subagent** with no shared context — provide all necessary information in the prompt. Collect outputs and integrate.
+
+**Citation verification** (using execute_code):
+```python
+# In execute_code:
+from semanticscholar import SemanticScholar
+import requests
+
+sch = SemanticScholar()
+results = sch.search_paper("attention mechanism transformers", limit=5)
+for paper in results:
+    doi = paper.externalIds.get('DOI', 'N/A')
+    if doi != 'N/A':
+        bibtex = requests.get(f"https://doi.org/{doi}",
+                              headers={"Accept": "application/x-bibtex"}).text
+        print(bibtex)
+```
+
+### State Management with `memory` and `todo`
+
+**`memory` tool** — persist key decisions (bounded: ~2200 chars for MEMORY.md):
+
+```
+memory("add", "Paper: autoreason. Venue: NeurIPS 2025 (9 pages).
+  Contribution: structured refinement works when generation-evaluation gap is wide.
+  Key results: Haiku 42/42, Sonnet 3/5, S4.6 constrained 2/3.
+  Status: Phase 5 — drafting Methods section.")
+```
+
+Update memory after major decisions or phase transitions. This persists across sessions.
+
+**`todo` tool** — track granular progress:
+
+```
+todo("add", "Design constrained task experiments for Sonnet 4.6")
+todo("add", "Run Haiku baseline comparison")
+todo("add", "Draft Methods section")
+todo("update", id=3, status="in_progress")
+todo("update", id=1, status="completed")
+```
+
+**Session startup protocol:**
+```
+1. todo("list")                           # Check current task list
+2. memory("read")                         # Recall key decisions
+3. terminal("git log --oneline -10")      # Check recent commits
+4. terminal("ps aux | grep python")       # Check running experiments
+5. terminal("ls results/ | tail -20")     # Check for new results
+6. Report status to user, ask for direction
+```
+
+### Cron Monitoring with `cronjob`
+
+Use the `cronjob` tool to schedule periodic experiment checks:
+
+```
+cronjob("create", {
+  "schedule": "*/30 * * * *",  # Every 30 minutes
+  "prompt": "Check experiment status:
+    1. ps aux | grep run_experiment
+    2. tail -30 logs/experiment_haiku.log
+    3. ls results/haiku_baselines/
+    4. If complete: read results, compute Borda scores,
+       git add -A && git commit -m 'Add Haiku results' && git push
+    5. Report: table of results, key finding, next step
+    6. If nothing changed: respond with [SILENT]"
+})
+```
+
+**[SILENT] protocol**: When nothing has changed since the last check, respond with exactly `[SILENT]`. This suppresses notification delivery to the user. Only report when there are genuine changes worth knowing about.
+
+**Deadline tracking**:
+```
+cronjob("create", {
+  "schedule": "0 9 * * *",  # Daily at 9am
+  "prompt": "NeurIPS 2025 deadline: May 22. Today is {date}.
+    Days remaining: {compute}.
+    Check todo list — are we on track?
+    If <7 days: warn user about remaining tasks."
+})
+```
+
+### Communication Patterns
+
+**When to notify the user** (via your direct/final response, or a cron `deliver:` target for unattended runs):
+- Experiment batch completed (with results table)
+- Unexpected finding or failure requiring decision
+- Draft section ready for review
+- Deadline approaching with incomplete tasks
+
+**When NOT to notify:**
+- Experiment still running, no new results → `[SILENT]`
+- Routine monitoring with no changes → `[SILENT]`
+- Intermediate steps that don't need attention
+
+**Report format** — always include structured data:
+```

--- a/skills/research/research-paper-writing/references/latex-and-templates.md
+++ b/skills/research/research-paper-writing/references/latex-and-templates.md
@@ -1,0 +1,386 @@
+# LaTeX Templates and Publication Formatting
+
+Progressive-disclosure reference for the research-paper-writing skill. Load with `skill_view("research-paper-writing", file_path="references/latex-and-templates.md")`.
+
+## Using LaTeX Templates
+
+**Always copy the entire template directory first, then write within it.**
+
+```
+Template Setup Checklist:
+- [ ] Step 1: Copy entire template directory to new project
+- [ ] Step 2: Verify template compiles as-is (before any changes)
+- [ ] Step 3: Read the template's example content to understand structure
+- [ ] Step 4: Replace example content section by section
+- [ ] Step 5: Use template macros (check preamble for \newcommand definitions)
+- [ ] Step 6: Clean up template artifacts only at the end
+```
+
+**Step 1: Copy the Full Template**
+
+```bash
+cp -r templates/neurips2025/ ~/papers/my-paper/
+cd ~/papers/my-paper/
+ls -la  # Should see: main.tex, neurips.sty, Makefile, etc.
+```
+
+Copy the ENTIRE directory, not just the .tex file. Templates include style files (.sty), bibliography styles (.bst), example content, and Makefiles.
+
+**Step 2: Verify Template Compiles First**
+
+Before making ANY changes:
+```bash
+latexmk -pdf main.tex
+# Or manual: pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex
+```
+
+If the unmodified template doesn't compile, fix that first (usually missing TeX packages — install via `tlmgr install <package>`).
+
+**Step 3: Keep Template Content as Reference**
+
+Don't immediately delete example content. Comment it out and use as formatting reference:
+```latex
+% Template example (keep for reference):
+% \begin{figure}[t]
+%   \centering
+%   \includegraphics[width=0.8\linewidth]{example-image}
+%   \caption{Template shows caption style}
+% \end{figure}
+
+% Your actual figure:
+\begin{figure}[t]
+  \centering
+  \includegraphics[width=0.8\linewidth]{your-figure.pdf}
+  \caption{Your caption following the same style.}
+\end{figure}
+```
+
+**Step 4: Replace Content Section by Section**
+
+Work through systematically: title/authors → abstract → introduction → methods → experiments → related work → conclusion → references → appendix. Compile after each section.
+
+**Step 5: Use Template Macros**
+
+```latex
+\newcommand{\method}{YourMethodName}  % Consistent method naming
+\newcommand{\eg}{e.g.,\xspace}        % Proper abbreviations
+\newcommand{\ie}{i.e.,\xspace}
+```
+
+### Template Pitfalls
+
+| Pitfall | Problem | Solution |
+|---------|---------|----------|
+| Copying only `.tex` file | Missing `.sty`, won't compile | Copy entire directory |
+| Modifying `.sty` files | Breaks conference formatting | Never edit style files |
+| Adding random packages | Conflicts, breaks template | Only add if necessary |
+| Deleting template content early | Lose formatting reference | Keep as comments until done |
+| Not compiling frequently | Errors accumulate | Compile after each section |
+| Raster PNGs for figures | Blurry in paper | Always use vector PDF via `savefig('fig.pdf')` |
+
+### Quick Template Reference
+
+| Conference | Main File | Style File | Page Limit |
+|------------|-----------|------------|------------|
+| NeurIPS 2025 | `main.tex` | `neurips.sty` | 9 pages |
+| ICML 2026 | `example_paper.tex` | `icml2026.sty` | 8 pages |
+| ICLR 2026 | `iclr2026_conference.tex` | `iclr2026_conference.sty` | 9 pages |
+| ACL 2025 | `acl_latex.tex` | `acl.sty` | 8 pages (long) |
+| AAAI 2026 | `aaai2026-unified-template.tex` | `aaai2026.sty` | 7 pages |
+| COLM 2025 | `colm2025_conference.tex` | `colm2025_conference.sty` | 9 pages |
+
+**Universal**: Double-blind, references don't count, appendices unlimited, LaTeX required.
+
+Templates in `templates/` directory. See [templates/README.md](templates/README.md) for compilation setup (VS Code, CLI, Overleaf, other IDEs).
+
+### Tables and Figures
+
+**Tables** — use `booktabs` for professional formatting:
+
+```latex
+\usepackage{booktabs}
+\begin{tabular}{lcc}
+\toprule
+Method & Accuracy $\uparrow$ & Latency $\downarrow$ \\
+\midrule
+Baseline & 85.2 & 45ms \\
+\textbf{Ours} & \textbf{92.1} & 38ms \\
+\bottomrule
+\end{tabular}
+```
+
+Rules:
+- Bold best value per metric
+- Include direction symbols ($\uparrow$ higher better, $\downarrow$ lower better)
+- Right-align numerical columns
+- Consistent decimal precision
+
+**Figures**:
+- **Vector graphics** (PDF, EPS) for all plots and diagrams — `plt.savefig('fig.pdf')`
+- **Raster** (PNG 600 DPI) only for photographs
+- **Colorblind-safe palettes** (Okabe-Ito or Paul Tol)
+- Verify **grayscale readability** (8% of men have color vision deficiency)
+- **No title inside figure** — the caption serves this function
+- **Self-contained captions** — reader should understand without main text
+
+### Conference Resubmission
+
+For converting between venues, see Phase 7 (Submission Preparation) — it covers the full conversion workflow, page-change table, and post-rejection guidance.
+
+### Professional LaTeX Preamble
+
+Add these packages to any paper for professional quality. They are compatible with all major conference style files:
+
+```latex
+% --- Professional Packages (add after conference style file) ---
+
+% Typography
+\usepackage{microtype}              % Microtypographic improvements (protrusion, expansion)
+                                     % Makes text noticeably more polished — always include
+
+% Tables
+\usepackage{booktabs}               % Professional table rules (\toprule, \midrule, \bottomrule)
+\usepackage{siunitx}                % Consistent number formatting, decimal alignment
+                                     % Usage: \num{12345} → 12,345; \SI{3.5}{GHz} → 3.5 GHz
+                                     % Table alignment: S column type for decimal-aligned numbers
+
+% Figures
+\usepackage{graphicx}               % Include graphics (\includegraphics)
+\usepackage{subcaption}             % Subfigures with (a), (b), (c) labels
+                                     % Usage: \begin{subfigure}{0.48\textwidth} ... \end{subfigure}
+
+% Diagrams and Algorithms
+\usepackage{tikz}                   % Programmable vector diagrams
+\usetikzlibrary{arrows.meta, positioning, shapes.geometric, calc, fit, backgrounds}
+\usepackage[ruled,vlined]{algorithm2e}  % Professional pseudocode
+                                     % Alternative: \usepackage{algorithmicx} if template bundles it
+
+% Cross-references
+\usepackage{cleveref}               % Smart references: \cref{fig:x} → "Figure 1"
+                                     % MUST be loaded AFTER hyperref
+                                     % Handles: figures, tables, sections, equations, algorithms
+
+% Math (usually included by conference .sty, but verify)
+\usepackage{amsmath,amssymb}        % AMS math environments and symbols
+\usepackage{mathtools}              % Extends amsmath (dcases, coloneqq, etc.)
+
+% Colors (for figures and diagrams)
+\usepackage{xcolor}                 % Color management
+% Okabe-Ito colorblind-safe palette:
+\definecolor{okblue}{HTML}{0072B2}
+\definecolor{okorange}{HTML}{E69F00}
+\definecolor{okgreen}{HTML}{009E73}
+\definecolor{okred}{HTML}{D55E00}
+\definecolor{okpurple}{HTML}{CC79A7}
+\definecolor{okcyan}{HTML}{56B4E9}
+\definecolor{okyellow}{HTML}{F0E442}
+```
+
+**Notes:**
+- `microtype` is the single highest-impact package for visual quality. It adjusts character spacing at a sub-pixel level. Always include it.
+- `siunitx` handles decimal alignment in tables via the `S` column type — eliminates manual spacing.
+- `cleveref` must be loaded **after** `hyperref`. Most conference .sty files load hyperref, so put cleveref last.
+- Check if the conference template already loads any of these (especially `algorithm`, `amsmath`, `graphicx`). Don't double-load.
+
+### siunitx Table Alignment
+
+`siunitx` makes number-heavy tables significantly more readable:
+
+```latex
+\begin{tabular}{l S[table-format=2.1] S[table-format=2.1] S[table-format=2.1]}
+\toprule
+Method & {Accuracy $\uparrow$} & {F1 $\uparrow$} & {Latency (ms) $\downarrow$} \\
+\midrule
+Baseline         & 85.2  & 83.7  & 45.3 \\
+Ablation (no X)  & 87.1  & 85.4  & 42.1 \\
+\textbf{Ours}    & \textbf{92.1} & \textbf{90.8} & \textbf{38.7} \\
+\bottomrule
+\end{tabular}
+```
+
+The `S` column type auto-aligns on the decimal point. Headers in `{}` escape the alignment.
+
+### Subfigures
+
+Standard pattern for side-by-side figures:
+
+```latex
+\begin{figure}[t]
+  \centering
+  \begin{subfigure}[b]{0.48\textwidth}
+    \centering
+    \includegraphics[width=\textwidth]{fig_results_a.pdf}
+    \caption{Results on Dataset A.}
+    \label{fig:results-a}
+  \end{subfigure}
+  \hfill
+  \begin{subfigure}[b]{0.48\textwidth}
+    \centering
+    \includegraphics[width=\textwidth]{fig_results_b.pdf}
+    \caption{Results on Dataset B.}
+    \label{fig:results-b}
+  \end{subfigure}
+  \caption{Comparison of our method across two datasets. (a) shows the scaling
+  behavior and (b) shows the ablation results. Both use 5 random seeds.}
+  \label{fig:results}
+\end{figure}
+```
+
+Use `\cref{fig:results}` → "Figure 1", `\cref{fig:results-a}` → "Figure 1a".
+
+### Pseudocode with algorithm2e
+
+```latex
+\begin{algorithm}[t]
+\caption{Iterative Refinement with Judge Panel}
+\label{alg:method}
+\KwIn{Task $T$, model $M$, judges $J_1 \ldots J_n$, convergence threshold $k$}
+\KwOut{Final output $A^*$}
+$A \gets M(T)$ \tcp*{Initial generation}
+$\text{streak} \gets 0$\;
+\While{$\text{streak} < k$}{
+  $C \gets \text{Critic}(A, T)$ \tcp*{Identify weaknesses}
+  $B \gets M(T, C)$ \tcp*{Revised version addressing critique}
+  $AB \gets \text{Synthesize}(A, B)$ \tcp*{Merge best elements}
+  \ForEach{judge $J_i$}{
+    $\text{rank}_i \gets J_i(\text{shuffle}(A, B, AB))$ \tcp*{Blind ranking}
+  }
+  $\text{winner} \gets \text{BordaCount}(\text{ranks})$\;
+  \eIf{$\text{winner} = A$}{
+    $\text{streak} \gets \text{streak} + 1$\;
+  }{
+    $A \gets \text{winner}$; $\text{streak} \gets 0$\;
+  }
+}
+\Return{$A$}\;
+\end{algorithm}
+```
+
+### TikZ Diagram Patterns
+
+TikZ is the standard for method diagrams in ML papers. Common patterns:
+
+**Pipeline/Flow Diagram** (most common in ML papers):
+
+```latex
+\begin{figure}[t]
+\centering
+\begin{tikzpicture}[
+  node distance=1.8cm,
+  box/.style={rectangle, draw, rounded corners, minimum height=1cm,
+              minimum width=2cm, align=center, font=\small},
+  arrow/.style={-{Stealth[length=3mm]}, thick},
+]
+  \node[box, fill=okcyan!20] (input) {Input\\$x$};
+  \node[box, fill=okblue!20, right of=input] (encoder) {Encoder\\$f_\theta$};
+  \node[box, fill=okgreen!20, right of=encoder] (latent) {Latent\\$z$};
+  \node[box, fill=okorange!20, right of=latent] (decoder) {Decoder\\$g_\phi$};
+  \node[box, fill=okred!20, right of=decoder] (output) {Output\\$\hat{x}$};
+
+  \draw[arrow] (input) -- (encoder);
+  \draw[arrow] (encoder) -- (latent);
+  \draw[arrow] (latent) -- (decoder);
+  \draw[arrow] (decoder) -- (output);
+\end{tikzpicture}
+\caption{Architecture overview. The encoder maps input $x$ to latent
+representation $z$, which the decoder reconstructs.}
+\label{fig:architecture}
+\end{figure}
+```
+
+**Comparison/Matrix Diagram** (for showing method variants):
+
+```latex
+\begin{tikzpicture}[
+  cell/.style={rectangle, draw, minimum width=2.5cm, minimum height=1cm,
+               align=center, font=\small},
+  header/.style={cell, fill=gray!20, font=\small\bfseries},
+]
+  % Headers
+  \node[header] at (0, 0) {Method};
+  \node[header] at (3, 0) {Converges?};
+  \node[header] at (6, 0) {Quality?};
+  % Rows
+  \node[cell] at (0, -1) {Single Pass};
+  \node[cell, fill=okgreen!15] at (3, -1) {N/A};
+  \node[cell, fill=okorange!15] at (6, -1) {Baseline};
+  \node[cell] at (0, -2) {Critique+Revise};
+  \node[cell, fill=okred!15] at (3, -2) {No};
+  \node[cell, fill=okred!15] at (6, -2) {Degrades};
+  \node[cell] at (0, -3) {Ours};
+  \node[cell, fill=okgreen!15] at (3, -3) {Yes ($k$=2)};
+  \node[cell, fill=okgreen!15] at (6, -3) {Improves};
+\end{tikzpicture}
+```
+
+**Iterative Loop Diagram** (for methods with feedback):
+
+```latex
+\begin{tikzpicture}[
+  node distance=2cm,
+  box/.style={rectangle, draw, rounded corners, minimum height=0.8cm,
+              minimum width=1.8cm, align=center, font=\small},
+  arrow/.style={-{Stealth[length=3mm]}, thick},
+  label/.style={font=\scriptsize, midway, above},
+]
+  \node[box, fill=okblue!20] (gen) {Generator};
+  \node[box, fill=okred!20, right=2.5cm of gen] (critic) {Critic};
+  \node[box, fill=okgreen!20, below=1.5cm of $(gen)!0.5!(critic)$] (judge) {Judge Panel};
+
+  \draw[arrow] (gen) -- node[label] {output $A$} (critic);
+  \draw[arrow] (critic) -- node[label, right] {critique $C$} (judge);
+  \draw[arrow] (judge) -| node[label, left, pos=0.3] {winner} (gen);
+\end{tikzpicture}
+```
+
+### latexdiff for Revision Tracking
+
+Essential for rebuttals — generates a marked-up PDF showing changes between versions:
+
+```bash
+# Install
+# macOS: brew install latexdiff (or comes with TeX Live)
+# Linux: sudo apt install latexdiff
+
+# Generate diff
+latexdiff paper_v1.tex paper_v2.tex > paper_diff.tex
+pdflatex paper_diff.tex
+
+# For multi-file projects (with \input{} or \include{})
+latexdiff --flatten paper_v1.tex paper_v2.tex > paper_diff.tex
+```
+
+This produces a PDF with deletions in red strikethrough and additions in blue — standard format for rebuttal supplements.
+
+### SciencePlots for matplotlib
+
+Install and use for publication-quality plots:
+
+```bash
+pip install SciencePlots
+```
+
+```python
+import matplotlib.pyplot as plt
+import scienceplots  # registers styles
+
+# Use science style (IEEE-like, clean)
+with plt.style.context(['science', 'no-latex']):
+    fig, ax = plt.subplots(figsize=(3.5, 2.5))  # Single-column width
+    ax.plot(x, y, label='Ours', color='#0072B2')
+    ax.plot(x, y2, label='Baseline', color='#D55E00', linestyle='--')
+    ax.set_xlabel('Training Steps')
+    ax.set_ylabel('Accuracy')
+    ax.legend()
+    fig.savefig('paper/fig_results.pdf', bbox_inches='tight')
+
+# Available styles: 'science', 'ieee', 'nature', 'science+ieee'
+# Add 'no-latex' if LaTeX is not installed on the machine generating plots
+```
+
+**Standard figure sizes** (two-column format):
+- Single column: `figsize=(3.5, 2.5)` — fits in one column
+- Double column: `figsize=(7.0, 3.0)` — spans both columns
+- Square: `figsize=(3.5, 3.5)` — for heatmaps, confusion matrices
+
+---

--- a/tests/agent/test_snapshot_skill_identity.py
+++ b/tests/agent/test_snapshot_skill_identity.py
@@ -1,0 +1,46 @@
+"""Snapshot entries expose folder slug and declared name unambiguously."""
+
+from pathlib import Path
+
+from agent.prompt_builder import _build_snapshot_entry
+
+
+def test_snapshot_entry_exposes_folder_slug_and_declared_name(tmp_path: Path):
+    """Folder/declared mismatch keeps both fields plus backward-compat keys."""
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "mlops" / "models" / "audiocraft"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(
+        "---\nname: audiocraft-audio-generation\ndescription: audio.\n---\n",
+        encoding="utf-8",
+    )
+
+    entry = _build_snapshot_entry(
+        skill_file,
+        skills_dir,
+        {"name": "audiocraft-audio-generation"},
+        "audio.",
+    )
+
+    assert entry["folder_slug"] == "audiocraft"
+    assert entry["declared_name"] == "audiocraft-audio-generation"
+    # Backward compatibility: historical keys remain populated.
+    assert entry["skill_name"] == "audiocraft"
+    assert entry["frontmatter_name"] == "audiocraft-audio-generation"
+    assert entry["category"] == "mlops/models"
+
+
+def test_snapshot_entry_matches_when_slug_equals_declared(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "demo" / "plain-skill"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\nname: plain-skill\n---\n", encoding="utf-8")
+
+    entry = _build_snapshot_entry(
+        skill_file, skills_dir, {"name": "plain-skill"}, "desc"
+    )
+
+    assert entry["folder_slug"] == entry["declared_name"] == "plain-skill"
+    assert entry["skill_name"] == entry["frontmatter_name"] == "plain-skill"

--- a/tests/agent/test_snapshot_skill_identity.py
+++ b/tests/agent/test_snapshot_skill_identity.py
@@ -1,8 +1,16 @@
 """Snapshot entries expose folder slug and declared name unambiguously."""
 
+import json
 from pathlib import Path
 
-from agent.prompt_builder import _build_snapshot_entry
+from agent.prompt_builder import (
+    _SKILLS_SNAPSHOT_VERSION,
+    _build_skills_manifest,
+    _build_snapshot_entry,
+    _load_skills_snapshot,
+    build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
+)
 
 
 def test_snapshot_entry_exposes_folder_slug_and_declared_name(tmp_path: Path):
@@ -44,3 +52,59 @@ def test_snapshot_entry_matches_when_slug_equals_declared(tmp_path: Path):
 
     assert entry["folder_slug"] == entry["declared_name"] == "plain-skill"
     assert entry["skill_name"] == entry["frontmatter_name"] == "plain-skill"
+
+
+def test_old_snapshot_version_invalidates_and_rebuilds_identity_fields(
+    tmp_path: Path, monkeypatch
+):
+    """Persisted pre-v3 snapshots are rejected even when the file manifest matches."""
+    from agent import prompt_builder as pb
+
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    skill_dir = skills_dir / "mlops" / "models" / "audiocraft"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: audiocraft-audio-generation\ndescription: audio.\n---\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(pb, "get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(pb, "get_all_skills_dirs", lambda: [skills_dir])
+    monkeypatch.setattr(pb, "get_disabled_skill_names", lambda *a, **k: set())
+    snap_path = hermes_home / ".skills_prompt_snapshot.json"
+    monkeypatch.setattr(pb, "_skills_prompt_snapshot_path", lambda: snap_path)
+
+    # Matching mtime/size manifest, but old schema version and no identity aliases.
+    old_payload = {
+        "version": 2,
+        "manifest": _build_skills_manifest(skills_dir),
+        "skills": [
+            {
+                "skill_name": "audiocraft",
+                "frontmatter_name": "audiocraft-audio-generation",
+                "category": "mlops/models",
+                "description": "audio.",
+                "platforms": [],
+                "conditions": {},
+            }
+        ],
+        "category_descriptions": {},
+    }
+    snap_path.write_text(json.dumps(old_payload), encoding="utf-8")
+    clear_skills_system_prompt_cache()
+
+    assert _SKILLS_SNAPSHOT_VERSION >= 3
+    assert _load_skills_snapshot(skills_dir) is None
+
+    prompt = build_skills_system_prompt()
+    assert "audiocraft" in prompt
+
+    rebuilt = json.loads(snap_path.read_text(encoding="utf-8"))
+    assert rebuilt["version"] == _SKILLS_SNAPSHOT_VERSION
+    assert len(rebuilt["skills"]) == 1
+    entry = rebuilt["skills"][0]
+    assert entry["folder_slug"] == "audiocraft"
+    assert entry["declared_name"] == "audiocraft-audio-generation"
+    assert entry["skill_name"] == "audiocraft"
+    assert entry["frontmatter_name"] == "audiocraft-audio-generation"

--- a/tests/agent/test_wrong_case_skill_md.py
+++ b/tests/agent/test_wrong_case_skill_md.py
@@ -1,0 +1,53 @@
+"""Wrong-case skill.md packages are diagnosed but never silently loaded."""
+
+from pathlib import Path
+
+from agent.skill_utils import (
+    find_wrong_case_skill_md_files,
+    format_wrong_case_skill_md_warning,
+    iter_skill_index_files,
+)
+
+
+def test_wrong_case_skill_md_detected_but_not_indexed(tmp_path: Path):
+    """Lowercase skill.md is warned about and excluded from SKILL.md index."""
+    good = tmp_path / "good-skill"
+    good.mkdir()
+    (good / "SKILL.md").write_text("---\nname: good-skill\n---\n", encoding="utf-8")
+
+    bad = tmp_path / "grafana-operations"
+    bad.mkdir()
+    (bad / "skill.md").write_text(
+        "---\nname: grafana-operations\ndescription: ops.\n---\n",
+        encoding="utf-8",
+    )
+
+    indexed = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+    wrong = find_wrong_case_skill_md_files(tmp_path)
+
+    assert indexed == [good / "SKILL.md"]
+    assert wrong == [bad / "skill.md"]
+    warning = format_wrong_case_skill_md_warning(wrong, skills_dir=tmp_path)
+    assert "will NOT be loaded" in warning
+    assert "grafana-operations" in warning
+
+
+def test_wrong_case_ignored_under_support_dirs(tmp_path: Path):
+    """Archived skill.md under references/ is not an active-package warning."""
+    real = tmp_path / "umbrella"
+    real.mkdir()
+    (real / "SKILL.md").write_text("---\nname: umbrella\n---\n", encoding="utf-8")
+    archived = real / "references" / "old"
+    archived.mkdir(parents=True)
+    (archived / "skill.md").write_text("---\nname: old\n---\n", encoding="utf-8")
+
+    assert find_wrong_case_skill_md_files(tmp_path) == []
+
+
+def test_canonical_skill_md_not_reported_as_wrong_case(tmp_path: Path):
+    skill = tmp_path / "ok"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: ok\n---\n", encoding="utf-8")
+
+    assert find_wrong_case_skill_md_files(tmp_path) == []
+    assert list(iter_skill_index_files(tmp_path, "SKILL.md")) == [skill / "SKILL.md"]

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -76,8 +76,17 @@ def test_skills_breakdown_shape_sorted_and_attributed(isolated_home):
     names = {s["name"] for s in skills}
     assert {"small-skill", "big-skill"} <= names
     for s in skills:
-        assert set(s) >= {"name", "index_line_bytes", "skill_md_bytes", "path"}
+        assert set(s) >= {
+            "name",
+            "declared_name",
+            "folder_slug",
+            "index_line_bytes",
+            "skill_md_bytes",
+            "path",
+        }
         assert s["index_line_bytes"] > 0
+        assert s["declared_name"] == s["name"]
+        assert s["folder_slug"]  # directory slug always present when path maps
     # Sorted largest-first by on-disk SKILL.md size.
     md_sizes = [s["skill_md_bytes"] or 0 for s in skills]
     assert md_sizes == sorted(md_sizes, reverse=True)

--- a/tests/hermes_cli/test_tools_summary_noninteractive.py
+++ b/tests/hermes_cli/test_tools_summary_noninteractive.py
@@ -1,0 +1,39 @@
+"""``hermes tools --summary`` must work without an interactive TTY."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def test_cmd_tools_summary_skips_tty_requirement(capsys):
+    """Summary mode is a read-only diagnostic; pipes/CI must not be refused."""
+    from hermes_cli.main import cmd_tools
+
+    args = SimpleNamespace(tools_action=None, summary=True)
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "terminal", "file"]}}
+
+    with patch("hermes_cli.main._require_tty") as require_tty, patch(
+        "hermes_cli.tools_config.load_config", return_value=config
+    ), patch(
+        "hermes_cli.tools_config._get_enabled_platforms", return_value=["cli"]
+    ), patch(
+        "sys.stdin.isatty", return_value=False
+    ):
+        cmd_tools(args)
+
+    require_tty.assert_not_called()
+    out = capsys.readouterr().out
+    assert "Tool Summary" in out
+
+
+def test_cmd_tools_interactive_still_requires_tty():
+    """Bare ``hermes tools`` (curses UI) still refuses non-interactive stdin."""
+    from hermes_cli.main import cmd_tools
+
+    args = SimpleNamespace(tools_action=None, summary=False)
+
+    with patch("hermes_cli.main._require_tty", side_effect=SystemExit(1)) as require_tty:
+        with pytest.raises(SystemExit):
+            cmd_tools(args)
+    require_tty.assert_called_once_with("tools")

--- a/tests/skills/test_research_paper_writing_skill.py
+++ b/tests/skills/test_research_paper_writing_skill.py
@@ -1,0 +1,47 @@
+"""Invariants for the research-paper-writing bundled skill size split."""
+
+import re
+from pathlib import Path
+
+from tools.skill_manager_tool import MAX_SKILL_CONTENT_CHARS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "research" / "research-paper-writing" / "SKILL.md"
+REFS = REPO_ROOT / "skills" / "research" / "research-paper-writing" / "references"
+
+
+def test_skill_md_under_serving_limit():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert len(text) < MAX_SKILL_CONTENT_CHARS
+    assert SKILL_MD.stat().st_size < MAX_SKILL_CONTENT_CHARS + 4096
+
+
+def test_description_authoring_limit():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    match = re.search(r"^description:\s*(.*)$", text, re.MULTILINE)
+    assert match is not None
+    desc = match.group(1).strip().strip("\"'")
+    assert len(desc) <= 60
+    assert desc.endswith(".")
+
+
+def test_standard_sections_and_reference_split():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    for section in (
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ):
+        assert section in text, section
+
+    assert "references/latex-and-templates.md" in text
+    assert "references/hermes-integration.md" in text
+    assert (REFS / "latex-and-templates.md").is_file()
+    assert (REFS / "hermes-integration.md").is_file()
+    # Bulky LaTeX guidance lives in the reference, not the served skill body.
+    latex_ref = (REFS / "latex-and-templates.md").read_text(encoding="utf-8")
+    assert "SciencePlots" in latex_ref or "latexmk" in latex_ref

--- a/tests/tools/test_missing_bundled_skills.py
+++ b/tests/tools/test_missing_bundled_skills.py
@@ -11,11 +11,14 @@ from hermes_cli.skills_hub import _report_missing_bundled_skills
 from tools.skills_sync import (
     ACTIONABLE_MISSING_BUNDLED_PROVENANCE,
     INTENTIONAL_MISSING_BUNDLED_PROVENANCE,
+    RESTORE_WITH_BUNDLED_SOURCE_PROVENANCE,
+    clean_stale_manifest_orphans,
     format_missing_bundled_restore_guidance,
     is_actionable_missing_bundled_provenance,
     list_missing_bundled_skills,
     partition_missing_bundled_skills,
     provenance_counts,
+    _read_manifest,
     _write_manifest,
 )
 
@@ -161,11 +164,119 @@ def test_restore_guidance_actionable_scopes_restore_away_from_intentional():
         _entry("c", "source_present_never_installed"),
     ]
     text = format_missing_bundled_restore_guidance(missing)
-    assert "Restore unexpected absences" in text
+    assert "Restore unexpected absences with bundled source" in text
     assert "hermes skills reset <name> --restore" in text
     assert "Do not restore opt_out or curator_suppressed" in text
+    # Orphans are not in this fixture — cleanup path stays quiet.
+    assert "clean-manifest" not in text
+    assert "manifest_orphan_no_source / unknown" not in text
     # Must not use the old blanket "when intentional absence is ruled out" phrasing
     assert "when intentional absence is ruled out" not in text
+
+
+def test_restore_guidance_orphans_get_cleanup_not_restore():
+    missing = [
+        _entry("gone", "manifest_tracked_absent"),
+        _entry("orphan", "manifest_orphan_no_source"),
+        _entry("mystery", "unknown"),
+    ]
+    text = format_missing_bundled_restore_guidance(missing)
+    assert "Restore unexpected absences with bundled source" in text
+    # Categories are sorted() for stable wording.
+    assert "manifest_tracked_absent / source_present_never_installed / unknown" in text
+    assert "hermes skills clean-manifest" in text
+    assert "source-backed tracking is never deleted" in text
+    # Orphan must not be listed among --restore targets.
+    assert "manifest_orphan_no_source / unknown" not in text
+    assert "Do not use `hermes skills reset <name> --restore` for orphans" in text
+
+
+def test_restore_guidance_orphan_only_skips_restore_command():
+    text = format_missing_bundled_restore_guidance(
+        [_entry("orphan", "manifest_orphan_no_source")]
+    )
+    assert "hermes skills clean-manifest" in text
+    # No affirmative restore instruction — only the explicit "do not use" warning.
+    assert "Restore unexpected absences" not in text
+    assert "Do not use `hermes skills reset <name> --restore` for orphans" in text
+    assert "manifest_orphan_no_source" not in RESTORE_WITH_BUNDLED_SOURCE_PROVENANCE
+
+
+def test_clean_stale_manifest_orphans_removes_only_source_less_keys(
+    tmp_path: Path, monkeypatch
+):
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    skills_dir.mkdir(parents=True)
+    bundled = tmp_path / "bundled_skills"
+    _make_bundled(bundled, "still-bundled", "still-bundled")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    manifest_file = skills_dir / ".bundled_manifest"
+
+    with patch("tools.skills_sync.MANIFEST_FILE", manifest_file), patch(
+        "tools.skills_sync.SKILLS_DIR", skills_dir
+    ), patch("tools.skills_sync.HERMES_HOME", hermes_home), patch(
+        "tools.skills_sync._get_bundled_dir", return_value=bundled
+    ):
+        _write_manifest(
+            {
+                "still-bundled": "abc123",
+                "removed-upstream": "deadbeef",
+                "also-gone": "00ff",
+            }
+        )
+        result = clean_stale_manifest_orphans()
+        remaining = _read_manifest()
+
+    assert result["ok"] is True
+    assert result["removed"] == ["also-gone", "removed-upstream"]
+    assert result["kept"] == 1
+    assert remaining == {"still-bundled": "abc123"}
+
+
+def test_clean_stale_manifest_orphans_cannot_delete_valid_manifests(
+    tmp_path: Path, monkeypatch
+):
+    """Source-backed tracking must survive cleanup even when install is missing."""
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    skills_dir.mkdir(parents=True)
+    bundled = tmp_path / "bundled_skills"
+    _make_bundled(bundled, "tracked-absent", "tracked-absent")
+    _make_bundled(bundled, "present-skill", "present-skill")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Install only one of the two source-backed skills — the other is a
+    # classic manifest_tracked_absent case and must NOT be cleaned.
+    present_dest = skills_dir / "research" / "present-skill"
+    present_dest.mkdir(parents=True)
+    (present_dest / "SKILL.md").write_text(
+        "---\nname: present-skill\ndescription: test.\n---\n",
+        encoding="utf-8",
+    )
+    manifest_file = skills_dir / ".bundled_manifest"
+
+    with patch("tools.skills_sync.MANIFEST_FILE", manifest_file), patch(
+        "tools.skills_sync.SKILLS_DIR", skills_dir
+    ), patch("tools.skills_sync.HERMES_HOME", hermes_home), patch(
+        "tools.skills_sync._get_bundled_dir", return_value=bundled
+    ):
+        _write_manifest(
+            {
+                "tracked-absent": "aaa",
+                "present-skill": "bbb",
+            }
+        )
+        before = _read_manifest()
+        result = clean_stale_manifest_orphans()
+        after = _read_manifest()
+
+    assert before == after == {
+        "tracked-absent": "aaa",
+        "present-skill": "bbb",
+    }
+    assert result["removed"] == []
+    assert result["kept"] == 2
 
 
 def test_doctor_all_intentional_is_ok_not_warn(capsys):
@@ -227,7 +338,7 @@ def test_skills_check_lists_all_provenance_and_scoped_restore(monkeypatch):
     assert "opted" in out and "opt_out" in out
     assert "pruned" in out and "curator_suppressed" in out
     assert "gone" in out and "manifest_tracked_absent" in out
-    assert "Restore unexpected absences" in out
+    assert "Restore unexpected absences with bundled source" in out
     assert "Do not restore opt_out or curator_suppressed" in out
     assert "when intentional absence is ruled out" not in out
 

--- a/tests/tools/test_missing_bundled_skills.py
+++ b/tests/tools/test_missing_bundled_skills.py
@@ -1,0 +1,251 @@
+"""Diagnostic for source/manifest-present but installed-missing bundled skills."""
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from rich.console import Console
+
+from hermes_cli.doctor import report_missing_bundled_skills_check
+from hermes_cli.skills_hub import _report_missing_bundled_skills
+from tools.skills_sync import (
+    ACTIONABLE_MISSING_BUNDLED_PROVENANCE,
+    INTENTIONAL_MISSING_BUNDLED_PROVENANCE,
+    format_missing_bundled_restore_guidance,
+    is_actionable_missing_bundled_provenance,
+    list_missing_bundled_skills,
+    partition_missing_bundled_skills,
+    provenance_counts,
+    _write_manifest,
+)
+
+
+def _make_bundled(bundled: Path, folder: str, declared: str) -> Path:
+    skill_dir = bundled / "research" / folder
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {declared}\ndescription: test.\n---\nbody\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _entry(name: str, provenance: str) -> dict:
+    return {
+        "name": name,
+        "folder_slug": name,
+        "bundled_src": None,
+        "expected_dest": Path(name),
+        "in_manifest": provenance != "source_present_never_installed",
+        "in_source": provenance != "manifest_orphan_no_source",
+        "provenance": provenance,
+    }
+
+
+def test_missing_bundled_reports_provenance(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    skills_dir.mkdir(parents=True)
+    bundled = tmp_path / "bundled_skills"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    suppressed_src = _make_bundled(bundled, "suppressed-skill", "suppressed-skill")
+    tracked_src = _make_bundled(bundled, "tracked-absent", "tracked-absent")
+    never_src = _make_bundled(bundled, "never-installed", "never-installed")
+    present_src = _make_bundled(bundled, "present-skill", "present-skill")
+
+    # One skill is actually installed.
+    present_dest = skills_dir / "research" / "present-skill"
+    present_dest.mkdir(parents=True)
+    (present_dest / "SKILL.md").write_text(
+        (present_src / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    manifest_file = skills_dir / ".bundled_manifest"
+    with patch("tools.skills_sync.MANIFEST_FILE", manifest_file), patch(
+        "tools.skills_sync.SKILLS_DIR", skills_dir
+    ), patch("tools.skills_sync.HERMES_HOME", hermes_home), patch(
+        "tools.skills_sync._get_bundled_dir", return_value=bundled
+    ), patch(
+        "tools.skills_sync._read_suppressed_names",
+        return_value={"suppressed-skill"},
+    ):
+        _write_manifest(
+            {
+                "tracked-absent": "abc",
+                "present-skill": "def",
+                "suppressed-skill": "ghi",
+            }
+        )
+        missing = list_missing_bundled_skills()
+
+    by_name = {e["name"]: e for e in missing}
+    assert "present-skill" not in by_name
+    assert by_name["suppressed-skill"]["provenance"] == "curator_suppressed"
+    assert by_name["suppressed-skill"]["in_manifest"] is True
+    assert by_name["suppressed-skill"]["in_source"] is True
+    assert by_name["tracked-absent"]["provenance"] == "manifest_tracked_absent"
+    assert by_name["never-installed"]["provenance"] == "source_present_never_installed"
+    assert by_name["never-installed"]["folder_slug"] == "never-installed"
+    assert by_name["tracked-absent"]["bundled_src"] == tracked_src
+    assert suppressed_src.exists() and never_src.exists()
+
+
+def test_missing_bundled_opt_out_provenance(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    skills_dir.mkdir(parents=True)
+    (hermes_home / ".no-bundled-skills").write_text("opted out\n", encoding="utf-8")
+    bundled = tmp_path / "bundled_skills"
+    _make_bundled(bundled, "seed-me", "seed-me")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch("tools.skills_sync.MANIFEST_FILE", skills_dir / ".bundled_manifest"), patch(
+        "tools.skills_sync.SKILLS_DIR", skills_dir
+    ), patch("tools.skills_sync.HERMES_HOME", hermes_home), patch(
+        "tools.skills_sync._get_bundled_dir", return_value=bundled
+    ), patch("tools.skills_sync._read_suppressed_names", return_value=set()):
+        missing = list_missing_bundled_skills()
+
+    assert len(missing) == 1
+    assert missing[0]["name"] == "seed-me"
+    assert missing[0]["provenance"] == "opt_out"
+
+
+def test_actionable_provenance_classification():
+    for prov in INTENTIONAL_MISSING_BUNDLED_PROVENANCE:
+        assert is_actionable_missing_bundled_provenance(prov) is False
+    for prov in ACTIONABLE_MISSING_BUNDLED_PROVENANCE:
+        assert is_actionable_missing_bundled_provenance(prov) is True
+    assert is_actionable_missing_bundled_provenance(None) is True
+    assert is_actionable_missing_bundled_provenance("") is True
+    assert is_actionable_missing_bundled_provenance("weird") is True
+
+
+def test_partition_and_provenance_counts():
+    missing = [
+        _entry("a", "opt_out"),
+        _entry("b", "curator_suppressed"),
+        _entry("c", "manifest_tracked_absent"),
+        _entry("d", "unknown"),
+    ]
+    intentional, actionable = partition_missing_bundled_skills(missing)
+    assert {e["name"] for e in intentional} == {"a", "b"}
+    assert {e["name"] for e in actionable} == {"c", "d"}
+    assert provenance_counts(missing) == {
+        "opt_out": 1,
+        "curator_suppressed": 1,
+        "manifest_tracked_absent": 1,
+        "unknown": 1,
+    }
+
+
+def test_restore_guidance_all_intentional_does_not_recommend_restore():
+    missing = [
+        _entry("a", "opt_out"),
+        _entry("b", "curator_suppressed"),
+    ]
+    text = format_missing_bundled_restore_guidance(missing)
+    assert "opt_out" in text
+    assert "curator_suppressed" in text
+    assert "manifest_tracked_absent" in text  # category legend still present
+    assert "restore is not recommended" in text
+    assert "hermes skills reset" not in text
+
+
+def test_restore_guidance_actionable_scopes_restore_away_from_intentional():
+    missing = [
+        _entry("a", "opt_out"),
+        _entry("b", "manifest_tracked_absent"),
+        _entry("c", "source_present_never_installed"),
+    ]
+    text = format_missing_bundled_restore_guidance(missing)
+    assert "Restore unexpected absences" in text
+    assert "hermes skills reset <name> --restore" in text
+    assert "Do not restore opt_out or curator_suppressed" in text
+    # Must not use the old blanket "when intentional absence is ruled out" phrasing
+    assert "when intentional absence is ruled out" not in text
+
+
+def test_doctor_all_intentional_is_ok_not_warn(capsys):
+    missing = [
+        _entry("opted", "opt_out"),
+        _entry("pruned", "curator_suppressed"),
+    ]
+    severity = report_missing_bundled_skills_check(missing)
+    out = capsys.readouterr().out
+    assert severity == "ok_intentional"
+    assert "Bundled skill absences are intentional" in out
+    assert "opt_out=1" in out
+    assert "curator_suppressed=1" in out
+    assert "intentional absence(s)" in out
+    assert "⚠" not in out
+
+
+def test_doctor_actionable_absence_warns(capsys):
+    missing = [
+        _entry("opted", "opt_out"),
+        _entry("gone", "manifest_tracked_absent"),
+        _entry("never", "source_present_never_installed"),
+        _entry("orphan", "manifest_orphan_no_source"),
+        _entry("mystery", "unknown"),
+    ]
+    severity = report_missing_bundled_skills_check(missing)
+    out = capsys.readouterr().out
+    assert severity == "warn_actionable"
+    assert "⚠" in out
+    assert "bundled skill(s) missing from install" in out
+    assert "unexpected=4" in out
+    assert "opt_out=1" in out  # full provenance counts still shown
+
+
+def test_doctor_no_missing_is_ok_match(capsys):
+    severity = report_missing_bundled_skills_check([])
+    out = capsys.readouterr().out
+    assert severity == "ok_match"
+    assert "Bundled skills installed match source/manifest baseline" in out
+    assert "⚠" not in out
+
+
+def test_skills_check_lists_all_provenance_and_scoped_restore(monkeypatch):
+    missing = [
+        _entry("opted", "opt_out"),
+        _entry("pruned", "curator_suppressed"),
+        _entry("gone", "manifest_tracked_absent"),
+    ]
+    monkeypatch.setattr(
+        "tools.skills_sync.list_missing_bundled_skills",
+        lambda: missing,
+    )
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    count = _report_missing_bundled_skills(console)
+    # Rich wraps long dim footers; compare on whitespace-normalized text.
+    out = " ".join(sink.getvalue().split())
+    assert count == 3
+    assert "opted" in out and "opt_out" in out
+    assert "pruned" in out and "curator_suppressed" in out
+    assert "gone" in out and "manifest_tracked_absent" in out
+    assert "Restore unexpected absences" in out
+    assert "Do not restore opt_out or curator_suppressed" in out
+    assert "when intentional absence is ruled out" not in out
+
+
+def test_skills_check_all_intentional_guidance(monkeypatch):
+    missing = [
+        _entry("opted", "opt_out"),
+        _entry("pruned", "curator_suppressed"),
+    ]
+    monkeypatch.setattr(
+        "tools.skills_sync.list_missing_bundled_skills",
+        lambda: missing,
+    )
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    count = _report_missing_bundled_skills(console)
+    out = " ".join(sink.getvalue().split())
+    assert count == 2
+    assert "opted" in out and "pruned" in out
+    assert "restore is not recommended" in out
+    assert "hermes skills reset" not in out

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -1145,6 +1145,157 @@ def list_user_modified_bundled_skills() -> List[dict]:
     return modified
 
 
+# Absences that are deliberate policy — doctor treats an all-intentional set as
+# healthy/informational. skills check still lists them with full provenance.
+INTENTIONAL_MISSING_BUNDLED_PROVENANCE = frozenset({"opt_out", "curator_suppressed"})
+
+# Absences that warrant a doctor warning when present. ``unknown`` is handled
+# as actionable via the negative check in is_actionable_missing_bundled_provenance.
+ACTIONABLE_MISSING_BUNDLED_PROVENANCE = frozenset(
+    {
+        "manifest_tracked_absent",
+        "source_present_never_installed",
+        "manifest_orphan_no_source",
+        "unknown",
+    }
+)
+
+
+def is_actionable_missing_bundled_provenance(provenance: Optional[str]) -> bool:
+    """Return True when a missing-bundled absence should warn in doctor.
+
+    Intentional ``opt_out`` / ``curator_suppressed`` absences do not warn.
+    Recognized unexpected provenances and any unrecognized/blank value
+    (normalized to ``unknown``) do.
+    """
+    prov = (provenance or "").strip() or "unknown"
+    return prov not in INTENTIONAL_MISSING_BUNDLED_PROVENANCE
+
+
+def partition_missing_bundled_skills(
+    missing: List[dict],
+) -> Tuple[List[dict], List[dict]]:
+    """Split missing-bundled entries into (intentional, actionable) lists."""
+    intentional: List[dict] = []
+    actionable: List[dict] = []
+    for entry in missing:
+        if is_actionable_missing_bundled_provenance(
+            str(entry.get("provenance") or "")
+        ):
+            actionable.append(entry)
+        else:
+            intentional.append(entry)
+    return intentional, actionable
+
+
+def provenance_counts(missing: List[dict]) -> dict:
+    """Count missing-bundled entries by provenance key (blank → ``unknown``)."""
+    by_prov: dict = {}
+    for entry in missing:
+        key = str(entry.get("provenance") or "").strip() or "unknown"
+        by_prov[key] = by_prov.get(key, 0) + 1
+    return by_prov
+
+
+def format_missing_bundled_restore_guidance(missing: List[dict]) -> str:
+    """Footer guidance for ``hermes skills check`` missing-bundled output.
+
+    Always describes every provenance category. Restore instructions apply only
+    to unexpected absences — never imply opt_out / curator_suppressed should
+    be restored.
+    """
+    _, actionable = partition_missing_bundled_skills(missing)
+    base = (
+        f"{len(missing)} bundled skill(s) present in source/manifest but "
+        "not installed locally. Provenance: curator_suppressed (curator prune), "
+        "opt_out (.no-bundled-skills), manifest_tracked_absent (seeded then "
+        "removed — sync will not re-seed), source_present_never_installed, "
+        "manifest_orphan_no_source."
+    )
+    if not actionable:
+        return (
+            base
+            + " All listed absences are intentional "
+            "(opt_out / curator_suppressed); restore is not recommended."
+        )
+    return (
+        base
+        + " Restore unexpected absences "
+        "(manifest_tracked_absent / source_present_never_installed / "
+        "manifest_orphan_no_source / unknown) with "
+        "`hermes skills reset <name> --restore`. "
+        "Do not restore opt_out or curator_suppressed entries unless you "
+        "intentionally reverse that choice."
+    )
+
+
+def list_missing_bundled_skills() -> List[dict]:
+    """Return bundled skills present in source (and/or manifest) but not installed.
+
+    Diagnostic for the audit case where ``.bundled_manifest`` / the repo
+    ``skills/`` tree know about a skill but the active profile's skills root
+    does not have a discoverable copy. Includes seeding/curator provenance when
+    available so operators can tell deliberate prune from accidental absence.
+
+    Each entry:
+        ``name``, ``folder_slug``, ``bundled_src``, ``expected_dest``,
+        ``in_manifest``, ``in_source``, ``provenance`` where provenance is one
+        of ``curator_suppressed``, ``opt_out``, ``manifest_tracked_absent``
+        (was seeded, now missing — sync treats as user-deleted), or
+        ``source_present_never_installed``.
+    """
+    bundled_dir = _get_bundled_dir()
+    manifest = _read_manifest()
+    suppressed = _read_suppressed_names()
+    opted_out = is_bundled_skills_opt_out()
+    missing: List[dict] = []
+
+    for skill_name, skill_dir in _discover_bundled_skills(bundled_dir):
+        dest = _compute_relative_dest(skill_dir, bundled_dir)
+        if dest.exists() and (dest / "SKILL.md").exists():
+            continue
+        in_manifest = skill_name in manifest
+        if skill_name in suppressed:
+            provenance = "curator_suppressed"
+        elif opted_out:
+            provenance = "opt_out"
+        elif in_manifest:
+            provenance = "manifest_tracked_absent"
+        else:
+            provenance = "source_present_never_installed"
+        missing.append(
+            {
+                "name": skill_name,
+                "folder_slug": skill_dir.name,
+                "bundled_src": skill_dir,
+                "expected_dest": dest,
+                "in_manifest": in_manifest,
+                "in_source": True,
+                "provenance": provenance,
+            }
+        )
+
+    # Manifest entries whose bundled source was removed upstream are cleaned
+    # by sync; still surface orphaned manifest keys with no source as a
+    # separate diagnostic so operators can see stale tracking.
+    bundled_names = {name for name, _ in _discover_bundled_skills(bundled_dir)}
+    for skill_name in sorted(set(manifest) - bundled_names):
+        missing.append(
+            {
+                "name": skill_name,
+                "folder_slug": skill_name,
+                "bundled_src": None,
+                "expected_dest": SKILLS_DIR / skill_name,
+                "in_manifest": True,
+                "in_source": False,
+                "provenance": "manifest_orphan_no_source",
+            }
+        )
+
+    missing.sort(key=lambda e: e["name"])
+    return missing
+
+
 def _read_for_diff(path: Path) -> Tuple[Optional[bytes], Optional[str]]:
     """Read a file once for diffing.
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -916,7 +916,7 @@ def sync_skills(quiet: bool = False) -> dict:
             skipped += 1
 
     # Clean stale manifest entries (skills removed from bundled dir)
-    cleaned = sorted(set(manifest.keys()) - bundled_names)
+    cleaned = find_stale_manifest_orphans(manifest, bundled_names)
     for name in cleaned:
         del manifest[name]
 
@@ -1160,6 +1160,17 @@ ACTIONABLE_MISSING_BUNDLED_PROVENANCE = frozenset(
     }
 )
 
+# Actionable absences that still have (or may have) bundled source to restore
+# from. ``manifest_orphan_no_source`` is intentionally excluded — restore
+# returns ``bundled_missing`` and cannot recreate the skill.
+RESTORE_WITH_BUNDLED_SOURCE_PROVENANCE = frozenset(
+    {
+        "manifest_tracked_absent",
+        "source_present_never_installed",
+        "unknown",
+    }
+)
+
 
 def is_actionable_missing_bundled_provenance(provenance: Optional[str]) -> bool:
     """Return True when a missing-bundled absence should warn in doctor.
@@ -1197,12 +1208,56 @@ def provenance_counts(missing: List[dict]) -> dict:
     return by_prov
 
 
+def _normalize_missing_provenance(provenance: Optional[str]) -> str:
+    return (provenance or "").strip() or "unknown"
+
+
+def find_stale_manifest_orphans(
+    manifest: Optional[Dict[str, str]] = None,
+    bundled_names: Optional[Set[str]] = None,
+) -> List[str]:
+    """Return sorted manifest keys that have no discoverable bundled source.
+
+    Source-backed keys are never included. Used by sync cleanup and by
+    ``clean_stale_manifest_orphans``.
+    """
+    if manifest is None:
+        manifest = _read_manifest()
+    if not manifest:
+        return []
+    if bundled_names is None:
+        bundled_names = {
+            name for name, _ in _discover_bundled_skills(_get_bundled_dir())
+        }
+    return sorted(set(manifest) - set(bundled_names))
+
+
+def clean_stale_manifest_orphans() -> dict:
+    """Drop ``.bundled_manifest`` entries whose bundled source no longer exists.
+
+    Only removes orphaned tracking keys. Entries that still have a discoverable
+    bundled source are never deleted — including skills that are merely absent
+    from the local install (``manifest_tracked_absent``).
+
+    Returns:
+        ``{"ok": True, "removed": [str, ...], "kept": int}``
+    """
+    manifest = _read_manifest()
+    removed = find_stale_manifest_orphans(manifest)
+    if removed:
+        for name in removed:
+            del manifest[name]
+        _write_manifest(manifest)
+    return {"ok": True, "removed": removed, "kept": len(manifest)}
+
+
 def format_missing_bundled_restore_guidance(missing: List[dict]) -> str:
     """Footer guidance for ``hermes skills check`` missing-bundled output.
 
-    Always describes every provenance category. Restore instructions apply only
-    to unexpected absences — never imply opt_out / curator_suppressed should
-    be restored.
+    Always describes every provenance category. Source-backed restore
+    instructions never cover ``manifest_orphan_no_source`` (no bundled source
+    to restore from) — those get a distinct stale-manifest cleanup path.
+    Never imply opt_out / curator_suppressed should be restored.
     """
     _, actionable = partition_missing_bundled_skills(missing)
     base = (
@@ -1218,15 +1273,36 @@ def format_missing_bundled_restore_guidance(missing: List[dict]) -> str:
             + " All listed absences are intentional "
             "(opt_out / curator_suppressed); restore is not recommended."
         )
-    return (
-        base
-        + " Restore unexpected absences "
-        "(manifest_tracked_absent / source_present_never_installed / "
-        "manifest_orphan_no_source / unknown) with "
-        "`hermes skills reset <name> --restore`. "
-        "Do not restore opt_out or curator_suppressed entries unless you "
-        "intentionally reverse that choice."
-    )
+
+    # Orphans are actionable but not restorable (no bundled source). Every
+    # other actionable provenance — including unrecognized/blank→unknown —
+    # keeps the source-backed restore path.
+    orphans = [
+        e
+        for e in actionable
+        if _normalize_missing_provenance(str(e.get("provenance") or ""))
+        == "manifest_orphan_no_source"
+    ]
+    restorable = [e for e in actionable if e not in orphans]
+
+    parts = [base]
+    if restorable:
+        restore_cats = " / ".join(sorted(RESTORE_WITH_BUNDLED_SOURCE_PROVENANCE))
+        parts.append(
+            " Restore unexpected absences with bundled source "
+            f"({restore_cats}) with `hermes skills reset <name> --restore`. "
+            "Do not restore opt_out or curator_suppressed entries unless you "
+            "intentionally reverse that choice."
+        )
+    if orphans:
+        parts.append(
+            " Clear stale manifest_orphan_no_source tracking with "
+            "`hermes skills clean-manifest` (removes orphaned manifest keys "
+            "only; source-backed tracking is never deleted). Do not use "
+            "`hermes skills reset <name> --restore` for orphans — there is no "
+            "bundled source to restore from."
+        )
+    return "".join(parts)
 
 
 def list_missing_bundled_skills() -> List[dict]:


### PR DESCRIPTION
## Summary

- add wrong-case skill metadata diagnostics without breaking discovery
- add noninteractive `hermes tools --summary` support
- preserve skill identity in snapshots and report missing bundled-skill provenance
- reduce the research-paper-writing skill below the prompt-size ceiling and move detailed guidance into references
- treat intentional opt-out and curator-suppressed skills as healthy in doctor output

## Validation

- 74/74 critical and skill-size tests passed
- 2/2 skills-sync discovery tests passed
- noninteractive `tools --summary` CLI smoke passed with a temporary `HERMES_HOME`
- staged whitespace and exact 17-file scope checks passed
- research-paper-writing `SKILL.md` is 84,573 characters

## Safety

The live checkout's two pre-existing web edits were excluded from the commit and remained byte-identical and unstaged throughout integration.
