### PR TITLE
feat(dashboard): email allowlist for self-hosted OIDC provider

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1288,6 +1288,15 @@ DEFAULT_CONFIG = {
         "oauth": {
             "client_id": "",  # agent:{instance_id} — Portal provisions this
             "portal_url": "",  # blank → use plugin default (production Portal)
+            # Self-hosted OIDC provider config (dashboard_auth/self_hosted plugin).
+            # Set when using Google/Authentik/Keycloak/etc. as the IDP.
+            "self_hosted": {
+                "issuer": "",
+                "client_id": "",
+                # Optional: restrict login to these emails (comma-separated).
+                # Empty = allow any valid OIDC identity.
+                "allowed_emails": "",
+            },
         },
         # Username/password gate configuration — read by the bundled
         # ``dashboard_auth/basic`` plugin (a self-hosted "just put a

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -184,6 +184,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         client_id: str,
         scopes: str = _DEFAULT_SCOPES,
         client_secret: str = "",
+        allowed_emails: str = "",
     ) -> None:
         if not issuer:
             raise ValueError("issuer is required")
@@ -202,6 +203,11 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # provisioned-but-blank secret can't flip us into a broken confidential
         # mode that sends an empty client_secret. Non-empty ⇒ confidential.
         self._client_secret = (client_secret or "").strip()
+        # Optional email allowlist — comma-separated. When set, only these
+        # emails can complete login. Empty = allow any valid OIDC identity.
+        self._allowed_emails = {
+            e.strip().lower() for e in (allowed_emails or "").split(",") if e.strip()
+        }
 
         # Discovery + JWKS are lazily resolved on first use so plugin
         # registration never makes a network call (the IDP may be down at
@@ -680,6 +686,12 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             raise ProviderError("ID token missing 'sub' (user_id) claim")
 
         email = str(claims.get("email", "") or "")
+        # Email allowlist: when configured, reject identities not on the list.
+        if self._allowed_emails and email.lower() not in self._allowed_emails:
+            raise ProviderError(
+                f"Email '{email}' is not in the allowed list. "
+                f"Contact the administrator."
+            )
         # Standard OIDC display claims, in preference order.
         display_name = str(
             claims.get("name")
@@ -822,6 +834,10 @@ def register(ctx) -> None:
     client_secret = _resolve_setting(
         "HERMES_DASHBOARD_OIDC_CLIENT_SECRET", oidc_cfg.get("client_secret")
     )
+    # Optional email allowlist — comma-separated. Env var or config.yaml.
+    allowed_emails = _resolve_setting(
+        "HERMES_DASHBOARD_OIDC_ALLOWED_EMAILS", oidc_cfg.get("allowed_emails")
+    )
 
     if not issuer or not client_id:
         LAST_SKIP_REASON = (
@@ -842,6 +858,7 @@ def register(ctx) -> None:
             client_id=client_id,
             scopes=scopes,
             client_secret=client_secret,
+            allowed_emails=allowed_emails,
         )
     except (ValueError, ProviderError) as exc:
         LAST_SKIP_REASON = (

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -204,10 +204,18 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # mode that sends an empty client_secret. Non-empty ⇒ confidential.
         self._client_secret = (client_secret or "").strip()
         # Optional email allowlist — comma-separated. When set, only these
-        # emails can complete login. Empty = allow any valid OIDC identity.
+        # emails can complete login. Empty/unset = allow any (backward compat).
+        # Track "configured" separately so malformed input doesn't disable.
+        self._allowed_emails_raw = allowed_emails or ""
         self._allowed_emails = {
             e.strip().lower() for e in (allowed_emails or "").split(",") if e.strip()
         }
+        # If a non-empty value was provided but produced no valid emails, fail.
+        if self._allowed_emails_raw.strip() and not self._allowed_emails:
+            raise ValueError(
+                "allowed_emails is non-empty but contains no valid email "
+                f"addresses: {allowed_emails!r}"
+            )
 
         # Discovery + JWKS are lazily resolved on first use so plugin
         # registration never makes a network call (the IDP may be down at
@@ -686,6 +694,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             raise ProviderError("ID token missing 'sub' (user_id) claim")
 
         email = str(claims.get("email", "") or "")
+        # Reject unverified emails if the IDP provides email_verified.
+        # Some IDPs (Google) always verify, but others allow unverified claims.
+        if "email_verified" in claims and not claims.get("email_verified"):
+            raise ProviderError("Email claim is not verified by the identity provider.")
         # Email allowlist: when configured, reject identities not on the list.
         if self._allowed_emails and email.lower() not in self._allowed_emails:
             raise ProviderError(
@@ -834,10 +846,9 @@ def register(ctx) -> None:
     client_secret = _resolve_setting(
         "HERMES_DASHBOARD_OIDC_CLIENT_SECRET", oidc_cfg.get("client_secret")
     )
-    # Optional email allowlist — comma-separated. Env var or config.yaml.
-    allowed_emails = _resolve_setting(
-        "HERMES_DASHBOARD_OIDC_ALLOWED_EMAILS", oidc_cfg.get("allowed_emails")
-    )
+    # Optional email allowlist — config.yaml only (non-secret access policy).
+    # Per AGENTS.md convention, non-secret settings belong in config.yaml, not .env.
+    allowed_emails = oidc_cfg.get("allowed_emails") or ""
 
     if not issuer or not client_id:
         LAST_SKIP_REASON = (

--- a/tests/plugins/dashboard_auth/test_email_allowlist.py
+++ b/tests/plugins/dashboard_auth/test_email_allowlist.py
@@ -1,0 +1,153 @@
+"""Tests for the email allowlist feature of SelfHostedOIDCProvider.
+
+Covers:
+  - Mixed-case matching
+  - Empty and missing email claims
+  - Malformed non-empty allowlist (fail-closed)
+  - Unverified email claim rejection
+  - Backward compatibility (unset = allow any)
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# These imports are guarded so the test file can be collected even if the
+# plugin module is not on the path in certain CI environments.
+try:
+    from plugins.dashboard_auth.self_hosted import SelfHostedOIDCProvider
+    from hermes_cli.dashboard_auth import ProviderError
+except ImportError:
+    pytest.skip("dashboard_auth not available", allow_module_level=True)
+
+_CLAIMS_BASE = {
+    "sub": "user-123",
+    "email": "alice@example.com",
+    "email_verified": True,
+    "exp": 9999999999,
+    "iss": "https://idp.example.com",
+    "aud": "client-id",
+}
+
+
+def _make_provider(allowed_emails=""):
+    return SelfHostedOIDCProvider(
+        issuer="https://idp.example.com",
+        client_id="client-id",
+        allowed_emails=allowed_emails,
+    )
+
+
+class TestEmailAllowlistMatching:
+    """Email matching behavior."""
+
+    def test_exact_match_accepted(self):
+        p = _make_provider("alice@example.com")
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=dict(_CLAIMS_BASE)
+        )
+        assert session.email == "alice@example.com"
+
+    def test_mixed_case_match_accepted(self):
+        p = _make_provider("Alice@Example.COM")
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=dict(_CLAIMS_BASE)
+        )
+        assert session.email == "alice@example.com"
+
+    def test_claim_uppercase_accepted(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email"] = "ALICE@EXAMPLE.COM"
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=claims
+        )
+        assert session is not None
+
+    def test_non_match_rejected(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email"] = "bob@example.com"
+        with pytest.raises(ProviderError, match="not in the allowed list"):
+            p._session_from_tokens(id_token="tok", refresh_token="", claims=claims)
+
+    def test_multiple_emails_match(self):
+        p = _make_provider("alice@example.com,bob@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email"] = "bob@example.com"
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=claims
+        )
+        assert session.email == "bob@example.com"
+
+
+class TestEmptyAndMissingEmail:
+    """Edge cases for empty/missing email claims."""
+
+    def test_missing_email_with_allowlist_rejected(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        del claims["email"]
+        with pytest.raises(ProviderError):
+            p._session_from_tokens(id_token="tok", refresh_token="", claims=claims)
+
+    def test_empty_email_with_allowlist_rejected(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email"] = ""
+        with pytest.raises(ProviderError):
+            p._session_from_tokens(id_token="tok", refresh_token="", claims=claims)
+
+    def test_missing_email_without_allowlist_accepted(self):
+        p = _make_provider("")  # no allowlist
+        claims = dict(_CLAIMS_BASE)
+        del claims["email"]
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=claims
+        )
+        assert session.email == ""
+
+
+class TestMalformedAllowlist:
+    """Malformed non-empty allowlist must fail closed."""
+
+    def test_comma_only_raises_value_error(self):
+        with pytest.raises(ValueError, match="no valid email"):
+            _make_provider(",")
+
+    def test_whitespace_only_raises_value_error(self):
+        with pytest.raises(ValueError, match="no valid email"):
+            _make_provider("   ")
+
+    def test_empty_string_is_ok(self):
+        p = _make_provider("")
+        assert p._allowed_emails == set()
+
+
+class TestEmailVerified:
+    """Unverified email claims should be rejected."""
+
+    def test_unverified_email_rejected(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email_verified"] = False
+        with pytest.raises(ProviderError, match="not verified"):
+            p._session_from_tokens(id_token="tok", refresh_token="", claims=claims)
+
+    def test_verified_email_accepted(self):
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        claims["email_verified"] = True
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=claims
+        )
+        assert session.email == "alice@example.com"
+
+    def test_missing_email_verified_accepted(self):
+        """If IDP doesn't send email_verified, don't enforce it."""
+        p = _make_provider("alice@example.com")
+        claims = dict(_CLAIMS_BASE)
+        del claims["email_verified"]
+        session = p._session_from_tokens(
+            id_token="tok", refresh_token="", claims=claims
+        )
+        assert session.email == "alice@example.com"


### PR DESCRIPTION
## Summary

Adds an optional `allowed_emails` configuration to the self-hosted OIDC dashboard auth provider. When set, only identities with matching email addresses can complete login. This enables single-operator deployments using Google OIDC directly (without OAuth2 Proxy) where email-based access control is needed.

## Changes

### `plugins/dashboard_auth/self_hosted/__init__.py`
- **`__init__`**: New `allowed_emails` parameter (comma-separated string, parsed to lowercase set)
- **`_session_from_tokens`**: Rejects emails not in allowlist via `ProviderError`; also rejects unverified email claims when IDP provides `email_verified`
- **`register`**: Reads `allowed_emails` from `dashboard.oauth.self_hosted.allowed_emails` in config.yaml
- **Fail-closed**: Malformed non-empty input (e.g. `","` or whitespace-only) raises `ValueError` instead of silently disabling the check

### `hermes_cli/config_defaults.py`
- Added `dashboard.oauth.self_hosted` section with `issuer`, `client_id`, and `allowed_emails` to `DEFAULT_CONFIG`

### `tests/plugins/dashboard_auth/test_email_allowlist.py` (new)
- Mixed-case matching
- Empty/missing email claims
- Malformed allowlist fail-closed
- Unverified email rejection
- Backward compatibility (unset = allow any)

## Configuration

```yaml
# config.yaml
dashboard:
  oauth:
    self_hosted:
      issuer: https://accounts.google.com
      client_id: <client_id>
      client_secret: <secret>  # or via HERMES_DASHBOARD_OIDC_CLIENT_SECRET
      allowed_emails: admin@example.com,user@example.com
```

Empty/unset `allowed_emails` = allow any valid OIDC identity (backward compatible).

## Code Review

Reviewed with Codex (gpt-5.6-luna, high reasoning). Initial findings addressed in the follow-up commit:
- **P1 (Critical)**: Malformed allowlist `" "` or `","` → empty set → silently disables restriction → **Fixed**: raises `ValueError`
- **P2**: Unverified email claims accepted → **Fixed**: rejects when `email_verified=False`
- **S1**: Non-secret env var conflicts with repo policy → **Fixed**: config.yaml only
- **S2**: Missing from `DEFAULT_CONFIG` → **Fixed**: added
- **S3**: No test coverage → **Fixed**: added comprehensive test suite