### PR TITLE
fix(cron): follow `.` as well as `source` in the lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -188,7 +188,12 @@ def _iter_referenced_shell_scripts(
         if index is None:
             continue
         executable = segment[index]
-        executable_name = Path(executable).name
+        # `Path(".").name` is the empty string, so deriving the name alone
+        # would make the `.` branch below unreachable and let POSIX
+        # dot-sourcing (`. helper.sh`) skip the scan entirely while its
+        # `source helper.sh` synonym is followed. Fall back to the raw token
+        # whenever `Path().name` yields nothing.
+        executable_name = Path(executable).name or executable
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -643,6 +643,23 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily", "restart.sh")
 
+    @pytest.mark.parametrize("source_verb", [".", "source"])
+    def test_sourced_script_is_scanned(self, tmp_path, source_verb):
+        """Both spellings of sourcing must be followed.
+
+        `.` and `source` are synonyms in bash, so a script that hides the
+        command one level down via `. helper.sh` has to be scanned the same
+        way `source helper.sh` is — otherwise the cheapest possible bypass is
+        a single character.
+        """
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        helper = tmp_path / "helper.sh"
+        helper.write_text("launchctl kickstart -k gui/501/ai.hermes.gateway\n")
+        entry = tmp_path / "entry.sh"
+        entry.write_text(f"#!/bin/bash\n{source_verb} {helper}\n")
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops job", str(entry))
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path


### PR DESCRIPTION
## What does this PR do?

`_iter_referenced_shell_scripts()` has a branch for POSIX sourcing:

```python
executable_name = Path(executable).name
if executable_name in {".", "source"}:
```

`Path(".").name` is the **empty string**, so that branch can never match `.` — only `source`. The two are synonyms in bash, so today a cron script (or an in-gateway terminal command) that hides the command one level down is scanned or not depending on a single character:

```bash
source /path/helper.sh   # helper.sh IS scanned  → blocked
. /path/helper.sh        # helper.sh is NOT scanned → allowed
```

with `helper.sh` containing `launchctl kickstart -k gui/501/ai.hermes.gateway`. Verified against `main`:

```python
>>> from cron.lifecycle_guard import _iter_referenced_shell_scripts as R
>>> list(R(". /tmp/helper.sh"))
[]                                    # nothing to scan
>>> list(R("source /tmp/helper.sh"))
[PosixPath('/tmp/helper.sh')]
```

That is a bypass of the guard added in #30719 / #62891, not just a cosmetic gap: `check_gateway_lifecycle("job", entry_sh)` returns cleanly for the `.` spelling.

### The fix

Fall back to the raw token when `Path().name` yields nothing:

```python
executable_name = Path(executable).name or executable
```

One line, at the point where the name is derived, so both `.` and any other token whose `Path().name` is empty reach the branches below intact. No detection pattern changes.

## Related Issue

No existing issue — found while reading the guard for a separate false-positive fix (#76507, independent: that one touches `_read_referenced_script`, this one touches `_iter_referenced_shell_scripts`; they do not conflict and can merge in either order).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (closes a one-character bypass of an existing guard)

## Changes Made

- `cron/lifecycle_guard.py` — `_iter_referenced_shell_scripts()`: `executable_name = Path(executable).name or executable`.
- `tests/hermes_cli/test_gateway_restart_loop.py` — `test_sourced_script_is_scanned`, parametrized over `.` and `source`, in `TestLifecycleGuardModule`.

## How to Test

```bash
mkdir -p /tmp/t && printf 'launchctl kickstart -k gui/501/ai.hermes.gateway\n' > /tmp/t/helper.sh
printf '#!/bin/bash\n. /tmp/t/helper.sh\n' > /tmp/t/entry.sh
python -c "from cron.lifecycle_guard import check_gateway_lifecycle; check_gateway_lifecycle('daily', '/tmp/t/entry.sh')"
# main:     exits 0  ← the bypass
# this PR:  GatewayLifecycleBlocked
```

Swapping `.` for `source` in `entry.sh` is blocked on both, which is what makes the parametrized test meaningful — the `source` case is the control that stays green while the `.` case goes red without the fix:

```
tests/hermes_cli/test_gateway_restart_loop.py (macOS 15, Python 3.11)
  with fix:     80 passed
  without fix:  1 failed, 1 passed   ← only test_sourced_script_is_scanned[.] fails
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Tests: the guard's own file passes — `tests/hermes_cli/test_gateway_restart_loop.py`, **86 passed** on my working checkout (80 on this branch alone). I am **not** claiming a clean full-suite run: `pytest tests/ -q` on my machine is ~24k tests / 35 min and ends `1016 failed, 23019 passed, 150 skipped, 10 errors`. Those failures look environment-dependent (network / API keys / system state — e.g. the tavily and website-policy suites) and this change touches only `cron/lifecycle_guard.py` (consumed by `cron/jobs.py`, `hermes_cli/cron.py`, `tools/terminal_tool.py`), but I have not yet run a with/without comparison to prove they are unrelated, so please treat CI as the authority here rather than my local numbers
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the fix carries an explanatory comment; no user-facing docs describe this internal branch
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: `Path(".").name` is `""` on every platform, so the branch is dead everywhere and the fix applies uniformly
- [x] N/A — no tool description or schema change

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
