### PR TITLE
fix(skills): evict oldest watermark IDs, not a hash-ordered subset

### DIFF
--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -7,7 +7,8 @@ Contract:
 - First run: record all IDs from the fetched batch, emit nothing.
 - Subsequent runs: emit items whose ID isn't in the stored set.
 - Bounded: keep at most `max_seen` IDs (default 500), evicting the
-  least-recently-seen ones first.
+  oldest stored IDs first (FIFO by insertion order — seeing an ID again
+  does not move it back to the newest end).
 - Atomic: write to a .tmp file and rename, so a crashed script can't
   leave a half-written state file that permanently breaks dedup.
 

--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -6,7 +6,8 @@ runs, so the next run only emits items we haven't seen before.
 Contract:
 - First run: record all IDs from the fetched batch, emit nothing.
 - Subsequent runs: emit items whose ID isn't in the stored set.
-- Bounded: keep at most `max_seen` IDs (default 500).
+- Bounded: keep at most `max_seen` IDs (default 500), evicting the
+  least-recently-seen ones first.
 - Atomic: write to a .tmp file and rename, so a crashed script can't
   leave a half-written state file that permanently breaks dedup.
 
@@ -80,7 +81,13 @@ class Watermark:
         batch (so save() persists the full new watermark).  On first run,
         records every id but returns an empty list (baseline, no replay).
         """
-        existing = set(str(x) for x in self._data.get("seen_ids", []))
+        # `stored` keeps insertion order so the truncation below drops the
+        # oldest IDs. Rebuilding it from a set would order it by string hash,
+        # which PYTHONHASHSEED randomizes per process, so each run would evict
+        # an arbitrary slice and re-emit whichever of those are still on the
+        # feed. `existing` stays a set for O(1) membership.
+        stored = list(dict.fromkeys(str(x) for x in self._data.get("seen_ids", [])))
+        existing = set(stored)
         was_first_run = self.is_first_run
 
         new_items: List[Dict[str, Any]] = []
@@ -97,7 +104,7 @@ class Watermark:
                 continue  # record but don't emit
             new_items.append(item)
 
-        combined = list(existing) + [i for i in batch_ids if i not in existing]
+        combined = stored + [i for i in batch_ids if i not in existing]
         if len(combined) > self.max_seen:
             combined = combined[-self.max_seen:]
         self._data["seen_ids"] = combined

--- a/tests/skills/test_watchers_watermark.py
+++ b/tests/skills/test_watchers_watermark.py
@@ -1,0 +1,100 @@
+"""Tests for the watchers skill's shared watermark helper.
+
+The bounded seen-ID set is what keeps a watcher from re-reporting items it has
+already delivered. Once a feed saturates the cap, every run has to evict
+something, and evicting the wrong entries is silent: no error, exit code 0,
+just an old item showing up as new.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+WATERMARK_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills/devops/watchers/scripts/_watermark.py"
+)
+
+
+def _seed_state(state_dir: Path, name: str, ids: list[str]) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{name}.json").write_text(
+        json.dumps({"seen_ids": ids, "first_run": False}), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def watermark_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path))
+    spec = importlib.util.spec_from_file_location(
+        "watchers_watermark_test", WATERMARK_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_truncation_evicts_oldest_first(watermark_module, tmp_path):
+    _seed_state(tmp_path, "feed", [f"id-{i}" for i in range(10)])
+    wm = watermark_module.Watermark.load("feed", max_seen=10)
+
+    wm.filter_new([{"id": "id-10"}, {"id": "id-11"}], id_key="id")
+
+    assert wm.seen == [f"id-{i}" for i in range(2, 12)]
+
+
+def test_retained_ids_are_not_re_emitted(watermark_module, tmp_path):
+    _seed_state(tmp_path, "feed", [f"id-{i}" for i in range(10)])
+    wm = watermark_module.Watermark.load("feed", max_seen=10)
+    wm.filter_new([{"id": "id-10"}, {"id": "id-11"}], id_key="id")
+
+    # id-2 is the oldest survivor: seeing it again must stay quiet. Before the
+    # fix it was evicted roughly at random, and a feed still carrying it would
+    # get it delivered a second time.
+    assert wm.filter_new([{"id": "id-2"}], id_key="id") == []
+
+
+def test_duplicate_stored_ids_do_not_inflate_the_cap(watermark_module, tmp_path):
+    _seed_state(tmp_path, "feed", ["a", "b", "b", "c"])
+    wm = watermark_module.Watermark.load("feed", max_seen=4)
+
+    wm.filter_new([{"id": "d"}], id_key="id")
+
+    assert wm.seen == ["a", "b", "c", "d"]
+
+
+# Run in a subprocess: PYTHONHASHSEED is read at interpreter start, so the
+# randomization this guards against cannot be toggled from inside a test.
+_DETERMINISM_SNIPPET = """
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("wm", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+wm = module.Watermark.load("feed", max_seen=10)
+wm.filter_new([{"id": "id-10"}, {"id": "id-11"}], id_key="id")
+print(",".join(wm.seen))
+"""
+
+
+def test_truncation_is_deterministic_across_hash_seeds(tmp_path):
+    _seed_state(tmp_path, "feed", [f"id-{i}" for i in range(10)])
+
+    results = set()
+    for seed in ("0", "1", "12345"):
+        env = dict(os.environ, PYTHONHASHSEED=seed, WATCHER_STATE_DIR=str(tmp_path))
+        proc = subprocess.run(
+            [sys.executable, "-c", _DETERMINISM_SNIPPET, str(WATERMARK_PATH)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        results.add(proc.stdout.strip())
+
+    assert len(results) == 1, f"eviction set depends on the hash seed: {results}"


### PR DESCRIPTION
## What does this PR do?

The watchers skill's shared watermark caps the seen-ID set at `max_seen` and keeps the tail — which reads as "drop the oldest". But the list being sliced is rebuilt from a `set`:

```python
existing = set(str(x) for x in self._data.get("seen_ids", []))
combined = list(existing) + [i for i in batch_ids if i not in existing]
if len(combined) > self.max_seen:
    combined = combined[-self.max_seen:]
```

`list()` over a set of `str` follows string hash order, which `PYTHONHASHSEED` randomizes per process. Once a watcher saturates the cap, every run evicts a different arbitrary slice, and any evicted ID still present in the source feed comes back as new. Nothing fails: no exception, exit code 0, just a duplicate notification — so the only symptom is a feed item the user already saw.

The fix keeps the stored order (deduplicated with `dict.fromkeys`) so the existing slice drops the oldest stored IDs — FIFO by insertion order, which is what the slice always read as. (Seeing an ID again does not move it to the newest end; this is not an LRU.) The `set` stays for O(1) membership tests, so the hot loop is unchanged.

I picked insertion order over a `deque` to keep the diff to the two lines that are wrong, but `gateway/platforms/msgraph_webhook.py` solves the same bounded-seen-set problem with `set` + `deque` if you would rather the two matched.

## Related Issue

Fixes #76542

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/devops/watchers/scripts/_watermark.py` — `filter_new` now rebuilds the retained list from the stored order instead of from the `set`; the module docstring's Contract section now states that eviction is FIFO by insertion order.
- `tests/skills/test_watchers_watermark.py` — new. The skill had no tests.

## How to Test

Reproduction without the fix (no network or Hermes runtime needed — the helper is self-contained):

```python
from _watermark import Watermark

wm = Watermark("dbg", max_seen=10)
wm._data = {"seen_ids": [f"id-{i}" for i in range(10)], "first_run": False}

before = set(wm.seen)
wm.filter_new([{"id": f"id-{i}"} for i in range(8, 12)])   # 2 new ids -> 2 evictions
after = set(wm.seen)
evicted = sorted(before - after)

again = wm.filter_new([{"id": "id-3"}])   # id-3 is still in the feed
print(f"evicted={evicted}  re-emitted={bool(again)}")
```

Six runs on `main` (each run is a fresh process, so a fresh hash seed):

```
evicted=['id-5', 'id-9']  re-emitted=False
evicted=['id-5', 'id-9']  re-emitted=False
evicted=['id-0', 'id-4']  re-emitted=False
evicted=['id-1', 'id-7']  re-emitted=False
evicted=['id-1', 'id-2']  re-emitted=False
evicted=['id-3', 'id-7']  re-emitted=True     <-- already-reported item comes back
```

With this PR, `evicted` is `['id-0', 'id-1']` on every run and `re-emitted` is always `False`.

The four new tests cover it directly:

```
pytest tests/skills/test_watchers_watermark.py -q
....                                                                     [100%]
4 passed in 0.09s
```

All four fail against `main` — including `test_truncation_is_deterministic_across_hash_seeds`, which runs the helper in subprocesses under three different `PYTHONHASHSEED` values and gets three different retained sets. (That one has to be a subprocess: `PYTHONHASHSEED` is read at interpreter start, and `tests/conftest.py` pins it to 0 for the test process itself.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran `tests/skills/test_watchers_watermark.py` (4 passed, and 4 failed against `main`). I did not run the full suite locally; happy to if CI does not cover it.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the helper's docstring now states the eviction order. See the note below about the docs page.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib, no platform-specific behavior. `dict` preserving insertion order is guaranteed from Python 3.7.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Note on a related gap (not fixed here)

SKILL.md and the docs page suggest tuning the cap:

> Unbounded watermark growth. The shared helper caps at 500 IDs. Raise it for high-churn feeds; lower it on constrained filesystems.

But all three shipped scripts call `Watermark.load(args.name)` without passing `max_seen` (`watch_rss.py:103`, `watch_github.py:154`, `watch_http_json.py:111`), and `--max` is unrelated — it caps how many items are *emitted*, after `filter_new` has already processed the whole feed. So the documented workaround is only reachable from a hand-written script. I left that out to keep this PR to the bug, but I'm glad to add a `--max-seen` flag to the three scripts in a follow-up if you want it.
