### PR TITLE
fix(npm): allow Node 22 / npm 11 installs (#76486)

### DIFF
--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -5,7 +5,7 @@ pins an ``engines.npm`` range, so an npm outside that range aborts every
 ``npm ci`` / ``npm install`` we run inside the checkout::
 
     npm error code EBADENGINE
-    npm error notsup Required: {"node":">=20.0.0","npm":"<11.10.0 || >=12.0.0"}
+    npm error notsup Required: {"node":">=20.0.0","npm":">=11.17.0"}
     npm error notsup Actual:   {"npm":"10.9.8","node":"v22.23.1"}
 
 Rather than predicting the failure (which would mean a semver range matcher and

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=12.0.0"
+        "npm": ">=11.17.0"
       }
     },
     "apps/bootstrap-installer": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=12.0.0"
+    "npm": ">=11.17.0"
   },
   "allowScripts": {
     "unicode-animations": false,

--- a/website/package.json
+++ b/website/package.json
@@ -54,7 +54,7 @@
   },
   "engines": {
     "node": ">=20.0",
-    "npm": "<11.10.0 || >=12.0.0"
+    "npm": ">=11.17.0"
   },
   "allowScripts": {
     "core-js@3.49.0": true,


### PR DESCRIPTION
Closes #76486

## Problem

Since commit `f88ed6c71` ("fix: fix @nousresearch/ui version, update to npm 12"), the root `package.json` declares `"npm": ">=12.0.0"`. npm 11 is the stable line bundled with Node 22 (e.g. npm 11.16.0 ships with Node 22.22.2), and npm 11.x is still actively maintained (11.19.0 is the latest 11.x). With `engine-strict=true` in `.npmrc`, every `npm install` / `npm ci` on a stock Node 22 + npm 11 setup fails with `EBADENGINE`, and `hermes update` reports a partial/unclean dependency refresh.

## Root cause

`>=12.0.0` is unsatisfiable on a stock Node 22 install — there is no npm 12 bundled with Node, and npm 11 is the current stable major line. The previous range (`<11.10.0 || >=12.0.0`, added in `3975e9d75`) already handled the important constraint: npm 11.10.0–11.16.x implements `min-release-age` but **not** `min-release-age-exclude`, so those versions would silently ignore the exclusion list in `.npmrc` (`min-release-age=14` + excludes for fast-moving packages like `@assistant-ui/*`, `@radix-ui/*`, `vite`, `rolldown`, etc.) and block installs of any package released within the last 14 days. That is the "bad band" that must stay excluded.

`min-release-age-exclude` was added to npm CLI on 2026-06-10 (npm/cli commit `c3e1a7175c`) and first shipped in **npm 11.17.0** (2026-06-11), which I verified by inspecting the published tarballs:

| npm version | `min-release-age-exclude` support |
|---|---|
| 11.16.0 | ❌ (0 files) |
| 11.17.0 | ✅ (5 files) |
| 12.0.0 | ✅ (5 files) |

## Fix

Relax the range to `>=11.17.0` in the root `package.json`, its `package-lock.json` mirror, and the mirrored `website/package.json` (which still had the stale `<11.10.0 || >=12.0.0`).

`>=11.17.0`:
- **Unblocks Node 22 / npm 11 installs** — every npm 11 release with full `min-release-age` + `min-release-age-exclude` support (11.17.x, 11.18.x, 11.19.x) is accepted, as is npm 12+.
- **Keeps the "bad band" excluded** — npm 11.10.0–11.16.x still fail `EBADENGINE` (they would break installs by ignoring the `.npmrc` exclusion list), and old npm 10.x still fails so the EBADENGINE auto-repair in `hermes_cli/npm_engine.py` upgrades the managed npm instead of leaving users stuck on a stale npm with the eternal "new major version" notice.
- The existing `npm_engine.py` repair already parses the required range out of the EBADENGINE error text, so no changes to the repair logic or its tests were needed (tests are range-agnostic by design — all 20 pass unchanged).

## Changes

- `package.json` — `engines.npm`: `>=12.0.0` → `>=11.17.0`
- `package-lock.json` — root engines mirror: `>=12.0.0` → `>=11.17.0`
- `website/package.json` — engines mirror: `<11.10.0 || >=12.0.0` → `>=11.17.0` (kept in sync with root; its lockfile root entry only pins `node`, no change needed)
- `hermes_cli/npm_engine.py` — docstring example updated to the new range (documentation only)

## Verification

- `python3 -m pytest tests/hermes_cli/test_npm_engine.py -q` → **20 passed**
- All edited files parse as valid JSON; `npm_engine.py` compiles cleanly.
