### PR TITLE
fix(email): suppress standalone gateway notices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13146,6 +13146,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    @staticmethod
+    def _should_send_standalone_notice(source) -> bool:
+        """Whether a setup/reset notice should be emitted separately."""
+        return getattr(source, "platform", None) != Platform.EMAIL
+
+    async def _deliver_auto_reset_notice(
+        self, source, reset_reason: str, policy, had_activity: bool
+    ) -> None:
+        """Deliver a user-facing auto-reset notice when policy permits."""
+        platform_name = source.platform.value if source.platform else ""
+        # Suspended and restart-recovery-expired sessions always notify
+        # regardless of policy.notify — the user had an active session
+        # that was silently replaced, so they need to know they can
+        # /resume it. Idle/daily resets respect the policy flag.
+        should_notify = reset_reason in {"suspended", "resume_pending_expired"} or (
+            policy.notify
+            and had_activity
+            and platform_name not in policy.notify_exclude_platforms
+        )
+        if not should_notify or not self._should_send_standalone_notice(source):
+            return
+
+        adapter = self._adapter_for_source(source)
+        if not adapter:
+            return
+
+        if reset_reason == "suspended":
+            reason_text = "previous session was stopped or interrupted"
+        elif reset_reason == "resume_pending_expired":
+            reason_text = "gateway restart recovery timed out"
+        elif reset_reason == "daily":
+            reason_text = f"daily schedule at {policy.at_hour}:00"
+        else:
+            hours = policy.idle_minutes // 60
+            mins = policy.idle_minutes % 60
+            duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
+            reason_text = f"inactive for {duration}"
+        notice = (
+            f"◐ Session automatically reset ({reason_text}). "
+            f"Conversation history cleared.\n"
+            f"Use /resume to browse and restore a previous session.\n"
+            f"Adjust reset timing in config.yaml under session_reset."
+        )
+        try:
+            session_info = await asyncio.to_thread(
+                self._reset_notice_session_info, source
+            )
+            if session_info:
+                notice = f"{notice}\n\n{session_info}"
+        except Exception:
+            pass
+        await adapter.send(
+            source.chat_id, notice,
+            metadata=self._thread_metadata_for_source(source),
+        )
+
     async def _deliver_platform_notice(self, source, content: str) -> None:
         """Deliver a setup/operational notice using platform-specific privacy rules."""
         adapter = self._adapter_for_source(source)
@@ -15734,49 +15790,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform=source.platform,
                     session_type=getattr(source, 'chat_type', 'dm'),
                 )
-                platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended and restart-recovery-expired sessions always notify
-                # regardless of policy.notify — the user had an active session
-                # that was silently replaced, so they need to know they can
-                # /resume it.  Idle/daily resets respect the policy flag.
-                should_notify = reset_reason in {"suspended", "resume_pending_expired"} or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
+                await self._deliver_auto_reset_notice(
+                    source, reset_reason, policy, had_activity
                 )
-                if should_notify:
-                    adapter = self._adapter_for_source(source)
-                    if adapter:
-                        if reset_reason == "suspended":
-                            reason_text = "previous session was stopped or interrupted"
-                        elif reset_reason == "resume_pending_expired":
-                            reason_text = "gateway restart recovery timed out"
-                        elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
-                        else:
-                            hours = policy.idle_minutes // 60
-                            mins = policy.idle_minutes % 60
-                            duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
-                            reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
-                        try:
-                            session_info = await asyncio.to_thread(
-                                self._reset_notice_session_info, source
-                            )
-                            if session_info:
-                                notice = f"{notice}\n\n{session_info}"
-                        except Exception:
-                            pass
-                        await adapter.send(
-                            source.chat_id, notice,
-                            metadata=self._thread_metadata_for_source(source),
-                        )
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)
 
@@ -16539,7 +16556,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        if (
+            not history
+            and source.platform
+            and source.platform != Platform.LOCAL
+            and source.platform != Platform.WEBHOOK
+            and self._should_send_standalone_notice(source)
+        ):
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             # Multiplex: home channel may live only in the profile secret

--- a/tests/gateway/test_notice_delivery.py
+++ b/tests/gateway/test_notice_delivery.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig, SessionResetPolicy
 from gateway.platforms.base import SendResult
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -15,6 +15,15 @@ def _make_source() -> SessionSource:
         chat_type="channel",
         user_id="U123",
         thread_id="111.222",
+    )
+
+
+def _make_email_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.EMAIL,
+        chat_id="person@example.com",
+        chat_type="dm",
+        user_id="person@example.com",
     )
 
 
@@ -47,3 +56,45 @@ async def test_deliver_platform_notice_uses_private_delivery_when_configured():
     adapter.send.assert_not_awaited()
 
 
+def test_standalone_reset_and_setup_notices_are_suppressed_for_email():
+    """Email maps standalone notices to separate messages, unlike chat apps."""
+    assert GatewayRunner._should_send_standalone_notice(_make_email_source()) is False
+    assert GatewayRunner._should_send_standalone_notice(_make_source()) is True
+
+
+def _make_auto_reset_runner():
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="reset-1"))
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._reset_notice_session_info = MagicMock(return_value=None)
+    runner._thread_metadata_for_source = MagicMock(return_value={"thread_id": "111.222"})
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_auto_reset_notice_does_not_send_a_standalone_email():
+    runner, adapter = _make_auto_reset_runner()
+
+    await runner._deliver_auto_reset_notice(
+        _make_email_source(),
+        "idle",
+        SessionResetPolicy(notify=True, idle_minutes=60),
+        had_activity=True,
+    )
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_reset_notice_still_sends_for_chat_platforms():
+    runner, adapter = _make_auto_reset_runner()
+
+    await runner._deliver_auto_reset_notice(
+        _make_source(),
+        "idle",
+        SessionResetPolicy(notify=True, idle_minutes=60),
+        had_activity=True,
+    )
+
+    adapter.send.assert_awaited_once()


### PR DESCRIPTION
## Bug Description

On Email, gateway administrative notices are delivered as separate messages. An automatic session reset followed by the one-time no-home-channel prompt therefore produced two unsolicited emails before the actual agent reply.

Related to #27804. This is a focused notification-volume fix; it does not address the issue's separate subject-based session-isolation work.

## Root Cause

The gateway emits reset and onboarding notices as standalone platform sends. That is appropriate for chat surfaces, but the Email adapter maps every send to an individual email.

## Fix

- Add an Email-aware policy for standalone setup/reset notices.
- Skip the auto-reset banner and no-home-channel onboarding prompt only for Email.
- Keep the shared operational-notice delivery rail unchanged, so credit notices retain their existing behavior.
- Cover the direct auto-reset path for both Email and a chat platform.

## How to Verify

1. Configure the Email gateway without an Email home channel.
2. Let an Email conversation pass its reset threshold, then send a new message.
3. Confirm Hermes sends only the agent response, not separate reset or `/sethome` emails.

## Test Plan

- [x] Added regression coverage for standalone setup/reset notices, including direct reset delivery for Email and a chat platform.
- [x] `scripts/run_tests.sh tests/gateway/test_notice_delivery.py tests/gateway/test_notice_rendering.py tests/gateway/test_session_reset_notify.py tests/gateway/test_fresh_reset_skill_injection.py tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_sms.py tests/gateway/test_config.py` — 126 passed.
- [x] Manually reproduced the Email behavior, applied the fix, and confirmed a fresh Email test received only the intended reply.
- [ ] Full suite: attempted with `scripts/run_tests.sh`; local shared venv lacks the optional `anthropic` SDK, causing unrelated failures in `tests/agent/test_auxiliary_transport_autodetect.py` and `tests/agent/test_auxiliary_named_custom_providers.py` before completion.

## Risk Assessment

Low — the change is limited to two administrative Email notice emitters. Normal agent replies and the shared operational-notice rail remain unchanged.
