### PR TITLE
fix: retry session DB flush during compression rotation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1963,12 +1963,54 @@ class AIAgent:
         messages: List[Dict],
         conversation_history: Optional[List[Dict]] = None,
     ):
-        """Serialize direct and turn-boundary session flushes per agent."""
+        """Serialize direct and turn-boundary session flushes per agent.
+
+        Compression owns the session for up to its lease TTL (300s); a flush
+        racing a rotation raises CompressionSessionBusyError (re-raised by the
+        unlocked flush below). Retry with bounded backoff so a transient
+        rotation doesn't drop the tail; marker-based dedup makes re-entry
+        idempotent. On final failure the deferred tail is retried by the next
+        flush — the existing crash-resilience path.
+        """
         persist_lock = getattr(self, "_session_persist_lock", None)
-        if persist_lock is None:
-            return self._flush_messages_to_session_db_unlocked(messages, conversation_history)
-        with persist_lock:
-            return self._flush_messages_to_session_db_unlocked(messages, conversation_history)
+
+        # ponytail: fixed 3 attempts / 2s-4s backoff; upgrade path: make
+        # configurable (config.yaml session.compression_flush_retries) if a
+        # workload needs tuning.
+        for attempt in range(1, 4):
+            try:
+                if persist_lock is None:
+                    return self._flush_messages_to_session_db_unlocked(messages, conversation_history)
+                with persist_lock:
+                    return self._flush_messages_to_session_db_unlocked(messages, conversation_history)
+            except Exception as e:
+                # Lazy import mirrors the existing SessionDB lazy import in
+                # _get_session_db (top-level import would pull hermes_state
+                # eagerly); isinstance is robust to subclassing.
+                from hermes_state import CompressionSessionBusyError
+                if not isinstance(e, CompressionSessionBusyError):
+                    raise
+                if attempt < 3:
+                    time.sleep(2.0 if attempt == 1 else 4.0)
+                    continue
+                self._log_db_flush_warning(
+                    f"Session DB flush deferred for {getattr(self, 'session_id', '?')} — "
+                    "compression busy after 3 attempts; unpersisted tail retries on next flush"
+                )
+                return None
+
+    def _log_db_flush_warning(self, message: str) -> None:
+        """Log a DB flush warning at most once per session per 60s window."""
+        now = time.time()
+        sid = getattr(self, "session_id", "?")
+        last_ts = getattr(self, "_last_db_flush_warn_ts", 0.0)
+        last_sid = getattr(self, "_last_db_flush_warn_sid", None)
+        if sid == last_sid and (now - last_ts) < 60:
+            logger.debug("DB flush warning suppressed (rate-limited): %s", message)
+            return
+        self._last_db_flush_warn_ts = now
+        self._last_db_flush_warn_sid = sid
+        logger.warning("%s", message)
 
     def _flush_messages_to_session_db_unlocked(
         self,
@@ -2232,7 +2274,14 @@ class AIAgent:
             # Force a full re-scan on the next flush: an exception mid-loop
             # leaves messages with mixed dispositions.
             self._db_flush_scan_prefix = None
-            logger.warning("Session DB append_message failed: %s", e)
+            # Re-raise compression-busy errors so the caller
+            # (_flush_messages_to_session_db) can retry with backoff. Any
+            # other failure is logged (rate-limited) and swallowed — the
+            # marker dedup retries unpersisted messages on the next flush.
+            from hermes_state import CompressionSessionBusyError
+            if isinstance(e, CompressionSessionBusyError):
+                raise
+            self._log_db_flush_warning(f"Session DB append_message failed: {e}")
             return False
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
## Problem

During session compression, the session DB flush can race the compression rotation. `CompressionSessionBusyError` is raised, logged as a warning, and the flush returns `False` — the un-persisted tail of messages is dropped if the process dies inside the compression window. Marker-based dedup means no loss in the normal case (the tail retries on the next flush), but the durability gap and per-message log spam are real: in a 48h lookback, a single session logged 2,595 "being compressed by another writer" warnings.

## Fix

- **`_flush_messages_to_session_db`** — bounded retry (3 attempts, 2s/4s backoff) on `CompressionSessionBusyError`, so a transient rotation doesn't drop the tail. On final failure, logs a single deferred warning and returns `None` (the existing crash-resilience path retries on next flush).
- **`_flush_messages_to_session_db_unlocked`** — re-raises `CompressionSessionBusyError` so the wrapper retry sees it (previously the exception was swallowed and logged per-message). Other failures still log and return `False`.
- **`_log_db_flush_warning`** — new helper, rate-limits DB flush warnings to once per session per 60s.

Fixes the whole bug class: any caller racing compression now retries instead of logging noise and dropping the tail.

## Verification

- `pytest tests/state/test_compression_lineage_guard.py tests/gateway/test_compression_concurrent_sessions.py` — 8/8 pass
- Chain tests (stubbed `session_db`): busy×2 → retry → persisted; always-busy → 3 attempts → single deferred warning; non-busy error → swallowed + logged (unchanged behavior); rate limiter suppresses 2nd warning <60s

## Notes

- `ponytail:` — retry params fixed (3 attempts / 2s-4s); configurable upgrade path noted in code if a workload needs tuning.
