### PR TITLE
fix(slack): expose triggering message IDs in threads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15316,6 +15316,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
+        # Slack event timestamps are also message IDs, and threaded replies
+        # have a different ID from their thread root. Surface both per turn so
+        # skills can use the triggering ID as a stable idempotency/source
+        # reference without confusing it with the thread ID. Like the Discord
+        # note above, this belongs in volatile user content rather than the
+        # cached session prompt.
+        if (
+            source is not None
+            and getattr(source, "platform", None) == Platform.SLACK
+            and getattr(event, "message_id", None)
+            and source.thread_id
+            and source.thread_id != event.message_id
+        ):
+            message_text = (
+                f"[Slack event metadata — triggering message id: `{event.message_id}`; "
+                f"thread id: `{source.thread_id}`. Use the triggering message id as "
+                f"the unique event/source reference for this message.]\n\n"
+                f"{message_text}"
+            )
+
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -148,7 +148,12 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
         for call in runner.session_store.append_to_transcript.call_args_list
     ]
     assert transcript_roles == ["session_meta", "user"]
-    assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
+    user_content = runner.session_store.append_to_transcript.call_args_list[1].args[1][
+        "content"
+    ]
+    assert "triggering message id: `m-1`" in user_content
+    assert "thread id: `171717`" in user_content
+    assert user_content.endswith("hello")
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -36,6 +36,17 @@ def _source() -> SessionSource:
     )
 
 
+def _slack_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_name="reel-review",
+        chat_type="group",
+        user_id="U123",
+        thread_id="1712345000.000100",
+    )
+
+
 @pytest.mark.asyncio
 async def test_reply_prefix_injected_when_text_absent_from_history():
     runner = _make_runner()
@@ -99,3 +110,47 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+@pytest.mark.asyncio
+async def test_slack_thread_reply_exposes_triggering_message_id_separately_from_thread():
+    """A thread root is not a safe idempotency key for each reply in it."""
+    runner = _make_runner()
+    source = _slack_source()
+    event = MessageEvent(
+        text="reels skip R0001",
+        source=source,
+        message_id="1712345678.000200",
+        reply_to_message_id="1712345000.000100",
+        reply_to_text="Reel R0001 is ready for review.",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert "triggering message id: `1712345678.000200`" in result
+    assert "thread id: `1712345000.000100`" in result
+    assert result.startswith('[Replying to: "Reel R0001 is ready for review."]')
+    assert result.endswith("reels skip R0001")
+
+
+@pytest.mark.asyncio
+async def test_slack_top_level_message_does_not_duplicate_its_thread_id():
+    runner = _make_runner()
+    source = _slack_source()
+    source.thread_id = "1712345678.000200"
+    event = MessageEvent(
+        text="reels ingest R0003",
+        source=source,
+        message_id="1712345678.000200",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "reels ingest R0003"


### PR DESCRIPTION
## What does this PR do?

Threaded Slack commands can now use the triggering message's own timestamp as a stable source reference. Previously, Hermes exposed only the thread-root timestamp, so idempotent workflows could not identify the command event and refused to change state. Hermes now supplies both IDs in volatile per-turn content, preserving the cached system prompt; top-level Slack messages remain unchanged.

## Related Issue

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: expose distinct Slack triggering-message and thread-root IDs to the agent per turn.
- `tests/gateway/test_reply_to_injection.py`: cover threaded Slack messages and verify top-level messages avoid redundant metadata.
- `tests/gateway/test_incomplete_gateway_turns.py`: verify the metadata survives the real gateway transcript path.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_reply_to_injection.py tests/gateway/test_incomplete_gateway_turns.py tests/gateway/test_prompt_tail_freeze.py tests/gateway/test_slack.py -q`.
2. Send a Slack command as a reply in a thread and verify the agent receives both the command timestamp and thread-root timestamp.
3. Verify a top-level Slack command retains its original text without redundant metadata.

Focused validation passed: 177 tests, including Slack adapter, transcript, reply-pointer, and prompt-cache coverage. Ruff and `git diff --check` also pass. A full `scripts/run_tests.sh -q` run completed with 23,847 passes and 23 failures across 13 files; all failures are outside this PR's changed files and include platform/environment assumptions plus unrelated upstream behavior. One additional flaky file passed on retry. Because the full suite is not green on macOS, the all-tests-pass checklist item remains unchecked.

## Post-Deploy Monitoring & Validation

- Exercise the next threaded Slack command that requires a unique source reference; it should complete without the "Slack gateway did not expose this command's message ID" rejection.
- Confirm the acknowledgement and final result stay in the originating Slack thread and the command produces only one state transition.
- Watch gateway errors for message-preparation or transcript regressions during the next 24 hours.
- Roll back by reverting this commit and restarting the gateway if Slack prompt preparation regresses.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or command contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral prompt preparation
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is gateway prompt plumbing covered by behavioral tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
