### PR TITLE
fix(secrets): finish profile secret-scope migration — get_env_value, anthropic adapter, ACP env scrub (cluster salvage)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -24,6 +24,18 @@ from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
+from agent.secret_scope import get_secret as _get_secret
+
+
+def _getenv(name: str, default: str = "") -> str:
+    """Profile-scoped replacement for os.getenv on credential reads.
+
+    Routes through the secret scope (Workstream A): identical to os.getenv
+    when multiplexing is off, scope-aware (and fail-closed on an unscoped
+    read) when on. Mirrors the same wrapper in hermes_cli/runtime_provider.py.
+    """
+    val = _get_secret(name, default)
+    return val if val is not None else default
 
 # NOTE: `import anthropic` is deliberately NOT at module top — the SDK pulls
 # ~220 ms of imports (anthropic.types, anthropic.lib.tools._beta_runner, etc.)
@@ -1358,7 +1370,7 @@ def resolve_anthropic_token() -> Optional[str]:
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var
-    token = os.getenv("ANTHROPIC_TOKEN", "").strip()
+    token = _getenv("ANTHROPIC_TOKEN").strip()
     if token:
         preferred = _prefer_refreshable_claude_code_token(token, creds)
         if preferred:
@@ -1366,7 +1378,7 @@ def resolve_anthropic_token() -> Optional[str]:
         return token
 
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
-    cc_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
     if cc_token:
         preferred = _prefer_refreshable_claude_code_token(cc_token, creds)
         if preferred:
@@ -1385,7 +1397,7 @@ def resolve_anthropic_token() -> Optional[str]:
 
     # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
-    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    api_key = _getenv("ANTHROPIC_API_KEY").strip()
     if api_key:
         return api_key
 
@@ -1428,7 +1440,7 @@ def run_oauth_setup_token() -> Optional[str]:
 
     # Check env vars that may have been set
     for env_var in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_TOKEN"):
-        val = os.getenv(env_var, "").strip()
+        val = _getenv(env_var).strip()
         if val:
             return val
 

--- a/contributors/emails/phm543@gmail.com
+++ b/contributors/emails/phm543@gmail.com
@@ -1,0 +1,1 @@
+keepConcentration

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -316,6 +316,14 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
+    # ACP (Agent Client Protocol) keys — profile-isolable so different
+    # profiles can use different ACP backends without cross-leak.
+    "HERMES_ACP_AUTH_METHOD",
+    "HERMES_ACP_AUTO_APPROVE",
+    "HERMES_COPILOT_ACP_COMMAND",
+    "HERMES_COPILOT_ACP_ARGS",
+    "COPILOT_CLI_PATH",
+    "COPILOT_ACP_BASE_URL",
 })
 import yaml
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4107,10 +4107,36 @@ def reload_env() -> int:
 
 
 def get_env_value(key: str) -> Optional[str]:
-    """Get a value from ~/.hermes/.env or environment."""
-    # Check environment first
-    if key in os.environ:
-        return os.environ[key]
+    """Get a value from ``os.environ`` or ``~/.hermes/.env``, scope-aware.
+
+    The ``os.environ`` read routes through ``agent.secret_scope.get_secret``
+    so that, under an active profile scope (multiplexed gateway turn), this
+    is scope-checked rather than leaking another profile's raw ``os.environ``
+    value. ``get_secret`` encodes the whole policy: global vars pass through;
+    scope is authoritative under multiplexing (miss -> None, no environ
+    fallthrough); when multiplexing is off it behaves exactly like the
+    legacy ``os.environ`` read. Its siblings ``get_env_value_prefer_dotenv``
+    and ``gateway.config._getenv`` already work this way — this was the last
+    scope-blind reader of the trio (#67027).
+    """
+    try:
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            get_secret as _get_secret,
+        )
+    except Exception:
+        if key in os.environ:
+            return os.environ[key]
+        return load_env().get(key)
+
+    try:
+        val = _get_secret(key)
+    except UnscopedSecretError:
+        raise
+    except Exception:
+        val = os.environ.get(key)
+    if val is not None:
+        return val
 
     # Then check .env file
     env_vars = load_env()

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -84,6 +84,8 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
+        if line.startswith("export "):
+            line = line[7:]
         key = line.split("=", 1)[0].strip()
         if key:
             keys.add(key)

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -64,6 +64,23 @@ def _known_hermes_env_keys() -> set[str]:
     return set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
 
 
+# Behavioral routing keys a parent Hermes process injects into child env and
+# that silently redirect a profile onto the wrong provider path (ACP auth
+# method, copilot-ACP endpoints). These — and ONLY these — are scrubbed from
+# os.environ at startup when absent from the profile's .env. Credential keys
+# (API keys/tokens) are excluded: shell exports are a legitimate,
+# documented way to supply them, and read-time secret-scope checks
+# (agent/secret_scope.py) own cross-profile credential isolation.
+_PROFILE_MANAGED_ENV_KEYS: frozenset[str] = frozenset({
+    "HERMES_ACP_AUTH_METHOD",
+    "HERMES_ACP_AUTO_APPROVE",
+    "HERMES_COPILOT_ACP_COMMAND",
+    "HERMES_COPILOT_ACP_ARGS",
+    "COPILOT_CLI_PATH",
+    "COPILOT_ACP_BASE_URL",
+})
+
+
 def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
     """Return KEY names assigned in a dotenv file (including empty ``KEY=``).
 
@@ -93,18 +110,27 @@ def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
 
 
 def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
-    """Remove inherited known Hermes keys absent from the profile ``.env``.
+    """Remove inherited profile-managed Hermes keys absent from ``.env``.
 
     After the profile's ``.env`` has been loaded with ``override=True``,
-    scan the file for which known Hermes keys it explicitly defines and
-    delete any known key that exists in ``os.environ`` but is *not* present
+    scan the file for which profile-managed keys it explicitly defines and
+    delete any such key that exists in ``os.environ`` but is *not* present
     in the file.
 
-    This mirrors the semantics of ``reload_env()`` in ``config.py`` (which
-    already deletes missing known keys on hot-reload) and closes the gap
-    between startup and hot-reload: without this, a known key inherited
-    from the parent process leaks into the profile, silently mutating
-    provider / ACP / platform behaviour.
+    Scope is deliberately NARROW: only ``_PROFILE_MANAGED_ENV_KEYS`` —
+    behavioral routing keys (ACP auth method, copilot-ACP endpoints) that a
+    parent Hermes process injects and that silently change *which provider
+    path* a profile uses. Provider API keys (OPENAI_API_KEY, …) are
+    intentionally excluded: users legitimately export those in their shell
+    (``export OPENAI_API_KEY=…`` is a documented flow — see
+    ``tests/hermes_cli/test_dump_env_visibility.py``), and a startup scrub
+    cannot distinguish a shell export from parent-process leakage. Clearing
+    the full known-key set would delete user-exported credentials on every
+    ``hermes`` invocation.
+
+    Cross-profile *credential* isolation is handled at read time by
+    ``agent.secret_scope.get_secret`` (scope authoritative under
+    multiplexing), not by mutating ``os.environ`` here.
 
     Does **not** run when the ``.env`` file does not exist (bare-profile
     case, which follows ``#66930`` / ``#67027`` semantics).
@@ -112,7 +138,7 @@ def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
     if not path.exists():
         return
     defined = _env_keys_defined_in_dotenv(path)
-    for key in _known_hermes_env_keys():
+    for key in _PROFILE_MANAGED_ENV_KEYS:
         if key not in defined and key in os.environ:
             del os.environ[key]
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -50,6 +50,71 @@ _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
 _APPLIED_HOMES: set[str] = set()
 
 
+def _known_hermes_env_keys() -> set[str]:
+    """Return the combined set of known Hermes env-var keys.
+
+    Includes both ``OPTIONAL_ENV_VARS`` (setup-flow vars with metadata) and
+    ``_EXTRA_ENV_KEYS`` (provider/platform keys managed outside the setup
+    wizard).  Lazy-imported to avoid circular-dependency during early-bootstrap
+    ``load_hermes_dotenv()`` calls.
+    """
+    from hermes_cli.config import _EXTRA_ENV_KEYS
+    from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
+
+    return set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
+
+
+def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
+    """Return KEY names assigned in a dotenv file (including empty ``KEY=``).
+
+    Uses a fast line scanner rather than full dotenv parsing so it works
+    during early bootstrap without importing python-dotenv.  Ignores comment
+    and blank lines.  Non-ASCII encoding errors fall back to ``latin-1``,
+    matching ``_load_dotenv_with_fallback``.
+    """
+    keys: set[str] = set()
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        try:
+            text = path.read_text(encoding="latin-1", errors="replace")
+        except Exception:
+            return keys
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key = line.split("=", 1)[0].strip()
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _clear_known_keys_missing_from_dotenv(path: Path) -> None:
+    """Remove inherited known Hermes keys absent from the profile ``.env``.
+
+    After the profile's ``.env`` has been loaded with ``override=True``,
+    scan the file for which known Hermes keys it explicitly defines and
+    delete any known key that exists in ``os.environ`` but is *not* present
+    in the file.
+
+    This mirrors the semantics of ``reload_env()`` in ``config.py`` (which
+    already deletes missing known keys on hot-reload) and closes the gap
+    between startup and hot-reload: without this, a known key inherited
+    from the parent process leaks into the profile, silently mutating
+    provider / ACP / platform behaviour.
+
+    Does **not** run when the ``.env`` file does not exist (bare-profile
+    case, which follows ``#66930`` / ``#67027`` semantics).
+    """
+    if not path.exists():
+        return
+    defined = _env_keys_defined_in_dotenv(path)
+    for key in _known_hermes_env_keys():
+        if key not in defined and key in os.environ:
+            del os.environ[key]
+
+
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
@@ -320,6 +385,9 @@ def load_hermes_dotenv(
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
+        # Mirror reload_env() known-key cleanup so inherited Hermes keys
+        # absent from this profile's .env do not leak into the runtime.
+        _clear_known_keys_missing_from_dotenv(user_env)
 
     # Load .op.env AFTER .env so that .env values win, but the bootstrap
     # token (OP_SERVICE_ACCOUNT_TOKEN) becomes available for

--- a/tests/agent/test_anthropic_token_scope_isolation.py
+++ b/tests/agent/test_anthropic_token_scope_isolation.py
@@ -1,0 +1,254 @@
+"""Regression tests: resolve_anthropic_token() must honour the profile secret scope.
+
+BUG LOCATION
+    agent/anthropic_adapter.py lines 1218, 1226, 1245
+
+ROOT CAUSE
+    resolve_anthropic_token() calls os.getenv() directly at three call sites,
+    bypassing get_secret() from agent/secret_scope.py:
+
+        line 1218: os.getenv("ANTHROPIC_TOKEN", "")
+        line 1226: os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+        line 1245: os.getenv("ANTHROPIC_API_KEY", "")
+
+    Every other credential reader in the resolution chain (hermes_cli/runtime_provider.py
+    _getenv, secret_scope.get_secret) correctly uses the profile-scoped wrapper.
+
+IMPACT
+    In a multiplexed gateway (set_multiplex_active(True)), any Anthropic API call
+    reads the process-level os.environ instead of the active profile's secret scope.
+    This causes:
+      - Cross-profile credential leakage (profile A's key used for profile B's turn)
+      - Cron jobs in multiplex mode silently reading the wrong key
+      - No fail-closed signal (UnscopedSecretError) when no scope is installed
+
+STATUS
+    All tests in this file are RED (failing) while the bug exists.
+    They turn GREEN when os.getenv() at the three sites is replaced with
+    get_secret() from agent.secret_scope (matching the pattern in runtime_provider.py).
+"""
+
+import pytest
+from unittest.mock import patch
+
+from agent import secret_scope as ss
+from agent.anthropic_adapter import resolve_anthropic_token
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    """Isolate global multiplex flag between tests."""
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+@pytest.fixture(autouse=True)
+def _pin_file_and_pool_sources():
+    """Pin credential-file (source 3) and pool (source 4) to None.
+
+    This isolates the three os.getenv() call sites (sources 1, 2, 5) so each
+    test exercises exactly the env-var reading behaviour under scope control.
+    """
+    with patch("agent.anthropic_adapter.read_claude_code_credentials", return_value=None), \
+         patch("agent.anthropic_adapter._resolve_anthropic_pool_token", return_value=None):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Core isolation: scoped key must beat os.environ in multiplex mode
+# ---------------------------------------------------------------------------
+
+class TestApiKeyScopeIsolation:
+    """ANTHROPIC_API_KEY (source 5, line 1245) must read from scope, not os.environ."""
+
+    def test_scoped_api_key_used_over_environ(self, monkeypatch):
+        """Profile scope's ANTHROPIC_API_KEY wins over os.environ value.
+
+        Bug: os.getenv("ANTHROPIC_API_KEY") at line 1245 reads the wrong profile's
+        key when a profile scope with a different value is active.
+        Fix: replace with get_secret("ANTHROPIC_API_KEY").
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-WRONG-OTHER-PROFILE")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-CORRECT-PROFILE"})
+        try:
+            result = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert result == "sk-ant-api-CORRECT-PROFILE", (
+            f"resolve_anthropic_token() returned {result!r} (from os.environ) "
+            f"instead of 'sk-ant-api-CORRECT-PROFILE' (from profile scope). "
+            f"Bug confirmed at anthropic_adapter.py:1245 — os.getenv bypasses get_secret()."
+        )
+
+    def test_two_profiles_return_different_keys(self, monkeypatch):
+        """Each profile scope must resolve to its own ANTHROPIC_API_KEY.
+
+        This is the canonical credential-isolation invariant.
+        With the bug, both calls return the same os.environ value.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-SHARED-ENVIRON-WRONG")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        ss.set_multiplex_active(True)
+
+        tok_a = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-A"})
+        try:
+            result_a = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok_a)
+
+        tok_b = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-B"})
+        try:
+            result_b = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok_b)
+
+        assert result_a == "sk-ant-api-PROFILE-A", (
+            f"Profile A got {result_a!r} — expected its own key."
+        )
+        assert result_b == "sk-ant-api-PROFILE-B", (
+            f"Profile B got {result_b!r} — expected its own key."
+        )
+        assert result_a != result_b, (
+            f"Both profiles resolved to {result_a!r}. "
+            f"Credential isolation is broken — both read from os.environ."
+        )
+
+
+# ---------------------------------------------------------------------------
+# OAuth token leakage: ANTHROPIC_TOKEN (source 1, line 1218)
+# ---------------------------------------------------------------------------
+
+class TestOAuthTokenLeakageFromEnviron:
+    """ANTHROPIC_TOKEN in os.environ must not override the active profile scope."""
+
+    def test_anthropic_token_env_does_not_shadow_scoped_api_key(self, monkeypatch):
+        """An ANTHROPIC_TOKEN present in os.environ from another profile must not be used.
+
+        Scenario: Profile B's OAuth token was set in os.environ (e.g., by a previous
+        process or a different profile's session). Profile A's scope only has
+        ANTHROPIC_API_KEY. resolve_anthropic_token() must use Profile A's API key.
+
+        Bug: os.getenv("ANTHROPIC_TOKEN") at line 1218 reads the leaked env var
+        and returns Profile B's OAuth token for Profile A's Anthropic calls.
+        Fix: replace with get_secret("ANTHROPIC_TOKEN"), which returns None when
+        ANTHROPIC_TOKEN is absent from the active scope.
+        """
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat-LEAKED-PROFILE-B")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-A"})
+        try:
+            result = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert result != "sk-ant-oat-LEAKED-PROFILE-B", (
+            f"Profile B's OAuth token leaked from os.environ[ANTHROPIC_TOKEN] "
+            f"(anthropic_adapter.py:1218). Profile A received the wrong credential."
+        )
+        assert result == "sk-ant-api-PROFILE-A", (
+            f"Expected Profile A's API key but got {result!r}."
+        )
+
+    def test_anthropic_token_in_scope_is_used(self, monkeypatch):
+        """When ANTHROPIC_TOKEN IS in the active profile scope, it must be used.
+
+        This verifies the positive case: scoped OAuth tokens work after the fix.
+        """
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_TOKEN": "sk-ant-oat-PROFILE-A-OWN-OAUTH"})
+        try:
+            result = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert result == "sk-ant-oat-PROFILE-A-OWN-OAUTH", (
+            f"Profile A's own OAuth token (in scope) was not returned; got {result!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Claude Code OAuth token leakage: CLAUDE_CODE_OAUTH_TOKEN (source 2, line 1226)
+# ---------------------------------------------------------------------------
+
+class TestClaudeCodeOAuthTokenLeakage:
+    """CLAUDE_CODE_OAUTH_TOKEN in os.environ must not override the active profile scope."""
+
+    def test_cc_oauth_env_does_not_shadow_scoped_api_key(self, monkeypatch):
+        """CLAUDE_CODE_OAUTH_TOKEN from os.environ must not be used when it's not in scope.
+
+        Bug: os.getenv("CLAUDE_CODE_OAUTH_TOKEN") at line 1226 reads the global env
+        var even when the active profile scope doesn't include it.
+        Fix: replace with get_secret("CLAUDE_CODE_OAUTH_TOKEN").
+        """
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-CC-LEAKED-ENVIRON")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-X"})
+        try:
+            result = resolve_anthropic_token()
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert result != "sk-ant-oat-CC-LEAKED-ENVIRON", (
+            f"CLAUDE_CODE_OAUTH_TOKEN leaked from os.environ (anthropic_adapter.py:1226). "
+            f"Profile X's Anthropic call used the wrong credential."
+        )
+        assert result == "sk-ant-api-PROFILE-X", (
+            f"Expected Profile X's API key but got {result!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cron scheduler scenario: unscoped call in multiplex mode
+# ---------------------------------------------------------------------------
+
+class TestCronSchedulerUnscopedCall:
+    """Cron scheduler in multiplex mode: resolve_anthropic_token() must fail closed.
+
+    The cron scheduler (cron/scheduler.py) loads a credential_pool for the job's
+    provider, but does NOT call set_secret_scope() before running Anthropic calls.
+    In multiplex mode, this means resolve_anthropic_token() runs with:
+      - _MULTIPLEX_ACTIVE = True
+      - No active profile scope
+
+    With os.getenv() (current code): silently reads the process-level os.environ,
+    which may be empty or hold a different profile's value. No error is raised.
+
+    With get_secret() (after fix): raises UnscopedSecretError, signalling that the
+    cron scheduler must be updated to call set_secret_scope() for each job's profile.
+    """
+
+    def test_unscoped_call_in_multiplex_mode_fails_closed(self, monkeypatch):
+        """An unscoped resolve_anthropic_token() in multiplex mode must raise UnscopedSecretError.
+
+        Bug: os.getenv() at lines 1218/1226/1245 never raises — silently returning
+        the process-level key, masking the missing scope in cron scheduler context.
+        Fix: use get_secret(), which raises UnscopedSecretError when multiplex is
+        active and no scope is installed (matching secret_scope.py's fail-closed contract).
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-PROCESS-LEVEL-SHOULD-NOT-LEAK")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        ss.set_multiplex_active(True)
+        # No set_secret_scope() call — simulates cron scheduler context
+
+        with pytest.raises(ss.UnscopedSecretError, match="ANTHROPIC"):
+            resolve_anthropic_token()

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -281,3 +281,47 @@ def test_export_prefixed_known_key_in_user_env_is_kept(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
     load_hermes_dotenv(hermes_home=home)
     assert os.getenv("HERMES_ACP_AUTH_METHOD") == "claude_code_cli"
+
+
+def test_shell_exported_credentials_survive_cleanup(tmp_path, monkeypatch):
+    """User-shell-exported provider credentials must NOT be scrubbed.
+
+    ``export OPENAI_API_KEY=…`` in the shell with a ``.env`` that doesn't
+    contain the key is a documented, legitimate flow (see
+    test_dump_env_visibility.py). The startup cleanup is scoped to
+    _PROFILE_MANAGED_ENV_KEYS (ACP routing keys) precisely so it can never
+    delete shell-supplied credentials — a process cannot distinguish a
+    shell export from parent-process leakage, so credential isolation is
+    owned by read-time secret scoping instead.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("SOME_OTHER_KEY=x\n", encoding="utf-8")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-shell")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-shell")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "12345:token-from-shell")
+    # A profile-managed routing key inherited alongside them IS cleared.
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("OPENAI_API_KEY") == "sk-from-shell"
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-ant-from-shell"
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "12345:token-from-shell"
+    assert "HERMES_ACP_AUTH_METHOD" not in os.environ
+
+
+def test_cleanup_scope_is_the_profile_managed_set():
+    """Lock the invariant: the startup scrub set contains only behavioral
+    ACP/routing keys — never credential-shaped keys. If this fails, someone
+    widened _PROFILE_MANAGED_ENV_KEYS toward the full known-key set, which
+    re-introduces the shell-export deletion bug.
+    """
+    from hermes_cli.env_loader import _PROFILE_MANAGED_ENV_KEYS
+
+    for key in _PROFILE_MANAGED_ENV_KEYS:
+        assert not key.endswith(("_API_KEY", "_TOKEN", "_SECRET")), (
+            f"{key} looks credential-shaped; startup scrub must not "
+            "cover credentials — read-time secret scoping owns those"
+        )

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -265,3 +265,19 @@ def test_known_key_explicitly_set_in_user_env_is_kept(tmp_path, monkeypatch):
     load_hermes_dotenv(hermes_home=home)
 
     assert os.getenv("HERMES_ACP_AUTH_METHOD") == "claude_code_cli"
+
+
+def test_export_prefixed_known_key_in_user_env_is_kept(tmp_path, monkeypatch):
+    """A known Hermes key defined with the bash-compatible ``export KEY=value``
+    form in the profile .env must be recognized as defined and survive the
+    cleanup - mirrors the ``export `` stripping in config.py's load_env()
+    (#6659).
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "export HERMES_ACP_AUTH_METHOD=claude_code_cli\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("HERMES_ACP_AUTH_METHOD") == "claude_code_cli"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -169,3 +169,99 @@ def test_cp1252_env_regression_does_not_crash(tmp_path, monkeypatch):
     assert os.getenv("LATIN1_VALUE") == "café"
     # Sanitize must not have rewritten (would have persisted U+FFFD).
     assert env_file.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# Profile .env isolation: inherited known-key cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_known_keys_absent_from_user_env_are_cleared(tmp_path, monkeypatch):
+    """Known Hermes keys inherited from parent process are removed when absent
+    from the profile's .env.
+
+    This is the startup equivalent of ``reload_env()``'s known-key cleanup and
+    fixes the isolation gap where one profile's ACP/provider settings silently
+    leak into another profile's runtime via ``os.environ`` inheritance.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "OPENAI_BASE_URL=https://profile.example/v1\n", encoding="utf-8"
+    )
+
+    # Inherited known keys from parent process / other profile
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://stale.example/v1")
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+    monkeypatch.setenv("COPILOT_CLI_PATH", "/usr/bin/claude-code")
+    # Unrelated shell var must NOT be touched
+    monkeypatch.setenv("MY_SHELL_ONLY_VAR", "keep-me")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    # OPENAI_BASE_URL is defined in the profile .env → overridden to the new value
+    assert os.getenv("OPENAI_BASE_URL") == "https://profile.example/v1"
+    # HERMES_ACP_AUTH_METHOD and COPILOT_CLI_PATH are NOT in the profile .env → cleared
+    assert "HERMES_ACP_AUTH_METHOD" not in os.environ
+    assert "COPILOT_CLI_PATH" not in os.environ
+    # Unrelated shell vars must survive
+    assert os.getenv("MY_SHELL_ONLY_VAR") == "keep-me"
+
+
+def test_empty_assignment_in_user_env_is_preserved(tmp_path, monkeypatch):
+    """An explicit ``KEY=`` (empty value) in the profile .env keeps the key
+    in ``os.environ`` — distinct from a key absent from .env entirely.
+
+    Empty ``HERMES_ACP_AUTH_METHOD=`` tells the ACP adapter to skip
+    ``authenticate`` (the key exists, its value is just empty).  This is the
+    documented workaround for the leak and must still work after the cleanup.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("HERMES_ACP_AUTH_METHOD=\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+    monkeypatch.setenv("COPILOT_CLI_PATH", "/usr/bin/sneaky")  # NOT in .env → cleared
+
+    load_hermes_dotenv(hermes_home=home)
+
+    # KEY= in .env keeps the key (now empty string)
+    assert "HERMES_ACP_AUTH_METHOD" in os.environ
+    assert os.environ["HERMES_ACP_AUTH_METHOD"] == ""
+    # COPILOT_CLI_PATH is absent from .env → cleared
+    assert "COPILOT_CLI_PATH" not in os.environ
+
+
+def test_no_user_env_does_not_clear_anything(tmp_path, monkeypatch):
+    """When no profile .env exists (bare profile), load_hermes_dotenv must not
+    wipe inherited known keys — the bare-profile case follows #66930 / #67027
+    semantics and the user's shell environment should not be mutilated.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    # No .env in home — bare profile
+
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("HERMES_ACP_AUTH_METHOD") == "cursor_login"
+    assert os.getenv("PATH") == "/usr/bin:/bin"
+
+
+def test_known_key_explicitly_set_in_user_env_is_kept(tmp_path, monkeypatch):
+    """A known Hermes key that IS explicitly set in the profile .env survives
+    the cleanup (overrides the inherited value).
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "HERMES_ACP_AUTH_METHOD=claude_code_cli\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("HERMES_ACP_AUTH_METHOD", "cursor_login")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("HERMES_ACP_AUTH_METHOD") == "claude_code_cli"

--- a/tests/hermes_cli/test_get_env_value_scope.py
+++ b/tests/hermes_cli/test_get_env_value_scope.py
@@ -1,0 +1,79 @@
+"""get_env_value must be scope-aware — the last scope-blind reader (#67027).
+
+Under a multiplexed profile turn, ``os.environ`` can hold another profile's
+value. ``get_env_value`` previously returned it before any scope check;
+its siblings (``get_env_value_prefer_dotenv``, ``gateway.config._getenv``)
+were already scope-aware. Salvaged premise from PR #67065 (@webtecnica),
+reimplemented to delegate policy fully to ``agent.secret_scope.get_secret``
+(the PR's own diff fell through to ``os.environ`` on a scoped miss,
+re-opening the leak it targeted).
+"""
+
+import contextlib
+
+import pytest
+
+from agent.secret_scope import (
+    UnscopedSecretError,
+    reset_secret_scope,
+    set_multiplex_active,
+    set_secret_scope,
+)
+from hermes_cli.config import get_env_value
+
+
+@contextlib.contextmanager
+def _scope(secrets, *, multiplex: bool):
+    set_multiplex_active(multiplex)
+    token = set_secret_scope(secrets) if secrets is not None else None
+    try:
+        yield
+    finally:
+        if token is not None:
+            reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def test_scoped_value_wins_over_environ(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-other-profile")
+    with _scope({"OPENAI_API_KEY": "sk-this-profile"}, multiplex=True):
+        assert get_env_value("OPENAI_API_KEY") == "sk-this-profile"
+
+
+def test_multiplexed_scope_miss_does_not_leak_environ(monkeypatch, tmp_path):
+    """The #67027 repro: envless named profile must NOT inherit the other
+    profile's credential from process environ during a multiplexed turn."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-other-profile")
+    with _scope({}, multiplex=True):  # profile has no .env / empty scope
+        assert get_env_value("OPENAI_API_KEY") is None
+
+
+def test_multiplex_off_scope_miss_falls_back_to_environ(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-shell")
+    with _scope({}, multiplex=False):
+        assert get_env_value("OPENAI_API_KEY") == "sk-from-shell"
+
+
+def test_no_scope_single_profile_behaves_like_legacy(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-legacy")
+    with _scope(None, multiplex=False):
+        assert get_env_value("OPENAI_API_KEY") == "sk-legacy"
+
+
+def test_multiplex_active_unscoped_read_fails_closed(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak")
+    with _scope(None, multiplex=True):
+        # No scope installed — must raise, not silently serve environ.
+        with pytest.raises(UnscopedSecretError):
+            get_env_value("OPENAI_API_KEY")
+
+
+def test_dotenv_fallback_still_works(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("MY_TEST_KEY=from-dotenv\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("MY_TEST_KEY", raising=False)
+    with _scope(None, multiplex=False):
+        assert get_env_value("MY_TEST_KEY") == "from-dotenv"


### PR DESCRIPTION
## Summary
Consolidated fix for the profile secret-scoping PR cluster: every remaining scope-blind credential read now routes through `agent.secret_scope.get_secret`, and the ACP routing-key inheritance leak is scrubbed at startup — without deleting user-shell-exported credentials.

Main had already centralized the correct semantic in `get_secret` (`c758ded6d2`: scope authoritative under multiplexing, environ fallback only when multiplexing is off; `0583692c2d`: credential-pool seeding scoped). This PR migrates the three verified stragglers onto it, salvaging the live pieces of #67065, #51604, and #75197 with contributor authorship preserved.

## Changes
- `hermes_cli/config.py` — `get_env_value()` (the last scope-blind reader; siblings `get_env_value_prefer_dotenv` / `gateway.config._getenv` were already scope-aware): delegates fully to `get_secret`, propagates `UnscopedSecretError`, then falls back to `.env`. Authored as @webtecnica (premise from #67065/#67027; reimplemented — the original diff fell through to `os.environ` on a scoped miss, re-opening its own leak).
- `agent/anthropic_adapter.py` — `resolve_anthropic_token()` / `run_oauth_setup_token()` read `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` via a scope-routed `_getenv` wrapper instead of bare `os.getenv` (verified live on main at lines 1361/1369/1388). Cherry-picked from #51604 (@JoaoMarcos44) with its 6-test RED→GREEN suite; the PR's cron hunks (superseded by `fdab380a1a`) and unrelated logging hunk were dropped.
- `hermes_cli/env_loader.py` + `hermes_cli/config.py` `_EXTRA_ENV_KEYS` — startup scrub of parent-injected ACP routing keys absent from the profile `.env` (`HERMES_ACP_*`, `HERMES_COPILOT_ACP_*`, `COPILOT_CLI_PATH`, `COPILOT_ACP_BASE_URL`), fixing the #75141 "wrong ACP auth method inherited" class. Cherry-picked from #75197 (@keepConcentration), then **narrowed**: the original scrubbed every known Hermes key, which deleted user-shell-exported credentials (`export OPENAI_API_KEY=…`) on every invocation — confirmed by the author's own failing test. Credential keys are now explicitly excluded (read-time scoping owns them) and an invariant test fails if the scrub set is ever widened toward credential-shaped keys.

## Validation
| Path | Before | After |
|---|---|---|
| `get_env_value` under multiplexed turn | serves other profile's `os.environ` value | scoped value; miss → None; unscoped → fail-closed |
| Anthropic adapter under multiplex, no scope | leaks process env token | raises `UnscopedSecretError` |
| Profile start with inherited `HERMES_ACP_AUTH_METHOD` | wrong ACP backend ("Internal error") | key scrubbed |
| `export OPENAI_API_KEY` + any `.env` | (with #75197 as filed: deleted) | survives |

Tests: 6 new (`test_get_env_value_scope.py`, sabotage-verified RED on the old impl) + 6 salvaged (`test_anthropic_token_scope_isolation.py`) + 2 new env-loader regressions; 118 sibling tests green (`test_config`, `test_auth_commands`, `test_secret_scope`, `test_multiplex_credential_isolation`, `test_env_loader`). E2E: all three paths exercised with real imports (scoped read, scrub+shell-survival, adapter fail-closed).

Credits: @webtecnica (#67065), @JoaoMarcos44 (#51604), @keepConcentration (#75197).
Related: closes #67027, #51603, #75141. Cluster review also found #66182 and #58102 fully superseded by `0583692c2d`/`c758ded6d2` (closed separately with credit).

## Infographic

![profile scope sealed](https://v3b.fal.media/files/b/0aa4a648/05rwEygD8HafFeLJhH0JQ_u25cRbIC.png)
