### PR TITLE
fix(telegram): preserve explicit topic titles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19047,21 +19047,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         future.add_done_callback(_log_rename_failure)
 
+    _TELEGRAM_TOPIC_TITLE_GENERATION_LOCK = threading.Lock()
+
+    def _telegram_topic_title_generation_is_current(
+        self,
+        generation_key: tuple[str, str],
+        token: Optional[tuple[str, int, int]],
+    ) -> bool:
+        """Check a priority-aware per-topic title-operation token."""
+        if token is None:
+            return True
+        kind, counter, explicit_epoch = token
+        with self._TELEGRAM_TOPIC_TITLE_GENERATION_LOCK:
+            states = getattr(self, "_telegram_topic_title_generation_states", {})
+            state = states.get(generation_key, {})
+            if kind == "explicit":
+                return state.get("explicit", 0) == counter
+            return (
+                kind == "automatic"
+                and explicit_epoch == 0
+                and state.get("explicit", 0) == 0
+                and state.get("automatic", 0) == counter
+            )
+
     async def _rename_telegram_topic_for_session_title(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
+        *,
+        registry_provenance: Optional[str] = None,
+        rename_generation: Optional[tuple[str, int, int]] = None,
     ) -> None:
-        """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
+        """Best-effort rename of a Telegram DM topic for auto or explicit titles."""
         if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
             return
 
-        # Operator can fully disable per-topic auto-rename via
-        # extra.disable_topic_auto_rename. Useful when topics are managed
-        # by the user (ad-hoc Threaded Mode) and auto-rename would
-        # overwrite their chosen names every time the auto-title fires.
-        if self._telegram_topic_auto_rename_disabled(source):
+        # The operator flag disables only automatic title changes. Exactly one
+        # trusted provenance value identifies an explicit /title. Reject other
+        # non-None values so callers cannot manufacture a bypass (including an
+        # empty string that would bypass the flag without writing the Registry).
+        is_user_confirmed = registry_provenance == "user_confirmed"
+        if registry_provenance is not None and not is_user_confirmed:
+            logger.warning(
+                "Rejected unrecognized Telegram title Registry provenance: %r",
+                registry_provenance,
+            )
+            return
+        if (
+            self._telegram_topic_auto_rename_disabled(source)
+            and not is_user_confirmed
+        ):
+            return
+
+        generation_key = (str(source.chat_id), str(source.thread_id))
+
+        def _is_current_generation() -> bool:
+            return self._telegram_topic_title_generation_is_current(
+                generation_key,
+                rename_generation,
+            )
+
+        if not _is_current_generation():
             return
 
         # Skip rename when the topic is operator-declared via
@@ -19098,39 +19145,107 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Failed to verify Telegram topic binding before rename", exc_info=True)
                 return
 
+            if not is_user_confirmed:
+                try:
+                    verified_title = await session_db.get_verified_telegram_topic_title(
+                        chat_id=str(source.chat_id),
+                        thread_id=str(source.thread_id),
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to check Verified Telegram title before automatic rename",
+                        exc_info=True,
+                    )
+                    return
+                if verified_title is not None:
+                    return
+
+        if not _is_current_generation():
+            return
+
         if adapter is None:
             return
         topic_name = self._sanitize_telegram_topic_title(title)
-        try:
-            rename_topic = getattr(adapter, "rename_dm_topic", None)
-            if rename_topic is not None:
-                await rename_topic(
+
+        async def _record_verified_title() -> None:
+            if not is_user_confirmed or session_db is None:
+                return
+            try:
+                recorded = await session_db.record_verified_telegram_topic_title(
+                    chat_id=str(source.chat_id),
+                    thread_id=str(source.thread_id),
+                    title=topic_name,
+                    provenance=registry_provenance,
+                    expected_session_id=str(session_id),
+                )
+            except Exception:
+                logger.error(
+                    "Telegram topic rename succeeded but Verified title Registry write failed",
+                    exc_info=True,
+                )
+                raise
+            if recorded is not True:
+                logger.warning(
+                    "Telegram topic binding changed during rename; skipped Verified Registry write"
+                )
+
+        rename_topic = getattr(adapter, "rename_dm_topic", None)
+        if rename_topic is not None:
+            try:
+                renamed = await rename_topic(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
                     name=topic_name,
                 )
+            except Exception:
+                if is_user_confirmed:
+                    logger.warning("Explicit Telegram topic rename failed", exc_info=True)
+                else:
+                    logger.debug("Failed to rename Telegram topic", exc_info=True)
                 return
+            if renamed is not True:
+                log = logger.warning if is_user_confirmed else logger.debug
+                log("Telegram adapter did not confirm topic rename")
+                return
+            if not _is_current_generation():
+                logger.info("Skipped stale Telegram title Registry write")
+                return
+            await _record_verified_title()
+            return
 
-            bot = getattr(adapter, "_bot", None)
-            edit_forum_topic = getattr(bot, "edit_forum_topic", None) if bot is not None else None
-            if edit_forum_topic is None:
-                edit_forum_topic = getattr(bot, "editForumTopic", None) if bot is not None else None
-            if edit_forum_topic is None:
-                return
+        bot = getattr(adapter, "_bot", None)
+        edit_forum_topic = getattr(bot, "edit_forum_topic", None) if bot is not None else None
+        if edit_forum_topic is None:
+            edit_forum_topic = getattr(bot, "editForumTopic", None) if bot is not None else None
+        if edit_forum_topic is None:
+            return
+        try:
             try:
-                await edit_forum_topic(
+                renamed = await edit_forum_topic(
                     chat_id=int(source.chat_id),
                     message_thread_id=int(source.thread_id),
                     name=topic_name,
                 )
             except (TypeError, ValueError):
-                await edit_forum_topic(
+                renamed = await edit_forum_topic(
                     chat_id=source.chat_id,
                     message_thread_id=source.thread_id,
                     name=topic_name,
                 )
         except Exception:
-            logger.debug("Failed to rename Telegram topic for auto-generated title", exc_info=True)
+            if is_user_confirmed:
+                logger.warning("Explicit Telegram topic rename failed", exc_info=True)
+            else:
+                logger.debug("Failed to rename Telegram topic", exc_info=True)
+            return
+        if renamed is not True:
+            log = logger.warning if is_user_confirmed else logger.debug
+            log("Telegram bot API did not confirm topic rename")
+            return
+        if not _is_current_generation():
+            logger.info("Skipped stale Telegram title Registry write")
+            return
+        await _record_verified_title()
 
     def _telegram_topic_auto_rename_disabled(self, source: SessionSource) -> bool:
         """Return True when operator disabled per-topic auto-rename for this Telegram chat.
@@ -19160,11 +19275,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_id: str,
         title: str,
+        *,
+        registry_provenance: Optional[str] = None,
     ) -> None:
-        """Schedule a topic rename from the auto-title background thread."""
+        """Schedule a Telegram topic rename from auto-title or explicit /title."""
         if not title or not self._is_telegram_topic_lane(source):
             return
-        if self._telegram_topic_auto_rename_disabled(source):
+        is_user_confirmed = registry_provenance == "user_confirmed"
+        if registry_provenance is not None and not is_user_confirmed:
+            logger.warning(
+                "Rejected unrecognized Telegram title Registry provenance: %r",
+                registry_provenance,
+            )
+            return
+        if self._telegram_topic_auto_rename_disabled(source) and not is_user_confirmed:
             return
         try:
             loop = asyncio.get_running_loop()
@@ -19176,8 +19300,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             copied_source = dataclasses.replace(source)
         except Exception:
             copied_source = source
+        generation_key = (str(copied_source.chat_id), str(copied_source.thread_id))
+        with self._TELEGRAM_TOPIC_TITLE_GENERATION_LOCK:
+            states = getattr(self, "_telegram_topic_title_generation_states", None)
+            if states is None:
+                states = {}
+                self._telegram_topic_title_generation_states = states
+            state = states.setdefault(
+                generation_key,
+                {"explicit": 0, "automatic": 0},
+            )
+            if is_user_confirmed:
+                state["explicit"] += 1
+                state["automatic"] += 1
+                generation = ("explicit", state["explicit"], 0)
+            else:
+                state["automatic"] += 1
+                generation = (
+                    "automatic",
+                    state["automatic"],
+                    state["explicit"],
+                )
+
+        async def _run_latest_title_operation() -> None:
+            topic_locks = getattr(self, "_telegram_topic_title_locks", None)
+            if topic_locks is None:
+                topic_locks = {}
+                self._telegram_topic_title_locks = topic_locks
+            topic_lock = topic_locks.get(generation_key)
+            if topic_lock is None:
+                topic_lock = asyncio.Lock()
+                topic_locks[generation_key] = topic_lock
+            async with topic_lock:
+                if not self._telegram_topic_title_generation_is_current(
+                    generation_key,
+                    generation,
+                ):
+                    return
+                await self._rename_telegram_topic_for_session_title(
+                    copied_source,
+                    session_id,
+                    title,
+                    registry_provenance=registry_provenance,
+                    rename_generation=generation,
+                )
+
         future = safe_schedule_threadsafe(
-            self._rename_telegram_topic_for_session_title(copied_source, session_id, title),
+            _run_latest_title_operation(),
             loop,
             logger=logger,
             log_message="Telegram topic title rename failed to schedule",

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4290,7 +4290,13 @@ class GatewaySlashCommandsMixin:
                     )
                     if callable(schedule_rename):
                         try:
-                            await asyncio.to_thread(schedule_rename, source, session_id, sanitized)
+                            await asyncio.to_thread(
+                                schedule_rename,
+                                source,
+                                session_id,
+                                sanitized,
+                                registry_provenance="user_confirmed",
+                            )
                         except Exception:
                             logger.debug(
                                 "Failed to rename Telegram topic from /title",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7946,6 +7946,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    @staticmethod
+    def _ensure_telegram_topic_title_registry(conn) -> None:
+        """Create the Verified-title Registry and advance topic schema to v3."""
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS telegram_dm_topic_title_registry (
+                chat_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                provenance TEXT NOT NULL CHECK (provenance = 'user_confirmed'),
+                confirmed_at REAL NOT NULL,
+                PRIMARY KEY (chat_id, thread_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO state_meta (key, value) VALUES (?, '3')
+            ON CONFLICT(key) DO UPDATE SET value =
+                CASE
+                    WHEN CAST(value AS INTEGER) < 3 THEN excluded.value
+                    ELSE value
+                END
+            """,
+            ("telegram_dm_topic_schema_version",),
+        )
+
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.
 
@@ -7958,6 +7985,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           v1 — initial shape (no ON DELETE CASCADE on session_id FK)
           v2 — session_id FK gets ON DELETE CASCADE so session pruning
                automatically clears bindings.
+          v3 — Verified Telegram topic-title Registry.
         """
         def _do(conn):
             conn.executescript(
@@ -7992,6 +8020,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
                 CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
                 ON telegram_dm_topic_bindings(user_id, chat_id);
+
                 """
             )
 
@@ -8039,11 +8068,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         """
                     )
 
-            conn.execute(
-                "INSERT INTO state_meta (key, value) VALUES (?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                ("telegram_dm_topic_schema_version", "2"),
-            )
+            self._ensure_telegram_topic_title_registry(conn)
         self._execute_write(_do)
 
     def enable_telegram_topic_mode(
@@ -8165,6 +8190,78 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.OperationalError:
                 return None
         return dict(row) if row else None
+
+    def get_verified_telegram_topic_title(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the user-confirmed topic title without creating schema."""
+        with self._lock:
+            try:
+                row = self._conn.execute(
+                    "SELECT title, provenance, confirmed_at "
+                    "FROM telegram_dm_topic_title_registry "
+                    "WHERE chat_id = ? AND thread_id = ?",
+                    (str(chat_id), str(thread_id)),
+                ).fetchone()
+            except sqlite3.OperationalError as exc:
+                message = str(exc).strip().lower()
+                if message in {
+                    "no such table: telegram_dm_topic_title_registry",
+                    "no such table: main.telegram_dm_topic_title_registry",
+                }:
+                    return None
+                raise
+        return dict(row) if row else None
+
+    def record_verified_telegram_topic_title(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        title: str,
+        provenance: str,
+        expected_session_id: str,
+    ) -> bool:
+        """Record a verified title if the topic still belongs to the session."""
+        if not title:
+            raise ValueError("Verified topic titles require a title")
+        if provenance != "user_confirmed":
+            raise ValueError("Verified topic title provenance must be user_confirmed")
+        if not expected_session_id:
+            raise ValueError("Verified topic titles require an expected session ID")
+        now = time.time()
+
+        def _do(conn):
+            # Existing installations may already carry topic schema v2 and
+            # therefore never re-run /topic after upgrading. Create the v3
+            # Registry lazily on the first verified rename write rather than
+            # mutating topic-mode state during ordinary SessionDB startup.
+            self._ensure_telegram_topic_title_registry(conn)
+            binding = conn.execute(
+                "SELECT session_id FROM telegram_dm_topic_bindings "
+                "WHERE chat_id = ? AND thread_id = ?",
+                (str(chat_id), str(thread_id)),
+            ).fetchone()
+            if binding is None or str(binding[0]) != str(expected_session_id):
+                return False
+            conn.execute(
+                """
+                INSERT INTO telegram_dm_topic_title_registry (
+                    chat_id, thread_id, title, provenance, confirmed_at
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(chat_id, thread_id) DO UPDATE SET
+                    title = excluded.title,
+                    provenance = excluded.provenance,
+                    confirmed_at = excluded.confirmed_at
+                """,
+                (str(chat_id), str(thread_id), str(title), str(provenance), now),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
 
     def list_telegram_topic_bindings_for_chat(
         self,
@@ -8755,6 +8852,25 @@ class AsyncSessionDB:
 
     def __init__(self, db: "SessionDB") -> None:
         self._db = db
+
+    async def record_verified_telegram_topic_title(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        title: str,
+        provenance: str,
+        expected_session_id: str,
+    ) -> bool:
+        """Offload the fail-closed Verified-title write explicitly."""
+        return await asyncio.to_thread(
+            self._db.record_verified_telegram_topic_title,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            title=title,
+            provenance=provenance,
+            expected_session_id=expected_session_id,
+        )
 
     def __getattr__(self, name: str):
         attr = getattr(self._db, name)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3354,23 +3354,26 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: int,
         thread_id: int,
         name: str,
-    ) -> None:
-        """Rename a forum topic in a private (DM) chat."""
+    ) -> bool:
+        """Rename a DM forum topic and report whether Telegram was called."""
         if not self._bot:
-            return
+            return False
         try:
             chat_id_arg = int(chat_id)
         except (TypeError, ValueError):
             chat_id_arg = chat_id
-        await self._bot.edit_forum_topic(
+        renamed = await self._bot.edit_forum_topic(
             chat_id=chat_id_arg,
             message_thread_id=int(thread_id),
             name=name,
         )
+        if renamed is not True:
+            return False
         logger.info(
             "[%s] Renamed DM topic in chat %s thread_id=%s -> '%s'",
             self.name, chat_id, thread_id, name,
         )
+        return True
 
     def _persist_dm_topic_thread_id(
         self,

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -8,6 +8,7 @@ facade's contract and lock the gateway boundary so a 39th raw call can't regress
 
 import ast
 import asyncio
+import inspect
 import threading
 from pathlib import Path
 
@@ -47,6 +48,10 @@ class _SpyDB:
         self._ran_on("returns_list")
         return [{"id": "s1"}, {"id": "s2"}]
 
+    def record_verified_telegram_topic_title(self, **_kwargs):
+        self._ran_on("record_verified_telegram_topic_title")
+        return True
+
     def raises(self):
         self._ran_on("raises")
         raise ValueError("boom")
@@ -85,6 +90,34 @@ async def test_offload_goes_through_to_thread(monkeypatch):
     monkeypatch.setattr(hermes_state.asyncio, "to_thread", _spy)
     await facade.returns_str()
     assert "returns_str" in seen
+
+
+@pytest.mark.asyncio
+async def test_verified_title_write_is_an_explicit_offloaded_async_contract():
+    declared = inspect.getattr_static(
+        AsyncSessionDB,
+        "record_verified_telegram_topic_title",
+    )
+    assert inspect.iscoroutinefunction(declared)
+
+    db = _SpyDB()
+    facade = AsyncSessionDB(db)
+    caller_ident = threading.get_ident()
+    recorded = await facade.record_verified_telegram_topic_title(
+        chat_id="1",
+        thread_id="2",
+        title="Title",
+        provenance="user_confirmed",
+        expected_session_id="session",
+    )
+
+    assert recorded is True
+    ran_idents = [
+        ident
+        for name, ident in db.calls
+        if name == "record_verified_telegram_topic_title"
+    ]
+    assert ran_idents and all(ident != caller_ident for ident in ran_idents)
 
 
 # --------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -5,6 +5,8 @@ Telegram topics act as independent Hermes session lanes.
 """
 
 from datetime import datetime
+import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -66,7 +68,7 @@ def _make_runner(session_db=None):
     adapter.send_image_file = AsyncMock()
     adapter._bot = None
     adapter._create_dm_topic = AsyncMock(return_value=None)
-    adapter.rename_dm_topic = AsyncMock()
+    adapter.rename_dm_topic = AsyncMock(return_value=True)
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(
@@ -618,6 +620,625 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
         thread_id="42",
         name="Build Telegram Topic UX",
     )
+
+
+@pytest.mark.asyncio
+async def test_explicit_title_scheduler_bypasses_auto_rename_disable(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+    runner._gateway_loop = asyncio.get_running_loop()
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Eng Training 1",
+        registry_provenance="user_confirmed",
+    )
+
+    row = None
+    for _ in range(100):
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT title, provenance FROM telegram_dm_topic_title_registry "
+                "WHERE chat_id = ? AND thread_id = ?",
+                ("208214988", "42"),
+            ).fetchone()
+        if row is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once()
+    assert row is not None
+    assert tuple(row) == ("Eng Training 1", "user_confirmed")
+
+
+@pytest.mark.asyncio
+async def test_newer_scheduled_title_cannot_be_overwritten_by_stale_completion(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner._gateway_loop = asyncio.get_running_loop()
+    old_started = asyncio.Event()
+    release_old = asyncio.Event()
+    calls = []
+
+    async def _rename(*, name, **_kwargs):
+        calls.append(name)
+        if name == "Old Title":
+            old_started.set()
+            await release_old.wait()
+        return True
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = _rename
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Old Title",
+        registry_provenance="user_confirmed",
+    )
+    await asyncio.wait_for(old_started.wait(), timeout=1)
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "New Title",
+        registry_provenance="user_confirmed",
+    )
+
+    await asyncio.sleep(0.05)
+    assert calls == ["Old Title"]
+    release_old.set()
+
+    for _ in range(100):
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT title FROM telegram_dm_topic_title_registry "
+                "WHERE chat_id = ? AND thread_id = ?",
+                ("208214988", "42"),
+            ).fetchone()
+        if row is not None and row[0] == "New Title":
+            break
+        await asyncio.sleep(0.01)
+
+    assert row[0] == "New Title"
+    assert calls == ["Old Title", "New Title"]
+
+
+@pytest.mark.asyncio
+async def test_later_automatic_title_cannot_supersede_inflight_explicit_title(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner._gateway_loop = asyncio.get_running_loop()
+    explicit_started = asyncio.Event()
+    release_explicit = asyncio.Event()
+    calls = []
+
+    async def _rename(*, name, **_kwargs):
+        calls.append(name)
+        if name == "Explicit Title":
+            explicit_started.set()
+            await release_explicit.wait()
+        return True
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = _rename
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Explicit Title",
+        registry_provenance="user_confirmed",
+    )
+    await asyncio.wait_for(explicit_started.wait(), timeout=1)
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Automatic Title",
+    )
+    release_explicit.set()
+
+    for _ in range(100):
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT title FROM telegram_dm_topic_title_registry "
+                "WHERE chat_id = ? AND thread_id = ?",
+                ("208214988", "42"),
+            ).fetchone()
+        if row is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    assert row is not None
+    assert row[0] == "Explicit Title"
+    assert calls == ["Explicit Title"]
+
+
+@pytest.mark.asyncio
+async def test_automatic_title_after_restart_respects_verified_registry(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    db.record_verified_telegram_topic_title(
+        chat_id="208214988",
+        thread_id="42",
+        title="Explicit Title",
+        provenance="user_confirmed",
+        expected_session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Automatic Title",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_automatic_title_scheduler_respects_auto_rename_disable(tmp_path):
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+    runner._gateway_loop = asyncio.get_running_loop()
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Automatic Title",
+    )
+    await asyncio.sleep(0.02)
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provenance", ["", "automatic", "plugin"])
+async def test_only_user_confirmed_provenance_bypasses_auto_rename_disable(
+    provenance,
+):
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Untrusted Title",
+        registry_provenance=provenance,
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_telegram_adapter_reports_no_api_call_without_bot():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = None
+
+    renamed = await adapter.rename_dm_topic(
+        chat_id=208214988,
+        thread_id=42,
+        name="Eng Training 1",
+    )
+
+    assert renamed is False
+
+
+@pytest.mark.asyncio
+async def test_real_telegram_adapter_propagates_false_api_result():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = SimpleNamespace(edit_forum_topic=AsyncMock(return_value=False))
+
+    renamed = await adapter.rename_dm_topic(
+        chat_id=208214988,
+        thread_id=42,
+        name="Eng Training 1",
+    )
+
+    assert renamed is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_title_does_not_register_when_adapter_reports_no_rename(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.return_value = False
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Eng Training 1",
+        registry_provenance="user_confirmed",
+    )
+
+    row = db._conn.execute(
+        "SELECT 1 FROM telegram_dm_topic_title_registry "
+        "WHERE chat_id = ? AND thread_id = ?",
+        ("208214988", "42"),
+    ).fetchone()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_title_does_not_register_false_legacy_bot_result(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    bot = SimpleNamespace(edit_forum_topic=AsyncMock(return_value=False))
+    runner.adapters[Platform.TELEGRAM] = SimpleNamespace(_bot=bot)
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Eng Training 1",
+        registry_provenance="user_confirmed",
+    )
+
+    with db._lock:
+        row = db._conn.execute(
+            "SELECT 1 FROM telegram_dm_topic_title_registry "
+            "WHERE chat_id = ? AND thread_id = ?",
+            ("208214988", "42"),
+        ).fetchone()
+    assert row is None
+
+
+def test_verified_title_write_lazily_upgrades_existing_v2_topic_schema(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+
+    # Simulate an installation that opted into topic mode before the Verified
+    # title Registry existed. Its v2 marker remains, so startup and /topic do
+    # not run again before the next successful title rename.
+    conn = db._conn
+    assert conn is not None
+    with db._lock:
+        conn.execute("DROP TABLE telegram_dm_topic_title_registry")
+        conn.execute(
+            "UPDATE state_meta SET value = '2' "
+            "WHERE key = 'telegram_dm_topic_schema_version'"
+        )
+        conn.commit()
+
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    db.record_verified_telegram_topic_title(
+        chat_id="208214988",
+        thread_id="42",
+        title="Eng Training 1",
+        provenance="user_confirmed",
+        expected_session_id="sess-topic",
+    )
+
+    with db._lock:
+        row = conn.execute(
+            "SELECT title, provenance FROM telegram_dm_topic_title_registry "
+            "WHERE chat_id = ? AND thread_id = ?",
+            ("208214988", "42"),
+        ).fetchone()
+        version = conn.execute(
+            "SELECT value FROM state_meta "
+            "WHERE key = 'telegram_dm_topic_schema_version'"
+        ).fetchone()
+
+    assert tuple(row) == ("Eng Training 1", "user_confirmed")
+    assert version[0] == "3"
+
+
+def test_verified_registry_rejects_untrusted_provenance_at_storage_boundary(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+
+    with pytest.raises(ValueError, match="user_confirmed"):
+        db.record_verified_telegram_topic_title(
+            chat_id="208214988",
+            thread_id="42",
+            title="Untrusted",
+            provenance="plugin",
+            expected_session_id="sess-topic",
+        )
+
+
+def test_verified_registry_requires_expected_session_id(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+
+    with pytest.raises(TypeError):
+        db.record_verified_telegram_topic_title(
+            chat_id="208214988",
+            thread_id="42",
+            title="Unbound",
+            provenance="user_confirmed",
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_title_bypasses_auto_rename_disable_and_registers_after_success(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Eng Training 1",
+        registry_provenance="user_confirmed",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Eng Training 1",
+    )
+    row = db._conn.execute(
+        "SELECT title, provenance FROM telegram_dm_topic_title_registry "
+        "WHERE chat_id = ? AND thread_id = ?",
+        ("208214988", "42"),
+    ).fetchone()
+    assert tuple(row) == ("Eng Training 1", "user_confirmed")
+
+
+@pytest.mark.asyncio
+async def test_failed_explicit_title_rename_does_not_register(tmp_path, caplog):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "disable_topic_auto_rename": True,
+    }
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = RuntimeError(
+        "Telegram rejected rename"
+    )
+    with caplog.at_level(logging.WARNING):
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "Eng Training 1",
+            registry_provenance="user_confirmed",
+        )
+
+    row = db._conn.execute(
+        "SELECT title, provenance FROM telegram_dm_topic_title_registry "
+        "WHERE chat_id = ? AND thread_id = ?",
+        ("208214988", "42"),
+    ).fetchone()
+    assert row is None
+    assert "Explicit Telegram topic rename failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_registry_failure_after_successful_rename_is_observable(
+    tmp_path, monkeypatch
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    registry_error = RuntimeError("registry unavailable")
+    monkeypatch.setattr(
+        db,
+        "record_verified_telegram_topic_title",
+        MagicMock(side_effect=registry_error),
+    )
+
+    with pytest.raises(RuntimeError, match="registry unavailable"):
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "Eng Training 1",
+            registry_provenance="user_confirmed",
+        )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_registry_failure_does_not_release_automatic_overwrite(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner._gateway_loop = asyncio.get_running_loop()
+    calls = []
+
+    async def _rename(*, name, **_kwargs):
+        calls.append(name)
+        return True
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = _rename
+    monkeypatch.setattr(
+        db,
+        "record_verified_telegram_topic_title",
+        MagicMock(side_effect=RuntimeError("registry unavailable")),
+    )
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Explicit Title",
+        registry_provenance="user_confirmed",
+    )
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Automatic Title",
+    )
+
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if calls:
+            break
+    await asyncio.sleep(0.05)
+
+    assert calls == ["Explicit Title"]
+
+
+@pytest.mark.asyncio
+async def test_rebind_during_rename_prevents_stale_verified_registry_write(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("old-session", source="telegram", user_id="208214988")
+    db.create_session("new-session", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="old-session",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    async def _rename_and_rebind(**_kwargs):
+        db.bind_telegram_topic(
+            chat_id="208214988",
+            thread_id="42",
+            user_id="208214988",
+            session_key="agent:main:telegram:dm:208214988:42",
+            session_id="new-session",
+        )
+        return True
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = _rename_and_rebind
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "old-session",
+        "Stale Title",
+        registry_provenance="user_confirmed",
+    )
+
+    with db._lock:
+        row = db._conn.execute(
+            "SELECT title FROM telegram_dm_topic_title_registry "
+            "WHERE chat_id = ? AND thread_id = ?",
+            ("208214988", "42"),
+        ).fetchone()
+    assert row is None
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -105,7 +105,10 @@ class TestHandleTitleCommand:
 
         assert "My Topic Name" in result
         runner._schedule_telegram_topic_title_rename.assert_called_once_with(
-            event.source, "test_session_123", "My Topic Name"
+            event.source,
+            "test_session_123",
+            "My Topic Name",
+            registry_provenance="user_confirmed",
         )
         db.close()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1272,8 +1272,36 @@ class TestSchemaInit:
         assert binding["user_id"] == "208214988"
         assert binding["session_key"] == "telegram:dm:208214988:thread:17585"
         assert binding["session_id"] == "topic-session"
-        assert db.get_meta("telegram_dm_topic_schema_version") == "2"
+        assert int(db.get_meta("telegram_dm_topic_schema_version")) >= 3
+        registry = db._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'telegram_dm_topic_title_registry'"
+        ).fetchone()
+        assert registry is not None
         db.close()
+
+    def test_verified_title_read_propagates_unexpected_operational_error(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        assert db.get_verified_telegram_topic_title(
+            chat_id="208214988",
+            thread_id="42",
+        ) is None
+        original_connection = db._conn
+
+        class FailingConnection:
+            def execute(self, *_args, **_kwargs):
+                raise sqlite3.OperationalError("database is locked")
+
+        db._conn = FailingConnection()
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                db.get_verified_telegram_topic_title(
+                    chat_id="208214988",
+                    thread_id="42",
+                )
+        finally:
+            db._conn = original_connection
+            db.close()
 
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves explicit Telegram DM topic titles as user-confirmed state instead of treating them like automatic session titles.

An explicit `/title` may now bypass `disable_topic_auto_rename`, but only with the exact trusted provenance `user_confirmed`. Telegram rename success is confirmed before the Verified-title Registry is written; no bot/client, no API call, a false API result, an exception, a stale generation, or a changed topic binding cannot create a verified record.

This also makes automatic and explicit title operations deterministic under concurrency: explicit user intent takes priority, per-topic operations are serialized, and automatic renames respect persisted verified titles after restart.

## Related Issue

Related to #52734, which covers the basic `/title` → Telegram topic rename behavior. This PR is intentionally separate and references that overlap explicitly because it adds the fail-closed API-result, persistence, migration, binding, async-offload, and concurrency guarantees needed for the behavior to remain correct when automatic renaming is disabled or operations fail/race.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`
  - mark explicit `/title` propagation with trusted `user_confirmed` provenance
- `gateway/run.py`
  - allow only explicit user-confirmed renames to bypass automatic-rename disablement
  - serialize title changes per Telegram topic and enforce explicit-over-automatic ordering
  - require confirmed Telegram API success before Registry writes
  - fail closed for stale operations, changed bindings, Registry read errors, and post-restart verified titles
  - make explicit rename and Registry-write failures observable
- `hermes_state.py`
  - add the v3 Verified Telegram topic-title Registry with lazy migration from v2
  - enforce provenance and expected binding at the storage boundary
  - add async offload wrappers for gateway DB access
- `plugins/platforms/telegram/adapter.py`
  - return strict boolean rename results and report no-call/false-result paths accurately
- `tests/`
  - add deterministic regressions for API false/no-call/exception paths, migration, binding changes, Registry failures, restart behavior, and explicit/automatic concurrency orderings

## How to Test

1. Run the related regression suites:
   ```bash
   HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
     tests/gateway/test_telegram_topic_mode.py \
     tests/gateway/test_title_command.py \
     tests/gateway/test_async_session_db.py \
     tests/test_hermes_state.py -q
   ```
   Result on this branch: **190 passed, 0 failed**.
2. Run static and patch checks:
   ```bash
   python -m ruff check gateway/run.py gateway/slash_commands.py hermes_state.py \
     plugins/platforms/telegram/adapter.py tests/gateway/test_title_command.py \
     tests/gateway/test_telegram_topic_mode.py tests/gateway/test_async_session_db.py \
     tests/test_hermes_state.py
   python -m py_compile gateway/run.py gateway/slash_commands.py hermes_state.py \
     plugins/platforms/telegram/adapter.py tests/gateway/test_title_command.py \
     tests/gateway/test_telegram_topic_mode.py tests/gateway/test_async_session_db.py \
     tests/test_hermes_state.py
   git diff --check origin/main...HEAD
   ```
3. The full canonical suite was also attempted. The available environment has unrelated baseline failures from missing optional ACP/Anthropic SDK dependencies and a WeCom ET issue; those same failures were reproduced on the clean base. No failure occurred in the changed title/Telegram topic/SessionDB paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs and found/compared the overlapping #52734
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked by pre-existing environment/baseline failures documented above
- [x] I've added tests for my changes
- [x] I've tested on Linux (kernel 6.8)

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing config key or command syntax changed
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; implementation uses existing asyncio, threading, SQLite, and adapter abstractions
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Not applicable. The change is covered by deterministic gateway, adapter, migration, and storage regressions.
