### PR TITLE
fix(agent): multimodal-aware context token estimation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -90,19 +90,150 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
       - dict with ``messages`` -> Chat Completions (+ ``tools`` if present)
       - dict with ``input`` -> Responses API (+ ``instructions``/``tools``)
       - any other dict -> fall back to summing string values
+
+    Multimodal payloads (structured ``image_url`` / ``input_image`` /
+    ``image`` parts) are NOT counted as raw text: the base64 transport bytes
+    would inflate the estimate ~4x (issue #76411) and shift the watchdog
+    tiers. Only the conversational region (``messages`` / ``input``) is
+    walked for image parts; each image contributes a fixed bounded visual
+    cost and surrounding text still counts (text chars are accumulated and
+    divided once, so short fragments keep their remainders). A plain string
+    that happens to look like a data URL remains text — only structured
+    multimodal parts switch modes. ``tools`` and ``instructions`` stay
+    opaque with the legacy ``len(str(...))`` cost. Pure-text payloads keep
+    the exact legacy char/4 estimate.
     """
 
-    def _chars(value: Any) -> int:
-        if value is None:
-            return 0
-        if isinstance(value, str):
-            return len(value)
-        return len(str(value))
+    target, extra_chars = _estimation_parts(api_payload)
+    has_image, text_chars, image_tokens = _scan_context_payload(target)
+    if not has_image:
+        return _legacy_estimate(api_payload)
+    # Multimodal payload: bounded per-image cost + accumulated text.
+    # Opaque fields (tools/instructions) keep legacy char cost and share
+    # the single //4 so remainders are not dropped twice.
+    return (text_chars + extra_chars) // 4 + image_tokens
+
+
+# ── Multimodal-aware context scan (issue #76411) ──────────────────────────
+#
+# Structured image parts must NOT have their base64 transport counted as
+# text: that encoding inflates the estimate ~4x and shifts the watchdog
+# tiers. Each image contributes a fixed bounded cost; surrounding text
+# still counts. The scan is a single iterative pass (explicit stack — no
+# recursion, no depth limit) that returns ``(has_image, text_chars,
+# image_tokens)``, so the detector and the estimator can never disagree
+# and no subtree is silently dropped.
+#
+# Only structured multimodal parts (image_url / input_image / image with
+# their expected fields) switch modes. A plain string that looks like a
+# data URL is still text. Multimodal scanning is limited to messages /
+# input; tools and instructions use the legacy opaque char estimate.
+#
+# This PR intentionally does not decode image payloads; a fixed bounded cost
+# replaces byte-dependent inflation with a stable visual estimate. It does
+# not try to reproduce any provider's image tokenizer.
+
+# Bounded default visual cost per image. A screenshot (1920x1080) would
+# tile to more than this under a tile-based heuristic; the point here is a
+# stable per-image bound, not a per-provider ground truth.
+_DEFAULT_IMAGE_TOKEN_ESTIMATE = 170
+
+
+def _legacy_chars(value: Any) -> int:
+    """Opaque char count matching the historical estimator."""
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    return len(str(value))
+
+
+def _is_multimodal_part(part: Any) -> bool:
+    """True for a content part that carries an image (any provider shape).
+
+    Requires the structural field expected for each shape so bare tool-schema
+    dicts like ``{"type": "image", "description": "..."}`` are not treated as
+    multimodal content.
+    """
+    if not isinstance(part, dict):
+        return False
+    part_type = part.get("type")
+    if part_type == "image_url":
+        return "image_url" in part
+    if part_type == "input_image":
+        return "image_url" in part or "file_id" in part
+    if part_type == "image":
+        return "source" in part
+    return False
+
+
+def _estimation_parts(api_payload: Any) -> tuple:
+    """Split the payload into a multimodal-scannable region and opaque chars.
+
+    Only ``messages`` / ``input`` (and bare message lists) are walked for
+    images. ``tools`` and ``instructions`` stay opaque with the legacy char
+    cost — same fields the legacy path counted, without interpreting tool
+    schemas as multimodal content.
+    """
+    if isinstance(api_payload, list):
+        return api_payload, 0
+    if isinstance(api_payload, dict):
+        messages = api_payload.get("messages")
+        if isinstance(messages, list):
+            extra_chars = 0
+            if "tools" in api_payload:
+                extra_chars += _legacy_chars(api_payload.get("tools"))
+            return messages, extra_chars
+        if "input" in api_payload:
+            extra_chars = (
+                _legacy_chars(api_payload.get("instructions"))
+                + _legacy_chars(api_payload.get("tools"))
+            )
+            return api_payload.get("input"), extra_chars
+        return list(api_payload.values()), 0
+    return api_payload, 0
+
+
+def _scan_context_payload(value: Any) -> tuple:
+    """Single iterative pass returning ``(has_image, text_chars, image_tokens)``.
+
+    Structured image parts cost a fixed amount and are not walked further
+    (so nested base64 transport bytes never count as text). Plain strings —
+    including a data URL used as textual content — always add their chars.
+    Containers are walked with an explicit stack, never stringified, so a
+    structured image nested at any depth is still detected and no deep text
+    subtree is dropped.
+    """
+    has_image = False
+    text_chars = 0
+    image_tokens = 0
+    stack = [value]
+    while stack:
+        node = stack.pop()
+        if _is_multimodal_part(node):
+            has_image = True
+            image_tokens += _DEFAULT_IMAGE_TOKEN_ESTIMATE
+            # Do not descend: base64 inside the part must not count as text.
+        elif isinstance(node, str):
+            text_chars += len(node)
+        elif isinstance(node, list):
+            stack.extend(node)
+        elif isinstance(node, dict):
+            stack.extend(node.values())
+        elif node is None:
+            continue
+        else:
+            text_chars += len(str(node))
+    return has_image, text_chars, image_tokens
+
+
+def _legacy_estimate(api_payload: Any) -> int:
+    """The original char/4 estimate, byte-for-byte unchanged."""
 
     def _message_chars(messages: Any) -> int:
         if not isinstance(messages, list):
-            return _chars(messages)
-        return sum(_chars(item) for item in messages)
+            return _legacy_chars(messages)
+        return sum(_legacy_chars(item) for item in messages)
 
     if isinstance(api_payload, list):
         return _message_chars(api_payload) // 4
@@ -112,20 +243,20 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
         if isinstance(messages, list):
             total_chars = _message_chars(messages)
             if "tools" in api_payload:
-                total_chars += _chars(api_payload.get("tools"))
+                total_chars += _legacy_chars(api_payload.get("tools"))
             return total_chars // 4
 
         if "input" in api_payload:
             total_chars = (
-                _chars(api_payload.get("input"))
-                + _chars(api_payload.get("instructions"))
-                + _chars(api_payload.get("tools"))
+                _legacy_chars(api_payload.get("input"))
+                + _legacy_chars(api_payload.get("instructions"))
+                + _legacy_chars(api_payload.get("tools"))
             )
             return total_chars // 4
 
-        return sum(_chars(value) for value in api_payload.values()) // 4
+        return sum(_legacy_chars(value) for value in api_payload.values()) // 4
 
-    return _chars(api_payload) // 4
+    return _legacy_chars(api_payload) // 4
 
 
 def _is_openai_codex_backend(agent) -> bool:

--- a/tests/agent/test_context_estimator_multimodal.py
+++ b/tests/agent/test_context_estimator_multimodal.py
@@ -1,0 +1,507 @@
+"""Tests for multimodal-aware context estimation (issue #76411).
+
+Reproduces the base64 inflation: the legacy estimator counts base64 image
+bytes as text (``len(str(payload)) // 4``), inflating the estimate ~4x
+and shifting watchdog tiers. These tests pin the properties of the
+multimodal-aware walker:
+
+- base64 byte size must NOT drive the estimate proportionally;
+- text around images is still counted;
+- distinct images still contribute (per-image cost);
+- data URLs are not ignored entirely — bounded visual cost;
+- pure-text payloads keep the exact legacy estimate (backward compat);
+- both Chat Completions (``image_url``) and Responses (``input_image``)
+  shapes are interpreted;
+- the estimate selects the expected watchdog tier.
+
+See contribution-queue/issues/76411-multimodal-context-estimator.md for
+the design and the PR-declaration boundary (estimator only; payload
+deduplication is a separate follow-up).
+"""
+
+from __future__ import annotations
+
+import copy
+
+
+# ── payload builders ──────────────────────────────────────────────────────
+
+
+def _b64(chars: str) -> str:
+    """A data-URL image payload. Real base64 content is not required for
+    the estimator; the walker must not depend on decodable bytes."""
+    return "data:image/png;base64," + chars
+
+
+def _chat_payload(*, text: str = "", images: list[str] | None = None) -> dict:
+    """Chat Completions payload with optional multimodal content parts."""
+    images = images or []
+    content: list = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for url in images:
+        content.append({"type": "image_url", "image_url": {"url": url}})
+    if len(content) == 1 and content[0]["type"] == "text":
+        content = text  # plain string content for pure-text shape
+    return {"model": "gpt-5.5", "messages": [{"role": "user", "content": content}]}
+
+
+def _codex_payload(*, text: str = "", images: list[str] | None = None) -> dict:
+    """Responses API payload with input_text / input_image items."""
+    images = images or []
+    inp: list = []
+    if text:
+        inp.append({"type": "input_text", "text": text})
+    for url in images:
+        inp.append({"type": "input_image", "image_url": url})
+    return {"model": "gpt-5.5", "input": inp}
+
+
+# ── core properties ───────────────────────────────────────────────────────
+
+
+def test_base64_size_does_not_drive_estimate_linear():
+    """Growing base64 size must NOT change the estimate at all.
+
+    Same structure, only base64 size differs -> identical estimate. This is
+    the reproduction: the legacy estimator returns ~chars/4, so a
+    100_000-char data URL estimates ~25k tokens from the image alone.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    small = _chat_payload(text="describe", images=[_b64("a" * 100)])
+    large = _chat_payload(text="describe", images=[_b64("a" * 100_000)])
+    small_est = estimate_request_context_tokens(small)
+    large_est = estimate_request_context_tokens(large)
+    # A 1000x byte growth must produce ZERO change: base64 is never text.
+    assert large_est == small_est, (
+        f"base64 inflation: small={small_est} large={large_est}"
+    )
+
+
+def test_irrelevant_metadata_not_counted_in_multimodal_mode():
+    """Multimodal mode must count the same fields the legacy path counted.
+
+    Review finding: the walker must not start counting ``model`` or random
+    metadata just because an image is present — that would change the
+    textual semantics purely from the image's existence.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    base = _codex_payload(text="describe", images=[_b64("a" * 1000)])
+    with_metadata = dict(base)
+    with_metadata["irrelevant_metadata"] = "x" * 100_000
+    assert estimate_request_context_tokens(with_metadata) == estimate_request_context_tokens(
+        base
+    )
+
+
+def test_text_around_image_still_counted():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    img = [_b64("a" * 1000)]
+    with_text = _chat_payload(text="describe this in detail please", images=img)
+    without_text = _chat_payload(text="", images=img)
+    assert estimate_request_context_tokens(with_text) > estimate_request_context_tokens(
+        without_text
+    )
+
+
+def test_distinct_images_still_contribute():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    one = _chat_payload(text="describe", images=[_b64("a" * 1000)])
+    two = _chat_payload(text="describe", images=[_b64("a" * 1000), _b64("b" * 1000)])
+    assert estimate_request_context_tokens(two) > estimate_request_context_tokens(one)
+
+
+def test_data_url_not_ignored_gets_bounded_cost():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    no_image = _chat_payload(text="describe", images=[])
+    with_image = _chat_payload(text="describe", images=[_b64("a" * 1000)])
+    # Image contributes a bounded visual cost, so the estimate grows.
+    assert estimate_request_context_tokens(with_image) > estimate_request_context_tokens(
+        no_image
+    )
+
+
+def test_pure_text_payload_unchanged():
+    """Backward compat: a text-only payload yields the exact legacy estimate."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    text = "hello world this is a test message"
+    payload = _chat_payload(text=text)
+    # Legacy semantics for a dict with `messages`: sum of str(item) // 4.
+    legacy = sum(len(str(item)) for item in payload["messages"]) // 4
+    assert estimate_request_context_tokens(payload) == legacy
+
+
+def test_short_text_fragments_match_single_text_block():
+    """Short fragments must not lose division remainders vs one block.
+
+    Uses plain string content parts so structural metadata is identical on
+    both sides — this isolates remainder accumulation and does not couple
+    the assertion to whether typed parts also count the value ``"text"``.
+    Per-fragment ``// 4`` would score 100 single-char strings as 0 text
+    tokens; a single 100-char string scores 25. Accumulating before the
+    single final division makes both shapes match (within one token of
+    combined-division remainder).
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    image_part = {"type": "image_url", "image_url": {"url": _b64("a" * 1000)}}
+    fragmented = {
+        "messages": [
+            {
+                "role": "user",
+                "content": (["a"] * 100) + [image_part],
+            }
+        ],
+    }
+    combined = {
+        "messages": [
+            {
+                "role": "user",
+                "content": ["a" * 100, image_part],
+            }
+        ],
+    }
+    fragmented_est = estimate_request_context_tokens(fragmented)
+    combined_est = estimate_request_context_tokens(combined)
+    assert abs(fragmented_est - combined_est) <= 1, (
+        f"short fragments diverged from combined block: "
+        f"fragmented={fragmented_est} combined={combined_est}"
+    )
+
+
+def test_chat_and_responses_shapes_both_handled():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    url = _b64("a" * 10_000)  # ~2500 tokens if counted as text
+    chat = _chat_payload(text="describe", images=[url])
+    codex = _codex_payload(text="describe", images=[url])
+    chat_est = estimate_request_context_tokens(chat)
+    codex_est = estimate_request_context_tokens(codex)
+    # Both shapes must understand the image as a bounded visual cost, NOT
+    # count the base64 (~2500 tokens) as text.
+    assert chat_est < 500, f"chat shape inflated: {chat_est}"
+    assert codex_est < 500, f"responses shape inflated: {codex_est}"
+
+
+# ── watchdog tier selection ───────────────────────────────────────────────
+
+
+def test_large_image_does_not_select_giant_tier():
+    """A single large image must select the LOWEST watchdog tier.
+
+    Legacy would estimate ~125k tokens -> 1200s floor (giant tier). The
+    multimodal scan must stay bounded: image cost (170) + tiny text.
+    """
+    from agent.chat_completion_helpers import (
+        estimate_request_context_tokens,
+        openai_codex_stale_timeout_floor,
+    )
+
+    big = _codex_payload(text="describe", images=[_b64("a" * 500_000)])
+    est = estimate_request_context_tokens(big)
+    # Concrete expected tier: < 10k tokens -> no floor engaged (0.0).
+    assert est < 10_000, f"giant tier triggered by single image: est={est}"
+    assert openai_codex_stale_timeout_floor(est) == 0.0, (
+        f"expected lowest tier, got floor for est={est}"
+    )
+
+
+# ── hardening ─────────────────────────────────────────────────────────────
+
+
+def test_unknown_multimodal_part_uses_fallback_not_zero():
+    """Unknown parts contribute their full text (never dropped to zero)."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    image_part = {"type": "image_url", "image_url": {"url": _b64("a" * 1000)}}
+    without_audio = {
+        "model": "gpt-5.5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    image_part,
+                ],
+            }
+        ],
+    }
+    with_audio = {
+        "model": "gpt-5.5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    image_part,
+                    {"type": "audio", "input_audio": {"data": "A" * 10_000}},
+                ],
+            }
+        ],
+    }
+    increase = (
+        estimate_request_context_tokens(with_audio)
+        - estimate_request_context_tokens(without_audio)
+    )
+    # Audio data (10_000 chars) must contribute ~10_000 // 4 tokens, not be
+    # dropped or truncated to a token or two.
+    assert increase >= 10_000 // 4, f"audio text undercounted: increase={increase}"
+
+
+def test_unknown_wrapper_does_not_recount_base64_as_text():
+    """Structured image nested in an unknown wrapper must not scale with bytes.
+
+    The walker recurses into arbitrary wrappers and recognizes the structured
+    multimodal part inside — base64 transport under the part is never
+    stringified as text. A bare data-URL string (no structured part) is
+    deliberately treated as text; see
+    ``test_plain_text_data_url_remains_text``.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    def wrap(url: str) -> dict:
+        return {
+            "model": "gpt-5.5",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "custom": {
+                            "image": {
+                                "type": "input_image",
+                                "image_url": url,
+                            }
+                        }
+                    },
+                }
+            ],
+        }
+
+    small = wrap(_b64("a" * 100))
+    large = wrap(_b64("a" * 100_000))
+    small_est = estimate_request_context_tokens(small)
+    large_est = estimate_request_context_tokens(large)
+    assert large_est == small_est, (
+        f"base64 re-counted through unknown wrapper: "
+        f"small={small_est} large={large_est}"
+    )
+
+
+def test_plain_text_data_url_remains_text():
+    """A data URL used as plain string content is text, not an image.
+
+    Only structured multimodal parts switch estimation modes. A user
+    (or tool result) that pastes a data URL as a string must keep the
+    exact legacy char/4 cost — otherwise ~25k text tokens collapse to 170.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "data:image/png;base64," + "A" * 100_000,
+            }
+        ]
+    }
+    legacy = sum(len(str(item)) for item in payload["messages"]) // 4
+    assert estimate_request_context_tokens(payload) == legacy
+
+
+def test_corrupt_base64_does_not_break_estimator():
+    """Corrupt base64 still gets the same bounded visual cost as valid data URLs."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    bad = _chat_payload(text="describe", images=["data:image/png;base64,!!!not-valid!!!"])
+    good = _chat_payload(text="describe", images=[_b64("a" * 1000)])
+    # Estimator never decodes image bytes, so corrupt and well-formed data
+    # URLs of the same shape must cost the same.
+    assert estimate_request_context_tokens(bad) == estimate_request_context_tokens(good)
+
+
+def test_http_image_url_bounded_fallback_without_download():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    payload = {
+        "model": "gpt-5.5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/huge.jpg"},
+                    }
+                ],
+            }
+        ],
+    }
+    # Must not attempt a download; bounded fallback.
+    est = estimate_request_context_tokens(payload)
+    assert 0 < est < 100_000
+
+
+def test_same_image_twice_counted_twice_until_payload_dedup():
+    """No estimator-side dedup: two occurrences count two visual costs.
+
+    While the payload still transmits the image twice, counting it once
+    would underestimate the work actually sent to the provider.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    url = _b64("a" * 1000)
+    one = _codex_payload(text="describe", images=[url])
+    two = _codex_payload(text="describe", images=[url, url])
+    assert estimate_request_context_tokens(two) > estimate_request_context_tokens(one)
+
+
+def test_metadata_and_tools_still_contribute():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    base = _codex_payload(text="describe", images=[_b64("a" * 1000)])
+    with_tools = dict(base)
+    with_tools["tools"] = [{"name": "t", "description": "d" * 500}]
+    assert estimate_request_context_tokens(with_tools) > estimate_request_context_tokens(base)
+
+
+def test_tool_schema_type_image_does_not_trigger_multimodal_mode():
+    """Tool schemas with type=image must keep the exact legacy estimate.
+
+    tools are opaque metadata, not multimodal content. A schema dict with
+    ``"type": "image"`` must not false-trigger multimodal mode and drop a
+    large description to a single fixed image cost.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    payload = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [{"type": "image", "description": "x" * 10_000}],
+    }
+    legacy = (
+        sum(len(str(item)) for item in payload["messages"])
+        + len(str(payload["tools"]))
+    ) // 4
+    assert estimate_request_context_tokens(payload) == legacy
+
+
+def test_tools_keep_legacy_cost_when_messages_are_multimodal():
+    """When messages carry a real image, tools still use opaque legacy cost."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    base = _chat_payload(text="describe", images=[_b64("a" * 1_000)])
+    with_tools = dict(base)
+    with_tools["tools"] = [
+        {
+            "name": "large_tool",
+            "description": "x" * 10_000,
+        }
+    ]
+    increase = (
+        estimate_request_context_tokens(with_tools)
+        - estimate_request_context_tokens(base)
+    )
+    # -1 accommodates only the combined-division remainder.
+    assert increase >= len(str(with_tools["tools"])) // 4 - 1
+
+
+def test_instructions_keep_legacy_cost_when_input_is_multimodal():
+    """Responses instructions stay opaque even when input has an image."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    base = _codex_payload(text="describe", images=[_b64("a" * 1_000)])
+    with_instructions = dict(base)
+    with_instructions["instructions"] = "y" * 10_000
+    increase = (
+        estimate_request_context_tokens(with_instructions)
+        - estimate_request_context_tokens(base)
+    )
+    assert increase >= len(str(with_instructions["instructions"])) // 4 - 1
+
+
+def test_deeply_nested_image_does_not_fall_back_to_base64_counting():
+    """A structured image nested beyond any depth cap must still be detected.
+
+    The scan is iterative (explicit stack), so no depth limit can silently
+    send the payload back to the legacy path where base64 is text. Nest the
+    whole multimodal part — a bare data-URL string is text, not an image.
+    """
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    def deeply_wrap(url: str, depth: int = 200) -> dict:
+        node: object = {
+            "type": "image_url",
+            "image_url": {"url": url},
+        }
+        for _ in range(depth):
+            node = {"nested": node}
+        return {
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": node}],
+        }
+
+    small = deeply_wrap(_b64("a" * 100))
+    large = deeply_wrap(_b64("a" * 100_000))
+    assert estimate_request_context_tokens(small) == estimate_request_context_tokens(large)
+
+
+def test_deep_text_subtree_is_not_silently_dropped():
+    """Text nested deep inside a multimodal payload still contributes."""
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    def deeply_wrap(text: str, depth: int = 200) -> object:
+        node: object = text
+        for _ in range(depth):
+            node = {"nested": node}
+        return node
+
+    image_only = {
+        "model": "gpt-5.5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": _b64("a" * 1000)}},
+                ],
+            }
+        ],
+    }
+    with_deep_text = {
+        "model": "gpt-5.5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": _b64("a" * 1000)}},
+                    deeply_wrap("x" * 10_000),
+                ],
+            }
+        ],
+    }
+    increase = (
+        estimate_request_context_tokens(with_deep_text)
+        - estimate_request_context_tokens(image_only)
+    )
+    assert increase >= 10_000 // 4, f"deep text subtree dropped: increase={increase}"
+
+
+def test_huge_image_estimate_bounded():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    giant = _codex_payload(text="describe", images=[_b64("a" * 2_000_000)])
+    est = estimate_request_context_tokens(giant)
+    assert est < 100_000, f"2MB image inflated estimate to {est}"
+
+
+def test_estimator_does_not_mutate_payload():
+    from agent.chat_completion_helpers import estimate_request_context_tokens
+
+    payload = _chat_payload(text="describe", images=[_b64("a" * 1000)])
+    before = copy.deepcopy(payload)
+    estimate_request_context_tokens(payload)
+    assert payload == before


### PR DESCRIPTION
## What does this PR do?

Addresses the multimodal context-estimation portion of #76411.

`estimate_request_context_tokens()` treated base64 image data as ordinary text (`len(str(...)) // 4`). A single native screenshot could inflate the local estimate to ~100k+ tokens and select giant-conversation watchdog tiers (600s–1200s), even when the provider reported far fewer input tokens.

This PR makes the estimator multimodal-aware while keeping the implementation bounded and provider-agnostic:

- Structured image parts (`image_url` / `input_image` / `image` with expected fields) cost a fixed bounded visual default (170 tokens); base64 transport under those parts is never counted as text.
- Only the conversational region (`messages` / `input`) is scanned for images.
- `tools` and `instructions` stay **opaque** with the legacy `len(str(...))` cost so tool schemas cannot false-trigger image mode.
- A plain string that looks like a data URL remains **text** (exact legacy estimate).
- Pure-text payloads keep the exact legacy char/4 path.
- Single iterative stack walk (no recursion, no depth limit); detector and estimator share one pass.
- No image decoder, no tile parser, no estimator-side dedup.

**Out of scope (declared boundary of #76411):** duplicate native vision attachment / `vision_analyze` re-attaching an image already present in the turn. That remains a follow-up.

## Related Issue

Addresses the multimodal context-estimation portion of #76411. (estimator portion only; does not close the duplicate-attachment half of the issue narrative)

If maintainers prefer partial close semantics: this PR addresses the context-estimation defect described in #76411; the vision-attachment duplication path is intentionally not changed here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/chat_completion_helpers.py`**: Rewrite of `estimate_request_context_tokens` path used by Codex/Responses and Chat Completions watchdogs:
  - `_estimation_parts()` — split multimodal-scannable region vs opaque `tools`/`instructions` chars
  - `_scan_context_payload()` — iterative structured walk returning `(has_image, text_chars, image_tokens)`
  - `_is_multimodal_part()` — requires structural fields (`image_url` / `file_id` / `source`), not bare `type=image`
  - `_legacy_chars()` / `_legacy_estimate()` — preserve pure-text byte-for-byte legacy behavior
  - Does **not** treat bare `data:image/...` strings as images (only structured parts)
- **`tests/agent/test_context_estimator_multimodal.py`** (new): behavioral coverage for base64 inflation, opaque tools/instructions, tool-schema false positives, plain-text data URLs, deep nesting of structured parts, fragment remainder accumulation, watchdog tier, non-mutation, etc.

## How to Test

1. Checkout the branch
2. Activate the project venv
3. Run the focused suite (CI-parity wrapper, same as project convention):

   ```bash
   scripts/run_tests.sh tests/agent/test_context_estimator_multimodal.py tests/agent/test_non_stream_stale_timeout.py -q
   ```

   Expected: **28 passed** (23 multimodal + 5 stale-timeout).

4. Optional quick sanity checks in a Python shell:

   ```python
   from agent.chat_completion_helpers import estimate_request_context_tokens

   # Structured image: bounded, size-invariant
   small = {"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,"+"a"*100}}]}]}
   large = {"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,"+"a"*100_000}}]}]}
   assert estimate_request_context_tokens(small) == estimate_request_context_tokens(large)

   # Plain text data URL: exact legacy text cost (not 170)
   text_url = {"messages":[{"role":"user","content":"data:image/png;base64,"+"A"*100_000}]}
   legacy = sum(len(str(m)) for m in text_url["messages"]) // 4
   assert estimate_request_context_tokens(text_url) == legacy
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] ~~I've run `pytest tests/ -q` and all tests pass~~ — full suite is ~70+ minutes locally; not run end-to-end here. Focused suite for this change passes (see How to Test). CI will run the full matrix on the PR.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (estimator is internal watchdog helper; behavior change is covered by tests/docstrings in the helper)
- [x] N/A — I've updated `cli-config.yaml.example` (no new config keys)
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` (no architecture/workflow change for contributors)
- [x] N/A — I've considered cross-platform impact (pure Python token estimate; no OS I/O, process, or terminal APIs)
- [x] N/A — I've updated tool descriptions/schemas (no tool behavior change)

## Notes

- **Related but distinct open work:** #63913 (TTFB watchdog over-estimation for image-heavy turns), #70463 (image token estimate undercount elsewhere), #32133 (Codex screenshot materialization / vision fallback). None of those implement a multimodal-aware `estimate_request_context_tokens` walker for base64 inflation; this PR targets that specific path.
- **Design decisions pinned in tests:**
  - `tools` / `instructions` never scanned as multimodal content
  - bare `{"type": "image"}` tool schemas do not switch modes
  - plain-string data URLs remain text (exact legacy)
  - structured parts nested under unknown wrappers / deep trees stay size-invariant
  - short text fragments accumulate before a single `// 4`
  - no estimator-side image dedup (payload still transmits duplicates until a separate fix)
- Focused verification:

  ```text
  scripts/run_tests.sh tests/agent/test_context_estimator_multimodal.py tests/agent/test_non_stream_stale_timeout.py -q
  → 28 passed
  ```