### PR TITLE
fix(fallback): restore primary route after picker errors

### DIFF
--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -13,6 +13,9 @@ from hermes_cli.fallback_config import get_fallback_chain
 _read_chain = get_fallback_chain
 
 
+_MISSING_ACTIVE_PROVIDER = object()
+
+
 def _identity(entry: Dict[str, Any]):
     """BackendIdentity for a ``{provider, model, base_url?}`` entry."""
     from agent.backend_identity import BackendIdentity
@@ -45,23 +48,25 @@ def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]
 
 
 def _snapshot_auth_active_provider() -> Any:
-    """Current ``active_provider`` in auth.json, or None if unavailable."""
-    try:
-        from hermes_cli.auth import _load_auth_store
-        return _load_auth_store().get("active_provider")
-    except Exception:
-        return None
+    """Return the current ``active_provider`` in auth.json."""
+    from hermes_cli.auth import _auth_store_lock, _load_auth_store
+
+    with _auth_store_lock():
+        store = _load_auth_store()
+        return store.get("active_provider", _MISSING_ACTIVE_PROVIDER)
 
 
 def _restore_auth_active_provider(value: Any) -> None:
-    """Write back a snapshotted ``active_provider``; best-effort (user re-runs `hermes model`), never fails the add."""
-    try:
-        from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
-        with _auth_store_lock():
-            _save_auth_store({**_load_auth_store(), "active_provider": value})
-    except Exception:
-        pass
+    """Write back a previously snapshotted ``active_provider`` value."""
+    from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
 
+    with _auth_store_lock():
+        store = _load_auth_store()
+        if value is _MISSING_ACTIVE_PROVIDER:
+            store.pop("active_provider", None)
+        else:
+            store["active_provider"] = value
+        _save_auth_store(store)
 
 def _restore_model_cfg(model_before: Any) -> None:
     """Restore ``config["model"]`` to a previously-captured snapshot."""
@@ -72,6 +77,21 @@ def _restore_model_cfg(model_before: Any) -> None:
         cfg["model"] = copy.deepcopy(model_before)
     save_config(cfg)
 
+
+def _restore_primary_route(model_before: Any, active_provider_before: Any) -> None:
+    """Attempt both halves of temporary picker-route restoration."""
+    errors: list[BaseException] = []
+    try:
+        _restore_model_cfg(model_before)
+    except BaseException as exc:
+        errors.append(exc)
+    try:
+        _restore_auth_active_provider(active_provider_before)
+    except BaseException as exc:
+        errors.append(exc)
+    if errors:
+        details = "; ".join(str(exc) for exc in errors)
+        raise RuntimeError(f"Could not fully restore the primary route: {details}") from errors[0]
 
 def _entries(n: int) -> str:
     return f"{n} {'entry' if n == 1 else 'entries'}"
@@ -122,45 +142,43 @@ def cmd_fallback_add(args) -> None:
     from hermes_cli.config import load_config, save_config
     _require_tty("fallback add")
 
-    # Snapshot BEFORE the picker runs: "picked" vs "cancelled" is decided by comparing before/after,
-    # and the primary must be restored either way.
+    # Snapshot BEFORE the picker runs; both route stores must be restored on every exit path.
     model_before = copy.deepcopy(load_config().get("model"))
     active_provider_before = _snapshot_auth_active_provider()
     print("\n  Adding a fallback provider.  The picker below is the same one used by\n"
           "  `hermes model` — select the provider + model you want as a fallback.\n")
 
-    def _restore() -> None:
-        _restore_model_cfg(model_before)
-
-        _restore_auth_active_provider(active_provider_before)
     try:
         select_provider_and_model(args=args)
-    except SystemExit:  # some provider flows exit on auth failure — restore state and re-raise
-        _restore()
+        after_cfg = load_config()
+        model_after = after_cfg.get("model")
+        new_entry = _extract_fallback_from_model_cfg(model_after)
+    except BaseException as picker_error:
+        try:
+            _restore_primary_route(model_before, active_provider_before)
+        except Exception as restore_error:
+            picker_error.add_note(
+                "Could not fully restore the primary route after fallback "
+                f"selection failed: {restore_error}"
+            )
         raise
-    new_entry = _extract_fallback_from_model_cfg(load_config().get("model"))
-    if not new_entry:  # picker didn't complete (user cancelled or flow bailed)
-        _restore()
+
+    # From here onward no identity/import/append failure can strand the temporary picker route.
+    _restore_primary_route(model_before, active_provider_before)
+
+    if not new_entry:
         print("\n  No fallback added.")
         return
 
-    # Same deployment as the primary → nothing to add. Identity semantics are owned by
-    # agent.backend_identity: same provider+model on a DIFFERENT explicit base_url is a different
-    # backend (multi-endpoint pool) and a legitimate fallback.
-    # Picker picked the same thing that's already the primary → nothing changed, and there's nothing useful
-    # to add as a fallback to itself. See #54250, #57584, #62984.
     from agent.backend_identity import same_deployment
     new_ident = _identity(new_entry)
     primary_entry = _extract_fallback_from_model_cfg(model_before)
     if primary_entry and same_deployment(_identity(primary_entry), new_ident):
-        _restore()
         print(f"\n  Selected model matches the current primary ({_format_entry(new_entry)}).")
         print("  A provider cannot be a fallback for itself — no change.")
         return
 
-    # Restore the primary, then re-load (rather than mutating the post-picker config) because the
-    # picker may have touched other top-level keys (custom_providers, credentials) we want to keep.
-    _restore()
+    # Reload after primary restoration; picker-created providers/credentials remain.
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
     if any(same_deployment(_identity(existing), new_ident) for existing in chain):
@@ -172,7 +190,6 @@ def cmd_fallback_add(args) -> None:
     print(f"\n  Added fallback: {_format_entry(new_entry)}")
     print(f"  Chain is now {_entries(len(chain))} long.\n")
     print("  Run `hermes fallback list` to view, or `hermes fallback remove` to delete.")
-
 
 def cmd_fallback_remove(args) -> None:  # noqa: ARG001
     """Pick an entry from the chain and remove it."""

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -24,6 +24,9 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.fallback_config import get_fallback_chain
 
 
+_MISSING_ACTIVE_PROVIDER = object()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -76,28 +79,25 @@ def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]
 
 
 def _snapshot_auth_active_provider() -> Any:
-    """Return the current ``active_provider`` in auth.json, or a sentinel if unavailable."""
-    try:
-        from hermes_cli.auth import _load_auth_store
+    """Return the current ``active_provider`` in auth.json."""
+    from hermes_cli.auth import _auth_store_lock, _load_auth_store
+
+    with _auth_store_lock():
         store = _load_auth_store()
-        return store.get("active_provider")
-    except Exception:
-        return None
+        return store.get("active_provider", _MISSING_ACTIVE_PROVIDER)
 
 
 def _restore_auth_active_provider(value: Any) -> None:
     """Write back a previously snapshotted ``active_provider`` value."""
-    try:
-        from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
-        with _auth_store_lock():
-            store = _load_auth_store()
+    from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
+
+    with _auth_store_lock():
+        store = _load_auth_store()
+        if value is _MISSING_ACTIVE_PROVIDER:
+            store.pop("active_provider", None)
+        else:
             store["active_provider"] = value
-            _save_auth_store(store)
-    except Exception:
-        # Best-effort — if auth.json can't be restored, the user's primary
-        # provider may have been deactivated by the picker.  They can re-run
-        # `hermes model` to fix it.  Don't fail the fallback add.
-        pass
+        _save_auth_store(store)
 
 
 # ---------------------------------------------------------------------------
@@ -164,21 +164,28 @@ def cmd_fallback_add(args) -> None:
 
     try:
         select_provider_and_model(args=args)
-    except SystemExit:
-        # Some provider flows exit on auth failure — restore state and re-raise.
-        _restore_model_cfg(model_before)
-        _restore_auth_active_provider(active_provider_before)
+        # Read the post-picker state before restoring the temporary primary.
+        after_cfg = load_config()
+        model_after = after_cfg.get("model")
+        new_entry = _extract_fallback_from_model_cfg(model_after)
+    except BaseException as picker_error:
+        # Provider flows can raise SystemExit, and post-picker reads can fail;
+        # every error after the snapshot must still restore both route stores.
+        try:
+            _restore_primary_route(model_before, active_provider_before)
+        except Exception as restore_error:
+            picker_error.add_note(
+                "Could not fully restore the primary route after fallback "
+                f"selection failed: {restore_error}"
+            )
         raise
 
-    # Read the post-picker state to see what the user selected.
-    after_cfg = load_config()
-    model_after = after_cfg.get("model")
+    # From here onward, no identity/import/append failure can strand the
+    # temporary picker route as primary.
+    _restore_primary_route(model_before, active_provider_before)
 
-    new_entry = _extract_fallback_from_model_cfg(model_after)
     if not new_entry:
-        # Picker didn't complete (user cancelled or flow bailed).  Nothing to do.
-        _restore_model_cfg(model_before)
-        _restore_auth_active_provider(active_provider_before)
+        # Picker didn't complete (user cancelled or flow bailed). Nothing to do.
         print()
         print("  No fallback added.")
         return
@@ -204,20 +211,13 @@ def cmd_fallback_add(args) -> None:
         ),
         new_ident,
     ):
-        _restore_model_cfg(model_before)
-        _restore_auth_active_provider(active_provider_before)
         print()
         print(f"  Selected model matches the current primary ({_format_entry(new_entry)}).")
         print("  A provider cannot be a fallback for itself — no change.")
         return
 
-    # Reload the config with the primary restored, then append the new entry
-    # to ``fallback_providers``.  We deliberately re-load (rather than mutating
-    # ``after_cfg``) because the picker may have touched other top-level keys
-    # (custom_providers, providers credentials) that we want to keep.
-    _restore_model_cfg(model_before)
-    _restore_auth_active_provider(active_provider_before)
-
+    # Reload after primary restoration, then append the selected entry to
+    # ``fallback_providers``. Picker-created providers and credentials remain.
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
 
@@ -257,6 +257,22 @@ def _restore_model_cfg(model_before: Any) -> None:
     else:
         cfg["model"] = copy.deepcopy(model_before)
     save_config(cfg)
+
+
+def _restore_primary_route(model_before: Any, active_provider_before: Any) -> None:
+    """Attempt both halves of temporary picker-route restoration."""
+    errors: list[BaseException] = []
+    try:
+        _restore_model_cfg(model_before)
+    except BaseException as exc:
+        errors.append(exc)
+    try:
+        _restore_auth_active_provider(active_provider_before)
+    except BaseException as exc:
+        errors.append(exc)
+    if errors:
+        details = "; ".join(str(exc) for exc in errors)
+        raise RuntimeError(f"Could not fully restore the primary route: {details}") from errors[0]
 
 
 def cmd_fallback_remove(args) -> None:  # noqa: ARG001

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -15,7 +15,6 @@ import yaml
 
 @pytest.fixture()
 def isolated_home(tmp_path, monkeypatch):
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     home = tmp_path / ".hermes"
     home.mkdir(exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -118,6 +117,20 @@ class TestListCommand:
 # ---------------------------------------------------------------------------
 
 class TestAddCommand:
+    def test_auth_snapshot_failure_aborts_before_picker(self):
+        from hermes_cli import fallback_cmd
+
+        picker = object()
+        with patch(
+            "hermes_cli.auth._load_auth_store",
+            side_effect=OSError("auth read failed"),
+        ), patch(
+            "hermes_cli.main.select_provider_and_model",
+            picker,
+        ), patch("hermes_cli.main._require_tty"):
+            with pytest.raises(OSError, match="auth read failed"):
+                fallback_cmd.cmd_fallback_add(types.SimpleNamespace())
+
     def test_add_appends_new_entry(self, isolated_home, capsys):
         _write_config(isolated_home, {
             "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
@@ -199,6 +212,13 @@ class TestAddCommand:
                 "base_url": "https://openrouter.ai/api/v1",
                 "api_mode": "chat_completions",
             }
+            cfg["custom_providers"] = [
+                {
+                    "name": "Picker-created endpoint",
+                    "base_url": "https://picker.example/v1",
+                    "model": "picker-model",
+                }
+            ]
             save_config(cfg)
 
         with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
@@ -215,6 +235,130 @@ class TestAddCommand:
         # Fallback added
         assert len(cfg["fallback_providers"]) == 1
         assert cfg["fallback_providers"][0]["provider"] == "openrouter"
+        assert cfg["custom_providers"] == [
+            {
+                "name": "Picker-created endpoint",
+                "base_url": "https://picker.example/v1",
+                "model": "picker-model",
+            }
+        ]
+
+    def test_post_picker_config_read_failure_restores_route(self):
+        from hermes_cli import fallback_cmd
+
+        primary_model = {
+            "provider": "anthropic",
+            "default": "claude-sonnet-4-6",
+        }
+        post_read_error = OSError("post-picker config read failed")
+        reads = iter([{"model": primary_model}, post_read_error])
+
+        def load_config():
+            value = next(reads)
+            if isinstance(value, BaseException):
+                raise value
+            return value
+
+        restore_calls = []
+        with patch("hermes_cli.config.load_config", side_effect=load_config), patch(
+            "hermes_cli.main._require_tty"
+        ), patch("hermes_cli.main.select_provider_and_model"), patch.object(
+            fallback_cmd, "_snapshot_auth_active_provider", return_value="old-provider"
+        ), patch.object(
+            fallback_cmd,
+            "_restore_primary_route",
+            side_effect=lambda model, provider: restore_calls.append((model, provider)),
+        ):
+            with pytest.raises(OSError) as exc_info:
+                fallback_cmd.cmd_fallback_add(types.SimpleNamespace())
+
+        assert exc_info.value is post_read_error
+        assert restore_calls == [(primary_model, "old-provider")]
+
+    @pytest.mark.parametrize(
+        ("failure_type", "message"),
+        [
+            (OSError, "config write failed"),
+            (KeyboardInterrupt, "config restore interrupted"),
+        ],
+    )
+    def test_restore_attempts_auth_after_model_restore_failure(
+        self, failure_type, message
+    ):
+        from hermes_cli import fallback_cmd
+
+        auth_calls = []
+        with patch.object(
+            fallback_cmd,
+            "_restore_model_cfg",
+            side_effect=failure_type(message),
+        ), patch.object(
+            fallback_cmd,
+            "_restore_auth_active_provider",
+            side_effect=lambda value: auth_calls.append(value),
+        ):
+            with pytest.raises(RuntimeError, match=message):
+                fallback_cmd._restore_primary_route("old-model", "old-provider")
+
+        assert auth_calls == ["old-provider"]
+
+    def test_restore_preserves_absent_active_provider(self):
+        from contextlib import nullcontext
+
+        from hermes_cli import auth, fallback_cmd
+
+        store = {"version": 1, "providers": {}}
+
+        def save_auth(value):
+            store.clear()
+            store.update(value)
+
+        with patch.object(auth, "_load_auth_store", lambda: dict(store)), patch.object(
+            auth, "_save_auth_store", save_auth
+        ), patch.object(auth, "_auth_store_lock", nullcontext):
+            before = fallback_cmd._snapshot_auth_active_provider()
+            fallback_cmd._restore_auth_active_provider(before)
+
+        assert "active_provider" not in store
+
+    def test_picker_failure_restores_persisted_primary_without_masking_error(
+        self, isolated_home
+    ):
+        from hermes_cli import fallback_cmd
+
+        primary_model = {
+            "provider": "anthropic",
+            "default": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        }
+        _write_config(isolated_home, {"model": primary_model, "theme": "midnight"})
+        picker_error = LookupError("picker failed")
+
+        def failing_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            }
+            save_config(cfg)
+            raise picker_error
+
+        with patch(
+            "hermes_cli.main.select_provider_and_model",
+            side_effect=failing_picker,
+        ), patch("hermes_cli.main._require_tty"):
+            with pytest.raises(LookupError, match="picker failed") as exc_info:
+                fallback_cmd.cmd_fallback_add(types.SimpleNamespace())
+
+        assert exc_info.value is picker_error
+        persisted = _read_config(isolated_home)
+        assert persisted["model"] == primary_model
+        assert persisted["theme"] == "midnight"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hermes fallback add` reuses the canonical model picker, which temporarily writes the selected route as the primary model/provider before appending it to the fallback chain.

The old cleanup path restored only part of that route and only on limited exits. Ordinary picker exceptions, post-picker config-read failures, and cleanup failures could leave the temporary route active or skip the second half of restoration.

## Fix

- Abort before launching the mutating picker if the primary auth route cannot be snapshotted.
- Cover both the picker call and post-picker selection read/extraction with the same error-preserving cleanup boundary.
- Restore the temporary primary route exactly once on the successful path, before identity/import/append work can fail.
- Attempt model and auth restoration independently across `BaseException`, so an error or interrupt in one half cannot skip the other.
- Preserve the original picker exception and attach cleanup failure details instead of masking it.
- Preserve exact auth-store key presence: an absent `active_provider` remains absent rather than becoming persisted `null`.
- Snapshot and restore the auth route under the auth-store lock.
- Retain picker-created providers/credentials and other setup side effects while restoring only the primary model/auth route.
- Refuse to print cancellation/success when route restoration failed.

## Development context

This pre-existing fallback bug was discovered while developing the CLI subagent model/reasoning picker in #76480, because that feature reuses the same canonical provider/model setup flow. It is intentionally extracted here as an independent mainline fix so the picker PR remains feature-scoped.

This does not duplicate whole-config stale-write concurrency work already tracked in #62232.

## Verification

- `20 passed` — `tests/hermes_cli/test_fallback_cmd.py`
- Regression coverage includes ordinary picker failure, post-picker read failure, cleanup errors and interrupts, independent two-store restore, exact absent-key restoration, and setup-side-effect retention.
- Ruff passed for the changed production/test files.
- `py_compile` passed.
- Secret scan and `git diff --check` passed.

## Coordination graph

- **Issue interlock:** Fixes #85651
- **Related sibling:** #76480 discovered this failure while reusing the same canonical picker, but the fix is independently mergeable
- **Dependency edges:** none; #76480 neither requires nor contains this patch
- **Collision constraints:** no current file overlap with #76480. Search found other picker/provider work, but none edits `hermes_cli/fallback_cmd.py` or its focused test on the audited heads
- **Merge order:** may land before or after #76480; if both are queued, this narrower bug fix is the lower-risk first merge
- **Scope boundary:** primary-route restoration for `hermes fallback add` only

## Hermes triage dashboard graph

Live dashboard neighbourhood: https://hermes-triage.gottz.de/?node=76497

```mermaid
flowchart LR
    classDef focus fill:#fef3c7,stroke:#b45309,stroke-width:3px,color:#451a03
    classDef issue fill:#ede9fe,stroke:#6d28d9,color:#2e1065
    classDef open fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a
    classDef closed fill:#e5e7eb,stroke:#6b7280,color:#1f2937
    P76497["PR #76497 (open)"]
    I85651(["issue #85651 (open)"])
    P6554["PR #6554 (merged)"]
    P9803["PR #9803 (closed)"]
    P33846["PR #33846 (closed)"]
    P36789["PR #36789 (closed)"]
    P47433["PR #47433 (closed)"]
    P60176["PR #60176 (open)"]
    P62417["PR #62417 (merged)"]
    P65656["PR #65656 (merged)"]
    P66400["PR #66400 (open)"]
    P71533["PR #71533 (open)"]
    P77631["PR #77631 (merged)"]
    P76497 -->|closes| I85651
    P76497 -->|related| I85651
    P60176 -.->|duplicate of 0.71| P76497
    P65656 -.->|duplicate of 0.71| P76497
    P71533 -.->|duplicate of 0.71| P76497
    P9803 -.->|duplicate of 0.71| P76497
    P62417 -.->|duplicate of 0.71| P76497
    P47433 -.->|duplicate of 0.71| P76497
    P66400 -.->|duplicate of 0.71| P76497
    P6554 -.->|duplicate of 0.70| P76497
    P36789 -.->|duplicate of 0.70| P76497
    P76497 -.->|duplicate of 0.70| P77631
    P33846 -.->|duplicate of 0.70| P76497
    class P76497 focus
    click P76497 "https://github.com/NousResearch/hermes-agent/pull/76497"
    class I85651 issue
    click I85651 "https://github.com/NousResearch/hermes-agent/issues/85651"
    class P6554 merged
    click P6554 "https://github.com/NousResearch/hermes-agent/pull/6554"
    class P9803 closed
    click P9803 "https://github.com/NousResearch/hermes-agent/pull/9803"
    class P33846 closed
    click P33846 "https://github.com/NousResearch/hermes-agent/pull/33846"
    class P36789 closed
    click P36789 "https://github.com/NousResearch/hermes-agent/pull/36789"
    class P47433 closed
    click P47433 "https://github.com/NousResearch/hermes-agent/pull/47433"
    class P60176 open
    click P60176 "https://github.com/NousResearch/hermes-agent/pull/60176"
    class P62417 merged
    click P62417 "https://github.com/NousResearch/hermes-agent/pull/62417"
    class P65656 merged
    click P65656 "https://github.com/NousResearch/hermes-agent/pull/65656"
    class P66400 open
    click P66400 "https://github.com/NousResearch/hermes-agent/pull/66400"
    class P71533 open
    click P71533 "https://github.com/NousResearch/hermes-agent/pull/71533"
    class P77631 merged
    click P77631 "https://github.com/NousResearch/hermes-agent/pull/77631"
```

Dashboard interpretation:

- solid edges are structural GitHub links (`closes` / `related`);
- dashed edges are embedding-discovery candidates and show the dashboard score;
- the fold thresholds reported by the dashboard are embedding `0.88` and file overlap `0.75`;
- a dashed `duplicate of` edge below the fold threshold is a similarity lead for review, **not** an accepted duplicate or merge-order edge;
- the gold node is this PR; purple nodes are issues; blue/gray nodes are open/closed neighbouring PRs.

This graph is additive to the hand-audited coordination block above: the dashboard supplies discovery neighbourhoods, while the declared dependency, collision, ownership, and merge-order edges remain the reviewed coordination contract.
