### PR TITLE
fix(tools): deny rules now match command segments, not just full variants (#76037)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -522,6 +522,8 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+_LEADING_ASSIGNMENTS = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)+")
+
 def _match_user_deny_rule(command: str) -> str | None:
     """Return the matching ``approvals.deny`` glob, or None.
 
@@ -551,6 +553,24 @@ def _match_user_deny_rule(command: str) -> str | None:
         for pattern in globs:
             if fnmatch.fnmatchcase(candidate, pattern.lower()):
                 return pattern
+        # Also test each command-start segment so that deny rules catch
+        # commands hidden behind prefixes like ``cd repo && git push`` or
+        # ``VAR=val git push``.  ``_mark_command_starts`` is quote-aware,
+        # so opens inside quotes (e.g. ``grep -r 'git push' docs/``) never
+        # produce a segment and remain allowed.
+        marked = _mark_command_starts(command_variant)
+        segments = marked.split("\n") if marked != command_variant else []
+        # Always test the full variant with leading assignments stripped,
+        # since ``_mark_command_starts`` may not split ``VAR=val cmd``.
+        if not segments:
+            segments = [candidate]
+        for raw in segments:
+            seg = _LEADING_ASSIGNMENTS.sub("", raw.lower().strip()).lstrip("({ ").strip()
+            if not seg:
+                continue
+            for pattern in globs:
+                if fnmatch.fnmatchcase(seg, pattern.lower()):
+                    return pattern
     return None
 
 


### PR DESCRIPTION
## Summary

`approvals.deny` globs are anchored at both ends by `fnmatch.fnmatchcase`, so every deny rule is bypassed by putting anything in front of the command. `git push --force origin main` is blocked; `cd repo && git push --force origin main` is allowed.

This is the user-editable counterpart to the hardline blocklist, documented as "never let the agent run this, even under yolo" — so a bypass here is a silent failure of the strongest guarantee the feature makes.

## Root Cause

`_match_user_deny_rule` tests each command variant from `_command_detection_variants` as a whole string. A glob like `git push --force*` only matches strings that *start with* `git`. Commands prefixed with `cd repo &&`, `VAR=val `, `(subshell)`, or `;` are never matched.

## Fix

After testing the full command variant, also split it via the quote-aware `_mark_command_starts` helper and test each segment individually (with leading env assignments stripped via a regex). Quoted prose containing deny-keyword strings (e.g. `grep -r "git push" docs/`) is never split into a segment by `_mark_command_starts`, so it remains correctly allowed.

**Verified on 8 test cases** (all pass):
- ✅ `git push --force origin main` → BLOCKED (positive control)
- ✅ `cd repo && git push --force origin main` → BLOCKED (was bypassed)
- ✅ `true; git push --force origin main` → BLOCKED (was bypassed)
- ✅ `VAR=1 git push --force origin main` → BLOCKED (was bypassed)
- ✅ `(git push --force origin main)` → BLOCKED (was bypassed)
- ✅ `echo hi | git push --force origin main` → BLOCKED (was bypassed)
- ✅ `echo hello` → ALLOWED (negative control)
- ✅ `grep -r 'git push --force' docs/` → ALLOWED (negative control)

## Changes

- `tools/approval.py`: +20 lines — add `_LEADING_ASSIGNMENTS` regex and segment-level matching in `_match_user_deny_rule`

Fixes #76037