### PR TITLE
fix(agent): drop client web_search on OpenRouter xAI :online requests (#76481)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -16,6 +16,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from utils import base_url_host_matches
 
 
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
@@ -101,6 +102,46 @@ def _snake_case_gemini_thinking_config(config: dict | None) -> dict | None:
     if isinstance(config.get("thinkingBudget"), (int, float)):
         translated["thinking_budget"] = int(config["thinkingBudget"])
     return translated or None
+
+
+def _tool_effective_name(tool: Any) -> str | None:
+    """Return a tool's effective name for both OpenAI-style and flat tools.
+
+    OpenAI function tools nest the name under ``{"function": {"name": …}}``;
+    some providers/tools carry a flat top-level ``{"name": …}``.
+    """
+    if not isinstance(tool, dict):
+        return None
+    fn = tool.get("function")
+    if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+        return fn["name"]
+    name = tool.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _omit_openrouter_online_web_search(
+    tools: list | None, model: str, base_url: Any
+) -> list | None:
+    """Drop the client ``web_search`` tool on OpenRouter xAI ``:online`` requests.
+
+    An OpenRouter ``x-ai/…:online`` request already carries OpenRouter's own
+    server-side online-search tool named ``web_search``.  Also forwarding
+    Hermes' client ``web_search`` makes xAI reject the whole request with
+    ``HTTP 400: Duplicate tool names: web_search`` (#76481).  Only the client
+    ``web_search`` is removed — ``web_extract``, terminal, and every other tool
+    are preserved.  Bare xAI, non-OpenRouter xAI, and non-xAI OpenRouter
+    requests keep the client ``web_search`` unchanged.
+    """
+    if not tools:
+        return tools
+    model_lower = (model or "").lower()
+    if not (
+        model_lower.endswith(":online")
+        and "x-ai/" in model_lower
+        and base_url_host_matches(str(base_url or ""), "openrouter.ai")
+    ):
+        return tools
+    return [t for t in tools if _tool_effective_name(t) != "web_search"]
 
 
 def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
@@ -371,7 +412,11 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
-            api_kwargs["tools"] = tools
+            tools = _omit_openrouter_online_web_search(
+                tools, model, params.get("base_url")
+            )
+            if tools:
+                api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")
@@ -556,7 +601,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
-            api_kwargs["tools"] = tools
+            tools = _omit_openrouter_online_web_search(
+                tools, model, params.get("base_url")
+            )
+            if tools:
+                api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -260,6 +260,46 @@ def _apply_max_tokens(api_kwargs: dict, model: str, reasoning_config: Any, param
         api_kwargs["max_tokens"] = params["anthropic_max_output"]
 
 
+def _tool_effective_name(tool: Any) -> str | None:
+    """Return a tool's effective name for both OpenAI-style and flat tools.
+
+    OpenAI function tools nest the name under ``{"function": {"name": …}}``;
+    some providers/tools carry a flat top-level ``{"name": …}``.
+    """
+    if not isinstance(tool, dict):
+        return None
+    fn = tool.get("function")
+    if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+        return fn["name"]
+    name = tool.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _omit_openrouter_online_web_search(tools: Any, model: str, base_url: Any) -> Any:
+    """Drop the client ``web_search`` tool on OpenRouter xAI ``:online`` requests.
+
+    An OpenRouter ``x-ai/…:online`` request already carries OpenRouter's own
+    server-side online-search tool named ``web_search``. Also forwarding Hermes'
+    client ``web_search`` makes xAI reject the whole request with
+    ``HTTP 400: Duplicate tool names: web_search`` (#76481). Only the client
+    ``web_search`` is removed — ``web_extract``, terminal, and every other tool
+    are preserved. Bare xAI, non-OpenRouter xAI, and non-xAI OpenRouter requests
+    keep the client ``web_search`` unchanged.
+    """
+    if not tools:
+        return tools
+    from utils import base_url_host_matches
+
+    model_lower = (model or "").lower()
+    if not (
+        model_lower.endswith(":online")
+        and "x-ai/" in model_lower
+        and base_url_host_matches(str(base_url or ""), "openrouter.ai")
+    ):
+        return tools
+    return [t for t in tools if _tool_effective_name(t) != "web_search"]
+
+
 def _base_kwargs(model: str, sanitized: list, tools: Any, params: dict, profile: Any = None) -> dict[str, Any]:
     """Shared ``{model, messages[, temperature][, timeout][, tools]}`` scaffold for both build paths.
 
@@ -277,6 +317,8 @@ def _base_kwargs(model: str, sanitized: list, tools: Any, params: dict, profile:
             api_kwargs["temperature"] = params["temperature"]
     if params.get("timeout") is not None:
         api_kwargs["timeout"] = params["timeout"]
+    if tools:
+        tools = _omit_openrouter_online_web_search(tools, model, params.get("base_url"))
     if tools:
         # Moonshot/Kimi uses a stricter JSON Schema flavor; rewriting here also covers aggregator routes.
         api_kwargs["tools"] = sanitize_moonshot_tools(tools) if is_moonshot_model(model) else tools

--- a/tests/providers/test_openrouter_xai_online_web_search.py
+++ b/tests/providers/test_openrouter_xai_online_web_search.py
@@ -1,0 +1,121 @@
+"""OpenRouter xAI ``:online`` must not duplicate the client ``web_search`` tool.
+
+Regression for #76481: an OpenRouter ``x-ai/…:online`` request already carries
+OpenRouter's own server-side ``web_search`` tool, so forwarding Hermes' client
+``web_search`` as well makes xAI reject the request with
+``HTTP 400: Duplicate tool names: web_search``.  The client ``web_search`` is
+dropped only for that exact provider+namespace+suffix combination; every other
+tool and every other request keeps its tools unchanged.
+"""
+
+import pytest
+
+from agent.transports.chat_completions import (
+    ChatCompletionsTransport,
+    _omit_openrouter_online_web_search,
+)
+from providers import get_provider_profile
+
+OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+
+
+def _fn_tool(name):
+    return {"type": "function", "function": {"name": name, "parameters": {}}}
+
+
+def _flat_tool(name):
+    return {"name": name, "parameters": {}}
+
+
+def _tool_names(tools):
+    out = []
+    for t in tools or []:
+        fn = t.get("function")
+        out.append(fn["name"] if isinstance(fn, dict) else t.get("name"))
+    return out
+
+
+# ── Unit tests on the filter helper ─────────────────────────────────────────
+
+
+class TestOmitHelper:
+    def test_drops_client_web_search_openai_shape(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract"), _fn_tool("terminal")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract", "terminal"]
+
+    def test_drops_client_web_search_flat_shape(self):
+        tools = [_flat_tool("web_search"), _flat_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract"]
+
+    def test_namespace_prefixed_model_still_matches(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "openrouter/x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract"]
+
+    def test_bare_grok_keeps_web_search(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_search", "web_extract"]
+
+    def test_non_openrouter_xai_keeps_web_search(self):
+        # Direct xAI endpoint, not OpenRouter — no server-side collision.
+        tools = [_fn_tool("web_search")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", "https://api.x.ai/v1"
+        )
+        assert _tool_names(out) == ["web_search"]
+
+    def test_non_xai_openrouter_online_keeps_web_search(self):
+        tools = [_fn_tool("web_search")]
+        out = _omit_openrouter_online_web_search(
+            tools, "perplexity/sonar:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_search"]
+
+    def test_empty_and_none_tools_pass_through(self):
+        assert _omit_openrouter_online_web_search(None, "x-ai/grok-4.5:online", OPENROUTER_BASE) is None
+        assert _omit_openrouter_online_web_search([], "x-ai/grok-4.5:online", OPENROUTER_BASE) == []
+
+
+# ── Integration through build_kwargs (the real OpenRouter profile path) ──────
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+def _messages():
+    return [{"role": "user", "content": "search the web"}]
+
+
+class TestBuildKwargs:
+    def test_online_request_omits_client_web_search(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5:online",
+            messages=_messages(),
+            tools=[_fn_tool("web_search"), _fn_tool("web_extract")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert _tool_names(kw.get("tools")) == ["web_extract"]
+
+    def test_bare_grok_request_keeps_client_web_search(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5",
+            messages=_messages(),
+            tools=[_fn_tool("web_search"), _fn_tool("web_extract")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert _tool_names(kw.get("tools")) == ["web_search", "web_extract"]

--- a/tests/providers/test_openrouter_xai_online_web_search.py
+++ b/tests/providers/test_openrouter_xai_online_web_search.py
@@ -1,0 +1,133 @@
+"""OpenRouter xAI ``:online`` must not duplicate the client ``web_search`` tool.
+
+Regression for #76481: an OpenRouter ``x-ai/…:online`` request already carries
+OpenRouter's own server-side ``web_search`` tool, so forwarding Hermes' client
+``web_search`` as well makes xAI reject the request with
+``HTTP 400: Duplicate tool names: web_search``.  The client ``web_search`` is
+dropped only for that exact provider+namespace+suffix combination; every other
+tool and every other request keeps its tools unchanged.
+"""
+
+import pytest
+
+from agent.transports.chat_completions import (
+    ChatCompletionsTransport,
+    _omit_openrouter_online_web_search,
+)
+from providers import get_provider_profile
+
+OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+
+
+def _fn_tool(name):
+    return {"type": "function", "function": {"name": name, "parameters": {}}}
+
+
+def _flat_tool(name):
+    return {"name": name, "parameters": {}}
+
+
+def _tool_names(tools):
+    out = []
+    for t in tools or []:
+        fn = t.get("function")
+        out.append(fn["name"] if isinstance(fn, dict) else t.get("name"))
+    return out
+
+
+# ── Unit tests on the filter helper ─────────────────────────────────────────
+
+
+class TestOmitHelper:
+    def test_drops_client_web_search_openai_shape(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract"), _fn_tool("terminal")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract", "terminal"]
+
+    def test_drops_client_web_search_flat_shape(self):
+        tools = [_flat_tool("web_search"), _flat_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract"]
+
+    def test_namespace_prefixed_model_still_matches(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "openrouter/x-ai/grok-4.5:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_extract"]
+
+    def test_bare_grok_keeps_web_search(self):
+        tools = [_fn_tool("web_search"), _fn_tool("web_extract")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_search", "web_extract"]
+
+    def test_non_openrouter_xai_keeps_web_search(self):
+        # Direct xAI endpoint, not OpenRouter — no server-side collision.
+        tools = [_fn_tool("web_search")]
+        out = _omit_openrouter_online_web_search(
+            tools, "x-ai/grok-4.5:online", "https://api.x.ai/v1"
+        )
+        assert _tool_names(out) == ["web_search"]
+
+    def test_non_xai_openrouter_online_keeps_web_search(self):
+        tools = [_fn_tool("web_search")]
+        out = _omit_openrouter_online_web_search(
+            tools, "perplexity/sonar:online", OPENROUTER_BASE
+        )
+        assert _tool_names(out) == ["web_search"]
+
+    def test_empty_and_none_tools_pass_through(self):
+        assert _omit_openrouter_online_web_search(None, "x-ai/grok-4.5:online", OPENROUTER_BASE) is None
+        assert _omit_openrouter_online_web_search([], "x-ai/grok-4.5:online", OPENROUTER_BASE) == []
+
+
+# ── Integration through build_kwargs (the real OpenRouter profile path) ──────
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+def _messages():
+    return [{"role": "user", "content": "search the web"}]
+
+
+class TestBuildKwargs:
+    def test_online_request_omits_client_web_search(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5:online",
+            messages=_messages(),
+            tools=[_fn_tool("web_search"), _fn_tool("web_extract")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert _tool_names(kw.get("tools")) == ["web_extract"]
+
+    def test_bare_grok_request_keeps_client_web_search(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5",
+            messages=_messages(),
+            tools=[_fn_tool("web_search"), _fn_tool("web_extract")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert _tool_names(kw.get("tools")) == ["web_search", "web_extract"]
+
+    def test_online_request_with_only_web_search_omits_tools_key(self, transport):
+        # web_search is the sole tool: dropping it must omit the ``tools`` key
+        # entirely, never forward an empty ``tools: []`` (which xAI rejects).
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5:online",
+            messages=_messages(),
+            tools=[_fn_tool("web_search")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert "tools" not in kw

--- a/tests/providers/test_openrouter_xai_online_web_search.py
+++ b/tests/providers/test_openrouter_xai_online_web_search.py
@@ -119,3 +119,15 @@ class TestBuildKwargs:
             base_url=OPENROUTER_BASE,
         )
         assert _tool_names(kw.get("tools")) == ["web_search", "web_extract"]
+
+    def test_online_request_with_only_web_search_omits_tools_key(self, transport):
+        # web_search is the sole tool: dropping it must omit the ``tools`` key
+        # entirely, never forward an empty ``tools: []`` (which xAI rejects).
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.5:online",
+            messages=_messages(),
+            tools=[_fn_tool("web_search")],
+            provider_profile=get_provider_profile("openrouter"),
+            base_url=OPENROUTER_BASE,
+        )
+        assert "tools" not in kw


### PR DESCRIPTION
## What & why

Fixes #76481. On an OpenRouter xAI `:online` request (e.g. `x-ai/grok-4.5:online`), OpenRouter injects its **own** server-side search tool named `web_search`. Hermes also forwarded its **client** `web_search`, so xAI saw two tools with the same name and rejected the whole request:

```
HTTP 400: Duplicate tool names: web_search
```

The bare `x-ai/grok-4.5` model works fine — the collision is specific to the OpenRouter `:online` route. Both chat-completions kwargs builders assigned the unfiltered client tool list, and the separate xAI Responses path does not cover this OpenRouter chat-completions path.

## Fix

Immediately before each `api_kwargs["tools"] = tools` assignment in `agent/transports/chat_completions.py` (the legacy fallback and the provider-profile path), omit **only** the client tool whose effective name is `web_search`, and only when **all** of:

- the request is routed through OpenRouter (`base_url` host is `openrouter.ai`);
- the model is in the `x-ai/` namespace; and
- the model ends in `:online`.

`web_extract`, terminal, and every other tool are preserved. Bare xAI, non-OpenRouter xAI, and non-xAI OpenRouter (`:online`) requests keep the client `web_search` unchanged. The helper handles both OpenAI-style function-tool objects (`{"function": {"name": …}}`) and flat tool objects (`{"name": …}`). If filtering leaves the list empty, `tools` is omitted rather than sent as `[]`.

This is the narrow, provider-scoped filter proposed in the issue — it does not globally disable Hermes web search or require an `XAI_API_KEY`.

## Tests

`tests/providers/test_openrouter_xai_online_web_search.py`:
- Helper unit tests: drops client `web_search` for both tool shapes; namespace-prefixed model still matches; negatives keep it (bare Grok, non-OpenRouter xAI, non-xAI OpenRouter `:online`); `None`/`[]` pass through.
- `build_kwargs` integration through the real `openrouter` provider profile: `:online` request omits client `web_search`; bare Grok request keeps it.

```
tests/providers/test_openrouter_xai_online_web_search.py  9 passed
tests/providers/test_transport_parity.py + test_profile_wiring.py  22 passed
```
