### PR TITLE
fix(desktop): clear unread dot on tile open + add mark-as-read actions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -93,6 +93,8 @@ import {
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
+  $unreadFinishedSessionIds,
+  markAllSessionsRead,
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
@@ -303,6 +305,7 @@ export function ChatSidebar({
   const sessionsLoading = useStore($sessionsLoading)
   const sessionProfilesTruncated = useStore($sessionProfilesTruncated)
   const workingSessionIds = useStore($workingSessionIds)
+  const unreadCount = useStore($unreadFinishedSessionIds).length
   const profiles = useStore($profiles)
   const profileScope = useStore($profileScope)
   // Only surface the profile switcher when more than one profile exists, so
@@ -1332,7 +1335,24 @@ export function ChatSidebar({
                 forceEmptyState={showSessionSkeletons}
                 groups={displayAgentGroups}
                 headerAction={
-                  inProject && enteredProject ? (
+                  <>
+                    {unreadCount > 0 && (
+                      <Tip label={s.markAllRead}>
+                        <Button
+                          aria-label={s.markAllRead}
+                          className={HEADER_ACTION_BTN}
+                          onClick={event => {
+                            event.stopPropagation()
+                            markAllSessionsRead()
+                          }}
+                          size="icon-xs"
+                          variant="ghost"
+                        >
+                          <Codicon name="check-all" size="0.75rem" />
+                        </Button>
+                      </Tip>
+                    )}
+                    {inProject && enteredProject ? (
                     <div className="group/workspace flex shrink-0 items-center gap-0.5">
                       {enteredProject.path && (
                         <StartWorkButton onStarted={onNewSessionInWorkspace} repoPath={enteredProject.path} />
@@ -1409,7 +1429,8 @@ export function ChatSidebar({
                         ) : null}
                       </div>
                     </div>
-                  )
+                  )}
+                  </>
                 }
                 label={sessionsLabel}
                 labelMeta={

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@/i18n', () => ({
           copyIdFailed: 'Failed to copy ID',
           export: 'Export',
           hideTabBar: 'Hide tab bar',
+          markRead: 'Mark as read',
           pin: 'Pin',
           rename: 'Rename',
           renameDesc: 'Leave empty to clear.',
@@ -54,6 +55,8 @@ vi.mock('@/store/session', () => ({
   $activeSessionId: atom<null | string>(null),
   $selectedStoredSessionId: atom<null | string>(null),
   $sessions: atom<unknown[]>([]),
+  $unreadFinishedSessionIds: atom<string[]>([]),
+  markSessionRead: vi.fn(),
   sessionMatchesStoredId: vi.fn(() => false),
   sessionPinId: vi.fn((s: { id: string }) => s.id),
   setSessions: vi.fn()

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -33,6 +33,8 @@ import {
   $activeSessionId,
   $selectedStoredSessionId,
   $sessions,
+  $unreadFinishedSessionIds,
+  markSessionRead,
   sessionMatchesStoredId,
   sessionPinId,
   setSessions
@@ -151,6 +153,9 @@ function useSessionActions({
   const [renameOpen, setRenameOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  // The row's finished-unread dot is cleared by opening the session (main or
+  // tile) — this menu item is the explicit escape hatch for the rest.
+  const isUnread = useStore($unreadFinishedSessionIds).includes(sessionId)
 
   // Already showing as a tab somewhere (a tile, or loaded in main — main IS
   // a tab): offering "Open in new tab" again is noise.
@@ -211,7 +216,22 @@ function useSessionActions({
         triggerHaptic('selection')
         onPin?.()
       }
-    })
+    }),
+    // Only meaningful for a row still carrying the finished-unread dot; once
+    // read (or never unread) the item vanishes.
+    ...(isUnread
+      ? [
+          spec({
+            disabled: !sessionId,
+            icon: 'check-all',
+            label: r.markRead,
+            onSelect: () => {
+              triggerHaptic('selection')
+              markSessionRead(sessionId)
+            }
+          })
+        ]
+      : [])
   ]
 
   // WORK — derive/extract from the session.

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1920,6 +1920,7 @@ export const en: Translations = {
       openInSplit: 'Open in split',
       copyIdFailed: 'Could not copy session ID',
       sessionActions: 'Session actions',
+      markRead: 'Mark as read',
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
       waitingForAnswer: 'Waiting for your answer',
@@ -1944,7 +1945,8 @@ export const en: Translations = {
       thisWeek: 'Earlier this week',
       lastWeek: 'Last week',
       thisMonth: 'Earlier this month'
-    }
+    },
+    markAllRead: 'Mark all as read'
   },
 
   composer: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1619,6 +1619,7 @@ export interface Translations {
       openInSplit: string
       copyIdFailed: string
       sessionActions: string
+      markRead: string
       sessionRunning: string
       needsInput: string
       waitingForAnswer: string
@@ -1644,6 +1645,7 @@ export interface Translations {
       lastWeek: string
       thisMonth: string
     }
+    markAllRead: string
   }
 
   composer: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2113,6 +2113,7 @@ export const zh: Translations = {
       copyIdFailed: '无法复制会话 ID',
 
       sessionActions: '会话操作',
+      markRead: '标记为已读',
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
       waitingForAnswer: '正在等待你的回答',
@@ -2137,7 +2138,8 @@ export const zh: Translations = {
       thisWeek: '本周',
       lastWeek: '上周',
       thisMonth: '本月'
-    }
+    },
+    markAllRead: '全部标记为已读'
   },
 
   composer: {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -36,6 +36,7 @@ import {
   $activeSessionId,
   $selectedStoredSessionId,
   $unreadFinishedSessionIds,
+  markSessionRead,
   setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
@@ -535,6 +536,12 @@ export function openSessionTile(
   before?: null | string
 ) {
   const tiles = $sessionTiles.get()
+
+  // Opening a session in a tab/tile is "reading" it — clear its unread dot
+  // exactly like main-thread resume does. Previously only
+  // setSelectedStoredSessionId cleared unread, so tile-opened sessions kept
+  // their green dot even while the user was reading them.
+  markSessionRead(storedSessionId)
 
   if (storedSessionId === $selectedStoredSessionId.get()) {
     return

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -484,13 +484,30 @@ export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStor
 // Written by session-states.ts (handleTransition), cleared here on session open.
 export const $unreadFinishedSessionIds = atom<string[]>([])
 
+/** A session is "read" the moment the user opens it — main-thread resume AND
+ *  tile/tab open both call this, so the green dot can't stick while the user
+ *  is looking at the session. */
+export function markSessionRead(storedSessionId: string) {
+  if ($unreadFinishedSessionIds.get().includes(storedSessionId)) {
+    $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(x => x !== storedSessionId))
+  }
+}
+
+/** Sidebar "mark all as read" — clears every finished-unread dot. Purely
+ *  renderer-local, like the atom itself. */
+export function markAllSessionsRead() {
+  if ($unreadFinishedSessionIds.get().length > 0) {
+    $unreadFinishedSessionIds.set([])
+  }
+}
+
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
   updateAtom($selectedStoredSessionId, next)
   // Opening a session clears its unread state — the user is now looking at it.
   const id = $selectedStoredSessionId.get()
 
-  if (id && $unreadFinishedSessionIds.get().includes(id)) {
-    $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(x => x !== id))
+  if (id) {
+    markSessionRead(id)
   }
 }
 


### PR DESCRIPTION
## Summary

The green "finished — unread" dot in the Desktop session sidebar only cleared when a session was opened via **main-thread resume** (`setSelectedStoredSessionId`). Opening a session in a **tab/tile** (middle-click, Cmd/Ctrl-click, tile strip, drag-to-tile) never cleared it — so the dot stayed green while the user was actively reading that session in a tile.

This change makes any open count as "read" and adds explicit mark-as-read affordances:

- **`openSessionTile` now calls `markSessionRead()`** — opening a session in a tab/tile clears its unread dot, exactly like main-thread resume.
- **"Mark as read" per-row action** in the session ⋯ menu (only rendered while the row is unread).
- **"Mark all as read" header action** in the recents sidebar (only rendered when unread sessions exist).
- New `markSessionRead` / `markAllSessionsRead` helpers in `store/session.ts`, reused by `setSelectedStoredSessionId` (single source of truth for clearing unread state).

## Root cause

`$unreadFinishedSessionIds` is a renderer-local transient atom (`apps/desktop/src/store/session.ts`), written by `handleTransition` in `session-states.ts` on every busy→idle transition where `storedId !== $selectedStoredSessionId.get()`.

Two compounding issues:

1. **Clear path was single-slot.** Only `setSelectedStoredSessionId` cleared unread (`session.ts:487-495`). `openSessionTile` (`session-states.ts:531-563`) never touched it, so a session opened as a tile kept its dot even while visible in the tile the user was reading (`session-tile.tsx` renders the dot).
2. **Guard only knows the main selection.** `handleTransition` compares against `$selectedStoredSessionId`; a session open in a tile is never "selected", so a turn finishing while the user reads it in a tile marks it unread and it can never clear (except by clicking the sidebar row).

**Amplified with a remote `hermes serve` backend:** `gateway-event.ts` ("the running→busy transition must reach EVERY session") delivers transitions for every backend session — CLI/cron/kanban turns finishing on the server mark unread in the desktop client, so dots accumulate from sessions the user never opened.

## Changes

| File | Change |
|---|---|
| `apps/desktop/src/store/session.ts` | `markSessionRead(id)` + `markAllSessionsRead()` helpers; `setSelectedStoredSessionId` delegates to `markSessionRead` |
| `apps/desktop/src/store/session-states.ts` | `openSessionTile` clears unread via `markSessionRead` |
| `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` | "Mark as read" item (shown only when unread) |
| `apps/desktop/src/app/chat/sidebar/index.tsx` | "Mark all as read" header button (shown only when `unreadCount > 0`) |
| `apps/desktop/src/i18n/types.ts`, `en.ts`, `zh.ts` | `markRead` (row), `markAllRead` (sidebar) strings |

## Test plan

- `npx tsc --noEmit -p tsconfig.json` — 0 errors.
- `npx vitest run` on `session.test.ts`, `session-states.test.ts`, `session-actions-menu.test.tsx` — no new failures vs. baseline (pre-existing failures in `session.test.ts` are unrelated `window.localStorage` test-env issues).
- Updated `session-actions-menu.test.tsx` mocks for `$unreadFinishedSessionIds` / `markSessionRead`.

Manual: open a session via tile/tab → dot clears; unread rows show "Mark as read" in ⋯; header shows the check-all button only while unread sessions exist.

## Notes

- All state changes are renderer-local (the atom was already local) — no backend change required.
- Semantic shift: "unread" now means "not opened anywhere (main or tile)", which matches user expectation.
