### PR TITLE
feat(agent): add per-turn provider request budget

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -517,6 +517,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    provider_request_budget_exempt: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -580,6 +581,7 @@ def init_agent(
     agent.tool_progress_mode = tool_progress_mode
     agent.ephemeral_system_prompt = ephemeral_system_prompt
     agent.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+    agent._provider_request_budget_exempt = provider_request_budget_exempt
     agent._user_id = user_id  # Platform user identifier (gateway sessions)
     agent._user_id_alt = user_id_alt  # Optional stable alternate platform identifier
     agent._user_name = user_name
@@ -1748,6 +1750,18 @@ def init_agent(
     if not isinstance(_agent_section, dict):
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+
+    # Optional per-user-turn main-agent provider request ceiling. Keep this
+    # separate from tool iterations and session token/cost accounting.
+    from agent.provider_request_budget import (
+        parse_provider_request_limit,
+        reset_provider_request_budget,
+    )
+
+    agent.max_provider_requests_per_turn = parse_provider_request_limit(
+        _agent_section.get("max_provider_requests_per_turn", 0)
+    )
+    reset_provider_request_budget(agent)
 
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2981,6 +2981,7 @@ def create_anthropic_message(
     prefer_stream: bool = True,
     on_stream_event=None,
     on_response=None,
+    before_request=None,
 ) -> Any:
     """Create an Anthropic message, aggregating via stream when available.
 
@@ -3013,6 +3014,8 @@ def create_anthropic_message(
         stream_kwargs = dict(api_kwargs)
         stream_kwargs.pop("stream", None)
         try:
+            if callable(before_request):
+                before_request(reason="anthropic messages stream request")
             with stream_fn(**stream_kwargs) as stream:
                 if callable(on_response):
                     try:
@@ -3047,4 +3050,6 @@ def create_anthropic_message(
 
     create_kwargs = dict(api_kwargs)
     create_kwargs.pop("stream", None)
+    if callable(before_request):
+        before_request(reason="anthropic messages create fallback")
     return messages_api.create(**create_kwargs)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -448,7 +448,9 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     return None
 
 
-def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+def _dispatch_nonstreaming_api_request(
+    agent, api_kwargs: dict, *, make_client, reserve_request=None
+):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
     Shared by the interrupt-worker path (``interruptible_api_call``) and the
@@ -464,13 +466,21 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     interrupt, abort, cancellation, and close semantics stay in the callers —
     this helper only issues the request.
     """
+    if reserve_request is None:
+        from agent.provider_request_budget import capture_provider_request_reservation
+
+        reserve_request = capture_provider_request_reservation(agent)
+
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")
-        return agent._run_codex_stream(
-            api_kwargs,
-            client=request_client,
-            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-        )
+        stream_kwargs = {
+            "client": request_client,
+            "on_first_delta": getattr(agent, "_codex_on_first_delta", None),
+        }
+        budget = getattr(agent, "provider_request_budget", None)
+        if budget is not None and budget.enabled is True:
+            stream_kwargs["reserve_request"] = reserve_request
+        return agent._run_codex_stream(api_kwargs, **stream_kwargs)
     if agent.api_mode == "anthropic_messages":
         # #67142: use a request-local Anthropic client so the stale/interrupt
         # watchdog aborts sockets from the stranger thread while the worker
@@ -478,6 +488,13 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         request_client = make_client(
             "anthropic_messages_request", kind="anthropic_messages"
         )
+        budget = getattr(agent, "provider_request_budget", None)
+        if budget is not None and budget.enabled is True:
+            return agent._anthropic_messages_create(
+                api_kwargs,
+                client=request_client,
+                before_request=reserve_request,
+            )
         return agent._anthropic_messages_create(api_kwargs, client=request_client)
     if agent.api_mode == "bedrock_converse":
         # Bedrock uses boto3 directly — no OpenAI client needed.
@@ -494,6 +511,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         api_kwargs.pop("__bedrock_converse__", None)
         client = _get_bedrock_runtime_client(region)
         try:
+            reserve_request(reason="bedrock converse request")
             raw_response = client.converse(**api_kwargs)
         except Exception as _bedrock_exc:
             # Evict the cached client on stale-connection failures
@@ -508,6 +526,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         # OpenAI client from the virtual runtime metadata.
         return agent.client.chat.completions.create(**api_kwargs)
     request_client = make_client("chat_completion_request")
+    reserve_request(reason="chat completions request")
     return request_client.chat.completions.create(**api_kwargs)
 
 
@@ -570,6 +589,9 @@ def direct_api_call(agent, api_kwargs: dict):
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
     request_client_lock = threading.Lock()
+    from agent.provider_request_budget import capture_provider_request_reservation
+
+    reserve_request = capture_provider_request_reservation(agent)
 
     def _abort_active_request(reason: str) -> None:
         """Abort the inline request from a watchdog/interrupt thread."""
@@ -601,7 +623,10 @@ def direct_api_call(agent, api_kwargs: dict):
     succeeded = False
     try:
         response = _dispatch_nonstreaming_api_request(
-            agent, api_kwargs, make_client=_make_client
+            agent,
+            api_kwargs,
+            make_client=_make_client,
+            reserve_request=reserve_request,
         )
     except Exception:
         if getattr(agent, "_interrupt_requested", False):
@@ -647,6 +672,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         return direct_api_call(agent, api_kwargs)
 
     result = {"response": None, "error": None}
+    from agent.provider_request_budget import capture_provider_request_reservation
+
+    reserve_request = capture_provider_request_reservation(agent)
 
     # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
     # of the guard in interruptible_streaming_api_call.  Quiet-mode /
@@ -744,6 +772,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     ),
                     kind=kind,
                 ),
+                reserve_request=reserve_request,
             )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
@@ -2074,6 +2103,21 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
+    from agent.provider_request_budget import (
+        ProviderRequestBudgetExceeded,
+        capture_provider_request_reservation,
+    )
+
+    reserve_request = capture_provider_request_reservation(agent)
+
+    def _anthropic_summary_call(request):
+        budget = getattr(agent, "provider_request_budget", None)
+        if budget is not None and budget.enabled is True:
+            return agent._anthropic_messages_create(
+                request,
+                before_request=reserve_request,
+            )
+        return agent._anthropic_messages_create(request)
 
     def _managed_summary_call(request, callback, *, retry_count: int):
         from agent import relay_llm
@@ -2292,7 +2336,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _ant_kw = _merge_nous_portal_messages_extra_body(agent, _ant_kw)
                 summary_response = _managed_summary_call(
                     _ant_kw,
-                    agent._anthropic_messages_create,
+                    _anthropic_summary_call,
                     retry_count=0,
                 )
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
@@ -2301,9 +2345,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary"
                 )
+                def _create_summary(request):
+                    reserve_request(reason="iteration limit summary request")
+                    return summary_client.chat.completions.create(**request)
+
                 summary_response = _managed_summary_call(
                     summary_kwargs,
-                    lambda request: summary_client.chat.completions.create(**request),
+                    _create_summary,
                     retry_count=0,
                 )
                 _summary_result = agent._get_transport().normalize_response(summary_response)
@@ -2341,7 +2389,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _ant_kw2 = _merge_nous_portal_messages_extra_body(agent, _ant_kw2)
                 retry_response = _managed_summary_call(
                     _ant_kw2,
-                    agent._anthropic_messages_create,
+                    _anthropic_summary_call,
                     retry_count=1,
                 )
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
@@ -2363,9 +2411,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary_retry"
                 )
+                def _create_summary_retry(request):
+                    reserve_request(reason="iteration limit summary retry")
+                    return summary_client.chat.completions.create(**request)
+
                 summary_response = _managed_summary_call(
                     summary_kwargs,
-                    lambda request: summary_client.chat.completions.create(**request),
+                    _create_summary_retry,
                     retry_count=1,
                 )
                 _retry_result = agent._get_transport().normalize_response(summary_response)
@@ -2382,6 +2434,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             else:
                 final_response = "I reached the iteration limit and couldn't generate a summary."
 
+    except ProviderRequestBudgetExceeded:
+        raise
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
@@ -2496,6 +2550,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
 
+    from agent.provider_request_budget import capture_provider_request_reservation
+
+    reserve_request = capture_provider_request_reservation(agent)
+
     # Cron and other non-interactive, nested-pool contexts deadlock on the
     # spawned worker thread (#62151). They also have no stream consumer, so the
     # deltas this path produces go nowhere. Delegate to the non-streaming entry
@@ -2570,6 +2628,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     final_kwargs.pop("__bedrock_converse__", None)
                     client = _get_bedrock_runtime_client(region)
                     try:
+                        reserve_request(reason="bedrock converse stream request")
                         raw_response = client.converse_stream(**final_kwargs)
                     except Exception as _bedrock_exc:
                         # InvokeModel-only policies cannot open a stream. Keep
@@ -2588,6 +2647,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 "using non-streaming converse() for this session.",
                                 type(_bedrock_exc).__name__,
                             )
+                            reserve_request(reason="bedrock converse IAM fallback")
                             return normalize_converse_response(
                                 client.converse(**final_kwargs)
                             )
@@ -3053,6 +3113,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             attempt_request_client["value"] = request_client
             last_chunk_time["t"] = time.time()
             agent._touch_activity("waiting for provider response (streaming)")
+            reserve_request(reason="chat completions stream request")
             return request_client.chat.completions.create(**stream_kwargs)
 
         def _stream_created(raw_stream: Any) -> None:
@@ -3537,6 +3598,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 final_kwargs,
                 log_prefix=getattr(agent, "log_prefix", ""),
             )
+            reserve_request(reason="anthropic messages stream request")
             manager = request_client.messages.stream(**final_kwargs)
             _stream_context["manager"] = manager
             return manager.__enter__()

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -694,8 +694,25 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    from agent.provider_request_budget import ProviderRequestBudgetExceeded
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        _turn_kwargs = {}
+        _budget = getattr(agent, "provider_request_budget", None)
+        if _budget is not None and _budget.enabled:
+            from agent.provider_request_budget import (
+                capture_provider_request_reservation,
+            )
+
+            _turn_kwargs["before_request"] = (
+                capture_provider_request_reservation(agent)
+            )
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            **_turn_kwargs,
+        )
+    except ProviderRequestBudgetExceeded:
+        raise
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
@@ -1228,7 +1245,13 @@ def _consume_codex_event_stream(
     return final
 
 
-def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
+def run_codex_stream(
+    agent,
+    api_kwargs: dict,
+    client: Any = None,
+    on_first_delta=None,
+    reserve_request=None,
+):
     """Execute one streaming Responses API request and return the final response.
 
     Uses ``responses.create(stream=True)`` (low-level raw event iteration)
@@ -1240,6 +1263,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     import httpx as _httpx
 
     from agent import relay_llm
+
+    if reserve_request is None:
+        from agent.provider_request_budget import capture_provider_request_reservation
+
+        reserve_request = capture_provider_request_reservation(agent)
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
@@ -1271,6 +1299,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
             stream_kwargs = dict(next_api_kwargs)
             stream_kwargs["stream"] = True
+            reserve_request(reason="codex responses stream request")
             return active_client.responses.create(**stream_kwargs)
 
         def _codex_stream_created(_raw_stream: Any) -> None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2468,7 +2468,17 @@ def _compress_context_via_codex_app_server(
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     try:
         _activity_heartbeat = _CompressionActivityHeartbeat(agent).start()
-        result = codex_session.compact_thread()
+        compact_kwargs = {}
+        budget = getattr(agent, "provider_request_budget", None)
+        if budget is not None and budget.enabled is True:
+            from agent.provider_request_budget import (
+                capture_provider_request_reservation,
+            )
+
+            compact_kwargs["before_request"] = (
+                capture_provider_request_reservation(agent)
+            )
+        result = codex_session.compact_thread(**compact_kwargs)
     except BaseException:
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression failed")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -69,6 +69,7 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.provider_request_budget import ProviderRequestBudgetExceeded
 from agent.prompt_caching import (
     build_prompt_cache_plan,
     strip_anthropic_cache_control,
@@ -3437,6 +3438,8 @@ def run_conversation(
                 agent._persist_session(messages, conversation_history)
                 break
 
+            except ProviderRequestBudgetExceeded:
+                raise
             except Exception as api_error:
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
@@ -7018,7 +7021,18 @@ def run_conversation(
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
-            
+
+        except ProviderRequestBudgetExceeded as e:
+            if thinking_spinner:
+                thinking_spinner.stop("")
+                thinking_spinner = None
+            if agent.thinking_callback:
+                agent.thinking_callback("")
+            failed = True
+            final_response = str(e)
+            _turn_exit_reason = "provider_request_budget_exhausted"
+            messages.append({"role": "assistant", "content": final_response})
+            break
         except Exception as e:
             # Phase-aware error classification. The huge outer try/except spans
             # both the actual API request and all local post-processing of the

--- a/agent/provider_request_budget.py
+++ b/agent/provider_request_budget.py
@@ -1,0 +1,138 @@
+"""Opt-in per-turn main-agent provider request budget."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+
+class ProviderRequestBudgetExceeded(RuntimeError):
+    """Raised before a covered provider request would exceed its turn limit."""
+
+
+def parse_provider_request_limit(value: object) -> int:
+    """Return a positive integer-like request limit, or zero when disabled."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value if value > 0 else 0
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            parsed = int(stripped)
+            return parsed if parsed > 0 else 0
+    return 0
+
+
+class ProviderRequestBudget:
+    """Thread-safe counter for an optional provider request limit."""
+
+    def __init__(self, max_total: object = 0):
+        self.max_total = parse_provider_request_limit(max_total)
+        self._used = 0
+        self._exhausted = False
+        self._lock = threading.Lock()
+
+    def reserve(self, *, reason: str) -> int:
+        """Reserve one request slot, or no-op when the budget is disabled."""
+        if not self.enabled:
+            return 0
+        with self._lock:
+            if self._used >= self.max_total:
+                self._exhausted = True
+                raise ProviderRequestBudgetExceeded(
+                    "provider request budget exhausted "
+                    f"({self._used}/{self.max_total}) before {reason}"
+                )
+            self._used += 1
+            return self._used
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_total > 0
+
+    @property
+    def used(self) -> int:
+        with self._lock:
+            return self._used
+
+    @property
+    def exhausted(self) -> bool:
+        with self._lock:
+            return self._exhausted
+
+    @property
+    def remaining(self) -> int | None:
+        if not self.enabled:
+            return None
+        with self._lock:
+            return max(0, self.max_total - self._used)
+
+
+def _is_background_execution(agent: object) -> bool:
+    """Return whether this agent is running auxiliary/background model work."""
+    if getattr(agent, "_provider_request_budget_exempt", False) is True:
+        return True
+    platform = str(getattr(agent, "platform", "") or "").lower()
+    if platform == "curator":
+        return True
+    return any(
+        getattr(agent, field, None) == "background_review"
+        for field in ("_memory_write_context", "_memory_write_origin")
+    )
+
+
+def _is_covered_main_agent(agent: object) -> bool:
+    """Return whether provider transports on this agent are in budget scope."""
+    if str(getattr(agent, "provider", "") or "").lower() == "moa":
+        return False
+    if str(getattr(agent, "platform", "") or "").lower() == "subagent":
+        return False
+    if getattr(agent, "is_subagent", False) is True:
+        return False
+    if int(getattr(agent, "_delegate_depth", 0) or 0) > 0:
+        return False
+    if _is_background_execution(agent):
+        return False
+    if getattr(agent, "_persist_disabled", False) is True:
+        return False
+    return True
+
+
+def capture_provider_request_reservation(
+    agent: object,
+) -> Callable[..., int]:
+    """Capture this turn's budget so late workers cannot charge a later turn."""
+    budget = getattr(agent, "provider_request_budget", None)
+    covered = _is_covered_main_agent(agent)
+
+    def reserve(*, reason: str) -> int:
+        if not covered or budget is None:
+            return 0
+        return budget.reserve(reason=reason)
+
+    return reserve
+
+
+def reserve_provider_request(agent: object, *, reason: str) -> int:
+    """Reserve against the current turn for a synchronous physical request."""
+    return capture_provider_request_reservation(agent)(reason=reason)
+
+
+def reset_provider_request_budget(agent: object) -> ProviderRequestBudget:
+    """Replace an agent's per-turn request budget with a fresh instance."""
+    budget = ProviderRequestBudget(
+        getattr(agent, "max_provider_requests_per_turn", 0)
+    )
+    setattr(agent, "provider_request_budget", budget)
+    return budget
+
+
+__all__ = [
+    "ProviderRequestBudget",
+    "ProviderRequestBudgetExceeded",
+    "capture_provider_request_reservation",
+    "parse_provider_request_limit",
+    "reserve_provider_request",
+    "reset_provider_request_budget",
+]

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -474,6 +474,7 @@ class CodexAppServerSession:
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
+        before_request=None,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
@@ -519,6 +520,8 @@ class CodexAppServerSession:
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
         try:
+            if callable(before_request):
+                before_request(reason="codex app-server turn/start")
             ts = self._client.request(
                 "turn/start",
                 {
@@ -793,6 +796,7 @@ class CodexAppServerSession:
         *,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
+        before_request=None,
     ) -> TurnResult:
         """Trigger Codex-native history compaction for the current thread.
 
@@ -817,6 +821,8 @@ class CodexAppServerSession:
         projector = CodexEventProjector()
 
         try:
+            if callable(before_request):
+                before_request(reason="codex app-server thread/compact/start")
             self._client.request(
                 "thread/compact/start",
                 {"threadId": self._thread_id},

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -41,6 +41,7 @@ from agent.conversation_compression import (
 from agent.context_engine import automatic_compaction_status_message
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
+from agent.provider_request_budget import reset_provider_request_budget
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -489,6 +490,7 @@ def build_turn_context(
 
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
     agent.iteration_budget = IterationBudget(agent.max_iterations)
+    reset_provider_request_budget(agent)
 
     # Log conversation turn start for debugging/observability.
     _preview_text = summarize_user_message_for_log(user_message)

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -53,6 +53,74 @@ _VERIFICATION_CONTINUATION_FLAGS = (
 )
 
 
+def finalize_provider_request_budget_exhaustion(
+    agent,
+    *,
+    error,
+    user_message,
+    conversation_history,
+    effective_task_id,
+    persist_user_message=None,
+    persist_user_timestamp=None,
+    persist_user_display_kind=None,
+    persist_user_display_metadata=None,
+):
+    """Normalize an exhaustion raised before the main loop owns turn locals."""
+    if conversation_history is not None:
+        messages = list(conversation_history)
+    else:
+        messages = list(getattr(agent, "_session_messages", []) or [])
+
+    persisted_content = (
+        persist_user_message
+        if persist_user_message is not None
+        else user_message
+    )
+    user_row = {"role": "user", "content": persisted_content}
+    if persist_user_display_kind:
+        user_row["display_kind"] = persist_user_display_kind
+        if persist_user_display_metadata:
+            user_row["display_metadata"] = persist_user_display_metadata
+    if not (
+        messages
+        and isinstance(messages[-1], dict)
+        and messages[-1].get("role") == "user"
+        and messages[-1].get("content") == persisted_content
+    ):
+        messages.append(user_row)
+
+    agent._persist_user_message_idx = len(messages) - 1
+    agent._persist_user_message_override = persist_user_message
+    agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._current_task_id = effective_task_id
+    turn_id = str(
+        getattr(agent, "_current_turn_id", None)
+        or getattr(agent, "_relay_pending_turn_id", None)
+        or effective_task_id
+    )
+    result = finalize_turn(
+        agent,
+        final_response=str(error),
+        api_call_count=0,
+        interrupted=False,
+        failed=True,
+        messages=messages,
+        conversation_history=(
+            list(conversation_history)
+            if conversation_history is not None
+            else []
+        ),
+        effective_task_id=effective_task_id,
+        turn_id=turn_id,
+        user_message=user_message,
+        original_user_message=persisted_content,
+        _should_review_memory=False,
+        _turn_exit_reason="provider_request_budget_exhausted",
+    )
+    result["error"] = str(error)
+    return result
+
+
 def _drop_verification_continuation_scaffolding(messages) -> None:
     """Remove verification-continuation nudge messages from *messages* in place.
 
@@ -90,6 +158,7 @@ def finalize_turn(
     loop). See module docstring.
     """
     from agent.conversation_loop import logger
+    from agent.provider_request_budget import ProviderRequestBudgetExceeded
 
     budget_exhausted = (
         api_call_count >= agent.max_iterations
@@ -109,6 +178,7 @@ def finalize_turn(
 
     iteration_limit_fallback = False
     preserved_verification_fallback = False
+    terminal_error = None
     if continuation_budget_exhausted:
         # A verification/continuation gate deliberately withheld a composed
         # answer, then consumed the remaining budget before producing a newer
@@ -138,8 +208,14 @@ def finalize_turn(
                 f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
                 "— requesting summary..."
             )
-        final_response = agent._handle_max_iterations(messages, api_call_count)
-        iteration_limit_fallback = True
+        try:
+            final_response = agent._handle_max_iterations(messages, api_call_count)
+            iteration_limit_fallback = True
+        except ProviderRequestBudgetExceeded as exc:
+            final_response = str(exc)
+            terminal_error = str(exc)
+            failed = True
+            _turn_exit_reason = "provider_request_budget_exhausted"
 
     if iteration_limit_fallback:
         # If running as a kanban worker, signal the dispatcher that the
@@ -663,6 +739,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if terminal_error is not None:
+        result["error"] = terminal_error
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16156,6 +16156,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
                                     session_db=_hyg_session_db,
+                                    provider_request_budget_exempt=True,
                                 )
                                 _seed_hygiene_system_prompt(
                                     _hyg_agent,
@@ -18625,6 +18626,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     provider_data_collection=pr.get("data_collection"),
                     session_id=task_id,
                     platform=platform_key,
+                    provider_request_budget_exempt=True,
                     user_id=source.user_id,
                     user_id_alt=source.user_id_alt,
                     user_name=source.user_name,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3955,6 +3955,7 @@ class GatewaySlashCommandsMixin:
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
                 session_db=getattr(self._session_db, "_db", self._session_db),
+                provider_request_budget_exempt=True,
             )
             _seed_hygiene_system_prompt(tmp_agent, session_row)
             # Keep the real source platform during construction so external

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1911,6 +1911,7 @@ class CLICommandsMixin:
                     verbose_logging=False,
                     session_id=task_id,
                     platform="cli",
+                    provider_request_budget_exempt=True,
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -67,6 +67,10 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Optional hard ceiling on covered main-agent physical provider
+        # requests per user turn. 0 disables the budget. This is separate from
+        # max_turns/tool iterations and from token/cost telemetry.
+        "max_provider_requests_per_turn": 0,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json
+++ b/hermes_cli/observability/schemas/hermes.shared_metrics.v1.schema.json
@@ -239,6 +239,7 @@
                 "failed",
                 "guardrail_blocked",
                 "iteration_limit",
+                "provider_request_limit",
                 "system_aborted",
                 "timed_out",
                 "unknown",

--- a/hermes_cli/observability/shared_metrics_contract.py
+++ b/hermes_cli/observability/shared_metrics_contract.py
@@ -52,6 +52,7 @@ TASK_END_REASONS: frozenset[str] = frozenset({
     "failed",
     "guardrail_blocked",
     "iteration_limit",
+    "provider_request_limit",
     "system_aborted",
     "timed_out",
     "unknown",
@@ -377,6 +378,8 @@ def task_terminal_state(kwargs: dict[str, Any]) -> tuple[str, str, str]:
         return "cancelled", "user_cancelled", "user_cancelled"
     if "timeout" in reason or "timed_out" in reason:
         return "timed_out", "timed_out", "timed_out"
+    if "provider_request_budget_exhausted" in reason:
+        return "failed", "provider_request_limit", "system_aborted"
     if "max_iterations" in reason or "budget_exhausted" in reason:
         return "failed", "iteration_limit", "system_aborted"
     if "approval" in reason and ("denied" in reason or "rejected" in reason):

--- a/run_agent.py
+++ b/run_agent.py
@@ -503,6 +503,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        provider_request_budget_exempt: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -586,6 +587,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            provider_request_budget_exempt=provider_request_budget_exempt,
         )
 
     def _get_session_db_for_recall(self):
@@ -5017,10 +5019,22 @@ class AIAgent:
                 exc,
             )
 
-    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
+    def _run_codex_stream(
+        self,
+        api_kwargs: dict,
+        client: Any = None,
+        on_first_delta: callable = None,
+        reserve_request=None,
+    ):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream
-        return run_codex_stream(self, api_kwargs, client, on_first_delta)
+        return run_codex_stream(
+            self,
+            api_kwargs,
+            client,
+            on_first_delta,
+            reserve_request,
+        )
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_create_stream_fallback``."""
@@ -5548,7 +5562,13 @@ class AIAgent:
             return False
         return pool.has_available()
 
-    def _anthropic_messages_create(self, api_kwargs: dict, *, client: Any = None):
+    def _anthropic_messages_create(
+        self,
+        api_kwargs: dict,
+        *,
+        client: Any = None,
+        before_request=None,
+    ):
         # When a request-local client is supplied it was already credential-
         # refreshed in ``_create_request_anthropic_client``; only the shared
         # fallback path refreshes here.
@@ -5563,6 +5583,7 @@ class AIAgent:
             api_kwargs,
             log_prefix=getattr(self, "log_prefix", ""),
             prefer_stream=not bool(getattr(self, "_disable_streaming", False)),
+            before_request=before_request,
             # Rate-limit + credits state live in response headers, which the
             # parsed Message drops. No-ops on providers that don't send the
             # matching header families (x-ratelimit-* / x-nous-credits-*).
@@ -7170,6 +7191,7 @@ class AIAgent:
         )
         from agent import relay_runtime
         from agent.conversation_loop import run_conversation
+        from agent.provider_request_budget import ProviderRequestBudgetExceeded
         from agent.portal_tags import (
             reset_conversation_context,
             set_conversation_context,
@@ -7241,20 +7263,45 @@ class AIAgent:
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
             with bind_subagent_parent(self), scoped_runtime_main({}):
-                result = run_conversation(
-                    self,
-                    user_message,
-                    system_message,
-                    conversation_history,
-                    effective_task_id,
-                    stream_callback,
-                    persist_user_message,
-                    persist_user_timestamp=persist_user_timestamp,
-                    persist_user_display_kind=persist_user_display_kind,
-                    persist_user_display_metadata=persist_user_display_metadata,
-                    moa_config=moa_config,
-                )
+                try:
+                    result = run_conversation(
+                        self,
+                        user_message,
+                        system_message,
+                        conversation_history,
+                        effective_task_id,
+                        stream_callback,
+                        persist_user_message,
+                        persist_user_timestamp=persist_user_timestamp,
+                        persist_user_display_kind=persist_user_display_kind,
+                        persist_user_display_metadata=persist_user_display_metadata,
+                        moa_config=moa_config,
+                    )
+                except ProviderRequestBudgetExceeded as exc:
+                    from agent.turn_finalizer import (
+                        finalize_provider_request_budget_exhaustion,
+                    )
+
+                    result = finalize_provider_request_budget_exhaustion(
+                        self,
+                        error=exc,
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        effective_task_id=effective_task_id,
+                        persist_user_message=persist_user_message,
+                        persist_user_timestamp=persist_user_timestamp,
+                        persist_user_display_kind=persist_user_display_kind,
+                        persist_user_display_metadata=persist_user_display_metadata,
+                    )
             terminal = result if isinstance(result, dict) else {}
+            budget = getattr(self, "provider_request_budget", None)
+            if isinstance(result, dict) and budget is not None:
+                result["provider_requests"] = budget.used
+                result["provider_request_limit"] = budget.max_total
+                result["provider_requests_remaining"] = budget.remaining
+                result["provider_request_budget_exhausted"] = budget.exhausted
+                if budget.exhausted:
+                    result["failure_reason"] = "provider_request_budget_exhausted"
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"
             elif terminal.get("failed") is True:

--- a/tests/agent/test_provider_request_budget.py
+++ b/tests/agent/test_provider_request_budget.py
@@ -1,0 +1,251 @@
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.provider_request_budget import (
+    ProviderRequestBudget,
+    ProviderRequestBudgetExceeded,
+    capture_provider_request_reservation,
+    parse_provider_request_limit,
+    reserve_provider_request,
+    reset_provider_request_budget,
+)
+
+
+def test_disabled_budget_is_a_noop_without_a_finite_remaining_count():
+    budget = ProviderRequestBudget()
+
+    assert budget.reserve(reason="normal") == 0
+    assert budget.reserve(reason="retry") == 0
+    assert budget.enabled is False
+    assert budget.used == 0
+    assert budget.remaining is None
+
+
+def test_enabled_budget_raises_before_exceeding_the_limit():
+    budget = ProviderRequestBudget(2)
+
+    assert budget.reserve(reason="normal") == 1
+    assert budget.reserve(reason="fallback") == 2
+
+    with pytest.raises(
+        ProviderRequestBudgetExceeded,
+        match=r"provider request budget exhausted \(2/2\).*retry",
+    ):
+        budget.reserve(reason="retry")
+
+    assert budget.enabled is True
+    assert budget.used == 2
+    assert budget.remaining == 0
+
+
+def test_provider_request_limit_parser_accepts_only_positive_integer_like_values():
+    assert parse_provider_request_limit(3) == 3
+    assert parse_provider_request_limit("4") == 4
+    assert parse_provider_request_limit(0) == 0
+    assert parse_provider_request_limit(-1) == 0
+    assert parse_provider_request_limit(True) == 0
+    assert parse_provider_request_limit(3.5) == 0
+    assert parse_provider_request_limit("3.5") == 0
+    assert parse_provider_request_limit("invalid") == 0
+    assert parse_provider_request_limit(None) == 0
+
+
+def test_concurrent_reservations_never_exceed_the_limit():
+    budget = ProviderRequestBudget(3)
+
+    def reserve(index: int) -> bool:
+        try:
+            budget.reserve(reason=f"worker-{index}")
+        except ProviderRequestBudgetExceeded:
+            return False
+        return True
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        outcomes = list(pool.map(reserve, range(10)))
+
+    assert outcomes.count(True) == 3
+    assert outcomes.count(False) == 7
+    assert budget.used == 3
+    assert budget.remaining == 0
+
+
+def test_reservation_helper_covers_only_the_main_agent():
+    main = SimpleNamespace(
+        provider="openai",
+        platform="cli",
+        is_subagent=False,
+        provider_request_budget=ProviderRequestBudget(1),
+    )
+    assert reserve_provider_request(main, reason="normal") == 1
+
+    for excluded in (
+        SimpleNamespace(
+            provider="moa",
+            platform="cli",
+            is_subagent=False,
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="subagent",
+            is_subagent=True,
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="cli",
+            is_subagent=False,
+            _delegate_depth=1,
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="cli",
+            is_subagent=False,
+            _memory_write_context="background_review",
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="curator",
+            is_subagent=False,
+            _memory_write_origin="background_review",
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="cli",
+            is_subagent=False,
+            _memory_write_origin="background_review",
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="cli",
+            is_subagent=False,
+            _persist_disabled=True,
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+        SimpleNamespace(
+            provider="openai",
+            platform="cli",
+            is_subagent=False,
+            _provider_request_budget_exempt=True,
+            provider_request_budget=ProviderRequestBudget(1),
+        ),
+    ):
+        assert reserve_provider_request(excluded, reason="excluded") == 0
+        assert excluded.provider_request_budget.used == 0
+
+
+def test_reset_rebuilds_a_fresh_budget_from_the_agent_limit():
+    class Agent:
+        max_provider_requests_per_turn = 1
+
+    agent = Agent()
+    first = reset_provider_request_budget(agent)
+    first.reserve(reason="normal")
+
+    second = reset_provider_request_budget(agent)
+
+    assert second is agent.provider_request_budget
+    assert second is not first
+    assert second.max_total == 1
+    assert second.used == 0
+
+
+def test_captured_reservation_never_charges_a_later_turn():
+    agent = SimpleNamespace(
+        provider="openai",
+        platform="cli",
+        is_subagent=False,
+        max_provider_requests_per_turn=1,
+    )
+    first = reset_provider_request_budget(agent)
+    reserve_first_turn = capture_provider_request_reservation(agent)
+    second = reset_provider_request_budget(agent)
+
+    reserve_first_turn(reason="late worker")
+
+    assert first.used == 1
+    assert second.used == 0
+
+
+def test_default_config_disables_the_provider_request_budget():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["agent"]["max_provider_requests_per_turn"] == 0
+
+
+def test_observability_does_not_misclassify_request_exhaustion_as_iteration_limit():
+    from hermes_cli.observability.shared_metrics_contract import task_terminal_state
+
+    assert task_terminal_state(
+        {"turn_exit_reason": "provider_request_budget_exhausted"}
+    ) == ("failed", "provider_request_limit", "system_aborted")
+
+
+def test_agent_initializes_the_budget_from_config():
+    from run_agent import AIAgent
+
+    config = {"agent": {"max_provider_requests_per_turn": "2"}}
+    with (
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.max_provider_requests_per_turn == 2
+    assert agent.provider_request_budget.max_total == 2
+    assert agent.provider_request_budget.used == 0
+
+
+def test_new_user_turn_resets_the_provider_request_budget():
+    from run_agent import AIAgent
+
+    config = {"agent": {"max_provider_requests_per_turn": 1}}
+    with (
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    previous = agent.provider_request_budget
+    previous.reserve(reason="previous-turn")
+    agent._interruptible_api_call = MagicMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="done", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        )
+    )
+
+    result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "done"
+    assert agent.provider_request_budget is not previous
+    assert agent.provider_request_budget.max_total == 1
+    assert agent.provider_request_budget.used == 0

--- a/tests/agent/test_provider_request_budget_transports.py
+++ b/tests/agent/test_provider_request_budget_transports.py
@@ -1,0 +1,313 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.provider_request_budget import ProviderRequestBudgetExceeded
+
+
+def _make_agent(limit=1):
+    from run_agent import AIAgent
+
+    config = {"agent": {"max_provider_requests_per_turn": limit}}
+    with (
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def _chat_response(text="done"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+
+def test_nonstreaming_dispatch_reserves_one_request_and_reports_it():
+    agent = _make_agent()
+    request_client = MagicMock()
+    request_client.chat.completions.create.return_value = _chat_response()
+
+    with patch.object(
+        agent, "_create_request_openai_client", return_value=request_client
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "done"
+    assert result["provider_requests"] == 1
+    assert result["provider_request_limit"] == 1
+    assert result["provider_requests_remaining"] == 0
+    assert result["provider_request_budget_exhausted"] is False
+    assert agent.provider_request_budget.used == 1
+    request_client.chat.completions.create.assert_called_once()
+
+
+def test_budget_exhaustion_does_not_retry_or_activate_fallback():
+    agent = _make_agent()
+    calls = 0
+
+    def capped_call(_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            agent.provider_request_budget.reserve(reason="first request")
+        agent.provider_request_budget.reserve(reason="blocked request")
+
+    agent._interruptible_api_call = capped_call
+    agent._api_max_retries = 3
+    agent._try_activate_fallback = MagicMock(return_value=False)
+
+    with patch("agent.conversation_loop.jittered_backoff", return_value=0):
+        result = agent.run_conversation("hello")
+
+    assert "provider request budget exhausted" in result["final_response"]
+    assert result["provider_requests"] == 1
+    assert result["provider_request_budget_exhausted"] is True
+    assert result["failure_reason"] == "provider_request_budget_exhausted"
+    assert calls == 1
+    agent._try_activate_fallback.assert_not_called()
+
+
+def test_stream_retry_is_blocked_before_a_second_transport(monkeypatch):
+    import httpx
+
+    agent = _make_agent()
+    request_client = MagicMock()
+    request_client.chat.completions.create.side_effect = httpx.RemoteProtocolError(
+        "peer closed connection"
+    )
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+    with (
+        patch.object(
+            agent, "_create_request_openai_client", return_value=request_client
+        ),
+        pytest.raises(ProviderRequestBudgetExceeded),
+    ):
+        agent._interruptible_streaming_api_call(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        )
+
+    assert agent.provider_request_budget.used == 1
+    request_client.chat.completions.create.assert_called_once()
+
+
+def test_bedrock_stream_fallback_is_blocked_before_second_transport():
+    agent = _make_agent()
+    agent.api_mode = "bedrock_converse"
+    agent.provider = "bedrock"
+    agent.model = "anthropic.claude-test"
+    client = MagicMock()
+    client.converse_stream.side_effect = RuntimeError("stream denied")
+
+    with (
+        patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ),
+        patch(
+            "agent.bedrock_adapter.is_streaming_access_denied_error",
+            return_value=True,
+        ),
+        pytest.raises(ProviderRequestBudgetExceeded),
+    ):
+        agent._interruptible_streaming_api_call(
+            {
+                "modelId": agent.model,
+                "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+                "__bedrock_region__": "us-east-1",
+            }
+        )
+
+    assert agent.provider_request_budget.used == 1
+    client.converse_stream.assert_called_once()
+    client.converse.assert_not_called()
+
+
+def test_codex_retry_is_blocked_before_a_second_transport():
+    import httpx
+
+    agent = _make_agent()
+    agent.api_mode = "codex_responses"
+    client = MagicMock()
+    client.responses.create.side_effect = httpx.RemoteProtocolError(
+        "peer closed connection"
+    )
+
+    def execute_relay_wrapper(request, callback, **_kwargs):
+        return callback(request)
+
+    with (
+        patch(
+            "agent.relay_llm.stream",
+            side_effect=execute_relay_wrapper,
+        ) as relay_execute,
+        pytest.raises(ProviderRequestBudgetExceeded),
+    ):
+        agent._run_codex_stream({}, client=client)
+
+    assert agent.provider_request_budget.used == 1
+    client.responses.create.assert_called_once()
+    assert relay_execute.call_count == 2
+
+
+def test_anthropic_stream_to_create_fallback_counts_each_transport():
+    from agent.anthropic_adapter import create_anthropic_message
+    from agent.provider_request_budget import capture_provider_request_reservation
+
+    agent = _make_agent()
+    agent.api_mode = "anthropic_messages"
+    agent.provider = "anthropic"
+    client = MagicMock()
+    client.messages.stream.side_effect = RuntimeError("stream unavailable")
+    reserve = capture_provider_request_reservation(agent)
+
+    with (
+        patch(
+            "agent.anthropic_adapter._is_stream_unavailable_error",
+            return_value=True,
+        ),
+        pytest.raises(ProviderRequestBudgetExceeded),
+    ):
+        create_anthropic_message(
+            client,
+            {"model": "test", "messages": []},
+            before_request=reserve,
+        )
+
+    assert agent.provider_request_budget.used == 1
+    client.messages.stream.assert_called_once()
+    client.messages.create.assert_not_called()
+
+
+def test_max_iteration_summary_is_blocked_before_a_second_request():
+    agent = _make_agent()
+    agent.provider_request_budget.reserve(reason="initial request")
+    agent.client.chat.completions.create.reset_mock()
+    agent.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="unexpected"))]
+    )
+
+    with pytest.raises(ProviderRequestBudgetExceeded):
+        agent._handle_max_iterations(
+            [{"role": "user", "content": "do work"}], 1
+        )
+
+    assert agent.provider_request_budget.used == 1
+    agent.client.chat.completions.create.assert_not_called()
+
+
+def test_codex_app_server_reserves_only_before_turn_start():
+    from agent.provider_request_budget import capture_provider_request_reservation
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    agent = _make_agent()
+    agent.provider_request_budget.reserve(reason="prior request")
+    client = MagicMock()
+    session = CodexAppServerSession()
+    session._client = client
+    session._thread_id = "thread-1"
+
+    with pytest.raises(ProviderRequestBudgetExceeded):
+        session.run_turn(
+            "hello",
+            before_request=capture_provider_request_reservation(agent),
+        )
+
+    client.request.assert_not_called()
+
+
+def test_codex_app_server_compaction_reserves_before_compact_start():
+    from agent.provider_request_budget import capture_provider_request_reservation
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    agent = _make_agent()
+    agent.provider_request_budget.reserve(reason="prior request")
+    client = MagicMock()
+    session = CodexAppServerSession()
+    session._client = client
+    session._thread_id = "thread-1"
+
+    with pytest.raises(ProviderRequestBudgetExceeded):
+        session.compact_thread(
+            before_request=capture_provider_request_reservation(agent),
+        )
+
+    client.request.assert_not_called()
+
+
+def test_codex_native_compaction_consumes_final_slot_before_turn_start():
+    from agent.provider_request_budget import capture_provider_request_reservation
+    from agent.transports.codex_app_server import CodexAppServerError
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    agent = _make_agent()
+    reserve_request = capture_provider_request_reservation(agent)
+    client = MagicMock()
+    client.request.side_effect = CodexAppServerError(-1, "synthetic compaction stop")
+    session = CodexAppServerSession()
+    session._client = client
+    session._thread_id = "thread-1"
+
+    session.compact_thread(before_request=reserve_request)
+
+    assert agent.provider_request_budget.used == 1
+    client.request.assert_called_once()
+    client.reset_mock()
+    client.request.side_effect = None
+
+    with pytest.raises(ProviderRequestBudgetExceeded):
+        session.run_turn("hello", before_request=reserve_request)
+
+    client.request.assert_not_called()
+
+
+def test_universal_turn_boundary_preserves_provider_budget_exit_reason():
+    agent = _make_agent()
+    agent._session_messages = [{"role": "assistant", "content": "prior turn"}]
+    agent._save_trajectory = MagicMock()
+    agent._cleanup_task_resources = MagicMock()
+    agent._persist_session = MagicMock()
+
+    def exhaust_budget(*_args, **_kwargs):
+        agent.provider_request_budget.reserve(reason="idle compaction")
+        agent.provider_request_budget.reserve(reason="preflight compaction")
+
+    with patch(
+        "agent.conversation_loop.run_conversation",
+        side_effect=exhaust_budget,
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "provider_request_budget_exhausted"
+    assert result["failure_reason"] == "provider_request_budget_exhausted"
+    assert result["provider_request_budget_exhausted"] is True
+    assert result["provider_requests"] == 1
+    assert result["api_calls"] == 0
+    assert result["messages"] == [
+        {"role": "assistant", "content": "prior turn"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": result["final_response"]},
+    ]
+    agent._save_trajectory.assert_called_once()
+    agent._cleanup_task_resources.assert_called_once()
+    agent._persist_session.assert_called_once()
+    assert agent._persist_session.call_args.args[0] == result["messages"]

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agent.provider_request_budget import ProviderRequestBudget
 from agent.turn_finalizer import finalize_turn
 
 
@@ -233,5 +234,36 @@ def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch)
     assert agent.persisted_messages is not None
     persisted_roles = [m["role"] for m in agent.persisted_messages]
     assert persisted_roles == ["user", "assistant"]
+
+
+def test_summary_request_exhaustion_still_runs_normal_finalizer_cleanup(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    agent.provider_request_budget = ProviderRequestBudget(1)
+    agent.provider_request_budget.reserve(reason="earlier request")
+    agent._save_trajectory = MagicMock()
+    agent._cleanup_task_resources = MagicMock()
+
+    def exhaust_summary(_messages, _api_call_count):
+        agent.provider_request_budget.reserve(reason="iteration summary")
+
+    agent._handle_max_iterations = MagicMock(side_effect=exhaust_summary)
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+    )
+
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "provider_request_budget_exhausted"
+    assert result["error"] == result["final_response"]
+    assert "provider request budget exhausted" in result["final_response"]
+    agent._save_trajectory.assert_called_once()
+    agent._cleanup_task_resources.assert_called_once_with("task")
+    assert agent.persisted_messages[-1] == {
+        "role": "assistant",
+        "content": result["final_response"],
+    }
 
 

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -195,6 +195,7 @@ class TestCliApprovalUi:
 
         class FakeAgent:
             def __init__(self, **kwargs):
+                seen["agent_kwargs"] = kwargs
                 self._print_fn = None
                 self.thinking_callback = None
 
@@ -229,6 +230,7 @@ class TestCliApprovalUi:
         assert seen["approval"].__func__ is HermesCLI._approval_callback
         assert seen["sudo"].__self__ is cli
         assert seen["sudo"].__func__ is HermesCLI._sudo_password_callback
+        assert seen["agent_kwargs"]["provider_request_budget_exempt"] is True
         assert not cli._background_tasks
 
 

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -159,6 +159,7 @@ class TestRunBackgroundTask:
         assert "Background task complete" in content
         assert "Hello from background!" in content
         agent_kwargs = MockAgent.call_args.kwargs
+        assert agent_kwargs["provider_request_budget_exempt"] is True
         assert agent_kwargs["checkpoints_enabled"] is True
         assert agent_kwargs["checkpoint_max_snapshots"] == 8
         assert agent_kwargs["checkpoint_max_total_size_mb"] == 222

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3491,6 +3491,23 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     assert kwargs["fallback_model"] == chain
 
 
+def test_tui_background_agent_kwargs_exempt_both_background_consumers(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="anthropic",
+        _fallback_chain=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    background_kwargs = server._background_agent_kwargs(agent, "background-task")
+    preview_kwargs = server._ephemeral_preview_agent_kwargs(agent, "preview-task")
+
+    assert background_kwargs["provider_request_budget_exempt"] is True
+    assert preview_kwargs["provider_request_budget_exempt"] is True
+
+
 def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
     agent = types.SimpleNamespace(
         model="gpt-5.5",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5820,6 +5820,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "service_tier": getattr(agent, "service_tier", None) or _load_service_tier(),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
+        "provider_request_budget_exempt": True,
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
     }


### PR DESCRIPTION
## What does this PR do?

- Add an opt-in, disabled-by-default per-user-turn budget for physical main-agent provider requests.
- Reserve immediately before concrete OpenAI-compatible, Anthropic, Bedrock, Codex Responses, and Codex app-server requests, including retries, fallbacks, summaries, reconnects, and native compaction.
- Keep delegated, MoA, curator/review, persistence-disabled, auxiliary, CLI/gateway/TUI background, gateway hygiene, and preview-restart work outside the main-turn budget.
- Make exhaustion terminal while preserving normal transcript persistence, cleanup, hooks, and deterministic observability metadata.
- Report logical `api_calls` independently from physical `provider_requests`.

## Related Issue

No linked issue.

## Compatibility and safety

- Default: `agent.max_provider_requests_per_turn = 0` (disabled).
- Stale worker callbacks retain the originating turn's budget and cannot charge later turns.
- No live configuration migration or provider call is required.

## Test plan

- [x] Expanded affected matrix: 851 passed, 1 skipped.
- [x] Canonical isolated provider/background/hygiene/TUI matrix: 565 passed, 0 failed.
- [x] Full TUI gateway suite: 502 passed.
- [x] Ruff, Python compilation, schema synchronization, and diff checks passed.
- [x] Independent exact-commit review accepted the final tree with no blocking findings.

## Notes for reviewers

Please focus on the concrete transport reservation ownership, terminal exhaustion path, stale-turn capture, and explicit background/auxiliary exclusions. The feature remains inert until a nonzero limit is configured.