### PR TITLE
fix(vision): preprocess images before native image_input_mode (#76505)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2545,9 +2545,10 @@ def try_shrink_image_parts_in_messages(
     api_messages: list,
     *,
     max_dimension: int = 8000,
+    max_pixels: Optional[int] = None,
 ) -> bool:
     """Re-encode all native image parts at a smaller size to recover from
-    image-too-large errors (Anthropic 5 MB, unknown other providers).
+    image-too-large errors (Anthropic 5 MB, Qwen VL max_pixels, others).
 
     Mutates ``api_messages`` in place. Returns True if any image part was
     actually replaced, False if there were no image parts to shrink or
@@ -2557,8 +2558,11 @@ def try_shrink_image_parts_in_messages(
     ``data:image/...;base64,...`` payload, plus Anthropic-native
     ``{"type": "image", "source": {"type": "base64", ...}}`` blocks.
     For each one whose encoded size exceeds 4 MB (a safe target that slides
-    under Anthropic's 5 MB ceiling with header overhead) or whose longest side
-    exceeds ``max_dimension``, write the base64 to a tempfile, call
+    under Anthropic's 5 MB ceiling with header overhead), whose longest side
+    exceeds ``max_dimension``, or whose total pixel count exceeds
+    ``max_pixels`` (Qwen2.5/3-VL processors reject images above their
+    ``max_pixels`` budget — default 1,505,280 px — even when bytes and the
+    per-side cap are fine), write the base64 to a tempfile, call
     ``vision_tools._resize_image_for_vision`` to produce a smaller data
     URL, and substitute it in place.
 
@@ -2633,16 +2637,20 @@ def try_shrink_image_parts_in_messages(
         triggered_by = "bytes" if needs_shrink else None
         if not needs_shrink:
             # Bytes are fine — check pixel dimensions against the provider's
-            # reported per-side cap.  A screenshot can be tiny in bytes yet
-            # too large in pixels.
+            # reported per-side cap AND (when present) its total-pixel budget.
+            # A screenshot can be tiny in bytes yet too large in pixels; a
+            # wide-but-short image can be under the per-side cap yet over the
+            # pixel budget (5120x1440: 7.4M px vs Qwen's 1,505,280).
             dims = _decode_pixels(url)
             if dims is None:
                 # Pillow missing or corrupt data — fall back to byte-only.
                 return None, False
-            if max(dims) <= max_dimension:
-                return None, False  # both bytes and pixels are within limits
+            within_dim = max(dims) <= max_dimension
+            within_pixels = max_pixels is None or dims[0] * dims[1] <= max_pixels
+            if within_dim and within_pixels:
+                return None, False  # bytes, per-side and pixel budget all OK
             needs_shrink = True
-            triggered_by = "dimension"
+            triggered_by = "dimension" if not within_dim else "pixels"
 
         try:
             header, _, data = url.partition(",")
@@ -2668,6 +2676,7 @@ def try_shrink_image_parts_in_messages(
                     mime_type=mime,
                     max_base64_bytes=target_bytes,
                     max_dimension=max_dimension,
+                    max_pixels=max_pixels,
                 )
             finally:
                 try:
@@ -2677,32 +2686,44 @@ def try_shrink_image_parts_in_messages(
             if not resized:
                 # Resize returned nothing — Pillow couldn't help.
                 return None, True
+
+            def _within_limits(dims: tuple) -> bool:
+                """True when a decoded (w, h) satisfies every active pixel constraint."""
+                w, h = dims
+                if max(w, h) > max_dimension:
+                    return False
+                if max_pixels is not None and w * h > max_pixels:
+                    return False
+                return True
+
             if triggered_by == "bytes":
                 # Byte budget is the binding constraint — bytes must shrink.
                 if len(resized) >= len(url):
                     return None, True  # re-encode made it bigger
-                # The per-side dimension cap is ALSO an active provider
-                # constraint on this request (the caller passes the parsed cap
-                # to both this helper and the resizer).  _resize_image_for_vision
-                # returns a best-effort, possibly-over-cap blob when it
-                # exhausts its halving budget — it freezes the long side once
-                # the short side hits its 64px floor, so a very-high-aspect
-                # image can stay over the cap even after bytes shrank.  If the
-                # output is still over the cap, retrying would re-400 on
-                # dimensions; treat it as unshrinkable.  (Skip when dims can't
-                # be decoded — preserves historical byte-only behaviour.)
+                # The per-side dimension cap and total-pixel budget are ALSO
+                # active provider constraints on this request (the caller
+                # passes them to both this helper and the resizer).
+                # _resize_image_for_vision returns a best-effort, possibly
+                # over-cap blob when it exhausts its halving budget — it
+                # freezes the long side once the short side hits its 64px
+                # floor, so a very-high-aspect image can stay over the cap
+                # even after bytes shrank.  If the output is still over any
+                # pixel constraint, retrying would re-400; treat it as
+                # unshrinkable.  (Skip when dims can't be decoded — preserves
+                # historical byte-only behaviour.)
                 new_dims = _decode_pixels(resized)
-                if new_dims is not None and max(new_dims) > max_dimension:
+                if new_dims is not None and not _within_limits(new_dims):
                     return None, True
                 return resized, False
-            # triggered_by == "dimension": the per-side cap is binding.  The
-            # re-encode may have grown in bytes; accept it as long as it is now
-            # within the dimension cap.  Verify the new dimensions when we can.
+            # triggered_by in {"dimension", "pixels"}: a pixel constraint is
+            # binding.  The re-encode may have grown in bytes; accept it as
+            # long as every pixel constraint is now satisfied.  Verify the
+            # new dimensions when we can.
             new_dims = _decode_pixels(resized)
             if new_dims is not None:
-                if max(new_dims) <= max_dimension:
+                if _within_limits(new_dims):
                     return resized, False
-                # Still over the per-side cap — the resize didn't satisfy it.
+                # Still over a pixel constraint — the resize didn't satisfy it.
                 return None, True
             # Couldn't verify the re-encode's dimensions (corrupt output or
             # Pillow gone mid-call).  Fall back to the historical "bytes must

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -272,6 +272,40 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+# Qwen2.5/3-VL processor default ``max_pixels`` budget (1920*28*28).  vLLM's
+# Qwen3VLProcessor rejects images above this with a 400 that carries NO
+# dimension cap — only the "Failed to apply Qwen3VLProcessor" wording — so
+# the shrink retry needs an explicit total-pixel budget, not just a per-side
+# cap.  A 5120x1440 multi-monitor screenshot is 7.4M px: under the 8000px
+# per-side default but ~5x over the pixel budget (#76505).
+_QWEN_VL_MAX_PIXELS = 1_505_280
+
+
+def _image_error_max_pixels(error: Exception) -> Optional[int]:
+    """Extract a provider-reported total-pixel budget, if present.
+
+    Only Qwen-style processor rejections carry a pixel budget today; the
+    wording identifies the family ("Failed to apply Qwen3VLProcessor on
+    data=...").  Returns None for every other error shape — the shrink path
+    then falls back to its byte-size / per-side-dimension heuristics.
+    """
+    parts = []
+    for value in (
+        error,
+        getattr(error, "message", None),
+        getattr(error, "body", None),
+    ):
+        if value:
+            try:
+                parts.append(str(value))
+            except Exception:
+                pass
+    text = " ".join(parts).lower()
+    if "qwen3vlprocessor" not in text:
+        return None
+    return _QWEN_VL_MAX_PIXELS
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -3802,9 +3836,14 @@ def run_conversation(
                 ):
                     _retry.image_shrink_retry_attempted = True
                     image_max_dimension = _image_error_max_dimension(api_error) or 8000
+                    # Qwen-style processor rejections also carry a total-pixel
+                    # budget (max_pixels) that the per-side cap alone can't
+                    # express — pass it through so the shrink can satisfy it.
+                    image_max_pixels = _image_error_max_pixels(api_error)
                     if agent._try_shrink_image_parts_in_messages(
                         api_messages,
                         max_dimension=image_max_dimension,
+                        max_pixels=image_max_pixels,
                     ):
                         agent._vprint(
                             f"{agent.log_prefix}📐 Image(s) exceeded provider size limit — "

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -241,6 +241,13 @@ _IMAGE_TOO_LARGE_PATTERNS = [
     "image dimensions exceed",  # Anthropic: "image dimensions exceed max allowed size: 8000 pixels"
     "dimensions exceed max allowed size",  # Anthropic dimension-cap (wording variant)
     "max allowed size: 8000",  # Anthropic dimension-cap (explicit pixel ceiling)
+    # Qwen2.5/3-VL processors (incl. vLLM's Qwen3VLProcessor) hard-fail with
+    # a 400 when an image exceeds the processor's ``max_pixels`` budget
+    # (default 1920*28*28 = 1,505,280 px): "Failed to apply Qwen3VLProcessor
+    # on data=...".  Classifying it as image_too_large lets the shrink-retry
+    # loop fire instead of falling all the way back to the text-mode
+    # ``vision_analyze`` path (#76505).
+    "failed to apply qwen3vlprocessor",  # vLLM Qwen3-VL processor rejection
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
 ]

--- a/run_agent.py
+++ b/run_agent.py
@@ -6374,12 +6374,14 @@ class AIAgent:
         api_messages: list,
         *,
         max_dimension: int = 8000,
+        max_pixels: Optional[int] = None,
     ) -> bool:
         """Forwarder — see ``agent.conversation_compression.try_shrink_image_parts_in_messages``."""
         from agent.conversation_compression import try_shrink_image_parts_in_messages
         return try_shrink_image_parts_in_messages(
             api_messages,
             max_dimension=max_dimension,
+            max_pixels=max_pixels,
         )
 
     def _try_strip_image_parts_from_tool_messages(

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -22,7 +22,7 @@ import sys
 from types import SimpleNamespace
 
 
-from agent.conversation_loop import _image_error_max_dimension
+from agent.conversation_loop import _image_error_max_dimension, _image_error_max_pixels
 from agent.error_classifier import FailoverReason, classify_api_error
 
 
@@ -53,6 +53,45 @@ class TestImageTooLargeClassification:
         assert result.reason == FailoverReason.image_too_large
         assert result.retryable is True
 
+    def test_qwen3vlprocessor_400_classified_image_too_large(self):
+        """vLLM's Qwen3VLProcessor rejection (#76505) must classify as
+        image_too_large so the shrink-retry loop fires instead of falling all
+        the way back to the text-mode ``vision_analyze`` path."""
+        err = _FakeApiError(
+            status_code=400,
+            message=(
+                "Failed to apply Qwen3VLProcessor on data={'text': '...', "
+                "'images': [<PIL.Image.Image image mode=RGB size=5120x1440 "
+                "at 0x7607095144D0>]} with kwargs={'return_tensors': 'pt'}"
+            ),
+        )
+        result = classify_api_error(err, provider="vllm", model="qwen3-vl-72b")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
+
+
+class TestImageErrorMaxPixels:
+    """``_image_error_max_pixels`` derives the total-pixel budget from the error."""
+
+    def test_qwen3vlprocessor_error_yields_default_pixel_budget(self):
+        err = _FakeApiError(
+            status_code=400,
+            message="Failed to apply Qwen3VLProcessor on data={'text': '...'}",
+        )
+        assert _image_error_max_pixels(err) == 1_505_280
+
+    def test_qwen_wording_in_body_yields_budget(self):
+        err = _FakeApiError(
+            status_code=400,
+            message="vLLM error 400",
+            body={"error": {"message": "Failed to apply Qwen3VLProcessor on data=..."}},
+        )
+        assert _image_error_max_pixels(err) == 1_505_280
+
+    def test_non_qwen_error_returns_none(self):
+        err = _FakeApiError(status_code=400, message="image exceeds 5 MB maximum")
+        assert _image_error_max_pixels(err) is None
+
 
 
 
@@ -66,6 +105,34 @@ def _big_png_data_url(size_kb: int) -> str:
     # Use real PNG header so MIME detection works; fill to target size.
     raw = b"\x89PNG\r\n\x1a\n" + b"X" * (size_kb * 1024)
     return "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _make_real_image_data_url(width: int, height: int, fmt: str) -> str:
+    """Build a real, Pillow-decodable data URL of the given size/format."""
+    import io as _io
+
+    from PIL import Image as _PILImage
+
+    buf = _io.BytesIO()
+    if fmt == "GIF":
+        img = _PILImage.new("P", (width, height), 0)
+    else:
+        img = _PILImage.new("RGB", (width, height), (120, 40, 200))
+    img.save(buf, format=fmt)
+    raw = buf.getvalue()
+    mime = {"PNG": "image/png", "GIF": "image/gif", "JPEG": "image/jpeg"}[fmt]
+    return f"data:{mime};base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _decoded_dimensions(data_url: str) -> tuple:
+    """Return ``(width, height)`` decoded from a base64 data URL via Pillow."""
+    import io as _io
+
+    from PIL import Image as _PILImage
+
+    _, _, b64 = data_url.partition(",")
+    with _PILImage.open(_io.BytesIO(base64.b64decode(b64))) as im:
+        return im.size
 
 
 def _install_fake_pillow(
@@ -160,7 +227,7 @@ class TestShrinkImagePartsHelper:
         oversized_url = _big_png_data_url(5000)  # ~5 MB raw → ~6.7 MB b64
         shrunk = "data:image/jpeg;base64," + "A" * 1000  # small
 
-        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None):
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None, max_pixels=None):
             return shrunk
 
         monkeypatch.setattr(
@@ -190,7 +257,7 @@ class TestShrinkImagePartsHelper:
         shrunk = "data:image/jpeg;base64," + "N" * 1000
         seen = {}
 
-        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None):
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None, max_pixels=None):
             seen["mime_type"] = mime_type
             seen["max_dimension"] = max_dimension
             return shrunk
@@ -226,6 +293,103 @@ class TestShrinkImagePartsHelper:
         assert source["type"] == "base64"
         assert source["media_type"] == "image/jpeg"
         assert source["data"] == "N" * 1000
+
+
+    def test_max_pixels_forwarded_to_resizer(self, monkeypatch):
+        """The Qwen pixel budget must reach ``_resize_image_for_vision``."""
+        agent = _make_agent()
+        oversized = _big_png_data_url(5000)
+        seen = {}
+
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None,
+                         max_dimension=None, max_pixels=None):
+            seen["max_pixels"] = max_pixels
+            return "data:image/jpeg;base64," + "Z" * 500
+
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            _fake_resize,
+            raising=False,
+        )
+
+        msgs = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": oversized}}],
+        }]
+        assert agent._try_shrink_image_parts_in_messages(
+            msgs, max_pixels=1_505_280,
+        ) is True
+        assert seen["max_pixels"] == 1_505_280
+
+    def test_pixel_budget_trigger_shrinks_reported_qwen_shape(self):
+        """The #76505 reported shape (5120x1440) is under the 4 MB byte budget
+        and under the 8000px per-side default, so the historical shrink never
+        fired for it.  With ``max_pixels=1_505_280`` (Qwen3VLProcessor's
+        budget) the pixel trigger fires and the re-encode lands within the
+        budget — validating the reactive retry against the reported shape."""
+        agent = _make_agent()
+        png_url = _make_real_image_data_url(5120, 1440, "PNG")
+        assert len(png_url) < 4 * 1024 * 1024  # byte budget is not binding
+        msgs = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": png_url}}],
+        }]
+        changed = agent._try_shrink_image_parts_in_messages(
+            msgs,
+            max_dimension=8000,
+            max_pixels=1_505_280,
+        )
+        assert changed is True
+        new_url = msgs[0]["content"][0]["image_url"]["url"]
+        w, h = _decoded_dimensions(new_url)
+        assert w * h <= 1_505_280
+        assert max(w, h) <= 8000
+
+    def test_pixel_budget_still_over_after_resize_blocks_retry(self, monkeypatch):
+        """A pixel-oversized image whose re-encode stays over the budget is
+        unshrinkable — retrying would re-send the same rejected payload."""
+        agent = _make_agent()
+        # Original AND re-encode both decode to 5120x1440 (over the budget).
+        _install_fake_pillow(monkeypatch, (5120, 1440))
+        url = _big_png_data_url(100)
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda *a, **kw: url,  # echoes the still-oversized payload
+            raising=False,
+        )
+
+        msgs = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": url}}],
+        }]
+        assert agent._try_shrink_image_parts_in_messages(
+            msgs, max_pixels=1_505_280,
+        ) is False
+        # Original left in place — caller surfaces the provider's 400.
+        assert msgs[0]["content"][0]["image_url"]["url"] == url
+
+    def test_oversized_gif_mime_matches_decoded_format(self):
+        """Regression for the GIF MIME mismatch flagged in PR #76525 review:
+        an oversized GIF shrunk through the reactive path must declare a
+        data-URL MIME that matches the decoded output format (GIF → JPEG
+        normalization), never a stale ``image/gif`` label on JPEG bytes."""
+        agent = _make_agent()
+        gif_url = _make_real_image_data_url(5000, 2000, "GIF")
+        msgs = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": gif_url}}],
+        }]
+        changed = agent._try_shrink_image_parts_in_messages(
+            msgs,
+            max_dimension=2000,  # 5000px side trips the dimension trigger
+        )
+        assert changed is True
+        new_url = msgs[0]["content"][0]["image_url"]["url"]
+        header, _, b64 = new_url.partition(",")
+        declared_mime = header[len("data:"):].split(";", 1)[0]
+        assert declared_mime == "image/jpeg"  # normalized, not stale image/gif
+        decoded = base64.b64decode(b64)
+        assert decoded[:2] == b"\xff\xd8"  # actual JPEG magic — MIME matches bytes
 
 
     def test_multiple_images_all_shrunk(self, monkeypatch):
@@ -347,7 +511,7 @@ class TestShrinkImagePartsHelper:
         dimensionally_shrunk = "data:image/png;base64," + "G" * 200 * 1024
         seen = {}
 
-        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None):
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None, max_pixels=None):
             seen["max_dimension"] = max_dimension
             return dimensionally_shrunk
 
@@ -425,7 +589,7 @@ class TestShrinkImagePartsHelper:
         second = _big_png_data_url(90)
         calls = {"n": 0}
 
-        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None):
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None, max_pixels=None):
             calls["n"] += 1
             if calls["n"] == 1:
                 return "data:image/png;base64," + "G" * 200 * 1024  # in-cap

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -624,7 +624,8 @@ def _image_exceeds_dimension(image_path: Path, max_dimension: int) -> bool:
 
 def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                               max_base64_bytes: int = _RESIZE_TARGET_BYTES,
-                              max_dimension: Optional[int] = None) -> str:
+                              max_dimension: Optional[int] = None,
+                              max_pixels: Optional[int] = None) -> str:
     """Convert an image to a base64 data URL, auto-resizing if too large.
 
     Tries Pillow first to progressively downscale oversized images.  If Pillow
@@ -636,6 +637,11 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
             count are forcibly downscaled even if they're under the byte
             budget.  Anthropic enforces an 8000 px per-side cap independently
             of the 5 MB byte cap.
+        max_pixels: If set, images whose total pixel count (width * height)
+            exceeds this budget are forcibly downscaled even when bytes and
+            the per-side cap are fine.  Qwen2.5/3-VL processors (incl. vLLM's
+            Qwen3VLProcessor) reject images above their ``max_pixels``
+            default (1,505,280) with a 400 (#76505).
 
     Returns the base64 data URL string.
     """
@@ -656,7 +662,20 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         except Exception:
             pass  # can't check; Pillow path below will handle or skip
 
-    if not needs_resize_for_bytes and not needs_resize_for_dims:
+    # Total-pixel budget (e.g. Qwen VL max_pixels): a wide-but-short image can
+    # be under the per-side cap yet over the pixel budget (5120x1440 = 7.4M px).
+    needs_resize_for_pixels = False
+    if max_pixels is not None:
+        try:
+            from PIL import Image as _PILQuick
+            with _PILQuick.open(image_path) as _quick_img:
+                _qw, _qh = _quick_img.size
+                if _qw * _qh > max_pixels:
+                    needs_resize_for_pixels = True
+        except Exception:
+            pass  # can't check; Pillow path below will handle or skip
+
+    if not needs_resize_for_bytes and not needs_resize_for_dims and not needs_resize_for_pixels:
         # Small enough — just encode directly.
         data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
         if len(data_url) <= max_base64_bytes:
@@ -717,10 +736,12 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
     candidate = None  # will be set on first loop iteration
 
     def _dims_ok(w: int, h: int) -> bool:
-        """True if both pixel dimensions are within the limit."""
-        if max_dimension is None:
-            return True
-        return max(w, h) <= max_dimension
+        """True if both pixel dimensions and the total-pixel budget are within the limit."""
+        if max_dimension is not None and max(w, h) > max_dimension:
+            return False
+        if max_pixels is not None and w * h > max_pixels:
+            return False
+        return True
 
     for attempt in range(5):
         if attempt > 0:


### PR DESCRIPTION
Closes #76505

## Problem

When `agent.image_input_mode: native` is set, the agent embeds local images at their **original resolution** with no dimension/size preprocessing. Qwen2.5/3-VL processors (including vLLM's `Qwen3VLProcessor`) hard-fail with an HTTP 400 (`Failed to apply Qwen3VLProcessor on data=...`) when an image exceeds the processor's `max_pixels` budget (default `1920*28*28 = 1,505,280` px). A 5120×1440 multi-monitor screenshot (7.4M px) trips this on every native request — and because the error was not classified as `FailoverReason.image_too_large`, the existing shrink-retry loop never fired, so the turn fell all the way back to the text-mode `vision_analyze` path (which then succeeds with the same image).

## Fix (reactive, quality-preserving)

Follows the existing native-path philosophy: images are delivered at **full resolution** and only resized *after* a provider actually rejects them (see the policy note at `agent/image_routing.py:509-521`). No unconditional caps are applied to the native path — providers that accept large images (OpenAI, Gemini) keep full-res pixels, and `agent/image_routing.py` carries no diff vs `main`.

1. **`agent/error_classifier.py`** — classify the Qwen rejection wording (`Failed to apply Qwen3VLProcessor`) as `FailoverReason.image_too_large`, so the shrink-retry loop fires instead of falling through to the text-mode fallback.
2. **Pixel-budget-aware shrink** (`agent/conversation_loop.py`, `agent/conversation_compression.py`, `run_agent.py`, `tools/vision_tools.py`) — the reported shape is 5120×1440: under the 4 MB byte budget and under the 8000px per-side cap, so the *existing* shrink heuristics would not fire for it (and a byte-driven shrink can produce a ≤4 MB JPEG that still exceeds `max_pixels`). The recovery now derives a total-pixel budget from Qwen-style errors (`_image_error_max_pixels` → 1,505,280) and threads it through `try_shrink_image_parts_in_messages` → `_resize_image_for_vision` so the retried request lands inside the processor's pixel budget. Non-Qwen errors keep their previous byte/per-side behavior unchanged.
3. **GIF MIME consistency** — the earlier draft downscaled in `_file_to_data_url` and could emit PNG-normalized bytes under a stale `image/gif` MIME. That downscale is gone from the native path (full-res delivery restored). The surviving reactive shrink (`_resize_image_for_vision`) always declares the MIME that matches the re-encoded format (GIF → `image/jpeg`); a regression test asserts the declared data-URL MIME matches the decoded output format.

## Test coverage

- `5120×1440` (the reported case) — pixel-budget trigger shrinks it inside 1,505,280 px, validating the retry against the reported shape.
- Qwen3VLProcessor 400 → classified `image_too_large`, `retryable=True`.
- `_image_error_max_pixels` derives 1,505,280 from Qwen wording (exception message or body); `None` otherwise.
- Oversized GIF → shrink declares `image/jpeg` and the payload decodes as JPEG (MIME matches bytes).
- Existing byte/dimension shrink tests (incl. the #48013 regressions) unchanged and passing; `repro_48013_image_shrink_brick.py` still PASS.

## Notes

- Only local file attachments go through the native path; remote `http(s)://` image URLs are passed through verbatim (the provider fetches them server-side).
- The shrink-retry remains best-effort: if the resized image still can't satisfy the provider, the turn falls through to the existing error handling (`vision_analyze` text fallback), which already works with the same image.
