### PR TITLE
fix(update): make npm recovery resumable on no-op retries (salvage #76250)

### DIFF
--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -272,16 +273,25 @@ def _print_manual_fix(
         )
         if part
     )
+    install_cmd = f"npm install -g {shlex.quote(f'npm@{npm_range}')}"
     print(
         "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
         + (f"  Current toolchain: {current}\n" if current else "")
         + f"  Required npm: {npm_range}\n"
         + f"  Resolved npm: {npm}\n"
+<<<<<<< HEAD
         + "  Hermes could not provision its own Node.js runtime and never\n"
         + "  modifies a system/nvm/brew/Nix npm. Upgrade yours yourself with:\n"
         + f'      npm install -g npm@"{npm_range}"\n'
         + "  If Node/npm are coupled by their version manager, select a\n"
         + "  compatible Node/npm pair instead, then re-run `hermes update`.\n"
+=======
+        + "  Hermes only upgrades npm inside its own managed Node install, so this\n"
+        + "  one is left alone. Install a compatible npm release yourself with:\n"
+        + f"      {install_cmd}\n"
+        + "  If Node/npm are coupled by their version manager, select "
+        + "a compatible Node/npm pair instead. Then re-run the original command.\n"
+>>>>>>> da24aa4154 (fix(npm): keep compatible remediation actionable)
         + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -43,6 +43,8 @@ from hermes_constants import (
 __all__ = [
     "is_ebadengine",
     "required_npm_range",
+    "actual_node_version",
+    "actual_npm_version",
     "managed_npm_prefix",
     "upgrade_managed_npm",
     "maybe_repair_npm_engine",
@@ -115,6 +117,18 @@ def actual_npm_version(output: str) -> str | None:
             continue
         if isinstance(parsed, dict) and parsed.get("npm"):
             return str(parsed["npm"]).strip()
+    return None
+
+
+def actual_node_version(output: str) -> str | None:
+    """Return the Node version npm reported as ``Actual`` in *output*."""
+    for match in _ACTUAL_RE.finditer(output or ""):
+        try:
+            parsed = json.loads(match.group(1))
+        except ValueError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("node"):
+            return str(parsed["node"]).strip().removeprefix("v")
     return None
 
 
@@ -244,14 +258,31 @@ def _probe_version(npm: str) -> str | None:
     return (result.stdout or "").strip() or None
 
 
-def _print_manual_fix(npm: str, npm_range: str, actual: str | None) -> None:
-    have = f"npm {actual} " if actual else "This npm "
+def _print_manual_fix(
+    npm: str,
+    npm_range: str,
+    actual_npm: str | None,
+    actual_node: str | None,
+) -> None:
+    current = ", ".join(
+        part
+        for part in (
+            f"Node {actual_node}" if actual_node else None,
+            f"npm {actual_npm}" if actual_npm else None,
+        )
+        if part
+    )
     print(
-        f"\n✗ {have}does not satisfy the range this project requires: {npm_range}\n"
-        f"  Resolved npm: {npm}\n"
-        "  Hermes could not provision its own Node.js runtime and never\n"
-        "  modifies a system/nvm/brew/Nix npm. Upgrade yours yourself with:\n"
-        f'      npm install -g npm@"{npm_range}"',
+        "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
+        + (f"  Current toolchain: {current}\n" if current else "")
+        + f"  Required npm: {npm_range}\n"
+        + f"  Resolved npm: {npm}\n"
+        + "  Hermes could not provision its own Node.js runtime and never\n"
+        + "  modifies a system/nvm/brew/Nix npm. Upgrade yours yourself with:\n"
+        + f'      npm install -g npm@"{npm_range}"\n'
+        + "  If Node/npm are coupled by their version manager, select a\n"
+        + "  compatible Node/npm pair instead, then re-run `hermes update`.\n"
+        + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )
 
@@ -335,5 +366,10 @@ def maybe_repair_npm_engine(
         return managed
 
     if not quiet and npm_range:
-        _print_manual_fix(npm, npm_range, actual_npm_version(output))
+        _print_manual_fix(
+            npm,
+            npm_range,
+            actual_npm_version(output),
+            actual_node_version(output),
+        )
     return None

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -273,28 +273,28 @@ def _print_manual_fix(
         )
         if part
     )
-    install_cmd = f"npm install -g {shlex.quote(f'npm@{npm_range}')}"
+    install_cmd = _manual_install_command(npm_range, windows=os.name == "nt")
     print(
         "\n✗ This Node/npm toolchain does not satisfy the project's engine requirements.\n"
         + (f"  Current toolchain: {current}\n" if current else "")
         + f"  Required npm: {npm_range}\n"
         + f"  Resolved npm: {npm}\n"
-<<<<<<< HEAD
         + "  Hermes could not provision its own Node.js runtime and never\n"
         + "  modifies a system/nvm/brew/Nix npm. Upgrade yours yourself with:\n"
-        + f'      npm install -g npm@"{npm_range}"\n'
+        + f"      {install_cmd}\n"
         + "  If Node/npm are coupled by their version manager, select a\n"
         + "  compatible Node/npm pair instead, then re-run `hermes update`.\n"
-=======
-        + "  Hermes only upgrades npm inside its own managed Node install, so this\n"
-        + "  one is left alone. Install a compatible npm release yourself with:\n"
-        + f"      {install_cmd}\n"
-        + "  If Node/npm are coupled by their version manager, select "
-        + "a compatible Node/npm pair instead. Then re-run the original command.\n"
->>>>>>> da24aa4154 (fix(npm): keep compatible remediation actionable)
         + "  Do not disable engine-strict; npm releases do not support every Node major.",
         file=sys.stderr,
     )
+
+
+def _manual_install_command(npm_range: str, *, windows: bool) -> str:
+    """Render the copy/paste remediation for the user's command shell."""
+    argv = ["npm", "install", "-g", f"npm@{npm_range}"]
+    if windows:
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)
 
 
 def _provision_managed_npm(npm_range: str | None, *, quiet: bool = False) -> str | None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3888,8 +3888,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # not the helpers' return values: missing npm is a soft skip in
             # _update_node_dependencies(), and _build_web_ui() may serve a
             # stale dist after a failed build.
+            from hermes_constants import get_default_hermes_root
+
             node_failures = _update_node_dependencies()
-            node_refresh_pending = _npm_lockfile_changed(_m().PROJECT_ROOT)
+            node_refresh_pending = _npm_lockfile_changed(
+                get_default_hermes_root()
+            )
             web_refresh_pending = False
             if not node_failures and not node_refresh_pending:
                 _m()._build_web_ui(_m().PROJECT_ROOT / "web")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3884,10 +3884,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # "fix npm and re-run hermes update" recovery lands in this
             # commit_count == 0 branch. Re-check the manifest digest here and
             # rebuild a stale web bundle after the dependency refresh succeeds.
+            # Successful recovery is defined by the persisted digest/stamp,
+            # not the helpers' return values: missing npm is a soft skip in
+            # _update_node_dependencies(), and _build_web_ui() may serve a
+            # stale dist after a failed build.
             node_failures = _update_node_dependencies()
-            web_ok = False
-            if not node_failures:
-                web_ok = _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+            node_refresh_pending = _npm_lockfile_changed(_m().PROJECT_ROOT)
+            web_refresh_pending = False
+            if not node_failures and not node_refresh_pending:
+                _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+                web_refresh_pending = _m()._web_ui_build_needed(
+                    _m().PROJECT_ROOT / "web"
+                )
 
             healthy, detail = _venv_core_imports_healthy()
             if not healthy:
@@ -3929,7 +3937,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
-            elif node_failures or not web_ok:
+            elif node_failures or node_refresh_pending or web_refresh_pending:
                 print(
                     "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
                 )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3941,12 +3941,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
-            elif node_failures or node_refresh_pending or web_refresh_pending:
+            if node_failures or node_refresh_pending or web_refresh_pending:
                 print(
                     "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
                 )
                 print("  Fix the npm error above and re-run `hermes update`.")
-            else:
+            elif healthy:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3879,6 +3879,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # versions). Probe the venv's core imports and repair if broken —
             # otherwise "Already up to date!" gaslights the user while their
             # install stays bricked.
+            # The same is true for Node dependencies. A failed npm refresh has
+            # already moved HEAD to the fetched commit, so the documented
+            # "fix npm and re-run hermes update" recovery lands in this
+            # commit_count == 0 branch. Re-check the manifest digest here and
+            # rebuild a stale web bundle after the dependency refresh succeeds.
+            node_failures = _update_node_dependencies()
+            web_ok = False
+            if not node_failures:
+                web_ok = _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+
             healthy, detail = _venv_core_imports_healthy()
             if not healthy:
                 print("⚠ Checkout is current, but the venv is unhealthy:")
@@ -3919,6 +3929,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
+            elif node_failures or not web_ok:
+                print(
+                    "⚠ Checkout is current, but Node.js dependency recovery is still incomplete."
+                )
+                print("  Fix the npm error above and re-run `hermes update`.")
             else:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -256,13 +256,17 @@ class TestCmdUpdateBranchFallback:
         from hermes_cli import update_cmd
 
         mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        shared_hermes_root = PROJECT_ROOT / ".test-hermes-root"
         with patch.object(
             hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch(
+            "hermes_constants.get_default_hermes_root",
+            return_value=shared_hermes_root,
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=[]
         ) as refresh_node, patch.object(
             update_cmd, "_npm_lockfile_changed", return_value=False
-        ), patch.object(
+        ) as refresh_pending, patch.object(
             hm, "_build_web_ui", return_value=True
         ) as build_web, patch.object(
             hm, "_web_ui_build_needed", return_value=False
@@ -272,6 +276,7 @@ class TestCmdUpdateBranchFallback:
             cmd_update(mock_args)
 
         refresh_node.assert_called_once_with()
+        refresh_pending.assert_called_once_with(shared_hermes_root)
         build_web.assert_called_once_with(PROJECT_ROOT / "web")
         assert "Already up to date!" in capsys.readouterr().out
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -366,6 +366,43 @@ class TestCmdUpdateBranchFallback:
         assert "Already up to date!" not in out
         assert "Node.js dependency recovery is still incomplete" in out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_reports_node_failure_while_repairing_venv(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Python repair must not mask an independently incomplete Node refresh."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=["repo root"]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd,
+            "_venv_core_imports_healthy",
+            side_effect=[(False, "missing imports"), (True, "ok")],
+        ), patch(
+            "hermes_cli.managed_uv.ensure_uv", return_value="/managed/uv"
+        ), patch.object(
+            update_cmd, "venv_python_path", return_value=PROJECT_ROOT / "venv" / "python"
+        ), patch.object(
+            hm, "_install_python_dependencies_with_optional_fallback"
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Dependencies repaired!" in out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -215,6 +215,7 @@ class TestCmdUpdateBranchFallback:
         origin but behind NousResearch/hermes-agent silently misses updates.
         """
         from hermes_cli import main as hm
+        from hermes_cli import update_cmd
 
         mock_run.side_effect = _make_run_side_effect(
             branch="main", verify_ok=True, commit_count="0"
@@ -224,7 +225,17 @@ class TestCmdUpdateBranchFallback:
             hm,
             "_get_origin_url",
             return_value="https://github.com/example/hermes-agent.git",
-        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock, patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
+            hm, "_build_web_ui", return_value=True
+        ), patch.object(
+            hm, "_web_ui_build_needed", return_value=False
+        ), patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
             cmd_update(mock_args)
 
         expected_git_cmd = (
@@ -250,8 +261,12 @@ class TestCmdUpdateBranchFallback:
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=[]
         ) as refresh_node, patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
             hm, "_build_web_ui", return_value=True
         ) as build_web, patch.object(
+            hm, "_web_ui_build_needed", return_value=False
+        ), patch.object(
             update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
         ):
             cmd_update(mock_args)
@@ -274,6 +289,8 @@ class TestCmdUpdateBranchFallback:
         ), patch.object(
             update_cmd, "_update_node_dependencies", return_value=["repo root"]
         ) as refresh_node, patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
             hm, "_build_web_ui"
         ) as build_web, patch.object(
             update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
@@ -286,6 +303,63 @@ class TestCmdUpdateBranchFallback:
         assert "Already up to date!" not in out
         assert "Node.js dependency recovery is still incomplete" in out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_treats_stale_manifest_digest_as_incomplete(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Missing npm is a soft skip, not successful stale dependency repair."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=True
+        ), patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_checks_web_stamp_after_soft_build_success(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """A stale-dist fallback must not be reported as completed recovery."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ), patch.object(
+            update_cmd, "_npm_lockfile_changed", return_value=False
+        ), patch.object(
+            hm, "_build_web_ui", return_value=True
+        ) as build_web, patch.object(
+            hm, "_web_ui_build_needed", return_value=True
+        ), patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        build_web.assert_called_once_with(PROJECT_ROOT / "web")
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -234,6 +234,58 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_repairs_stale_node_deps_and_web_ui(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """The documented recovery after a partial npm update must work even
+        when the failed pull already moved HEAD to the latest commit."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=[]
+        ) as refresh_node, patch.object(
+            hm, "_build_web_ui", return_value=True
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        refresh_node.assert_called_once_with()
+        build_web.assert_called_once_with(PROJECT_ROOT / "web")
+        assert "Already up to date!" in capsys.readouterr().out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_up_to_date_rerun_does_not_claim_success_when_node_repair_fails(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(commit_count="0")
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+        ), patch.object(
+            update_cmd, "_update_node_dependencies", return_value=["repo root"]
+        ) as refresh_node, patch.object(
+            hm, "_build_web_ui"
+        ) as build_web, patch.object(
+            update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ):
+            cmd_update(mock_args)
+
+        refresh_node.assert_called_once_with()
+        build_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Already up to date!" not in out
+        assert "Node.js dependency recovery is still incomplete" in out
+
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.npm_engine import (
+    actual_node_version,
     actual_npm_version,
     is_ebadengine,
     managed_npm_prefix,
@@ -28,6 +29,13 @@ npm error engine Not compatible with your version of node/npm: hermes-agent@1.0.
 npm error notsup Not compatible with your version of node/npm: hermes-agent@1.0.0
 npm error notsup Required: {"node":">=20.0.0","npm":"<11.10.0 || >=12.0.0"}
 npm error notsup Actual:   {"npm":"11.10.0","node":"v22.23.1"}
+"""
+
+NODE25_EBADENGINE_OUTPUT = """
+npm error code EBADENGINE
+npm error engine Unsupported engine
+npm error notsup Required: {"node":">=20.0.0","npm":"<11.10.0 || >=12.0.0"}
+npm error notsup Actual:   {"node":"v25.9.0","npm":"11.12.1"}
 """
 
 LEGACY_EBADENGINE_OUTPUT = """
@@ -62,6 +70,7 @@ class TestDetection:
 
     def test_actual_version_is_reported_back(self):
         assert actual_npm_version(EBADENGINE_OUTPUT) == "11.10.0"
+        assert actual_node_version(EBADENGINE_OUTPUT) == "22.23.1"
 
     def test_no_range_for_non_engine_output(self):
         assert required_npm_range(ELOCK_OUTPUT) is None
@@ -242,11 +251,19 @@ class TestRepairDecision:
         monkeypatch.setattr(
             npm_engine, "bootstrap_hermes_managed_node", lambda: None
         )
-        assert not maybe_repair_npm_engine(str(system_npm), EBADENGINE_OUTPUT)
+        assert not maybe_repair_npm_engine(
+            str(system_npm), NODE25_EBADENGINE_OUTPUT
+        )
 
-        # The user gets the exact command to run, since we refuse to run it.
+        # A foreign npm stays untouched. The guidance names the actual
+        # Node/npm pair, gives the exact upgrade command, and warns about
+        # version managers that couple Node and npm.
         err = capsys.readouterr().err
+        assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
+        assert "Required npm: <11.10.0 || >=12.0.0" in err
         assert 'npm install -g npm@"<11.10.0 || >=12.0.0"' in err
+        assert "compatible Node/npm pair" in err
+        assert "re-run `hermes update`" in err
 
     def test_non_engine_failure_never_repairs(self, managed_npm, monkeypatch):
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.npm_engine import (
+    _manual_install_command,
     actual_node_version,
     actual_npm_version,
     is_ebadengine,
@@ -91,6 +92,21 @@ class TestDetection:
             "npm error notsup Required: {not json}\n"
         )
         assert required_npm_range(broken) is None
+
+    @pytest.mark.parametrize(
+        ("windows", "expected"),
+        [
+            (False, "npm install -g 'npm@<11.10.0 || >=12.0.0'"),
+            (True, 'npm install -g "npm@<11.10.0 || >=12.0.0"'),
+        ],
+    )
+    def test_manual_install_command_quotes_range_for_target_shell(
+        self, windows, expected
+    ):
+        assert (
+            _manual_install_command("<11.10.0 || >=12.0.0", windows=windows)
+            == expected
+        )
 
 
 class TestManagedDetection:
@@ -255,28 +271,15 @@ class TestRepairDecision:
             str(system_npm), NODE25_EBADENGINE_OUTPUT
         )
 
-<<<<<<< HEAD
-        # A foreign npm stays untouched. The guidance names the actual
-        # Node/npm pair, gives the exact upgrade command, and warns about
-        # version managers that couple Node and npm.
-        err = capsys.readouterr().err
-        assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
-        assert "Required npm: <11.10.0 || >=12.0.0" in err
-        assert 'npm install -g npm@"<11.10.0 || >=12.0.0"' in err
-        assert "compatible Node/npm pair" in err
-        assert "re-run `hermes update`" in err
-=======
         # A foreign npm stays untouched. The guidance reports the current pair,
         # preserves an actionable, shell-safe range command (npm resolves a
         # Node-compatible release), and also covers coupled Node/npm managers.
         err = capsys.readouterr().err
         assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
         assert "Required npm: <11.10.0 || >=12.0.0" in err
-        assert "Install a compatible npm release" in err
         assert "npm install -g 'npm@<11.10.0 || >=12.0.0'" in err
-        assert "select a compatible Node/npm pair instead" in err
-        assert "re-run the original command" in err
->>>>>>> da24aa4154 (fix(npm): keep compatible remediation actionable)
+        assert "compatible Node/npm pair" in err
+        assert "re-run `hermes update`" in err
 
     def test_non_engine_failure_never_repairs(self, managed_npm, monkeypatch):
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -255,6 +255,7 @@ class TestRepairDecision:
             str(system_npm), NODE25_EBADENGINE_OUTPUT
         )
 
+<<<<<<< HEAD
         # A foreign npm stays untouched. The guidance names the actual
         # Node/npm pair, gives the exact upgrade command, and warns about
         # version managers that couple Node and npm.
@@ -264,6 +265,18 @@ class TestRepairDecision:
         assert 'npm install -g npm@"<11.10.0 || >=12.0.0"' in err
         assert "compatible Node/npm pair" in err
         assert "re-run `hermes update`" in err
+=======
+        # A foreign npm stays untouched. The guidance reports the current pair,
+        # preserves an actionable, shell-safe range command (npm resolves a
+        # Node-compatible release), and also covers coupled Node/npm managers.
+        err = capsys.readouterr().err
+        assert "Current toolchain: Node 25.9.0, npm 11.12.1" in err
+        assert "Required npm: <11.10.0 || >=12.0.0" in err
+        assert "Install a compatible npm release" in err
+        assert "npm install -g 'npm@<11.10.0 || >=12.0.0'" in err
+        assert "select a compatible Node/npm pair instead" in err
+        assert "re-run the original command" in err
+>>>>>>> da24aa4154 (fix(npm): keep compatible remediation actionable)
 
     def test_non_engine_failure_never_repairs(self, managed_npm, monkeypatch):
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached


### PR DESCRIPTION
## Summary

`hermes update` re-runs after a failed Node dependency refresh now actually repair the install instead of printing "Already up to date!" while leaving stale Node deps and a stale web UI. Salvage of #76250 by @hanzckernel, rebased onto the post-#76464 recovery contract.

A failed npm refresh has already moved HEAD to the fetched commit, so the documented "fix npm and re-run `hermes update`" recovery lands in the `commit_count == 0` branch — which previously only repaired Python deps. The retry returned "Already up to date!" without retrying npm or rebuilding the web UI.

## Changes

- `hermes_cli/update_cmd.py`: the zero-new-commit path re-checks the npm manifest digest, re-runs the Node dependency refresh, rebuilds a stale web bundle, and reports "Node.js dependency recovery is still incomplete" instead of a false success when it isn't. Recovery success is judged by the persisted digest/stamp, not helper return values (missing npm is a soft skip; a failed web build can serve a stale dist).
- `hermes_cli/npm_engine.py`: EBADENGINE diagnostics now report the actual Node+npm pair (`actual_node_version()`), render the manual command shell-safely per platform (`shlex.join` / `list2cmdline`), and warn about version managers that couple Node and npm. Merged with the managed-runtime provisioning flow from #76464 — the manual hint remains the fallback when provisioning fails.
- Tests: resumable-recovery coverage in `test_cmd_update.py` (repairs on re-run, refuses false success on failed/soft-skipped repair, web-stamp check after soft build success), diagnostics coverage in `test_npm_engine.py`.

Contributor commits cherry-picked with authorship preserved (5 commits by @hanzckernel); conflicts against the #76464 provisioning flow resolved in favor of both: provisioning first, hanzckernel's richer diagnostic as the fallback.

## Validation

| | Before | After |
|---|---|---|
| Re-run after failed npm refresh (HEAD current) | "Already up to date!", npm never retried | Node deps refreshed, web UI rebuilt |
| Repair fails / npm missing on re-run | false "Already up to date!" | "recovery is still incomplete" + guidance |
| EBADENGINE manual hint | npm-only version, unquoted range | Node+npm pair, shell-safe command, pair guidance |

117 targeted tests green (`test_npm_engine.py`, `test_cmd_update.py`, `test_web_ui_build.py`, `test_hermes_constants.py`); ruff clean.

Closes #76250.

## Infographic

![Resumable npm recovery](https://v3b.fal.media/files/b/0aa4a6fd/oU9BTiMGikiDZ_fZhb_r__IGnsbmVi.png)
