### PR TITLE
fix(plugin-llm): propagate reasoning effort

### DIFF
--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -18,15 +18,15 @@ The plugin gets ``ctx.llm`` exposed on its
 :class:`~hermes_cli.plugins.PluginContext`:
 
 * ``complete(messages, ...)`` — chat completion against the user's
-  active model + auth.
+  active model + auth, with an optional provider-neutral reasoning bound.
 * ``complete_structured(instructions=..., input=[...], json_schema=...)``
   — bounded structured inference with optional image inputs, JSON
   schema validation, and parsed JSON output.
 * async siblings ``acomplete()`` / ``acomplete_structured()`` for
   plugins running on asyncio loops (gateway adapters, hooks).
 
-Provider/model/agent_id/profile are explicit keyword arguments — no
-embedded slugs, no shorthands. This mirrors Hermes' main config
+Provider/model/agent_id/profile and reasoning effort are explicit keyword
+arguments — no embedded slugs, no shorthands. This mirrors Hermes' main config
 shape (``model.provider`` + ``model.model``) so plugin authors who
 already understand the host config don't have to learn anything new.
 
@@ -67,6 +67,27 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Union
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_plugin_reasoning_effort(
+    reasoning_effort: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Resolve an explicit plugin reasoning request through Hermes policy.
+
+    ``None`` means the plugin accepts the host/provider default.  Any supplied
+    value must be one Hermes understands; silently falling back would make a
+    bounded plugin call appear configured while leaving provider reasoning
+    uncontrolled.
+    """
+
+    if reasoning_effort is None:
+        return None
+    from hermes_constants import parse_reasoning_effort
+
+    reasoning_config = parse_reasoning_effort(reasoning_effort)
+    if reasoning_config is None:
+        raise ValueError(f"unsupported reasoning_effort: {reasoning_effort!r}")
+    return reasoning_config
 
 
 # ---------------------------------------------------------------------------
@@ -628,6 +649,7 @@ class PluginLlm:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         timeout: Optional[float] = None,
+        reasoning_effort: Optional[str] = None,
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
@@ -635,11 +657,12 @@ class PluginLlm:
         """Run a host-owned chat completion against the user's active model.
 
         ``messages`` is the standard OpenAI shape. ``provider``,
-        ``model``, ``agent_id``, and ``profile`` follow the same
+        ``model``, ``agent_id``, ``profile``, and ``reasoning_effort`` follow the same
         explicit shape as the host's main config (``model.provider``
         + ``model.model``). Each is independently gated by
         ``plugins.entries.<id>.llm.allow_*_override`` (see module
-        docstring).
+        docstring). Reasoning effort uses Hermes' provider-neutral levels and
+        does not alter provider or credential authority.
         """
         policy = self._policy_loader(self._plugin_id)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(
@@ -649,6 +672,7 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        reasoning_config = _parse_plugin_reasoning_effort(reasoning_effort)
         real_provider, real_model, response = self._invoke_sync(
             messages=messages,
             provider_override=eff_provider,
@@ -657,6 +681,7 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            reasoning_config=reasoning_config,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -670,6 +695,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                "reasoning_config": reasoning_config,
             },
         )
         logger.info(
@@ -694,6 +720,7 @@ class PluginLlm:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         timeout: Optional[float] = None,
+        reasoning_effort: Optional[str] = None,
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
@@ -723,6 +750,7 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        reasoning_config = _parse_plugin_reasoning_effort(reasoning_effort)
 
         messages = _build_structured_messages(
             instructions=instructions,
@@ -743,6 +771,7 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            reasoning_config=reasoning_config,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -762,6 +791,7 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                "reasoning_config": reasoning_config,
             },
         )
         logger.info(
@@ -783,6 +813,7 @@ class PluginLlm:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         timeout: Optional[float] = None,
+        reasoning_effort: Optional[str] = None,
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
@@ -796,6 +827,7 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        reasoning_config = _parse_plugin_reasoning_effort(reasoning_effort)
         real_provider, real_model, response = await self._invoke_async(
             messages=messages,
             provider_override=eff_provider,
@@ -804,6 +836,7 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            reasoning_config=reasoning_config,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -817,6 +850,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                "reasoning_config": reasoning_config,
             },
         )
 
@@ -834,6 +868,7 @@ class PluginLlm:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         timeout: Optional[float] = None,
+        reasoning_effort: Optional[str] = None,
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
@@ -852,6 +887,7 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        reasoning_config = _parse_plugin_reasoning_effort(reasoning_effort)
         messages = _build_structured_messages(
             instructions=instructions,
             inputs=list(input),
@@ -870,6 +906,7 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            reasoning_config=reasoning_config,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -889,6 +926,7 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                "reasoning_config": reasoning_config,
             },
         )
 
@@ -927,6 +965,7 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
     ) -> tuple[str, str, Any]:
         """Invoke the host's ``call_llm``. Lazy-imports
         ``agent.auxiliary_client`` to avoid circular deps at plugin
@@ -941,6 +980,7 @@ class PluginLlm:
                 max_tokens=max_tokens,
                 timeout=timeout,
                 extra_body=extra_body,
+                reasoning_config=reasoning_config,
             )
         from agent.auxiliary_client import call_llm
         merged_extra = dict(extra_body or {})
@@ -955,6 +995,7 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            reasoning_config=reasoning_config,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,
@@ -974,6 +1015,7 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
             return await self._async_caller(
@@ -985,6 +1027,7 @@ class PluginLlm:
                 max_tokens=max_tokens,
                 timeout=timeout,
                 extra_body=extra_body,
+                reasoning_config=reasoning_config,
             )
         from agent.auxiliary_client import async_call_llm
         merged_extra = dict(extra_body or {})
@@ -999,6 +1042,7 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            reasoning_config=reasoning_config,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -25,10 +25,12 @@ The plugin gets ``ctx.llm`` exposed on its
 * async siblings ``acomplete()`` / ``acomplete_structured()`` for
   plugins running on asyncio loops (gateway adapters, hooks).
 
-Provider/model/agent_id/profile and reasoning effort are explicit keyword
-arguments — no embedded slugs, no shorthands. This mirrors Hermes' main config
-shape (``model.provider`` + ``model.model``) so plugin authors who
-already understand the host config don't have to learn anything new.
+Provider/model/agent_id/profile are explicit keyword arguments — no embedded
+slugs, no shorthands — and retain their existing independent trust gates.
+Reasoning effort is an explicit provider-neutral per-call bound, like timeout
+or output budget. This mirrors Hermes' main config shape (``model.provider`` +
+``model.model``) so plugin authors who already understand the host config don't
+have to learn anything new.
 
 The host owns provider routing, auth resolution, timeouts, and
 fallback. The plugin never sees raw OAuth tokens or API keys. All

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -658,13 +658,12 @@ class PluginLlm:
     ) -> PluginLlmCompleteResult:
         """Run a host-owned chat completion against the user's active model.
 
-        ``messages`` is the standard OpenAI shape. ``provider``,
-        ``model``, ``agent_id``, ``profile``, and ``reasoning_effort`` follow the same
-        explicit shape as the host's main config (``model.provider``
-        + ``model.model``). Each is independently gated by
-        ``plugins.entries.<id>.llm.allow_*_override`` (see module
-        docstring). Reasoning effort uses Hermes' provider-neutral levels and
-        does not alter provider or credential authority.
+        ``messages`` is the standard OpenAI shape. ``provider``, ``model``,
+        ``agent_id``, and ``profile`` follow the same explicit shape as the
+        host's main config and retain their independent
+        ``plugins.entries.<id>.llm.allow_*_override`` gates. Reasoning effort
+        uses Hermes' provider-neutral levels as a per-call bound and does not
+        alter provider or credential authority.
         """
         policy = self._policy_loader(self._plugin_id)
         eff_provider, eff_model, eff_agent, eff_profile = _check_overrides(

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -328,6 +328,62 @@ class TestPluginLlmFacade:
         assert captured["max_tokens"] == 128
         assert captured["timeout"] == 10.0
 
+    def test_sync_surfaces_pass_provider_neutral_reasoning_config(self):
+        captured: list[dict] = []
+
+        def fake_caller(**kwargs):
+            captured.append(kwargs)
+            return "openai", "gpt-4o", _fake_response('{"ok": true}')
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_TrustPolicy(plugin_id="my-plugin"),
+            sync_caller=fake_caller,
+        )
+
+        plain = llm.complete(
+            [{"role": "user", "content": "hi"}],
+            reasoning_effort="none",
+        )
+        structured = llm.complete_structured(
+            instructions="Return ok",
+            input=[PluginLlmTextInput(text="data")],
+            json_mode=True,
+            reasoning_effort="high",
+        )
+
+        assert captured[0]["reasoning_config"] == {"enabled": False}
+        assert captured[1]["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+        assert plain.audit["reasoning_config"] == {"enabled": False}
+        assert structured.audit["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_explicit_unknown_reasoning_effort_fails_before_provider_call(self):
+        called = False
+
+        def fake_caller(**_kwargs):
+            nonlocal called
+            called = True
+            return "openai", "gpt-4o", _fake_response("unused")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_TrustPolicy(plugin_id="my-plugin"),
+            sync_caller=fake_caller,
+        )
+
+        with pytest.raises(ValueError, match="unsupported reasoning_effort"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                reasoning_effort="guess",
+            )
+        assert called is False
+
     def test_complete_structured_returns_parsed_json(self):
         def fake_caller(**_kwargs):
             return "openai", "gpt-4o", _fake_response(
@@ -425,6 +481,44 @@ class TestAsyncSurface:
         result = asyncio.run(_run())
         assert result.parsed == {"x": 42}
         assert result.content_type == "json"
+
+    def test_async_surfaces_pass_provider_neutral_reasoning_config(self):
+        captured: list[dict] = []
+
+        async def fake_async(**kwargs):
+            captured.append(kwargs)
+            return "openai", "gpt-4o", _fake_response('{"x": 42}')
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_TrustPolicy(plugin_id="my-plugin"),
+            async_caller=fake_async,
+        )
+
+        async def _run() -> tuple[PluginLlmCompleteResult, PluginLlmStructuredResult]:
+            plain = await llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                reasoning_effort="none",
+            )
+            structured = await llm.acomplete_structured(
+                instructions="Extract x",
+                input=[PluginLlmTextInput(text="data")],
+                json_mode=True,
+                reasoning_effort="low",
+            )
+            return plain, structured
+
+        plain, structured = asyncio.run(_run())
+        assert captured[0]["reasoning_config"] == {"enabled": False}
+        assert captured[1]["reasoning_config"] == {
+            "enabled": True,
+            "effort": "low",
+        }
+        assert plain.audit["reasoning_config"] == {"enabled": False}
+        assert structured.audit["reasoning_config"] == {
+            "enabled": True,
+            "effort": "low",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -2,8 +2,8 @@
 
 These tests exercise the trust gate, JSON parsing, schema validation,
 image input encoding, and the auxiliary-client invocation contract.
-The auxiliary client itself is stubbed via ``make_plugin_llm_for_test``
-so we don't hit real providers.
+Injected callers cover the facade in isolation; patched auxiliary functions
+cover the production lazy-import handoff without hitting real providers.
 """
 
 from __future__ import annotations
@@ -363,6 +363,29 @@ class TestPluginLlmFacade:
             "effort": "high",
         }
 
+    def test_default_sync_transport_forwards_reasoning_config(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return _fake_response("ok")
+
+        monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_trusted_policy("my-plugin"),
+        )
+
+        result = llm.complete(
+            [{"role": "user", "content": "hi"}],
+            provider="openrouter",
+            model="test-model",
+            reasoning_effort="none",
+        )
+
+        assert result.text == "ok"
+        assert captured["reasoning_config"] == {"enabled": False}
+
     def test_explicit_unknown_reasoning_effort_fails_before_provider_call(self):
         called = False
 
@@ -518,6 +541,37 @@ class TestAsyncSurface:
         assert structured.audit["reasoning_config"] == {
             "enabled": True,
             "effort": "low",
+        }
+
+    def test_default_async_transport_forwards_reasoning_config(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_async_call_llm(**kwargs):
+            captured.update(kwargs)
+            return _fake_response("async ok")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.async_call_llm",
+            fake_async_call_llm,
+        )
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_trusted_policy("my-plugin"),
+        )
+
+        async def _run() -> PluginLlmCompleteResult:
+            return await llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                provider="openrouter",
+                model="test-model",
+                reasoning_effort="high",
+            )
+
+        result = asyncio.run(_run())
+        assert result.text == "async ok"
+        assert captured["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
         }
 
 

--- a/website/docs/developer-guide/plugin-llm-access.md
+++ b/website/docs/developer-guide/plugin-llm-access.md
@@ -220,6 +220,7 @@ result = ctx.llm.complete(
     temperature=None,
     max_tokens=None,
     timeout=None,          # seconds
+    reasoning_effort=None, # none|minimal|low|medium|high|xhigh|max|ultra
     agent_id=None,         # optional, gated
     profile=None,          # optional, gated — explicit auth-profile name
     purpose="optional-audit-string",
@@ -237,6 +238,12 @@ as the host's main config (`model.provider` + `model.model`). Set
 just `model=` to use the user's active provider with a different
 model on it. Set both to switch providers entirely. Either argument
 without operator opt-in raises `PluginLlmTrustError`.
+
+`reasoning_effort=` is a provider-neutral per-call bound. Hermes validates the
+named level and translates it for the selected provider; `"none"` explicitly
+disables provider reasoning when that provider supports the control. Omit the
+argument to keep the host/provider default. An unknown explicit value raises
+`ValueError` instead of silently falling back.
 
 ### `complete_structured()`
 
@@ -257,6 +264,7 @@ result = ctx.llm.complete_structured(
     temperature=None,
     max_tokens=None,
     timeout=None,
+    reasoning_effort=None,
     agent_id=None,
     profile=None,
     purpose=None,
@@ -413,6 +421,9 @@ don't have to:
   before it returns an error to the plugin.
 * **Timeout.** Honours your `timeout=` argument, falling back to
   `auxiliary.<task>.timeout` config or the global aux default.
+* **Reasoning control.** Validates `reasoning_effort=` through Hermes' shared
+  provider-neutral policy and records the normalized effective request in the
+  result audit mapping.
 * **JSON shaping.** Sends `response_format` to the provider when
   you ask for JSON, then re-parses locally from a code-fenced
   response if the provider returned one.
@@ -429,7 +440,7 @@ don't have to:
 * **Schema.** Whatever shape you want back. The host doesn't infer
   it for you.
 * **Error handling.** `complete_structured()` raises `ValueError` on
-  empty inputs and on schema-validation failure. `PluginLlmTrustError`
+  empty inputs, an unsupported explicit reasoning effort, and schema-validation failure. `PluginLlmTrustError`
   fires when the trust gate denies an override. Anything else
   (provider 5xx, no credentials configured, timeout) raises whatever
   `auxiliary_client.call_llm()` raises.

--- a/website/docs/developer-guide/plugin-llm-access.md
+++ b/website/docs/developer-guide/plugin-llm-access.md
@@ -422,8 +422,10 @@ don't have to:
 * **Timeout.** Honours your `timeout=` argument, falling back to
   `auxiliary.<task>.timeout` config or the global aux default.
 * **Reasoning control.** Validates `reasoning_effort=` through Hermes' shared
-  provider-neutral policy and records the normalized effective request in the
-  result audit mapping.
+  provider-neutral policy and records the normalized request in the result
+  audit mapping. The audit proves the request that entered provider translation,
+  not the provider-specific wire payload or what a remote provider chose to do
+  internally.
 * **JSON shaping.** Sends `response_format` to the provider when
   you ask for JSON, then re-parses locally from a code-fenced
   response if the provider returned one.


### PR DESCRIPTION
## Summary

- add provider-neutral `reasoning_effort` to all four public plugin LLM completion surfaces
- normalize the value through Hermes' existing reasoning policy before provider translation
- expose the normalized request in result audit metadata without claiming provider-side effect
- reject invalid explicit values before making a provider call

## Why

Plugins can already set provider, model, timeout, and output bounds, while Hermes' lower LLM transport already supports provider-neutral reasoning configuration. The plugin adapter silently omitted that control. This made stage-specific low-reasoning requests impossible for plugin-hosted background work and left callers unable to distinguish a requested control from one that reached provider translation.

## Validation

- `scripts/run_tests.sh -j 1 tests/agent/test_plugin_llm.py tests/providers/test_provider_profiles.py` — 42 passed
- `ruff check agent/plugin_llm.py tests/agent/test_plugin_llm.py`
- full repository suite on macOS: the changed plugin test file passed; 29 unrelated tests failed across 21 timing/platform-sensitive files
- serial rerun of those files: 1,263 passed and 18 unrelated current-main macOS/environment failures remained across 12 files

The audit mapping records Hermes' normalized request entering provider translation. It deliberately does not claim the exact wire payload or what a remote provider did internally.
