### PR TITLE
fix(gateway): accept MSYS drive paths in media delivery on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1445,6 +1445,28 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+# MSYS/Cygwin-style drive paths (``/c/Users/...``, ``/d/tmp``, or a bare
+# ``/c``). Git Bash rewrites Windows paths into this form, so any tool the
+# agent runs through it reports files this way.
+_MSYS_DRIVE_RE = re.compile(r"^/([A-Za-z])(?:/(?P<rest>.*))?$")
+
+
+def _msys_to_windows_path(path: str) -> str:
+    r"""Translate an MSYS/Cygwin drive path to native Windows form.
+
+    ``/c/Users/me/out.png`` -> ``C:\Users\me\out.png``. Windows-only: on
+    POSIX hosts ``/c/...`` is a legitimate absolute path and must be left
+    alone. Anything that is not a drive path is returned unchanged.
+    """
+    if not path or sys.platform != "win32":
+        return path
+    match = _MSYS_DRIVE_RE.match(path)
+    if not match:
+        return path
+    rest = (match.group("rest") or "").replace("/", "\\")
+    return f"{match.group(1).upper()}:\\{rest}"
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -1474,6 +1496,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
     if not candidate:
         return None
+
+    # A path produced via Git Bash arrives as ``/c/Users/...``. Path() on
+    # Windows treats that as rooted-but-driveless, so ``is_absolute()`` is
+    # False and the file is rejected as unsafe even though it exists.
+    candidate = _msys_to_windows_path(candidate)
 
     try:
         expanded = Path(os.path.expanduser(candidate))

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import os
+import sys
 import time
 from unittest.mock import patch
 
@@ -1117,3 +1118,56 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+class TestMsysMediaDeliveryPaths:
+    """Git Bash hands back ``/c/Users/...``; media delivery must still accept it.
+
+    ``Path("/c/Users/me/out.png")`` on Windows is rooted but driveless, so
+    ``is_absolute()`` is False and ``validate_media_delivery_path`` rejected
+    the file as unsafe even though it existed. Any tool the agent ran through
+    Git Bash therefore produced a path it could not then deliver, surfacing
+    as "Skipping unsafe MEDIA directive path".
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("/c/Users/me/out.png", r"C:\Users\me\out.png"),
+            ("/d/tmp/report.pdf", r"D:\tmp\report.pdf"),
+            ("/c/", "C:\\"),
+            ("/c", "C:\\"),
+            # Already-native paths and POSIX non-drive paths are untouched.
+            (r"C:\Users\me\out.png", r"C:\Users\me\out.png"),
+            ("/home/me/out.png", "/home/me/out.png"),
+            ("/usr/share/thing.png", "/usr/share/thing.png"),
+            ("", ""),
+        ],
+    )
+    def test_conversion_on_windows(self, raw, expected, monkeypatch):
+        import gateway.platforms.base as base
+
+        monkeypatch.setattr(base.sys, "platform", "win32")
+        assert base._msys_to_windows_path(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["/c/Users/me/out.png", "/d/tmp/report.pdf"])
+    def test_noop_on_posix(self, raw, monkeypatch):
+        """On POSIX ``/c/...`` is a real path and must never be rewritten."""
+        import gateway.platforms.base as base
+
+        monkeypatch.setattr(base.sys, "platform", "linux")
+        assert base._msys_to_windows_path(raw) == raw
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows drive semantics")
+    def test_msys_path_is_accepted_end_to_end(self, tmp_path, monkeypatch):
+        import gateway.platforms.base as base
+
+        monkeypatch.setattr(base, "MEDIA_DELIVERY_SAFE_ROOTS", (str(tmp_path),))
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+        target = tmp_path / "out.png"
+        target.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        drive, rest = str(target).split(":", 1)
+        msys = f"/{drive.lower()}{rest.replace(chr(92), '/')}"
+
+        assert base.validate_media_delivery_path(msys) is not None


### PR DESCRIPTION
## What does this PR do?

Git Bash rewrites Windows paths into MSYS form, so a command run through it reports files as `/c/Users/me/out.png` rather than `C:\Users\me\out.png`. Any file the agent produces that way is then handed to `validate_media_delivery_path` in MSYS form.

`Path("/c/Users/me/out.png")` on Windows is rooted but **driveless**, so `is_absolute()` is `False` and the function returns `None` at the absolute check. The file exists and is perfectly safe, but delivery is refused. The user sees nothing arrive, and the only trace is a warning:

```
WARNING gateway.platforms.base: Skipping unsafe MEDIA directive path: /c/Users/<user>/Downloads/track.mp3
```

The fix translates MSYS drive paths to native Windows form before the absolute check. It is gated on `sys.platform == "win32"`, because on POSIX hosts `/c/...` is a legitimate absolute path and must be left untouched.

This is purely a path-normalisation fix ahead of the existing checks. The denylist, allowlist-root, strict-mode and symlink-resolution logic all run afterwards exactly as before, so the security posture is unchanged: a normalised path still has to clear every existing gate.

## Related Issue

No existing issue. Searched open and merged PRs and issues for `msys`, `git bash path`, `validate_media_delivery_path`, and `MEDIA path windows drive letter` before filing. The other open Windows/MSYS PRs (#63012 prompt guidance, #39910 cron, #73782 terminal quoting, #75455 rg/grep) are in different components and do not touch media egress.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`:
  - Add `_MSYS_DRIVE_RE` and `_msys_to_windows_path()`, converting `/c/Users/...` to `C:\Users\...` (also handles a bare `/c` and `/c/`). No-op on non-Windows and for any path that is not an MSYS drive path.
  - Call it in `validate_media_delivery_path()` immediately before `Path(os.path.expanduser(...))`.
- `tests/gateway/test_platform_base.py`:
  - Add `TestMsysMediaDeliveryPaths` with 11 cases: conversion, bare-drive edge cases, already-native paths, POSIX paths left alone, no-op on non-Windows, and a Windows-only end-to-end check that `validate_media_delivery_path` now accepts an MSYS path to a real file.

## How to Test

**Repro on Windows before the fix:**
1. Have the agent produce or reference a file via a Git Bash command, so the path comes back as `/c/Users/<you>/Downloads/track.mp3`.
2. Ask it to send that file. The agent emits `MEDIA:/c/Users/...`.
3. Nothing is delivered. `logs/gateway.log` shows `Skipping unsafe MEDIA directive path`.

**After the fix:** the same path resolves to `C:\Users\...`, clears the existing safety checks, and the file is delivered.

**Automated:**
```bash
pytest tests/gateway/test_platform_base.py::TestMsysMediaDeliveryPaths -q
# 11 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro (26200), Python 3.11

Note on the suite: `tests/gateway/` has 11 pre-existing failures on Windows on an unmodified `main` (symlink cases needing `SeCreateSymbolicLinkPrivilege`, plus media-resend-dedup). The identical 11 fail before and after this change; the only delta is the 11 new passing tests (489 to 500 passed on the `media or document or path or delivery` subset).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — behaviour is covered by the new helper's docstring
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: the conversion is explicitly Windows-gated and covered by a POSIX no-op test
- [x] N/A — no tool behaviour change
