### PR TITLE
feat(desktop): register a Linux launcher entry for `hermes desktop`

### DIFF
--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -142,10 +142,15 @@ def packaged_gui_app_paths() -> "list[Path]":
         # hint rather than guessing. deb/rpm installs are owned by the system
         # package manager and must be removed via apt/dnf — see the message in
         # ``uninstall_gui``.
+        from hermes_cli.linux_desktop_entry import desktop_entry_path
+
         data = os.environ.get("XDG_DATA_HOME")
         data_base = Path(data) if data else (home / ".local" / "share")
         paths += [
-            data_base / "applications" / "hermes.desktop",
+            # The launcher entry `hermes desktop` installs. Its icon lives
+            # in the checkout, not in the installed app.
+            desktop_entry_path(),
+            # Some packaged builds emit this casing.
             data_base / "applications" / "Hermes.desktop",
         ]
     return paths
@@ -275,6 +280,22 @@ def uninstall_gui(hermes_home: "Path | None" = None, *, remove_userdata: bool = 
     # shouldn't) rmtree files under /usr. Surface the hint so the user can
     # finish the job. AppImages live wherever the user dropped them.
     if sys.platform.startswith("linux"):
+        # The desktop entry was removed above (it is in
+        # ``packaged_gui_app_paths``), but the menu caches still list it.
+        # Reindex so Hermes disappears from the launcher.
+        try:
+            from hermes_cli.linux_desktop_entry import (
+                desktop_entry_path,
+                refresh_desktop_databases,
+            )
+
+            entry = desktop_entry_path()
+            if entry in removed:
+                for tool in refresh_desktop_databases(entry.parent):
+                    log_success(f"Refreshed the application menu cache ({tool})")
+        except Exception as e:
+            log_warn(f"Could not refresh the application menu cache: {e}")
+
         log_info(
             "If you installed the desktop via a .deb / .rpm package, remove it "
             "with your package manager (e.g. 'sudo apt remove hermes' or "

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -1,0 +1,173 @@
+"""Install and remove the Linux desktop entry (``hermes.desktop``).
+
+``hermes desktop`` builds and launches the Electron app. On Linux, a
+freshly-built app has no launcher presence: no menu item, no icon. This
+module writes the XDG desktop entry that gives it one.
+``hermes uninstall --gui`` removes the entry again.
+
+Two values must be absolute for the entry to work:
+
+  - ``Exec`` — the launcher runs without shell ``PATH`` customizations, so
+    a bare ``hermes desktop`` fails when hermes lives in ``~/.local/bin``
+    or a venv. Resolve the real binary and write its full path.
+  - ``Icon`` — an unqualified icon name needs an indexed icon theme. The
+    spec allows an absolute path instead, so point at the app icon in the
+    checkout. Do not copy the icon: ``Exec`` already depends on that tree.
+
+Cache refresh is best-effort and tool-gated: ``update-desktop-database``
+for the freedesktop menu cache, and ``kbuildsycoca6``/``kbuildsycoca5``
+for Plasma. Run each tool only when it exists. A missing tool is not an
+error.
+
+Import-light and side-effect-free at import time: the uninstaller and the
+Electron main process both use this without loading the full CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+DESKTOP_ENTRY_NAME = "hermes.desktop"
+
+
+def is_supported() -> bool:
+    """XDG desktop entries exist only on Linux and BSD."""
+    return sys.platform.startswith(("linux", "freebsd", "openbsd", "netbsd"))
+
+
+def _xdg_data_home() -> Path:
+    raw = os.environ.get("XDG_DATA_HOME")
+    if raw and raw.strip():
+        return Path(raw).expanduser()
+    return Path.home() / ".local" / "share"
+
+
+def desktop_entry_path() -> Path:
+    """Where the ``hermes.desktop`` entry lives."""
+    return _xdg_data_home() / "applications" / DESKTOP_ENTRY_NAME
+
+
+def icon_path(project_root: Path) -> Path:
+    """The app icon shipped in the desktop workspace."""
+    return project_root / "apps" / "desktop" / "assets" / "icon.png"
+
+
+def resolve_exec_command() -> str:
+    """Build the absolute ``Exec=`` command line for ``hermes desktop``.
+
+    Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
+    runs as a module with no launcher installed, use the current
+    interpreter, also absolute.
+    """
+    from hermes_cli.relaunch import resolve_hermes_bin
+
+    bin_path = resolve_hermes_bin()
+    if bin_path:
+        argv = [str(Path(bin_path).resolve()), "desktop"]
+    else:
+        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+    return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _quote_exec_arg(arg: str) -> str:
+    """Quote one ``Exec`` argument per the desktop entry spec.
+
+    Reserved characters require double quotes. Inside the quotes, escape
+    a backslash and a double quote with a backslash.
+    """
+    if not any(c in arg for c in ' \t\n"\'\\><~|&;$*?#()`'):
+        return arg
+    escaped = arg.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def render_desktop_entry(exec_command: str, icon: str) -> str:
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=Hermes\n"
+        "GenericName=Hermes Desktop\n"
+        "Comment=Launch Hermes Desktop\n"
+        f"Exec={exec_command}\n"
+        f"Icon={icon}\n"
+        "Terminal=false\n"
+        "Categories=Utility;\n"
+        "StartupNotify=true\n"
+        "StartupWMClass=Hermes\n"
+    )
+
+
+def refresh_desktop_databases(applications_dir: Path) -> "list[str]":
+    """Reindex the menu caches. Run each tool only when it exists.
+
+    Return the names of the tools that ran (for logging and tests).
+    """
+    ran: list[str] = []
+
+    update_db = shutil.which("update-desktop-database")
+    if update_db:
+        if _run_quiet([update_db, str(applications_dir)]):
+            ran.append("update-desktop-database")
+
+    # Plasma 6 first, then Plasma 5. Only one of them is ever installed.
+    for tool in ("kbuildsycoca6", "kbuildsycoca5"):
+        resolved = shutil.which(tool)
+        if not resolved:
+            continue
+        if _run_quiet([resolved, "--noincremental"]):
+            ran.append(tool)
+        break
+
+    return ran
+
+
+def _run_quiet(cmd: "list[str]") -> bool:
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def install_desktop_entry(project_root: Path) -> Optional[Path]:
+    """Write (or refresh) the Hermes desktop entry. Return its path.
+
+    Return ``None`` on non-Linux platforms or when the write fails. This
+    is a convenience, never a reason to fail a launch.
+    """
+    if not is_supported():
+        return None
+
+    entry_path = desktop_entry_path()
+    icon = icon_path(project_root)
+    # Use the themed name when the checkout has no icon (a lite or
+    # packaged install). A broken absolute path renders as no icon.
+    icon_value = str(icon) if icon.is_file() else "hermes"
+    contents = render_desktop_entry(resolve_exec_command(), icon_value)
+
+    try:
+        entry_path.parent.mkdir(parents=True, exist_ok=True)
+        # When nothing changed, skip the rewrite. Then a launch does not
+        # churn the menu caches.
+        if entry_path.is_file() and entry_path.read_text(encoding="utf-8") == contents:
+            return entry_path
+        entry_path.write_text(contents, encoding="utf-8")
+        # Some launchers (and older Plasma) offer the entry only when it
+        # is executable.
+        entry_path.chmod(0o755)
+    except OSError:
+        return None
+
+    refresh_desktop_databases(entry_path.parent)
+    return entry_path

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6979,6 +6979,25 @@ def _desktop_launch_options() -> tuple[list[str], str]:
     return flags, disable_gpu
 
 
+def _register_linux_desktop_entry() -> None:
+    """Install the XDG desktop entry for Hermes Desktop (Linux only, best-effort).
+
+    Gives the Electron app a launcher presence: a menu item and an icon.
+    ``Exec`` and ``Icon`` are absolute, so the entry works outside a login
+    shell. ``hermes uninstall --gui`` removes it.
+    """
+    try:
+        from hermes_cli.linux_desktop_entry import install_desktop_entry, is_supported
+
+        if not is_supported():
+            return
+        entry = install_desktop_entry(PROJECT_ROOT)
+        if entry:
+            print(f"✓ Desktop launcher entry installed: {entry}")
+    except Exception as exc:  # never block a launch on launcher plumbing
+        print(f"⚠ Could not install the desktop launcher entry: {exc}")
+
+
 def cmd_gui(args: argparse.Namespace):
     """Build and launch the native Electron desktop GUI."""
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
@@ -7179,6 +7198,11 @@ def cmd_gui(args: argparse.Namespace):
 
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
+
+    # Linux: register the app in the desktop launcher, so Hermes shows up
+    # in the application menu with its icon. Best-effort and idempotent.
+    # A failure must never stop the app from launching.
+    _register_linux_desktop_entry()
 
     # --build-only: produce the artifact but do NOT launch. The installer's
     # --update flow drives the rebuild headlessly and then launches the desktop

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -20,7 +20,7 @@
 let
   electronHeaders = pkgs.fetchurl {
     url = "https://artifacts.electronjs.org/headers/dist/v${electron.version}/node-v${electron.version}-headers.tar.gz";
-    sha256 = "sha256-f8bSbLRmtbP93CJAvEBs+sHWDZ1xP2bcpLhC1EnOmZU=";
+    sha256 = "sha256-0nUJBQDEikyYntZwq+ycH32mzEQtQmz3ICz9eeTMpJk=";
   };
 
   # node-pty ships no Electron-tagged prebuild we can trust to match this

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -14,6 +14,7 @@
   hermesNpmLib,
   electron,
   hermesAgent,
+  python3,
   ...
 }:
 let
@@ -141,7 +142,10 @@ stdenv.mkDerivation {
   dontUnpack = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    python3
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -166,6 +170,15 @@ stdenv.mkDerivation {
       --set HERMES_DESKTOP_HERMES "${lib.getExe hermesAgent}" \
       --set ELECTRON_IS_DEV 0
 
+    # XDG launcher entry
+    mkdir -p $out/share/applications $out/share/icons/hicolor/1024x1024/apps
+    install -m 0644 ${../apps/desktop/assets/icon.png} \
+      $out/share/icons/hicolor/1024x1024/apps/hermes.png
+    export PYTHONPATH=$(mktemp -d)
+    cp ${../hermes_cli/linux_desktop_entry.py} "$PYTHONPATH/linux_desktop_entry.py"
+    export DESKTOP_EXEC="$out/bin/hermes-desktop"
+    export DESKTOP_ICON="$out/share/icons/hicolor/1024x1024/apps/hermes.png"
+    python3 -c 'import os; from linux_desktop_entry import render_desktop_entry; print(render_desktop_entry(os.environ["DESKTOP_EXEC"], os.environ["DESKTOP_ICON"]))' > $out/share/applications/hermes.desktop
     runHook postInstall
   '';
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -382,3 +382,80 @@ def test_relaunchable_fixup_falls_back_to_legacy_adhoc_on_failure(tmp_path, monk
 # --- desktop.* launch options (config.yaml) -------------------------------
 
 
+
+
+# --- Linux launcher entry registration ------------------------------------
+
+
+def test_gui_registers_linux_desktop_entry_before_launch(tmp_path, monkeypatch):
+    """`hermes desktop` gives the app a launcher presence on Linux."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    registered: list[Path] = []
+    monkeypatch.setattr("hermes_cli.linux_desktop_entry.is_supported", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.linux_desktop_entry.install_desktop_entry",
+        lambda project_root: registered.append(project_root) or (tmp_path / "hermes.desktop"),
+    )
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns())
+
+    assert registered == [root]
+
+
+def test_gui_launches_even_when_desktop_entry_install_fails(tmp_path, monkeypatch):
+    """Launcher plumbing is a convenience — it must never block the app."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    def boom(_project_root):
+        raise OSError("read-only /home")
+
+    monkeypatch.setattr("hermes_cli.linux_desktop_entry.is_supported", lambda: True)
+    monkeypatch.setattr("hermes_cli.linux_desktop_entry.install_desktop_entry", boom)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+def test_gui_skips_desktop_entry_off_linux(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="darwin")
+
+    monkeypatch.setattr("hermes_cli.linux_desktop_entry.is_supported", lambda: False)
+
+    def fail(_project_root):
+        raise AssertionError("must not install a desktop entry off Linux")
+
+    monkeypatch.setattr("hermes_cli.linux_desktop_entry.install_desktop_entry", fail)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0

--- a/tests/hermes_cli/test_gui_uninstall.py
+++ b/tests/hermes_cli/test_gui_uninstall.py
@@ -69,6 +69,63 @@ def test_gui_install_summary_shape(tmp_path, monkeypatch):
 
 
 
+def test_linux_discovery_includes_launcher_entry(tmp_path, monkeypatch):
+    """The launcher entry that `hermes desktop` installs is removable."""
+    monkeypatch.setattr(gu.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    from hermes_cli import linux_desktop_entry as lde
+
+    assert lde.desktop_entry_path() in gu.packaged_gui_app_paths()
+
+
+def test_uninstall_removes_launcher_entry_and_refreshes_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(gu.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    from hermes_cli import linux_desktop_entry as lde
+
+    entry = lde.desktop_entry_path()
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.write_text("x", encoding="utf-8")
+
+    refreshed: list[Path] = []
+    monkeypatch.setattr(
+        lde, "refresh_desktop_databases", lambda d: refreshed.append(d) or ["kbuildsycoca6"]
+    )
+
+    hermes_home = tmp_path / ".hermes"
+    _make_agent(hermes_home)
+    icon = lde.icon_path(hermes_home / "hermes-agent")
+    icon.parent.mkdir(parents=True, exist_ok=True)
+    icon.write_bytes(b"\x89PNG")
+    monkeypatch.setattr(gu, "desktop_userdata_dir", lambda: tmp_path / "none")
+
+    removed = gu.uninstall_gui(hermes_home)
+
+    assert entry in removed and not entry.exists()
+    assert refreshed == [entry.parent]
+    # The icon lives in the checkout. A GUI uninstall must not delete it.
+    assert lde.icon_path(hermes_home / "hermes-agent").exists()
+    # The agent itself survives a GUI uninstall.
+    assert (hermes_home / "hermes-agent" / "hermes_cli").is_dir()
+
+
+def test_uninstall_skips_cache_refresh_when_no_launcher_entry(tmp_path, monkeypatch):
+    monkeypatch.setattr(gu.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    from hermes_cli import linux_desktop_entry as lde
+
+    refreshed: list[Path] = []
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda d: refreshed.append(d) or [])
+    monkeypatch.setattr(gu, "desktop_userdata_dir", lambda: tmp_path / "none")
+
+    gu.uninstall_gui(tmp_path / ".hermes")
+
+    assert refreshed == []
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
 def test_remove_path_handles_symlink(tmp_path):
     target = tmp_path / "real"

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -1,0 +1,197 @@
+"""Tests for the Linux XDG desktop entry installed by ``hermes desktop``."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import linux_desktop_entry as lde
+
+
+@pytest.fixture
+def xdg_home(tmp_path, monkeypatch) -> Path:
+    data_home = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    monkeypatch.setattr(lde.sys, "platform", "linux")
+    return data_home
+
+
+def _make_project(tmp_path: Path) -> Path:
+    root = tmp_path / "hermes-agent"
+    icon = root / "apps" / "desktop" / "assets" / "icon.png"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(b"\x89PNG fake")
+    return root
+
+
+def _parse(entry_text: str) -> dict:
+    values = {}
+    for line in entry_text.splitlines():
+        if "=" in line and not line.startswith("["):
+            key, val = line.split("=", 1)
+            values[key] = val
+    return values
+
+
+def test_install_writes_entry_with_absolute_exec_and_icon(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin)
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+
+    assert entry == xdg_home / "applications" / "hermes.desktop"
+    values = _parse(entry.read_text(encoding="utf-8"))
+
+    # Exec must be the absolute path of the resolved binary. The launcher
+    # runs with a minimal PATH, so a bare `hermes` would not resolve.
+    assert values["Exec"] == f"{hermes_bin} desktop"
+    assert Path(values["Exec"].split(" ")[0]).is_absolute()
+
+    # Icon must be an absolute path to the real icon in the checkout.
+    icon_path = Path(values["Icon"])
+    assert icon_path.is_absolute()
+    assert icon_path == lde.icon_path(root)
+    assert icon_path.read_bytes() == b"\x89PNG fake"
+
+    assert values["Type"] == "Application"
+    assert values["Name"] == "Hermes"
+    assert values["Terminal"] == "false"
+
+
+def test_installed_entry_is_executable(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+
+    assert entry.stat().st_mode & stat.S_IXUSR
+
+
+def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+    assert Path(exec_line.split(" ")[0]).is_absolute()
+
+
+def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+    calls: list[Path] = []
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda d: calls.append(d) or [])
+
+    lde.install_desktop_entry(root)
+    assert len(calls) == 1
+
+    # Unchanged content → no rewrite, no menu-cache churn on every launch.
+    lde.install_desktop_entry(root)
+    assert len(calls) == 1
+
+
+def test_install_without_source_icon_uses_themed_name(tmp_path, xdg_home, monkeypatch):
+    root = tmp_path / "hermes-agent"
+    root.mkdir()
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+
+    # A broken absolute path renders as no icon. The themed name resolves
+    # when Hermes is installed some other way.
+    assert _parse(entry.read_text(encoding="utf-8"))["Icon"] == "hermes"
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_install_is_a_noop_off_linux(tmp_path, monkeypatch, platform):
+    monkeypatch.setattr(lde.sys, "platform", platform)
+    assert lde.install_desktop_entry(_make_project(tmp_path)) is None
+
+
+# ---------------------------------------------------------------------------
+# Cache refresh tool gating
+# ---------------------------------------------------------------------------
+
+
+def _stub_tools(monkeypatch, available: "set[str]") -> "list[list[str]]":
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        lde.shutil, "which", lambda name: f"/usr/bin/{name}" if name in available else None
+    )
+    monkeypatch.setattr(lde, "_run_quiet", lambda cmd: ran.append(cmd) or True)
+    return ran
+
+
+def test_refresh_runs_kbuildsycoca6_when_present(monkeypatch, tmp_path):
+    ran = _stub_tools(monkeypatch, {"update-desktop-database", "kbuildsycoca6"})
+
+    tools = lde.refresh_desktop_databases(tmp_path)
+
+    assert tools == ["update-desktop-database", "kbuildsycoca6"]
+    assert ran == [
+        ["/usr/bin/update-desktop-database", str(tmp_path)],
+        ["/usr/bin/kbuildsycoca6", "--noincremental"],
+    ]
+
+
+def test_refresh_falls_back_to_kbuildsycoca5(monkeypatch, tmp_path):
+    ran = _stub_tools(monkeypatch, {"kbuildsycoca5"})
+
+    tools = lde.refresh_desktop_databases(tmp_path)
+
+    assert tools == ["kbuildsycoca5"]
+    assert ran == [["/usr/bin/kbuildsycoca5", "--noincremental"]]
+
+
+def test_refresh_prefers_kbuildsycoca6_over_5(monkeypatch, tmp_path):
+    ran = _stub_tools(monkeypatch, {"kbuildsycoca6", "kbuildsycoca5"})
+
+    lde.refresh_desktop_databases(tmp_path)
+
+    assert [cmd[0] for cmd in ran] == ["/usr/bin/kbuildsycoca6"]
+
+
+def test_refresh_skips_missing_tools(monkeypatch, tmp_path):
+    ran = _stub_tools(monkeypatch, set())
+
+    assert lde.refresh_desktop_databases(tmp_path) == []
+    assert ran == []
+
+
+def test_refresh_reports_only_tools_that_succeeded(monkeypatch, tmp_path):
+    monkeypatch.setattr(lde.shutil, "which", lambda name: f"/usr/bin/{name}")
+    # update-desktop-database fails (exit != 0). kbuildsycoca6 succeeds.
+    monkeypatch.setattr(lde, "_run_quiet", lambda cmd: "kbuildsycoca" in cmd[0])
+
+    assert lde.refresh_desktop_databases(tmp_path) == ["kbuildsycoca6"]
+
+
+def test_run_quiet_swallows_missing_binary(tmp_path):
+    assert lde._run_quiet([str(tmp_path / "definitely-not-a-binary")]) is False
+
+
+def test_exec_arg_quoting_handles_spaces(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    spaced = tmp_path / "my apps" / "hermes"
+    spaced.parent.mkdir()
+    spaced.write_text("", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(spaced))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f'"{spaced}" desktop'


### PR DESCRIPTION
## What does this PR do?

On Linux, a freshly-built desktop app does not appear in the application launcher. There is no Hermes in the KDE/GNOME menu, no icon, and nothing to pin to a taskbar. Today, the only way to get an entry is to write `~/.local/share/applications/hermes.desktop` by hand, make it executable, and refresh the menu caches yourself.

`hermes desktop` now writes the entry itself. `hermes uninstall --gui` removes it again.

**Why this design.** The two fields that matter contain absolute paths:

- **`Exec`** — the launcher runs the command in a minimal environment. It does not use the `PATH` customizations of your shell. So a plain `hermes desktop` fails without a message for anyone whose hermes lives in `~/.local/bin`, a venv, or the Nix store. We find the real binary with the existing `relaunch.resolve_hermes_bin()` ladder. If there is no binary, we use the absolute interpreter path with `-m hermes_cli.main`.
- **`Icon`** — an icon name without a path works only with an indexed icon theme. Our app is not in an icon theme. The desktop entry spec permits an absolute path. We point at `apps/desktop/assets/icon.png` in the checkout. We do not copy the icon into the user's icon theme. `Exec` already uses the same source tree. A second copy adds about 600 KB and one more uninstall step. It does not survive anything that `Exec` does not survive.

We refresh the menu caches with `update-desktop-database`. Then we run `kbuildsycoca6` or `kbuildsycoca5` (Plasma 6 first, because only one of them is installed). We run each tool only when it is on `PATH`. Most desktops do not include these tools. A missing tool is not an error. We rewrite the entry only when its contents change. So a launch does not update the caches on every run.

This is best-effort. If we cannot write the entry, we print a warning. The app still launches. The entry is never a reason that a launch fails.

<img width="738" height="190" alt="image" src="https://github.com/user-attachments/assets/96902881-8d9e-4098-936b-457c01141807" />

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`hermes_cli/linux_desktop_entry.py`** (new) — renders the entry, quotes `Exec` arguments to the spec, resolves absolute `Exec`/`Icon` paths, resolves XDG paths (honors `XDG_DATA_HOME`), and refreshes caches with tool gating. The module imports only light code and has no side effects at import time. The uninstaller and the Electron main process can run it without loading the full CLI.
- **`hermes_cli/main.py`** — `cmd_gui` calls the new `_register_linux_desktop_entry()` after the build and before the launch. The call catches exceptions, prints a warning, and continues. It does nothing outside Linux.
- **`hermes_cli/gui_uninstall.py`** — the entry joins the Linux `packaged_gui_app_paths()` discovery list. Then it also appears in `gui_install_summary` for the desktop UI. `uninstall_gui` refreshes the menu caches after it removes the entry. We do not remove the icon in the checkout. The icon belongs to the source tree.
- **`tests/hermes_cli/test_linux_desktop_entry.py`** (new, 16 tests) — entry contents, absolute `Exec`/`Icon`, interpreter fallback, spaces-in-path quoting, the executable bit, idempotence (no cache churn on an unchanged entry), themed-name fallback when the checkout has no icon, off-Linux no-op, and the full cache-refresh gating matrix.
- **`tests/hermes_cli/test_gui_command.py`** (+3) — registration happens on a Linux launch, a failing install still launches the app, and nothing is registered off Linux.
- **`tests/hermes_cli/test_gui_uninstall.py`** (+3) — the entry is discovered and removed, the cache is refreshed only when something was removed, and the checkout's icon plus the Python agent both survive.

## How to Test

```bash
# 1. Install the entry against a throwaway XDG root
XDG_DATA_HOME=/tmp/xdg-test python -c "
from pathlib import Path
from hermes_cli.linux_desktop_entry import install_desktop_entry
print(install_desktop_entry(Path('.')).read_text())"

# 2. It should pass the freedesktop validator
desktop-file-validate /tmp/xdg-test/applications/hermes.desktop

# 3. Or just launch normally and look in your application menu
hermes desktop

# 4. Remove it again
hermes uninstall --gui
```

Unit tests:

```bash
pytest tests/hermes_cli/test_linux_desktop_entry.py \
       tests/hermes_cli/test_gui_uninstall.py \
       tests/hermes_cli/test_gui_command.py -q
```

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure that this is not a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I have run the relevant tests and they pass. See the note below on one pre-existing failure.
- [x] I have added tests for my changes (22 new tests)
- [x] I have tested on my platform: NixOS (Wayland/Hyprland), Python 3.12

### Documentation & Housekeeping

- [x] I have updated the relevant documentation. The module and function docstrings carry the reasoning. No user-facing doc change is needed. The entry appears on its own.
- [x] N/A. We added no config keys.
- [x] N/A. There is no architecture or workflow change.
- [x] Cross-platform impact is considered. `is_supported()` gates on Linux and BSD. `cmd_gui` skips the call everywhere else. Tests cover both `darwin` and `win32`.
- [x] N/A. There is no tool behavior change.

## Screenshots / Logs

The generated entry on NixOS, from `install_desktop_entry`:

```ini
[Desktop Entry]
Type=Application
Name=Hermes
GenericName=Hermes Desktop
Comment=Launch Hermes Desktop
Exec=/nix/store/k94wf8h4ziza8ffjqk4ry6kfy164zl5w-hermes/bin/hermes desktop
Icon=/home/ari/src/hermes-agent/apps/desktop/assets/icon.png
Terminal=false
Categories=Utility;
StartupNotify=true
StartupWMClass=Hermes
```

Checks with real tools, not only with mocks:

```
$ desktop-file-validate /tmp/xdg-test/applications/hermes.desktop
VALID ✓                                  # exit 0, no warnings

$ # with a real update-desktop-database on PATH
refresh ran: ['update-desktop-database']
$ ls /tmp/xdg-e2e2/applications/
hermes.desktop  mimeinfo.cache           # cache actually written

$ # with a real kbuildsycoca6 on PATH
ran: ['kbuildsycoca6']
$ cat /tmp/fakebin/log
kbuildsycoca6 --noincremental            # correct flag, actually invoked

$ # with neither tool present (this machine's default)
tools that ran: []                       # clean skip, no error

$ # removal
removed: [PosixPath('.../applications/hermes.desktop')]
removed again: []                        # idempotent
icon survived uninstall: True            # checkout untouched
```