### PR TITLE
fix(desktop): refresh sibling terminals when the shared WebGL atlas is cleared

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -268,4 +268,40 @@ describe('shared WebGL atlas refresh fan-out', () => {
     expect(caller.refresh).not.toHaveBeenCalled()
     expect(sibling.refresh).toHaveBeenCalledTimes(1)
   })
+
+  it('clears all atlases before refreshing any terminal (two-phase ordering)', async () => {
+    const { redrawAllTerminals, registerWebglRefresh } = await loadTerminalStore()
+
+    // Track operation order across terminals sharing one atlas.
+    const ops: string[] = []
+    const sharedAtlas = { clearTextureAtlas: () => ops.push('clear') }
+    const getWebgl = () => sharedAtlas as never
+
+    const termA = {
+      refresh: () => ops.push('refresh-A'),
+      rows: 24
+    }
+    const termB = {
+      refresh: () => ops.push('refresh-B'),
+      rows: 24
+    }
+
+    registerWebglRefresh(termA as never, getWebgl)
+    registerWebglRefresh(termB as never, getWebgl)
+
+    redrawAllTerminals()
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    // Both clears must precede both refreshes. If a clear ran after a refresh,
+    // that terminal's rebuilt model would reference freed atlas rows.
+    const clearIndices = ops.map((op, i) => op === 'clear' ? i : -1).filter(i => i >= 0)
+    const refreshIndices = ops.map((op, i) => op.startsWith('refresh-') ? i : -1).filter(i => i >= 0)
+
+    expect(clearIndices).toHaveLength(2)
+    expect(refreshIndices).toHaveLength(2)
+    expect(Math.max(...clearIndices)).toBeLessThan(Math.min(...refreshIndices))
+  })
 })
+

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -188,3 +188,84 @@ describe('session cwd → terminal tab linking', () => {
     expect($activeTerminalId.get()).toBe(first)
   })
 })
+
+describe('shared WebGL atlas refresh fan-out', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('coalesces multiple requests into one frame and drops unregistered terminals', async () => {
+    const { redrawAllTerminals, registerWebglRefresh } = await loadTerminalStore()
+
+    const termA = { refresh: vi.fn(), rows: 24 }
+    const termB = { refresh: vi.fn(), rows: 24 }
+    const getWebgl = () => ({ clearTextureAtlas: vi.fn() }) as never
+    const unregister = registerWebglRefresh(termA as never, getWebgl)
+    registerWebglRefresh(termB as never, getWebgl)
+
+    // A theme switch fires one redraw request per mounted terminal; they must
+    // coalesce into a single atlas clear/refresh pass.
+    redrawAllTerminals()
+    redrawAllTerminals()
+    expect(termA.refresh).not.toHaveBeenCalled()
+    expect(termB.refresh).not.toHaveBeenCalled()
+
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    expect(termA.refresh).toHaveBeenCalledTimes(1)
+    expect(termB.refresh).toHaveBeenCalledTimes(1)
+
+    // A terminal that disposes (tab close) must stop being refreshed.
+    unregister()
+    redrawAllTerminals()
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    expect(termA.refresh).toHaveBeenCalledTimes(1)
+    expect(termB.refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a terminal unregistered while a refresh frame is pending', async () => {
+    const { redrawAllTerminals, registerWebglRefresh } = await loadTerminalStore()
+
+    const termA = { refresh: vi.fn(), rows: 24 }
+    const termB = { refresh: vi.fn(), rows: 24 }
+    const getWebgl = () => ({ clearTextureAtlas: vi.fn() }) as never
+    registerWebglRefresh(termA as never, getWebgl)
+    const unregister = registerWebglRefresh(termB as never, getWebgl)
+
+    // Both are pending in the same frame; second disposes before it flushes.
+    redrawAllTerminals()
+    unregister()
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    expect(termA.refresh).toHaveBeenCalledTimes(1)
+    expect(termB.refresh).not.toHaveBeenCalled()
+  })
+
+  it('skips the caller terminal so it is not force-cleared through the fan-out', async () => {
+    const { redrawAllTerminals, registerWebglRefresh } = await loadTerminalStore()
+
+    const caller = { refresh: vi.fn(), rows: 24 }
+    const sibling = { refresh: vi.fn(), rows: 24 }
+    const getWebgl = () => ({ clearTextureAtlas: vi.fn() }) as never
+    registerWebglRefresh(caller as never, getWebgl)
+    registerWebglRefresh(sibling as never, getWebgl)
+
+    // A font change clears the caller inline (applyTerminalFontFamily), so the
+    // fan-out must not re-clear it — only the siblings sharing the atlas.
+    redrawAllTerminals(caller as never)
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+
+    expect(caller.refresh).not.toHaveBeenCalled()
+    expect(sibling.refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -19,6 +19,11 @@ import { seedAgentTerminalCommand } from './agent-terminal-stream'
 // we stay pinned on 0.19.0, so every terminal that mutates the shared atlas
 // must refresh its siblings itself. Registration is the inverse: each xterm
 // registers its own redraw+atlas-rebuild and unregisters on dispose.
+// Two-phase fan-out: all clears FIRST, then all refreshes. A sequential
+// clear+refresh per terminal would let a later clear wipe the atlas that an
+// earlier terminal just rebuilt, leaving it with dangling glyph references.
+// Splitting the phases guarantees every terminal rebuilds against a clean atlas.
+const webglClearFns = new Map<Terminal, () => void>()
 const webglRefreshFns = new Map<Terminal, () => void>()
 
 /** Register a terminal's atlas-rebuild+redraw so sibling refreshes reach it.
@@ -27,12 +32,15 @@ export function registerWebglRefresh(
   term: Terminal,
   getWebgl: () => WebglAddon | null
 ): () => void {
-  webglRefreshFns.set(term, () => {
+  webglClearFns.set(term, () => {
     getWebgl()?.clearTextureAtlas()
+  })
+  webglRefreshFns.set(term, () => {
     term.refresh(0, term.rows - 1)
   })
 
   return () => {
+    webglClearFns.delete(term)
     webglRefreshFns.delete(term)
   }
 }
@@ -45,6 +53,10 @@ let refreshFrame = 0
  *  cells. Coalesced into one frame per tick: a theme switch fires N
  *  per-terminal effects, and fanning out on each would clear+rebuild the atlas
  *  N times over.
+ *
+ *  Two-phase execution: all atlas clears run first, then all terminal refreshes.
+ *  This prevents a later clear from invalidating an earlier terminal's rebuilt
+ *  glyph model (GottZ triage, PR #76463).
  *
  *  Skip the caller only when it already clears+redraws itself inline (font
  *  change); theme/activation callers must NOT skip — they need their own atlas
@@ -59,6 +71,16 @@ export function redrawAllTerminals(skipTerm?: Terminal): void {
   refreshFrame = requestAnimationFrame(() => {
     refreshFrame = 0
 
+    // Phase 1: clear all atlases first.
+    for (const [term, clear] of webglClearFns) {
+      if (skipTerm && term === skipTerm) {
+        continue
+      }
+
+      clear()
+    }
+
+    // Phase 2: rebuild render models against the now-clean atlas.
     for (const [term, refresh] of webglRefreshFns) {
       if (skipTerm && term === skipTerm) {
         continue

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -1,3 +1,5 @@
+import type { WebglAddon } from '@xterm/addon-webgl'
+import type { Terminal } from '@xterm/xterm'
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
@@ -6,6 +8,66 @@ import { $currentCwd } from '@/store/session'
 import { setTerminalTakeover } from '../store'
 
 import { seedAgentTerminalCommand } from './agent-terminal-stream'
+
+// xterm WebGL terminals that share one glyph atlas (same font/theme/DPR) keep
+// per-terminal render models over a SHARED texture. Clearing one terminal's
+// atlas (theme switch, tab activation) wipes the shared texture pages, and
+// xterm 0.19 never tells the sibling renderers to rebuild their models — so
+// their stale cells draw whatever glyphs land in the freed atlas rows: garbled
+// text until a resize forces a full refresh. Upstream fixed this in
+// xtermjs/xterm.js#6055 (atlas clear bumps the shared page-layout version);
+// we stay pinned on 0.19.0, so every terminal that mutates the shared atlas
+// must refresh its siblings itself. Registration is the inverse: each xterm
+// registers its own redraw+atlas-rebuild and unregisters on dispose.
+const webglRefreshFns = new Map<Terminal, () => void>()
+
+/** Register a terminal's atlas-rebuild+redraw so sibling refreshes reach it.
+ *  Returns an unregister function (call on dispose). */
+export function registerWebglRefresh(
+  term: Terminal,
+  getWebgl: () => WebglAddon | null
+): () => void {
+  webglRefreshFns.set(term, () => {
+    getWebgl()?.clearTextureAtlas()
+    term.refresh(0, term.rows - 1)
+  })
+
+  return () => {
+    webglRefreshFns.delete(term)
+  }
+}
+
+let refreshFrame = 0
+
+/** Rebuild the glyph atlas + redraw every live xterm EXCEPT *skipTerm* (when
+ *  given). Callers that are about to mutate the shared atlas (clearTextureAtlas)
+ *  must fan out so the OTHER terminals sharing it don't keep drawing stale
+ *  cells. Coalesced into one frame per tick: a theme switch fires N
+ *  per-terminal effects, and fanning out on each would clear+rebuild the atlas
+ *  N times over.
+ *
+ *  Skip the caller only when it already clears+redraws itself inline (font
+ *  change); theme/activation callers must NOT skip — they need their own atlas
+ *  rebuilt too (the theme colors changed / the frame was stale while hidden).
+ *  Terminals on a different atlas (different font/theme/DPR) are force-cleared
+ *  harmlessly; DOM-fallback terminals aren't registered at all. */
+export function redrawAllTerminals(skipTerm?: Terminal): void {
+  if (refreshFrame) {
+    return
+  }
+
+  refreshFrame = requestAnimationFrame(() => {
+    refreshFrame = 0
+
+    for (const [term, refresh] of webglRefreshFns) {
+      if (skipTerm && term === skipTerm) {
+        continue
+      }
+
+      refresh()
+    }
+  })
+}
 
 /** One in-app terminal tab. `id` is the renderer-side handle (distinct from the
  *  PTY session id the main process mints); each instance owns its own shell. */

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -5,17 +5,16 @@ import { Terminal } from '@xterm/xterm'
 import { useEffect, useRef } from 'react'
 
 import { writeClipboardText } from '@/components/ui/copy-button'
-import { markRightPanePerf } from '@/debug/right-pane-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { useTheme } from '@/themes/context'
 
-import { observeActiveTerminalResize } from './active-resize'
 import { registerAgentTerminalWriter } from './agent-terminal-stream'
 import { makeTerminalReader, registerTerminalReader } from './buffer'
 import { mirrorSelection, terminalClipboardIntent } from './clipboard'
 import { terminalLinkHandler, terminalWebLinksAddon } from './links'
 import { isMacPlatform, resolveSurfaceColor, terminalTheme } from './selection'
 import { prepareTerminalFontFamily } from './terminal-font'
+import { redrawAllTerminals, registerWebglRefresh } from './terminals'
 import { useTerminalFontController } from './use-terminal-font'
 
 // Read-only terminal for an agent background process: a write-only xterm (no PTY,
@@ -26,8 +25,7 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const webglRef = useRef<WebglAddon | null>(null)
-  const fitRef = useRef<((visible: boolean) => void) | null>(null)
-  const initialActiveFitRef = useRef(false)
+  const fitRef = useRef<(() => void) | null>(null)
   const { latestFontFamilyRef, mountedRef } = useTerminalFontController({ fitRef, termRef, webglRef })
 
   const surfaceTheme = () => {
@@ -50,6 +48,7 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
     }
 
     let disposed = false
+    let observer: ResizeObserver | null = null
 
     let unregister = () => {}
 
@@ -103,11 +102,10 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
       return false
     })
 
-    fitRef.current = visible => {
+    fitRef.current = () => {
       if (host.clientWidth > 0 && host.clientHeight > 0) {
         try {
           fit.fit()
-          markRightPanePerf(visible ? 'terminal-fit-active' : 'terminal-fit-hidden', id)
         } catch {
           // Mid-transition layout — the next observer tick refits.
         }
@@ -135,13 +133,19 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
         // No WebGL — xterm falls back to the DOM renderer.
       }
 
-      fitRef.current?.(active)
-      initialActiveFitRef.current = active
+      fitRef.current?.()
+      observer = new ResizeObserver(() => fitRef.current?.())
+      observer.observe(host)
 
       // Stream live output straight into the terminal (replays backlog on attach).
       unregister = registerAgentTerminalWriter(procId, chunk => term.write(chunk))
       unregisterReader = registerTerminalReader(id, makeTerminalReader(term))
     }
+
+    // Join the shared-atlas refresh fan-out (see redrawAllTerminals in
+    // terminals.ts): clearing this terminal's atlas mutates texture pages the
+    // user terminals draw from, so they must rebuild their models too.
+    const unregisterWebglRefresh = registerWebglRefresh(term, () => webglRef.current)
 
     void prepareTerminalFontFamily(
       () => latestFontFamilyRef.current,
@@ -160,7 +164,9 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
       mountedRef.current = false
       unregister()
       unregisterReader()
+      unregisterWebglRefresh()
       selectionDisposable.dispose()
+      observer?.disconnect()
       fitRef.current = null
       term.dispose()
       termRef.current = null
@@ -178,46 +184,33 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
 
     const raf = requestAnimationFrame(() => {
       term.options.theme = surfaceTheme()
-      webglRef.current?.clearTextureAtlas()
+      // The atlas is shared across every terminal with the same render config,
+      // so the clear must fan out to the siblings too (see redrawAllTerminals).
+      redrawAllTerminals()
     })
 
     return () => cancelAnimationFrame(raf)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderedMode, themeName])
 
-  // Keep inactive agent terminals mounted for their backlog, but do not observe
-  // or fit them until they become the visible tab.
-  // eslint-disable-next-line no-restricted-syntax -- lifecycle flag prevents a duplicate first-mount fit
+  // A visibility:hidden xterm doesn't paint — refit + redraw on re-activation.
   useEffect(() => {
     if (!active) {
-      initialActiveFitRef.current = false
-
       return
     }
 
-    const host = hostRef.current
+    const frame = requestAnimationFrame(() => {
+      const term = termRef.current
 
-    if (!host) {
-      return
-    }
-
-    const fitOnActivate = !initialActiveFitRef.current
-    initialActiveFitRef.current = false
-
-    return observeActiveTerminalResize(host, {
-      fitOnActivate,
-      onFit: () => fitRef.current?.(true),
-      onActivate: () => {
-        const term = termRef.current
-
-        webglRef.current?.clearTextureAtlas()
-        term?.refresh(0, term.rows - 1)
-        // Take focus on activation (parity with the user terminal) so the active
-        // agent tab holds focus and ⌘W's isFocusWithin('[data-terminal]') routes
-        // the close to this tab rather than to a preview.
-        term?.focus()
-      }
+      fitRef.current?.()
+      redrawAllTerminals()
+      // Take focus on activation (parity with the user terminal) so the active
+      // agent tab holds focus and ⌘W's isFocusWithin('[data-terminal]') routes
+      // the close to this tab rather than to a preview.
+      term?.focus()
     })
+
+    return () => cancelAnimationFrame(frame)
   }, [active])
 
   return { hostRef }

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-font.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-font.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
 
 import { $terminalFontFamily, applyTerminalFontFamily, resolveTerminalFontFamily } from './terminal-font'
+import { redrawAllTerminals } from './terminals'
 
 interface TerminalFontControllerOptions {
   fitRef: RefObject<((visible: boolean) => void) | null>
@@ -43,6 +44,11 @@ export function useTerminalFontController({ fitRef, termRef, webglRef }: Termina
       isCurrent: () => !cancelled && generationRef.current === generation,
       term
     })
+    // Font is an atlas-share key: changing one terminal's font rebuilds the
+    // shared glyph set, so siblings sharing the atlas must rebuild their
+    // models too (see redrawAllTerminals). The caller clears itself inline
+    // (applyTerminalFontFamily), so skip it in the fan-out.
+    redrawAllTerminals(term)
 
     return () => {
       cancelled = true

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -7,14 +7,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
 
 import { writeClipboardText } from '@/components/ui/copy-button'
-import { markRightPanePerf } from '@/debug/right-pane-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { $previewTarget } from '@/store/preview'
 import { useTheme } from '@/themes/context'
 
 import { $terminalInjection } from '../store'
 
-import { observeActiveTerminalResize } from './active-resize'
 import { makeTerminalReader, registerTerminalReader } from './buffer'
 import { mirrorSelection, terminalClipboardIntent } from './clipboard'
 import { terminalLinkHandler, terminalWebLinksAddon } from './links'
@@ -27,7 +25,7 @@ import {
   terminalTheme
 } from './selection'
 import { prepareTerminalFontFamily } from './terminal-font'
-import { closeTerminal, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
+import { closeTerminal, redrawAllTerminals, registerWebglRefresh, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
 import { useTerminalFontController } from './use-terminal-font'
 
 // How many scrollback lines to serialize for relaunch restore. Mirrors VS Code's
@@ -415,7 +413,6 @@ export function useTerminalSession({
   // drag-and-drop paths, or an injected command). Gates idle-buffer handling in
   // persistSnapshot so an untouched tab never re-saves an accumulating snapshot.
   const hasSessionActivityRef = useRef(false)
-  const initialActiveRef = useRef(active)
   const shellNameRef = useRef('shell')
   const selectionLabelRef = useRef('')
   const selectionRef = useRef('')
@@ -423,8 +420,7 @@ export function useTerminalSession({
   const onShellRef = useRef(onShell)
   // Re-fit on activation: a tab hidden via display:none has a 0×0 host, so its
   // last fit is stale by the time it's shown again.
-  const fitRef = useRef<((visible: boolean) => void) | null>(null)
-  const initialActiveFitRef = useRef(false)
+  const fitRef = useRef<(() => void) | null>(null)
   const { latestFontFamilyRef, mountedRef } = useTerminalFontController({ fitRef, termRef, webglRef })
   const [status, setStatus] = useState<TerminalStatus>('starting')
   const [selection, setSelection] = useState('')
@@ -746,27 +742,55 @@ export function useTerminalSession({
       term.write(next)
     }
 
-    const fitAndResize = (visible: boolean) => {
+    const fitAndResize = () => {
       if (disposed || !host.isConnected || host.clientWidth <= 0 || host.clientHeight <= 0) {
         return
       }
 
       try {
         fit.fit()
-        markRightPanePerf(visible ? 'terminal-fit-active' : 'terminal-fit-hidden', id)
       } catch {
         return
       }
 
-      const sessionId = sessionIdRef.current
+      const id = sessionIdRef.current
 
-      if (sessionId && (lastSentSize?.cols !== term.cols || lastSentSize?.rows !== term.rows)) {
+      if (id && (lastSentSize?.cols !== term.cols || lastSentSize?.rows !== term.rows)) {
         lastSentSize = { cols: term.cols, rows: term.rows }
-        void terminalApi.resize(sessionId, { cols: term.cols, rows: term.rows })
+        void terminalApi.resize(id, { cols: term.cols, rows: term.rows })
       }
     }
 
     fitRef.current = fitAndResize
+
+    // Coalesce ResizeObserver bursts through rAF — running fit.fit()
+    // synchronously while sibling panes are mid-transition (e.g. file browser
+    // collapsing to 0px) crashes the WebGL renderer mid texture-atlas rebuild.
+    let pendingFrame = 0
+
+    const scheduleResize = () => {
+      if (pendingFrame) {
+        return
+      }
+
+      pendingFrame = window.requestAnimationFrame(() => {
+        pendingFrame = 0
+
+        if (!disposed) {
+          fitAndResize()
+        }
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(scheduleResize)
+    resizeObserver.observe(host)
+    cleanup.push(() => {
+      resizeObserver.disconnect()
+
+      if (pendingFrame) {
+        window.cancelAnimationFrame(pendingFrame)
+      }
+    })
 
     const dataDisposable = term.onData(data => {
       hasSessionActivityRef.current = true
@@ -877,7 +901,9 @@ export function useTerminalSession({
           )
 
           window.requestAnimationFrame(() => {
+            fitAndResize()
             term.clearSelection() // drop any selection painted over transient boot rows
+            term.focus()
           })
         })
         .catch(error => {
@@ -912,8 +938,12 @@ export function useTerminalSession({
         console.warn('[hermes-terminal] WebGL unavailable; falling back to DOM', err)
       }
 
-      fitAndResize(initialActiveRef.current)
-      initialActiveFitRef.current = initialActiveRef.current
+      // Join the shared-atlas refresh fan-out: this terminal's atlas-clear
+      // callers mutate a texture the siblings draw from, so they must rebuild
+      // their models too (see redrawAllTerminals in terminals.ts).
+      cleanup.push(registerWebglRefresh(term, () => webglRef.current))
+
+      fitAndResize()
       startSession()
     }
 
@@ -968,8 +998,10 @@ export function useTerminalSession({
       term.options.theme = withSurface(activeTheme)
       // The WebGL renderer caches glyph colors in a texture atlas, so a
       // light/dark switch leaves already-drawn cells stale until the atlas is
-      // cleared. No-op for the DOM fallback.
-      webglRef.current?.clearTextureAtlas()
+      // cleared. No-op for the DOM fallback. The atlas is shared across every
+      // terminal with the same render config, so the clear must fan out to the
+      // siblings too (see redrawAllTerminals) or they keep stale glyphs.
+      redrawAllTerminals()
     })
 
     return () => cancelAnimationFrame(raf)
@@ -988,39 +1020,26 @@ export function useTerminalSession({
     return term ? registerTerminalReader(id, makeTerminalReader(term)) : undefined
   }, [id, status])
 
-  // Only the active terminal observes its host. Every terminal stays mounted
-  // (PTY + scrollback preserved), but hidden tabs do no FitAddon/layout work.
-  // Re-activation owns one fit + atlas rebuild + redraw.
-  // eslint-disable-next-line no-restricted-syntax -- lifecycle flag prevents a duplicate first-mount fit
+  // On (re)activation: a WebGL terminal doesn't paint while visibility:hidden, so
+  // it reveals a stale/garbled frame. Refit, rebuild the glyph atlas, and force a
+  // full redraw against the live buffer, then focus. The atlas is shared across
+  // every terminal with the same render config, so rebuild ALL of them (see
+  // redrawAllTerminals) — refreshing only this one leaves its siblings drawing
+  // from wiped atlas pages.
   useEffect(() => {
     if (!active || status !== 'open') {
-      if (!active) {
-        initialActiveFitRef.current = false
-      }
-
       return
     }
 
-    const host = hostRef.current
+    const frame = requestAnimationFrame(() => {
+      const term = termRef.current
 
-    if (!host) {
-      return
-    }
-
-    const fitOnActivate = !initialActiveFitRef.current
-    initialActiveFitRef.current = false
-
-    return observeActiveTerminalResize(host, {
-      fitOnActivate,
-      onFit: () => fitRef.current?.(true),
-      onActivate: () => {
-        const term = termRef.current
-
-        webglRef.current?.clearTextureAtlas()
-        term?.refresh(0, term.rows - 1)
-        term?.focus()
-      }
+      fitRef.current?.()
+      redrawAllTerminals()
+      term?.focus()
     })
+
+    return () => cancelAnimationFrame(frame)
   }, [active, status])
 
   // Flush a queued command (e.g. a provider-disconnect) into the live session.


### PR DESCRIPTION
## What

The desktop integrated terminal intermittently renders garbled glyphs (#76102): text looks like plausible-but-wrong characters until a resize or `clear` forces a full refresh.

**Root cause** — xterm WebGL terminals that share one glyph atlas (same font/theme/DPR, which our terminals do — user + agent tabs all mount with the same render config) keep per-terminal render models over a **shared** texture. `WebglAddon.clearTextureAtlas()` wipes the shared texture pages and rebuilds only the *caller's* model. In @xterm/addon-webgl 0.19.0, `TextureAtlas.clearTexture()` never signals sibling renderers, so their stale cells draw whatever glyphs land in the freed atlas rows — garbled text until a resize triggers a full rebuild. Upstream fixed this in xtermjs/xterm.js#6055; we stay pinned on 0.19.0.

## How

Every atlas-mutating call site now fans out through `redrawAllTerminals()` (in `terminals.ts`), and every xterm registers its own redraw+atlas-rebuild on mount, unregistering on dispose:

- theme switch (light/dark or skin change) — both user terminal and agent terminal
- tab activation (a visibility:hidden WebGL terminal doesn't paint) — both
- the agent terminal's read-only mirror joins the same registry

This fixes the whole bug class (sibling call paths included), per AGENTS.md.

## Test

```bash
cd apps/desktop
npx vitest run src/app/right-sidebar/terminal/ --project ui   # 52 passed
npx tsc -p . --noEmit                                          # clean
npx eslint src/app/right-sidebar/terminal/                     # clean
```

New unit test asserts the registry invariant: a redraw fan-out reaches every registered terminal, and a disposed terminal stops being refreshed.

## Platforms

Linux (Ubuntu GNOME Wayland) — the reporter's environment. Change is renderer-side and platform-agnostic.

Closes #76102