### PR TITLE
feat(delegation): add parent-scoped live controls

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5139,6 +5139,79 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             current = child_id
         return current
 
+    def get_compression_lineage_root(self, session_id: str) -> Optional[str]:
+        """Return a proven compression-only ancestor, or ``None`` on doubt.
+
+        This is deliberately narrower than :meth:`get_conversation_root`.
+        Delegate, branch, and tool children use the same parent column, so a
+        generic lineage walk would accidentally make them co-owners of a
+        parent's live delegation. Each backwards hop proves a real compression
+        edge: a compression-ended parent, exactly one eligible child, no
+        explicit branch/delegate marker, and no tool source.
+        """
+        if not isinstance(session_id, str) or not session_id.strip():
+            return None
+
+        current = session_id.strip()
+        seen: set[str] = set()
+        conn = self._conn
+        if conn is None:
+            return None
+        try:
+            with self._lock:
+                for _ in range(100):
+                    if current in seen:
+                        return None
+                    seen.add(current)
+                    child = conn.execute(
+                        """SELECT id, parent_session_id, source, model_config
+                           FROM sessions WHERE id = ?""",
+                        (current,),
+                    ).fetchone()
+                    if child is None:
+                        return None
+                    source = str(child["source"] or "").strip().lower()
+                    if source in {"delegate", "subagent", "tool"}:
+                        return None
+                    try:
+                        config = json.loads(child["model_config"] or "{}")
+                    except (TypeError, ValueError):
+                        return None
+                    if not isinstance(config, dict) or any(
+                        marker in config
+                        for marker in ("_branched_from", "_delegate_from")
+                    ):
+                        return None
+                    parent_id = child["parent_session_id"]
+                    if not parent_id:
+                        return current
+                    parent = conn.execute(
+                        """SELECT ended_at, end_reason FROM sessions
+                           WHERE id = ?""",
+                        (parent_id,),
+                    ).fetchone()
+                    if (
+                        parent is None
+                        or parent["ended_at"] is None
+                        or parent["end_reason"] != "compression"
+                    ):
+                        return None
+                    siblings = conn.execute(
+                        """SELECT id FROM sessions
+                           WHERE parent_session_id = ?
+                             AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL
+                             AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL
+                             AND COALESCE(source, '') != 'tool'
+                           LIMIT 2""",
+                        (parent_id,),
+                    ).fetchall()
+                    if len(siblings) != 1 or siblings[0]["id"] != current:
+                        return None
+                    current = str(parent_id)
+        except Exception:
+            return None
+        return None
+
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
     # routing fields and desktop sidebar fields like git_branch — stays, and

--- a/tests/tools/test_delegate_control.py
+++ b/tests/tools/test_delegate_control.py
@@ -1,0 +1,704 @@
+"""Focused contracts for parent-scoped async delegation controls."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+@pytest.fixture
+def profile_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+    return tmp_path
+
+
+def _db(root: Path, monkeypatch: pytest.MonkeyPatch, profile: str):
+    from hermes_state import SessionDB
+
+    home = root / profile
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return SessionDB(home / "state.db")
+
+
+def _bind_session(session_id: str):
+    from gateway.session_context import set_session_vars
+
+    return set_session_vars(session_id=session_id)
+
+
+def _create_session(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+    session_id: str,
+    **kwargs,
+) -> None:
+    db = _db(root, monkeypatch, profile)
+    try:
+        db.create_session(session_id, source=kwargs.pop("source", "cli"), **kwargs)
+    finally:
+        db.close()
+
+
+def _current_owner(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str = "profile-a",
+    session_id: str = "parent",
+) -> tuple[str, str]:
+    _create_session(root, monkeypatch, profile, session_id)
+    _bind_session(session_id)
+    owner = ad._current_control_owner()
+    assert owner is not None
+    return owner
+
+
+def _record(delegation_id: str, owner: tuple[str, str], **changes):
+    record = {
+        "delegation_id": delegation_id,
+        "owner_profile": owner[0],
+        "owner_session_id": owner[1],
+        "status": "running",
+        "goal": "private goal",
+        "role": "leaf",
+        "context": "private context",
+        "session_key": "route",
+        "interrupt_fn": None,
+        "steer_fn": None,
+        "progress_fn": None,
+        "dispatched_at": 1.0,
+        "delivery_state": "pending",
+        "delivery_claim": "claim",
+    }
+    record.update(changes)
+    with ad._records_lock:
+        ad._records[delegation_id] = record
+    return record
+
+
+def _context_thread(target):
+    context = contextvars.copy_context()
+    return threading.Thread(target=lambda: context.run(target), daemon=True)
+
+
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+def _delegate_env(monkeypatch, children):
+    import tools.delegate_tool as dt
+
+    child_iter = iter(children)
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **_: next(child_iter))
+    monkeypatch.setattr(
+        dt,
+        "_resolve_delegation_credentials",
+        lambda *_: {
+            "model": "m",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+    monkeypatch.setattr(dt, "_get_max_concurrent_children", lambda: 2)
+    monkeypatch.setattr(dt, "_get_max_async_children", lambda: 2)
+    monkeypatch.setattr(
+        "gateway.session_context.async_delivery_supported", lambda: True
+    )
+    parent = MagicMock(
+        session_id="parent",
+        _delegate_depth=0,
+        _interrupt_requested=False,
+        _active_children=[],
+        _active_children_lock=None,
+    )
+    return dt, parent
+
+
+def _real_child(run):
+    child = MagicMock(
+        _credential_pool=None,
+        session_id="",
+        model="m",
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_estimated_cost_usd=0,
+        tool_progress_callback=None,
+    )
+    child.run_conversation.side_effect = run
+    child.get_activity_summary.return_value = {"api_call_count": 1}
+    return child
+
+
+def test_compression_only_owner_survives_rotation_and_rejects_noncontinuations(
+    profile_root, monkeypatch
+):
+    db = _db(profile_root, monkeypatch, "profile-a")
+    try:
+        db.create_session("A", source="cli")
+        db.end_session("A", "compression")
+        db.create_session("B", source="cli", parent_session_id="A")
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="A",
+            model_config={"_branched_from": "A"},
+        )
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id="A",
+            model_config={"_delegate_from": "A"},
+        )
+        db.create_session("tool", source="tool", parent_session_id="A")
+    finally:
+        db.close()
+
+    _bind_session("A")
+    owner = ad._current_control_owner()
+    assert owner is not None
+    effects = []
+    _record(
+        "deleg_a11ce001",
+        owner,
+        interrupt_fn=lambda: effects.append("interrupt"),
+        steer_fn=lambda message: effects.append(message) or True,
+    )
+
+    _bind_session("B")
+    assert [
+        item["delegation_id"]
+        for item in ad.list_owned_async_delegations()["delegations"]
+    ] == ["deleg_a11ce001"]
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "focus") == {
+        "status": "accepted"
+    }
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {"status": "accepted"}
+    assert effects == ["focus", "interrupt"]
+
+    for foreign_session in ("branch", "delegate", "tool"):
+        _bind_session(foreign_session)
+        assert ad.list_owned_async_delegations()["delegations"] == []
+        assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {
+            "status": "not_found"
+        }
+
+    db = _db(profile_root, monkeypatch, "profile-a")
+    try:
+        db.create_session("sibling", source="cli", parent_session_id="A")
+    finally:
+        db.close()
+    _bind_session("sibling")
+    assert ad.list_owned_async_delegations()["delegations"] == []
+
+
+def test_same_session_id_in_foreign_profile_is_opaque(profile_root, monkeypatch):
+    owner = _current_owner(profile_root, monkeypatch)
+    _record("deleg_a11ce001", owner, interrupt_fn=lambda: None, steer_fn=lambda _: True)
+
+    _current_owner(profile_root, monkeypatch, "profile-b", "parent")
+    assert ad.list_owned_async_delegations()["delegations"] == []
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {"status": "not_found"}
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "continue") == {
+        "status": "not_found"
+    }
+
+
+def test_parentless_branch_delegate_and_tool_sessions_are_not_control_roots(
+    profile_root, monkeypatch
+):
+    db = _db(profile_root, monkeypatch, "profile-a")
+    try:
+        db.create_session(
+            "root-branch",
+            source="cli",
+            model_config={"_branched_from": "deleted-parent"},
+        )
+        db.create_session(
+            "root-delegate",
+            source="delegate",
+            model_config={"_delegate_from": "deleted-parent"},
+        )
+        db.create_session("root-delegate-markerless", source="delegate")
+        db.create_session("root-subagent-markerless", source="subagent")
+        db.create_session("root-tool", source="tool")
+        db.create_session(
+            "root-null-branch-marker",
+            source="cli",
+            model_config={"_branched_from": None},
+        )
+        db.create_session(
+            "root-null-delegate-marker",
+            source="cli",
+            model_config={"_delegate_from": None},
+        )
+        rejected = (
+            "root-branch",
+            "root-delegate",
+            "root-delegate-markerless",
+            "root-subagent-markerless",
+            "root-tool",
+            "root-null-branch-marker",
+            "root-null-delegate-marker",
+        )
+        for session_id in rejected:
+            assert db.get_compression_lineage_root(session_id) is None
+    finally:
+        db.close()
+
+    for session_id in rejected:
+        _bind_session(session_id)
+        assert ad._current_control_owner() is None
+
+
+def test_control_owner_opens_session_db_read_only(profile_root, monkeypatch):
+    import hermes_state
+
+    _create_session(profile_root, monkeypatch, "profile-a", "parent")
+    _bind_session("parent")
+    real_session_db = hermes_state.SessionDB
+    read_only_values = []
+
+    def session_db(*args, **kwargs):
+        read_only_values.append(kwargs.get("read_only"))
+        return real_session_db(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", session_db)
+    assert ad._current_control_owner() is not None
+    assert read_only_values == [True]
+
+
+def test_list_is_a_bounded_chooser_with_non_authorizing_pagination(
+    profile_root, monkeypatch
+):
+    owner = _current_owner(profile_root, monkeypatch)
+    for index in range(ad._MAX_OWNER_LIVE_SNAPSHOTS + 3):
+        _record(
+            f"deleg_{index:08x}",
+            owner,
+            goal=(f"goal-{index}-" + "x" * 500),
+            role="orchestrator" + "x" * 500,
+            dispatched_at=float(index),
+        )
+    _record("deleg_f0e1a001", (owner[0], "other"), dispatched_at=999.0)
+    _record("deleg_malformed", owner, dispatched_at=998.0)
+
+    first_page = ad.list_owned_async_delegations()
+    assert first_page["total_live"] == ad._MAX_OWNER_LIVE_SNAPSHOTS + 3
+    assert first_page["truncated"] is True
+    assert first_page["next_cursor"] == ad._MAX_OWNER_LIVE_SNAPSHOTS
+    assert len(first_page["delegations"]) == ad._MAX_OWNER_LIVE_SNAPSHOTS
+    assert all(
+        set(item)
+        == {"delegation_id", "status", "is_batch", "dispatched_at", "goal", "role"}
+        and len(item["goal"]) <= ad._MAX_OWNER_GOAL_CHARS
+        and len(item["role"]) <= ad._MAX_OWNER_ROLE_CHARS
+        and item["delegation_id"] != "deleg_f0e1a001"
+        for item in first_page["delegations"]
+    )
+
+    second_page = ad.list_owned_async_delegations(cursor=first_page["next_cursor"])
+    assert second_page["total_live"] == ad._MAX_OWNER_LIVE_SNAPSHOTS + 3
+    assert second_page["truncated"] is False
+    assert second_page["next_cursor"] is None
+    assert [item["delegation_id"] for item in second_page["delegations"]] == [
+        "deleg_00000002",
+        "deleg_00000001",
+        "deleg_00000000",
+    ]
+
+
+def test_model_dispatch_exposes_only_paged_safe_metadata(profile_root, monkeypatch):
+    import model_tools
+
+    owner = _current_owner(profile_root, monkeypatch)
+    _record("deleg_a11ce001", owner, goal="choose me", role="leaf")
+    result = json.loads(
+        model_tools.handle_function_call(
+            "delegate_control",
+            {"action": "list", "cursor": 0},
+            session_id="parent",
+            skip_pre_tool_call_hook=True,
+            skip_tool_execution_middleware=True,
+        )
+    )
+    assert result == {
+        "status": "ok",
+        "delegations": [
+            {
+                "delegation_id": "deleg_a11ce001",
+                "status": "running",
+                "is_batch": False,
+                "dispatched_at": 1.0,
+                "goal": "choose me",
+                "role": "leaf",
+            }
+        ],
+        "total_live": 1,
+        "truncated": False,
+        "next_cursor": None,
+    }
+
+
+def test_control_tool_is_deferred_minimal_and_excluded_from_leaf_surface():
+    import model_tools
+    from tools.delegate_tool import DELEGATE_CONTROL_SCHEMA
+    from tools.registry import registry
+    from toolsets import _HERMES_CORE_TOOLS
+
+    properties = DELEGATE_CONTROL_SCHEMA["parameters"]["properties"]
+    assert set(properties) == {"action", "id", "message", "cursor"}
+    assert properties["id"]["maxLength"] == ad._MAX_DELEGATION_ID_CHARS
+    assert "delegate_control" not in _HERMES_CORE_TOOLS
+    control_entry = registry.get_entry("delegate_control")
+    delegate_entry = registry.get_entry("delegate_task")
+    assert control_entry is not None
+    assert delegate_entry is not None
+    assert control_entry.check_fn is delegate_entry.check_fn
+
+    raw = model_tools.get_tool_definitions(
+        ["delegation"], quiet_mode=True, skip_tool_search_assembly=True
+    )
+    normal = model_tools.get_tool_definitions(["delegation"], quiet_mode=True)
+    leaf = model_tools.get_tool_definitions(
+        ["delegation"],
+        ["delegation"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    assert "delegate_control" in {item["function"]["name"] for item in raw}
+    assert "delegate_control" not in {
+        item["function"]["name"] for item in normal + leaf
+    }
+    assert "tool_search" in {item["function"]["name"] for item in normal}
+    search_result = json.loads(
+        model_tools.handle_function_call(
+            "tool_search",
+            {"query": "delegate control"},
+            enabled_toolsets=["delegation"],
+        )
+    )
+    assert "delegate_control" in {item["name"] for item in search_result["matches"]}
+
+
+def test_steering_bounds_charge_only_accepted_messages(profile_root, monkeypatch):
+    owner = _current_owner(profile_root, monkeypatch)
+    calls = []
+    record = _record(
+        "deleg_a11ce001",
+        owner,
+        steer_fn=lambda message: calls.append(message) or False,
+    )
+
+    oversized = "x" * (ad._MAX_DELEGATION_ID_CHARS + 1)
+    huge = "🍣" * (ad._MAX_STEER_MESSAGE_CHARS + 1)
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", " ") == {
+        "status": "rejected"
+    }
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", huge) == {
+        "status": "rejected"
+    }
+    assert ad.cancel_owned_async_delegation(oversized) == {"status": "not_found"}
+    assert ad.steer_owned_async_delegation(oversized, "ok") == {"status": "not_found"}
+    for malformed in ("deleg_owned", "deleg_ABCDEF12", "deleg_1234567g"):
+        assert ad.cancel_owned_async_delegation(malformed) == {"status": "not_found"}
+        assert ad.steer_owned_async_delegation(malformed, "ok") == {
+            "status": "not_found"
+        }
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "try") == {
+        "status": "rejected"
+    }
+    assert record.get("_steer_message_count", 0) == 0
+
+    record["steer_fn"] = lambda message: calls.append(message) or True
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "ok") == {
+        "status": "accepted"
+    }
+    assert record["_steer_message_count"] == 1
+    assert record["_steer_character_count"] == 2
+    record["_steer_message_count"] = ad._MAX_STEER_MESSAGES
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "again") == {
+        "status": "rejected"
+    }
+    record["_steer_message_count"] = 1
+    record["_steer_character_count"] = ad._MAX_STEER_TOTAL_CHARS - 1
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "xx") == {
+        "status": "rejected"
+    }
+    assert calls == ["try", "ok"]
+
+
+def test_control_callbacks_are_serialized_without_holding_registry_lock(
+    profile_root, monkeypatch
+):
+    owner = _current_owner(profile_root, monkeypatch)
+    entered, release = threading.Event(), threading.Event()
+    effects = []
+
+    def interrupt():
+        effects.append(("interrupt", ad._records_lock.locked()))
+        entered.set()
+        release.wait(2)
+
+    _record(
+        "deleg_a11ce001",
+        owner,
+        interrupt_fn=interrupt,
+        steer_fn=lambda message: (
+            effects.append((message, ad._records_lock.locked())) or True
+        ),
+    )
+    result = []
+    thread = _context_thread(
+        lambda: result.append(ad.cancel_owned_async_delegation("deleg_a11ce001"))
+    )
+    thread.start()
+    assert entered.wait(2)
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "late") == {
+        "status": "pending"
+    }
+    assert effects == [("interrupt", False)]
+    release.set()
+    thread.join(2)
+    assert result == [{"status": "accepted"}]
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "late") == {
+        "status": "rejected"
+    }
+
+
+def test_steer_first_serializes_competing_cancel_then_cancel_retry(
+    profile_root, monkeypatch
+):
+    owner = _current_owner(profile_root, monkeypatch)
+    entered, release = threading.Event(), threading.Event()
+    effects = []
+
+    def steer(message):
+        effects.append(message)
+        entered.set()
+        release.wait(2)
+        return True
+
+    _record(
+        "deleg_a11ce001",
+        owner,
+        interrupt_fn=lambda: effects.append("interrupt"),
+        steer_fn=steer,
+    )
+    result = []
+    thread = _context_thread(
+        lambda: result.append(
+            ad.steer_owned_async_delegation("deleg_a11ce001", "focus")
+        )
+    )
+    thread.start()
+    assert entered.wait(2)
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {"status": "pending"}
+    assert effects == ["focus"]
+    release.set()
+    thread.join(2)
+    assert result == [{"status": "accepted"}]
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {"status": "accepted"}
+    assert effects == ["focus", "interrupt"]
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "late") == {
+        "status": "rejected"
+    }
+
+
+def test_interrupt_exception_is_indeterminate_and_cannot_be_reissued(
+    profile_root, monkeypatch
+):
+    owner = _current_owner(profile_root, monkeypatch)
+    effects = []
+
+    def interrupt():
+        effects.append("issued")
+        raise RuntimeError("side effect happened before transport failed")
+
+    _record(
+        "deleg_a11ce001",
+        owner,
+        interrupt_fn=interrupt,
+        steer_fn=lambda _: pytest.fail("steer"),
+    )
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {
+        "status": "indeterminate"
+    }
+    assert ad.cancel_owned_async_delegation("deleg_a11ce001") == {
+        "status": "indeterminate"
+    }
+    assert ad.steer_owned_async_delegation("deleg_a11ce001", "late") == {
+        "status": "rejected"
+    }
+    assert effects == ["issued"]
+
+
+def test_two_child_partial_interrupt_failure_remains_indeterminate(
+    profile_root, monkeypatch
+):
+    child_one = _real_child(lambda **_: {"final_response": "ok", "completed": True})
+    child_two = _real_child(lambda **_: {"final_response": "ok", "completed": True})
+    child_two.interrupt.side_effect = RuntimeError("transport failed")
+    pending = []
+    monkeypatch.setattr(
+        ad,
+        "_get_executor",
+        lambda _: MagicMock(submit=lambda callback: pending.append(callback)),
+    )
+    _current_owner(profile_root, monkeypatch)
+    dt, parent = _delegate_env(monkeypatch, [child_one, child_two])
+    delegation_id = json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": "one"}, {"goal": "two"}],
+            background=True,
+            parent_agent=parent,
+        )
+    )["delegation_id"]
+
+    assert ad.cancel_owned_async_delegation(delegation_id) == {
+        "status": "indeterminate"
+    }
+    assert ad.cancel_owned_async_delegation(delegation_id) == {
+        "status": "indeterminate"
+    }
+    assert ad.steer_owned_async_delegation(delegation_id, "late") == {
+        "status": "rejected"
+    }
+    assert child_one.interrupt.call_count == 1
+    assert child_two.interrupt.call_count == 1
+    assert pending
+
+
+def test_blocked_batch_callback_does_not_hold_the_lifecycle_lock(
+    profile_root, monkeypatch
+):
+    child_started, child_release, interrupt_entered, interrupt_release = (
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+    )
+
+    def run(**_):
+        child_started.set()
+        child_release.wait(2)
+        return {"final_response": "ok", "completed": True}
+
+    child = _real_child(run)
+    child.interrupt.side_effect = lambda _: (
+        interrupt_entered.set(),
+        interrupt_release.wait(2),
+    )
+    _current_owner(profile_root, monkeypatch)
+    dt, parent = _delegate_env(monkeypatch, [child])
+    delegation_id = json.loads(
+        dt.delegate_task(goal="one", background=True, parent_agent=parent)
+    )["delegation_id"]
+    assert child_started.wait(2)
+
+    cancellation = []
+    thread = _context_thread(
+        lambda: cancellation.append(ad.cancel_owned_async_delegation(delegation_id))
+    )
+    thread.start()
+    assert interrupt_entered.wait(2)
+    child_release.set()
+    assert _wait_until(
+        lambda: (
+            ad._records.get(delegation_id, {}).get("status")
+            not in {"running", "stalling"}
+        )
+    )
+    interrupt_release.set()
+    thread.join(2)
+    assert cancellation == [{"status": "not_found"}]
+
+
+@pytest.mark.parametrize("interrupt_kind", ["session", "all"])
+def test_lifecycle_interrupt_supersedes_a_blocked_batch_steer(
+    profile_root, monkeypatch, interrupt_kind
+):
+    child_started, child_release, steer_entered, steer_release = (
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+    )
+
+    def run(**_):
+        child_started.set()
+        child_release.wait(2)
+        return {"final_response": "ok", "completed": True}
+
+    def steer(_message):
+        steer_entered.set()
+        steer_release.wait(2)
+        return True
+
+    child = _real_child(run)
+    child.steer.side_effect = steer
+    _current_owner(profile_root, monkeypatch)
+    dt, parent = _delegate_env(monkeypatch, [child])
+    delegation_id = json.loads(
+        dt.delegate_task(goal="one", background=True, parent_agent=parent)
+    )["delegation_id"]
+    assert child_started.wait(2)
+
+    steer_result = []
+    steer_thread = _context_thread(
+        lambda: steer_result.append(
+            ad.steer_owned_async_delegation(delegation_id, "focus")
+        )
+    )
+    steer_thread.start()
+    assert steer_entered.wait(2)
+    interrupted = (
+        ad.interrupt_for_session(parent_session_id="parent")
+        if interrupt_kind == "session"
+        else ad.interrupt_all()
+    )
+    assert interrupted == 1
+    child.interrupt.assert_called_once()
+
+    steer_release.set()
+    steer_thread.join(2)
+    child_release.set()
+    assert steer_result == [{"status": "rejected"}]
+
+
+def test_foreign_and_terminal_controls_are_opaque(profile_root, monkeypatch):
+    owner = _current_owner(profile_root, monkeypatch)
+    terminal = _record("deleg_dead0001", owner, status="completed")
+    _record("deleg_f0e1a001", (owner[0], "other"))
+    before = dict(terminal)
+    for delegation_id in ("deleg_dead0001", "deleg_f0e1a001", "deleg_0000ffff"):
+        assert ad.cancel_owned_async_delegation(delegation_id) == {
+            "status": "not_found"
+        }
+        assert ad.steer_owned_async_delegation(delegation_id, "continue") == {
+            "status": "not_found"
+        }
+    assert terminal == before

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -76,6 +76,16 @@ _records: Dict[str, Dict[str, Any]] = {}
 _DEFAULT_MAX_ASYNC_CHILDREN = 3
 # How many completed records to retain for status queries before pruning.
 _MAX_RETAINED_COMPLETED = 50
+# Parent-facing controls use a bounded, in-memory live snapshot only.
+_MAX_OWNER_LIVE_SNAPSHOTS = 20
+_MAX_OWNER_LIVE_CURSOR = 10_000
+_MAX_OWNER_GOAL_CHARS = 160
+_MAX_OWNER_ROLE_CHARS = 80
+_MAX_DELEGATION_ID_CHARS = 128
+_MAX_STEER_MESSAGE_CHARS = 4000
+_MAX_STEER_MESSAGES = 20
+_MAX_STEER_TOTAL_CHARS = 12000
+_NATIVE_DELEGATION_ID_LENGTH = len("deleg_") + 8
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 _MAX_DURABLE_PENDING = 1000
 # A pending completion whose delivery keeps failing is retried across claim
@@ -621,6 +631,34 @@ def _current_origin_session_id() -> str:
         return ""
 
 
+def _current_control_owner(session_id: Optional[str] = None) -> Optional[tuple[str, str]]:
+    """Return a canonical profile plus a proven compression-only session root."""
+    try:
+        from agent.relay_runtime import current_profile_key
+        from gateway.session_context import get_session_env
+        from hermes_state import SessionDB
+
+        profile = current_profile_key()
+        if session_id is None:
+            session_id = get_session_env("HERMES_SESSION_ID", "")
+    except Exception:
+        return None
+    if not isinstance(profile, str) or not isinstance(session_id, str):
+        return None
+    profile, session_id = profile.strip(), session_id.strip()
+    if not profile or not session_id:
+        return None
+    try:
+        db = SessionDB(get_hermes_home() / "state.db", read_only=True)
+        try:
+            root = db.get_compression_lineage_root(session_id)
+        finally:
+            db.close()
+    except Exception:
+        return None
+    return (profile, root) if root else None
+
+
 def dispatch_async_delegation(
     *,
     goal: str,
@@ -634,6 +672,7 @@ def dispatch_async_delegation(
     origin_ui_session_id: str = "",
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
+    steer_fn: Optional[Callable[[str], bool]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
@@ -680,6 +719,7 @@ def dispatch_async_delegation(
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
     delegation_id = _new_delegation_id()
+    owner = _current_control_owner(parent_session_id) if isinstance(parent_session_id, str) and parent_session_id.strip() else None
     dispatched_at = time.time()
     record: Dict[str, Any] = {
         "delegation_id": delegation_id,
@@ -692,10 +732,13 @@ def dispatch_async_delegation(
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
+        "owner_profile": owner[0] if owner else "",
+        "owner_session_id": owner[1] if owner else "",
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
+        "steer_fn": steer_fn,
         "progress_fn": progress_fn,
         # Stale-monitor bookkeeping (see _stale_monitor_loop).
         "_progress_token": None,
@@ -793,6 +836,7 @@ def _begin_finalization(
         record["completed_at"] = time.time()
         interrupt_fn = record.get("interrupt_fn")
         record["interrupt_fn"] = None  # drop the closure; child is done
+        record["steer_fn"] = None  # controls are only valid while live
         record["progress_fn"] = None  # stop stale-monitor sampling
         event_record = dict(record)
 
@@ -889,6 +933,7 @@ def dispatch_async_delegation_batch(
     origin_ui_session_id: str = "",
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
+    steer_fn: Optional[Callable[[str], bool]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
@@ -914,6 +959,9 @@ def dispatch_async_delegation_batch(
     capacity.
     """
     delegation_id = delegation_id or _new_delegation_id()
+    if not _is_native_delegation_id(delegation_id):
+        return {"status": "rejected", "error": "Invalid async delegation id"}
+    owner = _current_control_owner(parent_session_id) if isinstance(parent_session_id, str) and parent_session_id.strip() else None
     dispatched_at = time.time()
     n = len(goals)
     # A combined goal label for status listings / the completion header.
@@ -932,10 +980,13 @@ def dispatch_async_delegation_batch(
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
+        "owner_profile": owner[0] if owner else "",
+        "owner_session_id": owner[1] if owner else "",
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
+        "steer_fn": steer_fn,
         "is_batch": True,
         "progress_fn": progress_fn,
         "_progress_token": None,
@@ -1182,15 +1233,8 @@ def _stale_monitor_loop() -> None:
             )
             with _records_lock:
                 record = _records.get(delegation_id)
-                fn = record.get("interrupt_fn") if record else None
-            if callable(fn):
-                try:
-                    fn()
-                except Exception as exc:
-                    logger.debug(
-                        "Async delegation %s stall interrupt failed: %s",
-                        delegation_id, exc,
-                    )
+            if record is not None:
+                _interrupt_live_record(record, "stale_monitor")
         for delegation_id in expired:
             _finalize_stalled(delegation_id)
         if not any_monitorable:
@@ -1296,6 +1340,222 @@ def _children_activity_from_token(token: Any, now: float) -> Optional[List]:
     return out
 
 
+def _owned_live_record_locked(owner: tuple[str, str], delegation_id: str) -> Optional[Dict[str, Any]]:
+    record = _records.get(delegation_id)
+    if (
+        record is None
+        or record.get("owner_profile") != owner[0]
+        or record.get("owner_session_id") != owner[1]
+        or record.get("status") not in ("running", "stalling")
+    ):
+        return None
+    return record
+
+
+def _control_lock_locked(record: Dict[str, Any]) -> threading.Lock:
+    """Return this record's control mutex while the registry lock is held."""
+    lock = record.get("_control_lock")
+    if not hasattr(lock, "acquire") or not hasattr(lock, "release"):
+        lock = threading.Lock()
+        record["_control_lock"] = lock
+    return lock
+
+
+def _safe_control_text(value: Any, limit: int) -> str:
+    return value[:limit] if isinstance(value, str) else ""
+
+
+def _is_native_delegation_id(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != _NATIVE_DELEGATION_ID_LENGTH:
+        return False
+    suffix = value.removeprefix("deleg_")
+    return len(suffix) == 8 and all(char in "0123456789abcdef" for char in suffix)
+
+
+def list_owned_async_delegations(
+    owner_session_id: Optional[str] = None,
+    cursor: int = 0,
+) -> Dict[str, Any]:
+    """Return one bounded, non-authorizing chooser page for the current owner."""
+    if (
+        isinstance(cursor, bool)
+        or not isinstance(cursor, int)
+        or not 0 <= cursor <= _MAX_OWNER_LIVE_CURSOR
+    ):
+        return {
+            "delegations": [],
+            "total_live": 0,
+            "truncated": False,
+            "next_cursor": None,
+        }
+    owner = _current_control_owner(owner_session_id)
+    if owner is None:
+        return {
+            "delegations": [],
+            "total_live": 0,
+            "truncated": False,
+            "next_cursor": None,
+        }
+    with _records_lock:
+        items = [
+            {
+                "delegation_id": delegation_id,
+                "status": record["status"],
+                "is_batch": bool(record.get("is_batch")),
+                "dispatched_at": record.get("dispatched_at"),
+                "goal": _safe_control_text(record.get("goal"), _MAX_OWNER_GOAL_CHARS),
+                "role": _safe_control_text(record.get("role"), _MAX_OWNER_ROLE_CHARS),
+            }
+            for delegation_id, record in _records.items()
+            if (
+                _is_native_delegation_id(delegation_id)
+                and _owned_live_record_locked(owner, delegation_id) is record
+            )
+        ]
+    items.sort(
+        key=lambda item: (item["dispatched_at"] or 0, item["delegation_id"]),
+        reverse=True,
+    )
+    total_live = len(items)
+    page = items[cursor: cursor + _MAX_OWNER_LIVE_SNAPSHOTS]
+    next_cursor = cursor + len(page)
+    return {
+        "delegations": page,
+        "total_live": total_live,
+        "truncated": next_cursor < total_live,
+        "next_cursor": next_cursor if next_cursor < total_live else None,
+    }
+
+
+def cancel_owned_async_delegation(
+    delegation_id: str,
+    owner_session_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Issue one cooperative interrupt request for the current owner."""
+    if not _is_native_delegation_id(delegation_id):
+        return {"status": "not_found"}
+    owner = _current_control_owner(owner_session_id)
+    if owner is None:
+        return {"status": "not_found"}
+    with _records_lock:
+        record = _owned_live_record_locked(owner, delegation_id)
+        if record is None:
+            return {"status": "not_found"}
+        control_lock = _control_lock_locked(record)
+    if not control_lock.acquire(blocking=False):
+        return {"status": "pending"}
+    try:
+        with _records_lock:
+            if _owned_live_record_locked(owner, delegation_id) is not record:
+                return {"status": "not_found"}
+            state = record.get("_cancel_state")
+            if state == "accepted":
+                return {"status": "accepted"}
+            if state in ("indeterminate", "error"):
+                return {"status": "indeterminate"}
+            if state == "requesting":
+                return {"status": "pending"}
+            callback = record.get("interrupt_fn")
+            if not callable(callback):
+                return {"status": "rejected"}
+            record["_cancel_state"] = "requesting"
+        try:
+            callback()
+        except Exception:  # noqa: BLE001 - issuance may have taken effect
+            logger.debug(
+                "Async delegation %s cancel callback failed",
+                delegation_id,
+                exc_info=True,
+            )
+            with _records_lock:
+                if _owned_live_record_locked(owner, delegation_id) is not record:
+                    return {"status": "not_found"}
+                record["_cancel_state"] = "indeterminate"
+            return {"status": "indeterminate"}
+        with _records_lock:
+            if _owned_live_record_locked(owner, delegation_id) is not record:
+                return {"status": "not_found"}
+            record["_cancel_state"] = "accepted"
+        return {"status": "accepted"}
+    finally:
+        control_lock.release()
+
+
+def steer_owned_async_delegation(
+    delegation_id: str,
+    message: str,
+    owner_session_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Offer bounded guidance to one live delegation owned by this runtime."""
+    if (
+        not isinstance(message, str)
+        or not message.strip()
+        or len(message) > _MAX_STEER_MESSAGE_CHARS
+    ):
+        return {"status": "rejected"}
+    if not _is_native_delegation_id(delegation_id):
+        return {"status": "not_found"}
+    owner = _current_control_owner(owner_session_id)
+    if owner is None:
+        return {"status": "not_found"}
+    with _records_lock:
+        record = _owned_live_record_locked(owner, delegation_id)
+        if record is None:
+            return {"status": "not_found"}
+        control_lock = _control_lock_locked(record)
+    if not control_lock.acquire(blocking=False):
+        return {"status": "pending"}
+    try:
+        with _records_lock:
+            if _owned_live_record_locked(owner, delegation_id) is not record:
+                return {"status": "not_found"}
+            if record.get("_cancel_state") in (
+                "requesting",
+                "accepted",
+                "indeterminate",
+                "error",
+            ):
+                return {"status": "rejected"}
+            used_count = int(record.get("_steer_message_count", 0))
+            used_chars = int(record.get("_steer_character_count", 0))
+            if (
+                used_count >= _MAX_STEER_MESSAGES
+                or used_chars + len(message) > _MAX_STEER_TOTAL_CHARS
+            ):
+                return {"status": "rejected"}
+            callback = record.get("steer_fn")
+            if not callable(callback):
+                return {"status": "rejected"}
+        try:
+            accepted = bool(callback(message))
+        except Exception:  # noqa: BLE001 - child callback boundary
+            logger.debug(
+                "Async delegation %s steer callback failed",
+                delegation_id,
+                exc_info=True,
+            )
+            accepted = None
+        with _records_lock:
+            if _owned_live_record_locked(owner, delegation_id) is not record:
+                return {"status": "not_found"}
+            if record.get("_cancel_state") in (
+                "requesting",
+                "accepted",
+                "indeterminate",
+                "error",
+            ):
+                return {"status": "rejected"}
+            if accepted is None:
+                return {"status": "error"}
+            if not accepted:
+                return {"status": "rejected"}
+            record["_steer_message_count"] = used_count + 1
+            record["_steer_character_count"] = used_chars + len(message)
+        return {"status": "accepted"}
+    finally:
+        control_lock.release()
+
+
 def list_async_delegations() -> List[Dict[str, Any]]:
     """Snapshot of async delegations (running + recently completed).
 
@@ -1319,7 +1579,9 @@ def list_async_delegations() -> List[Dict[str, Any]]:
             item = {
                 k: v
                 for k, v in r.items()
-                if k not in {"interrupt_fn", "progress_fn"}
+                if k not in {
+                    "interrupt_fn", "steer_fn", "progress_fn", "owner_profile", "owner_session_id"
+                }
                 and not k.startswith("_")
             }
             status = r.get("status")
@@ -1358,6 +1620,41 @@ def list_async_delegations() -> List[Dict[str, Any]]:
     return items
 
 
+def _interrupt_live_record(record: Dict[str, Any], source: str) -> bool:
+    """Issue one lifecycle interrupt while superseding concurrent steering."""
+    with _records_lock:
+        delegation_id = record.get("delegation_id")
+        if (
+            not isinstance(delegation_id, str)
+            or _records.get(delegation_id) is not record
+            or record.get("status") not in ("running", "stalling")
+        ):
+            return False
+        if record.get("_cancel_state") in (
+            "requesting",
+            "accepted",
+            "indeterminate",
+            "error",
+        ):
+            return False
+        callback = record.get("interrupt_fn")
+        if not callable(callback):
+            return False
+        record["_cancel_state"] = "requesting"
+    try:
+        callback()
+    except Exception as exc:
+        with _records_lock:
+            if _records.get(delegation_id) is record:
+                record["_cancel_state"] = "indeterminate"
+        logger.debug("%s: %s interrupt failed: %s", source, delegation_id, exc)
+        return False
+    with _records_lock:
+        if _records.get(delegation_id) is record:
+            record["_cancel_state"] = "accepted"
+    return True
+
+
 def interrupt_all(reason: str = "shutdown") -> int:
     """Signal every running async delegation to stop. Returns how many.
 
@@ -1372,16 +1669,8 @@ def interrupt_all(reason: str = "shutdown") -> int:
             if r.get("status") in ("running", "stalling")
         ]
     for r in targets:
-        fn = r.get("interrupt_fn")
-        if callable(fn):
-            try:
-                fn()
-                count += 1
-            except Exception as exc:
-                logger.debug(
-                    "interrupt_all: %s interrupt failed: %s",
-                    r.get("delegation_id"), exc,
-                )
+        if _interrupt_live_record(r, "interrupt_all"):
+            count += 1
     if count:
         logger.info("Interrupted %d async delegation(s) (%s)", count, reason)
     return count
@@ -1425,16 +1714,8 @@ def interrupt_for_session(
             )
         ]
     for r in targets:
-        fn = r.get("interrupt_fn")
-        if callable(fn):
-            try:
-                fn()
-                count += 1
-            except Exception as exc:
-                logger.debug(
-                    "interrupt_for_session: %s interrupt failed: %s",
-                    r.get("delegation_id"), exc,
-                )
+        if _interrupt_live_record(r, "interrupt_for_session"):
+            count += 1
     if count:
         logger.info(
             "Interrupted %d async delegation(s) for ending session (%s)",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2177,11 +2177,11 @@ def _run_single_child(
             from agent.delegation_context import delegated_child_context
 
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
-                    user_message=goal,
-                    task_id=child_task_id,
-                    stream_callback=_relay_child_text,
-                )
+                (_lifecycle := _kwargs.get("_child_lifecycle", lambda _: None))(True)
+                try:
+                    return child.run_conversation(user_message=goal, task_id=child_task_id, stream_callback=_relay_child_text)
+                finally:
+                    _lifecycle(False)
 
         _child_context = contextvars.copy_context()
         _child_future = _timeout_executor.submit(
@@ -2974,6 +2974,18 @@ def delegate_task(
             child._live_transcript_path = str(_writer.path)
         children.append((i, t, child))
 
+    _active_batch_children: Dict[int, List[Any]] = {i: [child, "queued"] for i, _, child in children}
+    _active_batch_lock = threading.Lock()
+
+    def _run_active_child(i, task, child):
+        def _lifecycle(running):
+            with _active_batch_lock:
+                _active_batch_children[i][1] = "running" if running else "done"
+        try:
+            return _run_single_child(i, task["goal"], child, parent_agent, _child_lifecycle=_lifecycle)
+        finally:
+            _lifecycle(False)
+
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
@@ -2987,7 +2999,7 @@ def delegate_task(
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
-            result = _run_single_child(_i, _t["goal"], child, parent_agent)
+            result = _run_active_child(_i, _t, child)
             results.append(result)
         else:
             # Batch -- run in parallel with per-task progress lines
@@ -3004,11 +3016,10 @@ def delegate_task(
                     child_context = contextvars.copy_context()
                     future = executor.submit(
                         child_context.run,
-                        _run_single_child,
-                        task_index=i,
-                        goal=t["goal"],
-                        child=child,
-                        parent_agent=parent_agent,
+                        _run_active_child,
+                        i,
+                        t,
+                        child,
                     )
                     futures[future] = i
 
@@ -3273,14 +3284,57 @@ def delegate_task(
             return _execute_and_aggregate(honor_parent_interrupt=False)
 
         def _batch_interrupt():
-            for _c in _child_agents:
+            failures, targets = [], []
+            with _active_batch_lock:
+                for index, (_c, state) in _active_batch_children.items():
+                    if state not in ("queued", "running", "steering"):
+                        continue
+                    _active_batch_children[index][1] = "interrupting"
+                    targets.append((index, _c, state))
+            for _index, _c, _state in targets:
                 try:
-                    if hasattr(_c, "interrupt"):
+                    if callable(getattr(_c, "interrupt", None)):
                         _c.interrupt("Async delegation cancelled")
                     elif hasattr(_c, "_interrupt_requested"):
                         _c._interrupt_requested = True
+                    else:
+                        raise RuntimeError("child has no supported interrupt")
+                except Exception as exc:
+                    failures.append((_index, exc))
+            failed_indexes = {index for index, _exc in failures}
+            with _active_batch_lock:
+                for index, _c, state in targets:
+                    if _active_batch_children[index][1] == "interrupting":
+                        _active_batch_children[index][1] = (
+                            state if index in failed_indexes else "interrupt_requested"
+                        )
+            if not targets or failures:
+                raise RuntimeError(
+                    f"{len(failures)} of {len(targets)} async child interrupt(s) failed"
+                ) from (failures[0][1] if failures else None)
+
+        def _batch_steer(message):
+            targets = []
+            with _active_batch_lock:
+                for index, (_c, state) in _active_batch_children.items():
+                    if state != "running":
+                        continue
+                    _active_batch_children[index][1] = "steering"
+                    targets.append((index, _c))
+            accepted_indexes = set()
+            for _index, _c in targets:
+                try:
+                    if _c.steer(message):
+                        accepted_indexes.add(_index)
                 except Exception:
-                    pass
+                    logger.debug("Async delegation child steer failed", exc_info=True)
+            committed = False
+            with _active_batch_lock:
+                for index, _c in targets:
+                    if _active_batch_children[index][1] == "steering":
+                        _active_batch_children[index][1] = "running"
+                        committed = index in accepted_indexes or committed
+            return committed
 
         def _batch_progress():
             # Progress token for the async registry's stale monitor: the
@@ -3329,6 +3383,7 @@ def delegate_task(
             parent_session_id=_parent_session_id,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
+            steer_fn=_batch_steer,
             max_async_children=_get_max_async_children(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
@@ -3911,6 +3966,53 @@ DELEGATE_TASK_SCHEMA = {
     },
 }
 
+DELEGATE_CONTROL_SCHEMA = {
+    "name": "delegate_control",
+    "description": "List, cancel, or steer only your own running delegated subagents.",
+    "parameters": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["action"],
+        "properties": {
+            "action": {"type": "string", "enum": ["list", "cancel", "steer"]},
+            "id": {"type": "string", "maxLength": 128},
+            "message": {"type": "string"},
+            "cursor": {"type": "integer", "minimum": 0, "maximum": 10_000},
+        },
+    },
+}
+
+
+def delegate_control(args: dict, session_id: Optional[str] = None, **_kw) -> str:
+    """Control live delegations using only dispatcher-provided ownership."""
+    if not isinstance(session_id, str) or not session_id.strip():
+        return json.dumps({"status": "rejected"})
+    args = args if isinstance(args, dict) else {}
+    action, delegation_id = args.get("action"), args.get("id")
+    from tools import async_delegation as _async
+    if action == "list":
+        cursor = args.get("cursor", 0)
+        if (
+            isinstance(cursor, bool)
+            or not isinstance(cursor, int)
+            or not 0 <= cursor <= 10_000
+        ):
+            result = {"status": "rejected"}
+        else:
+            result = {
+                "status": "ok",
+                **_async.list_owned_async_delegations(session_id, cursor),
+            }
+    elif not isinstance(delegation_id, str) or not delegation_id.strip():
+        result = {"status": "rejected"}
+    elif action == "cancel":
+        result = _async.cancel_owned_async_delegation(delegation_id, session_id)
+    elif action == "steer" and isinstance(args.get("message"), str):
+        result = _async.steer_owned_async_delegation(delegation_id, args["message"], session_id)
+    else:
+        result = {"status": "rejected"}
+    return json.dumps(result)
+
 
 # --- Registry ---
 from tools.registry import registry, tool_error
@@ -3954,6 +4056,15 @@ def _strip_model_hidden_task_fields(tasks: Any) -> Any:
         stripped_tasks.append(stripped)
     return stripped_tasks if changed else tasks
 
+
+registry.register(
+    name="delegate_control",
+    toolset="delegation",
+    schema=DELEGATE_CONTROL_SCHEMA,
+    handler=delegate_control,
+    check_fn=check_delegate_requirements,
+    emoji="🔀",
+)
 
 registry.register(
     name="delegate_task",

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -10,6 +10,24 @@ The `delegate_task` tool spawns child AIAgent instances with isolated context, i
 
 Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
 
+## Control Live Delegations
+
+With the `delegation` capability active, `delegate_control` is a deferred tool: it is discoverable through normal tool search, not always loaded in the core tool set.
+
+```python
+delegate_control(action="list", cursor=0)
+delegate_control(action="cancel", id="deleg_...")
+delegate_control(action="steer", id="deleg_...", message="...")
+```
+
+Use only the full native delegation ID returned by delegation—never an internal subagent ID. Access is scoped to the exact canonical profile namespace and the durable compression-only parent-session lineage; branches, delegate/tool sessions, foreign, missing, and terminal IDs are all opaque `not_found`.
+
+- **List** returns a bounded, live-only allowlisted chooser page with each full delegation ID, status, batch flag, dispatch time, and bounded goal/role previews. Its `total_live`, `truncated`, and `next_cursor` metadata lets a parent page through older live work; a cursor only discovers IDs and never grants authority. It neither claims nor mutates records, and never duplicates terminal completion delivery.
+- **Cancel** requests cooperative cancellation, not a hard kill. It is `accepted` idempotently after issuance and `pending` while any control callback is in flight. If a callback raises after issuing work, it is `indeterminate` and will not be blindly retried.
+- **Steer** is bounded per message and cumulatively, and is best-effort at the child's next safe/tool boundary. For a batch it is offered only to active children and is `accepted` when at least one child accepts. Session or global shutdown supersedes an overlapping steer so lifecycle cancellation cannot leave a child orphaned.
+
+Terminal results still arrive through normal completion delivery: there is no result history or retrieval API. Native control callbacks are in memory and do not survive a process restart.
+
 ## Single Task
 
 ```python


### PR DESCRIPTION
Fixes #76508

> Implementation and adversarial review were completed locally before the issue was opened; the issue records the product and security contract this PR implements.

## Summary

- Add one parent-scoped `delegate_control` surface with `list`, `cancel`, and `steer` actions for live asynchronous delegations.
- Preserve authority across genuine context-compression continuations while rejecting foreign profiles, branches, delegate/subagent/tool sessions, siblings, ambiguous lineage, cycles, and malformed handles.
- Keep the capability deferred in the existing `delegation` toolset, outside `_HERMES_CORE_TOOLS`, with leaf-agent exclusion.
- Preserve native terminal-result delivery and existing async-delegation lifecycle behavior.

## Design

### Trusted parent authority

Dispatch records capture a trusted compound owner:

```text
(canonical profile namespace, compression-only parent-conversation root)
```

The new read-only SessionDB resolver follows only proven compression edges. It fails closed for missing or malformed state, non-compression ancestry, ambiguous continuations, cycles, explicit branch/delegate markers, and delegate/subagent/tool sources. Model arguments and discovery cursors never establish authority.

Complete `deleg_<8 lowercase hex>` IDs remain useful user-facing handles, but possession is not authorization. Malformed, foreign, missing, terminal, and inaccessible targets all return opaque `not_found`.

### Bounded live chooser

`list` returns newest-first pages containing only:

- complete delegation ID;
- live status;
- batch flag;
- dispatch time;
- bounded goal preview;
- bounded role preview.

It exposes `total_live`, `truncated`, and `next_cursor` rather than silently truncating. It does not expose prompts, context, results, errors, routes, models, ownership/session fields, callbacks, credentials, or completion-delivery internals.

### Race-safe cancellation and steering

- Control callbacks execute outside the global registry lock and batch child-lifecycle lock.
- Per-record control serialization prevents cancel/steer dual acceptance.
- Cancellation is cooperative and reports `pending`, `accepted`, or stable non-retriable `indeterminate` states truthfully.
- A callback exception after interruption begins cannot re-enable steering or trigger a blind retry.
- Batch steering targets active children only and commits acceptance only while those children remain steerable.
- Session shutdown, `/stop`, and stale-lifecycle cancellation supersede an overlapping steer and cannot miss a child temporarily marked as steering.
- Steering has runtime per-message and cumulative bounds.

### Narrow-waist integration

`delegate_control` is registered in the existing `delegation` toolset and remains absent from `_HERMES_CORE_TOOLS`. Normal progressive disclosure discovers it through `tool_search`; eager exposure remains possible when tool search is disabled but delegation is enabled. Existing child toolset policy keeps it unavailable to leaf agents.

No parallel registry, persistence schema, configuration key, dependency, service, or migration is introduced.

## Verification

Final frozen patch:

```text
base:   d7c24f264631d48bd4018a1c1023d02837bf27f7
sha256: 2cdcadcdf11fa7e95ea04bebb1640cb49b4781e602e8deeb857b4a5222eee908
size:   56,703 bytes
scope:  5 maintained files, +1,231 / -44 lines
```

Executed evidence:

- `301/301` broader affected SessionDB/delegation/model-tool/gateway/lifecycle tests passed in the final security review.
- `66/66` adversarial authority cases passed, including normalized delegate/subagent/tool sources, malformed marker values, valid parent roots, multi-hop compression, ambiguous ancestry, foreign profiles, and real control-owner resolution.
- `3/3` lifecycle overlap regressions passed.
- Ruff lint and focused formatting checks passed.
- Changed Python files compile successfully.
- `git diff --check` passed.
- No introduced changed-line typing diagnostic was found; the sole reported changed-line diagnostic reproduces on the untouched base.
- Disposable temporary-`HERMES_HOME` model-tool integration exercised dispatch, listing, pagination, steering, cancellation, compression continuity, and foreign-profile opacity.

The repository-wide runner was also executed on the preceding frozen candidate. It completed with 34 test failures across 22 files plus 14 collection/import failures in known untouched-base optional-dependency/environment categories; no changed delegation-control test failed. After the final localized authority/lifecycle deltas, the focused and broader affected suites above were rerun on the exact final bytes. This PR does not claim repository-wide baseline health.

## Related work

- Related/adjacent: #70899 — TUI Mission Control visibility and steering. This PR does not adopt possession-as-authority; it adds strict parent-scoped model-facing control and can reuse accepted shared steering seams.
- Separate informational surface: #76390 — Telegram-only bounded delegation activity. This PR does not modify it.

## Non-goals

- No TUI or transport-specific UI.
- No internal-subagent model API.
- No hard thread kill, pause/resume scheduler, or result-history API.
- No persistence, restart resurrection, schema migration, config key, dependency, service, or runtime activation.
