### PR TITLE
fix: close stranded MCP OAuth auth flows

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -198,6 +198,102 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
     await flow.aclose()
 
 
+@pytest.mark.asyncio
+async def test_httpx_timeout_closes_inner_flow_and_releases_lock(tmp_path, monkeypatch):
+    """HTTPX teardown after a transport timeout must release the SDK lock
+    and leave the cached provider reusable for the next request.
+
+    This is the deterministic reproduction of the keepalive-reconnect deadlock
+    reported in #38193/#49543/#31987: httpx closes our wrapper generator in its
+    ``finally`` block after a transport error, which must close the inner SDK
+    generator (and its ``anyio.Lock``) from the same task.
+
+    Drives ``httpx.AsyncClient(auth=provider)`` through a real
+    ``MockTransport``, forces a ``ReadTimeout`` on the first request, asserts
+    the lock is released, then proves the same provider handles a second
+    request successfully — matching the cached-provider reuse path that
+    wedges in production.
+
+    Adapted from PR #63495 (by @NaMinhyeok, salvaging @igorhvr's #38198 fix).
+    """
+    import httpx
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    attempts = 0
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        assert provider.context.lock.locked()
+        if attempts == 1:
+            raise httpx.ReadTimeout("forced OAuth transport timeout", request=request)
+        return httpx.Response(200, request=request)
+
+    async with httpx.AsyncClient(
+        auth=provider,
+        transport=httpx.MockTransport(handle_request),
+    ) as client:
+        with pytest.raises(httpx.ReadTimeout, match="forced OAuth transport timeout"):
+            await client.post("https://example.com/mcp")
+
+        # HTTPX closes the outer auth flow in a finally block. The Hermes
+        # bridge must close the delegated SDK generator in that same task so
+        # the anyio.Lock is released from its owning task.
+        assert not provider.context.lock.locked(), (
+            "after HTTPX teardown, the SDK auth lock must be released — "
+            "the inner generator's ``async with self.context.lock`` must "
+            "have unwound in the same task"
+        )
+
+        # The same cached provider must handle a subsequent request — this is
+        # the reconnect path that deadlocks when the lock stays held.
+        response = await client.post("https://example.com/mcp")
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert not provider.context.lock.locked()
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
     return None

--- a/tests/tools/test_mcp_oauth_generator_cleanup.py
+++ b/tests/tools/test_mcp_oauth_generator_cleanup.py
@@ -1,0 +1,406 @@
+"""Regression tests for MCP OAuth auth-flow generator cleanup.
+
+Field report (``hermes mcp login <server>`` against a real OAuth MCP server):
+
+1. Hermes printed the authorization URL (PKCE + loopback callback).
+2. The callback landed — the local server answered
+   ``<h2>Authorization Successful</h2>``.
+3. Login never completed. No tokens were written; the bounded wait timed out.
+4. The console showed ``GeneratorExit`` followed by
+   ``RuntimeError: The current task is not holding this lock`` raised from
+   ``mcp/client/auth/oauth2.py`` while closing ``async_auth_flow`` — as an
+   unretrieved task exception.
+5. ``hermes mcp test <server>`` still reported "no cached tokens found".
+
+Root cause: ``HermesMCPOAuthProvider.async_auth_flow`` bridges httpx's
+bidirectional auth-flow protocol onto the SDK's generator, but never closed
+the inner SDK generator. When httpx abandoned a flow mid-stream (cancelled
+request, connect timeout, reconnect) it called ``aclose()`` on our wrapper;
+the wrapper exited and left ``inner`` suspended inside
+``async with self.context.lock``. The garbage collector later handed ``inner``
+to asyncio's async-generator finalizer, which runs ``aclose()`` in a *different*
+task — and anyio's ``Lock.release()`` is task-bound, so it raised and
+``_owner_task`` stayed pointing at the dead flow.
+
+Net effect: ``context.lock`` was held forever, so every later auth flow for
+that server blocked on it indefinitely. That is the wedge — the OAuth callback
+succeeded but the token exchange behind the lock could never run.
+
+These tests drive the real bridge (no mocked provider) and assert the lock is
+released and a subsequent flow can proceed. Nothing here performs network I/O:
+``_prefetch_oauth_metadata`` is stubbed out and every HTTP response is
+synthesised.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_redirect(authorization_url: str) -> None:
+    return None
+
+
+async def _noop_callback() -> tuple[str, str]:
+    return "test-auth-code", "test-state"
+
+
+async def _build_provider(tmp_path, monkeypatch, name: str = "srv"):
+    """Build a real HermesMCPOAuthProvider backed by a temp HERMES_HOME."""
+    from mcp.shared.auth import (
+        OAuthClientInformationFull,
+        OAuthClientMetadata,
+        OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage(name)
+    # Seed tokens + client info so _initialize has state to load and the flow
+    # reaches the first ``yield request`` without registration round-trips.
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="seeded_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="seeded_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name=name,
+        server_url="https://example.invalid/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    # Keep the test hermetic: _initialize() would otherwise run live PRM/ASM
+    # discovery over the network because tokens exist but metadata does not.
+    async def _no_prefetch(self=provider) -> None:
+        return None
+
+    monkeypatch.setattr(provider, "_prefetch_oauth_metadata", _no_prefetch)
+    return provider
+
+
+def _fake_401(request):
+    import httpx
+
+    return httpx.Response(
+        401,
+        request=request,
+        headers={
+            "www-authenticate": (
+                'Bearer resource_metadata='
+                '"https://example.invalid/.well-known/oauth-protected-resource"'
+            )
+        },
+    )
+
+
+async def _drive_into_oauth_branch(provider):
+    """Start a flow and park it mid-OAuth, holding ``context.lock``.
+
+    Returns the live wrapper generator, suspended after yielding the SDK's
+    metadata-discovery request — exactly the state a cancelled login leaves
+    behind.
+    """
+    import httpx
+
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://example.invalid/mcp")
+    )
+    outbound = await flow.__anext__()
+    discovery_request = await flow.asend(_fake_401(outbound))
+    assert isinstance(discovery_request, httpx.Request)
+    assert provider.context.lock.locked(), (
+        "precondition: the SDK holds context.lock for the duration of the flow"
+    )
+    return flow
+
+
+async def _run_flow_to_completion(provider):
+    """Drive one non-401 flow start-to-finish and return the outbound request.
+
+    Every step stays inside the *calling* task, matching httpx's contract
+    (``_send_handling_auth`` drives one auth flow from a single task) — anyio's
+    ``Lock`` is task-bound, so splitting ``__anext__`` and ``asend`` across
+    tasks would fail for reasons unrelated to what these tests cover.
+    """
+    import httpx
+
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://example.invalid/mcp")
+    )
+    outbound = await flow.__anext__()
+    try:
+        await flow.asend(httpx.Response(200, request=outbound))
+    except StopAsyncIteration:
+        return outbound
+    raise AssertionError("flow did not finish on a 200 response")
+
+
+# ---------------------------------------------------------------------------
+# The wedge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_mid_flow_releases_the_sdk_auth_lock(tmp_path, monkeypatch):
+    """Abandoning a flow must not strand ``context.lock``.
+
+    Before the fix the wrapper dropped the inner SDK generator, which kept the
+    lock until GC finalized it off-task — where anyio refused the release and
+    the lock stayed held forever.
+    """
+    provider = await _build_provider(tmp_path, monkeypatch)
+    flow = await _drive_into_oauth_branch(provider)
+
+    await flow.aclose()
+
+    assert not provider.context.lock.locked(), (
+        "aclose() on the wrapper must close the inner SDK generator so its "
+        "``async with self.context.lock`` unwinds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flow_after_abandoned_login_does_not_wedge(tmp_path, monkeypatch):
+    """The user-visible symptom: the *next* auth flow must still run.
+
+    This is the wedge itself. With a stranded lock, the follow-up flow — the
+    one that would exchange the authorization code for tokens — blocks on
+    ``async with self.context.lock`` forever, so a successful OAuth callback
+    never produces cached tokens.
+    """
+    provider = await _build_provider(tmp_path, monkeypatch)
+    flow = await _drive_into_oauth_branch(provider)
+    await flow.aclose()
+
+    try:
+        outbound = await asyncio.wait_for(
+            _run_flow_to_completion(provider), timeout=5
+        )
+    except asyncio.TimeoutError:  # pragma: no cover — this is the bug
+        pytest.fail(
+            "second auth flow deadlocked on a stranded context.lock — "
+            "OAuth login would hang after a successful callback"
+        )
+    assert outbound.url.host == "example.invalid"
+
+
+@pytest.mark.asyncio
+async def test_cross_task_cleanup_is_silent_and_still_frees_the_lock(
+    tmp_path, monkeypatch
+):
+    """Closing the wrapper from another task must not raise or leave it locked.
+
+    This is the GC-finalizer shape: asyncio's async-generator finalizer runs
+    ``aclose()`` in a task that never acquired the lock. anyio's task-bound
+    ``release()`` raises ``RuntimeError: The current task is not holding this
+    lock`` there. That RuntimeError must be swallowed (it used to escape as an
+    unretrieved task exception) and the lock reclaimed anyway.
+    """
+    provider = await _build_provider(tmp_path, monkeypatch)
+    flow = await _drive_into_oauth_branch(provider)
+
+    # A separate task — like the async-generator finalizer — does the close.
+    closer = asyncio.create_task(flow.aclose())
+    await asyncio.wait_for(closer, timeout=5)
+
+    assert closer.exception() is None, (
+        "cross-task auth-flow cleanup must not surface the SDK's task-bound "
+        "lock RuntimeError"
+    )
+    assert not provider.context.lock.locked(), (
+        "a lock stranded by cross-task cleanup must be reclaimed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_garbage_collected_flow_emits_no_unhandled_task_exception(
+    tmp_path, monkeypatch
+):
+    """Dropping the wrapper entirely must not log an unretrieved task error.
+
+    Reproduces the console noise from the field report: ``GeneratorExit`` then
+    ``RuntimeError: The current task is not holding this lock``, surfaced via
+    the event loop's exception handler because the finalizer task's exception
+    was never retrieved.
+    """
+    import gc
+
+    provider = await _build_provider(tmp_path, monkeypatch)
+    flow = await _drive_into_oauth_branch(provider)
+
+    handled: list[dict] = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: handled.append(context))
+    try:
+        del flow
+        gc.collect()
+        # Let the finalizer task asyncio schedules for the dropped generator run.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    lock_errors = [
+        ctx for ctx in handled
+        if "not holding this lock" in str(ctx.get("exception", ""))
+    ]
+    assert not lock_errors, (
+        f"SDK generator-cleanup noise leaked to the event loop: {lock_errors}"
+    )
+    assert not provider.context.lock.locked(), (
+        "a GC-finalized auth flow must not leave context.lock held"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The happy path must be untouched
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_still_ends_with_stop_async_iteration(
+    tmp_path, monkeypatch
+):
+    """Adding cleanup must not change the non-401 completion contract.
+
+    httpx relies on ``StopAsyncIteration`` to know the flow is done and to
+    return the final response.
+    """
+    import httpx
+
+    provider = await _build_provider(tmp_path, monkeypatch)
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://example.invalid/mcp")
+    )
+    outbound = await flow.__anext__()
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=outbound))
+
+    assert not provider.context.lock.locked(), (
+        "a normally-completed flow releases the lock via the SDK's own unwind"
+    )
+    # Closing an exhausted generator is a no-op and must stay quiet.
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_repeated_flows_reuse_the_lock(tmp_path, monkeypatch):
+    """Back-to-back flows on one provider must all acquire the lock."""
+    provider = await _build_provider(tmp_path, monkeypatch)
+    for _ in range(3):
+        await asyncio.wait_for(_run_flow_to_completion(provider), timeout=5)
+        assert not provider.context.lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# _reclaim_stranded_auth_lock must never steal a live lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reclaim_ignores_a_lock_held_by_a_different_flow():
+    """Only the exact recorded owner is reclaimable.
+
+    A clean release either clears ``_owner_task`` or hands it to a waiter, so
+    the identity check is what keeps the reclaim from stealing a lock held by
+    a genuinely concurrent auth flow.
+    """
+    import anyio
+
+    from tools.mcp_oauth_manager import _reclaim_stranded_auth_lock
+
+    lock = anyio.Lock()
+
+    async def _hold(started: asyncio.Event, release: asyncio.Event) -> None:
+        async with lock:
+            started.set()
+            await release.wait()
+
+    started, release = asyncio.Event(), asyncio.Event()
+    holder = asyncio.create_task(_hold(started, release))
+    await started.wait()
+
+    stale_owner = asyncio.current_task()  # never actually owned this lock
+    assert _reclaim_stranded_auth_lock(lock, stale_owner, server_name="srv") is False
+    assert lock.locked(), "a lock held by another running flow must be left alone"
+
+    release.set()
+    await holder
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_reclaim_is_a_noop_without_a_recorded_owner():
+    """No recorded owner (e.g. a plain ``asyncio.Lock``) means nothing to reclaim."""
+    import anyio
+
+    from tools.mcp_oauth_manager import _reclaim_stranded_auth_lock
+
+    assert _reclaim_stranded_auth_lock(None, None) is False
+    assert _reclaim_stranded_auth_lock(anyio.Lock(), None) is False
+    # Unlocked lock with an owner recorded from a prior flow: nothing to do.
+    assert _reclaim_stranded_auth_lock(anyio.Lock(), asyncio.current_task()) is False
+
+
+@pytest.mark.asyncio
+async def test_reclaim_hands_the_lock_to_a_waiting_flow():
+    """Reclaiming must not drop a queued waiter on the floor."""
+    import anyio
+
+    from tools.mcp_oauth_manager import _reclaim_stranded_auth_lock
+
+    lock = anyio.Lock()
+    await lock.acquire()
+    owner = asyncio.current_task()
+
+    acquired = asyncio.Event()
+
+    async def _waiter() -> None:
+        async with lock:
+            acquired.set()
+
+    waiting = asyncio.create_task(_waiter())
+    await asyncio.sleep(0)  # let the waiter queue up
+
+    assert _reclaim_stranded_auth_lock(lock, owner, server_name="srv") is True
+    await asyncio.wait_for(acquired.wait(), timeout=5)
+    await waiting
+    assert not lock.locked()

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -65,6 +65,58 @@ def _same_endpoint(a: str, b: str) -> bool:
     )
 
 
+def _reclaim_stranded_auth_lock(
+    lock: Any,
+    prior_owner: Any,
+    *,
+    server_name: str = "",
+) -> bool:
+    """Release an auth-flow lock stranded by cross-task generator cleanup.
+
+    anyio's asyncio ``Lock.release()`` is task-bound: it raises
+    ``RuntimeError("The current task is not holding this lock")`` unless the
+    *current* task is the recorded owner. When the MCP SDK's ``async_auth_flow``
+    generator is finalized from some other task, that release blows up and
+    ``_owner_task`` keeps pointing at the dead flow — every later auth flow for
+    the same provider then blocks on ``async with self.context.lock`` forever.
+
+    Reclaims only when the lock is still owned by exactly the task recorded
+    when this flow acquired it. A clean release either clears ``_owner_task``
+    or hands it to a waiting task, and both fail that identity check — so a
+    lock legitimately held by a concurrent flow is never stolen. Returns True
+    if the lock was reclaimed.
+    """
+    if lock is None or prior_owner is None:
+        return False
+    try:
+        if not lock.locked():
+            return False
+        if getattr(lock, "_owner_task", None) is not prior_owner:
+            return False
+        # Satisfy anyio's owner check, then release normally so a queued
+        # waiter (if any) is handed the lock instead of it going idle. If
+        # anyio's private owner field ever changes shape, leave the lock state
+        # exactly as found so a later, version-aware reclaim still has a shot.
+        lock._owner_task = asyncio.current_task()  # noqa: SLF001
+        try:
+            lock.release()
+        except Exception:
+            lock._owner_task = prior_owner  # noqa: SLF001
+            raise
+    except Exception as exc:  # pragma: no cover — defensive, must not throw
+        logger.debug(
+            "MCP OAuth '%s': could not reclaim stranded auth lock: %s",
+            server_name, exc,
+        )
+        return False
+    logger.warning(
+        "MCP OAuth '%s': reclaimed OAuth lock stranded by cross-task "
+        "auth-flow cleanup",
+        server_name,
+    )
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Per-server entry
 # ---------------------------------------------------------------------------
@@ -417,8 +469,15 @@ def _make_hermes_provider_class() -> Optional[type]:
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
             inner = super().async_auth_flow(request)
+            lock = getattr(self.context, "lock", None)
+            prior_lock_owner: Any = None
             try:
                 outgoing = await inner.__anext__()
+                # The SDK's flow opens with ``async with self.context.lock``,
+                # so once the first request is out the lock is held by *this*
+                # task. Record the owner: cleanup uses it to tell a clean
+                # release apart from one stranded by cross-task finalization.
+                prior_lock_owner = getattr(lock, "_owner_task", None)
                 while True:
                     incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
@@ -430,6 +489,70 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # 401 branch so a subsequent cold-load skips discovery.
                 self._persist_oauth_metadata_if_changed()
                 return
+            finally:
+                await self._close_inner_auth_flow(
+                    inner, lock, prior_lock_owner
+                )
+
+        async def _close_inner_auth_flow(
+            self,
+            inner: Any,
+            lock: Any,
+            prior_lock_owner: Any,
+        ) -> None:
+            """Close the SDK's auth-flow generator from *this* task.
+
+            httpx closes our wrapper (``await auth_flow.aclose()`` in
+            ``httpx._client._send_handling_auth``'s ``finally``) whenever a
+            request is cancelled or abandoned mid-flow — an OAuth login that
+            outran a connect timeout, a reconnect, an interrupt. Without this
+            cleanup the inner SDK generator was simply dropped while suspended
+            inside ``async with self.context.lock``: the garbage collector
+            later handed it to asyncio's async-generator finalizer, which runs
+            ``aclose()`` in a *different* task. Two consequences, both observed
+            in the wild:
+
+            1. ``GeneratorExit`` in ``mcp/client/auth/oauth2.py`` followed by
+               ``RuntimeError: The current task is not holding this lock``,
+               surfaced as unretrieved-task-exception noise on the console.
+            2. ``context.lock`` stayed permanently held, so every subsequent
+               auth flow for that server blocked on it forever. A successful
+               OAuth callback ("Authorization Successful") then never produced
+               tokens and ``hermes mcp login`` sat until its bounded timeout,
+               after which ``hermes mcp test`` still reported no cached tokens.
+
+            Closing ``inner`` here runs the SDK's ``async with`` unwind in the
+            task that acquired the lock, so the release succeeds. The reclaim
+            below is the belt-and-braces path for when our own wrapper was
+            itself finalized off-task.
+            """
+            # Outer try/finally so the reclaim still runs when aclose() raises
+            # a BaseException we deliberately let through (e.g. CancelledError).
+            try:
+                try:
+                    await inner.aclose()
+                except RuntimeError as exc:
+                    # Cross-task cleanup (our wrapper was GC-finalized rather
+                    # than closed by httpx) — the SDK's task-bound lock release
+                    # refuses. Swallow so it never escapes as an unhandled task
+                    # exception; the reclaim below keeps the provider usable.
+                    logger.debug(
+                        "MCP OAuth '%s': auth-flow cleanup raised "
+                        "(non-fatal): %s",
+                        self._hermes_server_name, exc,
+                    )
+                except Exception as exc:  # pragma: no cover — defensive
+                    logger.debug(
+                        "MCP OAuth '%s': auth-flow cleanup failed "
+                        "(non-fatal): %s",
+                        self._hermes_server_name, exc,
+                    )
+            finally:
+                _reclaim_stranded_auth_lock(
+                    lock,
+                    prior_lock_owner,
+                    server_name=self._hermes_server_name,
+                )
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
## Summary

Close the inner MCP SDK OAuth auth-flow generator when Hermes' wrapper is abandoned, cancelled, or timed out by HTTPX — and reclaim a stranded `anyio.Lock` when the wrapper itself is finalized from a different task.

This is the comprehensive fix for #38193 and the same class of failure reported in #49543 and #31987. It incorporates the strongest parts of both prior PRs (#38198 by @igorhvr, #63495 by @NaMinhyeok) while adding cross-task finalizer safety that neither covers.

## Root cause

`HermesMCPOAuthProvider.async_auth_flow` bridges httpx's bidirectional auth-flow protocol onto the SDK's generator. The SDK acquires an `anyio.Lock` (`self.context.lock`) at the top of its flow and holds it across every `yield`. When httpx closes our wrapper on transport failure, cancellation, or timeout, the inner SDK generator was simply dropped — still suspended inside `async with self.context.lock`.

Two consequences, both confirmed independently by multiple reporters (Granola, Databricks, Swiggy Instamart, Honeycomb, Reportify, gbrain):

1. Python's async-generator GC finalizer runs `aclose()` on the orphaned inner generator from a **different task**. anyio's task-bound `Lock.release()` raises `RuntimeError("The current task is not holding this lock")`, and `_owner_task` is never cleared.
2. `context.lock` stays permanently held. Every subsequent auth flow for that server blocks forever — a successful OAuth callback ("Authorization Successful") never produces tokens, `hermes mcp login` wedges, and `hermes mcp test` reports no cached tokens.

## What this PR does

**Production fix** (`tools/mcp_oauth_manager.py`):

- **`finally: await inner.aclose()`** — closes the inner SDK generator from the owning task, so the lock's `__aexit__` runs in the correct task and the release succeeds. (Same core mechanism as #38198/#63495.)
- **`_close_inner_auth_flow`** — wraps the above with exception handling for the cross-task case: when our own wrapper is GC-finalized off-task, the `inner.aclose()` itself hits the task-ownership RuntimeError. We swallow it (preventing the unretrieved-task-exception console noise) and fall through to the reclaim.
- **`_reclaim_stranded_auth_lock`** — belt-and-braces: if `inner.aclose()` couldn't release the lock (cross-task finalization), reclaim it by identity-checking `_owner_task` against the recorded prior owner. Only steals the lock when it's owned by the exact dead flow task; a lock held by a genuinely concurrent flow is never touched. Hands the lock to any queued waiter via the normal `release()` path.

**Regression tests** — organized so reviewers immediately see each scenario:

| Test | File | What it proves |
|------|------|----------------|
| `test_httpx_timeout_closes_inner_flow_and_releases_lock` | `test_mcp_oauth_bidirectional.py` | **(a)** Real HTTPX teardown path: `httpx.AsyncClient(auth=provider)` with `MockTransport`, forced `ReadTimeout`, lock released, provider reused with 200 |
| `test_aclose_mid_flow_releases_the_sdk_auth_lock` | `test_mcp_oauth_generator_cleanup.py` | **(b)** Wrapper `aclose()` releases lock |
| `test_flow_after_abandoned_login_does_not_wedge` | `test_mcp_oauth_generator_cleanup.py` | **(c)** Provider reuse after abandoned login — the user-visible wedge |
| `test_cross_task_cleanup_is_silent_and_still_frees_the_lock` | `test_mcp_oauth_generator_cleanup.py` | **(d)** Cross-task finalizer is silent and lock is reclaimed |
| `test_garbage_collected_flow_emits_no_unhandled_task_exception` | `test_mcp_oauth_generator_cleanup.py` | **(d')** GC-finalized flow produces no event-loop exception noise |
| `test_normal_completion_still_ends_with_stop_async_iteration` | `test_mcp_oauth_generator_cleanup.py` | **(e)** Normal bidirectional contract unchanged |
| `test_repeated_flows_reuse_the_lock` | `test_mcp_oauth_generator_cleanup.py` | **(e')** Back-to-back flows work |
| `test_reclaim_ignores_a_lock_held_by_a_different_flow` | `test_mcp_oauth_generator_cleanup.py` | Reclaim safety: concurrent flow's lock is never stolen |
| `test_reclaim_is_a_noop_without_a_recorded_owner` | `test_mcp_oauth_generator_cleanup.py` | Reclaim safety: no-op on missing owner |
| `test_reclaim_hands_the_lock_to_a_waiting_flow` | `test_mcp_oauth_generator_cleanup.py` | Reclaim correctness: queued waiter is handed the lock |

## Related issues and PRs

- Fixes #38193
- Related: #49543, #31987
- Supersedes #38198 (by @igorhvr — original fix; core `finally: await inner.aclose()` mechanism)
- Supersedes #63495 (by @NaMinhyeok — current-main salvage of #38198 with deterministic HTTPX timeout test)
- This PR incorporates both: @igorhvr's fix mechanism, @NaMinhyeok's deterministic HTTPX teardown test, plus cross-task finalizer handling and lock reclaim that neither covers.

## How this compares to the other PRs

| Capability | #38198 | #63495 | This PR |
|---|---|---|---|
| `finally: await inner.aclose()` | ✅ | ✅ | ✅ |
| Cross-task RuntimeError swallowed | ❌ | ❌ | ✅ |
| `_reclaim_stranded_auth_lock` | ❌ | ❌ | ✅ |
| Deterministic HTTPX teardown test | ❌ | ✅ | ✅ |
| Provider-reuse-after-abandon test | ❌ | ✅ (implicit) | ✅ (explicit) |
| Cross-task finalizer test | ❌ | ❌ | ✅ |
| GC-finalized noise suppression test | ❌ | ❌ | ✅ |
| Reclaim safety tests | ❌ | ❌ | ✅ |
| Normal-contract preservation tests | ❌ | ❌ | ✅ |

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## How to Test

1. Run the focused OAuth suite:
   ```bash
   scripts/run_tests.sh \
     tests/tools/test_mcp_oauth_generator_cleanup.py \
     tests/tools/test_mcp_oauth_bidirectional.py \
     tests/tools/test_mcp_oauth_metadata.py -q
   ```

2. Run the full MCP OAuth test surface:
   ```bash
   scripts/run_tests.sh tests/tools/test_mcp_oauth*.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_reconnect_signal.py -q
   ```

3. Static checks:
   ```bash
   python3 -m py_compile tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth_generator_cleanup.py tests/tools/test_mcp_oauth_bidirectional.py
   uv run ruff check tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth_generator_cleanup.py tests/tools/test_mcp_oauth_bidirectional.py
   git diff --check
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs; this PR explicitly consolidates #38198 and #63495 and preserves credit
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the bug — 10 tests covering every reported failure mode
- [x] I've tested on macOS arm64 with Python 3.11

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] Cross-platform impact considered; no platform-specific code
- [x] Tool descriptions/schemas update — N/A
