### PR TITLE
fix(security): harden delegated approval boundaries

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1585,6 +1585,56 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    # Cross-provider fallback context guard. This is local deterministic state
+    # only; no environment-variable bridge and no remote classifier.
+    _security_cfg = _agent_cfg.get("security", {})
+    if not isinstance(_security_cfg, dict):
+        _security_cfg = {}
+    _fallback_guard_cfg = _security_cfg.get("sensitive_fallback_guard", {})
+    if isinstance(_fallback_guard_cfg, bool):
+        _fallback_guard_cfg = {"enabled": _fallback_guard_cfg}
+    if not isinstance(_fallback_guard_cfg, dict):
+        _fallback_guard_cfg = {}
+    _fallback_guard_markers = _fallback_guard_cfg.get("explicit_markers") or []
+    if not isinstance(_fallback_guard_markers, (list, tuple, set)):
+        _fallback_guard_markers = []
+    _fallback_guard_paths = (
+        _fallback_guard_cfg.get("sensitive_path_prefixes") or []
+    )
+    if not isinstance(_fallback_guard_paths, (list, tuple, set)):
+        _fallback_guard_paths = []
+    agent._sensitive_fallback_guard = {
+        "enabled": is_truthy_value(_fallback_guard_cfg.get("enabled", False)),
+        "mode": str(_fallback_guard_cfg.get("mode", "block") or "block")
+        .strip()
+        .lower(),
+        "explicit_markers": [
+            str(value)
+            for value in _fallback_guard_markers
+            if isinstance(value, str) and value.strip()
+        ],
+        "sensitive_path_prefixes": [
+            str(value)
+            for value in _fallback_guard_paths
+            if isinstance(value, str) and value.strip()
+        ],
+    }
+    agent._current_fallback_context_messages = None
+
+    _send_guard_cfg = _security_cfg.get("customer_send_guard", {})
+    if isinstance(_send_guard_cfg, bool):
+        _send_guard_cfg = {"enabled": _send_guard_cfg}
+    if not isinstance(_send_guard_cfg, dict):
+        _send_guard_cfg = {}
+    agent._customer_send_guard = {
+        "enabled": is_truthy_value(_send_guard_cfg.get("enabled", False)),
+        "approval_prefix": str(
+            _send_guard_cfg.get("approval_prefix") or "SEND APPROVED:"
+        ).strip(),
+    }
+    agent._customer_send_approval_consumed_turn = None
+    agent._customer_send_approval_lock = threading.Lock()
+
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as
     # visible mid-turn updates through the interim message path. When false,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1691,6 +1691,47 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+def _sensitive_cross_provider_fallback_reason(
+    agent,
+    *,
+    fallback_provider: str,
+    current_provider: str,
+    fallback_base_url: str,
+    current_base_url: str,
+) -> Optional[tuple[str, str]]:
+    """Return safe block codes for an enabled cross-provider context guard."""
+    guard = getattr(agent, "_sensitive_fallback_guard", None)
+    if not isinstance(guard, dict) or not guard.get("enabled", False):
+        return None
+    from agent.backend_identity import BackendIdentity
+
+    fallback_ident = BackendIdentity.build(
+        provider=fallback_provider,
+        base_url=fallback_base_url,
+    )
+    current_ident = BackendIdentity.build(
+        provider=current_provider,
+        base_url=current_base_url,
+    )
+    if (
+        fallback_ident.provider == current_ident.provider
+        and fallback_ident.base_url == current_ident.base_url
+    ):
+        return None
+    if str(guard.get("mode", "block") or "block").strip().lower() != "block":
+        return ("guard_config", "unsupported_mode")
+    try:
+        from agent.redact import classify_sensitive_fallback_context
+
+        return classify_sensitive_fallback_context(
+            getattr(agent, "_current_fallback_context_messages", None),
+            explicit_markers=guard.get("explicit_markers") or [],
+            sensitive_path_prefixes=guard.get("sensitive_path_prefixes") or [],
+        )
+    except Exception:
+        return ("guard_error", "classifier_error")
+
+
 
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
@@ -1744,6 +1785,31 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback(reason)  # skip invalid, try next
+
+    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    sensitive_reason = _sensitive_cross_provider_fallback_reason(
+        agent,
+        fallback_provider=fb_provider,
+        current_provider=current_provider,
+        fallback_base_url=str(fb.get("base_url") or ""),
+        current_base_url=str(getattr(agent, "base_url", "") or ""),
+    )
+    if sensitive_reason is not None:
+        # This is a turn-local privacy decision, not a provider health failure.
+        # The index has already advanced, so this attempt will not loop; do not
+        # poison the session-wide unavailable set or a later non-sensitive turn
+        # would lose this fallback permanently.
+        category, reason_code = sensitive_reason
+        logger.warning(
+            "Cross-provider fallback blocked by sensitive context guard: "
+            "category=%s reason=%s",
+            category,
+            reason_code,
+        )
+        agent._buffer_status(
+            "🔒 Fallback blocked because sensitive context was detected."
+        )
+        return agent._try_activate_fallback(reason)
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2022,6 +2022,12 @@ def run_conversation(
                     int(getattr(_compressor, "threshold_tokens", 0) or 0),
                 )
         
+        # Keep the exact context that this iteration would resend after a
+        # provider failure. This list already includes the system prompt,
+        # assistant tool calls, and all tool outputs accumulated so far; later
+        # retry shaping mutates the same list object in place.
+        agent._current_fallback_context_messages = api_messages
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
         

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1305,6 +1305,11 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        scope = getattr(agent, "_delegated_approval_scope", None)
+        if getattr(scope, "enabled", False):
+            raise PermissionError(
+                "codex_app_server is unavailable under a delegated approval scope"
+            )
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,

--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -10,7 +10,545 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import asdict, dataclass
+import os
+import re
+import shlex
 from typing import Iterator, Mapping, MutableMapping
+
+
+@dataclass(frozen=True)
+class DelegatedApprovalScope:
+    """Serializable approval boundary inherited by ``delegate_task`` children."""
+
+    enabled: bool
+    approved_mission_summary: str
+    allowed_workspace_path: str
+    allow_local_non_destructive: bool = True
+    allow_external_transmission: bool = False
+    allow_destructive: bool = False
+    allow_credentials: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+_TERMINAL_EXTERNAL_RE = re.compile(
+    r"(?:https?://|\b(?:curl|wget|scp|sftp|ssh|rsync|nc|ncat|ftp|rclone|gsutil|"
+    r"mail|sendmail|mutt)\b|\baws\s+s3\b|\b(?:npm|pnpm|yarn)\s+publish\b|"
+    r"\btwine\s+upload\b|\bdocker\s+push\b|"
+    r"\b(?:vercel|netlify)\s+(?:deploy|publish)\b|\bgit\b.*\b(?:clone|fetch|pull)\b)",
+    re.IGNORECASE,
+)
+_TERMINAL_DESTRUCTIVE_RE = re.compile(
+    r"(?:^|[;&|]\s*|\bsudo\s+)(?:rm|rmdir|unlink|shred|truncate|mkfs|dd|mv)\b|"
+    r"\bfind\b[^;&|]*\s-delete\b",
+    re.IGNORECASE,
+)
+_TERMINAL_CREDENTIAL_RE = re.compile(
+    r"(?:\b(?:auth|login|logout|account|passwd|password|credential|secret|token|"
+    r"keychain)\b|(?:^|[/\\])\.ssh(?:[/\\]|$)|(?:^|[/\\])\.env(?:\.|[/\\]|$)|"
+    r"\[REDACTED PRIVATE KEY\]|«redacted|\*\*\*)",
+    re.IGNORECASE,
+)
+_TERMINAL_GIT_CHANGE_RE = re.compile(
+    r"(?:\bgit\b[^;&|]*\b(?:commit|push|merge|request-pull|reset|clean|tag|"
+    r"branch|checkout|switch|rebase|cherry-pick|revert|stash)\b|"
+    r"\b(?:gh\s+pr|glab\s+mr)\b)",
+    re.IGNORECASE,
+)
+_TERMINAL_PAYMENT_RE = re.compile(
+    r"\b(?:stripe|paypal|payment|checkout|invoice|charge|purchase|billing)\b",
+    re.IGNORECASE,
+)
+_TERMINAL_GLOBAL_MANAGER_RE = re.compile(
+    r"(?:\b(?:brew|apt|apt-get|yum|dnf|pacman|apk|choco|winget|pipx)\s+install\b|"
+    r"\b(?:npm|pnpm|yarn)\b[^;&|]*(?:\s-g\b|\s--global\b)|"
+    r"\b(?:cargo|gem|go)\s+install\b|\buv\s+tool\s+install\b|"
+    r"\bdotnet\s+tool\s+install\b|\buv\s+pip\s+install\b[^;&|]*\s--system\b)",
+    re.IGNORECASE,
+)
+_INLINE_EXEC_RE = re.compile(
+    r"(?:^|\s|[;&|]\s*|\benv\s+)(?:[^\s;&|]*/)?"
+    r"(?:python(?:\d+(?:\.\d+)*)?|node|ruby|perl)\s+(?:[^;&|]*\s)?-(?:c|e)\b|"
+    r"(?:^|\s|[;&|]\s*|\benv\s+)(?:[^\s;&|]*/)?(?:sh|bash|zsh)\s+(?:[^;&|]*\s)?-c\b",
+    re.IGNORECASE,
+)
+
+_LOCAL_PATH_TOOLS = frozenset({"read_file", "search_files", "write_file", "patch"})
+_PATH_ARG_NAMES = frozenset({
+    "path", "file_path", "filepath", "directory", "dir", "root", "cwd",
+    "workdir", "input_path", "output_path", "source_path", "target_path",
+})
+_COMPACT_PATH_ARG_NAMES = frozenset(
+    re.sub(r"[^a-z0-9]", "", key.lower()) for key in _PATH_ARG_NAMES
+)
+_OPERATION_KEYS = frozenset({
+    "action", "operation", "op", "method", "mode", "command", "request_type", "type",
+})
+
+
+def _normalise_path(value: object) -> str:
+    if not value:
+        return ""
+    try:
+        return os.path.realpath(os.path.abspath(os.path.expanduser(str(value))))
+    except (OSError, TypeError, ValueError):
+        return ""
+
+
+def _path_within(path: str, root: str) -> bool:
+    if not path or not root:
+        return False
+    try:
+        return os.path.commonpath([path, root]) == root
+    except (OSError, ValueError):
+        return False
+
+
+def _scope_workspace(scope: DelegatedApprovalScope) -> str:
+    return _normalise_path(scope.allowed_workspace_path)
+
+
+def _resolve_local_path(value: object, task_id: str) -> str:
+    if not isinstance(value, (str, os.PathLike)) or not str(value).strip():
+        return ""
+    try:
+        from tools.file_tools import _resolve_path_for_task
+
+        return _normalise_path(_resolve_path_for_task(str(value), task_id or "default"))
+    except Exception:
+        return ""
+
+
+def _path_argument_values(value: object) -> list[object]:
+    """Collect path-like arguments independent of snake/camel-case spelling."""
+    paths: list[object] = []
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, child in node.items():
+                compact_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                if compact_key in _COMPACT_PATH_ARG_NAMES:
+                    if isinstance(child, (list, tuple)):
+                        paths.extend(child)
+                    elif child:
+                        paths.append(child)
+                elif isinstance(child, (dict, list, tuple)):
+                    _walk(child)
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                _walk(child)
+
+    _walk(value)
+    return paths
+
+
+def _operation_tokens(value: object) -> set[str]:
+    tokens: set[str] = set()
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if str(key).lower() in _OPERATION_KEYS and isinstance(child, str):
+                    token = re.sub(r"[^a-z0-9]", "", child.lower())
+                    if token:
+                        tokens.add(token)
+                elif isinstance(child, (dict, list, tuple)):
+                    _walk(child)
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                _walk(child)
+
+    _walk(value)
+    return tokens
+
+
+def _truthy_nested(value: object, target_key: str) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).lower() == target_key and child is True:
+                return True
+            if isinstance(child, (dict, list, tuple)) and _truthy_nested(child, target_key):
+                return True
+    elif isinstance(value, (list, tuple)):
+        return any(_truthy_nested(child, target_key) for child in value)
+    return False
+
+
+def _operations_match(operations: set[str], verbs: set[str]) -> bool:
+    return any(
+        operation == verb or operation.startswith(verb) or operation.endswith(verb)
+        for operation in operations
+        for verb in verbs
+    )
+
+
+def _external_tool_denial_reason(function_name: str, function_args: dict) -> str | None:
+    name = function_name.lower()
+    operations = _operation_tokens(function_args)
+    email_draft_send = False
+
+    if function_name == "skill_manage":
+        return "skill_mutation"
+
+    if "google_workspace" in name:
+        if "manage_email" in name:
+            sends = {"send", "sendemail", "reply", "replyall", "forward"}
+            if _operations_match(operations, sends):
+                email_draft_send = _truthy_nested(function_args, "draft")
+                if not email_draft_send:
+                    return "external_transmission"
+        if "calendar" in name and _operations_match(operations, {
+            "create", "update", "delete", "quickadd", "move", "patch",
+        }):
+            return "external_calendar_mutation"
+        if "drive" in name and _operations_match(operations, {
+            "upload", "share", "unshare", "update", "delete", "copy", "comment",
+            "create", "move", "patch", "write",
+        }):
+            return "external_drive_mutation"
+        if ("docs" in name or "document" in name) and _operations_match(operations, {
+            "create", "write", "inserttext", "replacetext", "update", "delete", "patch",
+            "batchupdate",
+        }):
+            return "external_docs_mutation"
+        if "sheet" in name and _operations_match(operations, {
+            "write", "create", "append", "update", "clear", "delete", "insert",
+            "add", "remove", "move", "copy", "resize", "format", "batchupdate", "patch",
+        }):
+            return "external_sheets_mutation"
+
+    if "browser" in name or "aside" in name:
+        arbitrary = {"execute", "evaluate", "eval", "script", "javascript", "repl"}
+        interactive = {"click", "type", "fill", "submit", "upload", "download", "drag"}
+        has_arbitrary_payload = any(
+            str(key).lower() in {"code", "script", "expression", "javascript"}
+            for key in function_args
+        )
+        if has_arbitrary_payload or _operations_match(operations, arbitrary | interactive) or any(
+            marker in name for marker in (
+                "execute", "evaluate", "eval", "script", "javascript", "repl",
+                "click", "type", "fill", "upload",
+            )
+        ):
+            return "external_browser_mutation"
+
+    if any(service in name for service in ("gjc", "pencil", "kordoc")):
+        mutations = {"patch", "fill", "write", "create", "update", "delete", "insert", "replace", "apply"}
+        name_mutations = mutations | {
+            "batch", "batchdesign", "design", "execute", "modify", "render", "set",
+        }
+        compact_name = re.sub(r"[^a-z0-9]", "", name)
+        if _operations_match(operations, mutations) or any(marker in compact_name for marker in name_mutations):
+            return "external_document_mutation"
+
+    if any(marker in name for marker in ("send_message", "publish", "upload")):
+        return "external_transmission"
+    if not email_draft_send and _operations_match(
+        operations, {"send", "upload", "publish", "post", "share", "unshare"}
+    ):
+        return "external_transmission"
+    if any(marker in name for marker in ("payment", "checkout", "purchase", "charge")):
+        return "payment"
+    if any(marker in name for marker in (
+        "credential", "account_auth", "login", "logout", "oauth", "token", "secret",
+    )):
+        return "credentials_or_account"
+    if any(marker in name for marker in (
+        "git_commit", "git_push", "git_merge", "git_reset", "git_clean", "git_tag",
+        "git_branch", "create_pr", "create_pull_request", "merge_pull_request",
+    )):
+        return "git_state_change"
+    if _operations_match(operations, {"delete", "bulkmove"}) and "google_workspace" not in name:
+        return "destructive"
+    return None
+
+
+def _known_scoped_read_tool(function_name: str, function_args: dict) -> bool:
+    """Allow only reviewed read/draft operations on established providers."""
+    name = function_name.lower()
+    operations = _operation_tokens(function_args)
+    read_verbs = {
+        "get", "list", "read", "search", "agenda", "triage", "freebusy",
+        "labels", "threads", "export", "download", "view", "snapshot",
+    }
+
+    if "google_workspace" in name:
+        if "manage_email" in name and _truthy_nested(function_args, "draft"):
+            return _operations_match(
+                operations, {"send", "sendemail", "reply", "replyall", "forward"}
+            )
+        return bool(operations) and all(
+            _operations_match({operation}, read_verbs) for operation in operations
+        )
+    if "aside" in name:
+        return bool(operations) and all(
+            _operations_match({operation}, {"get", "list", "read", "snapshot", "attach"})
+            for operation in operations
+        )
+    if "pencil" in name:
+        compact_name = re.sub(r"[^a-z0-9]", "", name)
+        return any(marker in compact_name for marker in ("get", "snapshot"))
+    return False
+
+
+def customer_send_denial_reason(function_name: str, function_args: dict) -> str | None:
+    """Return a reason only for customer-facing send/post operations.
+
+    Draft creation is deliberately allowed. Upload/share mutations remain under
+    the broader delegated-scope policy rather than this root send gate.
+    """
+    name = function_name.lower()
+    compact_name = re.sub(r"[^a-z0-9]", "", name)
+    operations = _operation_tokens(function_args)
+    if "manage_email" in name:
+        sends = {"send", "sendemail", "reply", "replyall", "forward"}
+        if _operations_match(operations, sends) and not _truthy_nested(
+            function_args, "draft"
+        ):
+            return "customer_send_approval_required"
+        return None
+    if any(marker in compact_name for marker in (
+        "send", "reply", "forward", "publish", "postmessage",
+        "addcomment", "createcomment", "replycomment",
+    )) or _operations_match(
+        operations, {"send", "reply", "replyall", "forward", "post", "publish"}
+    ):
+        return "customer_send_approval_required"
+    return None
+
+
+def customer_send_targets(function_args: dict) -> tuple[str, ...]:
+    """Extract destination identifiers that an explicit approval must name."""
+    target_keys = {
+        "to", "cc", "bcc", "recipient", "recipients", "target",
+        "channel", "channel_id", "chat_id", "room_id", "user_id",
+        "message_id", "thread_id", "comment_id",
+    }
+    compact_target_keys = {
+        re.sub(r"[^a-z0-9]", "", key.lower()) for key in target_keys
+    }
+    values: list[str] = []
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, child in node.items():
+                compact_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                if compact_key in compact_target_keys:
+                    if isinstance(child, str) and child.strip():
+                        values.append(child.strip())
+                    elif isinstance(child, (list, tuple)):
+                        values.extend(
+                            str(item).strip()
+                            for item in child
+                            if isinstance(item, (str, int)) and str(item).strip()
+                        )
+                elif isinstance(child, (dict, list, tuple)):
+                    _walk(child)
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                _walk(child)
+
+    _walk(function_args)
+    return tuple(dict.fromkeys(values))
+
+
+def _venv_pip_install_is_scoped(tokens: list[str], workspace: str, base_dir: str) -> bool:
+    lowered = [token.lower() for token in tokens]
+    if "--user" in lowered or any(token == "sudo" for token in lowered):
+        return False
+
+    pip_index = None
+    executable_index = None
+    for index, token in enumerate(tokens):
+        base = os.path.basename(token).lower()
+        if re.fullmatch(r"pip\d*(?:\.\d+)*", base):
+            pip_index = index
+            executable_index = index
+            break
+        if re.fullmatch(r"python\d*(?:\.\d+)*", base):
+            if index + 2 < len(tokens) and tokens[index + 1:index + 3] == ["-m", "pip"]:
+                pip_index = index + 2
+                executable_index = index
+                break
+    if pip_index is None or "install" not in lowered[pip_index + 1:]:
+        return True
+
+    install_args = tokens[pip_index + 1:]
+    for index, token in enumerate(install_args):
+        target = None
+        if token in {"-t", "--target", "--prefix", "--root"} and index + 1 < len(install_args):
+            target = install_args[index + 1]
+        elif any(token.startswith(prefix) for prefix in ("--target=", "--prefix=", "--root=")):
+            target = token.split("=", 1)[1]
+        if target:
+            resolved_target = _normalise_path(
+                target if os.path.isabs(target) else os.path.join(base_dir, target)
+            )
+            return _path_within(resolved_target, workspace)
+
+    executable = tokens[executable_index or 0]
+    if "/" in executable or "\\" in executable:
+        resolved = _normalise_path(
+            executable if os.path.isabs(executable) else os.path.join(base_dir, executable)
+        )
+        components = {part.lower() for part in resolved.replace("\\", "/").split("/")}
+        return _path_within(resolved, workspace) and bool(components & {".venv", "venv"})
+
+    active_venv = _normalise_path(os.environ.get("VIRTUAL_ENV"))
+    if active_venv and _path_within(active_venv, workspace):
+        return True
+    for index, token in enumerate(tokens[:-1]):
+        if token in {"source", "."}:
+            activate = _normalise_path(os.path.join(base_dir, tokens[index + 1]))
+            components = {part.lower() for part in activate.replace("\\", "/").split("/")}
+            if _path_within(activate, workspace) and bool(components & {".venv", "venv"}):
+                return True
+    return False
+
+
+def delegated_terminal_denial_reason(
+    scope: DelegatedApprovalScope,
+    command: str,
+    *,
+    workdir: object = None,
+    task_id: str = "default",
+) -> str | None:
+    """Classify unsafe shell calls and require parent execution for the rest."""
+    if not scope.allow_local_non_destructive:
+        return "local_non_destructive_disabled"
+    workspace = _scope_workspace(scope)
+    if not workspace:
+        return "workspace_escape"
+    if not isinstance(command, str) or not command.strip():
+        return "unbounded_shell_execution"
+    if any(marker in command for marker in ("$(", "`", "<<", "<(", ">(")) or _INLINE_EXEC_RE.search(command):
+        return "unbounded_shell_execution"
+    if _TERMINAL_EXTERNAL_RE.search(command):
+        return "external_transmission"
+    if _TERMINAL_DESTRUCTIVE_RE.search(command):
+        return "destructive"
+    if _TERMINAL_CREDENTIAL_RE.search(command):
+        return "credentials_or_account"
+    try:
+        from agent.redact import redact_sensitive_text
+
+        if redact_sensitive_text(command, force=True, redact_url_credentials=True) != command:
+            return "credentials_or_account"
+    except Exception:
+        return "credentials_or_account"
+    if _TERMINAL_GIT_CHANGE_RE.search(command):
+        return "git_state_change"
+    if _TERMINAL_PAYMENT_RE.search(command):
+        return "payment"
+    if _TERMINAL_GLOBAL_MANAGER_RE.search(command):
+        return "global_package_install"
+
+    try:
+        from tools.file_tools import _resolve_base_dir
+
+        task_base = _normalise_path(_resolve_base_dir(task_id or "default"))
+    except Exception:
+        task_base = ""
+    base_dir = _normalise_path(
+        workdir if workdir and os.path.isabs(str(workdir)) else os.path.join(task_base, str(workdir or ""))
+    )
+    if not _path_within(base_dir, workspace):
+        return "workspace_escape"
+
+    try:
+        tokens = shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        return "unbounded_shell_execution"
+    if not _venv_pip_install_is_scoped(tokens, workspace, base_dir):
+        return "global_package_install"
+
+    for token in tokens:
+        candidate = token.strip().lstrip("0123456789<>").rstrip(",;)")
+        if "=" in candidate and candidate.startswith("-"):
+            candidate = candidate.split("=", 1)[1]
+        if not candidate or candidate in {".", ".."} or "://" in candidate:
+            if candidate == "..":
+                return "workspace_escape"
+            continue
+        if "$" in candidate and ("/" in candidate or "\\" in candidate):
+            return "workspace_escape"
+        expanded = os.path.expandvars(os.path.expanduser(candidate))
+        if os.path.isabs(expanded) or expanded.startswith(("./", "../")) or "/" in expanded or "\\" in expanded:
+            resolved = _normalise_path(
+                expanded if os.path.isabs(expanded) else os.path.join(base_dir, expanded)
+            )
+            if not _path_within(resolved, workspace):
+                return "workspace_escape"
+    # A child that may write workspace files can create then execute a script;
+    # regex inspection cannot make that shell boundary safe without a sandbox.
+    return "terminal_requires_parent_execution"
+
+
+def delegated_tool_denial_reason(
+    scope: DelegatedApprovalScope,
+    function_name: str,
+    function_args: dict,
+    *,
+    task_id: str = "default",
+) -> str | None:
+    """Preflight one delegated child tool call without executing side effects."""
+    if scope is None or not getattr(scope, "enabled", False):
+        return None
+    workspace = _scope_workspace(scope)
+    if not workspace:
+        return "workspace_escape"
+    if not scope.allow_local_non_destructive:
+        return "local_non_destructive_disabled"
+
+    external_reason = _external_tool_denial_reason(function_name, function_args)
+    if external_reason:
+        return external_reason
+
+    if function_name == "clarify":
+        return "user_interaction"
+    if function_name == "execute_code":
+        # execute_code dispatches nested RPC tool calls without the owning agent
+        # object, so its inner calls cannot inherit this approval scope safely.
+        return "nested_tool_execution"
+    if function_name == "terminal":
+        return delegated_terminal_denial_reason(
+            scope,
+            str(function_args.get("command") or ""),
+            workdir=function_args.get("workdir"),
+            task_id=task_id,
+        )
+
+    lower_name = function_name.lower()
+    paths = _path_argument_values(function_args)
+    path_tool = function_name in _LOCAL_PATH_TOOLS or (
+        ("file" in lower_name or "document" in lower_name or "kordoc" in lower_name)
+        and bool(paths)
+    ) or bool(paths)
+    if path_tool:
+        if not scope.allow_local_non_destructive:
+            return "local_non_destructive_disabled"
+        if function_name == "search_files" and not paths:
+            paths = ["."]
+        if function_name == "patch" and str(function_args.get("mode") or "") == "patch":
+            patch_text = str(function_args.get("patch") or "")
+            if re.search(r"^\*\*\* Delete File:", patch_text, re.MULTILINE):
+                return "destructive"
+            paths.extend(re.findall(r"^\*\*\* (?:Add|Update) File:\s*(.+)$", patch_text, re.MULTILINE))
+        if not paths:
+            return "workspace_escape"
+        for raw_path in paths:
+            resolved = _resolve_local_path(raw_path, task_id)
+            if not _path_within(resolved, workspace):
+                return "workspace_escape"
+        return None
+
+    if function_name == "todo" or _known_scoped_read_tool(
+        function_name, function_args
+    ):
+        return None
+    return "unapproved_tool"
 
 _DELEGATED_CHILD_CONTEXT: ContextVar[bool] = ContextVar(
     "hermes_delegated_child_context",

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,6 +7,7 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import json
 import logging
 import os
 import re
@@ -877,6 +878,118 @@ def redact_sensitive_text(
         text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
     return text
+
+
+_KOREAN_RESIDENT_NUMBER_RE = re.compile(
+    r"(?<!\d)\d{6}[- ]?[1-4]\d{6}(?!\d)"
+)
+_PHONE_NUMBER_RE = re.compile(
+    r"(?<!\d)(?:01[016789][-. ]?\d{3,4}[-. ]?\d{4}|"
+    r"\+\d{1,3}[-. ]?(?:\d{2,4}[-. ]?){2}\d{3,4})(?!\d)"
+)
+_EMAIL_ADDRESS_RE = re.compile(
+    r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@"
+    r"[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])"
+)
+_CLIENT_CONTEXT_RE = re.compile(
+    r"\b(?:client|customer)\b|(?:고객|클라이언트)", re.IGNORECASE
+)
+_BUSINESS_DETAIL_RE = re.compile(
+    r"\b(?:contract|contact|deadline|cost|price|quote|budget)\b|"
+    r"(?:계약|연락처|마감|납기|비용|견적)",
+    re.IGNORECASE,
+)
+_SENSITIVE_METADATA_VALUES = frozenset(
+    {"sensitive", "confidential", "restricted", "secret", "private"}
+)
+
+
+def _message_has_sensitive_metadata(message: object) -> bool:
+    if not isinstance(message, dict):
+        return False
+    containers = [message]
+    for key in ("metadata", "annotations"):
+        nested = message.get(key)
+        if isinstance(nested, dict):
+            containers.append(nested)
+    for container in containers:
+        for key in ("sensitive", "contains_sensitive_data"):
+            if container.get(key) is True:
+                return True
+        for key in ("classification", "sensitivity", "data_classification"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip().casefold() in _SENSITIVE_METADATA_VALUES:
+                return True
+    return False
+
+
+def classify_sensitive_fallback_context(
+    messages: object,
+    *,
+    explicit_markers: object = None,
+    sensitive_path_prefixes: object = None,
+) -> tuple[str, str] | None:
+    """Classify fallback context locally, returning only safe reason codes."""
+    if isinstance(messages, list) and any(
+        _message_has_sensitive_metadata(message) for message in messages
+    ):
+        return ("explicit_marker", "message_metadata")
+
+    text = json.dumps(
+        messages if messages is not None else [],
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+    )
+    folded = text.casefold()
+
+    if isinstance(explicit_markers, (list, tuple, set)):
+        for marker in explicit_markers:
+            marker_text = str(marker or "").strip().casefold()
+            if marker_text and marker_text in folded:
+                return ("explicit_marker", "configured_marker")
+
+    if isinstance(sensitive_path_prefixes, (list, tuple, set)):
+        for prefix in sensitive_path_prefixes:
+            prefix_text = str(prefix or "").strip()
+            if prefix_text and prefix_text.casefold() in folded:
+                return ("sensitive_path", "configured_prefix")
+
+    if _KOREAN_RESIDENT_NUMBER_RE.search(text):
+        return ("pii", "korean_resident_number")
+    if _PHONE_NUMBER_RE.search(text):
+        return ("pii", "phone_number")
+    if _EMAIL_ADDRESS_RE.search(text):
+        return ("pii", "email_address")
+
+    # Static system policies routinely describe customer/contract/deadline
+    # categories without carrying any customer's actual data.  Treating those
+    # policy words as sensitive would disable cross-provider fallback for every
+    # turn.  Apply this contextual rule only to individual non-system messages
+    # so customer + business-detail terms must co-occur in an active message.
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") == "system":
+                continue
+            message_text = json.dumps(
+                message,
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+            )
+            if _CLIENT_CONTEXT_RE.search(message_text) and _BUSINESS_DETAIL_RE.search(
+                message_text
+            ):
+                return ("client_context", "contract_contact_deadline_cost")
+
+    redacted = redact_sensitive_text(
+        text,
+        force=True,
+        redact_url_credentials=True,
+    )
+    if redacted != text:
+        return ("secret_material", "redaction_match")
+    return None
 
 
 # Commands whose stdout is an environment-variable dump (KEY=value lines),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -351,6 +351,146 @@ def _managed_values(
     )
 
 
+def _latest_user_text(agent) -> str:
+    messages = getattr(agent, "_current_fallback_context_messages", None) or []
+    for message in reversed(messages):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts = [
+                str(part.get("text") or "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") in {"text", "input_text"}
+            ]
+            return "\n".join(parts).strip()
+    return ""
+
+
+def _consume_root_send_approval(
+    agent,
+    function_args: dict,
+    *,
+    consume: bool,
+) -> bool:
+    from agent.delegation_context import customer_send_targets
+
+    config = getattr(agent, "_customer_send_guard", None)
+    if not isinstance(config, dict) or not config.get("enabled", False):
+        return True
+    prefix = str(config.get("approval_prefix") or "SEND APPROVED:").strip()
+    latest_user = _latest_user_text(agent)
+    if not prefix or not latest_user.startswith(prefix):
+        return False
+    approved_target = latest_user[len(prefix):].strip()
+    targets = customer_send_targets(function_args)
+
+    def _target_set(values: tuple[str, ...]) -> set[str]:
+        return {
+            part.strip().casefold()
+            for value in values
+            for part in value.replace(";", ",").replace("\n", ",").split(",")
+            if part.strip()
+        }
+
+    approved_targets = _target_set((approved_target,))
+    requested_targets = _target_set(targets)
+    if not approved_targets or not requested_targets or requested_targets != approved_targets:
+        return False
+    approval_lock = getattr(agent, "_customer_send_approval_lock", None)
+    if approval_lock is None:
+        return False
+    with approval_lock:
+        turn_key = str(getattr(agent, "_current_turn_id", "") or latest_user)
+        if getattr(agent, "_customer_send_approval_consumed_turn", None) == turn_key:
+            return False
+        if consume:
+            agent._customer_send_approval_consumed_turn = turn_key
+        return True
+
+
+def _delegated_scope_preflight(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    consume_send_approval: bool = True,
+) -> tuple[str, str] | None:
+    """Fail closed before inherited-scope or root send policy reaches dispatch."""
+    scope = getattr(agent, "_delegated_approval_scope", None)
+    scope_enabled = bool(getattr(scope, "enabled", False))
+    send_guard = getattr(agent, "_customer_send_guard", None)
+    send_guard_enabled = bool(
+        isinstance(send_guard, dict) and send_guard.get("enabled", False)
+    )
+    try:
+        if scope_enabled:
+            from agent.delegation_context import delegated_tool_denial_reason
+
+            assert scope is not None
+            reason = delegated_tool_denial_reason(
+                scope,
+                function_name,
+                function_args,
+                task_id=effective_task_id or "default",
+            )
+        elif send_guard_enabled:
+            from agent.delegation_context import customer_send_denial_reason
+
+            reason = customer_send_denial_reason(function_name, function_args)
+            if reason and _consume_root_send_approval(
+                agent,
+                function_args,
+                consume=consume_send_approval,
+            ):
+                reason = None
+        else:
+            return None
+    except Exception:
+        if not scope_enabled and not send_guard_enabled:
+            return None
+        reason = "scope_preflight_error" if scope_enabled else "customer_send_guard_error"
+
+    if not reason:
+        return None
+    raw_reason = str(reason)
+    safe_reason = (
+        raw_reason
+        if 1 <= len(raw_reason) <= 64
+        and raw_reason == raw_reason.lower()
+        and raw_reason.replace("_", "").isalnum()
+        else "policy_denial"
+    )
+    escalations = getattr(agent, "_approval_scope_escalations", None)
+    if not isinstance(escalations, list):
+        escalations = []
+        agent._approval_scope_escalations = escalations
+    if safe_reason not in escalations:
+        escalations.append(safe_reason)
+    logger.warning(
+        "Approval policy blocked tool call: tool=%s reason=%s",
+        function_name,
+        safe_reason,
+    )
+    result = json.dumps(
+        {
+            "error": (
+                "Delegated tool call blocked"
+                if scope_enabled
+                else "Customer send blocked"
+            ),
+            "reason_code": safe_reason,
+            "status": "blocked",
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return result, safe_reason
+
+
 def _run_agent_tool_execution_middleware(
     agent,
     *,
@@ -381,7 +521,67 @@ def _run_agent_tool_execution_middleware(
     }
     dispatch_lock = threading.Lock()
 
+    def _advance_start_order(callback=None) -> None:
+        if begin_execution is None:
+            if callback is not None:
+                callback()
+            return
+        begin_execution(callback)
+
+    def _delegated_denial(block: tuple[str, str]) -> str:
+        result, reason = block
+        with dispatch_lock:
+            if state["dispatched"]:
+                raise RuntimeError(
+                    "Hermes tool execution callback invoked more than once"
+                )
+            state["dispatched"] = True
+            state["blocked"] = True
+            state["args"] = {}
+            state["middleware_trace"] = []
+        _advance_start_order()
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args={},
+            result=result,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            status="blocked",
+            error_type="delegated_scope_block",
+            error_message=reason,
+            middleware_trace=[],
+        )
+        return result
+
+    if scope_block is None:
+        initial_block = _delegated_scope_preflight(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            effective_task_id=effective_task_id,
+            consume_send_approval=False,
+        )
+        if initial_block is not None:
+            result = _delegated_denial(initial_block)
+            return _ManagedToolResult(
+                result=result,
+                args=state["args"],
+                middleware_trace=state["middleware_trace"],
+                blocked=True,
+            )
+
     def _authorized_dispatch(final_args: dict[str, Any]) -> Any:
+        if scope_block is None:
+            final_block = _delegated_scope_preflight(
+                agent,
+                function_name=function_name,
+                function_args=final_args,
+                effective_task_id=effective_task_id,
+            )
+            if final_block is not None:
+                return _delegated_denial(final_block)
+
         with dispatch_lock:
             if state["dispatched"]:
                 raise RuntimeError(
@@ -400,13 +600,6 @@ def _run_agent_tool_execution_middleware(
                 tool_call_id=tool_call_id,
                 display_index=display_index,
             )
-
-        def _advance_start_order(callback=None) -> None:
-            if begin_execution is None:
-                if callback is not None:
-                    callback()
-                return
-            begin_execution(callback)
 
         block_message = scope_block
         block_error_type = "tool_scope_block"

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -446,6 +446,9 @@ def build_turn_context(
     agent._relay_pending_turn_id = None
     agent._current_turn_id = turn_id
     agent._current_api_request_id = ""
+    # Rebuilt from the exact API-bound message list before each provider call.
+    # Clearing here prevents a new turn from inheriting a stale sensitive view.
+    agent._current_fallback_context_messages = None
     # Tripwire: warn (with both turn ids) when this turn starts before the
     # previous turn's turn-end persist — concurrent turns on one session
     # interleave transcript writes. Cleared in _persist_session.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1664,6 +1664,10 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Opt-in safe approval inheritance for delegate_task children. Boolean
+        # true is accepted as shorthand for the local, non-destructive scope;
+        # the mapping form can further narrow that scope.
+        "approval_inheritance": {"enabled": False},
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -2071,6 +2075,20 @@ DEFAULT_CONFIG = {
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": True,
+        # Local-only classifier that prevents sensitive turn context from
+        # crossing provider boundaries during fallback. Opt-in upstream.
+        "sensitive_fallback_guard": {
+            "enabled": False,
+            "mode": "block",
+            "explicit_markers": [],
+            "sensitive_path_prefixes": [],
+        },
+        # Customer-facing email/message sends require a one-turn, exact-target
+        # user command. Draft/save-draft operations remain available.
+        "customer_send_guard": {
+            "enabled": False,
+            "approval_prefix": "SEND APPROVED:",
+        },
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/tests/agent/test_delegated_scope_preflight.py
+++ b/tests/agent/test_delegated_scope_preflight.py
@@ -1,0 +1,845 @@
+"""End-to-end executor coverage for delegated approval scope preflight."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.delegation_context import DelegatedApprovalScope
+from hermes_cli.middleware import RequestMiddlewareResult
+from run_agent import AIAgent
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": name,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture()
+def scoped_agent(tmp_path: Path) -> AIAgent:
+    names = (
+        "terminal",
+        "read_file",
+        "write_file",
+        "web_search",
+        "mcp__google_workspace__manage_email",
+    )
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._delegated_approval_scope = DelegatedApprovalScope(
+        enabled=True,
+        approved_mission_summary="Run repository checks",
+        allowed_workspace_path=str(tmp_path.resolve()),
+    )
+    agent._approval_scope_escalations = []
+    return agent
+
+
+def _call(name: str, arguments: dict, call_id: str = "call-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+    )
+
+
+def _message(*calls: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(content="", tool_calls=list(calls))
+
+
+def _post_hook_capture(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    calls: list[dict] = []
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda hook_name, **kwargs: calls.append(kwargs) if hook_name == "post_tool_call" else [],
+    )
+    return calls
+
+
+@pytest.mark.parametrize("tool_name", ["read_file", "write_file"])
+def test_sequential_file_escape_is_blocked_before_dispatch(
+    scoped_agent: AIAgent, tmp_path: Path, tool_name: str
+) -> None:
+    outside = tmp_path.parent / "outside-secret.txt"
+    args = {"path": str(outside)}
+    if tool_name == "write_file":
+        args["content"] = "must-not-be-written"
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call(tool_name, args)), messages, "task-1"
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"]) == {
+        "error": "Delegated tool call blocked",
+        "reason_code": "workspace_escape",
+        "status": "blocked",
+    }
+    assert scoped_agent._approval_scope_escalations == ["workspace_escape"]
+
+
+def test_concurrent_preflight_blocks_each_call_once_without_dispatch_or_duplicate_post(
+    scoped_agent: AIAgent, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    post_hooks = _post_hook_capture(monkeypatch)
+    secret_a = str(tmp_path.parent / "raw-secret-a.txt")
+    secret_b = str(tmp_path.parent / "raw-secret-b.txt")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_concurrent(
+            _message(
+                _call("read_file", {"path": secret_a}, "call-a"),
+                _call("write_file", {"path": secret_b, "content": "raw-body"}, "call-b"),
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert len(messages) == 2
+    assert len(post_hooks) == 2
+    assert all(hook["status"] == "blocked" for hook in post_hooks)
+    assert all(hook["error_type"] == "delegated_scope_block" for hook in post_hooks)
+    assert all(hook["args"] == {} for hook in post_hooks)
+    assert secret_a not in repr(messages + post_hooks)
+    assert secret_b not in repr(messages + post_hooks)
+
+
+def test_request_middleware_rewrite_is_checked_by_central_preflight(
+    scoped_agent: AIAgent, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outside = str(tmp_path.parent / "middleware-escape.txt")
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_tool_request_middleware",
+        lambda _name, args, **_kwargs: RequestMiddlewareResult(
+            payload={"path": outside, "content": "secret"},
+            original_payload=args,
+            changed=True,
+            trace=[{"source": "test"}],
+        ),
+    )
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("write_file", {"path": "inside.txt", "content": "ok"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"])["reason_code"] == "workspace_escape"
+
+
+def test_inline_interpreter_escape_is_blocked_before_terminal_dispatch(
+    scoped_agent: AIAgent, tmp_path: Path
+) -> None:
+    outside = tmp_path.parent / "outside" / "pwned"
+    command = f'python -c "open(\"{outside}\",\"w\").write(\"x\")"'
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("terminal", {"command": command})), messages, "task-1"
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"])["reason_code"] == "unbounded_shell_execution"
+
+
+def test_local_pytest_requires_parent_execution(scoped_agent: AIAgent) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call", return_value="tests passed") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "terminal",
+                    {"command": "pytest tests/agent/test_example.py", "workdir": scoped_agent._delegated_approval_scope.allowed_workspace_path},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"])["reason_code"] == "terminal_requires_parent_execution"
+
+
+@pytest.mark.parametrize(
+    ("command", "reason"),
+    [
+        ("pytest $(printf tests)", "unbounded_shell_execution"),
+        ("node -e 'require(\"fs\").writeFileSync(\"/tmp/pwned\", \"x\")'", "unbounded_shell_execution"),
+        ("git reset --hard HEAD~1", "git_state_change"),
+        ("pip install requests", "global_package_install"),
+        ("pip install --user requests", "global_package_install"),
+        ("pipx install ruff", "global_package_install"),
+    ],
+)
+def test_terminal_hard_exceptions_are_blocked_at_executor(
+    scoped_agent: AIAgent, command: str, reason: str
+) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "terminal",
+                    {
+                        "command": command,
+                        "workdir": scoped_agent._delegated_approval_scope.allowed_workspace_path,
+                    },
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert f'"reason_code": "{reason}"' in messages[0]["content"]
+
+
+def test_workspace_virtualenv_pip_requires_parent_execution(scoped_agent: AIAgent) -> None:
+    workspace = Path(scoped_agent._delegated_approval_scope.allowed_workspace_path)
+    venv_pip = workspace / ".venv" / "bin" / "pip"
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call", return_value="installed") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "terminal",
+                    {"command": f"{venv_pip} install requests", "workdir": str(workspace)},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"])["reason_code"] == "terminal_requires_parent_execution"
+
+
+def test_workspace_targeted_pip_requires_parent_execution(scoped_agent: AIAgent) -> None:
+    workspace = Path(scoped_agent._delegated_approval_scope.allowed_workspace_path)
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call", return_value="installed locally") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "terminal",
+                    {"command": "pip install --target vendor requests", "workdir": str(workspace)},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert json.loads(messages[0]["content"])["reason_code"] == "terminal_requires_parent_execution"
+
+
+def test_terminal_workdir_outside_scope_is_blocked(scoped_agent: AIAgent, tmp_path: Path) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "terminal",
+                    {"command": "pytest tests", "workdir": str(tmp_path.parent)},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "workspace_escape"' in messages[0]["content"]
+
+
+@pytest.mark.parametrize(
+    ("args", "blocked"),
+    [
+        ({"action": "send", "to": "customer@example.com", "body": "raw-message"}, True),
+        ({"action": "send", "draft": True, "to": "customer@example.com", "body": "raw-message"}, False),
+        ({"action": "search", "query": "status"}, False),
+    ],
+)
+def test_google_email_send_is_blocked_but_draft_and_read_are_allowed(
+    scoped_agent: AIAgent, args: dict, blocked: bool
+) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call", return_value="ok") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("mcp__google_workspace__manage_email", args)),
+            messages,
+            "task-1",
+        )
+
+    if blocked:
+        dispatch.assert_not_called()
+        assert '"reason_code": "external_transmission"' in messages[0]["content"]
+    else:
+        dispatch.assert_called_once()
+        assert messages[0]["content"] == "ok"
+
+
+def test_tool_search_unwrap_cannot_bypass_external_send_guard(
+    scoped_agent: AIAgent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "agent.tool_executor._tool_search_scoped_names",
+        lambda agent: frozenset({"mcp__google_workspace__manage_email"}),
+    )
+    monkeypatch.setattr("tools.tool_search.is_deferrable_tool_name", lambda name: True)
+    messages: list[dict] = []
+    bridged = {
+        "name": "mcp__google_workspace__manage_email",
+        "arguments": {"action": "send", "to": "customer@example.com"},
+    }
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("tool_call", bridged)), messages, "task-1"
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "external_transmission"' in messages[0]["content"]
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args", "reason"),
+    [
+        ("mcp__google_workspace__manage_calendar", {"operation": "events.quickAdd"}, "external_calendar_mutation"),
+        ("mcp__google_workspace__manage_drive", {"operation": "files.copy"}, "external_drive_mutation"),
+        ("mcp__google_workspace__manage_docs", {"operation": "documents.batchUpdate"}, "external_docs_mutation"),
+        ("mcp__google_workspace__manage_sheets", {"operation": "spreadsheets.values.append"}, "external_sheets_mutation"),
+        ("mcp__aside__browser", {"code": "await page.click('button')"}, "external_browser_mutation"),
+        ("mcp__pencil__batch_design", {"operations": []}, "external_document_mutation"),
+        ("mcp__kordoc__fill_template", {"path": "inside.docx"}, "external_document_mutation"),
+        ("skill_manage", {"action": "patch", "name": "unsafe"}, "skill_mutation"),
+    ],
+)
+def test_mutating_external_operations_are_blocked_at_executor(
+    scoped_agent: AIAgent, tool_name: str, args: dict, reason: str
+) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call(tool_name, args)), messages, "task-1"
+        )
+
+    dispatch.assert_not_called()
+    assert f'"reason_code": "{reason}"' in messages[0]["content"]
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        ("mcp__google_workspace__manage_calendar", {"operation": "events.list"}),
+        ("mcp__google_workspace__manage_drive", {"operation": "files.get"}),
+        ("mcp__google_workspace__manage_docs", {"operation": "documents.get"}),
+        ("mcp__google_workspace__manage_sheets", {"operation": "spreadsheets.values.get"}),
+        ("mcp__aside__browser", {"action": "snapshot"}),
+        ("mcp__pencil__get_editor_state", {}),
+    ],
+)
+def test_read_only_external_operations_remain_available(
+    scoped_agent: AIAgent, tool_name: str, args: dict
+) -> None:
+    messages: list[dict] = []
+    with patch("run_agent.handle_function_call", return_value="read ok") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call(tool_name, args)), messages, "task-1"
+        )
+
+    dispatch.assert_called_once()
+    assert messages[0]["content"] == "read ok"
+
+
+def test_mcp_document_path_outside_workspace_is_blocked(
+    scoped_agent: AIAgent, tmp_path: Path
+) -> None:
+    outside = str(tmp_path.parent / "customer-document.hwpx")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call("mcp__kordoc__parse_document", {"file_path": outside})
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "workspace_escape"' in messages[0]["content"]
+
+
+def test_narrowed_deny_all_scope_blocks_otherwise_read_only_tool(
+    scoped_agent: AIAgent,
+) -> None:
+    scope = getattr(scoped_agent, "_delegated_approval_scope")
+    setattr(
+        scoped_agent,
+        "_delegated_approval_scope",
+        DelegatedApprovalScope(
+            enabled=True,
+            approved_mission_summary=scope.approved_mission_summary,
+            allowed_workspace_path=scope.allowed_workspace_path,
+            allow_local_non_destructive=False,
+        ),
+    )
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("web_search", {"query": "public facts"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "local_non_destructive_disabled"' in messages[0]["content"]
+
+
+def test_scope_block_never_exposes_raw_args_in_error_hook_or_logs(
+    scoped_agent: AIAgent,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_marker = "UNIQUE-RAW-DELEGATED-ARG"
+    outside = str(tmp_path.parent / raw_marker)
+    post_hooks = _post_hook_capture(monkeypatch)
+    messages: list[dict] = []
+    caplog.set_level("DEBUG")
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("write_file", {"path": outside, "content": raw_marker})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert len(post_hooks) == 1
+    assert post_hooks[0]["args"] == {}
+    assert raw_marker not in repr(messages + post_hooks)
+    assert raw_marker not in caplog.text
+
+
+def test_disabled_inheritance_preserves_legacy_executor_behavior(
+    scoped_agent: AIAgent, tmp_path: Path
+) -> None:
+    scoped_agent._delegated_approval_scope = DelegatedApprovalScope(
+        enabled=False,
+        approved_mission_summary="",
+        allowed_workspace_path="",
+    )
+    outside = str(tmp_path.parent / "legacy-outside.txt")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call", return_value="legacy allowed") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("write_file", {"path": outside, "content": "legacy"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_called_once()
+    assert messages[0]["content"] == "legacy allowed"
+
+
+def _enable_root_send_guard(agent: AIAgent, latest_user_text: str) -> None:
+    agent._delegated_approval_scope = DelegatedApprovalScope(
+        enabled=False,
+        approved_mission_summary="",
+        allowed_workspace_path="",
+    )
+    agent._customer_send_guard = {
+        "enabled": True,
+        "approval_prefix": "발송 승인:",
+    }
+    agent._current_fallback_context_messages = [
+        {"role": "user", "content": latest_user_text}
+    ]
+    agent._customer_send_approval_consumed_turn = None
+    agent._current_turn_id = "turn-1"
+
+
+def test_root_email_send_requires_explicit_recipient_approval(
+    scoped_agent: AIAgent,
+) -> None:
+    _enable_root_send_guard(scoped_agent, "고객에게 이메일 보내줘")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {"operation": "send", "to": "customer@example.com"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+def test_root_email_draft_remains_allowed(scoped_agent: AIAgent) -> None:
+    _enable_root_send_guard(scoped_agent, "초안 저장해줘")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call", return_value="draft saved") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {
+                        "operation": "send",
+                        "draft": True,
+                        "to": "customer@example.com",
+                    },
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_called_once()
+    assert messages[0]["content"] == "draft saved"
+
+
+def test_root_send_exact_recipient_approval_is_single_use(scoped_agent: AIAgent) -> None:
+    _enable_root_send_guard(scoped_agent, "발송 승인: customer@example.com")
+    first_messages: list[dict] = []
+    second_messages: list[dict] = []
+    call = _call(
+        "mcp__google_workspace__manage_email",
+        {"operation": "send", "to": "customer@example.com"},
+    )
+
+    with patch("run_agent.handle_function_call", return_value="sent") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(_message(call), first_messages, "task-1")
+        scoped_agent._execute_tool_calls_sequential(_message(call), second_messages, "task-1")
+
+    dispatch.assert_called_once()
+    assert first_messages[0]["content"] == "sent"
+    assert '"reason_code": "customer_send_approval_required"' in second_messages[0]["content"]
+
+
+def test_root_send_approval_is_atomic_for_concurrent_calls(
+    scoped_agent: AIAgent,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    from agent.tool_executor import _consume_root_send_approval
+
+    class _DelayedConsumedTurn:
+        value = None
+
+        def __get__(self, instance, owner=None):
+            value = self.value
+            time.sleep(0.02)
+            return value
+
+        def __set__(self, instance, value):
+            self.value = value
+
+    _enable_root_send_guard(scoped_agent, "발송 승인: customer@example.com")
+    monkeypatch.setattr(
+        type(scoped_agent),
+        "_customer_send_approval_consumed_turn",
+        _DelayedConsumedTurn(),
+        raising=False,
+    )
+    barrier = threading.Barrier(2)
+
+    def _attempt() -> bool:
+        barrier.wait()
+        return _consume_root_send_approval(
+            scoped_agent,
+            {"operation": "send", "to": "customer@example.com"},
+            consume=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: _attempt(), range(2)))
+
+    assert sorted(results) == [False, True]
+
+
+def test_child_cannot_consume_root_send_approval(scoped_agent: AIAgent) -> None:
+    scoped_agent._customer_send_guard = {
+        "enabled": True,
+        "approval_prefix": "발송 승인:",
+    }
+    scoped_agent._current_fallback_context_messages = [
+        {"role": "user", "content": "발송 승인: customer@example.com"}
+    ]
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {"operation": "send", "to": "customer@example.com"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "external_transmission"' in messages[0]["content"]
+
+
+def test_root_send_approval_does_not_cover_a_different_recipient(
+    scoped_agent: AIAgent,
+) -> None:
+    _enable_root_send_guard(scoped_agent, "발송 승인: approved@example.com")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {"operation": "send", "to": "other@example.com"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+def test_root_send_approval_target_matching_is_not_substring_based(
+    scoped_agent: AIAgent,
+) -> None:
+    _enable_root_send_guard(scoped_agent, "발송 승인: customer@example.com.evil")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {"operation": "send", "to": "customer@example.com"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+def test_root_send_requires_exact_approved_recipient_set(
+    scoped_agent: AIAgent,
+) -> None:
+    _enable_root_send_guard(
+        scoped_agent,
+        "발송 승인: customer@example.com, other@example.com",
+    )
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {"operation": "send", "to": "customer@example.com"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+def test_root_generic_message_send_requires_explicit_target_approval(
+    scoped_agent: AIAgent,
+) -> None:
+    _enable_root_send_guard(scoped_agent, "메시지를 보내줘")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "send_message",
+                    {"operation": "send", "channel_id": "C_CUSTOMER"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+@pytest.mark.parametrize("tool_name", ["yb_send_dm", "yb_send_sticker", "feishu_drive_reply_comment"])
+def test_root_named_send_tools_require_explicit_approval(
+    scoped_agent: AIAgent, tool_name: str
+) -> None:
+    _enable_root_send_guard(scoped_agent, "고객에게 보내줘")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call(tool_name, {"userId": "customer-1", "content": "hello"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "customer_send_approval_required"' in messages[0]["content"]
+
+
+def test_root_send_approval_accepts_camel_case_target_key(scoped_agent: AIAgent) -> None:
+    _enable_root_send_guard(scoped_agent, "발송 승인: customer-1")
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call", return_value="sent") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("yb_send_dm", {"userId": "customer-1", "content": "hello"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_called_once()
+    assert messages[0]["content"] == "sent"
+
+
+def test_child_fetch_url_is_denied_by_default(scoped_agent: AIAgent) -> None:
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__fetch__fetch",
+                    {"url": "https://example.com/?customer=private"},
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "unapproved_tool"' in messages[0]["content"]
+
+
+def test_mcp_camel_case_output_path_cannot_escape_workspace(
+    scoped_agent: AIAgent, tmp_path: Path
+) -> None:
+    messages: list[dict] = []
+    outside = str(tmp_path.parent / "outside-download.bin")
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_drive",
+                    {
+                        "operation": "download",
+                        "fileId": "safe-id",
+                        "outputPath": outside,
+                    },
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "workspace_escape"' in messages[0]["content"]
+
+
+def test_child_execute_code_is_denied_before_rpc(scoped_agent: AIAgent) -> None:
+    messages: list[dict] = []
+
+    with patch("run_agent.handle_function_call") as dispatch:
+        scoped_agent._execute_tool_calls_sequential(
+            _message(_call("execute_code", {"code": "print('safe')"})),
+            messages,
+            "task-1",
+        )
+
+    dispatch.assert_not_called()
+    assert '"reason_code": "nested_tool_execution"' in messages[0]["content"]
+
+
+def test_blocked_raw_args_do_not_reach_request_middleware(
+    scoped_agent: AIAgent,
+) -> None:
+    messages: list[dict] = []
+
+    with (
+        patch(
+            "hermes_cli.middleware.apply_tool_request_middleware"
+        ) as middleware,
+        patch("run_agent.handle_function_call") as dispatch,
+    ):
+        scoped_agent._execute_tool_calls_sequential(
+            _message(
+                _call(
+                    "mcp__google_workspace__manage_email",
+                    {
+                        "operation": "send",
+                        "to": "customer@example.com",
+                        "body": "private",
+                    },
+                )
+            ),
+            messages,
+            "task-1",
+        )
+
+    middleware.assert_not_called()
+    dispatch.assert_not_called()
+    assert '"reason_code": "external_transmission"' in messages[0]["content"]

--- a/tests/agent/test_sensitive_fallback_guard.py
+++ b/tests/agent/test_sensitive_fallback_guard.py
@@ -1,0 +1,379 @@
+"""Deterministic local guard for cross-provider fallback context."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def test_sensitive_fallback_guard_is_disabled_by_default():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    guard = DEFAULT_CONFIG["security"]["sensitive_fallback_guard"]
+    assert guard["enabled"] is False
+    assert guard["mode"] == "block"
+
+
+@pytest.mark.parametrize(
+    ("messages", "markers", "prefixes", "expected"),
+    [
+        (
+            [{"role": "user", "content": "ordinary", "metadata": {"sensitive": True}}],
+            [],
+            [],
+            ("explicit_marker", "message_metadata"),
+        ),
+        (
+            [{"role": "system", "content": "INTERNAL_ONLY instructions"}],
+            ["INTERNAL_ONLY"],
+            [],
+            ("explicit_marker", "configured_marker"),
+        ),
+        (
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"/vault/private/client.txt"}',
+                            }
+                        }
+                    ],
+                }
+            ],
+            [],
+            ["/vault/private"],
+            ("sensitive_path", "configured_prefix"),
+        ),
+        (
+            [{"role": "tool", "content": "Authorization: Bearer sk-test-1234567890abcdef"}],
+            [],
+            [],
+            ("secret_material", "redaction_match"),
+        ),
+        (
+            [
+                {
+                    "role": "tool",
+                    "content": "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----",
+                }
+            ],
+            [],
+            [],
+            ("secret_material", "redaction_match"),
+        ),
+        (
+            [{"role": "user", "content": "주민번호 900101-1234567"}],
+            [],
+            [],
+            ("pii", "korean_resident_number"),
+        ),
+        (
+            [{"role": "user", "content": "연락처는 010-1234-5678입니다"}],
+            [],
+            [],
+            ("pii", "phone_number"),
+        ),
+        (
+            [{"role": "user", "content": "Contact client@example.com"}],
+            [],
+            [],
+            ("pii", "email_address"),
+        ),
+        (
+            [{"role": "user", "content": "고객 계약 비용과 납기를 검토해 주세요"}],
+            [],
+            [],
+            ("client_context", "contract_contact_deadline_cost"),
+        ),
+    ],
+)
+def test_local_classifier_returns_only_category_and_reason_codes(
+    messages, markers, prefixes, expected
+):
+    from agent.redact import classify_sensitive_fallback_context
+
+    assert classify_sensitive_fallback_context(
+        messages,
+        explicit_markers=markers,
+        sensitive_path_prefixes=prefixes,
+    ) == expected
+
+
+def test_local_classifier_allows_non_sensitive_probe_prompt():
+    from agent.redact import classify_sensitive_fallback_context
+
+    assert classify_sensitive_fallback_context(
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Reply with exactly FALLBACK_PROBE_OK."},
+        ]
+    ) is None
+
+
+def test_static_system_customer_policy_does_not_block_every_turn():
+    from agent.redact import classify_sensitive_fallback_context
+
+    assert classify_sensitive_fallback_context(
+        [
+            {
+                "role": "system",
+                "content": (
+                    "고객 계약, 연락처, 납기, 비용을 다룰 때는 확인한다. "
+                    "Do not disclose client contract or deadline data."
+                ),
+            },
+            {"role": "user", "content": "일반 로컬 테스트를 실행해 주세요."},
+        ]
+    ) is None
+
+
+@pytest.fixture()
+def fallback_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="primary-model",
+            provider="openrouter",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock(name="primary_client")
+    agent._fallback_chain = [
+        {"provider": "deepseek", "model": "deepseek-chat"}
+    ]
+    agent._fallback_index = 0
+    agent._fallback_activated = False
+    agent._unavailable_fallback_keys = set()
+    agent._sensitive_fallback_guard = {
+        "enabled": True,
+        "mode": "block",
+        "explicit_markers": [],
+        "sensitive_path_prefixes": [],
+    }
+    agent._current_fallback_context_messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Run a safe local fallback probe."},
+    ]
+    agent._buffer_status = MagicMock()
+    return agent
+
+
+def _fallback_client(provider="deepseek"):
+    client = MagicMock(name=f"{provider}_client")
+    client.base_url = (
+        "https://openrouter.ai/api/v1"
+        if provider == "openrouter"
+        else "https://api.deepseek.com/v1"
+    )
+    client.api_key = "fallback-key-1234567890"
+    client._custom_headers = None
+    client.default_headers = None
+    return client
+
+
+def _activate_with_resolver(agent, resolver):
+    with (
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=resolver,
+        ) as mock_resolver,
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=128000),
+    ):
+        result = agent._try_activate_fallback()
+    return result, mock_resolver
+
+
+def test_sensitive_cross_provider_fallback_blocks_before_resolver(fallback_agent):
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Contact client@example.com"
+    )
+    primary_client = fallback_agent.client
+
+    result, resolver = _activate_with_resolver(
+        fallback_agent,
+        lambda *args, **kwargs: (_fallback_client(), None),
+    )
+
+    assert result is False
+    resolver.assert_not_called()
+    assert fallback_agent.provider == "openrouter"
+    assert fallback_agent.model == "primary-model"
+    assert fallback_agent.client is primary_client
+    assert ("deepseek", "deepseek-chat", "") not in (
+        fallback_agent._unavailable_fallback_keys
+    )
+    fallback_agent._buffer_status.assert_called_with(
+        "🔒 Fallback blocked because sensitive context was detected."
+    )
+
+
+def test_sensitive_block_does_not_disable_fallback_for_later_safe_turn(fallback_agent):
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Contact client@example.com"
+    )
+    blocked, first_resolver = _activate_with_resolver(
+        fallback_agent,
+        lambda *args, **kwargs: (_fallback_client(), None),
+    )
+    assert blocked is False
+    first_resolver.assert_not_called()
+
+    fallback_agent._fallback_index = 0
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Run a safe local fallback probe."
+    )
+    activated, second_resolver = _activate_with_resolver(
+        fallback_agent,
+        lambda *args, **kwargs: (_fallback_client(), None),
+    )
+
+    assert activated is True
+    second_resolver.assert_called_once()
+    assert fallback_agent.provider == "deepseek"
+
+
+def test_non_sensitive_cross_provider_fallback_still_calls_resolver(fallback_agent):
+    from agent.redact import classify_sensitive_fallback_context
+
+    with patch(
+        "agent.redact.classify_sensitive_fallback_context",
+        wraps=classify_sensitive_fallback_context,
+    ) as classifier:
+        result, resolver = _activate_with_resolver(
+            fallback_agent,
+            lambda *args, **kwargs: (_fallback_client(), None),
+        )
+
+    assert result is True
+    classifier.assert_called_once()
+    resolver.assert_called_once()
+    assert fallback_agent.provider == "deepseek"
+
+
+def test_same_provider_fallback_bypasses_cross_provider_guard(fallback_agent):
+    fallback_agent._fallback_chain = [
+        {
+            "provider": "openrouter",
+            "model": "different-model",
+            "base_url": "https://openrouter.ai/api/v1/",
+        }
+    ]
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Contact client@example.com"
+    )
+
+    with patch(
+        "agent.redact.classify_sensitive_fallback_context"
+    ) as classifier:
+        result, resolver = _activate_with_resolver(
+            fallback_agent,
+            lambda *args, **kwargs: (_fallback_client("openrouter"), None),
+        )
+
+    assert result is True
+    classifier.assert_not_called()
+    resolver.assert_called_once()
+    assert fallback_agent.provider == "openrouter"
+    assert fallback_agent.model == "different-model"
+
+
+def test_same_provider_different_endpoint_is_blocked_for_sensitive_context(
+    fallback_agent,
+):
+    fallback_agent._fallback_chain = [
+        {
+            "provider": "openrouter",
+            "model": "different-model",
+            "base_url": "https://private-proxy.example/v1",
+        }
+    ]
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Contact client@example.com"
+    )
+
+    result, resolver = _activate_with_resolver(
+        fallback_agent,
+        lambda *args, **kwargs: (_fallback_client("openrouter"), None),
+    )
+
+    assert result is False
+    resolver.assert_not_called()
+    assert fallback_agent.provider == "openrouter"
+    assert fallback_agent.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_later_tool_output_can_make_current_turn_sensitive(fallback_agent):
+    fallback_agent._current_fallback_context_messages.extend(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "Customer email: client@example.com",
+            },
+        ]
+    )
+
+    result, resolver = _activate_with_resolver(
+        fallback_agent,
+        lambda *args, **kwargs: (_fallback_client(), None),
+    )
+
+    assert result is False
+    resolver.assert_not_called()
+
+
+def test_classifier_error_fails_closed_before_resolver(fallback_agent):
+    with patch(
+        "agent.redact.classify_sensitive_fallback_context",
+        side_effect=RuntimeError("classifier broke"),
+    ):
+        result, resolver = _activate_with_resolver(
+            fallback_agent,
+            lambda *args, **kwargs: (_fallback_client(), None),
+        )
+
+    assert result is False
+    resolver.assert_not_called()
+    assert fallback_agent.provider == "openrouter"
+
+
+def test_disabled_guard_preserves_cross_provider_fallback(fallback_agent):
+    fallback_agent._sensitive_fallback_guard["enabled"] = False
+    fallback_agent._current_fallback_context_messages[1]["content"] = (
+        "Contact client@example.com"
+    )
+
+    with patch(
+        "agent.redact.classify_sensitive_fallback_context"
+    ) as classifier:
+        result, resolver = _activate_with_resolver(
+            fallback_agent,
+            lambda *args, **kwargs: (_fallback_client(), None),
+        )
+
+    assert result is True
+    classifier.assert_not_called()
+    resolver.assert_called_once()
+    assert fallback_agent.provider == "deepseek"

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -73,6 +73,33 @@ class TestApiModeAccepted:
 
 
 class TestRunConversationCodexPath:
+    def test_scoped_child_cannot_enter_codex_app_server(self, monkeypatch):
+        from agent.delegation_context import DelegatedApprovalScope
+
+        entered = False
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            nonlocal entered
+            entered = True
+            raise AssertionError("scoped child entered codex app-server")
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        agent = _make_codex_agent()
+        setattr(
+            agent,
+            "_delegated_approval_scope",
+            DelegatedApprovalScope(
+                enabled=True,
+                approved_mission_summary="Inspect safely",
+                allowed_workspace_path="/tmp/workspace",
+            ),
+        )
+
+        with pytest.raises(PermissionError, match="delegated approval scope"):
+            agent.run_conversation("call browser_type")
+
+        assert entered is False
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1581,6 +1581,311 @@ class TestSubagentApprovalCallback(unittest.TestCase):
         self.assertIsNone(_get_approval_callback())
 
 
+class TestDelegatedApprovalScope(unittest.TestCase):
+    def test_approval_inheritance_is_disabled_by_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        self.assertEqual(
+            DEFAULT_CONFIG["delegation"]["approval_inheritance"],
+            {"enabled": False},
+        )
+        self.assertEqual(
+            DEFAULT_CONFIG["security"]["customer_send_guard"],
+            {"enabled": False, "approval_prefix": "SEND APPROVED:"},
+        )
+
+    def test_scope_is_immutable_and_json_serializable(self):
+        from dataclasses import FrozenInstanceError
+        from agent.delegation_context import DelegatedApprovalScope
+
+        scope = DelegatedApprovalScope(
+            enabled=True,
+            approved_mission_summary="Run focused tests",
+            allowed_workspace_path="/tmp/workspace",
+        )
+
+        self.assertEqual(
+            json.loads(json.dumps(scope.to_dict())),
+            {
+                "enabled": True,
+                "approved_mission_summary": "Run focused tests",
+                "allowed_workspace_path": "/tmp/workspace",
+                "allow_local_non_destructive": True,
+                "allow_external_transmission": False,
+                "allow_destructive": False,
+                "allow_credentials": False,
+            },
+        )
+        with self.assertRaises(FrozenInstanceError):
+            scope.enabled = False
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"approval_inheritance": True},
+    )
+    def test_true_shorthand_builds_safe_scope_and_child_prompt(self, _mock_cfg):
+        from tools.delegate_tool import _derive_delegated_approval_scope
+
+        parent = _make_mock_parent()
+        parent._delegated_approval_scope = None
+
+        scope = _derive_delegated_approval_scope(
+            parent,
+            goal="Run the focused tests",
+            resolved_workspace="/tmp/workspace",
+        )
+
+        self.assertTrue(scope.enabled)
+        self.assertEqual(
+            scope.allowed_workspace_path, os.path.realpath("/tmp/workspace")
+        )
+        self.assertTrue(scope.allow_local_non_destructive)
+        self.assertFalse(scope.allow_external_transmission)
+        self.assertFalse(scope.allow_destructive)
+        self.assertFalse(scope.allow_credentials)
+
+        prompt = _build_child_system_prompt(
+            "Run the focused tests",
+            workspace_path="/tmp/workspace",
+            approval_scope=scope,
+        )
+        self.assertIn("APPROVAL SCOPE", prompt)
+        self.assertIn("/tmp/workspace", prompt)
+        self.assertIn("never call clarify", prompt)
+
+    def test_nested_scope_can_narrow_but_never_widen(self):
+        from agent.delegation_context import DelegatedApprovalScope
+        from tools.delegate_tool import _derive_delegated_approval_scope
+
+        parent = _make_mock_parent(depth=1)
+        parent._delegated_approval_scope = DelegatedApprovalScope(
+            enabled=True,
+            approved_mission_summary="Inspect the repository",
+            allowed_workspace_path="/tmp/workspace",
+            allow_local_non_destructive=False,
+        )
+
+        narrowed = _derive_delegated_approval_scope(
+            parent,
+            goal="Inspect one module",
+            resolved_workspace="/tmp/workspace/module",
+        )
+        escaped = _derive_delegated_approval_scope(
+            parent,
+            goal="Inspect elsewhere",
+            resolved_workspace="/tmp/outside",
+        )
+
+        self.assertEqual(
+            narrowed.allowed_workspace_path,
+            os.path.realpath("/tmp/workspace/module"),
+        )
+        self.assertFalse(narrowed.allow_local_non_destructive)
+        self.assertTrue(escaped.enabled)
+        self.assertEqual(escaped.allowed_workspace_path, "")
+        self.assertFalse(escaped.allow_local_non_destructive)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "approval_inheritance": {"enabled": True},
+            "subagent_auto_approve": True,
+        },
+    )
+    def test_enabled_inheritance_without_workspace_stays_fail_closed(self, _mock_cfg):
+        from tools.delegate_tool import (
+            _derive_delegated_approval_scope,
+            _get_subagent_approval_callback,
+            _subagent_auto_approve,
+        )
+
+        parent = _make_mock_parent()
+        parent._delegated_approval_scope = None
+        child = types.SimpleNamespace(
+            _subagent_id="sa-no-workspace",
+            _approval_scope_escalations=[],
+        )
+        child._delegated_approval_scope = _derive_delegated_approval_scope(
+            parent,
+            goal="Inspect safely",
+            resolved_workspace=None,
+        )
+
+        callback = _get_subagent_approval_callback(child)
+
+        self.assertTrue(child._delegated_approval_scope.enabled)
+        self.assertEqual(child._delegated_approval_scope.allowed_workspace_path, "")
+        self.assertIsNot(callback, _subagent_auto_approve)
+        self.assertEqual(callback("pytest tests", "run tests"), "deny")
+        self.assertEqual(child._approval_scope_escalations, ["workspace_escape"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"approval_inheritance": True},
+    )
+    @patch(
+        "tools.delegate_tool._resolve_workspace_hint",
+        return_value="/tmp/workspace",
+    )
+    def test_child_construction_stores_scope_without_mutating_parent_prompt(
+        self, _mock_workspace, _mock_cfg
+    ):
+        parent = _make_mock_parent()
+        parent._cached_system_prompt = "PARENT PROMPT"
+        parent._delegated_approval_scope = None
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            MockAgent.return_value = child
+            _build_child_agent(
+                task_index=0,
+                goal="Run focused tests",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertTrue(child._delegated_approval_scope.enabled)
+        self.assertIn(
+            "APPROVAL SCOPE",
+            MockAgent.call_args.kwargs["ephemeral_system_prompt"],
+        )
+        self.assertEqual(parent._cached_system_prompt, "PARENT PROMPT")
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "approval_inheritance": {"enabled": False},
+            "subagent_auto_approve": True,
+        },
+    )
+    def test_disabled_scope_preserves_legacy_auto_approve(self, _mock_cfg):
+        from agent.delegation_context import DelegatedApprovalScope
+        from tools.delegate_tool import (
+            _get_subagent_approval_callback,
+            _subagent_auto_approve,
+        )
+
+        child = types.SimpleNamespace(
+            _delegated_approval_scope=DelegatedApprovalScope(
+                enabled=False,
+                approved_mission_summary="",
+                allowed_workspace_path="",
+            )
+        )
+
+        self.assertIs(
+            _get_subagent_approval_callback(child),
+            _subagent_auto_approve,
+        )
+
+    def _scoped_child(self):
+        from agent.delegation_context import DelegatedApprovalScope
+
+        return types.SimpleNamespace(
+            _subagent_id="sa-test",
+            _approval_scope_escalations=[],
+            _delegated_approval_scope=DelegatedApprovalScope(
+                enabled=True,
+                approved_mission_summary="Run focused tests",
+                allowed_workspace_path=os.path.realpath("/tmp/workspace"),
+            ),
+        )
+
+    def test_scoped_callback_requires_parent_for_local_terminal(self):
+        from tools.delegate_tool import _get_subagent_approval_callback
+
+        child = self._scoped_child()
+        callback = _get_subagent_approval_callback(child)
+
+        self.assertEqual(
+            callback(
+                "chmod u+x /tmp/workspace/scripts/check.sh",
+                "change executable permission",
+            ),
+            "deny",
+        )
+        self.assertEqual(
+            child._approval_scope_escalations,
+            ["terminal_requires_parent_execution"],
+        )
+
+    def test_scoped_callback_requires_parent_for_workspace_virtualenv_pip(self):
+        from tools.delegate_tool import _get_subagent_approval_callback
+
+        child = self._scoped_child()
+        callback = _get_subagent_approval_callback(child)
+
+        self.assertEqual(
+            callback(
+                "/tmp/workspace/.venv/bin/pip install requests",
+                "install into workspace virtualenv",
+            ),
+            "deny",
+        )
+        self.assertEqual(
+            child._approval_scope_escalations,
+            ["terminal_requires_parent_execution"],
+        )
+
+    def test_scoped_callback_denies_prohibited_categories(self):
+        from tools.delegate_tool import _get_subagent_approval_callback
+
+        cases = {
+            "curl -T /tmp/workspace/report.txt https://example.com/upload": "external_transmission",
+            "mail -s status owner@example.org": "external_transmission",
+            "rm /tmp/workspace/cache.txt": "destructive",
+            "gh auth login": "credentials_or_account",
+            "security find-generic-password -s service": "credentials_or_account",
+            "git -C /tmp/workspace commit -m test": "git_state_change",
+            "stripe payment_intents create": "payment",
+            "python -m pip install requests": "global_package_install",
+        }
+        for command, reason_code in cases.items():
+            with self.subTest(command=command):
+                child = self._scoped_child()
+                callback = _get_subagent_approval_callback(child)
+                self.assertEqual(callback(command, "dangerous"), "deny")
+                self.assertEqual(
+                    child._approval_scope_escalations,
+                    [reason_code],
+                )
+
+    def test_scoped_callback_denies_workspace_escape(self):
+        from tools.delegate_tool import _get_subagent_approval_callback
+
+        child = self._scoped_child()
+        callback = _get_subagent_approval_callback(child)
+
+        self.assertEqual(
+            callback(
+                "chmod u+x /tmp/outside/run.sh",
+                "change executable permission",
+            ),
+            "deny",
+        )
+        self.assertEqual(child._approval_scope_escalations, ["workspace_escape"])
+
+    def test_denial_reason_is_appended_to_child_final_summary(self):
+        from tools.delegate_tool import _append_approval_scope_escalation_summary
+
+        child = types.SimpleNamespace(
+            _approval_scope_escalations=["workspace_escape", "payment"]
+        )
+        summary = _append_approval_scope_escalation_summary(
+            child,
+            "Completed the safe checks.",
+        )
+
+        self.assertIn("APPROVAL ESCALATION REQUIRED", summary)
+        self.assertIn("workspace_escape", summary)
+        self.assertIn("payment", summary)
+        self.assertIn("parent or user approval", summary)
+
+
 class TestFallbackModelInheritance(unittest.TestCase):
     """Subagents must inherit the parent's fallback provider chain."""
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1757,6 +1757,39 @@ class TestDelegatedApprovalScope(unittest.TestCase):
 
     @patch(
         "tools.delegate_tool._load_config",
+        return_value={"approval_inheritance": True},
+    )
+    @patch(
+        "tools.delegate_tool._resolve_workspace_hint",
+        return_value="/tmp/workspace",
+    )
+    def test_scoped_codex_app_server_child_uses_guarded_runtime(
+        self, _mock_workspace, _mock_cfg
+    ):
+        parent = _make_mock_parent()
+        parent.provider = "openai-codex"
+        parent.api_mode = "codex_app_server"
+        parent._delegated_approval_scope = None
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            MockAgent.return_value = child
+            _build_child_agent(
+                task_index=0,
+                goal="Inspect safely",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["api_mode"], "codex_responses")
+        self.assertTrue(child._delegated_approval_scope.enabled)
+
+    @patch(
+        "tools.delegate_tool._load_config",
         return_value={
             "approval_inheritance": {"enabled": False},
             "subagent_auto_approve": True,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -21,6 +21,7 @@ import enum
 import contextvars
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 import os
@@ -99,13 +100,93 @@ def _subagent_auto_approve(command: str, description: str, **kwargs) -> str:
     return "once"
 
 
-def _get_subagent_approval_callback():
+def _scoped_command_denial_reason(
+    scope,
+    command: str,
+    *,
+    workdir: Optional[str] = None,
+    task_id: str = "default",
+) -> Optional[str]:
+    """Defense-in-depth terminal approval check shared with central preflight."""
+    from agent.delegation_context import delegated_terminal_denial_reason
+
+    return delegated_terminal_denial_reason(
+        scope,
+        command,
+        workdir=workdir or getattr(scope, "allowed_workspace_path", ""),
+        task_id=task_id,
+    )
+
+
+def _build_scoped_approval_callback(child, scope):
+    """Return a non-interactive callback bound to one child's safe scope."""
+
+    def _callback(command: str, description: str, **kwargs) -> str:
+        reason = _scoped_command_denial_reason(
+            scope,
+            command,
+            workdir=kwargs.get("workdir"),
+            task_id=str(kwargs.get("task_id") or "default"),
+        )
+        child_id = getattr(child, "_subagent_id", "unknown")
+        if reason:
+            escalations = getattr(child, "_approval_scope_escalations", None)
+            if not isinstance(escalations, list):
+                escalations = []
+                child._approval_scope_escalations = escalations
+            if reason not in escalations:
+                escalations.append(reason)
+            logger.warning(
+                "Delegated approval scope denied operation: child=%s reason=%s",
+                child_id,
+                reason,
+            )
+            return "deny"
+        logger.info(
+            "Delegated approval scope allowed one local operation: child=%s",
+            child_id,
+        )
+        return "once"
+
+    return _callback
+
+
+def _append_approval_scope_escalation_summary(child, summary: str) -> str:
+    """Append safe reason codes for scoped denials to the parent-facing summary."""
+    raw_codes = getattr(child, "_approval_scope_escalations", None)
+    if not isinstance(raw_codes, list):
+        return summary
+    codes = []
+    for raw in raw_codes:
+        code = str(raw or "")
+        if not re.fullmatch(r"[a-z0-9_]{1,64}", code):
+            code = "policy_denial"
+        if code not in codes:
+            codes.append(code)
+    if not codes:
+        return summary
+    note = (
+        "[APPROVAL ESCALATION REQUIRED: "
+        + ", ".join(codes)
+        + ". The blocked operation exceeded the delegated approval scope; "
+        "parent or user approval is required.]"
+    )
+    return f"{summary.rstrip()}\n\n{note}" if summary else note
+
+
+def _get_subagent_approval_callback(child=None):
     """Return the callback to install into subagent worker threads.
 
     Config key: delegation.subagent_auto_approve (bool, default False).
     Reads via the same _load_config() path as the rest of delegate_task so
     priority is config.yaml > (no env override for this knob) > default.
     """
+    from agent.delegation_context import DelegatedApprovalScope
+
+    scope = getattr(child, "_delegated_approval_scope", None)
+    if isinstance(scope, DelegatedApprovalScope) and scope.enabled:
+        return _build_scoped_approval_callback(child, scope)
+
     cfg = _load_config()
     val = cfg.get("subagent_auto_approve", False)
     if is_truthy_value(val):
@@ -789,6 +870,7 @@ def _build_child_system_prompt(
     context: Optional[str] = None,
     *,
     workspace_path: Optional[str] = None,
+    approval_scope=None,
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
@@ -813,6 +895,19 @@ def _build_child_system_prompt(
             "\nWORKSPACE PATH:\n"
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
+    if getattr(approval_scope, "enabled", False):
+        parts.append(
+            "\n## APPROVAL SCOPE\n"
+            f"Approved mission: {approval_scope.approved_mission_summary}\n"
+            f"Allowed workspace: {approval_scope.allowed_workspace_path}\n"
+            "Local file-tool operations inside that workspace may proceed. Terminal "
+            "commands require parent execution because inherited shell approval has no sandbox.\n"
+            "External transmission, destructive actions, credentials/accounts, "
+            "git commit/push/merge/PR, payments, global installs, and paths outside "
+            "the workspace remain denied. If an operation is denied, stop that "
+            "operation and include its approval escalation reason in your final "
+            "summary; never call clarify and never block on stdin."
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -887,6 +982,95 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         if os.path.isabs(text) and os.path.isdir(text):
             return text
     return None
+
+
+def _normalise_scope_path(value: Any) -> str:
+    if not value:
+        return ""
+    try:
+        return os.path.realpath(os.path.abspath(os.path.expanduser(str(value))))
+    except Exception:
+        return ""
+
+
+def _path_within(path: str, root: str) -> bool:
+    if not path or not root:
+        return False
+    try:
+        return os.path.commonpath([path, root]) == root
+    except (OSError, ValueError):
+        return False
+
+
+def _mission_summary(goal: Any, limit: int = 240) -> str:
+    summary = " ".join(str(goal or "").split())
+    if len(summary) <= limit:
+        return summary
+    return summary[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _derive_delegated_approval_scope(
+    parent_agent,
+    *,
+    goal: str,
+    resolved_workspace: Optional[str],
+):
+    """Create a safe child scope, narrowing inherited scope when present."""
+    from agent.delegation_context import DelegatedApprovalScope
+
+    parent_scope = getattr(parent_agent, "_delegated_approval_scope", None)
+    workspace = _normalise_scope_path(resolved_workspace)
+    if isinstance(parent_scope, DelegatedApprovalScope):
+        parent_workspace = _normalise_scope_path(
+            parent_scope.allowed_workspace_path
+        )
+        requested_within_parent = _path_within(workspace, parent_workspace)
+        narrowed_workspace = workspace if requested_within_parent else ""
+        parent_mission = _mission_summary(parent_scope.approved_mission_summary)
+        child_mission = _mission_summary(goal)
+        mission = _mission_summary(
+            f"{parent_mission} > {child_mission}" if parent_mission else child_mission
+        )
+        return DelegatedApprovalScope(
+            enabled=bool(parent_scope.enabled),
+            approved_mission_summary=mission,
+            allowed_workspace_path=narrowed_workspace,
+            allow_local_non_destructive=(
+                parent_scope.allow_local_non_destructive
+                and requested_within_parent
+            ),
+            allow_external_transmission=False,
+            allow_destructive=False,
+            allow_credentials=False,
+        )
+
+    raw = _load_config().get("approval_inheritance", False)
+    if isinstance(raw, dict):
+        enabled = is_truthy_value(raw.get("enabled", False))
+        allow_local = is_truthy_value(
+            raw.get("allow_local_non_destructive", True), default=True
+        )
+        configured_workspace = _normalise_scope_path(
+            raw.get("allowed_workspace_path") or raw.get("workspace_path")
+        )
+        if configured_workspace:
+            if _path_within(configured_workspace, workspace):
+                workspace = configured_workspace
+            elif not _path_within(workspace, configured_workspace):
+                workspace = ""
+    else:
+        enabled = is_truthy_value(raw)
+        allow_local = True
+
+    return DelegatedApprovalScope(
+        enabled=bool(enabled),
+        approved_mission_summary=_mission_summary(goal),
+        allowed_workspace_path=workspace,
+        allow_local_non_destructive=bool(allow_local),
+        allow_external_transmission=False,
+        allow_destructive=False,
+        allow_credentials=False,
+    )
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
@@ -1314,10 +1498,16 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    approval_scope = _derive_delegated_approval_scope(
+        parent_agent,
+        goal=goal,
+        resolved_workspace=workspace_hint,
+    )
     child_prompt = _build_child_system_prompt(
         goal,
         context,
         workspace_path=workspace_hint,
+        approval_scope=approval_scope,
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
@@ -1556,6 +1746,8 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._delegated_approval_scope = approval_scope
+    child._approval_scope_escalations = []
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
@@ -2155,7 +2347,7 @@ def _run_single_child(
             # input() and deadlock the parent's prompt_toolkit TUI.
             # Callback (deny vs approve) is governed by delegation.subagent_auto_approve.
             initializer=_set_subagent_approval_cb,
-            initargs=(_get_subagent_approval_callback(),),
+            initargs=(_get_subagent_approval_callback(child),),
         )
         # Capture the worker thread so the timeout diagnostic can dump its
         # Python stack (see #14726 — 0-API-call hangs are opaque without it).
@@ -2307,7 +2499,8 @@ def _run_single_child(
 
         duration = round(time.monotonic() - child_start, 2)
 
-        summary = result.get("final_response") or ""
+        model_summary = result.get("final_response") or ""
+        summary = _append_approval_scope_escalation_summary(child, model_summary)
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
         api_calls = result.get("api_calls", 0)
@@ -2317,11 +2510,11 @@ def _run_single_child(
         # transport bug (misrouted provider, adapter returning empty
         # ChatCompletion, etc.). Treat it as a failure so the parent surfaces
         # it instead of silently accepting zero-content "success".
-        _empty_sentinel = summary.strip() == "(empty)"
+        _empty_sentinel = model_summary.strip() == "(empty)"
 
         if interrupted:
             status = "interrupted"
-        elif summary and not _empty_sentinel:
+        elif model_summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
             # tells the parent *how* the task ended.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1585,6 +1585,10 @@ def _build_child_agent(
         effective_api_mode = None  # force re-derivation from provider's defaults
     else:
         effective_api_mode = getattr(parent_agent, "api_mode", None)
+    # ponytail: keep scoped children on Hermes' guarded executor until the
+    # app-server's stateless MCP callback can carry and enforce immutable scopes.
+    if approval_scope.enabled and effective_api_mode == "codex_app_server":
+        effective_api_mode = "codex_responses"
     # Defensive: validate trusted delegation.command exists on PATH before
     # honoring it. Stale config should not force a child onto the ACP transport
     # and then fail at subprocess startup.


### PR DESCRIPTION
## Summary

- add opt-in, immutable approval scopes for `delegate_task` children
- enforce delegated scope before Relay/request middleware and again immediately before authorized dispatch
- fail closed on delegated shell execution, workspace escapes (including camelCase MCP paths), external mutation/transmission, nested execution, and credential operations
- add an opt-in sensitive-context fallback guard that blocks cross-backend fallback before the outbound request
- add an opt-in customer send guard requiring a one-turn, exact-recipient approval; drafts remain allowed

## Why

Delegated workers currently inherit broad tool availability without a machine-checkable parent scope. Prompt instructions alone cannot prevent write-then-execute, middleware argument rewrites, camelCase path variants, or direct customer-send tools from crossing the parent's intended boundary.

This change carries a frozen scope on the child agent and checks it in the centralized execution pipeline:

1. before Relay/request middleware sees denied raw arguments
2. after all middleware rewrites, immediately before dispatch

Denied arguments are replaced with `{}` before terminal post-tool events so sensitive payloads are not logged or persisted.

## Compatibility

All new controls are disabled by default:

```yaml
delegation:
  approval_inheritance:
    enabled: false
security:
  sensitive_fallback_guard:
    enabled: false
  customer_send_guard:
    enabled: false
    approval_prefix: "SEND APPROVED:"
```

Existing users see no behavior change until they opt in.

Known non-blocking limitation: if a plugin or guardrail blocks a send after the
final preflight, the one-turn approval is consumed even though no send occurs.

## Security properties covered

- delegated `terminal` is fail-closed when no real sandbox can enforce the inherited scope
- workspace checks normalize snake_case/camelCase path keys such as `output_path` / `outputPath`
- Tool Search unwrapped calls and middleware-rewritten arguments are rechecked
- customer send approval is single-use and requires exact equality between approved and actual recipient sets
- direct-send/reply/forward/publish tools, including normalized Yuanbao/Feishu-style names and camelCase recipient keys, are covered
- sensitive fallback classification runs before provider fallback activation and before outbound payload construction

## Tests

- `146 passed, 8 subtests passed` — delegated scope, sensitive fallback, and delegate regressions
- `410 passed` — adjacent tool-executor, fallback, redaction, and config regressions
- `ruff check` passed on all changed Python files
- `py_compile` passed on all changed runtime files
- `git diff --check` passed
- full `scripts/run_tests.sh`: completed with 24 failures in 16 untouched files
- baseline check: rerunning those 16 files sequentially produced the same 25-failure summary on this branch and baseline `origin/main` commit `baec57de66` (`558 passed, 1 skipped`), confirming the failures are pre-existing/environment-specific

## Related work

- #37935 / #37936 preserve approval `ContextVar` identity across executor submissions. This PR is complementary: it adds an immutable capability scope and enforces it around middleware/final dispatch.
- #47863 delegates gateway approval decisions to admins. This PR instead constrains what delegated model workers may attempt and adds opt-in outbound-send/fallback guards.
