### PR TITLE
fix(cron): treat a referenced directory as "not a script" in the lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -256,6 +256,19 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     try:
         metadata = os.fstat(descriptor)
+        if stat.S_ISDIR(metadata.st_mode):
+            # A directory can never be executed or sourced as a script
+            # (`sh /some/dir` exits 126), so it cannot carry a lifecycle
+            # command — ignore it instead of failing closed. This matters
+            # because the tokenizer is shell-shaped but the scanned text
+            # often is not: `punctuation_chars` makes `()` a segment break,
+            # so a Python line like `HOME = Path.home() / ".hermes/scripts"`
+            # (or plain `pct = len(items) / total`) leaves a bare `/` as a
+            # segment's first token, which reads as a reference to the root
+            # directory. Failing closed there blocked legitimate cron jobs
+            # with a "contains a gateway lifecycle command" error that named
+            # nothing the script actually contained.
+            return None, False
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         if metadata.st_size > _MAX_REFERENCED_SCRIPT_BYTES:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -643,6 +643,50 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily", "restart.sh")
 
+    @pytest.mark.parametrize("line", [
+        # `punctuation_chars` makes `()` a segment break, so the remainder of
+        # each of these lines starts with a bare `/` token that the reference
+        # scanner reads as a path — the root directory. A directory is not a
+        # script, so it must not fail the scan closed.
+        'HERMES_SCRIPTS = Path.home() / ".hermes/scripts"',
+        'MISSING = Path.home() / "zzz-nonexistent"',
+        "pct = len(items) / total",
+        "ratio = (a + b) / 2",
+    ])
+    def test_python_path_and_division_lines_do_not_block(self, tmp_path, line):
+        """Python source is not shell, but the scanner tokenizes it as if it
+        were. Inline path/division expressions must not read as a reference to
+        `/` that fails closed (the error names a gateway command the script
+        does not contain)."""
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        script = tmp_path / "job.py"
+        script.write_text(f"from pathlib import Path\n{line}\n")
+        check_gateway_lifecycle("daily maintenance job", str(script))
+
+    def test_python_script_with_real_command_still_blocks(self, tmp_path):
+        """Negative control for the case above: the same Python shape carrying
+        an actual lifecycle command must still be rejected."""
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        script = tmp_path / "job.py"
+        script.write_text(
+            "from pathlib import Path\n"
+            'HERMES_SCRIPTS = Path.home() / ".hermes/scripts"\n'
+            'subprocess.run("launchctl kickstart -k gui/501/ai.hermes.gateway")\n'
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily maintenance job", str(script))
+
+    def test_referenced_script_recursion_still_blocks(self, tmp_path):
+        """Second negative control: ignoring directories must not disable the
+        referenced-script scanner itself."""
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        inner = tmp_path / "inner.sh"
+        inner.write_text("launchctl kickstart -k gui/501/ai.hermes.gateway\n")
+        outer = tmp_path / "outer.sh"
+        outer.write_text(f"#!/bin/bash\nsource {inner}\n")
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("clean prompt", str(outer))
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path


### PR DESCRIPTION
## What does this PR do?

The cron lifecycle guard rejects legitimate **Python** cron scripts with `Blocked: cron job contains a gateway lifecycle command …` even when the script contains nothing of the sort. The error names a command the script does not contain, so it is very hard to diagnose from the message alone.

Root cause is a mismatch between the tokenizer's shape and the text it is asked to scan. `_iter_command_segments()` uses `shlex(punctuation_chars=";&|()")`, so `(` / `)` act as **segment separators**. Applied to Python source, a perfectly ordinary line splits like this:

```
'HERMES_SCRIPTS = Path.home() / ".hermes/scripts"'
  → segments: [['HERMES_SCRIPTS', '=', 'Path.home'], ['/', '.hermes/scripts']]
```

The second segment's leading token is a bare `/`. `_iter_referenced_shell_scripts()` yields it as a referenced script (`"/" in executable`), `_read_referenced_script()` opens the **root directory**, `stat.S_ISREG` is false, and the non-regular branch fails closed with `unsafe=True` — which short-circuits the whole scan to `True`.

Two consequences worth noting:

- The path actually stat'd is always `/`, never the literal in the source, so a *nonexistent* path in the string blocks just as reliably as a real one.
- It is not specific to `Path.home()`. Any single line where a `(`/`)`/`;`/`&`/`|` token is followed by a segment whose first token contains `/` hits it:

  | line | blocked before this PR |
  |---|---|
  | `HERMES_SCRIPTS = Path.home() / ".hermes/scripts"` | yes |
  | `pct = len(items) / total` | yes |
  | `ratio = (a + b) / 2` | yes |
  | `x = y / z` | no (no paren to split on) |
  | `x = "/Users/me/.hermes/scripts"` | no (path is not the segment's first token) |

Because `tools/terminal_tool.py` calls the same helper when `_HERMES_GATEWAY=1`, the false positive also blocks in-gateway terminal commands that carry Python (e.g. a heredoc), not just cron creation.

### The fix

Treat a directory as **"not a script"** rather than as an unsafe read. A directory can never be executed or sourced by the shapes this scanner models — `sh /some/dir` exits 126 — so it cannot carry a lifecycle command, and failing closed on it buys no safety. Every other non-regular type (fifo, socket, device) and the oversize case keep failing closed exactly as before.

This deliberately does **not** gate the referenced-script scan on "does this look like shell" (shebang / `.sh` extension). `check_gateway_lifecycle()` concatenates prompt and script before scanning, so the scan site cannot tell the two apart; `terminal_tool` passes a real shell command where such a gate is meaningless; and it would drop real coverage — a Python cron script that shells out to `bash restart_gw.sh` is scanned today and should stay scanned.

## Related Issue

No existing issue — found while authoring a Python cron script. The behavior comes from the referenced-script scanner added for the guard work in #30719 / #62891; this PR narrows one fail-closed branch without touching the detection patterns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/lifecycle_guard.py` — `_read_referenced_script()` returns `(None, False)` for `S_ISDIR` instead of falling into the `not S_ISREG` → `(None, True)` fail-closed branch. Other non-regular types unchanged.
- `tests/hermes_cli/test_gateway_restart_loop.py` — 3 tests in `TestLifecycleGuardModule`: a parametrized false-positive case (4 lines), plus two negative controls.

## How to Test

Reproduce on `main` (fails), then re-run with the patch (passes):

```python
from cron.lifecycle_guard import contains_gateway_lifecycle_command as A
from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script as B

src = 'HERMES_SCRIPTS = Path.home() / ".hermes/scripts"'
A(src)  # False — the text genuinely has no lifecycle command
B(src)  # True on main (bug), False with this patch
```

Or through the public entry point:

```bash
printf 'from pathlib import Path\nHERMES_SCRIPTS = Path.home() / ".hermes/scripts"\n' > /tmp/job.py
python -c "from cron.lifecycle_guard import check_gateway_lifecycle; check_gateway_lifecycle('daily job', '/tmp/job.py')"
# main:      GatewayLifecycleBlocked: … contains a gateway lifecycle command …
# this PR:   exits 0
```

Guard-suite evidence (macOS 15, Python 3.11):

```
with patch:      15 passed          (tests/hermes_cli/test_gateway_restart_loop.py -k LifecycleGuardModule)
without patch:    4 failed, 11 passed   ← only the new false-positive parametrization fails
full file:       84 passed
```

The two negative controls fail on a weakened guard, which is the point of including them: a Python script that *does* contain `launchctl kickstart -k gui/501/ai.hermes.gateway` is still blocked, and a shell script that `source`s a sibling containing the command is still blocked (proves the referenced-script recursion is untouched).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Tests: the guard's own file passes — `tests/hermes_cli/test_gateway_restart_loop.py`, **86 passed** on my working checkout (80 on this branch alone). I am **not** claiming a clean full-suite run: `pytest tests/ -q` on my machine is ~24k tests / 35 min and ends `1016 failed, 23019 passed, 150 skipped, 10 errors`. Those failures look environment-dependent (network / API keys / system state — e.g. the tavily and website-policy suites) and this change touches only `cron/lifecycle_guard.py` (consumed by `cron/jobs.py`, `hermes_cli/cron.py`, `tools/terminal_tool.py`), but I have not yet run a with/without comparison to prove they are unrelated, so please treat CI as the authority here rather than my local numbers
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new branch carries an explanatory comment; no user-facing docs describe this internal branch
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: `stat.S_ISDIR` is stdlib. Verified on macOS only — on Windows `os.open()` on a directory is expected to raise, which the existing `except OSError` already turns into `(None, False)`, the same outcome this branch makes explicit on POSIX; happy to have a Windows user confirm
- [x] N/A — no tool description or schema change

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
