### PR TITLE
feat(desktop): app-drawn window controls — durable fix for missing controls on WSLg/Linux, foundation for custom window frames

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -768,6 +768,41 @@ function writePersistedTranslucency(intensity) {
 
 let translucencyIntensity = readPersistedTranslucency()
 
+// Window chrome mode. 'overlay' (default) = frameless title bar + native
+// Window Controls Overlay (Windows/Linux) or traffic lights (macOS), exactly
+// as today. 'app-drawn' = `frame: false` with the renderer painting
+// min/max/close itself (see computeWindowChromeOptions + WindowControls).
+// Persisted so window creation reads it before the renderer loads. `frame`
+// cannot change on a live BrowserWindow, so a runtime toggle applies to
+// windows created after the next launch. See store/window-chrome.
+const WINDOW_CHROME_CONFIG_PATH = path.join(app.getPath('userData'), 'window-chrome.json')
+const WINDOW_CHROME_MODES = new Set(['overlay', 'app-drawn'])
+
+function readWindowChromeMode() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(WINDOW_CHROME_CONFIG_PATH, 'utf8'))
+
+    if (parsed && WINDOW_CHROME_MODES.has(parsed.mode)) {
+      return parsed.mode
+    }
+  } catch {
+    // Missing / malformed → default overlay chrome.
+  }
+
+  return 'overlay'
+}
+
+function writeWindowChromeMode(mode) {
+  try {
+    fs.mkdirSync(path.dirname(WINDOW_CHROME_CONFIG_PATH), { recursive: true })
+    fs.writeFileSync(WINDOW_CHROME_CONFIG_PATH, JSON.stringify({ mode }, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[window-chrome] write failed: ${error.message}`)
+  }
+}
+
+let windowChromeMode = readWindowChromeMode()
+
 // Map the 0–100 lever to a window opacity. Floor at 0.3 so the most see-through
 // setting is still usable rather than nearly invisible. 0 → fully opaque.
 function windowOpacity() {
@@ -832,6 +867,31 @@ function getTitleBarOverlayOptions() {
           ? '#f7f7f7'
           : '#242424'
   }
+}
+
+// Shared window-chrome options for every full chat window (primary, instance,
+// session). Default 'overlay' mode is exactly the current behavior: frameless
+// title bar + native WCO on Windows/Linux, traffic lights on macOS. 'app-drawn'
+// mode (non-macOS only) drops the OS chrome entirely (`frame: false`) so the
+// renderer paints min/max/close itself — see src/app/shell/window-controls.
+function computeWindowChromeOptions(): Electron.BrowserWindowConstructorOptions {
+  const base: Electron.BrowserWindowConstructorOptions = {
+    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
+    vibrancy: IS_MAC ? 'sidebar' : undefined,
+    opacity: windowOpacity(),
+    backgroundColor: getWindowBackgroundColor()
+  }
+
+  // macOS is already app-drawn in both modes (hidden titlebar + native lights).
+  if (IS_MAC || windowChromeMode !== 'app-drawn') {
+    return {
+      ...base,
+      titleBarStyle: 'hidden',
+      titleBarOverlay: getTitleBarOverlayOptions()
+    }
+  }
+
+  return { ...base, frame: false }
 }
 
 // Push refreshed overlay options to a live window after a theme/appearance
@@ -5169,10 +5229,12 @@ function getNativeOverlayWidth() {
 function getWindowState(win = mainWindow) {
   return {
     isFullscreen: Boolean(win?.isFullScreen?.()),
+    isMaximized: Boolean(win?.isMaximized?.()),
     isMinimized: Boolean(win?.isMinimized?.()),
     isVisible: Boolean(win?.isVisible?.()),
     nativeOverlayWidth: getNativeOverlayWidth(),
-    windowButtonPosition: getWindowButtonPosition()
+    windowButtonPosition: getWindowButtonPosition(),
+    windowChromeMode
   }
 }
 
@@ -8734,11 +8796,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     minWidth: SESSION_WINDOW_MIN_WIDTH,
     minHeight: SESSION_WINDOW_MIN_HEIGHT,
     title: 'Hermes',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: getTitleBarOverlayOptions(),
-    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
-    vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    ...computeWindowChromeOptions(),
     icon,
     // Don't show until the renderer's first themed paint is ready. macOS
     // `vibrancy` ignores `backgroundColor` and paints a translucent OS
@@ -8747,7 +8805,6 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     // covers it. ready-to-show fires after the boot-time paint in
     // themes/context.tsx, so the window appears already themed.
     show: false,
-    backgroundColor: getWindowBackgroundColor(),
     webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
   })
 
@@ -8820,14 +8877,9 @@ function createInstanceWindow() {
     minWidth: WINDOW_MIN_WIDTH,
     minHeight: WINDOW_MIN_HEIGHT,
     title: 'Hermes',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: getTitleBarOverlayOptions(),
-    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
-    vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    ...computeWindowChromeOptions(),
     icon,
     show: false,
-    backgroundColor: getWindowBackgroundColor(),
     webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
   })
 
@@ -9231,17 +9283,14 @@ function createWindow() {
     // inside the same band. On Windows/Linux, titleBarOverlay tells Electron
     // to paint native min/max/close in the top-right of the renderer; on
     // macOS it just reserves a content inset alongside the traffic lights.
-    titleBarStyle: 'hidden',
-    titleBarOverlay: getTitleBarOverlayOptions(),
-    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
-    vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    // In 'app-drawn' chrome mode the OS chrome is dropped entirely and the
+    // renderer paints min/max/close (see computeWindowChromeOptions).
+    ...computeWindowChromeOptions(),
     icon,
     // Hidden until the first themed paint so macOS `vibrancy` (which ignores
     // `backgroundColor` and follows the OS appearance) can't flash a light
     // material before the renderer paints the app theme. See createSessionWindow.
     show: false,
-    backgroundColor: getWindowBackgroundColor(),
     // Shared with the secondary session windows (chatWindowWebPreferences);
     // stream-aware throttling is applied per-window via streamThrottle so a
     // live answer keeps painting while the window is blurred or minimized,
@@ -10614,6 +10663,45 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
   for (const win of BrowserWindow.getAllWindows()) {
     applyWindowTranslucency(win)
   }
+})
+
+// App-drawn window chrome: the renderer's min/max/close buttons (only
+// rendered in 'app-drawn' mode — see WindowControls). The sender's own window
+// is the target, so secondary/instance windows control themselves.
+ipcMain.on('hermes:window-control:minimize', event => {
+  BrowserWindow.fromWebContents(event.sender)?.minimize()
+})
+
+ipcMain.on('hermes:window-control:toggle-maximize', event => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  if (!win) {
+    return
+  }
+
+  if (win.isMaximized()) {
+    win.unmaximize()
+  } else {
+    win.maximize()
+  }
+})
+
+ipcMain.on('hermes:window-control:close', event => {
+  BrowserWindow.fromWebContents(event.sender)?.close()
+})
+
+// Persist the window-chrome mode. `frame` can't change on a live window, so
+// the new mode applies to windows created after the next launch; the renderer
+// switches its own controls immediately. See store/window-chrome.
+ipcMain.on('hermes:window-chrome', (_event, payload) => {
+  const mode = payload && payload.mode === 'app-drawn' ? 'app-drawn' : 'overlay'
+
+  if (mode === windowChromeMode) {
+    return
+  }
+
+  windowChromeMode = mode
+  writeWindowChromeMode(mode)
 })
 
 // Keep-awake: hold the machine awake for long/overnight runs. Main owns the one

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -874,7 +874,10 @@ function getTitleBarOverlayOptions() {
 // title bar + native WCO on Windows/Linux, traffic lights on macOS. 'app-drawn'
 // mode (non-macOS only) drops the OS chrome entirely (`frame: false`) so the
 // renderer paints min/max/close itself — see src/app/shell/window-controls.
-function computeWindowChromeOptions(): Electron.BrowserWindowConstructorOptions {
+// Compact session windows pass appDrawn: false: their slim shell trims the
+// titlebar controls (no WindowControls to fall back on), so they keep the
+// native overlay.
+function computeWindowChromeOptions({ appDrawn = true } = {}): Electron.BrowserWindowConstructorOptions {
   const base: Electron.BrowserWindowConstructorOptions = {
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
@@ -883,7 +886,7 @@ function computeWindowChromeOptions(): Electron.BrowserWindowConstructorOptions 
   }
 
   // macOS is already app-drawn in both modes (hidden titlebar + native lights).
-  if (IS_MAC || windowChromeMode !== 'app-drawn') {
+  if (IS_MAC || !appDrawn || windowChromeMode !== 'app-drawn') {
     return {
       ...base,
       titleBarStyle: 'hidden',
@@ -8796,7 +8799,10 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     minWidth: SESSION_WINDOW_MIN_WIDTH,
     minHeight: SESSION_WINDOW_MIN_HEIGHT,
     title: 'Hermes',
-    ...computeWindowChromeOptions(),
+    // Session windows keep the native overlay chrome even in app-drawn mode:
+    // their slim shell trims the titlebar controls, so there is no
+    // WindowControls cluster to fall back on.
+    ...computeWindowChromeOptions({ appDrawn: false }),
     icon,
     // Don't show until the renderer's first themed paint is ready. macOS
     // `vibrancy` ignores `backgroundColor` and paints a translucent OS

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -135,6 +135,16 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
+  // App-drawn window chrome: renderer min/max/close (see WindowControls) and
+  // the persisted chrome-mode setting ('overlay' | 'app-drawn'). Mirrors the
+  // translucency pattern: the renderer owns the value, main persists it for
+  // window creation before the renderer loads.
+  setWindowChrome: payload => ipcRenderer.send('hermes:window-chrome', payload),
+  windowControls: {
+    minimize: () => ipcRenderer.send('hermes:window-control:minimize'),
+    toggleMaximize: () => ipcRenderer.send('hermes:window-control:toggle-maximize'),
+    close: () => ipcRenderer.send('hermes:window-control:close')
+  },
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -110,6 +110,7 @@ import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
+import { useAppDrawnChrome, WINDOW_CONTROLS_WIDTH } from '../shell/window-controls'
 import { titlebarControlsPosition } from '../shell/titlebar'
 import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
@@ -967,9 +968,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const controlsTranslateY = 2
   // Windows/WSLg reserve native min/max/close on the right (AppShell parity:
   // prefer the live WCO measurement, fall back to the static reservation).
+  // In app-drawn mode the renderer's own window controls occupy that slot, so
+  // the system cluster reserves their width instead.
   const measuredOverlayWidth = useWindowControlsOverlayWidth()
   const nativeOverlayWidth = measuredOverlayWidth ?? connection?.nativeOverlayWidth ?? 0
-  const titlebarToolsRight = nativeOverlayWidth > 0 ? `${nativeOverlayWidth}px` : '0.75rem'
+  const appDrawn = useAppDrawnChrome()
+  const titlebarToolsRight = appDrawn ? WINDOW_CONTROLS_WIDTH : nativeOverlayWidth > 0 ? `${nativeOverlayWidth}px` : '0.75rem'
   // Pane-registered tools (preview's monitor/devtools cluster) anchor flush
   // against the static system cluster — in the tree layout the titlebar band
   // sits ABOVE the grid, so AppShell's pane-width anchoring doesn't apply.

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -18,6 +18,7 @@ import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/p
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
+import { $windowChrome, setWindowChrome } from '@/store/window-chrome'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
 import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
@@ -252,6 +253,7 @@ export function AppearanceSettings() {
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
+  const windowChrome = useStore($windowChrome)
   const reactionsEnabled = useStore($reactionsEnabled)
   const backdrop = useStore($backdrop)
   const installs = useStore($marketplaceInstalls)
@@ -457,6 +459,24 @@ export function AppearanceSettings() {
             }
             description={a.translucencyDesc}
             title={a.translucencyTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setWindowChrome(id === 'on' ? 'app-drawn' : 'overlay')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={windowChrome === 'app-drawn' ? 'on' : 'off'}
+              />
+            }
+            description={a.windowChromeDesc}
+            title={a.windowChromeTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -22,6 +22,7 @@ import {
 import { appViewForPath, isOverlayView, SETTINGS_ROUTE } from '../routes'
 
 import { titlebarButtonClass } from './titlebar'
+import { WindowControls } from './window-controls'
 
 export interface TitlebarTool {
   id: string
@@ -261,6 +262,11 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         ))}
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
       </div>
+
+      {/* App-drawn min/max/close — renders in place of the native WCO when the
+          window was created with frame: false. Hidden alongside the other
+          clusters while an overlay view owns the window. */}
+      <WindowControls />
     </>
   )
 }

--- a/apps/desktop/src/app/shell/window-controls.test.tsx
+++ b/apps/desktop/src/app/shell/window-controls.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { setConnection } from '@/store/session'
+import type { HermesConnection } from '@/global'
+
+import { WindowControls } from './window-controls'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const WCO_API = {
+  visible: true,
+  getTitlebarAreaRect: () => ({ right: 100, width: 100 }) as DOMRect,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined
+}
+
+function setWcoAvailable(available: boolean) {
+  Object.defineProperty(navigator, 'windowControlsOverlay', {
+    configurable: true,
+    value: available ? WCO_API : undefined
+  })
+}
+
+function connect(overrides: Partial<HermesConnection> = {}) {
+  setConnection({
+    baseUrl: 'http://box:9119',
+    isFullscreen: false,
+    mode: 'local',
+    nativeOverlayWidth: 144,
+    token: 't',
+    wsUrl: 'ws://box:9119',
+    logs: [],
+    windowButtonPosition: null,
+    windowChromeMode: 'overlay',
+    ...overrides
+  })
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  setConnection(null)
+  setWcoAvailable(true)
+})
+
+describe('WindowControls (app-drawn window chrome)', () => {
+  it('renders nothing in default overlay mode with a native overlay present', () => {
+    connect({ windowChromeMode: 'overlay' })
+    setWcoAvailable(true)
+
+    render(
+      <I18nProvider>
+        <WindowControls />
+      </I18nProvider>
+    )
+
+    expect(screen.queryByRole('button', { name: /minimize/i })).toBeNull()
+  })
+
+  it('renders min/max/close in app-drawn mode and drives window controls over IPC', () => {
+    connect({ windowChromeMode: 'app-drawn' })
+    const minimize = vi.fn()
+    const toggleMaximize = vi.fn()
+    const close = vi.fn()
+    vi.stubGlobal('hermesDesktop', { windowControls: { minimize, toggleMaximize, close } })
+
+    render(
+      <I18nProvider>
+        <WindowControls />
+      </I18nProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /minimize/i }))
+    fireEvent.click(screen.getByRole('button', { name: /maximize/i }))
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+    expect(minimize).toHaveBeenCalledTimes(1)
+    expect(toggleMaximize).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to app-drawn controls when no native overlay exists (WSLg bug class)', () => {
+    connect({ windowChromeMode: 'overlay', windowButtonPosition: null })
+    setWcoAvailable(false)
+
+    render(
+      <I18nProvider>
+        <WindowControls />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('button', { name: /minimize/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /close/i })).toBeTruthy()
+  })
+
+  it('never falls back on macOS (traffic lights are native, windowButtonPosition set)', () => {
+    connect({ windowChromeMode: 'overlay', windowButtonPosition: { x: 24, y: 10 } })
+    setWcoAvailable(false)
+
+    render(
+      <I18nProvider>
+        <WindowControls />
+      </I18nProvider>
+    )
+
+    expect(screen.queryByRole('button', { name: /minimize/i })).toBeNull()
+  })
+
+  it('flips the center button to restore when the window is maximized', () => {
+    connect({ windowChromeMode: 'app-drawn' })
+    let onState: ((state: { isMaximized?: boolean }) => void) | undefined
+    vi.stubGlobal('hermesDesktop', {
+      windowControls: { minimize: vi.fn(), toggleMaximize: vi.fn(), close: vi.fn() },
+      onWindowStateChanged: (callback: (state: { isMaximized?: boolean }) => void) => {
+        onState = callback
+        return () => undefined
+      }
+    })
+
+    render(
+      <I18nProvider>
+        <WindowControls />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('button', { name: /maximize/i })).toBeTruthy()
+
+    act(() => onState?.({ isMaximized: true }))
+
+    expect(screen.getByRole('button', { name: /restore/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /maximize/i })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/window-controls.tsx
+++ b/apps/desktop/src/app/shell/window-controls.tsx
@@ -1,0 +1,134 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { $connection } from '@/store/session'
+
+import { titlebarButtonClass } from './titlebar'
+
+// Renderer-drawn min/max/close for 'app-drawn' window chrome (frame: false,
+// non-macOS — see computeWindowChromeOptions in electron/main.ts). The cluster
+// sits in the exact slot the native Window Controls Overlay would occupy, so
+// the titlebar reservation math in contrib/wiring.tsx swaps one width for the
+// other.
+
+// Right-edge reservation the system titlebar tools need while the cluster is
+// visible: 3 buttons + 2 gaps (gap-x-1) + the cluster's right padding (pr-1.5),
+// in the same CSS-var arithmetic wiring.tsx uses for the system cluster.
+export const WINDOW_CONTROLS_WIDTH = 'calc(3 * (var(--titlebar-control-size) + 0.25rem) + 0.375rem)'
+
+interface WindowControlsOverlayLike {
+  visible: boolean
+  getTitlebarAreaRect: () => DOMRect
+  addEventListener: (type: 'geometrychange', cb: () => void) => void
+  removeEventListener: (type: 'geometrychange', cb: () => void) => void
+}
+
+// True when Chromium exposes the Window Controls Overlay API — i.e. Electron's
+// WCO is active (native Windows AND plain Linux). Absent on macOS (traffic
+// lights are native, never a WCO) and on WSLg without host-drawn controls —
+// the exact condition behind the "missing window controls" bug reports.
+export function isWindowControlsOverlayAvailable(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    (navigator as Navigator & { windowControlsOverlay?: WindowControlsOverlayLike | null }).windowControlsOverlay !=
+      null
+  )
+}
+
+/**
+ * Whether THIS window should draw its own window controls.
+ *
+ * - The persisted 'app-drawn' setting wins outright.
+ * - Otherwise fall back to app-drawn when there is no native controls overlay
+ *   at all — but never on macOS, where the traffic lights are native and the
+ *   renderer must keep clear of them (windowButtonPosition is non-null there).
+ */
+export function useAppDrawnChrome(): boolean {
+  const connection = useStore($connection)
+
+  if (connection?.windowChromeMode === 'app-drawn') {
+    return true
+  }
+
+  return !isWindowControlsOverlayAvailable() && connection?.windowButtonPosition === null
+}
+
+// Live maximize state so the center button flips maximize ⇄ restore. Rides the
+// existing hermes:window-state-changed push (main sends it on maximize,
+// unmaximize, minimize, restore, show/hide and fullscreen changes).
+export function useWindowMaximized(): boolean {
+  const [isMaximized, setIsMaximized] = useState(false)
+
+  useEffect(() => {
+    return (
+      window.hermesDesktop?.onWindowStateChanged?.(state => {
+        setIsMaximized(Boolean(state.isMaximized))
+      })
+    )
+  }, [])
+
+  return isMaximized
+}
+
+export function WindowControls() {
+  const { t } = useI18n()
+  const appDrawn = useAppDrawnChrome()
+  const isMaximized = useWindowMaximized()
+
+  if (!appDrawn) {
+    return null
+  }
+
+  const controls = window.hermesDesktop?.windowControls
+
+  return (
+    <div
+      aria-label={t.shell.windowControls}
+      className="fixed right-0 top-0 z-70 flex h-(--titlebar-height) flex-row items-center justify-end gap-x-1 pr-1.5 pointer-events-auto select-none [-webkit-app-region:no-drag]"
+    >
+      <Tip label={t.shell.windowButtons.minimize}>
+        <Button
+          aria-label={t.shell.windowButtons.minimize}
+          className={titlebarButtonClass}
+          onClick={() => controls?.minimize()}
+          onPointerDown={event => event.stopPropagation()}
+          size="icon-titlebar"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="chrome-minimize" />
+        </Button>
+      </Tip>
+      <Tip label={isMaximized ? t.shell.windowButtons.restore : t.shell.windowButtons.maximize}>
+        <Button
+          aria-label={isMaximized ? t.shell.windowButtons.restore : t.shell.windowButtons.maximize}
+          className={titlebarButtonClass}
+          onClick={() => controls?.toggleMaximize()}
+          onPointerDown={event => event.stopPropagation()}
+          size="icon-titlebar"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name={isMaximized ? 'chrome-restore' : 'chrome-maximize'} />
+        </Button>
+      </Tip>
+      <Tip label={t.shell.windowButtons.close}>
+        <Button
+          aria-label={t.shell.windowButtons.close}
+          className={titlebarButtonClass}
+          onClick={() => controls?.close()}
+          onPointerDown={event => event.stopPropagation()}
+          size="icon-titlebar"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="chrome-close" />
+        </Button>
+      </Tip>
+    </div>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -145,6 +145,14 @@ declare global {
       setActiveWork?: (payload: HermesActiveWork) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
+      // App-drawn window chrome: persist the mode and drive min/max/close
+      // over IPC (see WindowControls).
+      setWindowChrome?: (payload: { mode: 'overlay' | 'app-drawn' }) => void
+      windowControls?: {
+        minimize: () => void
+        toggleMaximize: () => void
+        close: () => void
+      }
       setTranslucency?: (payload: { intensity: number }) => void
       setKeepAwake?: (on: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
@@ -479,6 +487,9 @@ export interface HermesConnection {
   // connection belongs to.
   profile?: string
   windowButtonPosition: { x: number; y: number } | null
+  // 'overlay' = native WCO / traffic lights (default); 'app-drawn' = the
+  // renderer paints min/max/close (frame: false, non-macOS).
+  windowChromeMode: 'overlay' | 'app-drawn'
 }
 
 export interface HermesTitleBarTheme {
@@ -494,10 +505,14 @@ export interface HermesActiveWork {
 
 export interface HermesWindowState {
   isFullscreen: boolean
+  isMaximized?: boolean
   isMinimized?: boolean
   isVisible?: boolean
   nativeOverlayWidth: number
   windowButtonPosition: { x: number; y: number } | null
+  // 'overlay' = native WCO / traffic lights (default); 'app-drawn' = the
+  // renderer paints min/max/close (frame: false, non-macOS).
+  windowChromeMode: 'overlay' | 'app-drawn'
 }
 
 export interface DesktopActiveProfile {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -447,6 +447,9 @@ export const en: Translations = {
       terminalFontReset: 'Use default',
       translucencyTitle: 'Window Translucency',
       translucencyDesc: 'See your desktop through the whole window. macOS and Windows only.',
+      windowChromeTitle: 'App-Drawn Window Chrome',
+      windowChromeDesc:
+        'Draw min/max/close in the app instead of the OS. Needed for custom window-frame skins; also fixes missing window controls on WSLg. Applies after restart.',
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
       reactionsTitle: 'Message Reactions',
@@ -2387,6 +2390,12 @@ export const en: Translations = {
 
   shell: {
     windowControls: 'Window controls',
+    windowButtons: {
+      minimize: 'Minimize',
+      maximize: 'Maximize',
+      restore: 'Restore',
+      close: 'Close'
+    },
     paneControls: 'Pane controls',
     appControls: 'App controls',
     modelMenu: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -355,6 +355,8 @@ export interface Translations {
       terminalFontReset: string
       translucencyTitle: string
       translucencyDesc: string
+      windowChromeTitle: string
+      windowChromeDesc: string
       backdropTitle: string
       backdropDesc: string
       reactionsTitle: string
@@ -1990,6 +1992,12 @@ export interface Translations {
 
   shell: {
     windowControls: string
+    windowButtons: {
+      minimize: string
+      maximize: string
+      restore: string
+      close: string
+    }
     paneControls: string
     appControls: string
     modelMenu: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -439,6 +439,8 @@ export const zh: Translations = {
       terminalFontReset: '使用默认字体',
       translucencyTitle: '窗口透明',
       translucencyDesc: '让整个窗口透出桌面。仅支持 macOS 和 Windows。',
+      windowChromeTitle: '应用绘制窗口边框',
+      windowChromeDesc: '由应用绘制最小化/最大化/关闭按钮，而非系统。自定义窗口边框皮肤需要此选项；同时修复 WSLg 下窗口按钮缺失的问题。重启后生效。',
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
       reactionsTitle: '消息回应',
@@ -2568,6 +2570,12 @@ export const zh: Translations = {
 
   shell: {
     windowControls: '窗口控件',
+    windowButtons: {
+      minimize: '最小化',
+      maximize: '最大化',
+      restore: '还原',
+      close: '关闭'
+    },
     paneControls: '面板控件',
     appControls: '应用控件',
     modelMenu: {

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -80,7 +80,8 @@ const setRemote = (on: boolean) =>
     token: 't',
     wsUrl: 'ws://box:9119',
     logs: [],
-    windowButtonPosition: null
+    windowButtonPosition: null,
+    windowChromeMode: 'overlay'
   })
 
 describe('maybeNotifyUpdateAvailable', () => {

--- a/apps/desktop/src/store/window-chrome.ts
+++ b/apps/desktop/src/store/window-chrome.ts
@@ -1,0 +1,34 @@
+/**
+ * Window chrome mode: 'overlay' (native Window Controls Overlay / traffic
+ * lights, the default) or 'app-drawn' (frame: false — the renderer paints
+ * min/max/close itself via WindowControls).
+ *
+ * The renderer owns the value and mirrors it to the main process over IPC,
+ * exactly like window translucency. Main persists its own copy so window
+ * creation applies the mode before the renderer loads; `frame` can't change
+ * on a live window, so a toggle applies from the next launch (the controls
+ * themselves switch immediately on this side).
+ */
+
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.windowChrome.v1'
+
+export type WindowChromeMode = 'overlay' | 'app-drawn'
+
+const read = (): WindowChromeMode => (storedString(KEY) === 'app-drawn' ? 'app-drawn' : 'overlay')
+
+export const $windowChrome = atom<WindowChromeMode>(typeof window === 'undefined' ? 'overlay' : read())
+
+export function setWindowChrome(mode: WindowChromeMode): void {
+  $windowChrome.set(mode === 'app-drawn' ? 'app-drawn' : 'overlay')
+}
+
+if (typeof window !== 'undefined') {
+  $windowChrome.subscribe(mode => {
+    persistString(KEY, mode)
+    window.hermesDesktop?.setWindowChrome?.({ mode })
+  })
+}


### PR DESCRIPTION
## What & why

This PR adds an **app-drawn window chrome mode** to the desktop app: an opt-in setting that makes Hermes draw its own min/max/close buttons and drop the OS titlebar entirely (`frame: false`), driven by a tiny IPC surface (`hermes:window-control:*`).

Two audiences:

1. **The bug pile (immediate fix).** Window controls have been missing or broken on Linux/WSLg for months — #70400 and #57614 are still open. The native-overlay route keeps failing on WSLg (three open PRs attempt it: #57621, #71754, #70803; #64505, the previous renderer-drawn attempt, was closed `needs-decision` without a fix). App-drawn controls are the one approach that **cannot** be defeated by the platform: if the OS won't draw chrome for us, we draw it ourselves. This PR is the durable fix for that class, and it also gives users a workaround for the Electron 40+ Linux frame regressions (#53690, #54294) while those get sorted upstream.
2. **The foundation (feature).** A frameless, renderer-drawn chrome mode is the prerequisite for custom window-frame skins. The skin schema side (a `chrome:` section that themes the titlebar/statusbar/controls) is a follow-up PR — this one lands the mechanism, deliberately minimal.

## What changed

- **`electron/main.ts`** — `computeWindowChromeOptions()` factory replaces three repeated BrowserWindow chrome blocks; `windowChromeMode: 'overlay' | 'app-drawn'` persisted to `window-chrome.json` (modeled on the existing translucency persistence); IPC handlers `hermes:window-control:{minimize,toggle-maximize,close}` targeting `BrowserWindow.fromWebContents(event.sender)`; `isMaximized` + `windowChromeMode` added to the window-state push.
- **`electron/preload.ts`** — exposes `windowControls.{minimize,toggleMaximize,close}` and `setWindowChrome`.
- **Renderer** — new `WindowControls` component (min/max/close cluster) + a `window-chrome` store; mounted in the shell titlebar; the titlebar tool cluster reserves the right width so nothing shifts when the mode flips.
- **Settings** — Appearance → "App-Drawn Window Chrome" on/off row (i18n: en + zh).

## Design decisions

- **Default is `overlay` — byte-for-byte current behavior.** The mode only changes anything when turned on.
- **macOS is never `frame: false`** — the hidden-titlebar + traffic-lights setup there is already the good outcome; the setting row is hidden on macOS.
- **Session (secondary) windows are hard-gated to `overlay`** — their compact shell trims titlebar tools (#46951), so there'd be no close affordance without the OS controls.
- **`frame` can't change on a live BrowserWindow**, so the mode applies to windows created after the next launch (the settings copy says so).
- **WSLg auto-fallback:** when `navigator.windowControlsOverlay` is absent (WSLg), the app draws its own controls even in `overlay` mode — the renderer already owns the titlebar there.

## Testing

- `npx tsc -p . --noEmit` / `tsc --build tsconfig.electron.json` / shared typecheck — clean
- ESLint on changed files — 0 errors
- `vitest run --project ui` — full UI suite passes (379 files / 3274 tests, incl. 5 new `window-controls.test.tsx`)
- `npm run test:desktop:platforms` — 926 tests pass

No duplicate feature request exists upstream (searched: winamp, skinnable, frameless, custom title bar, app-drawn — zero feature hits; only the bug/PR pile above).
