### PR TITLE
fix(config): parse .env through pinned python-dotenv instead of hand-rolled parser (#76544)

### DIFF
--- a/contributors/emails/ethermandev@gmail.com
+++ b/contributors/emails/ethermandev@gmail.com
@@ -1,0 +1,2 @@
+etherman-os
+# PR #76545 contributor attribution

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3618,9 +3618,13 @@ def save_config(
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
-def _parse_env_value(raw_value: str) -> str:
-    """Parse the small .env value subset Hermes writes itself."""
-    value = raw_value.strip()
+def _unquote_env_value(value: str) -> Optional[str]:
+    """Unquote a fully-quoted .env value; ``None`` when not fully quoted.
+
+    Mirrors :func:`_quote_env_value` (the writer side): a value whose first
+    and last characters are matching quotes is unescaped. A ``#`` inside
+    the quotes is data, not a comment.
+    """
     if len(value) >= 2 and value[0] == value[-1] == '"':
         quoted = value[1:-1]
         parsed: list[str] = []
@@ -3638,6 +3642,50 @@ def _parse_env_value(raw_value: str) -> str:
         return "".join(parsed)
     if len(value) >= 2 and value[0] == value[-1] == "'":
         return value[1:-1]
+    return None
+
+
+def _parse_env_value(raw_value: str) -> str:
+    """Parse the small .env value subset Hermes writes itself.
+
+    Quoted values are unescaped and returned as-is (a ``#`` inside quotes
+    is data, not a comment). Unquoted values get any inline comment
+    stripped — a ``#`` preceded by whitespace starts a comment, matching
+    python-dotenv. Without this, lines like
+    ``MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # note`` silently
+    include the comment text in the value, corrupting the resolved base
+    URL and failing later with an opaque 404 (#76544).
+    """
+    value = raw_value.strip()
+    unquoted = _unquote_env_value(value)
+    if unquoted is not None:
+        return unquoted
+    # Inline comments: a ``#`` preceded by whitespace ends the value.
+    # A value that starts with a quote may still carry a trailing comment
+    # (``"a # b"  # note``), so the scan honours quotes it opened — a ``#``
+    # inside those quotes is data, not a comment.
+    quote_char = None
+    i = 0
+    n = len(value)
+    while i < n:
+        ch = value[i]
+        if quote_char is None:
+            if ch in ('"', "'"):
+                quote_char = ch
+            elif ch == "#" and i > 0 and value[i - 1] in (" ", "\t"):
+                value = value[:i].rstrip()
+                break
+        else:
+            # Backslash escapes the next character inside double quotes.
+            if quote_char == '"' and ch == "\\" and i + 1 < n:
+                i += 1
+            elif ch == quote_char:
+                quote_char = None
+        i += 1
+    # A comment can also trail a quoted value — re-check once it is gone.
+    unquoted = _unquote_env_value(value)
+    if unquoted is not None:
+        return unquoted
     return value
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3618,87 +3618,51 @@ def save_config(
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
-def _unquote_env_value(value: str) -> Optional[str]:
-    """Unquote a fully-quoted .env value; ``None`` when not fully quoted.
+def _parse_dotenv_text(text: str) -> Dict[str, str]:
+    """Parse .env text with the pinned python-dotenv (==1.2.2).
 
-    Mirrors :func:`_quote_env_value` (the writer side): a value whose first
-    and last characters are matching quotes is unescaped. A ``#`` inside
-    the quotes is data, not a comment.
+    #76544's root cause was two hand-rolled .env loaders diverging on inline
+    comments and quoting. Both loaders now feed the file text through
+    dotenv_values directly instead of maintaining a third parser:
+
+    - interpolate=False keeps ${VAR} values literal — Hermes never
+      expands .env values, and dotenv interpolates by default, so leaving it
+      on would silently change behavior.
+    - Keys without a value (a bare FOO line) come back as None and
+      are dropped, as are bindings whose value cannot be parsed (unclosed
+      quotes, junk after the closing quote).
+    - export KEY=..., inline # comments, duplicate keys (last wins)
+      and quoted/escaped values are handled by dotenv itself.
     """
-    if len(value) >= 2 and value[0] == value[-1] == '"':
-        quoted = value[1:-1]
-        parsed: list[str] = []
-        i = 0
-        while i < len(quoted):
-            ch = quoted[i]
-            if ch == "\\" and i + 1 < len(quoted):
-                next_ch = quoted[i + 1]
-                if next_ch in {'"', "\\"}:
-                    parsed.append(next_ch)
-                    i += 2
-                    continue
-            parsed.append(ch)
-            i += 1
-        return "".join(parsed)
-    if len(value) >= 2 and value[0] == value[-1] == "'":
-        return value[1:-1]
-    return None
+    from io import StringIO
 
+    from dotenv import dotenv_values
 
-def _parse_env_value(raw_value: str) -> str:
-    """Parse the small .env value subset Hermes writes itself.
-
-    Quoted values are unescaped and returned as-is (a ``#`` inside quotes
-    is data, not a comment). Unquoted values get any inline comment
-    stripped — a ``#`` preceded by whitespace starts a comment, matching
-    python-dotenv. Without this, lines like
-    ``MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # note`` silently
-    include the comment text in the value, corrupting the resolved base
-    URL and failing later with an opaque 404 (#76544).
-    """
-    value = raw_value.strip()
-    unquoted = _unquote_env_value(value)
-    if unquoted is not None:
-        return unquoted
-    # Inline comments: a ``#`` preceded by whitespace ends the value.
-    # A value that starts with a quote may still carry a trailing comment
-    # (``"a # b"  # note``), so the scan honours quotes it opened — a ``#``
-    # inside those quotes is data, not a comment.
-    quote_char = None
-    i = 0
-    n = len(value)
-    while i < n:
-        ch = value[i]
-        if quote_char is None:
-            if ch in ('"', "'"):
-                quote_char = ch
-            elif ch == "#" and i > 0 and value[i - 1] in (" ", "\t"):
-                value = value[:i].rstrip()
-                break
-        else:
-            # Backslash escapes the next character inside double quotes.
-            if quote_char == '"' and ch == "\\" and i + 1 < n:
-                i += 1
-            elif ch == quote_char:
-                quote_char = None
-        i += 1
-    # A comment can also trail a quoted value — re-check once it is gone.
-    unquoted = _unquote_env_value(value)
-    if unquoted is not None:
-        return unquoted
-    return value
+    return {
+        key: value
+        for key, value in dotenv_values(
+            stream=StringIO(text), interpolate=False
+        ).items()
+        if value is not None
+    }
 
 
 def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env.
 
-    Normalizes line endings before parsing while treating each assignment's
-    value as opaque data for boundary discovery.
+    The file text is handed to the pinned python-dotenv
+    (``dotenv_values(..., interpolate=False)``) via :func:`_parse_dotenv_text`
+    verbatim — the same parser the skill loader uses, so the two loaders can
+    never diverge again on inline comments, quoting or malformed lines
+    (#76544). No per-line normalization is applied first: dotenv's quoted
+    values may span physical lines, where every byte (including leading and
+    trailing whitespace) is value content, so any line-by-line
+    transformation would corrupt them.
 
     The parsed dict is memoised keyed on the .env file mtime, because
     ``get_env_value()`` is called dozens-to-hundreds of times per
     interactive menu render (`hermes tools`, `hermes setup`, status
-    panels). Sanitisation is O(lines), so re-parsing the
+    panels). Parsing is O(lines), so re-parsing the
     same file on every call was burning ~300ms of CPU per `hermes tools`
     menu paint on top of the OAuth-refresh slowness. The mtime check
     invalidates the cache when the user edits .env mid-process.
@@ -3728,19 +3692,8 @@ def load_env() -> Dict[str, str]:
         # via utf-8-sig since users may edit .env in Notepad which adds one.
         open_kw = {"encoding": "utf-8-sig", "errors": "replace"}
         with open(env_path, **open_kw) as f:
-            raw_lines = f.readlines()
-        # Normalize line endings without interpreting value contents as syntax.
-        lines = _sanitize_env_lines(raw_lines)
-        for line in lines:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                # Strip the bash-compatible ``export `` prefix so lines like
-                # ``export API_KEY=...`` parse as ``API_KEY`` rather than being
-                # stored under the wrong key ``"export API_KEY"`` (#6659).
-                if line.startswith('export '):
-                    line = line[7:]
-                key, _, value = line.partition('=')
-                env_vars[key.strip()] = _parse_env_value(value)
+            text = f.read()
+        env_vars = _parse_dotenv_text(text)
 
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))

--- a/tests/test_parse_env_value.py
+++ b/tests/test_parse_env_value.py
@@ -1,0 +1,114 @@
+"""Tests for .env value parsing in ``hermes_cli.config.load_env()``.
+
+Regression coverage for the inline-comment bug (#76544): a value like
+``MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official`` was
+stored including the comment text, corrupting the resolved base URL —
+requests then went to ``/anthropic%20%20/v1/messages`` and failed with
+an opaque 404. The two loaders disagreed: python-dotenv (used by
+``hermes_cli/env_loader.py``) strips inline comments, while
+``_parse_env_value`` (used by ``load_env``) did not.
+
+Behaviour contract asserted here:
+- ``#`` preceded by whitespace starts a comment (matching python-dotenv
+  and bash), so the trailing comment is dropped and trailing whitespace
+  stripped.
+- A ``#`` with no preceding whitespace is part of the value (URL
+  fragments, opaque tokens).
+- A ``#`` inside a quoted value is data, not a comment.
+- Quoted-value handling (single/double quotes, escaped quotes) is
+  unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the worktree importable without depending on the installed wheel.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli import config as hermes_config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Unit level — _parse_env_value
+# ---------------------------------------------------------------------------
+
+
+def test_inline_comment_is_stripped():
+    assert (
+        hermes_config._parse_env_value(
+            "https://api.minimax.io/anthropic  # Official endpoint"
+        )
+        == "https://api.minimax.io/anthropic"
+    )
+
+
+def test_inline_comment_after_tab_is_stripped():
+    assert hermes_config._parse_env_value("sk-abc\t# note") == "sk-abc"
+
+
+def test_hash_without_whitespace_is_data():
+    # URL fragments and hashes glued to the value are not comments.
+    assert (
+        hermes_config._parse_env_value("https://x.test/path#frag")
+        == "https://x.test/path#frag"
+    )
+    assert hermes_config._parse_env_value("abc#def") == "abc#def"
+
+
+def test_hash_inside_quotes_is_data():
+    assert hermes_config._parse_env_value('"a # b"') == "a # b"
+    assert hermes_config._parse_env_value("'a # b'") == "a # b"
+
+
+def test_plain_value_unchanged():
+    assert hermes_config._parse_env_value("plain") == "plain"
+
+
+def test_quoted_value_unescaping_unchanged():
+    assert hermes_config._parse_env_value('"a\\"b"') == 'a"b'
+    assert hermes_config._parse_env_value("'single'") == "single"
+
+
+def test_comment_trailing_quoted_value_is_stripped():
+    # The comment ends the line; the value before it is still unquoted.
+    assert hermes_config._parse_env_value('"a # b"  # note') == "a # b"
+    assert hermes_config._parse_env_value('"a\\"b"  # note') == 'a"b'
+
+
+# ---------------------------------------------------------------------------
+# E2E — load_env() on a real temp HERMES_HOME .env (the #76544 report path)
+# ---------------------------------------------------------------------------
+
+
+def test_load_env_strips_inline_comment_on_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text(
+        "MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official\n"
+        "MINIMAX_API_KEY=sk-cp-test\n",
+        encoding="utf-8",
+    )
+    env_vars = hermes_config.load_env()
+    assert env_vars["MINIMAX_BASE_URL"] == "https://api.minimax.io/anthropic"
+    assert env_vars["MINIMAX_API_KEY"] == "sk-cp-test"
+
+
+def test_load_env_handles_mixed_comment_shapes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text(
+        "PLAIN=value\n"
+        "COMMENTED=value  # trailing note\n"
+        "HASH=value#notacomment\n"
+        'QUOTED="a # b"\n'
+        'ESCAPED="a\\"b"  # note\n',
+        encoding="utf-8",
+    )
+    env_vars = hermes_config.load_env()
+    assert env_vars["PLAIN"] == "value"
+    assert env_vars["COMMENTED"] == "value"
+    assert env_vars["HASH"] == "value#notacomment"
+    assert env_vars["QUOTED"] == "a # b"
+    assert env_vars["ESCAPED"] == 'a"b'

--- a/tests/test_parse_env_value.py
+++ b/tests/test_parse_env_value.py
@@ -1,114 +1,269 @@
-"""Tests for .env value parsing in ``hermes_cli.config.load_env()``.
+"""load_env() parity with the pinned python-dotenv (==1.2.2).
 
-Regression coverage for the inline-comment bug (#76544): a value like
-``MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official`` was
-stored including the comment text, corrupting the resolved base URL —
-requests then went to ``/anthropic%20%20/v1/messages`` and failed with
-an opaque 404. The two loaders disagreed: python-dotenv (used by
-``hermes_cli/env_loader.py``) strips inline comments, while
-``_parse_env_value`` (used by ``load_env``) did not.
-
-Behaviour contract asserted here:
-- ``#`` preceded by whitespace starts a comment (matching python-dotenv
-  and bash), so the trailing comment is dropped and trailing whitespace
-  stripped.
-- A ``#`` with no preceding whitespace is part of the value (URL
-  fragments, opaque tokens).
-- A ``#`` inside a quoted value is data, not a comment.
-- Quoted-value handling (single/double quotes, escaped quotes) is
-  unchanged.
+#76544's root cause was two hand-rolled .env loaders diverging on inline
+comments and quoting. Both loaders now parse through python-dotenv
+(``dotenv_values(..., interpolate=False)``), so these tests pin the
+*contract* the loaders must keep: inline comments stripped, quoting and
+escapes honored, malformed lines dropped, ``export`` prefixes accepted,
+no ``${VAR}`` expansion, and agreement with dotenv itself on a corpus of
+edge shapes plus a deterministic fuzz sample.
 """
 
-from __future__ import annotations
-
-import sys
+import random
+import tempfile
 from pathlib import Path
 
-# Make the worktree importable without depending on the installed wheel.
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from dotenv import dotenv_values
 
-from hermes_cli import config as hermes_config  # noqa: E402
+from hermes_cli import config as hermes_config
 
 
-# ---------------------------------------------------------------------------
-# Unit level — _parse_env_value
-# ---------------------------------------------------------------------------
-
-
-def test_inline_comment_is_stripped():
-    assert (
-        hermes_config._parse_env_value(
-            "https://api.minimax.io/anthropic  # Official endpoint"
-        )
-        == "https://api.minimax.io/anthropic"
-    )
-
-
-def test_inline_comment_after_tab_is_stripped():
-    assert hermes_config._parse_env_value("sk-abc\t# note") == "sk-abc"
-
-
-def test_hash_without_whitespace_is_data():
-    # URL fragments and hashes glued to the value are not comments.
-    assert (
-        hermes_config._parse_env_value("https://x.test/path#frag")
-        == "https://x.test/path#frag"
-    )
-    assert hermes_config._parse_env_value("abc#def") == "abc#def"
-
-
-def test_hash_inside_quotes_is_data():
-    assert hermes_config._parse_env_value('"a # b"') == "a # b"
-    assert hermes_config._parse_env_value("'a # b'") == "a # b"
-
-
-def test_plain_value_unchanged():
-    assert hermes_config._parse_env_value("plain") == "plain"
-
-
-def test_quoted_value_unescaping_unchanged():
-    assert hermes_config._parse_env_value('"a\\"b"') == 'a"b'
-    assert hermes_config._parse_env_value("'single'") == "single"
-
-
-def test_comment_trailing_quoted_value_is_stripped():
-    # The comment ends the line; the value before it is still unquoted.
-    assert hermes_config._parse_env_value('"a # b"  # note') == "a # b"
-    assert hermes_config._parse_env_value('"a\\"b"  # note') == 'a"b'
-
-
-# ---------------------------------------------------------------------------
-# E2E — load_env() on a real temp HERMES_HOME .env (the #76544 report path)
-# ---------------------------------------------------------------------------
+def _load(tmp_path, monkeypatch, text):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text(text, encoding="utf-8")
+    hermes_config.invalidate_env_cache()
+    return hermes_config.load_env()
 
 
 def test_load_env_strips_inline_comment_on_base_url(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / ".env").write_text(
+    # The #76544 report path: a commented base URL must resolve without the
+    # comment text corrupting it (that corruption caused an opaque 404).
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
         "MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official\n"
         "MINIMAX_API_KEY=sk-cp-test\n",
-        encoding="utf-8",
     )
-    env_vars = hermes_config.load_env()
     assert env_vars["MINIMAX_BASE_URL"] == "https://api.minimax.io/anthropic"
     assert env_vars["MINIMAX_API_KEY"] == "sk-cp-test"
 
 
-def test_load_env_handles_mixed_comment_shapes(tmp_path, monkeypatch):
+def test_load_env_does_not_interpolate(tmp_path, monkeypatch):
+    # Critical regression for the dotenv switch: dotenv interpolates by
+    # default, but Hermes never expands .env values. ``interpolate=False``
+    # must stay on or ``${HOME}`` would silently become the home path.
+    env_vars = _load(tmp_path, monkeypatch, "PATH_REF=${HOME}\nLITERAL=$$HOME\n")
+    assert env_vars["PATH_REF"] == "${HOME}"
+    assert env_vars["LITERAL"] == "$$HOME"
+
+
+def test_load_env_tolerates_invalid_utf8(tmp_path, monkeypatch):
+    # load_env reads with errors="replace" so a partially-corrupted .env
+    # (e.g. a truncated copy-paste) keeps loading instead of raising
+    # UnicodeDecodeError and taking the whole loader down.
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / ".env").write_text(
+    (tmp_path / ".env").write_bytes(b"GOOD=value\nBROKEN=abc\xffdef\n")
+    hermes_config.invalidate_env_cache()
+
+    env_vars = hermes_config.load_env()
+
+    assert env_vars["GOOD"] == "value"
+    assert env_vars["BROKEN"] == "abc\ufffddef"
+
+
+def test_load_env_skips_unparseable_lines(tmp_path, monkeypatch):
+    # Unclosed quote -> dotenv error binding -> line dropped (key absent),
+    # same contract the old parser had.
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
+        'BROKEN="unclosed\n'
+        "OK=value\n"
+        "BARE_KEY\n"  # no ``=`` -> None value -> dropped
+        "\n"
+        "# full comment\n",
+    )
+    assert "BROKEN" not in env_vars
+    assert "BARE_KEY" not in env_vars
+    assert env_vars["OK"] == "value"
+
+
+def test_load_env_handles_mixed_comment_shapes(tmp_path, monkeypatch):
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
         "PLAIN=value\n"
         "COMMENTED=value  # trailing note\n"
         "HASH=value#notacomment\n"
         'QUOTED="a # b"\n'
-        'ESCAPED="a\\"b"  # note\n',
-        encoding="utf-8",
+        'ESCAPED="a\\"b"  # note\n'
+        'SINGLE=\'a\\\'b\'\n'
+        'TABBED=sk-abc\t# note\n'
+        "EMPTY=\n"
+        "SPACES  =   padded   \n",
     )
-    env_vars = hermes_config.load_env()
     assert env_vars["PLAIN"] == "value"
     assert env_vars["COMMENTED"] == "value"
     assert env_vars["HASH"] == "value#notacomment"
     assert env_vars["QUOTED"] == "a # b"
     assert env_vars["ESCAPED"] == 'a"b'
+    assert env_vars["SINGLE"] == "a'b"
+    assert env_vars["TABBED"] == "sk-abc"
+    assert env_vars["EMPTY"] == ""
+    assert env_vars["SPACES"] == "padded"
+
+
+def test_load_env_handles_export_prefix(tmp_path, monkeypatch):
+    # ``export KEY=...`` (bash-compatible form, #6659) parses as KEY, and
+    # plain lines keep working alongside it.
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
+        "export API_KEY=sk-export\n"
+        "NORMAL=value\n"
+        "export  DOUBLE_SPACE=ok\n",
+    )
+    assert env_vars["API_KEY"] == "sk-export"
+    assert env_vars["NORMAL"] == "value"
+    assert env_vars["DOUBLE_SPACE"] == "ok"
+    assert "export" not in env_vars
+
+
+def test_load_env_last_duplicate_wins(tmp_path, monkeypatch):
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
+        "DUP=first\nDUP=second\n",
+    )
+    assert env_vars["DUP"] == "second"
+
+
+def test_load_env_handles_multiline_quoted_value(tmp_path, monkeypatch):
+    # dotenv supports quoted values spanning physical lines; the old
+    # per-line parser could not. Both loaders share the same parser now.
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
+        'MULTI="line1\nline2"\nSINGLE=ok\n',
+    )
+    assert env_vars["MULTI"] == "line1\nline2"
+    assert env_vars["SINGLE"] == "ok"
+
+
+def test_load_env_preserves_multiline_value_whitespace(tmp_path, monkeypatch):
+    # Every byte inside a cross-line quoted value is value content: the
+    # opening line's trailing whitespace, the continuation lines' leading/
+    # trailing whitespace, and their #-markers are NOT comments. Any
+    # per-line normalization would corrupt the value (fuzz regression:
+    # seed 76544 cases K24/K358/K393).
+    env_vars = _load(
+        tmp_path,
+        monkeypatch,
+        "MULTI='a  \nb  # not a comment\nc'\n",
+    )
+    assert env_vars["MULTI"] == "a  \nb  # not a comment\nc"
+
+
+# ---------------------------------------------------------------------------
+# Differential parity against the pinned python-dotenv (==1.2.2)
+# ---------------------------------------------------------------------------
+#
+# The corpus and fuzz below compare load_env() output with dotenv's own
+# parser on the SAME file. They guard the wiring (sanitizer + interpolate
+# off + None filtering), not dotenv's internals.
+
+_CORPUS = [
+    "https://api.minimax.io/anthropic  # official",
+    "sk-abc\t# note",
+    "https://x.test/path#frag",
+    "abc#def",
+    '"a # b"',
+    "'a # b'",
+    '"a # b"  # note',
+    'abc" # note',
+    "abc' # note",
+    '"unclosed',
+    "'unclosed",
+    '"a"x',
+    "'a'x",
+    '"a"#note',
+    '"a"\t#note',
+    '"a\\nb"',
+    '"a\\tb"',
+    '"a\\qb"',
+    '"a\\\'b"',
+    '"a\\\\b"',
+    '"esc\\"q" # note',
+    "'a' # c",
+    "'a\\'b'",
+    "'a\\\\b'",
+    "'a\\nb'",
+    "plain",
+    "value # trailing note",
+    "",
+    "   ",
+    "\\n",
+    "12345",
+    '"  spaced  "',
+    '  "a"  ',
+    "  spaced  ",
+    "plain ",
+    "  a  # c",
+    '"a" x"y"',
+    '"a""b"',
+    '"a" # x"y"',
+    '"a\\"',
+    '"a\\"x"',
+    '"a\\rb"',
+    '"a\\\\""',
+    '"a\\\\"',
+    '"a\\\\" # c',
+    '"a\\\\"x',
+    '"x\\\\"y\\\\"',
+    "'\\\\'  # c",
+    "'x\\\\' # c",
+    "'\\\\' # c x",
+    "'\\\\'x",
+]
+
+
+def test_corpus_parity_with_python_dotenv(tmp_path, monkeypatch):
+    with tempfile.TemporaryDirectory() as d:
+        env_path = Path(d) / "t.env"
+        for raw in _CORPUS:
+            env_path.write_text("K=" + raw + "\n", encoding="utf-8")
+            expected = dotenv_values(str(env_path), interpolate=False).get("K")
+            env_vars = _load(tmp_path, monkeypatch, "K=" + raw + "\n")
+            ours = env_vars.get("K")
+            if expected is None:
+                assert "K" not in env_vars, f"expected line drop for {raw!r}, got {ours!r}"
+            else:
+                assert ours == expected, f"{raw!r}: ours {ours!r}, dotenv {expected!r}"
+
+
+def test_fuzz_parity_with_python_dotenv(tmp_path, monkeypatch):
+    # Deterministic sample of generated edge shapes; whole-file dict
+    # comparison against dotenv on the identical text.
+    random.seed(76544)
+    parts = [
+        "a", "b", "c", " ", "\t", "#", "# note", '"', "'", "\\", '\\"', "x",
+        ".", "/", "\\t", "\\r", "\\n", "sk-abc", "  ", '"a"  # z',
+    ]
+    lines = []
+    for i in range(400):
+        n = random.randint(1, 4)
+        v = "".join(random.choice(parts) for _ in range(n))
+        if random.random() < 0.45:
+            v = '"' + v
+        if random.random() < 0.45:
+            v = "'" + v
+        if random.random() < 0.35:
+            v = v + "  # c"
+        lines.append(f"K{i}={v}")
+    text = "\n".join(lines) + "\n"
+
+    env_vars = _load(tmp_path, monkeypatch, text)
+    expected = dotenv_values(stream=type("S", (), {"read": lambda s: text})(), interpolate=False)
+    assert env_vars == expected
+
+
+def test_writer_reader_round_trip(tmp_path, monkeypatch):
+    # Anything _quote_env_value writes must parse back to the original value
+    # (the writer emits only double quotes and backslash escapes).
+    from hermes_cli.config import _quote_env_value
+
+    values = ["plain", "a b", "a # b", 'qu"ote', "back\\slash", "tab\there", ""]
+    text = "".join(f"K{i}={_quote_env_value(v)}\n" for i, v in enumerate(values))
+    env_vars = _load(tmp_path, monkeypatch, text)
+    for i, v in enumerate(values):
+        assert env_vars[f"K{i}"] == v

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -923,3 +923,29 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+
+
+def test_load_env_parses_like_hermes_config(tmp_path, monkeypatch):
+    """skills_tool.load_env must agree with hermes_cli.config.load_env.
+
+    The two loaders parse the same HERMES_HOME/.env; a divergence here was
+    part of #76544 (config.load_env stripped inline ``#`` comments but
+    skills_tool.load_env did not). It now reuses the same value parser, so
+    quoting, comments, and dropped unparseable lines behave identically.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text(
+        "SKILL_ENDPOINT=https://x.test/api  # note\n"
+        'SKILL_QUOTED="a # b"  # note\n'
+        'SKILL_BROKEN="unclosed\n'
+        "export SKILL_EXPORT=value  # comment\n",
+        encoding="utf-8",
+    )
+    with patch.object(skills_tool_module, "get_hermes_home", return_value=tmp_path):
+        env = skills_tool_module.load_env()
+
+    assert env["SKILL_ENDPOINT"] == "https://x.test/api"
+    assert env["SKILL_QUOTED"] == "a # b"
+    assert "SKILL_BROKEN" not in env
+    assert env["SKILL_EXPORT"] == "value"
+    assert "export SKILL_EXPORT" not in env

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -204,21 +204,18 @@ def _skill_lookup_path_error(name: str) -> Optional[str]:
 
 
 def load_env() -> Dict[str, str]:
-    """Load profile-scoped environment variables from HERMES_HOME/.env."""
-    env_path = get_hermes_home() / ".env"
-    env_vars: Dict[str, str] = {}
-    if not env_path.exists():
-        return env_vars
+    """Load profile-scoped environment variables from HERMES_HOME/.env.
 
-    with env_path.open(encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                if line.startswith("export "):
-                    line = line[7:]
-                key, _, value = line.partition("=")
-                env_vars[key.strip()] = value.strip().strip("\"'")
-    return env_vars
+    Delegates to :func:`hermes_cli.config.load_env` — the canonical loader
+    (same ``HERMES_HOME/.env`` path, mtime cache, python-dotenv-backed
+    parser) — so the skill env loader can never diverge from the config
+    loader on quoting, inline ``#`` comments, ``export `` prefixes or
+    malformed lines (#76544). A hand-rolled copy here had diverged
+    (``value.strip().strip("\\"'")`` kept no comment handling at all).
+    """
+    from hermes_cli.config import load_env as _load_config_env
+
+    return _load_config_env()
 
 
 class SkillReadinessStatus(str, Enum):


### PR DESCRIPTION
## Summary

Fixes #76544. Two hand-rolled `.env` loaders diverged on inline comments: `load_env()`'s `_parse_env_value` kept a whitespace-preceded `#` comment as part of the value, while the other `.env` loader (`hermes_cli/env_loader.py`, python-dotenv) strips it.

A line like:

```
MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official
```

resolved to `https://api.minimax.io/anthropic  # official`, and the URL-encoded whitespace sent requests to `/anthropic%20%20/v1/messages`, failing with an opaque `404 page not found`.

## Change

The bug class is the duplicated loader logic itself, so both loaders now parse through the pinned `python-dotenv==1.2.2` instead of maintaining a third parser:

- `hermes_cli/config.py`: removed the hand-rolled `_parse_env_value` / `_unquote_env_value` / `_decode_env_quoted_content` / escape tables (~116 lines). Added `_parse_dotenv_text()` — `dotenv_values(stream=..., interpolate=False)` with `None` (bare-key / unparseable) bindings filtered. `load_env()` hands the raw file text (read with `utf-8-sig`, `errors="replace"` so partially-corrupted files keep loading) to that helper, keeping its mtime/size memo.
- `interpolate=False` is required: dotenv interpolates `${VAR}` by default, Hermes never has. A regression test pins `${HOME}` staying literal.
- `tools/skills_tool.py::load_env` delegates to `hermes_cli.config.load_env` — one canonical loader, so the two paths can never diverge again.
- `load_env()` now parses raw dotenv text directly. The explicit `sanitize_env_file()` rewrite command retains its existing line-oriented behavior and will be handled separately.

## Tests

- `tests/test_parse_env_value.py` — 12 tests: inline comments, no `${VAR}` interpolation, invalid-UTF-8 tolerance, unparseable-line drops, comment/quote/escape shapes, `export` prefix, duplicate-last-wins, multiline quoted values incl. whitespace preservation, corpus + deterministic fuzz (seed 76544, 400 lines) whole-dict parity against `dotenv_values(interpolate=False)`, writer round-trip.
- `tests/tools/test_skills_tool.py` — E2E: skill loader parses like the config loader.
- Note: python-dotenv logs a warning for malformed bindings it drops (e.g. unclosed quotes). Both Hermes loader entry points now share that same behavior; the warning is an accepted behavior change.

## Verification

- `scripts/run_tests.sh tests/test_parse_env_value.py` — 12 passed
- `scripts/run_tests.sh tests/tools/test_skills_tool.py tests/hermes_cli/test_config.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_env_sanitize_on_load.py` — 130 passed
- `ruff check hermes_cli/config.py tools/skills_tool.py tests/test_parse_env_value.py` — clean
- `ty check hermes_cli/config.py tools/skills_tool.py` — no new diagnostics (37 pre-existing baseline)

