### PR TITLE
fix(gateway): don't restart supervised services on clean exit

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -716,8 +716,12 @@ class S6ServiceManager:
         When the gateway exits with EX_CONFIG (78) — a fatal
         configuration error such as a token collision or no messaging
         platforms — we tell s6-supervise to stop restarting by exiting
-        125 (permanent failure).  Any other exit code lets s6 restart
-        normally.  See #51228.
+        125 (permanent failure).  A clean exit 0 is an intentional stop,
+        not a crash: restarting after it turns any normal gateway exit
+        into a reconnect loop (the ashriel-discord storm in #76435 —
+        1,000+ connections and a provider token reset).  Only non-zero,
+        non-78 exits (genuine crashes) let s6 restart normally.
+        See #51228, #76435.
         """
         from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 
@@ -727,7 +731,11 @@ class S6ServiceManager:
             "# shellcheck shell=sh\n"
             "# $1 = exit code from the run script.\n"
             f"# Exit {code} (EX_CONFIG) = fatal config error — don't restart.\n"
+            "# Exit 0 (clean stop) = intentional stop — don't restart.\n"
             f'if [ "$1" = "{code}" ]; then\n'
+            "  exit 125\n"
+            "fi\n"
+            'if [ "$1" = "0" ]; then\n'
             "  exit 125\n"
             "fi\n"
             "exit 0\n"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -286,6 +286,28 @@ def test_render_finish_script_exits_125_on_ex_config() -> None:
     assert "exit 0" in text
 
 
+def test_render_finish_script_does_not_restart_on_clean_exit(tmp_path) -> None:
+    """Behavioral: the rendered finish script, executed for each run-exit
+    code, must exit 125 (no restart) for clean exit 0 and EX_CONFIG 78,
+    and exit 0 (restart) for genuine crashes (#76435 — restart-on-normal-
+    exit turned a supervised gateway into a reconnect storm)."""
+    import subprocess
+
+    script = tmp_path / "finish"
+    script.write_text(S6ServiceManager._render_finish_script())
+    script.chmod(0o755)
+
+    def finish_exit(run_exit_code: int) -> int:
+        proc = subprocess.run(["sh", str(script), str(run_exit_code)],
+                              capture_output=True)
+        return proc.returncode
+
+    assert finish_exit(0) == 125   # clean stop — no restart
+    assert finish_exit(78) == 125  # fatal config — no restart
+    assert finish_exit(1) == 0     # crash — s6 restarts
+    assert finish_exit(137) == 0   # SIGKILL crash — s6 restarts
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

The s6 finish script for profile-gateway services restarted on ANY exit except EX_CONFIG (78) — including clean exit 0. Restart-on-normal-exit turns an intentional stop into a reconnect loop: the ashriel-discord storm in #76435 made 1,000+ connections and got the bot token reset by Discord. The finish script now exits 125 (permanent failure, no restart) for clean exit 0 as well; only non-zero, non-78 exits (genuine crashes) restart.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/76435

## Changes Made

- `fix/gateway-finish-restart-policy` — 2 file(s) changed vs base:
  - `hermes_cli/service_manager.py`
  - `tests/hermes_cli/test_service_manager.py`

hermes_cli/service_manager.py _render_finish_script(): add the exit-0 → 125 branch alongside the existing EX_CONFIG one; crash path (exit 0) unchanged. tests/hermes_cli/test_service_manager.py: new behavioral test executes the rendered script via sh for exit codes 0/78/1/137. Scope note: #76435 bundles a second symptom (Windows desktop updater showing the literal 'managed outside dashboard' sentinel) whose root cause is undiagnosed — #22733 covers the dialog-explanation path; this PR is the gateway half only. Design tension noted: #39381 (open) wants restart desired-up always — the maintainer picks the direction; the finish-script contract now encodes clean-stop ≠ crash.

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: pre-fix code fails the regression tests (1 failed), with the fix all pass (8 passed, 0 failed) — target `tests/hermes_cli/test_service_manager.py`.
2. Suite `tests/hermes_cli/`: branch 3925 passed / 31 failed vs baseline 3924 passed / 31 failed — zero branch-only failures.
3. Behavioral: rendered finish script executed via sh — exit 0 → 125 (no restart), 78 → 125 (no restart), 1 and 137 → 0 (restart). Pre-existing EX_CONFIG renderer test still passes (8/8 in tests/hermes_cli/test_service_manager.py). Full repo-wide suite NOT run locally (skipped by decision; CI owns full-suite validation).
4. Duplicate check: 49 potential matches reviewed — none covers this change.
5. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 7 passed, 1 failed
# head leg (with fix):
#   tests: 8 passed, 0 failed
```
