### PR TITLE
feat(tts): use endpoint-returned sample rate (#76466)

### DIFF
--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -52,6 +52,72 @@ _ABORT = object()
 _DONE = object()
 
 
+class _PcmResampler:
+    """Stateful linear-interpolation int16 resampler for streaming PCM.
+
+    An OpenAI-compatible TTS endpoint may return audio at a sample rate
+    different from the adapter-declared ``AudioFormat`` (issue #76466). The
+    adapter contract requires every delivered chunk to conform to the
+    declared format, so the consumer resamples on the fly. State is carried
+    across chunk boundaries so interpolation stays click-free, and the
+    source tail is buffered until enough input accumulates.
+    """
+
+    def __init__(self, src_rate: int, dst_rate: int):
+        self._ratio = src_rate / dst_rate  # source samples per output sample
+        self._pos = 0.0  # source index of the next output sample
+        self._buf = None  # lazily-imported numpy arrays; pending source samples
+        self._pending = None  # stray odd byte waiting for its pair
+
+    def _numpy(self):
+        import numpy as np
+
+        return np
+
+    def process(self, chunk: bytes) -> bytes:
+        """Resample one PCM chunk; may return fewer bytes than input."""
+        np = self._numpy()
+        if self._pending is not None:
+            chunk = self._pending + chunk
+            self._pending = None
+        if len(chunk) % 2:  # int16 samples must stay aligned
+            self._pending = chunk[-1:]
+            chunk = chunk[:-1]
+        src = np.frombuffer(chunk, dtype=np.int16).astype(np.float64)
+        if self._buf is None:
+            buf = src
+        else:
+            buf = np.concatenate([self._buf, src])
+        n_out = int((len(buf) - self._pos) // self._ratio)
+        if n_out <= 0:
+            self._buf = buf
+            return b""
+        idx = self._pos + np.arange(n_out) * self._ratio
+        i0 = idx.astype(np.int64)
+        i1 = np.minimum(i0 + 1, len(buf) - 1)
+        frac = idx - i0
+        out = buf[i0] * (1.0 - frac) + buf[i1] * frac
+        consumed = int(self._pos + n_out * self._ratio)
+        self._buf = buf[consumed:]
+        self._pos = (self._pos + n_out * self._ratio) - consumed
+        return out.astype(np.int16).tobytes()
+
+    def flush(self) -> bytes:
+        """Emit the final partial output sample (duration-preserving)."""
+        if self._buf is None or not len(self._buf):
+            return b""
+        np = self._numpy()
+        i0 = int(self._pos)
+        if i0 >= len(self._buf):
+            self._buf = None
+            return b""
+        i1 = min(i0 + 1, len(self._buf) - 1)
+        frac = self._pos - i0
+        out = self._buf[i0] * (1.0 - frac) + self._buf[i1] * frac
+        self._buf = None
+        return np.array([out], dtype=np.int16).tobytes()
+
+
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
 
@@ -338,15 +404,41 @@ class StreamingTTSConsumer:
                 self._suppress_whole_file = True
 
     async def _iter_stream_chunks(self, text: str):
-        """Yield provider PCM chunks one at a time without blocking the loop."""
+        """Yield provider PCM chunks one at a time without blocking the loop.
+
+        When the streamer's endpoint returns a sample rate different from the
+        adapter-declared ``AudioFormat`` (issue #76466), chunks are resampled
+        on the fly so the adapter contract — every chunk conforms to the
+        declared format — still holds.
+        """
         if self._streamer is None:
             return
         iterator = iter(self._streamer.stream(text))
+        resampler = None
         while True:
             has_chunk, chunk = await asyncio.to_thread(self._next_stream_chunk, iterator)
             if not has_chunk:
                 break
-            yield chunk
+            if chunk:
+                if resampler is None and self._streamer.sample_rate != self._audio_format.sample_rate:
+                    resampler = _PcmResampler(
+                        int(self._streamer.sample_rate),
+                        int(self._audio_format.sample_rate),
+                    )
+                    logger.info(
+                        "TTS endpoint sample rate %d Hz differs from adapter "
+                        "format %d Hz; resampling stream",
+                        self._streamer.sample_rate,
+                        self._audio_format.sample_rate,
+                    )
+                if resampler is not None:
+                    chunk = resampler.process(chunk)
+            if chunk:
+                yield chunk
+        if resampler is not None:
+            tail = resampler.flush()
+            if tail:
+                yield tail
 
     @staticmethod
     def _next_stream_chunk(iterator: Any) -> tuple[bool, Optional[bytes]]:

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -16,7 +16,7 @@ import time
 import pytest
 
 from gateway.platforms.base import AudioFormat, StreamingTTSHandle
-from gateway.streaming_tts_consumer import StreamingTTSConsumer
+from gateway.streaming_tts_consumer import StreamingTTSConsumer, _PcmResampler
 from tools.tts_streaming import SentenceChunker
 
 
@@ -673,3 +673,110 @@ class TestGatewayOuterFinalisationNoNameError:
         # This is trivially true with a holder, but was NOT true when
         # the consumer was a run_sync local.
         _ = holder[0]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-returned sample rate (#76466)
+# ---------------------------------------------------------------------------
+
+
+class _PcmRateShiftingStreamer(FakeStreamer):
+    """Fake OpenAI-compatible streamer that reports a new rate on first chunk.
+
+    Mirrors ``tools.tts_streaming.OpenAIStreamer``: the class-level assumption
+    is 24 kHz, and the instance attribute is updated when the first chunk is
+    pulled (the endpoint's ``X-Audio-Sample-Rate`` header arrives with the
+    response, i.e. on the first ``next()``).
+    """
+
+    def __init__(self, chunks=3, samples_per_chunk=4410, endpoint_rate=44100):
+        super().__init__(chunks_per_clause=chunks)
+        self.samples_per_chunk = samples_per_chunk
+        self.endpoint_rate = endpoint_rate
+
+    def stream(self, text: str):
+        self.sample_rate = self.endpoint_rate  # discovered on first next()
+        import numpy as np
+
+        for _ in range(self.chunks_per_clause):
+            yield np.zeros(self.samples_per_chunk, dtype=np.int16).tobytes()
+
+
+class TestPcmResampler:
+    """Linear-interpolation resampler keeps duration across chunk boundaries."""
+
+    def test_preserves_duration_44100_to_24000(self):
+        import numpy as np
+
+        resampler = _PcmResampler(44100, 24000)
+        src = (np.sin(np.arange(44100) * 2 * np.pi * 440 / 44100) * 1000).astype(np.int16)
+        raw = src.tobytes()
+        # Odd chunk size exercises the boundary state.
+        out = b""
+        for i in range(0, len(raw), 999):
+            out += resampler.process(raw[i:i + 999])
+        out += resampler.flush()
+
+        resampled = np.frombuffer(out, dtype=np.int16)
+        # 1.0 s of 44.1 kHz audio → ~1.0 s of 24 kHz audio (24000 samples).
+        assert abs(len(resampled) - 24000) <= 2
+
+    def test_chunked_and_whole_resample_agree(self):
+        import numpy as np
+
+        src = (np.arange(8000) * 13 % 60000 - 30000).astype(np.int16)
+        raw = src.tobytes()
+
+        def resample(chunk_size):
+            r = _PcmResampler(44100, 24000)
+            out = b""
+            for i in range(0, len(raw), chunk_size):
+                out += r.process(raw[i:i + chunk_size])
+            out += r.flush()
+            return np.frombuffer(out, dtype=np.int16)
+
+        whole = resample(len(raw))
+        tiniest = resample(2)  # one sample per call
+        assert len(whole) == len(tiniest)
+        assert np.allclose(whole, tiniest, atol=2)
+
+
+class TestConsumerResamplesToDeclaredFormat:
+    """When the endpoint rate differs from the adapter format, resample."""
+
+    def test_written_chunks_conform_to_declared_format(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = _PcmRateShiftingStreamer(chunks=3, samples_per_chunk=4410)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+            # Declared format derives from the streamer's *assumed* rate at
+            # resolve time (24000), before the endpoint is contacted.
+            assert consumer._audio_format.sample_rate == 24000
+
+            consumer.start()
+            consumer.on_delta("A sentence with real PCM. ")
+            consumer.finish()
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+
+            # 3 chunks × 4410 samples @ 44.1 kHz = 0.3 s of audio; delivered
+            # at the declared 24 kHz it must be ~7200 int16 samples.
+            total_bytes = sum(len(c) for c in adapter.written_chunks)
+            assert abs(total_bytes // 2 - 7200) <= 2
+
+        _run_test(run)
+
+    def test_same_rate_stream_passes_through_unchanged(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=2)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This is the first sentence. ")
+            consumer.finish()
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+            assert adapter.written_chunks == [b"chunk-1-0", b"chunk-1-1"]
+
+        _run_test(run)

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -154,6 +154,106 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     assert captured["client"]["api_key"] == "cfg-key"
 
 
+# ── Endpoint-returned sample rate (#76466) ───────────────────────────────
+
+
+def test_sample_rate_from_headers_parses_x_audio_sample_rate():
+    assert ts._sample_rate_from_headers({"X-Audio-Sample-Rate": "44100"}) == 44100
+    assert ts._sample_rate_from_headers({"x-audio-sample-rate": "22050"}) == 22050
+    assert ts._sample_rate_from_headers({}) is None
+    assert ts._sample_rate_from_headers(None) is None
+    assert ts._sample_rate_from_headers({"X-Audio-Sample-Rate": "not-a-number"}) is None
+    assert ts._sample_rate_from_headers({"X-Audio-Sample-Rate": "0"}) is None
+    assert ts._sample_rate_from_headers({"X-Audio-Sample-Rate": "-44100"}) is None
+    assert ts._sample_rate_from_headers({"X-Audio-Sample-Rate": " 44100 "}) == 44100
+
+
+def test_sample_rate_from_headers_falls_back_to_content_type():
+    assert ts._sample_rate_from_headers({"Content-Type": "audio/pcm; rate=44100"}) == 44100
+    assert ts._sample_rate_from_headers({"content-type": "audio/L16;rate=48000"}) == 48000
+    assert ts._sample_rate_from_headers({"Content-Type": "audio/mpeg"}) is None
+    # Explicit header wins over the Content-Type fallback.
+    assert ts._sample_rate_from_headers(
+        {"X-Audio-Sample-Rate": "44100", "Content-Type": "audio/pcm; rate=22050"}
+    ) == 44100
+
+
+def test_openai_streamer_honors_endpoint_sample_rate_header(monkeypatch):
+    captured = {}
+
+    class _Response:
+        headers = {"X-Audio-Sample-Rate": "44100"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            captured["kwargs"] = kwargs
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
+    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {"provider": "openai", "openai": {"api_key": "cfg-key"}}
+    streamer = ts.resolve_streaming_provider(config)
+    assert streamer is not None
+    assert streamer.sample_rate == 24000  # assumed default until the endpoint speaks
+
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+
+    # The rate advertised by the endpoint is honored once the response
+    # headers are known — i.e. after the first chunk is pulled.
+    assert streamer.sample_rate == 44100
+
+
+def test_openai_streamer_keeps_default_when_endpoint_says_nothing(monkeypatch):
+    class _Response:
+        headers = {}  # no X-Audio-Sample-Rate, no Content-Type rate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
+    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {"provider": "openai", "openai": {"api_key": "cfg-key"}}
+    streamer = ts.resolve_streaming_provider(config)
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert streamer.sample_rate == 24000
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -129,7 +129,15 @@ class SentenceChunker:
 # ---------------------------------------------------------------------------
 
 class StreamingTTSProvider(ABC):
-    """Yields raw int16, little-endian, mono PCM chunks at ``sample_rate``."""
+    """Yields raw int16, little-endian, mono PCM chunks at ``sample_rate``.
+
+    ``sample_rate`` is the provider's assumed default (24 kHz). A provider
+    ``stream()`` may *update* it — as an instance attribute — once the
+    endpoint's actual format is known (e.g. an OpenAI-compatible server
+    advertising ``X-Audio-Sample-Rate``). Consumers must therefore read
+    ``streamer.sample_rate`` **after** pulling the first chunk, never before
+    opening the stream.
+    """
 
     sample_rate: int = 24000
     channels: int = 1
@@ -261,9 +269,57 @@ def _openai_config_api_key() -> str:
     return openai_cfg.get("api_key") or ""
 
 
+def _sample_rate_from_headers(headers) -> Optional[int]:
+    """Extract the sample rate an OpenAI-compatible TTS endpoint advertises.
+
+    OpenAI's own API returns raw PCM at a fixed 24 kHz, but compatible
+    servers may return another rate — e.g. local FastAPI endpoints serving
+    Echo-TTS at 44.1 kHz — and advertise it via the ``X-Audio-Sample-Rate``
+    response header (the convention other consumers of such servers read).
+    A few endpoints instead encode it in ``Content-Type``
+    (``audio/pcm; rate=44100``). Returns the validated rate in Hz, or
+    ``None`` when the endpoint says nothing.
+
+    Header lookup is case-insensitive: response header objects from httpx /
+    the OpenAI SDK are case-insensitive mappings, but plain dicts (and some
+    proxies) are not.
+    """
+    if not headers:
+        return None
+    raw = None
+    try:
+        if hasattr(headers, "get"):
+            raw = headers.get("X-Audio-Sample-Rate") or headers.get("x-audio-sample-rate")
+    except Exception:  # pragma: no cover - defensive
+        raw = None
+    if raw is None:
+        # Fallback: ``audio/pcm; rate=44100`` / ``audio/L16;rate=44100`` …
+        try:
+            ctype = str(headers.get("Content-Type") or headers.get("content-type") or "")
+        except Exception:
+            ctype = ""
+        m = re.search(r"(?:^|[;\s])rate\s*=\s*(\d+)", ctype, flags=re.IGNORECASE)
+        if m:
+            raw = m.group(1)
+    if raw is None:
+        return None
+    try:
+        rate = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return rate if rate > 0 else None
+
+
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
-    """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
+    """OpenAI speech with ``response_format=pcm``.
+
+    OpenAI's API returns 24 kHz mono int16. Compatible servers may return
+    another rate (advertised via the ``X-Audio-Sample-Rate`` response
+    header); that rate is honored by updating ``self.sample_rate`` before
+    the first chunk is yielded, so consumers that read the attribute after
+    pulling the first chunk open their output device at the right rate.
+    """
 
     sample_rate = 24000
 
@@ -290,6 +346,21 @@ class OpenAIStreamer(StreamingTTSProvider):
             input=text,
             response_format="pcm",
         ) as response:
+            # OpenAI-compatible endpoints may return PCM at a rate other than
+            # OpenAI's 24 kHz (e.g. local Echo-TTS servers at 44.1 kHz),
+            # advertised via the X-Audio-Sample-Rate response header. Honor it:
+            # this generator body runs on the first next(), i.e. before any
+            # audio is yielded, so updating the instance attribute here is
+            # enough for consumers that read it after the first chunk.
+            rate = _sample_rate_from_headers(getattr(response, "headers", None))
+            if rate is not None and rate != self.sample_rate:
+                logger.info(
+                    "OpenAI-compatible TTS endpoint reported sample rate %d Hz "
+                    "(assumed %d Hz); honoring the endpoint rate",
+                    rate,
+                    self.sample_rate,
+                )
+                self.sample_rate = rate
             yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3469,10 +3469,7 @@ def stream_tts_to_speaker(
 
     try:
         output_stream = None
-        streamer = None  # type: ignore[assignment]
-        _worker_thread = None
-        _audio_queue = None  # type: ignore[assignment]
-        _prefetch_threads = []
+        _output_sd = None
         tts_config = _load_tts_config()
 
         # Prefer a chunked streamer for low time-to-first-audio; fall back to
@@ -3499,22 +3496,51 @@ def stream_tts_to_speaker(
             # output_stream=None routes each sentence through the tempfile
             # -> play_audio_file -> afplay path. See PR #62601 / #13291.
             if platform.system() == "Darwin":
-                output_stream = None
+                _output_sd = None
             else:
                 try:
-                    sd = _import_sounddevice()
-                    output_stream = sd.OutputStream(
-                        samplerate=streamer.sample_rate,
+                    _output_sd = _import_sounddevice()
+                except (ImportError, OSError) as exc:
+                    logger.debug("sounddevice not available, streamer→tempfile: %s", exc)
+                    _output_sd = None
+                except Exception as exc:
+                    logger.warning("sounddevice import failed: %s", exc)
+                    _output_sd = None
+
+            def _ensure_output_stream():
+                """(Re)open the OutputStream at the streamer's *current* rate.
+
+                An OpenAI-compatible endpoint may return PCM at a rate other
+                than the 24 kHz default (advertised via the
+                ``X-Audio-Sample-Rate`` response header); that rate is only
+                known after the first chunk has been pulled, so the device is
+                opened lazily and recreated when the rate changes between
+                sentences (#76466).
+                """
+                nonlocal output_stream
+                if _output_sd is None:
+                    return None
+                rate = int(streamer.sample_rate)
+                if output_stream is not None and getattr(output_stream, "samplerate", None) == rate:
+                    return output_stream
+                if output_stream is not None:
+                    try:
+                        output_stream.stop()
+                        output_stream.close()
+                    except Exception:
+                        pass
+                    output_stream = None
+                try:
+                    output_stream = _output_sd.OutputStream(
+                        samplerate=rate,
                         channels=streamer.channels,
                         dtype="int16",
                     )
                     output_stream.start()
-                except (ImportError, OSError) as exc:
-                    logger.debug("sounddevice not available, streamer→tempfile: %s", exc)
-                    output_stream = None
                 except Exception as exc:
                     logger.warning("sounddevice OutputStream failed: %s", exc)
                     output_stream = None
+                return output_stream
 
         chunker = SentenceChunker()
         long_flush_len = 100
@@ -3748,27 +3774,87 @@ def stream_tts_to_speaker(
             # Truncate very long sentences to the provider's per-request cap.
             if stream_max_len and len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]
-            # Every sentence gets its own prefetch thread — the HTTP request
-            # fires the moment the sentence boundary is detected, so audio for
-            # sentence N+1 is already buffering while sentence N plays.
-            _enqueue_audio(cleaned)
+            try:
+                audio_iter = streamer.stream(cleaned)
+                if _output_sd is not None:
+                    import numpy as _np
+                    from itertools import chain as _chain
 
-        def _align_int16_chunks(chunks, stop_evt):
-            """Yield int16-aligned byte chunks from an iterable."""
-            leftover = b""
-            for chunk in chunks:
-                if stop_evt.is_set():
-                    break
-                buf = leftover + chunk
-                aligned_len = len(buf) - (len(buf) % 2)
-                if aligned_len >= 2:
-                    yield buf[:aligned_len]
-                leftover = buf[aligned_len:] if aligned_len < len(buf) else b""
-            if leftover:
-                yield b"\x00"
+                    # Flag real speaker output for the duration of this
+                    # sentence so ambient cues (thinking sound) stay quiet.
+                    # Fail-open: stubbed/partial voice_mode modules (tests)
+                    # must never break sentence playback.
+                    try:
+                        from tools.voice_mode import mark_audio_output_active
+                    except Exception:
+                        def mark_audio_output_active(_active):
+                            return None
+                    # Pull the first chunk before opening the output device:
+                    # the first next() is what actually opens the HTTP request
+                    # and lets the streamer learn the endpoint's real sample
+                    # rate (X-Audio-Sample-Rate), which the device must be
+                    # opened at (#76466).
+                    try:
+                        first_chunk = next(audio_iter)
+                    except StopIteration:
+                        first_chunk = None
+                    if first_chunk is None:
+                        pass
+                    else:
+                        out = _ensure_output_stream()
+                        if out is None:
+                            # Device init failed at the discovered rate:
+                            # fall back to the tempfile player for the
+                            # remaining chunks of this sentence.
+                            _play_via_tempfile(_chain([first_chunk], audio_iter), stop_event, streamer)
+                        else:
+                            mark_audio_output_active(True)
+                            try:
+                                if not stop_event.is_set():
+                                    out.write(_np.frombuffer(first_chunk, dtype=_np.int16).reshape(-1, 1))
+                                for chunk in audio_iter:
+                                    if stop_event.is_set():
+                                        break
+                                    out.write(_np.frombuffer(chunk, dtype=_np.int16).reshape(-1, 1))
+                            finally:
+                                mark_audio_output_active(False)
+                else:
+                    # No audio device: buffer chunks to a temp WAV and play it.
+                    _play_via_tempfile(audio_iter, stop_event, streamer)
+            except Exception as exc:
+                logger.warning("Streaming TTS sentence failed: %s", exc)
 
-        def _play_via_tempfile(audio_iter, stop_evt, sample_rate=24000):
-            """Write PCM chunks to a temp WAV file and play it."""
+        def _speak_via_sync(cleaned: str):
+            """Synthesize one sentence via the proven sync tool, then block on
+            playback. No chunked API, but per-*sentence* granularity keeps the
+            flow conversational for edge and every other non-streaming provider.
+            """
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(suffix=".mp3")
+                os.close(fd)
+                text_to_speech_tool(text=cleaned, output_path=tmp_path)
+                if (not stop_event.is_set() and os.path.isfile(tmp_path)
+                        and os.path.getsize(tmp_path) > 0):
+                    from tools.voice_mode import play_audio_file
+                    play_audio_file(tmp_path)
+            except Exception as exc:
+                logger.warning("Sync per-sentence TTS failed: %s", exc)
+            finally:
+                if tmp_path:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+
+        def _play_via_tempfile(audio_iter, stop_evt, streamer):
+            """Write PCM chunks to a temp WAV file and play it.
+
+            The WAV header is written *after* the first chunk is pulled, so
+            the frame rate reflects the endpoint-returned sample rate
+            (X-Audio-Sample-Rate) instead of the pre-request 24 kHz default
+            (#76466).
+            """
             tmp = None
             tmp_path = None
             try:
@@ -3778,9 +3864,21 @@ def stream_tts_to_speaker(
                 with wave.open(tmp, "wb") as wf:
                     wf.setnchannels(1)
                     wf.setsampwidth(2)  # 16-bit
-                    wf.setframerate(sample_rate)
-                    for aligned in _align_int16_chunks(audio_iter, stop_evt):
-                        wf.writeframes(aligned)
+                    # First next() opens the HTTP request and lets the streamer
+                    # learn the endpoint's real sample rate; only then is the
+                    # WAV header written.
+                    it = iter(audio_iter)
+                    try:
+                        first = next(it)
+                    except StopIteration:
+                        first = None
+                    wf.setframerate(int(streamer.sample_rate))
+                    if first is not None:
+                        wf.writeframes(first)
+                        for chunk in it:
+                            if stop_evt.is_set():
+                                break
+                            wf.writeframes(chunk)
                 # wave.open() given a file object flushes but does NOT close it
                 # (it only closes files it opened itself, by name), so the OS
                 # handle to tmp stays open.  On Windows an open write handle


### PR DESCRIPTION
Closes #76466

## Summary

`OpenAIStreamer` (and every consumer of streaming TTS) assumed a fixed 24 kHz sample rate for raw PCM from OpenAI-compatible TTS endpoints. Compatible servers may return audio at a different rate — e.g. local FastAPI endpoints serving Echo-TTS at 44.1 kHz — which made playback run at the wrong speed (~50% speed for 44.1 kHz audio played as 24 kHz).

This PR makes Hermes read the sample rate the endpoint actually returns and respect it:

- **`tools/tts_streaming.py`** — `OpenAIStreamer.stream()` now reads the `X-Audio-Sample-Rate` response header (with a `Content-Type: audio/pcm; rate=N` fallback) when the response arrives and updates `self.sample_rate` before yielding the first chunk. The provider ABC documents the new contract: `stream()` may refine `sample_rate` once the endpoint's real format is known, so consumers must read it **after** pulling the first chunk.
- **`tools/tts_tool.py`** (`stream_tts_to_speaker`) — the sounddevice `OutputStream` is now opened lazily on the first chunk (and recreated only when the rate changes between sentences), so the device is opened at the endpoint-returned rate instead of the pre-request default. The temp-WAV fallback writes its header after the first chunk for the same reason.
- **`gateway/streaming_tts_consumer.py`** — when the endpoint's rate differs from the adapter-declared `AudioFormat`, chunks are resampled on the fly (stateful linear interpolation, click-free across chunk boundaries) so the adapter contract — every delivered chunk conforms to the declared format — still holds.

## Behavior

- Endpoint says nothing (OpenAI's own API): unchanged, 24 kHz as before.
- Endpoint advertises another rate (e.g. `X-Audio-Sample-Rate: 44100`): CLI/TUI playback and gateway delivery now honor it.

## Notes / limitations

- The desktop `/api/audio/speak-stream` WebSocket announces the sample rate up front (`start` frame) before the endpoint is contacted; honoring a non-24 kHz rate there needs a protocol change coordinated with the desktop client, so it is intentionally left out of this PR.
- The sync (non-streaming) TTS path is unaffected: it uses self-describing containers (mp3/wav/opus), not raw PCM.

## Tests

- New unit tests for `_sample_rate_from_headers` (header, case-insensitivity, Content-Type fallback, invalid values).
- New tests that `OpenAIStreamer` honors the header and keeps the default otherwise.
- New `_PcmResampler` tests (duration preservation across odd chunk boundaries, chunking stability) and a gateway-consumer test proving written chunks conform to the declared format.
- Full affected suites pass: `tests/tools/test_tts_streaming.py`, `tests/gateway/test_streaming_tts_consumer.py`, `tests/hermes_cli/test_web_server_speak_stream.py`, plus the broader TTS/voice suites.
