### PR TITLE
fix(desktop): answer the visible clarify card, not the first-mounted one

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,9 +1,12 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { hiddenPaneProps } from '@/components/pane-shell/pane-visibility'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -339,5 +342,91 @@ describe('ClarifyTool pending marker', () => {
 
     // No shortcuts → nothing to protect → composer type-to-focus stays live.
     expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+  })
+})
+
+describe('ClarifyTool visible-card scoping', () => {
+  const BACKGROUND_SESSION = 'session-background'
+  const FOREGROUND_SESSION = 'session-foreground'
+  const BACKGROUND_REQUEST = 'request-background'
+  const FOREGROUND_REQUEST = 'request-foreground'
+  const QUESTION = 'Which deployment target?'
+
+  /** Minimal per-session view — the pending card only reads `$runtimeId`. */
+  function tileView(sessionId: string): SessionView {
+    return { ...({} as SessionView), $runtimeId: atom<null | string>(sessionId), kind: 'tile' }
+  }
+
+  function pendingCardProps(toolCallId: string): ToolCallMessagePartProps {
+    const args = { choices: ['staging', 'production'], question: QUESTION }
+
+    return { ...liveClarifyProps(), args, argsText: JSON.stringify(args), toolCallId }
+  }
+
+  function parkClarify(requestId: string, sessionId: string) {
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      question: QUESTION,
+      requestId,
+      sessionId
+    })
+  }
+
+  /** A card inside an inactive tab layer — mounted and live, just not on screen. */
+  function backgroundCard() {
+    return (
+      <div {...hiddenPaneProps(true)}>
+        <SessionViewProvider value={tileView(BACKGROUND_SESSION)}>
+          <ClarifyTool {...pendingCardProps('clarify-background')} />
+        </SessionViewProvider>
+      </div>
+    )
+  }
+
+  it('answers the visible card, not a background one that mounted first', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(BACKGROUND_REQUEST, BACKGROUND_SESSION)
+    parkClarify(FOREGROUND_REQUEST, FOREGROUND_SESSION)
+
+    // The background card is rendered FIRST, so its window listener registers
+    // first. Registration order used to decide the winner, which meant the card
+    // the user was looking at lost to one parked in an inactive tab.
+    renderClarify(
+      <>
+        {backgroundCard()}
+        <SessionViewProvider value={tileView(FOREGROUND_SESSION)}>
+          <ClarifyTool {...pendingCardProps('clarify-foreground')} />
+        </SessionViewProvider>
+      </>
+    )
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // Exactly one answer, carrying the FOREGROUND request id — the background
+    // session's turn must not be resumed by a keystroke aimed at this one.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: FOREGROUND_REQUEST
+    })
+  })
+
+  it('leaves the key alone when the only pending card is hidden', () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(BACKGROUND_REQUEST, BACKGROUND_SESSION)
+
+    renderClarify(backgroundCard())
+
+    // Untouched (no preventDefault) ⇒ the keystroke stays available to the
+    // composer, matching what `clarifyCardOwnsKey` reports with no visible card.
+    expect(fireEvent.keyDown(window, { key: 'Enter' })).toBe(true)
+    expect(request).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { hiddenPaneProps } from '@/components/pane-shell/pane-visibility'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -851,7 +852,16 @@ describe('ClarifyTool visible-card scoping', () => {
   const FOREGROUND_SESSION = 'session-foreground'
   const BACKGROUND_REQUEST = 'request-background'
   const FOREGROUND_REQUEST = 'request-foreground'
+  const ZONE_A_SESSION = 'session-zone-a'
+  const ZONE_B_SESSION = 'session-zone-b'
+  const ZONE_A_REQUEST = 'request-zone-a'
+  const ZONE_B_REQUEST = 'request-zone-b'
   const QUESTION = 'Which deployment target?'
+
+  afterEach(() => {
+    $activeTreeGroup.set(null)
+    $hoveredTreeGroup.set(null)
+  })
 
   /** Minimal per-session view — the pending card only reads `$runtimeId`. */
   function tileView(sessionId: string): SessionView {
@@ -930,5 +940,72 @@ describe('ClarifyTool visible-card scoping', () => {
     // composer, matching what `clarifyCardOwnsKey` reports with no visible card.
     expect(fireEvent.keyDown(window, { key: 'Enter' })).toBe(true)
     expect(request).not.toHaveBeenCalled()
+  })
+
+  /** A card in its own split zone — unlike `backgroundCard` this one IS on
+   *  screen, so a split renders two cards that both clear the hidden-pane
+   *  filter and only the zone ladder can tell apart. */
+  function zoneCard(zone: string, sessionId: string) {
+    return (
+      <div data-tree-group={zone}>
+        <SessionViewProvider value={tileView(sessionId)}>
+          <ClarifyTool {...pendingCardProps(`clarify-${zone}`)} />
+        </SessionViewProvider>
+      </div>
+    )
+  }
+
+  /** Both zones visible, zone-a first in document order. */
+  function renderSplit() {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(ZONE_A_REQUEST, ZONE_A_SESSION)
+    parkClarify(ZONE_B_REQUEST, ZONE_B_SESSION)
+
+    renderClarify(
+      <>
+        {zoneCard('zone-a', ZONE_A_SESSION)}
+        {zoneCard('zone-b', ZONE_B_SESSION)}
+      </>
+    )
+
+    return request
+  }
+
+  it('answers the later-in-document card when its zone is the focused one', async () => {
+    const request = renderSplit()
+
+    $activeTreeGroup.set('zone-b')
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // Both cards are visible and both hold a live window listener, so this is
+    // the case document order gets wrong: it would answer zone-a's question.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: ZONE_B_REQUEST
+    })
+  })
+
+  it('answers the other visible card once the focus moves to its zone', async () => {
+    const request = renderSplit()
+
+    $activeTreeGroup.set('zone-a')
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // The direct pin for "the other visible card then cannot receive its
+    // shortcut": neither zone may be permanently starved of its own keys.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: ZONE_A_REQUEST
+    })
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { hiddenPaneProps } from '@/components/pane-shell/pane-visibility'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -350,7 +351,16 @@ describe('ClarifyTool visible-card scoping', () => {
   const FOREGROUND_SESSION = 'session-foreground'
   const BACKGROUND_REQUEST = 'request-background'
   const FOREGROUND_REQUEST = 'request-foreground'
+  const ZONE_A_SESSION = 'session-zone-a'
+  const ZONE_B_SESSION = 'session-zone-b'
+  const ZONE_A_REQUEST = 'request-zone-a'
+  const ZONE_B_REQUEST = 'request-zone-b'
   const QUESTION = 'Which deployment target?'
+
+  afterEach(() => {
+    $activeTreeGroup.set(null)
+    $hoveredTreeGroup.set(null)
+  })
 
   /** Minimal per-session view — the pending card only reads `$runtimeId`. */
   function tileView(sessionId: string): SessionView {
@@ -428,5 +438,72 @@ describe('ClarifyTool visible-card scoping', () => {
     // composer, matching what `clarifyCardOwnsKey` reports with no visible card.
     expect(fireEvent.keyDown(window, { key: 'Enter' })).toBe(true)
     expect(request).not.toHaveBeenCalled()
+  })
+
+  /** A card in its own split zone — unlike `backgroundCard` this one IS on
+   *  screen, so a split renders two cards that both clear the hidden-pane
+   *  filter and only the zone ladder can tell apart. */
+  function zoneCard(zone: string, sessionId: string) {
+    return (
+      <div data-tree-group={zone}>
+        <SessionViewProvider value={tileView(sessionId)}>
+          <ClarifyTool {...pendingCardProps(`clarify-${zone}`)} />
+        </SessionViewProvider>
+      </div>
+    )
+  }
+
+  /** Both zones visible, zone-a first in document order. */
+  function renderSplit() {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(ZONE_A_REQUEST, ZONE_A_SESSION)
+    parkClarify(ZONE_B_REQUEST, ZONE_B_SESSION)
+
+    renderClarify(
+      <>
+        {zoneCard('zone-a', ZONE_A_SESSION)}
+        {zoneCard('zone-b', ZONE_B_SESSION)}
+      </>
+    )
+
+    return request
+  }
+
+  it('answers the later-in-document card when its zone is the focused one', async () => {
+    const request = renderSplit()
+
+    $activeTreeGroup.set('zone-b')
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // Both cards are visible and both hold a live window listener, so this is
+    // the case document order gets wrong: it would answer zone-a's question.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: ZONE_B_REQUEST
+    })
+  })
+
+  it('answers the other visible card once the focus moves to its zone', async () => {
+    const request = renderSplit()
+
+    $activeTreeGroup.set('zone-a')
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // The direct pin for "the other visible card then cannot receive its
+    // shortcut": neither zone may be permanently starved of its own keys.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: ZONE_A_REQUEST
+    })
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,9 +1,12 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { hiddenPaneProps } from '@/components/pane-shell/pane-visibility'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -840,5 +843,92 @@ describe('ClarifyTool owner routing', () => {
     })
     expectOwnerCall(1, { answer: '', request_id: 'request-batch' })
     expect(ambient).not.toHaveBeenCalled()
+  })
+})
+
+describe('ClarifyTool visible-card scoping', () => {
+  const BACKGROUND_SESSION = 'session-background'
+  const FOREGROUND_SESSION = 'session-foreground'
+  const BACKGROUND_REQUEST = 'request-background'
+  const FOREGROUND_REQUEST = 'request-foreground'
+  const QUESTION = 'Which deployment target?'
+
+  /** Minimal per-session view — the pending card only reads `$runtimeId`. */
+  function tileView(sessionId: string): SessionView {
+    return { ...({} as SessionView), $runtimeId: atom<null | string>(sessionId), kind: 'tile' }
+  }
+
+  function pendingCardProps(toolCallId: string): ToolCallMessagePartProps {
+    const args = { choices: ['staging', 'production'], question: QUESTION }
+
+    return { ...liveClarifyProps(), args, argsText: JSON.stringify(args), toolCallId }
+  }
+
+  function parkClarify(requestId: string, sessionId: string) {
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: QUESTION,
+      requestId,
+      sessionId
+    })
+  }
+
+  /** A card inside an inactive tab layer — mounted and live, just not on screen. */
+  function backgroundCard() {
+    return (
+      <div {...hiddenPaneProps(true)}>
+        <SessionViewProvider value={tileView(BACKGROUND_SESSION)}>
+          <ClarifyTool {...pendingCardProps('clarify-background')} />
+        </SessionViewProvider>
+      </div>
+    )
+  }
+
+  it('answers the visible card, not a background one that mounted first', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(BACKGROUND_REQUEST, BACKGROUND_SESSION)
+    parkClarify(FOREGROUND_REQUEST, FOREGROUND_SESSION)
+
+    // The background card is rendered FIRST, so its window listener registers
+    // first. Registration order used to decide the winner, which meant the card
+    // the user was looking at lost to one parked in an inactive tab.
+    renderClarify(
+      <>
+        {backgroundCard()}
+        <SessionViewProvider value={tileView(FOREGROUND_SESSION)}>
+          <ClarifyTool {...pendingCardProps('clarify-foreground')} />
+        </SessionViewProvider>
+      </>
+    )
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+
+    // Exactly one answer, carrying the FOREGROUND request id — the background
+    // session's turn must not be resumed by a keystroke aimed at this one.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'staging',
+      request_id: FOREGROUND_REQUEST
+    })
+  })
+
+  it('leaves the key alone when the only pending card is hidden', () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $gateway.set({ request } as never)
+    parkClarify(BACKGROUND_REQUEST, BACKGROUND_SESSION)
+
+    renderClarify(backgroundCard())
+
+    // Untouched (no preventDefault) ⇒ the keystroke stays available to the
+    // composer, matching what `clarifyCardOwnsKey` reports with no visible card.
+    expect(fireEvent.keyDown(window, { key: 'Enter' })).toBe(true)
+    expect(request).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -24,6 +24,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
+import { visibleClarifyCard } from '@/lib/keybinds/composer-focus-keys'
 import { cn } from '@/lib/utils'
 import { clearClarifyRequest, normalizeChoices, sessionClarifyRequest, warnDroppedChoices } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -315,6 +316,9 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  // Identity for the visible-card check below — this is the element carrying
+  // `data-clarify-choices`, i.e. the one `visibleClarifyCard()` resolves.
+  const formRef = useRef<HTMLFormElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
@@ -445,7 +449,8 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // confirms the current answer (or acts on the highlighted row). Stands down
   // whenever a focusable control (a field, a choice button, the action bar) is
   // focused, so it never eats keystrokes meant for the composer, the Other box,
-  // or a button the user tabbed to.
+  // or a button the user tabbed to — and whenever this card is not the visible
+  // one, since the binding is window-wide but the answer is session-specific.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -453,6 +458,17 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) {
+        return
+      }
+
+      // Not the visible card ⇒ not our keystroke. Inactive tabs stay MOUNTED,
+      // so every parked clarify keeps a live `window` listener; without this the
+      // card that acts is whichever mounted first, and answering the question in
+      // front of you silently answers a background session's question instead —
+      // resuming an agent turn the user never saw. Same resolver the composer's
+      // `clarifyCardOwnsKey` yields to, so the two cannot disagree about which
+      // card is live.
+      if (visibleClarifyCard() !== formRef.current) {
         return
       }
 
@@ -551,6 +567,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       className="my-1.5 grid gap-4"
       data-clarify-choices={hasChoices ? choices.length : undefined}
       onSubmit={handleSubmit}
+      ref={formRef}
     >
       <ClarifyShell className="grid gap-2">
         <div className="flex items-start gap-2">

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -24,6 +24,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
+import { visibleClarifyCard } from '@/lib/keybinds/composer-focus-keys'
 import { cn } from '@/lib/utils'
 import {
   bareChoice,
@@ -444,6 +445,9 @@ function ClarifyToolSinglePending({
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  // Identity for the visible-card check below — this is the element carrying
+  // `data-clarify-choices`, i.e. the one `visibleClarifyCard()` resolves.
+  const formRef = useRef<HTMLFormElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. If the question text is
@@ -611,7 +615,8 @@ function ClarifyToolSinglePending({
   // confirms the current answer (or acts on the highlighted row). Stands down
   // whenever a focusable control (a field, a choice button, the action bar) is
   // focused, so it never eats keystrokes meant for the composer, the Other box,
-  // or a button the user tabbed to.
+  // or a button the user tabbed to — and whenever this card is not the visible
+  // one, since the binding is window-wide but the answer is session-specific.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -619,6 +624,17 @@ function ClarifyToolSinglePending({
 
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) {
+        return
+      }
+
+      // Not the visible card ⇒ not our keystroke. Inactive tabs stay MOUNTED,
+      // so every parked clarify keeps a live `window` listener; without this the
+      // card that acts is whichever mounted first, and answering the question in
+      // front of you silently answers a background session's question instead —
+      // resuming an agent turn the user never saw. Same resolver the composer's
+      // `clarifyCardOwnsKey` yields to, so the two cannot disagree about which
+      // card is live.
+      if (visibleClarifyCard() !== formRef.current) {
         return
       }
 
@@ -717,6 +733,7 @@ function ClarifyToolSinglePending({
       className="my-1.5 grid gap-4"
       data-clarify-choices={hasChoices ? choices.length : undefined}
       onSubmit={handleSubmit}
+      ref={formRef}
     >
       <ClarifyShell className="grid gap-2">
         <div className="flex items-start gap-2">

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $workspaceIsPage } from '@/app/routes'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { $switcherOpen, closeSwitcher } from '@/store/session-switcher'
 
 import {
   composerFocusBlockedBySurface,
   composerFocusKeysAllowed,
   isActivateOnEnterTarget,
-  typeToFocusChar
+  typeToFocusChar,
+  visibleClarifyCard
 } from './composer-focus-keys'
 
 function keydown(init: KeyboardEventInit & { target?: EventTarget }): KeyboardEvent {
@@ -121,9 +123,28 @@ describe('typeToFocusChar', () => {
 })
 
 describe('composerFocusKeysAllowed', () => {
+  // The clarify resolver reads the zone ladder, so these have to start neutral.
+  const resetZones = () => {
+    $activeTreeGroup.set(null)
+    $hoveredTreeGroup.set(null)
+  }
+
+  /** A live clarify card inside its own split zone, both on screen. */
+  function cardInZone(zone: string): HTMLElement {
+    const group = document.createElement('div')
+    group.setAttribute('data-tree-group', zone)
+    const card = document.createElement('div')
+    card.setAttribute('data-clarify-choices', '2')
+    group.append(card)
+    document.body.append(group)
+
+    return card
+  }
+
   beforeEach(() => {
     $workspaceIsPage.set(false)
     closeSwitcher()
+    resetZones()
     document.body.replaceChildren()
     vi.spyOn(document, 'activeElement', 'get').mockReturnValue(document.body)
   })
@@ -131,6 +152,7 @@ describe('composerFocusKeysAllowed', () => {
   afterEach(() => {
     $workspaceIsPage.set(false)
     closeSwitcher()
+    resetZones()
     document.body.replaceChildren()
     vi.restoreAllMocks()
   })
@@ -199,5 +221,48 @@ describe('composerFocusKeysAllowed', () => {
 
     expect(composerFocusKeysAllowed(keydown({ key: 'a', target: document.body }), 'type')).toBe(true)
     expect(composerFocusKeysAllowed(keydown({ key: 'Enter', target: document.body }), 'enter')).toBe(true)
+  })
+
+  it('picks the focused zone when a split shows two visible cards', () => {
+    const cardA = cardInZone('zone-a')
+    const cardB = cardInZone('zone-b')
+
+    // Document order would pin this to zone-a forever, so zone-b's card could
+    // never take its own shortcut. Both directions are asserted for that reason.
+    $activeTreeGroup.set('zone-b')
+    expect(visibleClarifyCard()).toBe(cardB)
+
+    $activeTreeGroup.set('zone-a')
+    expect(visibleClarifyCard()).toBe(cardA)
+  })
+
+  it('lets the hovered zone override the focused one', () => {
+    const cardA = cardInZone('zone-a')
+    const cardB = cardInZone('zone-b')
+
+    $activeTreeGroup.set('zone-a')
+    expect(visibleClarifyCard()).toBe(cardA)
+
+    // Hover-first, like every tab verb: pointing at the other pane arms its card
+    // without clicking into it.
+    $hoveredTreeGroup.set('zone-b')
+    expect(visibleClarifyCard()).toBe(cardB)
+  })
+
+  it('steps down the ladder instead of answering nothing', () => {
+    const cardA = cardInZone('zone-a')
+    const cardB = cardInZone('zone-b')
+
+    // Pointer parked on a zone with no pending question — fall through to the
+    // focused zone rather than returning null.
+    $hoveredTreeGroup.set('zone-empty')
+    $activeTreeGroup.set('zone-b')
+    expect(visibleClarifyCard()).toBe(cardB)
+
+    // Neither rung resolves ⇒ document order, deliberately. Returning null here
+    // would leave Enter doing nothing at all.
+    resetZones()
+    expect(visibleClarifyCard()).toBe(cardA)
+    expect(composerFocusKeysAllowed(keydown({ key: 'Enter', target: document.body }), 'enter')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -7,7 +7,8 @@
  */
 
 import { $workspaceIsPage } from '@/app/routes'
-import { queryVisible } from '@/components/pane-shell/pane-visibility'
+import { queryAllVisible } from '@/components/pane-shell/pane-visibility'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { switcherActive } from '@/store/session-switcher'
 
 import { isEditableTarget, isFocusWithin } from './combo'
@@ -48,6 +49,9 @@ const BLOCKING_OVERLAY =
 // must not take the foreground composer's letter keys.
 const BLOCKING_IN_SURFACE = '[data-clarify-choices]'
 
+/** The layout-tree zone a pane is rendered in — see `tree/renderer/tree-group`. */
+const TREE_GROUP = '[data-tree-group]'
+
 /**
  * THE live clarify card — the single card whose shortcuts are armed right now.
  *
@@ -56,8 +60,39 @@ const BLOCKING_IN_SURFACE = '[data-clarify-choices]'
  * disagree about which card is live they act for different sessions: this
  * resolver yields to the VISIBLE card, while a handler keyed on anything else
  * (mount order, say) answers one the user cannot see.
+ *
+ * Visible is not by itself an identity, though. A split layout puts two chat
+ * surfaces on screen at once, so both cards clear the hidden-pane filter and
+ * taking the first remaining DOM match would pick document ORDER — the earlier
+ * zone would own the keys permanently and the other visible card could never
+ * receive its shortcut. Break that tie on the SAME hovered → focused zone
+ * ladder every tab verb already runs (`tabTargetGroup` in `tree/store`,
+ * mirrored for the model hotkey by `composerTargetInHoveredZone`, #74447)
+ * rather than inventing a second notion of which surface is "the" one.
+ *
+ * The last resort stays document order rather than null on purpose: when
+ * neither rung names a zone that holds a card (pointer off every zone, nothing
+ * interacted with yet) returning null would leave Enter doing nothing at all,
+ * which is a worse regression than the single-card behaviour it replaces.
  */
-export const visibleClarifyCard = (): HTMLElement | null => queryVisible(BLOCKING_IN_SURFACE)
+export const visibleClarifyCard = (): HTMLElement | null => {
+  const cards = queryAllVisible<HTMLElement>(BLOCKING_IN_SURFACE)
+
+  // Overwhelmingly the common case — nothing to disambiguate, no store read.
+  if (cards.length < 2) {
+    return cards[0] ?? null
+  }
+
+  for (const zone of [$hoveredTreeGroup.get(), $activeTreeGroup.get()]) {
+    const card = zone ? cards.find(el => el.closest<HTMLElement>(TREE_GROUP)?.dataset.treeGroup === zone) : undefined
+
+    if (card) {
+      return card
+    }
+  }
+
+  return cards[0]
+}
 
 /** True when the focused control would normally handle Enter itself. */
 export function isActivateOnEnterTarget(target: EventTarget | null): boolean {

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -48,6 +48,17 @@ const BLOCKING_OVERLAY =
 // must not take the foreground composer's letter keys.
 const BLOCKING_IN_SURFACE = '[data-clarify-choices]'
 
+/**
+ * THE live clarify card — the single card whose shortcuts are armed right now.
+ *
+ * Exported because the card's own `keydown` handler has to resolve the same
+ * element this module does. Both bind the same keys on `window`, so if they
+ * disagree about which card is live they act for different sessions: this
+ * resolver yields to the VISIBLE card, while a handler keyed on anything else
+ * (mount order, say) answers one the user cannot see.
+ */
+export const visibleClarifyCard = (): HTMLElement | null => queryVisible(BLOCKING_IN_SURFACE)
+
 /** True when the focused control would normally handle Enter itself. */
 export function isActivateOnEnterTarget(target: EventTarget | null): boolean {
   const el = target as HTMLElement | null
@@ -70,7 +81,7 @@ export function isActivateOnEnterTarget(target: EventTarget | null): boolean {
  * with no store coupling.
  */
 export function clarifyCardOwnsKey(event: KeyboardEvent): boolean {
-  const card = queryVisible(BLOCKING_IN_SURFACE)
+  const card = visibleClarifyCard()
 
   if (!card) {
     return false


### PR DESCRIPTION
## What does this PR do?

**Symptom:** two chats are waiting on a clarify question — one in the tab you're looking at, one in a background tab. You read the question in front of you and press `Enter` (or `1`, or `A`). The card on screen does nothing. The *background* session's question is silently answered with its first option, and that agent's turn resumes — an answer you never gave, to a question you never saw.

**Cause.** `ClarifyToolPending` binds `Enter` / `1-9` / `A-Z` / arrows on `window`. Inactive tabs stay **mounted** (`pane-shell/pane-visibility.ts` — panes are hidden with `visibility: hidden` so scroll positions survive a tab round-trip), so N sessions with a parked clarify means N live `window` listeners. The handler guards modifiers, `defaultPrevented`, and focused controls — but never asks *"am I the card on screen?"*. The first listener registered wins, calls `preventDefault()`, and every other card bails on `defaultPrevented`. **Registration order is mount order, not visibility.**

`activateActive()` → `respond(choice)` → `gateway.request('clarify.respond', { request_id, answer })`, so the wrong session gets a real answer to a real blocking request.

**The codebase already states the invariant** — one file over, in `lib/keybinds/composer-focus-keys.ts`:

```ts
// Blockers that live INSIDE a chat surface. Inactive tabs stay mounted, so this
// one has to be visible-scoped: a clarify card waiting in a background thread
// must not take the foreground composer's letter keys.
const BLOCKING_IN_SURFACE = '[data-clarify-choices]'
```

`clarifyCardOwnsKey()` honours it via `queryVisible()`. **The card's own listener did not.** That asymmetry *is* the bug: the key-ownership resolver and the key handler disagreed about which card is live, so the composer would yield its keys to the visible card while the handler acted for a hidden one.

`771dfcc08` (*"keep background tabs out of blur, timeline, and key routing"*) fixed exactly this class in three sibling **lookups** — `blurComposerInput`, the timeline viewport, and `composer-focus-keys` — and its own body notes "a clarify card waiting in a background thread swallowed the foreground composer's letter keys". It scoped the three *lookups* and left the clarify card's own `window` listener unscoped. This is the fourth site.

### Why visible-card identity, not `usePaneVisible()`

`usePaneVisible()` is the idiomatic guard here (`thread/timeline.tsx` uses it), and it would fix the background-tab case — but it is **not sufficient**. `tree/renderer/tree-split.tsx` renders one `TreeNode` per split child and each `tree-group` marks *its own* active pane visible, so a split layout has **two visible chat surfaces at once**. A per-pane boolean says "yes" for both and cannot pick between them.

So this scopes by **identity against the same resolver the composer uses**: the shared `visibleClarifyCard()` lookup is exported from `composer-focus-keys.ts` and consumed by both sides. Whatever the layout, exactly one card is "the live card", and the handler and the resolver cannot drift apart again — which is the failure mode that produced this bug in the first place. It also subsumes the hidden-pane case, since a card under `[data-pane-hidden]` is never returned.

## Related Issue

N/A — found by reading `ClarifyToolPending`'s `keydown` effect against the visible-scoping policy in `pane-visibility.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/keybinds/composer-focus-keys.ts` — extract the existing `queryVisible('[data-clarify-choices]')` lookup as an exported `visibleClarifyCard()`; `clarifyCardOwnsKey()` now calls it. No behaviour change on this side.
- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` — add a `formRef` on the `<form>` that already carries `data-clarify-choices`, and bail out of the `keydown` handler when `visibleClarifyCard() !== formRef.current`. Placed with the other bail conditions, before any `preventDefault()`, so a hidden card cannot consume the key on the visible card's behalf.
- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx` — two regression tests (below).

### Sibling-site sweep

Every `window`/`document` `keydown` listener under `apps/desktop/src` that can be mounted more than once (one per session surface) was checked for the same root cause. The rest are already scoped, and deliberately so:

| Site | Status |
| --- | --- |
| `clarify-tool.tsx` | **unscoped — fixed here** |
| `composer/hooks/use-composer-esc-cancel.ts` | already scoped by `getActiveComposer() !== target`, with the comment *"otherwise every mounted busy tile stops at once (and the winner would be mount-order arbitrary)"* — the same failure mode, already solved |
| `right-rail/preview-file.tsx` (both listeners) | scoped by live `selection`, and by `hoverRef.current || focusWithin` |
| `composer/hooks/use-voice-conversation.ts` | gated on `status === 'listening'`; only one conversation listens at a time |
| `hooks/use-file-drop-zone.ts` | only registered during an in-progress drag on that zone |
| `assistant-ui/embeds/scroll-gate.tsx` | syncs a local modifier-held flag; no cross-session effect |

Window-level chrome (command palette, find bar, terminal, zone editor, titlebar, starmap, kanban) is single-instance per window and out of scope.

## How to Test

Automated — the two new tests fail on `main` and pass with this change:

```
cd apps/desktop && npx vitest run --project ui src/components/assistant-ui/clarify-tool.test.tsx
```

**Before** (production files at `main`, new tests applied) — 2 failed | 14 passed:

```
FAIL  ClarifyTool visible-card scoping > answers the visible card, not a background one that mounted first
AssertionError: expected "vi.fn()" to be called with arguments: [ 'clarify.respond', …(1) ]
  [
    "clarify.respond",
    {
      "answer": "staging",
-     "request_id": "request-foreground",
+     "request_id": "request-background",
    },
  ]

FAIL  ClarifyTool visible-card scoping > leaves the key alone when the only pending card is hidden
AssertionError: expected false to be true
- true
+ false
```

The first failure is the bug itself: the background session's `request_id` was answered. The second shows the hidden card called `preventDefault()`, swallowing a key the composer should have received.

**After** — 16 passed. Reverting only the production hunks reproduces the red again (verified both directions).

Adjacent suites (`src/lib/keybinds`, `src/components/pane-shell`, `src/app/chat/composer`, `src/components/assistant-ui`): **74 files / 595 tests passed**. `tsc -p . --noEmit` clean; `eslint` 0 errors on touched files; `prettier --check` clean.

Manual:

1. Open two chats as tabs in the same zone, and get both to a clarify question with choices (agent asks something with options).
2. Switch to tab A. Press `Enter`.
3. **Before:** whichever card mounted first is answered — often tab B's, whose turn resumes with an answer you never gave. **After:** tab A's card is answered; B stays parked until you switch to it.
4. Split the zone so both chats are visible side by side, and confirm a single keypress answers exactly one card.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — desktop renderer change; ran the vitest ui project instead (results above) -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Node via repo toolchain

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A; the doc comments on the touched effect and the new export are updated in place -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure renderer DOM logic, no platform-specific paths or key codes -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- the clarify tool's contract is unchanged; only which card answers it -->
