### PR TITLE
feat(gateway): support custom systemd unit names

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -963,6 +963,12 @@ platform_toolsets:
 # =============================================================================
 # Gateway Platform Settings
 # =============================================================================
+# Linux only: override the gateway systemd unit base name. A trailing
+# `.service` suffix is accepted and normalized. Omit this setting to keep the
+# default profile-derived unit name.
+# gateway:
+#   systemd_unit_name: hermes-gateway-staging
+#
 # Optional per-platform messaging settings.
 # Platform-specific knobs live under `extra`.
 #

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -97,7 +97,21 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    if _GATEWAY_LIFECYCLE_PATTERN.search(normalized):
+        return True
+
+    try:
+        from hermes_cli.gateway import get_service_name
+
+        unit_name = get_service_name()
+    except Exception:
+        return False
+    custom_systemd_pattern = re.compile(
+        rf"(?i)(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*"
+        rf"(?<![A-Za-z0-9_.@:-]){re.escape(unit_name)}(?:\.service)?"
+        rf"(?![A-Za-z0-9_.@:-]))"
+    )
+    return bool(custom_systemd_pattern.search(normalized))
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
@@ -339,8 +353,6 @@ def contains_gateway_lifecycle_command_or_referenced_script(
         visited=set(),
         read_remote_script=read_remote_script,
     )
-
-
 
 
 def _resolve_script_path(script_path: str) -> Path:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2392,6 +2392,11 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Optional systemd unit base name. A trailing .service is normalized
+        # away by the gateway service manager. None preserves profile-aware
+        # hermes-gateway[-<profile-or-hash>] naming.
+        "systemd_unit_name": None,
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -45,6 +46,7 @@ from hermes_cli.config import (
     is_managed,
     managed_error,
     read_raw_config,
+    read_user_config_raw,
     save_env_value,
     write_platform_config_field,
 )
@@ -106,13 +108,16 @@ def _get_service_pids() -> set:
 
     # --- systemd (Linux): user and system scopes ---
     if supports_systemd_services():
-        for scope_args in [["systemctl", "--user"], ["systemctl"]]:
+        for system, scope_args in [
+            (False, ["systemctl", "--user"]),
+            (True, ["systemctl"]),
+        ]:
             try:
                 result = subprocess.run(
                     scope_args
                     + [
                         "list-units",
-                        "hermes-gateway*",
+                        *_systemd_gateway_unit_patterns(system=system),
                         "--plain",
                         "--no-legend",
                         "--no-pager",
@@ -958,7 +963,10 @@ def _read_systemd_unit_environment(system: bool = False) -> dict[str, str]:
     return parsed
 
 
-def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
+def _hermes_home_from_systemd_unit_file(
+    system: bool = False,
+    unit_path: Path | None = None,
+) -> str | None:
     """Read ``HERMES_HOME`` from the on-disk unit file (not ``systemctl show``).
 
     Prefer the file when refreshing/comparing: under ``sudo``, ``systemctl``
@@ -966,25 +974,168 @@ def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
     ``systemd_unit_is_current`` / ``refresh_systemd_unit_if_needed`` already
     compare against.
     """
-    unit_path = get_systemd_unit_path(system=system)
-    if not unit_path.exists():
-        return None
-    try:
-        text = unit_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    for line in text.splitlines():
+    unit_path = unit_path or get_systemd_unit_path(system=system)
+    return _systemd_unit_file_environment(unit_path).get("HERMES_HOME") or None
+
+
+def _parse_systemd_unit_environment(unit_text: str) -> dict[str, str]:
+    """Parse simple ``Environment=KEY=VALUE`` directives from unit text."""
+    parsed: dict[str, str] = {}
+    for line in unit_text.splitlines():
         stripped = line.strip()
         if not stripped.startswith("Environment="):
             continue
         body = stripped[len("Environment=") :].strip().strip('"')
-        if body.startswith("HERMES_HOME="):
-            value = body.split("=", 1)[1].strip().strip('"')
-            return value or None
-    return None
+        if "=" not in body:
+            continue
+        key, value = body.split("=", 1)
+        parsed[key] = value.strip().strip('"')
+    return parsed
 
 
-def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
+def _read_systemd_unit_file(unit_path: Path) -> tuple[str, dict[str, str]]:
+    """Read unit text and its environment in one filesystem operation."""
+    try:
+        unit_text = unit_path.read_text(encoding="utf-8")
+    except OSError:
+        return "", {}
+    return unit_text, _parse_systemd_unit_environment(unit_text)
+
+
+def _systemd_unit_file_environment(unit_path: Path) -> dict[str, str]:
+    """Read simple ``Environment=KEY=VALUE`` directives from a unit file."""
+    return _read_systemd_unit_file(unit_path)[1]
+
+
+def _systemd_unit_invokes_hermes_gateway(unit_text: str) -> bool:
+    return any(marker in unit_text for marker in _LEGACY_UNIT_EXECSTART_MARKERS)
+
+
+def _systemd_unit_is_managed(
+    unit_path: Path,
+    expected_name: str | None = None,
+    conventional_name: str | None = None,
+) -> bool:
+    """Return whether Hermes may mutate the selected unit file.
+
+    Conventional ``hermes-gateway[-profile]`` units predate the private unit
+    marker and remain backward compatible. A configured custom path has no
+    such provenance, so require both the generated marker and Hermes gateway
+    ExecStart signature before changing an existing file.
+    """
+    expected_name = expected_name or get_service_name()
+    conventional_name = conventional_name or _profile_service_name()
+    if expected_name == conventional_name:
+        return True
+
+    unit_text, environment = _read_systemd_unit_file(unit_path)
+    if not unit_text:
+        return False
+    persisted = environment.get(_SYSTEMD_UNIT_NAME_ENV, "").strip()
+    try:
+        persisted = _normalize_systemd_unit_name(persisted, _SYSTEMD_UNIT_NAME_ENV)
+    except ValueError:
+        return False
+    return (
+        unit_path.name == f"{persisted}.service"
+        and persisted == expected_name
+        and _systemd_unit_invokes_hermes_gateway(unit_text)
+    )
+
+
+def _require_managed_systemd_unit(
+    unit_path: Path,
+    action: str,
+    expected_name: str | None = None,
+    conventional_name: str | None = None,
+) -> None:
+    if _systemd_unit_is_managed(unit_path, expected_name, conventional_name):
+        return
+    print(
+        f"✗ Refusing to {action} {unit_path}: the existing custom-name unit "
+        "is not a Hermes gateway service."
+    )
+    sys.exit(1)
+
+
+def _systemd_manager_fragment_path(
+    service_name: str,
+    system: bool = False,
+) -> tuple[bool, Path | None]:
+    """Probe the manager's selected unit file as ``(succeeded, path)``."""
+    try:
+        result = _run_systemctl(
+            [
+                "show",
+                service_name,
+                "--no-pager",
+                "--property",
+                "LoadState,FragmentPath",
+            ],
+            system=system,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired, OSError):
+        return False, None
+    if result.returncode != 0:
+        return False, None
+    properties: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        properties[key] = value.strip()
+    if "LoadState" not in properties or "FragmentPath" not in properties:
+        return False, None
+    load_state = properties["LoadState"]
+    fragment_path = properties["FragmentPath"]
+    if fragment_path:
+        if load_state == "not-found":
+            return False, None
+        return True, Path(fragment_path)
+    if load_state == "not-found":
+        return True, None
+    return False, None
+
+
+def _managed_systemd_fragment_outside_writable_path(
+    unit_path: Path,
+    service_name: str,
+    system: bool,
+    action: str,
+    conventional_name: str,
+) -> Path | None:
+    """Validate any manager-visible custom unit outside Hermes' write path."""
+    if service_name == conventional_name:
+        return None
+    probe_succeeded, fragment_path = _systemd_manager_fragment_path(
+        service_name, system=system
+    )
+    if not probe_succeeded:
+        print(
+            f"✗ Refusing to {action} {unit_path}: could not verify whether the "
+            "custom-name unit is already owned by another systemd service."
+        )
+        sys.exit(1)
+    if fragment_path is None or fragment_path == unit_path:
+        return fragment_path
+    _require_managed_systemd_unit(
+        fragment_path,
+        action,
+        service_name,
+        conventional_name,
+    )
+    return fragment_path
+
+
+def _sync_hermes_home_from_systemd_unit(
+    system: bool,
+    unit_path: Path | None = None,
+) -> None:
     """When acting on a system-scope unit, adopt its ``HERMES_HOME``.
 
     Under ``sudo``, ``HERMES_HOME`` is stripped and ``HOME=/root``, so
@@ -995,10 +1146,30 @@ def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
     """
     if not system:
         return
+    file_environment = (
+        _systemd_unit_file_environment(unit_path) if unit_path is not None else {}
+    )
+    persisted_name = file_environment.get(_SYSTEMD_UNIT_NAME_ENV, "").strip()
+    if persisted_name and unit_path is not None:
+        try:
+            persisted_name = _normalize_systemd_unit_name(
+                persisted_name, _SYSTEMD_UNIT_NAME_ENV
+            )
+        except ValueError:
+            persisted_name = ""
+        if unit_path.name != f"{persisted_name}.service":
+            persisted_name = ""
+    if persisted_name:
+        os.environ[_SYSTEMD_UNIT_NAME_ENV] = persisted_name
+
     # Prefer the on-disk unit (source of truth for refresh/compare). Fall
     # back to ``systemctl show`` for units that only exist in the manager.
-    unit_home = (_hermes_home_from_systemd_unit_file(system=True) or "").strip()
-    if not unit_home:
+    unit_home = file_environment.get("HERMES_HOME", "").strip()
+    if not unit_home and unit_path is None:
+        unit_home = (
+            _hermes_home_from_systemd_unit_file(system=True) or ""
+        ).strip()
+    if not unit_home and unit_path is None:
         unit_home = _read_systemd_unit_environment(system=True).get("HERMES_HOME", "").strip()
     if not unit_home:
         return
@@ -1721,10 +1892,62 @@ def _windows_gateway_should_absorb_console_controls() -> bool:
 # =============================================================================
 
 _SERVICE_BASE = "hermes-gateway"
+_SYSTEMD_UNIT_NAME_ENV = "_HERMES_GATEWAY_SYSTEMD_UNIT"
+_SYSTEMD_UNIT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@:-]{0,127}$")
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 
 
-def _profile_suffix() -> str:
+def _normalize_systemd_unit_name(value: object, source: str) -> str:
+    """Validate and return a systemd unit base name without ``.service``."""
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid {source}: expected a string")
+
+    name = value.removesuffix(".service")
+    if (
+        not name
+        or "/" in name
+        or ".." in name
+        or _SYSTEMD_UNIT_NAME_PATTERN.fullmatch(name) is None
+    ):
+        raise ValueError(f"Invalid {source}: {value!r}")
+    return name
+
+
+def _systemd_unit_name_override(
+    hermes_home: str | Path | None = None,
+) -> str | None:
+    """Resolve the private service-child marker or public gateway config."""
+    persisted = os.environ.get(_SYSTEMD_UNIT_NAME_ENV)
+    if persisted is not None and hermes_home is None:
+        return _normalize_systemd_unit_name(persisted, _SYSTEMD_UNIT_NAME_ENV)
+
+    config_home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    try:
+        config = read_user_config_raw(config_home / "config.yaml")
+    except Exception:
+        # A broken/unreadable user file must not suppress administrator-managed
+        # configuration. Continue with an empty user layer and apply managed
+        # policy below.
+        config = {}
+    from hermes_cli.config import _expand_env_vars
+    from hermes_cli.managed_scope import apply_managed_overlay
+
+    config = apply_managed_overlay(_expand_env_vars(config))
+    gateway_config = config.get("gateway") if isinstance(config, dict) else None
+    configured = (
+        gateway_config.get("systemd_unit_name")
+        if isinstance(gateway_config, dict)
+        else None
+    )
+    if configured is None:
+        return None
+    return _normalize_systemd_unit_name(configured, "gateway.systemd_unit_name")
+
+
+def _profile_suffix(
+    hermes_home: str | Path | None = None,
+    default_root: str | Path | None = None,
+) -> str:
     """Derive a service-name suffix from the current HERMES_HOME.
 
     Returns ``""`` for the default root, the profile name for
@@ -1735,8 +1958,16 @@ def _profile_suffix() -> str:
     import re
     from hermes_constants import get_default_hermes_root
 
-    home = get_hermes_home().resolve()
-    default = get_default_hermes_root().resolve()
+    home = (
+        Path(hermes_home).resolve()
+        if hermes_home is not None
+        else get_hermes_home().resolve()
+    )
+    default = (
+        Path(default_root).resolve()
+        if default_root is not None
+        else get_default_hermes_root().resolve()
+    )
     if home == default:
         return ""
     # Detect <root>/profiles/<name> pattern → use the profile name
@@ -1795,24 +2026,143 @@ def _profile_arg_for_target_user(hermes_home: str, target_home_dir: str) -> str:
         return _profile_arg(hermes_home)
 
 
-def get_service_name() -> str:
+def get_service_name(
+    hermes_home: str | Path | None = None,
+    default_root: str | Path | None = None,
+) -> str:
     """Derive a systemd service name scoped to this HERMES_HOME.
 
     Default ``~/.hermes`` returns ``hermes-gateway`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` returns ``hermes-gateway-coder``.
     Any other HERMES_HOME appends a short hash for uniqueness.
     """
-    suffix = _profile_suffix()
+    override = _systemd_unit_name_override(hermes_home)
+    if override is not None:
+        return override
+    return _profile_service_name(hermes_home, default_root)
+
+
+def _profile_service_name(
+    hermes_home: str | Path | None = None,
+    default_root: str | Path | None = None,
+) -> str:
+    """Return the conventional service name without a configured override."""
+    suffix = (
+        _profile_suffix()
+        if hermes_home is None and default_root is None
+        else _profile_suffix(hermes_home, default_root)
+    )
     if not suffix:
         return _SERVICE_BASE
     return f"{_SERVICE_BASE}-{suffix}"
 
 
-def get_systemd_unit_path(system: bool = False) -> Path:
-    name = get_service_name()
+def get_systemd_unit_path(
+    system: bool = False,
+    hermes_home: str | Path | None = None,
+    default_root: str | Path | None = None,
+) -> Path:
+    name = get_service_name(hermes_home, default_root)
+    return _systemd_unit_directory(system=system) / f"{name}.service"
+
+
+def _systemd_unit_directory(system: bool = False) -> Path:
     if system:
-        return Path("/etc/systemd/system") / f"{name}.service"
-    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+        return Path("/etc/systemd/system")
+    return Path.home() / ".config" / "systemd" / "user"
+
+
+def _persisted_systemd_gateway_unit_records(
+    system: bool,
+) -> list[tuple[Path, dict[str, str]]]:
+    """Find generated custom-name units and their persisted environment."""
+    units: list[tuple[Path, dict[str, str]]] = []
+    try:
+        candidates = _systemd_unit_directory(system=system).glob("*.service")
+        for path in candidates:
+            text, environment = _read_systemd_unit_file(path)
+            if not text:
+                continue
+            persisted = environment.get(_SYSTEMD_UNIT_NAME_ENV, "").strip()
+            if not persisted:
+                continue
+            try:
+                persisted = _normalize_systemd_unit_name(
+                    persisted, _SYSTEMD_UNIT_NAME_ENV
+                )
+            except ValueError:
+                continue
+            if path.name != f"{persisted}.service":
+                continue
+            if "-m hermes_cli.main" not in text or "gateway run" not in text:
+                continue
+            units.append((path, environment))
+    except OSError:
+        return []
+    return units
+
+
+def _persisted_systemd_gateway_units(system: bool) -> list[Path]:
+    return [path for path, _ in _persisted_systemd_gateway_unit_records(system)]
+
+
+def _adopt_persisted_systemd_unit(system: bool) -> None:
+    """Adopt a generated custom unit when root lacks the service-user config."""
+    if not system or os.environ.get(_SYSTEMD_UNIT_NAME_ENV):
+        return
+
+    records = _persisted_systemd_gateway_unit_records(system=True)
+    if not records:
+        return
+    environments = dict(records)
+    units = list(environments)
+
+    preferred_paths: list[Path] = []
+    target_user = _default_system_service_user()
+    target_hermes_home: str | None = None
+    if target_user:
+        try:
+            import pwd
+
+            target_home_dir = pwd.getpwnam(target_user).pw_dir
+            target_hermes_home = _hermes_home_for_target_user(target_home_dir)
+            target_default_root = Path(target_home_dir) / ".hermes"
+            target_name = get_service_name(
+                target_hermes_home,
+                target_default_root,
+            )
+            preferred_paths.append(
+                _systemd_unit_directory(system=True) / f"{target_name}.service"
+            )
+        except (KeyError, OSError):
+            pass
+    preferred_paths.append(get_systemd_unit_path(system=True))
+    for preferred in preferred_paths:
+        if preferred in units:
+            _sync_hermes_home_from_systemd_unit(system=True, unit_path=preferred)
+            return
+
+    candidate_homes = {str(get_hermes_home())}
+    if target_hermes_home:
+        candidate_homes.add(target_hermes_home)
+    matching_home = [
+        path
+        for path in units
+        if environments[path].get("HERMES_HOME") in candidate_homes
+    ]
+    candidates = matching_home or units
+    if len(candidates) != 1:
+        return
+    _sync_hermes_home_from_systemd_unit(system=True, unit_path=candidates[0])
+
+
+def _systemd_gateway_unit_patterns(system: bool = False) -> list[str]:
+    """Return systemctl patterns covering legacy/profile and owned custom units."""
+    patterns = ["hermes-gateway*"]
+    for path in _persisted_systemd_gateway_units(system=system):
+        if path.name not in patterns:
+            patterns.append(path.name)
+    return patterns
 
 
 class UserSystemdUnavailableError(RuntimeError):
@@ -2749,7 +3099,11 @@ def _systemd_watchdog_service_fields(
     return "notify", f"NotifyAccess=main\nWatchdogSec={seconds}s\n"
 
 
-def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
+def generate_systemd_unit(
+    system: bool = False,
+    run_as_user: str | None = None,
+    unit_name_override: str | None = None,
+) -> str:
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
     detected_venv = _detect_venv_dir()
@@ -2784,10 +3138,17 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     # 60s floor, so a configured 45s drain yields 75s rather than 90s.
     _drain_timeout = int(_get_restart_drain_timeout() or 0)
     restart_timeout = max(60, _drain_timeout + 30)
-
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
+        unit_name_override = unit_name_override or _systemd_unit_name_override(
+            hermes_home
+        )
+        unit_name_env_line = (
+            f'Environment="{_SYSTEMD_UNIT_NAME_ENV}={unit_name_override}"\n'
+            if unit_name_override is not None
+            else ""
+        )
         systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
             hermes_home
         )
@@ -2824,7 +3185,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+{unit_name_env_line}Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
@@ -2841,6 +3202,12 @@ WantedBy=multi-user.target
 """
 
     hermes_home = str(get_hermes_home().resolve())
+    unit_name_override = unit_name_override or _systemd_unit_name_override()
+    unit_name_env_line = (
+        f'Environment="{_SYSTEMD_UNIT_NAME_ENV}={unit_name_override}"\n'
+        if unit_name_override is not None
+        else ""
+    )
     systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
         hermes_home
     )
@@ -2862,7 +3229,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+{unit_name_env_line}Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
@@ -2925,6 +3292,21 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _generate_installed_systemd_unit(
+    system: bool,
+    run_as_user: str | None = None,
+) -> str:
+    """Generate against the selected persisted identity when one is active."""
+    selected_name = _systemd_unit_name_override()
+    if selected_name is None:
+        return generate_systemd_unit(system=system, run_as_user=run_as_user)
+    return generate_systemd_unit(
+        system=system,
+        run_as_user=run_as_user,
+        unit_name_override=selected_name,
+    )
+
+
 def systemd_unit_is_current(system: bool = False) -> bool:
     # ── HERMES_HOME sync chokepoint ──────────────────────────────────────
     # Every path that compares OR regenerates the unit funnels through here:
@@ -2950,7 +3332,7 @@ def systemd_unit_is_current(system: bool = False) -> bool:
 
     installed = unit_path.read_text(encoding="utf-8")
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    expected = generate_systemd_unit(system=system, run_as_user=expected_user)
+    expected = _generate_installed_systemd_unit(system, expected_user)
     # Normalize out directives that older systemd versions silently drop
     # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
     # those directives is not perpetually flagged as outdated.
@@ -3027,6 +3409,12 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
         return False
+    if not _systemd_unit_is_managed(unit_path):
+        print(
+            f"✗ Refusing to refresh {unit_path}: the existing custom-name unit "
+            "is not a Hermes gateway service."
+        )
+        return False
 
     # The gate below funnels through ``systemd_unit_is_current``, which is the
     # single HERMES_HOME-sync chokepoint (adopts the unit's pinned home before
@@ -3036,7 +3424,7 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
         return False
 
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    new_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
+    new_unit = _generate_installed_systemd_unit(system, expected_user)
 
     # ── Test-environment safety belt ─────────────────────────────────────
     # The user-scope unit path resolves under ``Path.home()``, which is NOT
@@ -3132,11 +3520,19 @@ def _ensure_linger_enabled() -> None:
 
 def _select_systemd_scope(system: bool = False) -> bool:
     if system:
+        _adopt_persisted_systemd_unit(system=True)
         return True
-    return (
-        get_systemd_unit_path(system=True).exists()
-        and not get_systemd_unit_path(system=False).exists()
-    )
+    user_unit_exists = get_systemd_unit_path(system=False).exists()
+    if user_unit_exists:
+        return False
+    _adopt_persisted_systemd_unit(system=True)
+    return get_systemd_unit_path(system=True).exists()
+
+
+def _systemd_service_is_installed(system: bool = False) -> bool:
+    """Resolve persisted custom names before testing the selected unit path."""
+    selected_system = _select_systemd_scope(system)
+    return get_systemd_unit_path(system=selected_system).exists()
 
 
 def _system_scope_wizard_would_need_root(system: bool = False) -> bool:
@@ -3216,7 +3612,22 @@ def systemd_install(
             remove_legacy_hermes_units(interactive=False)
             print()
 
-    unit_path = get_systemd_unit_path(system=system)
+    target_hermes_home = None
+    target_default_root = None
+    if system:
+        _, _, target_home_dir = _system_service_identity(run_as_user)
+        target_hermes_home = _hermes_home_for_target_user(target_home_dir)
+        target_default_root = Path(target_home_dir) / ".hermes"
+        service_name = get_service_name(target_hermes_home, target_default_root)
+        unit_path = get_systemd_unit_path(
+            system=True,
+            hermes_home=target_hermes_home,
+            default_root=target_default_root,
+        )
+    else:
+        service_name = get_service_name()
+        unit_path = get_systemd_unit_path(system=False)
+    conventional_name = _profile_service_name(target_hermes_home, target_default_root)
     scope_flag = " --system" if system else ""
 
     # Existing system units already pin HERMES_HOME; adopt it before any
@@ -3226,7 +3637,21 @@ def systemd_install(
     # ``sudo hermes gateway install --system --force`` would bake /root/.hermes
     # into an already-correct unit. Keep it to protect that bypass path.
     if unit_path.exists():
-        _sync_hermes_home_from_systemd_unit(system=system)
+        _require_managed_systemd_unit(
+            unit_path,
+            "overwrite",
+            service_name,
+            conventional_name,
+        )
+        _sync_hermes_home_from_systemd_unit(system=system, unit_path=unit_path)
+    else:
+        _managed_systemd_fragment_outside_writable_path(
+            unit_path,
+            service_name,
+            system,
+            "overwrite",
+            conventional_name,
+        )
 
     if unit_path.exists() and not force:
         if not systemd_unit_is_current(system=system):
@@ -3235,7 +3660,7 @@ def systemd_install(
             )
             refresh_systemd_unit_if_needed(system=system)
             if enable_on_startup:
-                _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
+                _run_systemctl(["enable", service_name], system=system, check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
             return
         print(f"Service already installed at: {unit_path}")
@@ -3248,10 +3673,12 @@ def systemd_install(
         return
     print(f"Installing {_service_scope_label(system)} systemd service to: {unit_path}")
     unit_path.write_text(new_unit, encoding="utf-8")
+    if system:
+        _sync_hermes_home_from_systemd_unit(system=True, unit_path=unit_path)
 
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     if enable_on_startup:
-        _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
+        _run_systemctl(["enable", service_name], system=system, check=True, timeout=30)
 
     print()
     enable_label = "installed and enabled" if enable_on_startup else "installed"
@@ -3265,7 +3692,7 @@ def systemd_install(
         f"  {'sudo ' if system else ''}hermes gateway status{scope_flag}             # Check status"
     )
     print(
-        f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # View logs"
+        f"  {'journalctl' if system else 'journalctl --user'} -u {service_name} -f  # View logs"
     )
     print()
 
@@ -3285,12 +3712,26 @@ def systemd_uninstall(system: bool = False):
     if system:
         _require_root_for_system_service("uninstall")
 
+    unit_path = get_systemd_unit_path(system=system)
+    if unit_path.exists():
+        _require_managed_systemd_unit(unit_path, "uninstall")
+    else:
+        fragment_path = _managed_systemd_fragment_outside_writable_path(
+            unit_path,
+            get_service_name(),
+            system,
+            "uninstall",
+            _profile_service_name(),
+        )
+        if get_service_name() != _profile_service_name() and fragment_path is None:
+            print("Gateway service is not installed")
+            return
+
     _run_systemctl(["stop", get_service_name()], system=system, check=False, timeout=90)
     _run_systemctl(
         ["disable", get_service_name()], system=system, check=False, timeout=30
     )
 
-    unit_path = get_systemd_unit_path(system=system)
     if unit_path.exists():
         unit_path.unlink()
         print(f"✓ Removed {unit_path}")
@@ -3318,6 +3759,7 @@ def systemd_start(system: bool = False):
         # Raises UserSystemdUnavailableError with a remediation message.
         _preflight_user_systemd()
     _require_service_installed("start", system=system)
+    _require_managed_systemd_unit(get_systemd_unit_path(system=system), "start")
     # HERMES_HOME sync happens inside refresh_systemd_unit_if_needed's
     # systemd_unit_is_current gate (the single chokepoint), and the unit is
     # guaranteed to exist here by _require_service_installed, so the gate runs.
@@ -3331,6 +3773,7 @@ def systemd_stop(system: bool = False):
     if system:
         _require_root_for_system_service("stop")
     _require_service_installed("stop", system=system)
+    _require_managed_systemd_unit(get_systemd_unit_path(system=system), "stop")
     _sync_hermes_home_from_systemd_unit(system=system)
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
@@ -3361,6 +3804,7 @@ def systemd_restart(system: bool = False):
     else:
         _preflight_user_systemd()
     _require_service_installed("restart", system=system)
+    _require_managed_systemd_unit(get_systemd_unit_path(system=system), "restart")
     # HERMES_HOME sync happens inside refresh_systemd_unit_if_needed's
     # systemd_unit_is_current gate (the single chokepoint). The unit exists
     # here (_require_service_installed), so the gate runs and its os.environ
@@ -7027,10 +7471,7 @@ def _gateway_command_inner(args):
         if stop_all:
             # --all: kill every gateway process on the machine
             service_available = False
-            if supports_systemd_services() and (
-                get_systemd_unit_path(system=False).exists()
-                or get_systemd_unit_path(system=True).exists()
-            ):
+            if supports_systemd_services() and _systemd_service_is_installed(system):
                 try:
                     systemd_stop(system=system)
                     service_available = True
@@ -7060,10 +7501,7 @@ def _gateway_command_inner(args):
         else:
             # Default: stop only the current profile's gateway
             service_available = False
-            if supports_systemd_services() and (
-                get_systemd_unit_path(system=False).exists()
-                or get_systemd_unit_path(system=True).exists()
-            ):
+            if supports_systemd_services() and _systemd_service_is_installed(system):
                 try:
                     systemd_stop(system=system)
                     service_available = True
@@ -7124,10 +7562,7 @@ def _gateway_command_inner(args):
         if restart_all:
             # --all: stop every gateway process across all profiles, then start fresh
             service_stopped = False
-            if supports_systemd_services() and (
-                get_systemd_unit_path(system=False).exists()
-                or get_systemd_unit_path(system=True).exists()
-            ):
+            if supports_systemd_services() and _systemd_service_is_installed(system):
                 try:
                     systemd_stop(system=system)
                     service_stopped = True
@@ -7156,10 +7591,7 @@ def _gateway_command_inner(args):
 
             # Start the current profile's service fresh
             print("Starting gateway...")
-            if supports_systemd_services() and (
-                get_systemd_unit_path(system=False).exists()
-                or get_systemd_unit_path(system=True).exists()
-            ):
+            if supports_systemd_services() and _systemd_service_is_installed(system):
                 systemd_start(system=system)
             elif is_macos() and get_launchd_plist_path().exists():
                 launchd_start()
@@ -7177,10 +7609,7 @@ def _gateway_command_inner(args):
                 run_gateway(verbose=0)
             return
 
-        if supports_systemd_services() and (
-            get_systemd_unit_path(system=False).exists()
-            or get_systemd_unit_path(system=True).exists()
-        ):
+        if supports_systemd_services() and _systemd_service_is_installed(system):
             service_configured = True
             try:
                 systemd_restart(system=system)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1708,12 +1708,21 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     old_home = os.environ.get("HERMES_HOME")
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
-        from hermes_cli.gateway import get_service_name, get_launchd_plist_path
+        from hermes_cli.gateway import (
+            _profile_service_name,
+            _systemd_unit_is_managed,
+            get_launchd_plist_path,
+            get_service_name,
+        )
 
         if _platform.system() == "Linux":
-            svc_name = get_service_name()
+            svc_name = get_service_name(profile_dir)
             svc_file = Path.home() / ".config" / "systemd" / "user" / f"{svc_name}.service"
-            if svc_file.exists():
+            if svc_file.exists() and _systemd_unit_is_managed(
+                svc_file,
+                expected_name=svc_name,
+                conventional_name=_profile_service_name(profile_dir),
+            ):
                 subprocess.run(
                     ["systemctl", "--user", "disable", svc_name],
                     capture_output=True, check=False, timeout=10,

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -218,15 +218,24 @@ def uninstall_gateway_service():
     if system == "Linux":
         try:
             from hermes_cli.gateway import (
+                _adopt_persisted_systemd_unit,
+                _systemd_unit_is_managed,
                 get_systemd_unit_path,
                 get_service_name,
                 _systemctl_cmd,
             )
-            svc_name = get_service_name()
 
             for is_system in (False, True):
+                if is_system:
+                    _adopt_persisted_systemd_unit(system=True)
+                svc_name = get_service_name()
                 unit_path = get_systemd_unit_path(system=is_system)
                 if not unit_path.exists():
+                    continue
+                if not _systemd_unit_is_managed(unit_path):
+                    log_warn(
+                        f"Skipping unrelated custom-name unit at {unit_path}"
+                    )
                     continue
 
                 scope = "system" if is_system else "user"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3251,10 +3251,11 @@ def _cold_start_windows_gateway_after_update() -> None:
 def _for_each_systemd_gateway_unit(
     list_units_stdout: str,
     *,
+    custom_unit_names: set[str] | None = None,
     process_unit,
     on_unit_timeout,
 ) -> None:
-    """Process each ``hermes-gateway*.service`` from ``systemctl list-units``.
+    """Process each recognized gateway service from ``systemctl list-units``.
 
     ``subprocess.TimeoutExpired`` raised by ``process_unit`` is isolated to
     that unit via ``on_unit_timeout`` so one wedged systemctl call cannot
@@ -3269,9 +3270,11 @@ def _for_each_systemd_gateway_unit(
             continue
         # list-units is already pattern-filtered, but keep the name gate so a
         # stray non-gateway line cannot enter the restart path.
-        if not unit.startswith("hermes-gateway"):
-            continue
         svc_name = unit.removesuffix(".service")
+        if not unit.startswith("hermes-gateway") and svc_name not in (
+            custom_unit_names or set()
+        ):
+            continue
         try:
             process_unit(svc_name)
         except subprocess.TimeoutExpired as exc:
@@ -4718,6 +4721,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 find_profile_gateway_processes,
                 _prepare_profile_gateway_update_restart,
                 _get_service_pids,
+                _systemd_gateway_unit_patterns,
                 _graceful_restart_via_sigusr1,
                 _wait_for_gateway_exit,
             )
@@ -4913,12 +4917,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     ("user", ["systemctl", "--user"]),
                     ("system", ["systemctl"]),
                 ]:
+                    unit_patterns = _systemd_gateway_unit_patterns(
+                        system=scope == "system"
+                    )
+                    custom_unit_names = {
+                        pattern.removesuffix(".service")
+                        for pattern in unit_patterns
+                        if pattern != "hermes-gateway*"
+                    }
                     try:
                         result = subprocess.run(
                             scope_cmd
                             + [
                                 "list-units",
-                                "hermes-gateway*",
+                                *unit_patterns,
                                 "--plain",
                                 "--no-legend",
                                 "--no-pager",
@@ -5197,6 +5209,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                     _for_each_systemd_gateway_unit(
                         result.stdout,
+                        custom_unit_names=custom_unit_names,
                         process_unit=_restart_one_systemd_gateway_unit,
                         on_unit_timeout=_on_unit_timeout,
                     )

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -106,6 +106,29 @@ class TestGatewayLifecyclePattern:
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "systemctl --user restart custom-hermes-service.service",
+            "systemctl --user restart 'custom-hermes-service.service'",
+            'systemctl --user stop "custom-hermes-service.service"',
+            "systemctl --user restart custom-hermes-service.service; echo done",
+            "systemctl --user restart \\\n custom-hermes-service.service",
+        ],
+    )
+    def test_configured_systemd_unit_is_blocked(
+        self, tmp_path, monkeypatch, command
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n  systemd_unit_name: custom-hermes-service\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _contains_gateway_lifecycle_command(command)
+
 
 class TestCronCreateLifecycleBlock:
     """Verify cron create rejects gateway lifecycle prompts."""
@@ -145,7 +168,9 @@ class TestCronCreateLifecycleBlock:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         scripts_dir = tmp_path / ".hermes" / "scripts"
         scripts_dir.mkdir(parents=True)
-        (scripts_dir / "restart.sh").write_text("#!/bin/bash\nhermes gateway restart\n")
+        (scripts_dir / "restart.sh").write_text(
+            "#!/bin/bash\nhermes gateway restart\n", encoding="utf-8"
+        )
         args = Namespace(
             cron_command="create",
             schedule="1h",
@@ -540,6 +565,21 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 0
         assert calls == [command]
 
+    def test_blocks_configured_unit_inside_gateway(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY_SYSTEMD_UNIT", "custom-hermes-service")
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(
+            tt.terminal_tool(
+                command="systemctl --user restart custom-hermes-service.service"
+            )
+        )
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""
         import tools.terminal_tool as tt
@@ -638,7 +678,8 @@ class TestLifecycleGuardModule:
         scripts_dir = tmp_path / ".hermes" / "scripts"
         scripts_dir.mkdir(parents=True)
         (scripts_dir / "restart.sh").write_text(
-            "launchctl kickstart -k gui/501/ai.hermes.gateway\n"
+            "launchctl kickstart -k gui/501/ai.hermes.gateway\n",
+            encoding="utf-8",
         )
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily", "restart.sh")

--- a/tests/hermes_cli/test_gateway_systemd_unit_name.py
+++ b/tests/hermes_cli/test_gateway_systemd_unit_name.py
@@ -1,0 +1,764 @@
+"""Behavioral coverage for the gateway systemd unit-name override."""
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import gateway
+
+
+UNIT_NAME = "hermes-gateway-worktree-docs-l2-topology-guide-personal-main"
+PRIVATE_UNIT_ENV = "_HERMES_GATEWAY_SYSTEMD_UNIT"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_gateway_config(monkeypatch, tmp_path):
+    monkeypatch.delenv(PRIVATE_UNIT_ENV, raising=False)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    yield
+    os.environ.pop(PRIVATE_UNIT_ENV, None)
+
+
+def _write_gateway_config(unit_name: object) -> None:
+    hermes_home = gateway.get_hermes_home()
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    value = "null" if unit_name is None else repr(unit_name)
+    (hermes_home / "config.yaml").write_text(
+        f"gateway:\n  systemd_unit_name: {value}\n",
+        encoding="utf-8",
+    )
+
+
+def _patch_stable_unit_inputs(monkeypatch):
+    monkeypatch.setattr(
+        gateway, "get_python_path", lambda: "/opt/hermes/venv/bin/python"
+    )
+    monkeypatch.setattr(gateway, "_detect_venv_dir", lambda: Path("/opt/hermes/venv"))
+    monkeypatch.setattr(
+        gateway, "_build_service_path_dirs", lambda: ["/opt/hermes/venv/bin"]
+    )
+    monkeypatch.setattr(gateway.shutil, "which", lambda executable: None)
+    monkeypatch.setattr(
+        gateway, "_build_user_local_paths", lambda home, path_entries: []
+    )
+    monkeypatch.setattr(gateway, "_build_wsl_interop_paths", lambda path_entries: [])
+    monkeypatch.setattr(
+        gateway, "_stable_service_working_dir", lambda: "/var/lib/hermes"
+    )
+    monkeypatch.setattr(gateway, "_get_restart_drain_timeout", lambda: 30)
+    monkeypatch.setattr(
+        gateway,
+        "_system_service_identity",
+        lambda run_as_user=None: ("service", "service", "/home/service"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_hermes_home_for_target_user",
+        lambda home_dir: f"{home_dir}/.hermes",
+    )
+
+
+def _capture_systemctl(monkeypatch):
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(args, system=False, **kwargs):
+        calls.append((list(args), system))
+        if args[0] == "show" and any("FragmentPath" in arg for arg in args):
+            return SimpleNamespace(
+                returncode=0,
+                stdout="LoadState=not-found\nFragmentPath=\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+
+    monkeypatch.setattr(gateway, "_run_systemctl", fake_run)
+    return calls
+
+
+def _prepare_target_user_config(monkeypatch, tmp_path, unit_name=UNIT_NAME):
+    root_home = tmp_path / "root"
+    service_home = tmp_path / "service"
+    root_hermes = root_home / ".hermes"
+    service_hermes = service_home / ".hermes"
+    root_hermes.mkdir(parents=True)
+    service_hermes.mkdir(parents=True)
+    (service_hermes / "config.yaml").write_text(
+        f"gateway:\n  systemd_unit_name: {unit_name}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: root_home))
+    monkeypatch.setenv("HERMES_HOME", str(root_hermes))
+    monkeypatch.setattr(gateway.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        gateway,
+        "_system_service_identity",
+        lambda run_as_user=None: ("service", "service", str(service_home)),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_hermes_home_for_target_user",
+        lambda home_dir: str(service_hermes),
+    )
+    return service_home, service_hermes
+
+
+def _prepare_persisted_system_unit(monkeypatch, tmp_path):
+    _, service_hermes = _prepare_target_user_config(monkeypatch, tmp_path)
+    system_dir = tmp_path / "system"
+    system_dir.mkdir()
+    unit_path = system_dir / f"{UNIT_NAME}.service"
+    unit_path.write_text(
+        "[Service]\n"
+        "ExecStart=/opt/hermes/venv/bin/python -m hermes_cli.main gateway run\n"
+        f'Environment="HERMES_HOME={service_hermes}"\n'
+        f'Environment="{PRIVATE_UNIT_ENV}={UNIT_NAME}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_systemd_unit_directory",
+        lambda system=False: system_dir,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "get_systemd_unit_path",
+        lambda system=False, hermes_home=None, default_root=None: (
+            system_dir
+            / f"{gateway.get_service_name(hermes_home, default_root)}.service"
+        ),
+    )
+    return service_hermes, unit_path
+
+
+def test_default_service_name_is_unchanged_without_override(monkeypatch):
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "")
+
+    assert gateway.get_service_name() == "hermes-gateway"
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (UNIT_NAME, UNIT_NAME),
+        (f"{UNIT_NAME}.service", UNIT_NAME),
+        ("hermes@worker:blue", "hermes@worker:blue"),
+    ],
+)
+def test_configured_unit_name_is_validated_and_normalized(configured, expected):
+    _write_gateway_config(configured)
+
+    assert gateway.get_service_name() == expected
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "",
+        "   ",
+        "/",
+        "..",
+        "../hermes-gateway-evil",
+        "hermes/gateway/evil",
+        "hermes..gateway",
+        "-hermes-gateway",
+        "hermes gateway",
+        "hermes-gateway-\nmalicious",
+        "h" * 129,
+    ],
+)
+def test_configured_unit_name_rejects_invalid_and_traversal_like_values(configured):
+    _write_gateway_config(configured)
+
+    with pytest.raises(ValueError, match="gateway.systemd_unit_name"):
+        gateway.get_service_name()
+
+
+def test_override_selects_user_and_system_unit_paths():
+    _write_gateway_config(f"{UNIT_NAME}.service")
+
+    assert gateway.get_systemd_unit_path(system=False) == (
+        Path.home() / ".config" / "systemd" / "user" / f"{UNIT_NAME}.service"
+    )
+    assert gateway.get_systemd_unit_path(system=True) == (
+        Path("/etc/systemd/system") / f"{UNIT_NAME}.service"
+    )
+
+
+@pytest.mark.parametrize("system", [False, True])
+def test_generated_units_persist_resolved_name(monkeypatch, system):
+    _patch_stable_unit_inputs(monkeypatch)
+    _write_gateway_config(f"{UNIT_NAME}.service")
+    if system:
+        monkeypatch.setattr(
+            gateway,
+            "_hermes_home_for_target_user",
+            lambda home_dir: str(gateway.get_hermes_home()),
+        )
+
+    unit = gateway.generate_systemd_unit(
+        system=system,
+        run_as_user="service" if system else None,
+    )
+
+    assert f'Environment="{PRIVATE_UNIT_ENV}={UNIT_NAME}"' in unit
+
+
+def test_unit_name_expands_environment_reference(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_SYSTEMD_UNIT", UNIT_NAME)
+    _write_gateway_config("${HERMES_TEST_SYSTEMD_UNIT}")
+
+    assert gateway.get_service_name() == UNIT_NAME
+
+
+def test_persisted_child_name_takes_precedence_over_changed_config(monkeypatch):
+    _patch_stable_unit_inputs(monkeypatch)
+    _write_gateway_config("new-config-name")
+    monkeypatch.setenv(PRIVATE_UNIT_ENV, f"{UNIT_NAME}.service")
+
+    assert gateway.get_service_name() == UNIT_NAME
+    assert f'Environment="{PRIVATE_UNIT_ENV}={UNIT_NAME}"' in (
+        gateway.generate_systemd_unit()
+    )
+
+
+@pytest.mark.parametrize("managed", [True, False])
+def test_profile_cleanup_only_removes_managed_custom_unit(
+    monkeypatch, tmp_path, managed
+):
+    import platform
+
+    from hermes_cli import profiles
+
+    current_name = "current-hermes-service"
+    target_name = "target-hermes-service"
+    current_home = tmp_path / "current" / ".hermes"
+    target_home = tmp_path / "target" / ".hermes"
+    user_units = tmp_path / ".config" / "systemd" / "user"
+    current_home.mkdir(parents=True)
+    target_home.mkdir(parents=True)
+    user_units.mkdir(parents=True)
+    (target_home / "config.yaml").write_text(
+        f"gateway:\n  systemd_unit_name: {target_name}\n",
+        encoding="utf-8",
+    )
+    current_unit = user_units / f"{current_name}.service"
+    target_unit = user_units / f"{target_name}.service"
+    current_unit.write_text("[Unit]\n", encoding="utf-8")
+    target_unit.write_text(
+        (
+            "[Service]\n"
+            "ExecStart=/opt/hermes/venv/bin/python -m hermes_cli.main gateway run\n"
+            f'Environment="{PRIVATE_UNIT_ENV}={target_name}"\n'
+            if managed
+            else "[Service]\nExecStart=/usr/bin/unrelated-application\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setenv("HERMES_HOME", str(current_home))
+    monkeypatch.setenv(PRIVATE_UNIT_ENV, current_name)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        profiles.subprocess,
+        "run",
+        lambda args, **kwargs: (
+            calls.append(list(args)) or SimpleNamespace(returncode=0)
+        ),
+    )
+
+    profiles._cleanup_gateway_service("target", target_home)
+
+    assert current_unit.exists()
+    assert target_unit.exists() is not managed
+    assert (["systemctl", "--user", "stop", target_name] in calls) is managed
+
+
+@pytest.mark.parametrize("managed", [True, False])
+def test_discovery_only_includes_owned_custom_unit(monkeypatch, tmp_path, managed):
+    _write_gateway_config("existing-application")
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    unit_path = unit_dir / "existing-application.service"
+    unit_path.write_text(
+        (
+            "[Service]\n"
+            "ExecStart=/opt/hermes/venv/bin/python -m hermes_cli.main gateway run\n"
+            f'Environment="{PRIVATE_UNIT_ENV}=existing-application"\n'
+            if managed
+            else "[Service]\nExecStart=/usr/bin/existing-application\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway, "_systemd_unit_directory", lambda system=False: unit_dir
+    )
+
+    patterns = gateway._systemd_gateway_unit_patterns()
+
+    assert ("existing-application.service" in patterns) is managed
+
+
+def test_system_install_uses_target_user_override_for_path_and_enable(
+    monkeypatch, tmp_path
+):
+    _prepare_target_user_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    calls = _capture_systemctl(monkeypatch)
+    resolved_paths: list[Path] = []
+
+    def fake_unit_path(system=False, hermes_home=None, default_root=None):
+        path = tmp_path / (
+            f"{gateway.get_service_name(hermes_home, default_root)}.service"
+        )
+        resolved_paths.append(path)
+        return path
+
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", fake_unit_path)
+    monkeypatch.setattr(gateway, "generate_systemd_unit", lambda **kwargs: "[Unit]\n")
+    monkeypatch.setattr(gateway, "_refuse_temp_home_service_write", lambda *args: False)
+    monkeypatch.setattr(gateway, "print_systemd_scope_conflict_warning", lambda: None)
+    monkeypatch.setattr(gateway, "print_legacy_unit_warning", lambda: None)
+
+    gateway.systemd_install(force=True, system=True, run_as_user="service")
+
+    assert resolved_paths[0].name == f"{UNIT_NAME}.service"
+    assert (["enable", UNIT_NAME], True) in calls
+
+
+def test_system_status_adopts_persisted_custom_system_unit(monkeypatch, tmp_path):
+    service_hermes, _ = _prepare_persisted_system_unit(monkeypatch, tmp_path)
+    calls = _capture_systemctl(monkeypatch)
+    monkeypatch.setattr(gateway, "has_conflicting_systemd_units", lambda: False)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: True)
+
+    gateway.systemd_status(system=True)
+
+    assert (["status", UNIT_NAME, "--no-pager"], True) in calls
+    assert (["is-active", UNIT_NAME], True) in calls
+    assert gateway.get_hermes_home() == service_hermes
+
+
+def test_system_scope_uses_sudo_user_config_when_multiple_custom_units_exist(
+    monkeypatch, tmp_path
+):
+    import pwd
+
+    service_hermes, unit_path = _prepare_persisted_system_unit(monkeypatch, tmp_path)
+    other_name = "other-hermes-service"
+    other_home = tmp_path / "other" / ".hermes"
+    other_home.mkdir(parents=True)
+    (unit_path.parent / f"{other_name}.service").write_text(
+        "[Service]\n"
+        "ExecStart=/opt/hermes/venv/bin/python -m hermes_cli.main gateway run\n"
+        f'Environment="HERMES_HOME={other_home}"\n'
+        f'Environment="{PRIVATE_UNIT_ENV}={other_name}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "service")
+    monkeypatch.setattr(
+        pwd,
+        "getpwnam",
+        lambda username: SimpleNamespace(pw_dir=str(service_hermes.parent)),
+    )
+
+    assert gateway._select_systemd_scope(system=True) is True
+    assert gateway.get_service_name() == UNIT_NAME
+    assert gateway.get_hermes_home() == service_hermes
+
+
+def test_system_uninstall_adopts_persisted_custom_system_unit(monkeypatch, tmp_path):
+    _, unit_path = _prepare_persisted_system_unit(monkeypatch, tmp_path)
+    calls = _capture_systemctl(monkeypatch)
+
+    gateway.systemd_uninstall(system=True)
+
+    assert (["stop", UNIT_NAME], True) in calls
+    assert (["disable", UNIT_NAME], True) in calls
+    assert not unit_path.exists()
+
+
+@pytest.mark.parametrize("subcommand", ["stop", "restart"])
+def test_command_dispatch_adopts_persisted_custom_system_unit(
+    monkeypatch, tmp_path, subcommand
+):
+    _prepare_persisted_system_unit(monkeypatch, tmp_path)
+    dispatched: list[tuple[str, bool, str]] = []
+
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(
+        gateway,
+        f"systemd_{subcommand}",
+        lambda system=False: dispatched.append((
+            subcommand,
+            system,
+            gateway.get_service_name(),
+        )),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "stop_profile_gateway",
+        lambda: pytest.fail("fell through to manual PID stop"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda **kwargs: pytest.fail("fell through to manual gateway start"),
+    )
+
+    gateway.gateway_command(
+        SimpleNamespace(gateway_command=subcommand, system=True, all=False)
+    )
+
+    assert dispatched == [(subcommand, True, UNIT_NAME)]
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+def test_custom_name_refuses_to_manage_unrelated_existing_unit(
+    monkeypatch, tmp_path, operation
+):
+    _write_gateway_config("existing-application")
+    unit_path = tmp_path / "existing-application.service"
+    original = "[Service]\nExecStart=/usr/bin/existing-application\n"
+    unit_path.write_text(original, encoding="utf-8")
+    calls = _capture_systemctl(monkeypatch)
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False, **kwargs: unit_path
+    )
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "_refuse_temp_home_service_write", lambda *args: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        if operation == "install":
+            gateway.systemd_install(force=True)
+        else:
+            gateway.systemd_uninstall()
+
+    assert exc_info.value.code == 1
+    assert unit_path.read_text(encoding="utf-8") == original
+    assert calls == []
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+@pytest.mark.parametrize("system", [False, True])
+def test_custom_name_refuses_manager_visible_unit_outside_writable_path(
+    monkeypatch, tmp_path, operation, system
+):
+    if system:
+        _, service_hermes = _prepare_target_user_config(
+            monkeypatch, tmp_path, "existing-application"
+        )
+        if operation == "uninstall":
+            monkeypatch.setenv("HERMES_HOME", str(service_hermes))
+    else:
+        _write_gateway_config("existing-application")
+
+    writable_path = tmp_path / "writable" / "existing-application.service"
+    vendor_path = tmp_path / "vendor" / "existing-application.service"
+    vendor_path.parent.mkdir()
+    original = "[Service]\nExecStart=/usr/bin/existing-application\n"
+    vendor_path.write_text(original, encoding="utf-8")
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(args, system=False, **kwargs):
+        calls.append((list(args), system))
+        if args[0] == "show":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"LoadState=loaded\nFragmentPath={vendor_path}\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway, "_run_systemctl", fake_run)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "_adopt_persisted_systemd_unit", lambda system: None)
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False, **kwargs: writable_path
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        if operation == "install":
+            gateway.systemd_install(
+                force=True,
+                system=system,
+                run_as_user="service" if system else None,
+            )
+        else:
+            gateway.systemd_uninstall(system=system)
+
+    assert exc_info.value.code == 1
+    assert vendor_path.read_text(encoding="utf-8") == original
+    assert calls == [
+        (
+            [
+                "show",
+                "existing-application",
+                "--no-pager",
+                "--property",
+                "LoadState,FragmentPath",
+            ],
+            system,
+        )
+    ]
+
+
+@pytest.mark.parametrize("system", [False, True])
+@pytest.mark.parametrize(
+    "probe_outcome",
+    ["exception", "timeout", "nonzero", "malformed", "empty", "transient"],
+)
+def test_custom_name_install_refuses_failed_manager_probe(
+    monkeypatch, tmp_path, system, probe_outcome
+):
+    if system:
+        _prepare_target_user_config(monkeypatch, tmp_path, "existing-application")
+    else:
+        _write_gateway_config("existing-application")
+
+    unit_path = tmp_path / "writable" / "existing-application.service"
+
+    def fake_run(args, system=False, **kwargs):
+        if args[0] != "show":
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if probe_outcome == "exception":
+            raise OSError("systemd manager unavailable")
+        if probe_outcome == "timeout":
+            raise subprocess.TimeoutExpired(args, 10)
+        if probe_outcome == "nonzero":
+            return SimpleNamespace(returncode=1, stdout="", stderr="failed")
+        if probe_outcome == "malformed":
+            stdout = "FragmentPath=\n"
+        elif probe_outcome == "transient":
+            stdout = "LoadState=loaded\nFragmentPath=\n"
+        else:
+            stdout = ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway, "_run_systemctl", fake_run)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False, **kwargs: unit_path
+    )
+    monkeypatch.setattr(gateway, "generate_systemd_unit", lambda **kwargs: "[Unit]\n")
+    monkeypatch.setattr(gateway, "_refuse_temp_home_service_write", lambda *args: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.systemd_install(
+            force=True,
+            system=system,
+            run_as_user="service" if system else None,
+        )
+
+    assert exc_info.value.code == 1
+    assert not unit_path.exists()
+
+
+@pytest.mark.parametrize("system", [False, True])
+def test_custom_name_install_accepts_confirmed_absent_manager_unit(
+    monkeypatch, tmp_path, system
+):
+    if system:
+        _prepare_target_user_config(monkeypatch, tmp_path, "available-application")
+    else:
+        _write_gateway_config("available-application")
+
+    unit_path = tmp_path / "writable" / "available-application.service"
+
+    def fake_run(args, system=False, **kwargs):
+        if args[0] == "show":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="LoadState=not-found\nFragmentPath=\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway, "_run_systemctl", fake_run)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False, **kwargs: unit_path
+    )
+    monkeypatch.setattr(gateway, "generate_systemd_unit", lambda **kwargs: "[Unit]\n")
+    monkeypatch.setattr(gateway, "_refuse_temp_home_service_write", lambda *args: False)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: None)
+
+    gateway.systemd_install(
+        force=True,
+        system=system,
+        run_as_user="service" if system else None,
+        enable_on_startup=False,
+    )
+
+    assert unit_path.read_text(encoding="utf-8") == "[Unit]\n"
+
+
+def test_refresh_refuses_unrelated_custom_name_collision(monkeypatch, tmp_path):
+    _write_gateway_config("existing-application")
+    unit_path = tmp_path / "existing-application.service"
+    original = "[Service]\nExecStart=/usr/bin/existing-application\n"
+    unit_path.write_text(original, encoding="utf-8")
+    calls = _capture_systemctl(monkeypatch)
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(gateway, "generate_systemd_unit", lambda **kwargs: "new unit\n")
+
+    assert gateway.refresh_systemd_unit_if_needed() is False
+    assert unit_path.read_text(encoding="utf-8") == original
+    assert calls == []
+
+
+def test_system_install_refuses_target_user_custom_name_collision(
+    monkeypatch, tmp_path
+):
+    _prepare_target_user_config(monkeypatch, tmp_path, "existing-application")
+    unit_path = tmp_path / "existing-application.service"
+    original = "[Service]\nExecStart=/usr/bin/existing-application\n"
+    unit_path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda **kwargs: unit_path)
+    monkeypatch.setattr(gateway, "_refuse_temp_home_service_write", lambda *args: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.systemd_install(force=True, system=True, run_as_user="service")
+
+    assert exc_info.value.code == 1
+    assert unit_path.read_text(encoding="utf-8") == original
+
+
+def test_full_uninstall_adopts_persisted_custom_system_unit(monkeypatch, tmp_path):
+    import platform
+
+    from hermes_cli import uninstall
+
+    _, unit_path = _prepare_persisted_system_unit(monkeypatch, tmp_path)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        uninstall.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0),
+    )
+
+    assert uninstall.uninstall_gateway_service() is True
+    assert not unit_path.exists()
+
+
+def test_full_uninstall_ignores_unrelated_custom_name_collision(monkeypatch, tmp_path):
+    import platform
+
+    from hermes_cli import uninstall
+
+    _write_gateway_config("existing-application")
+    unit_path = tmp_path / "existing-application.service"
+    unit_path.write_text(
+        "[Service]\nExecStart=/usr/bin/existing-application\n", encoding="utf-8"
+    )
+    missing_system_unit = tmp_path / "missing-system.service"
+    calls: list[list[str]] = []
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        gateway,
+        "get_systemd_unit_path",
+        lambda system=False: missing_system_unit if system else unit_path,
+    )
+    monkeypatch.setattr(gateway, "_adopt_persisted_systemd_unit", lambda system: None)
+    monkeypatch.setattr(
+        uninstall.subprocess,
+        "run",
+        lambda args, **kwargs: (
+            calls.append(list(args)) or SimpleNamespace(returncode=0)
+        ),
+    )
+
+    assert uninstall.uninstall_gateway_service() is False
+    assert unit_path.exists()
+    assert calls == []
+
+
+@pytest.mark.parametrize("system", [False, True])
+def test_refresh_preserves_persisted_name_after_config_change(
+    monkeypatch, tmp_path, system
+):
+    _patch_stable_unit_inputs(monkeypatch)
+    monkeypatch.setenv(PRIVATE_UNIT_ENV, UNIT_NAME)
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: Path("/var/lib/hermes"))
+    monkeypatch.setattr(
+        gateway, "_hermes_home_for_target_user", lambda home: "/var/lib/hermes"
+    )
+    unit_path = tmp_path / f"{UNIT_NAME}.service"
+    unit_path.write_text(
+        "[Service]\n"
+        "ExecStart=/opt/hermes/venv/bin/python -m hermes_cli.main gateway run\n"
+        'Environment="HERMES_HOME=/var/lib/hermes"\n'
+        f'Environment="{PRIVATE_UNIT_ENV}={UNIT_NAME}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(gateway, "_run_systemctl", lambda *args, **kwargs: None)
+
+    assert gateway.refresh_systemd_unit_if_needed(system=system) is True
+    assert f'Environment="{PRIVATE_UNIT_ENV}={UNIT_NAME}"' in unit_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_system_unit_remains_current_after_only_configured_name_changes(
+    monkeypatch, tmp_path
+):
+    _, service_hermes = _prepare_target_user_config(monkeypatch, tmp_path)
+    _patch_stable_unit_inputs(monkeypatch)
+    monkeypatch.setattr(
+        gateway, "_hermes_home_for_target_user", lambda home: str(service_hermes)
+    )
+    unit_path = tmp_path / f"{UNIT_NAME}.service"
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    unit_path.write_text(
+        gateway.generate_systemd_unit(system=True, run_as_user="service"),
+        encoding="utf-8",
+    )
+    (service_hermes / "config.yaml").write_text(
+        "gateway:\n  systemd_unit_name: renamed-service\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(PRIVATE_UNIT_ENV, UNIT_NAME)
+
+    assert gateway.systemd_unit_is_current(system=True) is True
+
+
+def test_service_pid_discovery_returns_pid_for_custom_unit(monkeypatch):
+    monkeypatch.setenv(PRIVATE_UNIT_ENV, UNIT_NAME)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+
+    def fake_run(args, **kwargs):
+        if "list-units" in args and "--user" in args:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"{UNIT_NAME}.service loaded active running Hermes\n",
+                stderr="",
+            )
+        if "show" in args:
+            return SimpleNamespace(returncode=0, stdout="4321\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._get_service_pids() == {4321}

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -90,6 +90,18 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == ["hermes-gateway-coder"]
 
+    def test_resolved_custom_gateway_unit_is_processed(self):
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            _list_units_stdout(["hermes-gateway", "custom-hermes-service"]),
+            custom_unit_names={"custom-hermes-service"},
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-gateway", "custom-hermes-service"]
+
     def test_process_errors_other_than_timeout_still_propagate(self):
         def process_unit(_svc_name: str) -> None:
             raise RuntimeError("not a timeout")
@@ -112,4 +124,3 @@ class TestIncompleteFleetRestartWarning:
         assert out.count("hermes-gateway-xiaomo5") == 1
         assert "hermes-gateway-xiaomo6" in out
         assert "pre-update code" in out
-

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -186,6 +186,28 @@ process when they stop. The default `0` keeps the existing `Type=simple`
 behavior. This setting is Linux/systemd-only and does not treat an ordinary
 platform network disconnect as an event-loop failure.
 
+### Custom Linux systemd unit name
+
+Set `gateway.systemd_unit_name` when an external deployment convention needs
+a stable unit name instead of Hermes' profile-derived default:
+
+```yaml title="~/.hermes/config.yaml"
+gateway:
+  systemd_unit_name: hermes-gateway-staging
+```
+
+The value must start with an ASCII letter or digit, may contain only ASCII
+letters, digits, `_`, `.`, `@`, `:`, and `-`, and may be at most 128
+characters. A trailing `.service` is accepted and removed automatically;
+slashes, `..`, whitespace, and empty values are rejected.
+
+Set the name before installing the service. Hermes persists the resolved name
+in generated user and system units so gateway-initiated lifecycle operations
+continue to target the same unit. To rename an existing service, uninstall it
+while the old setting is still active, change the setting, then install it
+again. This setting affects Linux systemd units only; macOS launchd labels
+remain profile-derived.
+
 ## Chat Commands (Inside Messaging)
 
 | Command | Description |


### PR DESCRIPTION
## What does this PR do?

Adds a generic `gateway.systemd_unit_name` configuration option for Linux deployments that need a stable gateway systemd unit name instead of the default profile-derived name.

The configured name accepts an optional `.service` suffix, is normalized to a base name, and is validated before it can be used in a unit path or lifecycle command. The resolved name is persisted in generated user and system units so install, status, restart, update, uninstall, profile cleanup, PID discovery, and child-triggered lifecycle operations all address the same unit. Existing systemd hardening and non-Linux behavior remain unchanged.

## Related Issue

- [Issue: gateway install overwrites custom systemd service configuration](https://github.com/NousResearch/hermes-agent/issues/7186) concerns preserving hand-edited unit contents; this PR addresses configurable unit names.
- [Issue: profile commands miss service-managed gateways](https://github.com/NousResearch/hermes-agent/issues/20254) and its [open PR](https://github.com/NousResearch/hermes-agent/pull/20488) concern gateway status detection without a PID file. They do not add a custom unit-name configuration or change gateway install/stop behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the validated `gateway.systemd_unit_name` config key in `hermes_cli/config_defaults.py` and unit-name resolution in `hermes_cli/gateway.py`.
- Applied the resolved name consistently across gateway lifecycle, update, uninstall, profile cleanup, and lifecycle-guard paths.
- Added ownership and collision checks before custom-name units are mutated.
- Added focused coverage for normalization, invalid values, user/system paths, persistence, lifecycle callers, collisions, and child behavior.
- Documented the Linux systemd configuration in `website/docs/user-guide/messaging/index.md` and `cli-config.yaml.example`.

## How to Test

1. Run the affected gateway and systemd tests:

   ```bash
   python -m pytest tests/hermes_cli/test_gateway_systemd_unit_name.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_update_fleet_restart_timeout.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_systemd_optional_directives.py tests/hermes_cli/test_gateway.py -q
   ```

   Expected: all selected tests pass.

2. Run lint and the cross-platform guard:

   ```bash
   ruff check cron/lifecycle_guard.py hermes_cli/config_defaults.py hermes_cli/gateway.py hermes_cli/profiles.py hermes_cli/uninstall.py hermes_cli/update_cmd.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_gateway_systemd_unit_name.py tests/hermes_cli/test_update_fleet_restart_timeout.py
   python scripts/check-windows-footguns.py --diff main
   ```

3. Run the full test suite:

   ```bash
   ./scripts/run_tests.sh
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - The earlier branch run completed with `23,827 passed, 17 failed`. A clean run at that target commit completed with `23,763 passed, 17 failed`, with the same failures in the same 9 unrelated test files.
  - After rebasing onto `7f4d15515`, the branch run completed with `23,993 passed, 17 failed`. Clean current `main` reproduced 16 failures in the same 8 unrelated files. The one additional failure was in untouched `tests/test_tui_gateway_server.py`; its focused rerun passed all 501 tests.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, with automated user- and system-scope systemd coverage

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS launchd and Windows behavior are unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## Screenshots / Logs

N/A — no UI changes.