### PR TITLE
fix(cron): heartbeat during cronjob(action=run) to prevent watchdog kill (#76502)

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -9,6 +9,8 @@ import json
 import logging
 import re
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -606,9 +608,45 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                 reason = "Job is already being fired by the scheduler; not run again."
             return {"claimed": False, "success": False, "error": reason}
 
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        # Start a heartbeat thread that ticks the parent agent's activity
+        # tracker while run_one_job executes.  Without this, the gateway
+        # inactivity watchdog sees a silent tool for the entire job duration
+        # and kills the calling turn at agent_timeout (default 1800s).
+        # (#76502)
+        _stop_heartbeat = threading.Event()
+
+        def _heartbeat_loop() -> None:
+            try:
+                from tools.environments.base import _get_activity_callback
+            except Exception:
+                return
+            start = time.monotonic()
+            while not _stop_heartbeat.wait(timeout=30.0):
+                try:
+                    cb = _get_activity_callback()
+                    if cb:
+                        elapsed = int(time.monotonic() - start)
+                        cb(
+                            "running cron job %r (%ds elapsed)"
+                            % (job.get("name", job_id), elapsed)
+                        )
+                except Exception:
+                    pass
+
+        hb_thread = threading.Thread(
+            target=_heartbeat_loop,
+            daemon=True,
+            name=f"cron-heartbeat-{job_id[:8]}",
+        )
+        hb_thread.start()
+        try:
+            # run_one_job records last_run_at/last_status via mark_job_run
+            # (which also clears the fire claim) and returns True iff it
+            # processed the job.
+            processed = run_one_job(job)
+        finally:
+            _stop_heartbeat.set()
+            hb_thread.join(timeout=5)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {


### PR DESCRIPTION
## Summary

When `cronjob(action="run")` executes a job synchronously, the parent agent's inactivity watchdog sees no activity for the entire job duration (which can be hours for long-running cron jobs). The gateway's `agent_timeout` (default 1800s) then kills the calling turn, losing any work in progress.

The job itself completes fine — the user just loses the turn that triggered it.

## Root Cause

`_execute_job_now()` calls `run_one_job(job)` synchronously on the caller's thread. During the entire execution, no activity is reported to `_touch_activity()`, so the watchdog (which checks `_last_activity_ts`) concludes the agent is stuck.

## Fix

Spawn a daemon heartbeat thread in `_execute_job_now` that ticks the parent agent's activity callback every 30 seconds while `run_one_job` executes. The thread uses the same `_get_activity_callback()` mechanism that terminal commands use for their own watchdog avoidance (see `tools/environments/base.py:touch_activity_if_due`).

The heartbeat thread is always cleaned up in a `finally` block — regardless of job success or failure.

## Changes

- `tools/cronjob_tools.py`: Add `threading` and `time` imports; wrap `run_one_job()` call in heartbeat thread with `try/finally` cleanup.

## Test Plan

- [ ] Create a cron job that takes >30 minutes to execute
- [ ] Call `cronjob(action="run", job_id=...)` from a chat turn
- [ ] Verify the parent turn survives past 1800s without watchdog kill
- [ ] Verify heartbeat messages appear in logs (activity callback)
- [ ] Verify the heartbeat thread stops after job completes

Fixes #76502