### PR TITLE
fix(dashboard): render the sidebar and footer plugin slots declared in slots.ts (#76381)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { SidebarFooter } from "@/components/SidebarFooter";
+import { CockpitSidebarSlot } from "@/components/CockpitSidebarSlot";
 import { SidebarStatusStrip, gatewayLine } from "@/components/SidebarStatusStrip";
 import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
 import { useSidebarStatus } from "@/hooks/useSidebarStatus";
@@ -689,6 +690,10 @@ export default function App() {
                 </div>
               )}
             </nav>
+
+            {/* Cockpit rail plugins — the `sidebar` slot renders only in the
+                cockpit layout variant (extending-the-dashboard.md). */}
+            <CockpitSidebarSlot layoutVariant={layoutVariant} />
 
             <SidebarSystemActions
               collapsed={isDesktopCollapsed}

--- a/web/src/components/CockpitSidebarSlot.tsx
+++ b/web/src/components/CockpitSidebarSlot.tsx
@@ -1,0 +1,8 @@
+import { PluginSlot } from "@/plugins";
+
+/** The `sidebar` slot renders only when `layoutVariant === "cockpit"`
+ *  (documented in extending-the-dashboard.md). Extracted so the rule is
+ *  testable without mounting the full App shell. */
+export function CockpitSidebarSlot({ layoutVariant }: { layoutVariant: string }) {
+  return layoutVariant === "cockpit" ? <PluginSlot name="sidebar" /> : null;
+}

--- a/web/src/components/SidebarFooter.tsx
+++ b/web/src/components/SidebarFooter.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import type { StatusResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/i18n";
+import { PluginSlot } from "@/plugins";
 
 export function SidebarFooter({ status }: SidebarFooterProps) {
   const { t } = useI18n();
@@ -14,24 +15,34 @@ export function SidebarFooter({ status }: SidebarFooterProps) {
         "border-t border-current/10",
       )}
     >
-      <Typography
-        className="font-mono-ui text-xs tabular-nums tracking-[0.08em] text-text-tertiary lowercase"
-      >
-        {status?.version != null ? `v${status.version}` : "—"}
-      </Typography>
+      <PluginSlot
+        name="footer-left"
+        fallback={
+          <Typography
+            className="font-mono-ui text-xs tabular-nums tracking-[0.08em] text-text-tertiary lowercase"
+          >
+            {status?.version != null ? `v${status.version}` : "—"}
+          </Typography>
+        }
+      />
 
-      <a
-        href="https://nousresearch.com"
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cn(
-          "font-sans text-display text-xs tracking-[0.12em] text-midground",
-          "transition-opacity hover:opacity-90",
-          "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
-        )}
-      >
-        {t.app.footer.org}
-      </a>
+      <PluginSlot
+        name="footer-right"
+        fallback={
+          <a
+            href="https://nousresearch.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "font-sans text-display text-xs tracking-[0.12em] text-midground",
+              "transition-opacity hover:opacity-90",
+              "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
+            )}
+          >
+            {t.app.footer.org}
+          </a>
+        }
+      />
     </div>
   );
 }

--- a/web/src/plugins/shell-slots.test.tsx
+++ b/web/src/plugins/shell-slots.test.tsx
@@ -1,0 +1,92 @@
+/** Regression tests for #76381: the sidebar / footer-left / footer-right
+ *  slots are declared in KNOWN_SLOT_NAMES and documented in
+ *  extending-the-dashboard.md, but the shell never rendered them — a plugin
+ *  targeting them mounted into nothing (silent no-op).
+ *
+ *  The footer slots live in SidebarFooter with the default cells as
+ *  `fallback` (plugin content replaces the default when registered); the
+ *  sidebar slot renders only when layoutVariant === "cockpit"
+ *  (CockpitSidebarSlot). Tests drive the REAL production components via
+ *  renderToStaticMarkup — no jsdom needed.
+ *
+ *  On the pre-fix tree the "replaces" assertions fail (no PluginSlot in
+ *  SidebarFooter) and CockpitSidebarSlot does not exist to import. */
+import { describe, it, expect, afterEach } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { registerSlot, unregisterPluginSlots } from "@/plugins/slots";
+import { SidebarFooter } from "@/components/SidebarFooter";
+import { CockpitSidebarSlot } from "@/components/CockpitSidebarSlot";
+
+const Mark = ({ text }: { text: string }) =>
+  React.createElement("span", null, text);
+
+afterEach(() => {
+  unregisterPluginSlots("test-plugin");
+});
+
+describe("footer-left / footer-right slots (SidebarFooter)", () => {
+  it("renders the default cells as fallback when no plugin claims them", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SidebarFooter, {
+        status: { version: "1.2.3" } as never,
+      }),
+    );
+    expect(html).toContain("v1.2.3");
+    expect(html).toContain("nousresearch.com");
+  });
+
+  it("plugin content replaces the default left cell", () => {
+    registerSlot("test-plugin", "footer-left", () =>
+      React.createElement(Mark, { text: "PLUGIN-LEFT" }),
+    );
+    const html = renderToStaticMarkup(
+      React.createElement(SidebarFooter, {
+        status: { version: "1.2.3" } as never,
+      }),
+    );
+    expect(html).toContain("PLUGIN-LEFT");
+    expect(html).not.toContain("v1.2.3");
+  });
+
+  it("plugin content replaces the default right cell", () => {
+    registerSlot("test-plugin", "footer-right", () =>
+      React.createElement(Mark, { text: "PLUGIN-RIGHT" }),
+    );
+    const html = renderToStaticMarkup(
+      React.createElement(SidebarFooter, { status: null }),
+    );
+    expect(html).toContain("PLUGIN-RIGHT");
+    expect(html).not.toContain("nousresearch.com");
+  });
+});
+
+describe("sidebar slot (CockpitSidebarSlot)", () => {
+  it("renders plugin content in the cockpit variant", () => {
+    registerSlot("test-plugin", "sidebar", () =>
+      React.createElement(Mark, { text: "COCKPIT-PLUGIN" }),
+    );
+    const html = renderToStaticMarkup(
+      React.createElement(CockpitSidebarSlot, { layoutVariant: "cockpit" }),
+    );
+    expect(html).toContain("COCKPIT-PLUGIN");
+  });
+
+  it("renders nothing in the standard variant", () => {
+    registerSlot("test-plugin", "sidebar", () =>
+      React.createElement(Mark, { text: "COCKPIT-PLUGIN" }),
+    );
+    const html = renderToStaticMarkup(
+      React.createElement(CockpitSidebarSlot, { layoutVariant: "standard" }),
+    );
+    expect(html).not.toContain("COCKPIT-PLUGIN");
+  });
+
+  it("renders nothing in the cockpit variant when unclaimed", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(CockpitSidebarSlot, { layoutVariant: "cockpit" }),
+    );
+    expect(html).not.toContain("COCKPIT-PLUGIN");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

KNOWN_SLOT_NAMES declares and extending-the-dashboard.md documents ten shell slots, but App.tsx rendered only seven — plugins targeting sidebar, footer-left, or footer-right mounted into nothing (silent no-op), including Nous's own strike-freedom-cockpit example. Render footer-left/footer-right in SidebarFooter with the default cells (version, org link) as PluginSlot fallbacks so plugin content replaces them exactly as documented, and render the sidebar slot in the shell rail only when layoutVariant === 'cockpit'. Fixes #76381.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/76381

## Changes Made

- `fix/pluginslot-shell-renders` — 4 file(s) changed vs base:
  - `web/src/App.tsx`
  - `web/src/components/CockpitSidebarSlot.tsx`
  - `web/src/components/SidebarFooter.tsx`
  - `web/src/plugins/shell-slots.test.tsx`

web/src/components/SidebarFooter.tsx: both cells wrapped in PluginSlot with the original content as fallback (replaces-default semantics per the docs). web/src/components/CockpitSidebarSlot.tsx (new): the cockpit-only rule extracted so it is testable without mounting the full App shell. web/src/App.tsx: rail renders CockpitSidebarSlot after the nav. web/src/plugins/shell-slots.test.tsx (new): 6 vitest tests via renderToStaticMarkup (node env, no jsdom) — fallback cells render, plugin content replaces each footer cell, sidebar renders only in cockpit, nothing when unclaimed.

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: vitest (node22, web/): base leg test-file fails (missing CockpitSidebarSlot + 2 footer fallback assertions), head leg 6/6 pass — RAN both directions on the real tree
2. Vitest (node 22, web/): 6/6 pass. Sabotage verified manually both directions — the test file fails on pre-fix main (missing CockpitSidebarSlot + footer fallback assertions), 6/6 pass with the fix (recorded via prp sabotage --waive; TS-only change, no pytest pin exists). Python-side gates: seams no call-target changes, claims CLEAR, docs CLEAR. Stage 0: high-confidence UNCLAIMED via swarm + prp dupcheck (closest neighbors #14776 origin PR, #44825 page-scoped slot, #75967 desktop reconciler — none render these slots). Full repo-wide Python suite NOT run (TS-only change; CI owns it).
3. Duplicate check: 47 potential matches reviewed — none covers this change.
4. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: vitest (node22, web/): base leg test-file fails (missing CockpitSidebarSlot + 2 footer fallback assertions), head leg 6/6 pass — RAN both directions on the real tree
```
