### PR TITLE
fix(buzz): discover joined channels added mid-run

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -922,9 +922,12 @@ class BuzzAdapter(BasePlatformAdapter):
         self._trim_seen(state)
 
     async def _discover_dms(self, *, seed: bool) -> None:
-        """Watch DM conversations.  New ones found mid-run dispatch from their
-        beginning (a fresh conversation has no history worth suppressing);
-        ones present at startup are seeded like channels.
+        """Refresh conversations that may appear after startup.
+
+        With an empty channel filter, every joined channel is watched, so new
+        regular channels must be enrolled as they appear. Explicit channel
+        filters remain bounded, but DMs are always discovered. New finds
+        dispatch from their beginning; startup finds are seeded like channels.
 
         ``dms list`` is only a best-effort source: on some hosted relays it
         returns ``[]`` even when DM conversations exist (#68871).  Those DMs
@@ -955,7 +958,12 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+            if ch_id in self._channel_state:
+                continue
+            # Empty self.channels means "all joined channels".  With an
+            # explicit filter, only the DM-shaped fallback may expand the
+            # runtime watch set.
+            if self.channels and not self._may_reclassify_as_dm(ch_id):
                 continue
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -360,10 +360,9 @@ class TestDmClassification:
 
 
     @pytest.mark.asyncio
-    async def test_dm_shaped_channel_discovered_when_dms_list_empty(self):
-        """Fallback discovery: with `dms list` broken (returns []), a
-        DM-shaped `channels list` entry gets watched; real channels not
-        already watched are left alone."""
+    async def test_all_joined_mode_discovers_new_channels_mid_run(self):
+        """An empty channel filter means every joined channel, including
+        channels added after the adapter connected."""
         a = _make_adapter()
         cli = _ScriptedCli()
         cli.script("dms", "list", [])
@@ -374,6 +373,26 @@ class TestDmClassification:
         ])
         a._run_cli = cli
         await a._discover_dms(seed=False)
+
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "group"
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        assert a._channel_names[CHANNEL] == "general"
+
+    @pytest.mark.asyncio
+    async def test_explicit_channel_filter_only_auto_discovers_dms(self):
+        """A configured channel allow-list stays bounded while DM discovery
+        remains available."""
+        a = _make_adapter({"channels": ["configured-channel"]})
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [
+            {"channel_id": DM_CHANNEL, "name": "DM", "description": "", "created_at": 1},
+            {"channel_id": CHANNEL, "name": "general",
+             "description": "General conversation and community updates.", "created_at": 2},
+        ])
+        a._run_cli = cli
+        await a._discover_dms(seed=False)
+
         # Watched as group; the p-tag latch flips it on the first real DM.
         assert a._channel_state[DM_CHANNEL]["chat_type"] == "group"
         assert a._may_reclassify_as_dm(DM_CHANNEL) is True


### PR DESCRIPTION
## Summary

Buzz adapters configured for “all joined channels” now begin watching channels added after startup, instead of silently ignoring them until the gateway restarts. Explicit channel filters remain bounded, while DM discovery continues to work as before.

The same refresh path serves WebSocket membership events and polling fallback, so dynamic enrollment behaves consistently across both transports.

## Test plan

- `python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q -o 'addopts='` — 28 passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)
