### PR TITLE
feat(skills): add task-scoped disabled-skill grants

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -844,12 +844,15 @@ def build_preloaded_skills_prompt(
 
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
 
-    Disabled skills are treated the same as missing ones: this loads via a
-    raw identifier straight into ``_load_skill_payload``, bypassing
-    ``get_skill_commands()``'s scan-time disabled filter — mirrors the
-    bundle-invocation gate (#59156). Without this, ``hermes -s <skill>`` or
-    a deployment's ``HERMES_TUI_SKILLS`` env var could force-load a skill an
-    operator disabled via ``skills.disabled``/``skills.platform_disabled``.
+    Disabled skills are treated the same as missing ones unless the active
+    task-scoped read grant authorizes the exact requested selector or resolved
+    skill name. This loads via a raw identifier straight into
+    ``_load_skill_payload``, bypassing ``get_skill_commands()``'s scan-time
+    disabled filter — mirrors the bundle-invocation gate (#59156). Without
+    this gate, ``hermes -s <skill>`` or a deployment's ``HERMES_TUI_SKILLS``
+    env var could force-load a skill an operator disabled via
+    ``skills.disabled``/``skills.platform_disabled``. The scoped exception
+    does not make the skill discoverable or authorize sibling selectors.
     """
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
@@ -876,8 +879,22 @@ def build_preloaded_skills_prompt(
         loaded_skill, skill_dir, skill_name = loaded
 
         if skill_name in disabled_names or identifier in disabled_names:
-            missing.append(identifier)
-            continue
+            # Phase 1A may grant this explicit CLI/Kanban preload without
+            # changing the profile's disabled baseline. Keep this second gate
+            # fail-closed and selector-bound: only the requested identifier or
+            # the loader's resolved name can authorize the already-loaded skill.
+            scoped_grant_allows = False
+            try:
+                from agent.skill_utils import is_skill_read_granted
+
+                scoped_grant_allows = is_skill_read_granted(
+                    identifier
+                ) or is_skill_read_granted(skill_name)
+            except Exception:
+                scoped_grant_allows = False
+            if not scoped_grant_allows:
+                missing.append(identifier)
+                continue
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -752,12 +752,15 @@ def build_preloaded_skills_prompt(
 
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
 
-    Disabled skills are treated the same as missing ones: this loads via a
-    raw identifier straight into ``_load_skill_payload``, bypassing
-    ``get_skill_commands()``'s scan-time disabled filter — mirrors the
-    bundle-invocation gate (#59156). Without this, ``hermes -s <skill>`` or
-    a deployment's ``HERMES_TUI_SKILLS`` env var could force-load a skill an
-    operator disabled via ``skills.disabled``/``skills.platform_disabled``.
+    Disabled skills are treated the same as missing ones unless the active
+    task-scoped read grant authorizes the exact requested selector or resolved
+    skill name. This loads via a raw identifier straight into
+    ``_load_skill_payload``, bypassing ``get_skill_commands()``'s scan-time
+    disabled filter — mirrors the bundle-invocation gate (#59156). Without
+    this gate, ``hermes -s <skill>`` or a deployment's ``HERMES_TUI_SKILLS``
+    env var could force-load a skill an operator disabled via
+    ``skills.disabled``/``skills.platform_disabled``. The scoped exception
+    does not make the skill discoverable or authorize sibling selectors.
     """
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
@@ -784,8 +787,22 @@ def build_preloaded_skills_prompt(
         loaded_skill, skill_dir, skill_name = loaded
 
         if skill_name in disabled_names or identifier in disabled_names:
-            missing.append(identifier)
-            continue
+            # Phase 1A may grant this explicit CLI/Kanban preload without
+            # changing the profile's disabled baseline. Keep this second gate
+            # fail-closed and selector-bound: only the requested identifier or
+            # the loader's resolved name can authorize the already-loaded skill.
+            scoped_grant_allows = False
+            try:
+                from agent.skill_utils import is_skill_read_granted
+
+                scoped_grant_allows = is_skill_read_granted(
+                    identifier
+                ) or is_skill_read_granted(skill_name)
+            except Exception:
+                scoped_grant_allows = False
+            if not scoped_grant_allows:
+                missing.append(identifier)
+                continue
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -6,14 +6,22 @@ tool registration or provider resolution.
 """
 
 import ast
+import contextvars
+import json
 import logging
 import os
 import re
 import sys
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import get_config_path, get_hermes_home, get_skills_dir, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +397,289 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 
 
 # ── Disabled skills ───────────────────────────────────────────────────────
+
+# A scoped read grant is an exception to the disabled-skill deny check only.
+# ContextVar keeps parallel sessions isolated while allowing the existing tool
+# executor context propagation to carry the grant to that session's tool calls.
+# Delegation explicitly suppresses it at the child boundary.
+DEFAULT_SKILL_READ_GRANT_TTL_SECONDS = 24 * 60 * 60
+_SKILL_GRANT_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "cancelled", "timed_out", "expired"}
+)
+
+
+@dataclass(frozen=True)
+class SkillReadGrant:
+    """Immutable authorization claims for one scoped disabled-skill read grant."""
+
+    grant_id: str
+    skill_names: frozenset[str]
+    session_id: str
+    task_id: Optional[str]
+    profile: str
+    requester: str
+    source: str
+    issued_at: float
+    expires_at: float
+    audit_path: Path
+
+
+@dataclass
+class _SkillReadGrantLifecycle:
+    """Mutable request lifecycle kept separate from immutable grant claims."""
+
+    grant: SkillReadGrant
+    terminal_status: Optional[str] = None
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    token: Optional[contextvars.Token] = field(default=None, repr=False)
+
+
+_ACTIVE_SKILL_READ_GRANT: contextvars.ContextVar[
+    Optional[_SkillReadGrantLifecycle]
+] = (
+    contextvars.ContextVar("active_skill_read_grant", default=None)
+)
+
+
+def _iso_timestamp(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _skill_grant_audit_record(
+    grant: SkillReadGrant, *, event: str, terminal_status: str
+) -> Dict[str, Any]:
+    return {
+        "event": event,
+        "grant_id": grant.grant_id,
+        "session_id": grant.session_id,
+        "task_id": grant.task_id,
+        "profile": grant.profile,
+        "skill_names": sorted(grant.skill_names),
+        "requester": grant.requester,
+        "source": grant.source,
+        "issued_at": _iso_timestamp(grant.issued_at),
+        "expires_at": _iso_timestamp(grant.expires_at),
+        "terminal_status": terminal_status,
+        "recorded_at": _iso_timestamp(time.time()),
+    }
+
+
+def _write_skill_grant_audit(
+    grant: SkillReadGrant, *, event: str, terminal_status: str
+) -> bool:
+    """Append one metadata-only audit event; never include skill/prompt content."""
+    try:
+        grant.audit_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            _skill_grant_audit_record(
+                grant, event=event, terminal_status=terminal_status
+            ),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ) + "\n"
+        fd = os.open(
+            grant.audit_path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            encoded = payload.encode("utf-8")
+            if os.write(fd, encoded) != len(encoded):
+                raise OSError("short write while appending skill-grant audit event")
+        finally:
+            os.close(fd)
+        return True
+    except Exception:
+        logger.warning("Could not append scoped skill-grant audit event", exc_info=True)
+        return False
+
+
+def issue_skill_read_grant(
+    skill_names,
+    *,
+    session_id: str,
+    profile: str,
+    requester: str,
+    source: str,
+    task_id: Optional[str] = None,
+    ttl_seconds: float = DEFAULT_SKILL_READ_GRANT_TTL_SECONDS,
+    audit_path: Optional[Path] = None,
+    authorization_aliases: Optional[Dict[str, Any]] = None,
+) -> Optional[SkillReadGrant]:
+    """Activate an exact-name, time-bounded exception for skill reads.
+
+    This does not mutate config, skill files, prompt state, or process-global
+    environment. Only selectors whose exact-target aliases are disabled in the
+    active profile are kept, so enabled-skill preloads retain their existing path.
+    """
+    if not isinstance(source, str) or source not in {"cli", "kanban"}:
+        raise ValueError("skill grant source must be exactly 'cli' or 'kanban'")
+    if source == "kanban" and (
+        not isinstance(task_id, str) or not task_id.strip()
+    ):
+        raise ValueError("kanban skill grants require a non-empty task_id")
+    for field_name, value in (
+        ("session_id", session_id),
+        ("profile", profile),
+        ("requester", requester),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field_name} is required for a skill grant")
+    if ttl_seconds <= 0:
+        raise ValueError("skill grant ttl_seconds must be greater than zero")
+
+    requested = _normalize_string_set(skill_names)
+    disabled = get_disabled_skill_names()
+    if authorization_aliases is None:
+        granted = requested & disabled
+    else:
+        normalized_aliases = {
+            str(identity).strip(): _normalize_string_set(aliases)
+            for identity, aliases in authorization_aliases.items()
+            if str(identity).strip()
+        }
+        granted = {
+            identity
+            for identity in requested
+            if disabled & (normalized_aliases.get(identity, set()) | {identity})
+        }
+    if not granted:
+        return None
+
+    issued_at = time.time()
+    grant = SkillReadGrant(
+        grant_id=uuid.uuid4().hex,
+        skill_names=frozenset(granted),
+        session_id=str(session_id),
+        task_id=str(task_id) if task_id else None,
+        profile=str(profile),
+        requester=str(requester),
+        source=str(source),
+        issued_at=issued_at,
+        expires_at=issued_at + float(ttl_seconds),
+        audit_path=audit_path or (get_hermes_home() / "logs" / "skill-grants.jsonl"),
+    )
+    if not _write_skill_grant_audit(
+        grant, event="issued", terminal_status="active"
+    ):
+        raise RuntimeError("could not create required skill-grant audit record")
+    lifecycle = _SkillReadGrantLifecycle(grant=grant)
+    lifecycle.token = _ACTIVE_SKILL_READ_GRANT.set(lifecycle)
+    return grant
+
+
+def close_skill_read_grant(
+    grant: Optional[SkillReadGrant], terminal_status: str = "completed"
+) -> None:
+    """Close *grant* idempotently and clear it from the current context."""
+    if grant is None:
+        return
+    if terminal_status not in _SKILL_GRANT_TERMINAL_STATUSES:
+        raise ValueError(f"invalid skill grant terminal status: {terminal_status}")
+
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    if lifecycle is None or lifecycle.grant is not grant:
+        return
+
+    with lifecycle.lock:
+        if lifecycle.terminal_status is None:
+            if time.time() >= grant.expires_at:
+                terminal_status = "expired"
+            lifecycle.terminal_status = terminal_status
+            _write_skill_grant_audit(
+                grant, event="closed", terminal_status=terminal_status
+            )
+    if _ACTIVE_SKILL_READ_GRANT.get() is lifecycle:
+        _ACTIVE_SKILL_READ_GRANT.set(None)
+
+
+def current_skill_read_grant() -> Optional[SkillReadGrant]:
+    """Return the active grant for lifecycle boundaries and diagnostics."""
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    return lifecycle.grant if lifecycle is not None else None
+
+
+def is_skill_read_granted(skill_name: str) -> bool:
+    """Return whether the active scope grants this exact disabled skill name."""
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    if lifecycle is None:
+        return False
+    grant = lifecycle.grant
+    with lifecycle.lock:
+        if lifecycle.terminal_status is not None:
+            return False
+        if time.time() < grant.expires_at:
+            return skill_name in grant.skill_names
+    close_skill_read_grant(grant, "expired")
+    return False
+
+
+@contextmanager
+def skill_read_grant_scope(
+    skill_names,
+    *,
+    session_id: str,
+    profile: str,
+    requester: str,
+    source: str,
+    task_id: Optional[str] = None,
+    ttl_seconds: float = DEFAULT_SKILL_READ_GRANT_TTL_SECONDS,
+    audit_path: Optional[Path] = None,
+    authorization_aliases: Optional[Dict[str, Any]] = None,
+) -> Iterator[Optional[SkillReadGrant]]:
+    """Context-manager API with completion/error/cancel/timeout cleanup."""
+    previous = _ACTIVE_SKILL_READ_GRANT.get()
+    grant = issue_skill_read_grant(
+        skill_names,
+        session_id=session_id,
+        task_id=task_id,
+        profile=profile,
+        requester=requester,
+        source=source,
+        ttl_seconds=ttl_seconds,
+        audit_path=audit_path,
+        authorization_aliases=authorization_aliases,
+    )
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    owns_lifecycle = grant is not None and lifecycle is not previous
+    try:
+        yield grant
+    except KeyboardInterrupt:
+        close_skill_read_grant(grant, "cancelled")
+        raise
+    except TimeoutError:
+        close_skill_read_grant(grant, "timed_out")
+        raise
+    except SystemExit as exc:
+        terminal_status = (
+            "completed"
+            if exc.code in (None, 0)
+            else "cancelled"
+            if exc.code == 130
+            else "failed"
+        )
+        close_skill_read_grant(grant, terminal_status)
+        raise
+    except BaseException:
+        close_skill_read_grant(grant, "failed")
+        raise
+    else:
+        close_skill_read_grant(grant, "completed")
+    finally:
+        if owns_lifecycle and lifecycle is not None and lifecycle.token is not None:
+            _ACTIVE_SKILL_READ_GRANT.reset(lifecycle.token)
+
+
+@contextmanager
+def suppress_skill_read_grants() -> Iterator[None]:
+    """Fail-closed boundary used while constructing/running delegated agents."""
+    token = _ACTIVE_SKILL_READ_GRANT.set(None)
+    try:
+        yield
+    finally:
+        _ACTIVE_SKILL_READ_GRANT.reset(token)
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,14 +5,22 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import contextvars
+import json
 import logging
 import os
 import re
 import sys
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import get_config_path, get_hermes_home, get_skills_dir, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +380,289 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 
 
 # ── Disabled skills ───────────────────────────────────────────────────────
+
+# A scoped read grant is an exception to the disabled-skill deny check only.
+# ContextVar keeps parallel sessions isolated while allowing the existing tool
+# executor context propagation to carry the grant to that session's tool calls.
+# Delegation explicitly suppresses it at the child boundary.
+DEFAULT_SKILL_READ_GRANT_TTL_SECONDS = 24 * 60 * 60
+_SKILL_GRANT_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "cancelled", "timed_out", "expired"}
+)
+
+
+@dataclass(frozen=True)
+class SkillReadGrant:
+    """Immutable authorization claims for one scoped disabled-skill read grant."""
+
+    grant_id: str
+    skill_names: frozenset[str]
+    session_id: str
+    task_id: Optional[str]
+    profile: str
+    requester: str
+    source: str
+    issued_at: float
+    expires_at: float
+    audit_path: Path
+
+
+@dataclass
+class _SkillReadGrantLifecycle:
+    """Mutable request lifecycle kept separate from immutable grant claims."""
+
+    grant: SkillReadGrant
+    terminal_status: Optional[str] = None
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    token: Optional[contextvars.Token] = field(default=None, repr=False)
+
+
+_ACTIVE_SKILL_READ_GRANT: contextvars.ContextVar[
+    Optional[_SkillReadGrantLifecycle]
+] = (
+    contextvars.ContextVar("active_skill_read_grant", default=None)
+)
+
+
+def _iso_timestamp(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _skill_grant_audit_record(
+    grant: SkillReadGrant, *, event: str, terminal_status: str
+) -> Dict[str, Any]:
+    return {
+        "event": event,
+        "grant_id": grant.grant_id,
+        "session_id": grant.session_id,
+        "task_id": grant.task_id,
+        "profile": grant.profile,
+        "skill_names": sorted(grant.skill_names),
+        "requester": grant.requester,
+        "source": grant.source,
+        "issued_at": _iso_timestamp(grant.issued_at),
+        "expires_at": _iso_timestamp(grant.expires_at),
+        "terminal_status": terminal_status,
+        "recorded_at": _iso_timestamp(time.time()),
+    }
+
+
+def _write_skill_grant_audit(
+    grant: SkillReadGrant, *, event: str, terminal_status: str
+) -> bool:
+    """Append one metadata-only audit event; never include skill/prompt content."""
+    try:
+        grant.audit_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            _skill_grant_audit_record(
+                grant, event=event, terminal_status=terminal_status
+            ),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ) + "\n"
+        fd = os.open(
+            grant.audit_path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            encoded = payload.encode("utf-8")
+            if os.write(fd, encoded) != len(encoded):
+                raise OSError("short write while appending skill-grant audit event")
+        finally:
+            os.close(fd)
+        return True
+    except Exception:
+        logger.warning("Could not append scoped skill-grant audit event", exc_info=True)
+        return False
+
+
+def issue_skill_read_grant(
+    skill_names,
+    *,
+    session_id: str,
+    profile: str,
+    requester: str,
+    source: str,
+    task_id: Optional[str] = None,
+    ttl_seconds: float = DEFAULT_SKILL_READ_GRANT_TTL_SECONDS,
+    audit_path: Optional[Path] = None,
+    authorization_aliases: Optional[Dict[str, Any]] = None,
+) -> Optional[SkillReadGrant]:
+    """Activate an exact-name, time-bounded exception for skill reads.
+
+    This does not mutate config, skill files, prompt state, or process-global
+    environment. Only selectors whose exact-target aliases are disabled in the
+    active profile are kept, so enabled-skill preloads retain their existing path.
+    """
+    if not isinstance(source, str) or source not in {"cli", "kanban"}:
+        raise ValueError("skill grant source must be exactly 'cli' or 'kanban'")
+    if source == "kanban" and (
+        not isinstance(task_id, str) or not task_id.strip()
+    ):
+        raise ValueError("kanban skill grants require a non-empty task_id")
+    for field_name, value in (
+        ("session_id", session_id),
+        ("profile", profile),
+        ("requester", requester),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field_name} is required for a skill grant")
+    if ttl_seconds <= 0:
+        raise ValueError("skill grant ttl_seconds must be greater than zero")
+
+    requested = _normalize_string_set(skill_names)
+    disabled = get_disabled_skill_names()
+    if authorization_aliases is None:
+        granted = requested & disabled
+    else:
+        normalized_aliases = {
+            str(identity).strip(): _normalize_string_set(aliases)
+            for identity, aliases in authorization_aliases.items()
+            if str(identity).strip()
+        }
+        granted = {
+            identity
+            for identity in requested
+            if disabled & (normalized_aliases.get(identity, set()) | {identity})
+        }
+    if not granted:
+        return None
+
+    issued_at = time.time()
+    grant = SkillReadGrant(
+        grant_id=uuid.uuid4().hex,
+        skill_names=frozenset(granted),
+        session_id=str(session_id),
+        task_id=str(task_id) if task_id else None,
+        profile=str(profile),
+        requester=str(requester),
+        source=str(source),
+        issued_at=issued_at,
+        expires_at=issued_at + float(ttl_seconds),
+        audit_path=audit_path or (get_hermes_home() / "logs" / "skill-grants.jsonl"),
+    )
+    if not _write_skill_grant_audit(
+        grant, event="issued", terminal_status="active"
+    ):
+        raise RuntimeError("could not create required skill-grant audit record")
+    lifecycle = _SkillReadGrantLifecycle(grant=grant)
+    lifecycle.token = _ACTIVE_SKILL_READ_GRANT.set(lifecycle)
+    return grant
+
+
+def close_skill_read_grant(
+    grant: Optional[SkillReadGrant], terminal_status: str = "completed"
+) -> None:
+    """Close *grant* idempotently and clear it from the current context."""
+    if grant is None:
+        return
+    if terminal_status not in _SKILL_GRANT_TERMINAL_STATUSES:
+        raise ValueError(f"invalid skill grant terminal status: {terminal_status}")
+
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    if lifecycle is None or lifecycle.grant is not grant:
+        return
+
+    with lifecycle.lock:
+        if lifecycle.terminal_status is None:
+            if time.time() >= grant.expires_at:
+                terminal_status = "expired"
+            lifecycle.terminal_status = terminal_status
+            _write_skill_grant_audit(
+                grant, event="closed", terminal_status=terminal_status
+            )
+    if _ACTIVE_SKILL_READ_GRANT.get() is lifecycle:
+        _ACTIVE_SKILL_READ_GRANT.set(None)
+
+
+def current_skill_read_grant() -> Optional[SkillReadGrant]:
+    """Return the active grant for lifecycle boundaries and diagnostics."""
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    return lifecycle.grant if lifecycle is not None else None
+
+
+def is_skill_read_granted(skill_name: str) -> bool:
+    """Return whether the active scope grants this exact disabled skill name."""
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    if lifecycle is None:
+        return False
+    grant = lifecycle.grant
+    with lifecycle.lock:
+        if lifecycle.terminal_status is not None:
+            return False
+        if time.time() < grant.expires_at:
+            return skill_name in grant.skill_names
+    close_skill_read_grant(grant, "expired")
+    return False
+
+
+@contextmanager
+def skill_read_grant_scope(
+    skill_names,
+    *,
+    session_id: str,
+    profile: str,
+    requester: str,
+    source: str,
+    task_id: Optional[str] = None,
+    ttl_seconds: float = DEFAULT_SKILL_READ_GRANT_TTL_SECONDS,
+    audit_path: Optional[Path] = None,
+    authorization_aliases: Optional[Dict[str, Any]] = None,
+) -> Iterator[Optional[SkillReadGrant]]:
+    """Context-manager API with completion/error/cancel/timeout cleanup."""
+    previous = _ACTIVE_SKILL_READ_GRANT.get()
+    grant = issue_skill_read_grant(
+        skill_names,
+        session_id=session_id,
+        task_id=task_id,
+        profile=profile,
+        requester=requester,
+        source=source,
+        ttl_seconds=ttl_seconds,
+        audit_path=audit_path,
+        authorization_aliases=authorization_aliases,
+    )
+    lifecycle = _ACTIVE_SKILL_READ_GRANT.get()
+    owns_lifecycle = grant is not None and lifecycle is not previous
+    try:
+        yield grant
+    except KeyboardInterrupt:
+        close_skill_read_grant(grant, "cancelled")
+        raise
+    except TimeoutError:
+        close_skill_read_grant(grant, "timed_out")
+        raise
+    except SystemExit as exc:
+        terminal_status = (
+            "completed"
+            if exc.code in (None, 0)
+            else "cancelled"
+            if exc.code == 130
+            else "failed"
+        )
+        close_skill_read_grant(grant, terminal_status)
+        raise
+    except BaseException:
+        close_skill_read_grant(grant, "failed")
+        raise
+    else:
+        close_skill_read_grant(grant, "completed")
+    finally:
+        if owns_lifecycle and lifecycle is not None and lifecycle.token is not None:
+            _ACTIVE_SKILL_READ_GRANT.reset(lifecycle.token)
+
+
+@contextmanager
+def suppress_skill_read_grants() -> Iterator[None]:
+    """Fail-closed boundary used while constructing/running delegated agents."""
+    token = _ACTIVE_SKILL_READ_GRANT.set(None)
+    try:
+        yield
+    finally:
+        _ACTIVE_SKILL_READ_GRANT.reset(token)
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}

--- a/cli.py
+++ b/cli.py
@@ -39,6 +39,7 @@ import time
 import uuid
 import textwrap
 from collections import deque
+from contextvars import copy_context
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
@@ -5489,6 +5490,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # interrupt), freeze further UI paints so we don't spin the main
         # thread at hundreds of escape-sequence writes/sec (#81521).
         self._terminal_io_broken = False
+        self._last_run_cancelled = False
         self._should_exit = False
         # /exit --delete: when True, the current session's SQLite history and
         # on-disk transcripts are deleted during shutdown. Set by
@@ -16682,7 +16684,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # finishes; reset on the next turn.
             self._prompt_start_time = time.time()
             self._prompt_duration = 0.0
-            agent_thread = threading.Thread(target=run_agent, daemon=True)
+            from tools.thread_context import propagate_context_to_thread
+
+            agent_thread = threading.Thread(
+                target=propagate_context_to_thread(run_agent), daemon=True
+            )
             agent_thread.start()
 
             # Ambient "thinking" sound: calm bubble blips while the agent
@@ -20593,7 +20599,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         
         # Start processing thread
-        process_thread = threading.Thread(target=process_loop, daemon=True)
+        process_context = copy_context()
+        process_thread = threading.Thread(
+            target=process_context.run,
+            args=(process_loop,),
+            daemon=True,
+        )
         process_thread.start()
 
         # Wake word ("Hey Hermes") — start the always-on hotword listener if
@@ -20650,6 +20661,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # never arm its own watchdog — leaving a "dead" CLI alive for
             # minutes (#65998 class).  Never raises.
             _arm_exit_watchdog_on_shutdown_signal()
+            self._last_run_cancelled = True
             try:
                 _signal_agent = getattr(self, "agent", None)
                 if _signal_agent is not None and getattr(self, "_agent_running", False):
@@ -20810,7 +20822,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
                 app.run()
-        except (EOFError, KeyboardInterrupt, BrokenPipeError):
+        except KeyboardInterrupt:
+            self._last_run_cancelled = True
+        except (EOFError, BrokenPipeError):
             pass
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
@@ -21042,6 +21056,56 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _active_skill_grant_profile() -> str:
+    """Resolve audit attribution from the active profile environment/home."""
+    explicit = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if explicit:
+        return explicit
+    home = get_hermes_home()
+    if home.parent.name == "profiles" and home.name:
+        return home.name
+    return "default"
+
+
+def _skill_grant_lifecycle(func):
+    """Close any grant created by one CLI invocation on every exit path."""
+    from functools import wraps
+
+    @wraps(func)
+    def _wrapped(*args, **kwargs):
+        from agent.skill_utils import close_skill_read_grant, current_skill_read_grant
+
+        previous = current_skill_read_grant()
+        terminal_status = "completed"
+        try:
+            return func(*args, **kwargs)
+        except KeyboardInterrupt:
+            terminal_status = "cancelled"
+            raise
+        except TimeoutError:
+            terminal_status = "timed_out"
+            raise
+        except SystemExit as exc:
+            terminal_status = (
+                "completed"
+                if exc.code in (None, 0)
+                else "cancelled"
+                if exc.code == 130
+                else "failed"
+            )
+            raise
+        except BaseException:
+            terminal_status = "failed"
+            raise
+        finally:
+            current = current_skill_read_grant()
+            if current is not None and current is not previous:
+                close_skill_read_grant(current, terminal_status)
+
+    return _wrapped
+
+
+@_skill_grant_lifecycle
 def main(
     query: str = None,
     q: str = None,
@@ -21260,6 +21324,29 @@ def main(
         ignore_rules=ignore_rules,
     )
 
+    # Explicit CLI/Kanban --skills requests may need a narrow exception to the
+    # profile's disabled-skill baseline. Resolve aliases and categorized paths
+    # to the exact identity checked by skill_view before issuing the grant.
+    from agent.skill_utils import close_skill_read_grant, issue_skill_read_grant
+    from tools.skills_tool import resolve_skill_read_grant_targets
+
+    _kanban_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip() or None
+    _skill_grant_source = "kanban" if _kanban_task_id else "cli"
+    _skill_grant_profile = _active_skill_grant_profile()
+    _skill_grant_targets = resolve_skill_read_grant_targets(parsed_skills)
+    _skill_grant_names = list(_skill_grant_targets)
+    _skill_grant = issue_skill_read_grant(
+        _skill_grant_names,
+        session_id=cli.session_id,
+        task_id=_kanban_task_id,
+        profile=_skill_grant_profile,
+        requester=_skill_grant_profile if _kanban_task_id else "local-cli",
+        source=_skill_grant_source,
+        authorization_aliases=_skill_grant_targets,
+    )
+    # Idempotent safety net for setup errors and hard-to-reach exit paths.
+    atexit.register(close_skill_read_grant, _skill_grant, "failed")
+
     if parsed_skills:
         # Load the skill payloads in the background: skill_view walks the
         # full skills tree per skill (~0.5s for a large library) and the
@@ -21278,8 +21365,12 @@ def main(
                 cli._preload_skills_error = exc
 
         cli._preload_skills_requested = parsed_skills
+        from tools.thread_context import propagate_context_to_thread
+
         cli._preload_skills_thread = threading.Thread(
-            target=_load_preloaded_skills, name="skills-preload", daemon=True
+            target=propagate_context_to_thread(_load_preloaded_skills),
+            name="skills-preload",
+            daemon=True,
         )
         cli._preload_skills_thread.start()
 
@@ -21364,6 +21455,9 @@ def main(
         # the flush against any rare blocking-I/O case (the reporter measured
         # flush in <1ms; the alarm is a failsafe, not the common path).
         if os.environ.get("HERMES_KANBAN_TASK"):
+            # Dispatcher timeout uses SIGTERM; close the metadata-only grant
+            # before os._exit bypasses normal finally/atexit cleanup.
+            close_skill_read_grant(_skill_grant, "timed_out")
             try:
                 import signal as _sig_mod
                 if hasattr(_sig_mod, "SIGALRM"):
@@ -21655,8 +21749,11 @@ def main(
             _finalize_single_query(cli)
         return
     
-    # Run interactive mode
+    # Run interactive mode. The outer lifecycle boundary handles every raised
+    # exit; a swallowed prompt cancellation is the sole status override.
     cli.run()
+    if getattr(cli, "_last_run_cancelled", False):
+        close_skill_read_grant(_skill_grant, "cancelled")
 
 
 if __name__ == "__main__":

--- a/cli.py
+++ b/cli.py
@@ -39,6 +39,7 @@ import time
 import uuid
 import textwrap
 from collections import deque
+from contextvars import copy_context
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
@@ -4627,6 +4628,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # don't auto-queue another continuation on top of a user-cancelled
         # turn (which would make Ctrl+C feel like it did nothing).
         self._last_turn_interrupted = False
+        self._last_run_cancelled = False
         self._should_exit = False
         # /exit --delete: when True, the current session's SQLite history and
         # on-disk transcripts are deleted during shutdown. Set by
@@ -13944,7 +13946,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # finishes; reset on the next turn.
             self._prompt_start_time = time.time()
             self._prompt_duration = 0.0
-            agent_thread = threading.Thread(target=run_agent, daemon=True)
+            from tools.thread_context import propagate_context_to_thread
+
+            agent_thread = threading.Thread(
+                target=propagate_context_to_thread(run_agent), daemon=True
+            )
             agent_thread.start()
 
             # Ambient "thinking" sound: calm bubble blips while the agent
@@ -17432,7 +17438,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         
         # Start processing thread
-        process_thread = threading.Thread(target=process_loop, daemon=True)
+        process_context = copy_context()
+        process_thread = threading.Thread(
+            target=process_context.run,
+            args=(process_loop,),
+            daemon=True,
+        )
         process_thread.start()
 
         # Wake word ("Hey Hermes") — start the always-on hotword listener if
@@ -17489,6 +17500,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # never arm its own watchdog — leaving a "dead" CLI alive for
             # minutes (#65998 class).  Never raises.
             _arm_exit_watchdog_on_shutdown_signal()
+            self._last_run_cancelled = True
             try:
                 if getattr(self, "agent", None) and getattr(self, "_agent_running", False):
                     self.agent.interrupt(f"received signal {signum}")
@@ -17641,7 +17653,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
                 app.run()
-        except (EOFError, KeyboardInterrupt, BrokenPipeError):
+        except KeyboardInterrupt:
+            self._last_run_cancelled = True
+        except (EOFError, BrokenPipeError):
             pass
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
@@ -17862,6 +17876,56 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _active_skill_grant_profile() -> str:
+    """Resolve audit attribution from the active profile environment/home."""
+    explicit = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if explicit:
+        return explicit
+    home = get_hermes_home()
+    if home.parent.name == "profiles" and home.name:
+        return home.name
+    return "default"
+
+
+def _skill_grant_lifecycle(func):
+    """Close any grant created by one CLI invocation on every exit path."""
+    from functools import wraps
+
+    @wraps(func)
+    def _wrapped(*args, **kwargs):
+        from agent.skill_utils import close_skill_read_grant, current_skill_read_grant
+
+        previous = current_skill_read_grant()
+        terminal_status = "completed"
+        try:
+            return func(*args, **kwargs)
+        except KeyboardInterrupt:
+            terminal_status = "cancelled"
+            raise
+        except TimeoutError:
+            terminal_status = "timed_out"
+            raise
+        except SystemExit as exc:
+            terminal_status = (
+                "completed"
+                if exc.code in (None, 0)
+                else "cancelled"
+                if exc.code == 130
+                else "failed"
+            )
+            raise
+        except BaseException:
+            terminal_status = "failed"
+            raise
+        finally:
+            current = current_skill_read_grant()
+            if current is not None and current is not previous:
+                close_skill_read_grant(current, terminal_status)
+
+    return _wrapped
+
+
+@_skill_grant_lifecycle
 def main(
     query: str = None,
     q: str = None,
@@ -18026,6 +18090,29 @@ def main(
         ignore_rules=ignore_rules,
     )
 
+    # Explicit CLI/Kanban --skills requests may need a narrow exception to the
+    # profile's disabled-skill baseline. Resolve aliases and categorized paths
+    # to the exact identity checked by skill_view before issuing the grant.
+    from agent.skill_utils import close_skill_read_grant, issue_skill_read_grant
+    from tools.skills_tool import resolve_skill_read_grant_targets
+
+    _kanban_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip() or None
+    _skill_grant_source = "kanban" if _kanban_task_id else "cli"
+    _skill_grant_profile = _active_skill_grant_profile()
+    _skill_grant_targets = resolve_skill_read_grant_targets(parsed_skills)
+    _skill_grant_names = list(_skill_grant_targets)
+    _skill_grant = issue_skill_read_grant(
+        _skill_grant_names,
+        session_id=cli.session_id,
+        task_id=_kanban_task_id,
+        profile=_skill_grant_profile,
+        requester=_skill_grant_profile if _kanban_task_id else "local-cli",
+        source=_skill_grant_source,
+        authorization_aliases=_skill_grant_targets,
+    )
+    # Idempotent safety net for setup errors and hard-to-reach exit paths.
+    atexit.register(close_skill_read_grant, _skill_grant, "failed")
+
     if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
             parsed_skills,
@@ -18125,6 +18212,9 @@ def main(
         # the flush against any rare blocking-I/O case (the reporter measured
         # flush in <1ms; the alarm is a failsafe, not the common path).
         if os.environ.get("HERMES_KANBAN_TASK"):
+            # Dispatcher timeout uses SIGTERM; close the metadata-only grant
+            # before os._exit bypasses normal finally/atexit cleanup.
+            close_skill_read_grant(_skill_grant, "timed_out")
             try:
                 import signal as _sig_mod
                 if hasattr(_sig_mod, "SIGALRM"):
@@ -18384,8 +18474,11 @@ def main(
             _finalize_single_query(cli)
         return
     
-    # Run interactive mode
+    # Run interactive mode. The outer lifecycle boundary handles every raised
+    # exit; a swallowed prompt cancellation is the sole status override.
     cli.run()
+    if getattr(cli, "_last_run_cancelled", False):
+        close_skill_read_grant(_skill_grant, "cancelled")
 
 
 if __name__ == "__main__":

--- a/run_agent.py
+++ b/run_agent.py
@@ -1926,7 +1926,6 @@ class AIAgent:
             spawn_background_review_thread,
         )
         from tools.thread_context import propagate_context_to_thread
-
         review_run = prepare_background_review_run(self)
         if review_run is None:
             return
@@ -1941,9 +1940,18 @@ class AIAgent:
                 review_run=review_run,
             )
             # Carry the active profile into the review thread so MEMORY.md /
-            # skill review writes land in the right profile (#54937).
+            # skill review writes land in the right profile (#54937), but
+            # explicitly suppress foreground preload grants across the
+            # unrelated autonomous review boundary. The wrapper covers both
+            # review-agent construction and execution.
+            def _run_isolated_review() -> None:
+                from agent.skill_utils import suppress_skill_read_grants
+
+                with suppress_skill_read_grants():
+                    target()
+
             t = threading.Thread(
-                target=propagate_context_to_thread(target),
+                target=propagate_context_to_thread(_run_isolated_review),
                 daemon=True,
                 name="bg-review",
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1790,9 +1790,19 @@ class AIAgent:
             review_skills=review_skills,
         )
         # Carry the active profile into the review thread so MEMORY.md / skill
-        # review writes land in the right profile (#54937).
+        # review writes land in the right profile (#54937), but explicitly
+        # suppress foreground preload grants across the unrelated autonomous
+        # review boundary. The wrapper covers both fork construction and run.
+        def _run_isolated_review() -> None:
+            from agent.skill_utils import suppress_skill_read_grants
+
+            with suppress_skill_read_grants():
+                target()
+
         t = threading.Thread(
-            target=propagate_context_to_thread(target), daemon=True, name="bg-review"
+            target=propagate_context_to_thread(_run_isolated_review),
+            daemon=True,
+            name="bg-review",
         )
         t.start()
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -34,6 +34,33 @@ from agent.transports import get_transport
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def isolate_anthropic_credentials(monkeypatch, tmp_path):
+    """Keep adapter unit tests isolated from machine-local auth sources."""
+    for env_var in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+    keychain_reader = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        keychain_reader,
+    )
+
+    empty_pool = SimpleNamespace(_available_entries=lambda **_kwargs: [])
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda _provider: empty_pool,
+    )
+
+    return keychain_reader
+
+
 class TestIsOAuthToken:
     def test_setup_token(self):
         assert _is_oauth_token("sk-ant-oat01-abcdef1234567890") is True
@@ -152,12 +179,22 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
-    @pytest.fixture(autouse=True)
-    def no_keychain(self, monkeypatch):
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
+    def test_module_isolation_fails_closed_before_keychain_subprocess(
+        self,
+        isolate_anthropic_credentials,
+        monkeypatch,
+    ):
+        subprocess_run = MagicMock(
+            side_effect=AssertionError("adapter unit tests must not invoke Keychain subprocesses")
         )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.subprocess.run",
+            subprocess_run,
+        )
+
+        assert read_claude_code_credentials() is None
+        isolate_anthropic_credentials.assert_called_once_with()
+        subprocess_run.assert_not_called()
 
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -34,6 +34,33 @@ from agent.transports import get_transport
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def isolate_anthropic_credentials(monkeypatch, tmp_path):
+    """Keep adapter unit tests isolated from machine-local auth sources."""
+    for env_var in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+    keychain_reader = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        keychain_reader,
+    )
+
+    empty_pool = SimpleNamespace(_available_entries=lambda **_kwargs: [])
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda _provider: empty_pool,
+    )
+
+    return keychain_reader
+
+
 class TestIsOAuthToken:
     def test_setup_token(self):
         assert _is_oauth_token("sk-ant-oat01-abcdef1234567890") is True
@@ -131,12 +158,22 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
-    @pytest.fixture(autouse=True)
-    def no_keychain(self, monkeypatch):
-        monkeypatch.setattr(
-            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
-            lambda: None,
+    def test_module_isolation_fails_closed_before_keychain_subprocess(
+        self,
+        isolate_anthropic_credentials,
+        monkeypatch,
+    ):
+        subprocess_run = MagicMock(
+            side_effect=AssertionError("adapter unit tests must not invoke Keychain subprocesses")
         )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.subprocess.run",
+            subprocess_run,
+        )
+
+        assert read_claude_code_credentials() is None
+        isolate_anthropic_credentials.assert_called_once_with()
+        subprocess_run.assert_not_called()
 
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"

--- a/tests/agent/test_skill_read_grants.py
+++ b/tests/agent/test_skill_read_grants.py
@@ -1,0 +1,1348 @@
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from agent import skill_utils
+from tools import skills_tool
+
+
+@pytest.fixture
+def disabled_skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled:\n    - alpha\n    - beta\n",
+        encoding="utf-8",
+    )
+    for name in ("alpha", "beta", "enabled"):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            (
+                f"---\nname: {name}\ndescription: {name} skill\n---\n\n"
+                f"{name} body\n"
+                "prompt-canary credential-canary user-data-canary\n"
+            ),
+            encoding="utf-8",
+        )
+        references = skill_dir / "references"
+        references.mkdir()
+        (references / "details.md").write_text(
+            f"{name} details\n", encoding="utf-8"
+        )
+
+    skill_utils._raw_config_cache_clear()
+    yield home, config_path
+    skill_utils._raw_config_cache_clear()
+
+
+def _view(name: str) -> dict:
+    return json.loads(skills_tool.skill_view(name, preprocess=False))
+
+
+def _write_alias_test_skill(
+    root: Path,
+    relative_selector: str,
+    canonical: str,
+    body: str,
+    *,
+    legacy_flat: bool,
+) -> Path:
+    target = root / relative_selector
+    skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text(
+        (
+            f"---\nname: {canonical}\ndescription: alias test\n---\n\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    return skill_md
+
+
+def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+
+def _audit_events(home: Path) -> list[dict]:
+    path = home / "logs" / "skill-grants.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_exact_disabled_skill_grant_preserves_config(disabled_skills_home):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+
+    assert _view("alpha")["success"] is False
+    assert _view("enabled")["success"] is True
+
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-1",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ):
+        assert _view("alpha")["success"] is True
+        alpha_file = json.loads(
+            skills_tool.skill_view(
+                "alpha", file_path="references/details.md", preprocess=False
+            )
+        )
+        assert alpha_file["success"] is True
+        assert alpha_file["content"] == "alpha details\n"
+        assert _view("beta")["success"] is False
+        listed = json.loads(skills_tool.skills_list())
+        listed_names = {skill["name"] for skill in listed["skills"]}
+        assert "alpha" not in listed_names
+
+    assert _view("alpha")["success"] is False
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled == {
+        "alpha",
+        "beta",
+    }
+    events = _audit_events(home)
+    assert [event["event"] for event in events] == ["issued", "closed"]
+    issued, closed = events
+    expected_fields = {
+        "event",
+        "grant_id",
+        "session_id",
+        "task_id",
+        "profile",
+        "skill_names",
+        "requester",
+        "source",
+        "issued_at",
+        "expires_at",
+        "recorded_at",
+        "terminal_status",
+    }
+    assert set(issued) == expected_fields
+    assert set(closed) == expected_fields
+    assert issued["session_id"] == "session-1"
+    assert issued["task_id"] is None
+    assert issued["profile"] == "build"
+    assert issued["skill_names"] == ["alpha"]
+    assert issued["requester"] == "local-cli"
+    assert issued["source"] == "cli"
+    assert issued["issued_at"] < issued["expires_at"]
+    assert issued["terminal_status"] == "active"
+    assert closed["terminal_status"] == "completed"
+    serialized = json.dumps(events).lower()
+    for forbidden in (
+        "content",
+        "prompt",
+        "credential",
+        "user-data",
+        "alpha body",
+    ):
+        assert forbidden not in serialized
+
+
+def test_grant_resolution_uses_active_profile_home(tmp_path, monkeypatch):
+    profile_home = tmp_path / ".hermes" / "profiles" / "build"
+    skill_md = profile_home / "skills" / "alpha" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text(
+        "---\nname: alpha\ndescription: profile skill\n---\n\nprofile body\n",
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  disabled: [alpha]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(
+        skills_tool, "SKILLS_DIR", skills_tool._SKILLS_DIR_AT_IMPORT
+    )
+    monkeypatch.setattr(skill_utils, "get_project_skills_dirs", lambda: [])
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert targets == {"alpha": {"alpha"}}
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="profile-session",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        result = _view("alpha")
+    assert result["success"] is True
+    assert "profile body" in result["content"]
+
+
+def test_project_precedence_does_not_inherit_local_disabled_alias(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    local_root = home / "skills"
+    project_root = tmp_path / "project" / ".hermes" / "skills"
+    _write_alias_test_skill(
+        local_root, "alpha", "local-alpha", "local body", legacy_flat=False
+    )
+    _write_alias_test_skill(
+        project_root,
+        "alpha",
+        "project-alpha",
+        "project body",
+        legacy_flat=False,
+    )
+    config_path = home / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", local_root)
+    monkeypatch.setattr(
+        skill_utils, "get_project_skills_dirs", lambda: [project_root]
+    )
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(
+        skill_utils, "is_quarantined_project_skill", lambda _skill_md: False
+    )
+
+    config_path.write_text(
+        "skills:\n  disabled: [local-alpha]\n", encoding="utf-8"
+    )
+    skill_utils._raw_config_cache_clear()
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert "local-alpha" not in targets["alpha"]
+    assert skill_utils.issue_skill_read_grant(
+        list(targets),
+        session_id="project-session-denied",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ) is None
+
+    config_path.write_text(
+        "skills:\n  disabled: [project-alpha]\n", encoding="utf-8"
+    )
+    skill_utils._raw_config_cache_clear()
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="project-session-allowed",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        result = _view("alpha")
+    assert result["success"] is True
+    assert "project body" in result["content"]
+    assert "local body" not in result["content"]
+
+
+def test_grant_claims_are_immutable(disabled_skills_home):
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-immutable",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ) as grant:
+        assert grant is not None
+        with pytest.raises(FrozenInstanceError):
+            grant.profile = "attacker"  # type: ignore[misc]
+
+
+def test_nested_grant_scope_restores_outer_context(disabled_skills_home):
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-outer",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ) as outer:
+        assert outer is not None
+        assert skill_utils.current_skill_read_grant() is outer
+        assert skill_utils.is_skill_read_granted("alpha") is True
+
+        with skill_utils.skill_read_grant_scope(
+            ["beta"],
+            session_id="session-inner",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ) as inner:
+            assert inner is not None
+            assert skill_utils.current_skill_read_grant() is inner
+            assert skill_utils.is_skill_read_granted("alpha") is False
+            assert skill_utils.is_skill_read_granted("beta") is True
+
+        assert skill_utils.current_skill_read_grant() is outer
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        assert skill_utils.is_skill_read_granted("beta") is False
+
+    assert skill_utils.current_skill_read_grant() is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"session_id": ""},
+        {"source": "untrusted"},
+        {"source": "kanban", "task_id": None},
+        {"ttl_seconds": 0},
+    ],
+)
+def test_invalid_grant_claims_fail_closed(
+    disabled_skills_home, tmp_path, overrides
+):
+    audit_path = tmp_path / f"invalid-{len(str(overrides))}.jsonl"
+    kwargs = {
+        "session_id": "session-valid",
+        "task_id": None,
+        "profile": "build",
+        "requester": "local-cli",
+        "source": "cli",
+        "ttl_seconds": 60,
+        "audit_path": audit_path,
+    }
+    kwargs.update(overrides)
+
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            skill_utils.issue_skill_read_grant(["alpha"], **kwargs)
+    finally:
+        active = skill_utils.current_skill_read_grant()
+        if active is not None:
+            skill_utils.close_skill_read_grant(active, "failed")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert not audit_path.exists()
+
+
+def test_enabled_skill_uses_existing_behavior_without_grant_or_audit(
+    disabled_skills_home,
+):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+
+    grant = skill_utils.issue_skill_read_grant(
+        ["enabled"],
+        session_id="session-enabled",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    )
+
+    assert grant is None
+    assert skill_utils.current_skill_read_grant() is None
+    assert _view("enabled")["success"] is True
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+    assert not (home / "logs" / "skill-grants.jsonl").exists()
+
+
+def test_expired_grant_is_denied_and_closed(disabled_skills_home, monkeypatch):
+    home, _ = disabled_skills_home
+    now = 1_000.0
+    monkeypatch.setattr(skill_utils.time, "time", lambda: now)
+
+    grant = skill_utils.issue_skill_read_grant(
+        ["alpha"],
+        session_id="session-expired",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=10,
+    )
+    assert grant is not None
+    assert skill_utils.is_skill_read_granted("alpha") is True
+
+    now = 1_011.0
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    skill_utils.close_skill_read_grant(grant, "completed")
+
+    events = _audit_events(home)
+    assert events[-1]["event"] == "closed"
+    assert events[-1]["terminal_status"] == "expired"
+    assert skill_utils.is_skill_read_granted("alpha") is False
+
+
+@pytest.mark.parametrize(
+    ("error", "terminal_status"),
+    [
+        (RuntimeError("boom"), "failed"),
+        (KeyboardInterrupt(), "cancelled"),
+        (TimeoutError("slow"), "timed_out"),
+    ],
+)
+def test_grant_scope_cleans_up_on_abnormal_exit(
+    disabled_skills_home, error, terminal_status
+):
+    home, _ = disabled_skills_home
+
+    with pytest.raises(type(error)):
+        with skill_utils.skill_read_grant_scope(
+            ["alpha"],
+            session_id=f"session-{terminal_status}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            raise error
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == terminal_status
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "terminal_status"),
+    [
+        (None, "completed"),
+        (0, "completed"),
+        (130, "cancelled"),
+        (1, "failed"),
+    ],
+)
+def test_grant_scope_classifies_system_exit(
+    disabled_skills_home, exit_code, terminal_status
+):
+    home, _ = disabled_skills_home
+
+    with pytest.raises(SystemExit) as exc_info:
+        with skill_utils.skill_read_grant_scope(
+            ["alpha"],
+            session_id=f"session-exit-{exit_code}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            raise SystemExit(exit_code)
+
+    assert exc_info.value.code == exit_code
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == terminal_status
+
+
+def test_parallel_grants_are_isolated(disabled_skills_home):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    barrier = threading.Barrier(2)
+    results: dict[str, tuple[bool, bool, str, str | None]] = {}
+
+    def run(name: str, other: str) -> None:
+        with skill_utils.skill_read_grant_scope(
+            [name],
+            session_id=f"session-{name}",
+            task_id=f"task-{name}",
+            profile="build",
+            requester="build",
+            source="kanban",
+            ttl_seconds=60,
+        ):
+            barrier.wait(timeout=5)
+            active = skill_utils.current_skill_read_grant()
+            assert active is not None
+            results[name] = (
+                skill_utils.is_skill_read_granted(name),
+                skill_utils.is_skill_read_granted(other),
+                active.session_id,
+                active.task_id,
+            )
+
+    alpha = threading.Thread(target=run, args=("alpha", "beta"))
+    beta = threading.Thread(target=run, args=("beta", "alpha"))
+    alpha.start()
+    beta.start()
+    alpha.join(timeout=5)
+    beta.join(timeout=5)
+
+    assert results == {
+        "alpha": (True, False, "session-alpha", "task-alpha"),
+        "beta": (True, False, "session-beta", "task-beta"),
+    }
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert skill_utils.is_skill_read_granted("beta") is False
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+
+    events = _audit_events(home)
+    by_grant: dict[str, list[dict]] = {}
+    for event in events:
+        by_grant.setdefault(event["grant_id"], []).append(event)
+    assert len(by_grant) == 2
+    attribution = {
+        (
+            records[0]["session_id"],
+            records[0]["task_id"],
+            records[0]["skill_names"][0],
+        )
+        for records in by_grant.values()
+    }
+    assert attribution == {
+        ("session-alpha", "task-alpha", "alpha"),
+        ("session-beta", "task-beta", "beta"),
+    }
+    assert all(
+        [record["terminal_status"] for record in records]
+        == ["active", "completed"]
+        for records in by_grant.values()
+    )
+
+
+def test_tool_thread_context_propagates_only_the_current_grant(
+    disabled_skills_home, tmp_path
+):
+    from tools.thread_context import propagate_context_to_thread
+
+    audit_path = tmp_path / "propagated.jsonl"
+    result = []
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-parent",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+        audit_path=audit_path,
+    ):
+        wrapped = propagate_context_to_thread(
+            lambda: result.append(
+                (
+                    skill_utils.is_skill_read_granted("alpha"),
+                    skill_utils.is_skill_read_granted("beta"),
+                )
+            )
+        )
+        thread = threading.Thread(target=wrapped)
+        thread.start()
+        thread.join()
+
+    assert result == [(True, False)]
+
+
+def test_grant_fails_closed_when_issuance_audit_cannot_be_written(
+    disabled_skills_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(skill_utils, "_write_skill_grant_audit", lambda *a, **k: False)
+
+    with pytest.raises(RuntimeError, match="required skill-grant audit"):
+        skill_utils.issue_skill_read_grant(
+            ["alpha"],
+            session_id="session-audit-failure",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+            audit_path=tmp_path / "unwritten.jsonl",
+        )
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+
+
+def test_categorized_skill_grant_stays_bound_to_requested_identity(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\nalpha body\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [alpha]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    for requested in ("category/directory-alias", "category:directory-alias"):
+        targets = skills_tool.resolve_skill_read_grant_targets([requested])
+        assert list(targets) == [requested]
+        assert "alpha" in targets[requested]
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=f"session-{requested}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ):
+            assert skill_utils.is_skill_read_granted(requested) is True
+            assert _view(requested)["success"] is True
+
+
+def test_categorized_colon_identity_matches_disabled_config(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\ncolon body\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "category:directory-alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert list(targets) == [requested]
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-colon",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        assert skill_utils.is_skill_read_granted(requested) is True
+        viewed = _view(requested)
+        assert viewed["success"] is True
+        assert "colon body" in viewed["content"]
+
+
+def test_colon_disabled_local_is_denied_via_slash_and_unique_bare_before_read(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    skill_md = target / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\n"
+        "disabled-content-canary\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    slash_targets = skills_tool.resolve_skill_read_grant_targets(
+        ["category/directory-alias"]
+    )
+    bare_targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert slash_targets["category/directory-alias"] >= {
+        "category/directory-alias",
+        "category:directory-alias",
+        "alpha",
+    }
+    assert bare_targets["alpha"] >= {
+        "category/directory-alias",
+        "category:directory-alias",
+        "alpha",
+    }
+
+    original_read_text = Path.read_text
+
+    def reject_full_skill_read(path, *args, **kwargs):
+        if path == skill_md:
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_full_skill_read)
+    for selector in ("category/directory-alias", "alpha"):
+        viewed = _view(selector)
+        assert viewed["success"] is False
+        assert "disabled" in viewed["error"].lower()
+        assert "disabled-content-canary" not in json.dumps(viewed)
+
+
+def test_slash_grant_authorizes_colon_disabled_target_but_not_sibling(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alias"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            (
+                "---\nname: shared\ndescription: collision\n---\n\n"
+                f"{category} body\n"
+            ),
+            encoding="utf-8",
+        )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [one:alias, two:alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "one/alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert "one:alias" in targets[requested]
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-slash-colon",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        assert skill_utils.is_skill_read_granted(requested) is True
+        selected = _view(requested)
+        sibling = _view("two/alias")
+        assert selected["success"] is True
+        assert "one body" in selected["content"]
+        assert sibling["success"] is False
+        assert "two body" not in json.dumps(sibling)
+
+
+def test_explicit_categorized_path_ignores_leaf_collision_and_denies_sibling(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alias"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            (
+                "---\nname: shared\ndescription: collision\n---\n\n"
+                f"{category} body\n"
+            ),
+            encoding="utf-8",
+        )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [shared]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "one/alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert list(targets) == [requested]
+    assert "shared" in targets[requested]
+    assert skills_tool.resolve_skill_read_grant_names(["alias"]) == []
+    assert skills_tool.resolve_skill_read_grant_names(["shared"]) == []
+    for selector in ("one/alias", "two/alias"):
+        denied = _view(selector)
+        assert denied["success"] is False
+        assert f"{selector.split('/')[0]} body" not in json.dumps(denied)
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-explicit",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        selected = _view(requested)
+        sibling = _view("two/alias")
+        assert selected["success"] is True
+        assert "one body" in selected["content"]
+        assert sibling["success"] is False
+        assert "two body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_fallback_name_disabled_denies_canonical_selector_and_sibling(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+
+    def write_skill(category, canonical, body):
+        target = skills_dir / category / "directory-alias"
+        skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+        skill_md.parent.mkdir(parents=True)
+        skill_md.write_text(
+            (
+                f"---\nname: {canonical}\ndescription: fallback alias\n---\n\n"
+                f"{body}\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_skill("category", "alpha", "alpha body")
+    write_skill("sibling", "beta", "beta body")
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert targets["alpha"] >= {"alpha", "directory-alias"}
+    assert skills_tool.resolve_skill_read_grant_names(["directory-alias"]) == []
+    for selector, body in (("alpha", "alpha body"), ("beta", "beta body")):
+        denied = _view(selector)
+        assert denied["success"] is False
+        assert body not in json.dumps(denied)
+
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id=f"session-fallback-{'flat' if legacy_flat else 'package'}",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ) as grant:
+        assert grant is not None
+        selected = _view("alpha")
+        sibling = _view("beta")
+        assert selected["success"] is True
+        assert "alpha body" in selected["content"]
+        assert sibling["success"] is False
+        assert "beta body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_ambiguous_relative_path_is_not_a_disabled_or_grant_alias(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    external_dir = tmp_path / "external-skills"
+
+    def write_skill(root, canonical, body):
+        target = root / "category" / "foo"
+        skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+        skill_md.parent.mkdir(parents=True)
+        skill_md.write_text(
+            (
+                f"---\nname: {canonical}\ndescription: relative collision\n---\n\n"
+                f"{body}\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_skill(skills_dir, "alpha", "primary body")
+    write_skill(external_dir, "beta", "external body")
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category/foo]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        skill_utils, "get_external_skills_dirs", lambda: [external_dir]
+    )
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert list(targets) == ["alpha"]
+    assert "category/foo" not in targets["alpha"]
+    assert "category:foo" not in targets["alpha"]
+    assert _view("alpha")["success"] is True
+
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id=f"session-relative-{'flat' if legacy_flat else 'package'}",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ) as grant:
+        assert grant is None
+        assert skill_utils.current_skill_read_grant() is None
+
+    assert skills_tool.resolve_skill_read_grant_names(["category/foo"]) == []
+    ambiguous = _view("category/foo")
+    assert ambiguous["success"] is False
+    assert "ambiguous" in ambiguous["error"].lower()
+    assert "primary body" not in json.dumps(ambiguous)
+    assert "external body" not in json.dumps(ambiguous)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_overlapping_roots_enumerate_every_same_file_selector_before_read(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    overlap_root = skills_dir / "overlap"
+    skill_md = _write_alias_test_skill(
+        skills_dir,
+        "overlap/category/foo",
+        "alpha",
+        "overlap body",
+        legacy_flat=legacy_flat,
+    )
+    _write_alias_test_skill(
+        skills_dir,
+        "sibling/bar",
+        "beta",
+        "sibling body",
+        legacy_flat=legacy_flat,
+    )
+    config_path = home / "config.yaml"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        skill_utils, "get_external_skills_dirs", lambda: [overlap_root]
+    )
+
+    expected_paths = {"overlap/category/foo", "category/foo"}
+    allow_full_read = False
+    original_read_text = Path.read_text
+
+    def reject_ungranted_full_read(path, *args, **kwargs):
+        if (
+            not allow_full_read
+            and skills_tool._same_local_skill_file(path, skill_md)
+        ):
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_ungranted_full_read)
+    for disabled_path in sorted(expected_paths):
+        config_path.write_text(
+            f"skills:\n  disabled: [{disabled_path}, beta]\n",
+            encoding="utf-8",
+        )
+        skill_utils._raw_config_cache_clear()
+        targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+        assert targets["alpha"] >= expected_paths | {"alpha"}
+
+        allow_full_read = False
+        denied = _view("alpha")
+        assert denied["success"] is False
+        assert "disabled" in denied["error"].lower()
+        assert "overlap body" not in json.dumps(denied)
+
+        allow_full_read = True
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=(
+                f"session-overlap-{'flat' if legacy_flat else 'package'}-"
+                f"{disabled_path}"
+            ),
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ) as grant:
+            assert grant is not None
+            selected = _view("alpha")
+            sibling = _view("beta")
+            assert selected["success"] is True
+            assert "overlap body" in selected["content"]
+            assert sibling["success"] is False
+            assert "sibling body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_symlink_aliases_enumerate_real_and_alias_selectors_before_read(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    skill_md = _write_alias_test_skill(
+        skills_dir,
+        "real/foo",
+        "alpha",
+        "symlink body",
+        legacy_flat=legacy_flat,
+    )
+    if legacy_flat:
+        alias_dir = skills_dir / "alias"
+        alias_dir.mkdir(parents=True)
+        _symlink_or_skip(
+            alias_dir / "foo.md", skill_md, target_is_directory=False
+        )
+    else:
+        _symlink_or_skip(
+            skills_dir / "alias",
+            skills_dir / "real",
+            target_is_directory=True,
+        )
+    _write_alias_test_skill(
+        skills_dir,
+        "sibling/bar",
+        "beta",
+        "sibling body",
+        legacy_flat=legacy_flat,
+    )
+    config_path = home / "config.yaml"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    expected_paths = {"real/foo", "alias/foo"}
+    allow_full_read = False
+    original_read_text = Path.read_text
+
+    def reject_ungranted_full_read(path, *args, **kwargs):
+        if (
+            not allow_full_read
+            and skills_tool._same_local_skill_file(path, skill_md)
+        ):
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_ungranted_full_read)
+    for disabled_path in sorted(expected_paths):
+        config_path.write_text(
+            f"skills:\n  disabled: [{disabled_path}, beta]\n",
+            encoding="utf-8",
+        )
+        skill_utils._raw_config_cache_clear()
+        targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+        assert targets["alpha"] >= expected_paths | {"alpha"}
+
+        allow_full_read = False
+        denied = _view("alpha")
+        assert denied["success"] is False
+        assert "disabled" in denied["error"].lower()
+        assert "symlink body" not in json.dumps(denied)
+
+        allow_full_read = True
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=(
+                f"session-symlink-{'flat' if legacy_flat else 'package'}-"
+                f"{disabled_path}"
+            ),
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ) as grant:
+            assert grant is not None
+            selected = _view("alpha")
+            sibling = _view("beta")
+            assert selected["success"] is True
+            assert "symlink body" in selected["content"]
+            assert sibling["success"] is False
+            assert "sibling body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize(
+    ("excluded_dir", "legacy_flat"),
+    [("node_modules", False), (".git", True)],
+    ids=["node-modules-package", "git-flat"],
+)
+def test_excluded_flat_markdown_cannot_resolve_or_collide(
+    tmp_path, monkeypatch, excluded_dir, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    canonical = f"visible-{'flat' if legacy_flat else 'package'}"
+    _write_alias_test_skill(
+        skills_dir,
+        "category/visible",
+        canonical,
+        "legitimate body",
+        legacy_flat=legacy_flat,
+    )
+
+    excluded_root = skills_dir / excluded_dir
+    excluded_root.mkdir(parents=True)
+    (excluded_root / "matching.md").write_text(
+        (
+            f"---\nname: {canonical}\ndescription: excluded collision\n---\n\n"
+            "excluded collision body\n"
+        ),
+        encoding="utf-8",
+    )
+    hidden_name = f"excluded-only-{'git' if excluded_dir == '.git' else 'deps'}"
+    (excluded_root / "hidden.md").write_text(
+        (
+            f"---\nname: {hidden_name}\ndescription: excluded only\n---\n\n"
+            "excluded only body\n"
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets([canonical])
+    assert list(targets) == [canonical]
+    assert all(excluded_dir not in alias for alias in targets[canonical])
+
+    visible = _view(canonical)
+    assert visible["success"] is True
+    assert "legitimate body" in visible["content"]
+    assert "excluded collision body" not in json.dumps(visible)
+
+    for hidden_selector in (hidden_name, "hidden"):
+        hidden = _view(hidden_selector)
+        assert hidden["success"] is False
+        assert "excluded only body" not in json.dumps(hidden)
+
+
+def test_canonicalization_refuses_ambiguous_bare_name(tmp_path, monkeypatch):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alpha"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: collision\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    assert skills_tool.resolve_skill_read_grant_names(["alpha"]) == []
+
+
+def test_canonicalization_distinguishes_plugin_colon_from_local_slash(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    local = skills_dir / "bundle" / "alpha"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: local-alpha\ndescription: local\n---\n\nlocal\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+
+    assert skills_tool.resolve_skill_read_grant_names(["bundle:alpha"]) == [
+        "bundle:alpha"
+    ]
+    assert skills_tool.resolve_skill_read_grant_names(["bundle/alpha"]) == [
+        "bundle/alpha"
+    ]
+
+
+def test_real_plugin_identity_neither_disables_nor_authorizes_local_slash(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    local = skills_dir / "bundle" / "alpha"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: local-alpha\ndescription: local\n---\n\nlocal body\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin body\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled: [bundle:alpha]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+    skill_utils._raw_config_cache_clear()
+
+    local_targets = skills_tool.resolve_skill_read_grant_targets(["bundle/alpha"])
+    assert "bundle:alpha" not in local_targets["bundle/alpha"]
+    assert _view("bundle/alpha")["success"] is True
+
+    config_path.write_text(
+        "skills:\n  disabled: [bundle:alpha, local-alpha]\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    plugin_targets = skills_tool.resolve_skill_read_grant_targets(["bundle:alpha"])
+    with skill_utils.skill_read_grant_scope(
+        list(plugin_targets),
+        session_id="session-plugin",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=plugin_targets,
+    ):
+        assert _view("bundle:alpha")["success"] is True
+        local_view = _view("bundle/alpha")
+        assert local_view["success"] is False
+        assert "local body" not in json.dumps(local_view)
+
+
+def test_plugin_owned_frontmatter_name_cannot_alias_local_skill(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    local = skills_dir / "local" / "foo"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: bundle:alpha\ndescription: local\n---\n\nlocal body\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin body\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [bundle:alpha]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+    skill_utils._raw_config_cache_clear()
+
+    local_targets = skills_tool.resolve_skill_read_grant_targets(["local/foo"])
+    assert "bundle:alpha" not in local_targets["local/foo"]
+    grant = skill_utils.issue_skill_read_grant(
+        list(local_targets),
+        session_id="session-local-poison",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=local_targets,
+    )
+    assert grant is None
+    assert skill_utils.current_skill_read_grant() is None
+    local_view = _view("local/foo")
+    plugin_view = _view("bundle:alpha")
+    assert local_view["success"] is True
+    assert "local body" in local_view["content"]
+    assert plugin_view["success"] is False
+    assert "plugin body" not in json.dumps(plugin_view)
+
+
+def test_frontmatter_slash_alias_must_resolve_back_to_selected_skill(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    selected = skills_dir / "local" / "foo"
+    selected.mkdir(parents=True)
+    (selected / "SKILL.md").write_text(
+        "---\nname: other/target\ndescription: selected\n---\n\nselected body\n",
+        encoding="utf-8",
+    )
+    actual = skills_dir / "other" / "target"
+    actual.mkdir(parents=True)
+    (actual / "SKILL.md").write_text(
+        "---\nname: actual-target\ndescription: actual\n---\n\nactual body\n",
+        encoding="utf-8",
+    )
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled: [other/target]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    selected_targets = skills_tool.resolve_skill_read_grant_targets(["local/foo"])
+    assert "other/target" not in selected_targets["local/foo"]
+    grant = skill_utils.issue_skill_read_grant(
+        list(selected_targets),
+        session_id="session-slash-poison",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=selected_targets,
+    )
+    assert grant is None
+    assert _view("local/foo")["success"] is True
+    assert _view("other/target")["success"] is False
+
+    config_path.write_text(
+        "skills:\n  disabled: [other/target, local/foo]\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    actual_targets = skills_tool.resolve_skill_read_grant_targets(["other/target"])
+    with skill_utils.skill_read_grant_scope(
+        list(actual_targets),
+        session_id="session-actual-target",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=actual_targets,
+    ):
+        assert _view("other/target")["success"] is True
+        poisoned_view = _view("local/foo")
+        assert poisoned_view["success"] is False
+        assert "selected body" not in json.dumps(poisoned_view)
+
+
+@pytest.mark.parametrize(
+    "requested",
+    ["../alpha", "/absolute/alpha", "missing", "bundle:", "alpha/../beta"],
+)
+def test_invalid_skill_identity_does_not_resolve_to_a_grant(
+    disabled_skills_home, requested
+):
+    assert skills_tool.resolve_skill_read_grant_names([requested]) == []

--- a/tests/agent/test_skill_read_grants.py
+++ b/tests/agent/test_skill_read_grants.py
@@ -1,0 +1,1252 @@
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from agent import skill_utils
+from tools import skills_tool
+
+
+@pytest.fixture
+def disabled_skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled:\n    - alpha\n    - beta\n",
+        encoding="utf-8",
+    )
+    for name in ("alpha", "beta", "enabled"):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            (
+                f"---\nname: {name}\ndescription: {name} skill\n---\n\n"
+                f"{name} body\n"
+                "prompt-canary credential-canary user-data-canary\n"
+            ),
+            encoding="utf-8",
+        )
+        references = skill_dir / "references"
+        references.mkdir()
+        (references / "details.md").write_text(
+            f"{name} details\n", encoding="utf-8"
+        )
+
+    skill_utils._raw_config_cache_clear()
+    yield home, config_path
+    skill_utils._raw_config_cache_clear()
+
+
+def _view(name: str) -> dict:
+    return json.loads(skills_tool.skill_view(name, preprocess=False))
+
+
+def _write_alias_test_skill(
+    root: Path,
+    relative_selector: str,
+    canonical: str,
+    body: str,
+    *,
+    legacy_flat: bool,
+) -> Path:
+    target = root / relative_selector
+    skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text(
+        (
+            f"---\nname: {canonical}\ndescription: alias test\n---\n\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    return skill_md
+
+
+def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+
+def _audit_events(home: Path) -> list[dict]:
+    path = home / "logs" / "skill-grants.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_exact_disabled_skill_grant_preserves_config(disabled_skills_home):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+
+    assert _view("alpha")["success"] is False
+    assert _view("enabled")["success"] is True
+
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-1",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ):
+        assert _view("alpha")["success"] is True
+        alpha_file = json.loads(
+            skills_tool.skill_view(
+                "alpha", file_path="references/details.md", preprocess=False
+            )
+        )
+        assert alpha_file["success"] is True
+        assert alpha_file["content"] == "alpha details\n"
+        assert _view("beta")["success"] is False
+        listed = json.loads(skills_tool.skills_list())
+        listed_names = {skill["name"] for skill in listed["skills"]}
+        assert "alpha" not in listed_names
+
+    assert _view("alpha")["success"] is False
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled == {
+        "alpha",
+        "beta",
+    }
+
+    events = _audit_events(home)
+    assert [event["event"] for event in events] == ["issued", "closed"]
+    issued, closed = events
+    expected_fields = {
+        "event",
+        "grant_id",
+        "session_id",
+        "task_id",
+        "profile",
+        "skill_names",
+        "requester",
+        "source",
+        "issued_at",
+        "expires_at",
+        "recorded_at",
+        "terminal_status",
+    }
+    assert set(issued) == expected_fields
+    assert set(closed) == expected_fields
+    assert issued["session_id"] == "session-1"
+    assert issued["task_id"] is None
+    assert issued["profile"] == "build"
+    assert issued["skill_names"] == ["alpha"]
+    assert issued["requester"] == "local-cli"
+    assert issued["source"] == "cli"
+    assert issued["issued_at"] < issued["expires_at"]
+    assert issued["terminal_status"] == "active"
+    assert closed["terminal_status"] == "completed"
+    serialized = json.dumps(events).lower()
+    for forbidden in (
+        "content",
+        "prompt",
+        "credential",
+        "user-data",
+        "alpha body",
+    ):
+        assert forbidden not in serialized
+
+
+def test_grant_claims_are_immutable(disabled_skills_home):
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-immutable",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ) as grant:
+        assert grant is not None
+        with pytest.raises(FrozenInstanceError):
+            grant.profile = "attacker"  # type: ignore[misc]
+
+
+def test_nested_grant_scope_restores_outer_context(disabled_skills_home):
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-outer",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ) as outer:
+        assert outer is not None
+        assert skill_utils.current_skill_read_grant() is outer
+        assert skill_utils.is_skill_read_granted("alpha") is True
+
+        with skill_utils.skill_read_grant_scope(
+            ["beta"],
+            session_id="session-inner",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ) as inner:
+            assert inner is not None
+            assert skill_utils.current_skill_read_grant() is inner
+            assert skill_utils.is_skill_read_granted("alpha") is False
+            assert skill_utils.is_skill_read_granted("beta") is True
+
+        assert skill_utils.current_skill_read_grant() is outer
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        assert skill_utils.is_skill_read_granted("beta") is False
+
+    assert skill_utils.current_skill_read_grant() is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"session_id": ""},
+        {"source": "untrusted"},
+        {"source": "kanban", "task_id": None},
+        {"ttl_seconds": 0},
+    ],
+)
+def test_invalid_grant_claims_fail_closed(
+    disabled_skills_home, tmp_path, overrides
+):
+    audit_path = tmp_path / f"invalid-{len(str(overrides))}.jsonl"
+    kwargs = {
+        "session_id": "session-valid",
+        "task_id": None,
+        "profile": "build",
+        "requester": "local-cli",
+        "source": "cli",
+        "ttl_seconds": 60,
+        "audit_path": audit_path,
+    }
+    kwargs.update(overrides)
+
+    try:
+        with pytest.raises((TypeError, ValueError)):
+            skill_utils.issue_skill_read_grant(["alpha"], **kwargs)
+    finally:
+        active = skill_utils.current_skill_read_grant()
+        if active is not None:
+            skill_utils.close_skill_read_grant(active, "failed")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert not audit_path.exists()
+
+
+def test_enabled_skill_uses_existing_behavior_without_grant_or_audit(
+    disabled_skills_home,
+):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+
+    grant = skill_utils.issue_skill_read_grant(
+        ["enabled"],
+        session_id="session-enabled",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    )
+
+    assert grant is None
+    assert skill_utils.current_skill_read_grant() is None
+    assert _view("enabled")["success"] is True
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+    assert not (home / "logs" / "skill-grants.jsonl").exists()
+
+
+def test_expired_grant_is_denied_and_closed(disabled_skills_home, monkeypatch):
+    home, _ = disabled_skills_home
+    now = 1_000.0
+    monkeypatch.setattr(skill_utils.time, "time", lambda: now)
+
+    grant = skill_utils.issue_skill_read_grant(
+        ["alpha"],
+        session_id="session-expired",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=10,
+    )
+    assert grant is not None
+    assert skill_utils.is_skill_read_granted("alpha") is True
+
+    now = 1_011.0
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    skill_utils.close_skill_read_grant(grant, "completed")
+
+    events = _audit_events(home)
+    assert events[-1]["event"] == "closed"
+    assert events[-1]["terminal_status"] == "expired"
+    assert skill_utils.is_skill_read_granted("alpha") is False
+
+
+@pytest.mark.parametrize(
+    ("error", "terminal_status"),
+    [
+        (RuntimeError("boom"), "failed"),
+        (KeyboardInterrupt(), "cancelled"),
+        (TimeoutError("slow"), "timed_out"),
+    ],
+)
+def test_grant_scope_cleans_up_on_abnormal_exit(
+    disabled_skills_home, error, terminal_status
+):
+    home, _ = disabled_skills_home
+
+    with pytest.raises(type(error)):
+        with skill_utils.skill_read_grant_scope(
+            ["alpha"],
+            session_id=f"session-{terminal_status}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            raise error
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == terminal_status
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "terminal_status"),
+    [
+        (None, "completed"),
+        (0, "completed"),
+        (130, "cancelled"),
+        (1, "failed"),
+    ],
+)
+def test_grant_scope_classifies_system_exit(
+    disabled_skills_home, exit_code, terminal_status
+):
+    home, _ = disabled_skills_home
+
+    with pytest.raises(SystemExit) as exc_info:
+        with skill_utils.skill_read_grant_scope(
+            ["alpha"],
+            session_id=f"session-exit-{exit_code}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            raise SystemExit(exit_code)
+
+    assert exc_info.value.code == exit_code
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == terminal_status
+
+
+def test_parallel_grants_are_isolated(disabled_skills_home):
+    home, config_path = disabled_skills_home
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    barrier = threading.Barrier(2)
+    results: dict[str, tuple[bool, bool, str, str | None]] = {}
+
+    def run(name: str, other: str) -> None:
+        with skill_utils.skill_read_grant_scope(
+            [name],
+            session_id=f"session-{name}",
+            task_id=f"task-{name}",
+            profile="build",
+            requester="build",
+            source="kanban",
+            ttl_seconds=60,
+        ):
+            barrier.wait(timeout=5)
+            active = skill_utils.current_skill_read_grant()
+            assert active is not None
+            results[name] = (
+                skill_utils.is_skill_read_granted(name),
+                skill_utils.is_skill_read_granted(other),
+                active.session_id,
+                active.task_id,
+            )
+
+    alpha = threading.Thread(target=run, args=("alpha", "beta"))
+    beta = threading.Thread(target=run, args=("beta", "alpha"))
+    alpha.start()
+    beta.start()
+    alpha.join(timeout=5)
+    beta.join(timeout=5)
+
+    assert results == {
+        "alpha": (True, False, "session-alpha", "task-alpha"),
+        "beta": (True, False, "session-beta", "task-beta"),
+    }
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert skill_utils.is_skill_read_granted("beta") is False
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+
+    events = _audit_events(home)
+    by_grant: dict[str, list[dict]] = {}
+    for event in events:
+        by_grant.setdefault(event["grant_id"], []).append(event)
+    assert len(by_grant) == 2
+    attribution = {
+        (
+            records[0]["session_id"],
+            records[0]["task_id"],
+            records[0]["skill_names"][0],
+        )
+        for records in by_grant.values()
+    }
+    assert attribution == {
+        ("session-alpha", "task-alpha", "alpha"),
+        ("session-beta", "task-beta", "beta"),
+    }
+    assert all(
+        [record["terminal_status"] for record in records]
+        == ["active", "completed"]
+        for records in by_grant.values()
+    )
+
+
+def test_tool_thread_context_propagates_only_the_current_grant(
+    disabled_skills_home, tmp_path
+):
+    from tools.thread_context import propagate_context_to_thread
+
+    audit_path = tmp_path / "propagated.jsonl"
+    result = []
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="session-parent",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+        audit_path=audit_path,
+    ):
+        wrapped = propagate_context_to_thread(
+            lambda: result.append(
+                (
+                    skill_utils.is_skill_read_granted("alpha"),
+                    skill_utils.is_skill_read_granted("beta"),
+                )
+            )
+        )
+        thread = threading.Thread(target=wrapped)
+        thread.start()
+        thread.join()
+
+    assert result == [(True, False)]
+
+
+def test_grant_fails_closed_when_issuance_audit_cannot_be_written(
+    disabled_skills_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(skill_utils, "_write_skill_grant_audit", lambda *a, **k: False)
+
+    with pytest.raises(RuntimeError, match="required skill-grant audit"):
+        skill_utils.issue_skill_read_grant(
+            ["alpha"],
+            session_id="session-audit-failure",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+            audit_path=tmp_path / "unwritten.jsonl",
+        )
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+
+
+def test_categorized_skill_grant_stays_bound_to_requested_identity(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\nalpha body\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [alpha]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    for requested in ("category/directory-alias", "category:directory-alias"):
+        targets = skills_tool.resolve_skill_read_grant_targets([requested])
+        assert list(targets) == [requested]
+        assert "alpha" in targets[requested]
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=f"session-{requested}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ):
+            assert skill_utils.is_skill_read_granted(requested) is True
+            assert _view(requested)["success"] is True
+
+
+def test_categorized_colon_identity_matches_disabled_config(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\ncolon body\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "category:directory-alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert list(targets) == [requested]
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-colon",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        assert skill_utils.is_skill_read_granted(requested) is True
+        viewed = _view(requested)
+        assert viewed["success"] is True
+        assert "colon body" in viewed["content"]
+
+
+def test_colon_disabled_local_is_denied_via_slash_and_unique_bare_before_read(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    target = skills_dir / "category" / "directory-alias"
+    target.mkdir(parents=True)
+    skill_md = target / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: alpha\ndescription: categorized\n---\n\n"
+        "disabled-content-canary\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    slash_targets = skills_tool.resolve_skill_read_grant_targets(
+        ["category/directory-alias"]
+    )
+    bare_targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert slash_targets["category/directory-alias"] >= {
+        "category/directory-alias",
+        "category:directory-alias",
+        "alpha",
+    }
+    assert bare_targets["alpha"] >= {
+        "category/directory-alias",
+        "category:directory-alias",
+        "alpha",
+    }
+
+    original_read_text = Path.read_text
+
+    def reject_full_skill_read(path, *args, **kwargs):
+        if path == skill_md:
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_full_skill_read)
+    for selector in ("category/directory-alias", "alpha"):
+        viewed = _view(selector)
+        assert viewed["success"] is False
+        assert "disabled" in viewed["error"].lower()
+        assert "disabled-content-canary" not in json.dumps(viewed)
+
+
+def test_slash_grant_authorizes_colon_disabled_target_but_not_sibling(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alias"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            (
+                "---\nname: shared\ndescription: collision\n---\n\n"
+                f"{category} body\n"
+            ),
+            encoding="utf-8",
+        )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [one:alias, two:alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "one/alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert "one:alias" in targets[requested]
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-slash-colon",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        assert skill_utils.is_skill_read_granted(requested) is True
+        selected = _view(requested)
+        sibling = _view("two/alias")
+        assert selected["success"] is True
+        assert "one body" in selected["content"]
+        assert sibling["success"] is False
+        assert "two body" not in json.dumps(sibling)
+
+
+def test_explicit_categorized_path_ignores_leaf_collision_and_denies_sibling(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alias"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            (
+                "---\nname: shared\ndescription: collision\n---\n\n"
+                f"{category} body\n"
+            ),
+            encoding="utf-8",
+        )
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [shared]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    requested = "one/alias"
+    targets = skills_tool.resolve_skill_read_grant_targets([requested])
+    assert list(targets) == [requested]
+    assert "shared" in targets[requested]
+    assert skills_tool.resolve_skill_read_grant_names(["alias"]) == []
+    assert skills_tool.resolve_skill_read_grant_names(["shared"]) == []
+    for selector in ("one/alias", "two/alias"):
+        denied = _view(selector)
+        assert denied["success"] is False
+        assert f"{selector.split('/')[0]} body" not in json.dumps(denied)
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id="session-explicit",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ):
+        selected = _view(requested)
+        sibling = _view("two/alias")
+        assert selected["success"] is True
+        assert "one body" in selected["content"]
+        assert sibling["success"] is False
+        assert "two body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_fallback_name_disabled_denies_canonical_selector_and_sibling(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+
+    def write_skill(category, canonical, body):
+        target = skills_dir / category / "directory-alias"
+        skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+        skill_md.parent.mkdir(parents=True)
+        skill_md.write_text(
+            (
+                f"---\nname: {canonical}\ndescription: fallback alias\n---\n\n"
+                f"{body}\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_skill("category", "alpha", "alpha body")
+    write_skill("sibling", "beta", "beta body")
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [directory-alias]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert targets["alpha"] >= {"alpha", "directory-alias"}
+    assert skills_tool.resolve_skill_read_grant_names(["directory-alias"]) == []
+    for selector, body in (("alpha", "alpha body"), ("beta", "beta body")):
+        denied = _view(selector)
+        assert denied["success"] is False
+        assert body not in json.dumps(denied)
+
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id=f"session-fallback-{'flat' if legacy_flat else 'package'}",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ) as grant:
+        assert grant is not None
+        selected = _view("alpha")
+        sibling = _view("beta")
+        assert selected["success"] is True
+        assert "alpha body" in selected["content"]
+        assert sibling["success"] is False
+        assert "beta body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_ambiguous_relative_path_is_not_a_disabled_or_grant_alias(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    external_dir = tmp_path / "external-skills"
+
+    def write_skill(root, canonical, body):
+        target = root / "category" / "foo"
+        skill_md = target.with_suffix(".md") if legacy_flat else target / "SKILL.md"
+        skill_md.parent.mkdir(parents=True)
+        skill_md.write_text(
+            (
+                f"---\nname: {canonical}\ndescription: relative collision\n---\n\n"
+                f"{body}\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_skill(skills_dir, "alpha", "primary body")
+    write_skill(external_dir, "beta", "external body")
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [category/foo]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        skill_utils, "get_external_skills_dirs", lambda: [external_dir]
+    )
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+    assert list(targets) == ["alpha"]
+    assert "category/foo" not in targets["alpha"]
+    assert "category:foo" not in targets["alpha"]
+    assert _view("alpha")["success"] is True
+
+    with skill_utils.skill_read_grant_scope(
+        list(targets),
+        session_id=f"session-relative-{'flat' if legacy_flat else 'package'}",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=targets,
+    ) as grant:
+        assert grant is None
+        assert skill_utils.current_skill_read_grant() is None
+
+    assert skills_tool.resolve_skill_read_grant_names(["category/foo"]) == []
+    ambiguous = _view("category/foo")
+    assert ambiguous["success"] is False
+    assert "ambiguous" in ambiguous["error"].lower()
+    assert "primary body" not in json.dumps(ambiguous)
+    assert "external body" not in json.dumps(ambiguous)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_overlapping_roots_enumerate_every_same_file_selector_before_read(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    overlap_root = skills_dir / "overlap"
+    skill_md = _write_alias_test_skill(
+        skills_dir,
+        "overlap/category/foo",
+        "alpha",
+        "overlap body",
+        legacy_flat=legacy_flat,
+    )
+    _write_alias_test_skill(
+        skills_dir,
+        "sibling/bar",
+        "beta",
+        "sibling body",
+        legacy_flat=legacy_flat,
+    )
+    config_path = home / "config.yaml"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        skill_utils, "get_external_skills_dirs", lambda: [overlap_root]
+    )
+
+    expected_paths = {"overlap/category/foo", "category/foo"}
+    allow_full_read = False
+    original_read_text = Path.read_text
+
+    def reject_ungranted_full_read(path, *args, **kwargs):
+        if (
+            not allow_full_read
+            and skills_tool._same_local_skill_file(path, skill_md)
+        ):
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_ungranted_full_read)
+    for disabled_path in sorted(expected_paths):
+        config_path.write_text(
+            f"skills:\n  disabled: [{disabled_path}, beta]\n",
+            encoding="utf-8",
+        )
+        skill_utils._raw_config_cache_clear()
+        targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+        assert targets["alpha"] >= expected_paths | {"alpha"}
+
+        allow_full_read = False
+        denied = _view("alpha")
+        assert denied["success"] is False
+        assert "disabled" in denied["error"].lower()
+        assert "overlap body" not in json.dumps(denied)
+
+        allow_full_read = True
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=(
+                f"session-overlap-{'flat' if legacy_flat else 'package'}-"
+                f"{disabled_path}"
+            ),
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ) as grant:
+            assert grant is not None
+            selected = _view("alpha")
+            sibling = _view("beta")
+            assert selected["success"] is True
+            assert "overlap body" in selected["content"]
+            assert sibling["success"] is False
+            assert "sibling body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize("legacy_flat", [False, True], ids=["package", "flat"])
+def test_symlink_aliases_enumerate_real_and_alias_selectors_before_read(
+    tmp_path, monkeypatch, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    skill_md = _write_alias_test_skill(
+        skills_dir,
+        "real/foo",
+        "alpha",
+        "symlink body",
+        legacy_flat=legacy_flat,
+    )
+    if legacy_flat:
+        alias_dir = skills_dir / "alias"
+        alias_dir.mkdir(parents=True)
+        _symlink_or_skip(
+            alias_dir / "foo.md", skill_md, target_is_directory=False
+        )
+    else:
+        _symlink_or_skip(
+            skills_dir / "alias",
+            skills_dir / "real",
+            target_is_directory=True,
+        )
+    _write_alias_test_skill(
+        skills_dir,
+        "sibling/bar",
+        "beta",
+        "sibling body",
+        legacy_flat=legacy_flat,
+    )
+    config_path = home / "config.yaml"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    expected_paths = {"real/foo", "alias/foo"}
+    allow_full_read = False
+    original_read_text = Path.read_text
+
+    def reject_ungranted_full_read(path, *args, **kwargs):
+        if (
+            not allow_full_read
+            and skills_tool._same_local_skill_file(path, skill_md)
+        ):
+            raise AssertionError("disabled skill content was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_ungranted_full_read)
+    for disabled_path in sorted(expected_paths):
+        config_path.write_text(
+            f"skills:\n  disabled: [{disabled_path}, beta]\n",
+            encoding="utf-8",
+        )
+        skill_utils._raw_config_cache_clear()
+        targets = skills_tool.resolve_skill_read_grant_targets(["alpha"])
+        assert targets["alpha"] >= expected_paths | {"alpha"}
+
+        allow_full_read = False
+        denied = _view("alpha")
+        assert denied["success"] is False
+        assert "disabled" in denied["error"].lower()
+        assert "symlink body" not in json.dumps(denied)
+
+        allow_full_read = True
+        with skill_utils.skill_read_grant_scope(
+            list(targets),
+            session_id=(
+                f"session-symlink-{'flat' if legacy_flat else 'package'}-"
+                f"{disabled_path}"
+            ),
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            authorization_aliases=targets,
+        ) as grant:
+            assert grant is not None
+            selected = _view("alpha")
+            sibling = _view("beta")
+            assert selected["success"] is True
+            assert "symlink body" in selected["content"]
+            assert sibling["success"] is False
+            assert "sibling body" not in json.dumps(sibling)
+
+
+@pytest.mark.parametrize(
+    ("excluded_dir", "legacy_flat"),
+    [("node_modules", False), (".git", True)],
+    ids=["node-modules-package", "git-flat"],
+)
+def test_excluded_flat_markdown_cannot_resolve_or_collide(
+    tmp_path, monkeypatch, excluded_dir, legacy_flat
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    canonical = f"visible-{'flat' if legacy_flat else 'package'}"
+    _write_alias_test_skill(
+        skills_dir,
+        "category/visible",
+        canonical,
+        "legitimate body",
+        legacy_flat=legacy_flat,
+    )
+
+    excluded_root = skills_dir / excluded_dir
+    excluded_root.mkdir(parents=True)
+    (excluded_root / "matching.md").write_text(
+        (
+            f"---\nname: {canonical}\ndescription: excluded collision\n---\n\n"
+            "excluded collision body\n"
+        ),
+        encoding="utf-8",
+    )
+    hidden_name = f"excluded-only-{'git' if excluded_dir == '.git' else 'deps'}"
+    (excluded_root / "hidden.md").write_text(
+        (
+            f"---\nname: {hidden_name}\ndescription: excluded only\n---\n\n"
+            "excluded only body\n"
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    skill_utils._raw_config_cache_clear()
+
+    targets = skills_tool.resolve_skill_read_grant_targets([canonical])
+    assert list(targets) == [canonical]
+    assert all(excluded_dir not in alias for alias in targets[canonical])
+
+    visible = _view(canonical)
+    assert visible["success"] is True
+    assert "legitimate body" in visible["content"]
+    assert "excluded collision body" not in json.dumps(visible)
+
+    for hidden_selector in (hidden_name, "hidden"):
+        hidden = _view(hidden_selector)
+        assert hidden["success"] is False
+        assert "excluded only body" not in json.dumps(hidden)
+
+
+def test_canonicalization_refuses_ambiguous_bare_name(tmp_path, monkeypatch):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    for category in ("one", "two"):
+        target = skills_dir / category / "alpha"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: collision\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+
+    assert skills_tool.resolve_skill_read_grant_names(["alpha"]) == []
+
+
+def test_canonicalization_distinguishes_plugin_colon_from_local_slash(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    local = skills_dir / "bundle" / "alpha"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: local-alpha\ndescription: local\n---\n\nlocal\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+
+    assert skills_tool.resolve_skill_read_grant_names(["bundle:alpha"]) == [
+        "bundle:alpha"
+    ]
+    assert skills_tool.resolve_skill_read_grant_names(["bundle/alpha"]) == [
+        "bundle/alpha"
+    ]
+
+
+def test_real_plugin_identity_neither_disables_nor_authorizes_local_slash(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    local = skills_dir / "bundle" / "alpha"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: local-alpha\ndescription: local\n---\n\nlocal body\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin body\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled: [bundle:alpha]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+    skill_utils._raw_config_cache_clear()
+
+    local_targets = skills_tool.resolve_skill_read_grant_targets(["bundle/alpha"])
+    assert "bundle:alpha" not in local_targets["bundle/alpha"]
+    assert _view("bundle/alpha")["success"] is True
+
+    config_path.write_text(
+        "skills:\n  disabled: [bundle:alpha, local-alpha]\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    plugin_targets = skills_tool.resolve_skill_read_grant_targets(["bundle:alpha"])
+    with skill_utils.skill_read_grant_scope(
+        list(plugin_targets),
+        session_id="session-plugin",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=plugin_targets,
+    ):
+        assert _view("bundle:alpha")["success"] is True
+        local_view = _view("bundle/alpha")
+        assert local_view["success"] is False
+        assert "local body" not in json.dumps(local_view)
+
+
+def test_plugin_owned_frontmatter_name_cannot_alias_local_skill(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    local = skills_dir / "local" / "foo"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text(
+        "---\nname: bundle:alpha\ndescription: local\n---\n\nlocal body\n",
+        encoding="utf-8",
+    )
+    plugin_md = tmp_path / "plugin" / "SKILL.md"
+    plugin_md.parent.mkdir()
+    plugin_md.write_text(
+        "---\nname: alpha\ndescription: plugin\n---\n\nplugin body\n",
+        encoding="utf-8",
+    )
+
+    class PluginManager:
+        def find_plugin_skill(self, name):
+            return plugin_md if name == "bundle:alpha" else None
+
+        def list_plugin_skills(self, namespace):
+            return ["alpha"] if namespace == "bundle" else []
+
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [bundle:alpha]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: PluginManager()
+    )
+    skill_utils._raw_config_cache_clear()
+
+    local_targets = skills_tool.resolve_skill_read_grant_targets(["local/foo"])
+    assert "bundle:alpha" not in local_targets["local/foo"]
+    grant = skill_utils.issue_skill_read_grant(
+        list(local_targets),
+        session_id="session-local-poison",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=local_targets,
+    )
+    assert grant is None
+    assert skill_utils.current_skill_read_grant() is None
+    local_view = _view("local/foo")
+    plugin_view = _view("bundle:alpha")
+    assert local_view["success"] is True
+    assert "local body" in local_view["content"]
+    assert plugin_view["success"] is False
+    assert "plugin body" not in json.dumps(plugin_view)
+
+
+def test_frontmatter_slash_alias_must_resolve_back_to_selected_skill(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    selected = skills_dir / "local" / "foo"
+    selected.mkdir(parents=True)
+    (selected / "SKILL.md").write_text(
+        "---\nname: other/target\ndescription: selected\n---\n\nselected body\n",
+        encoding="utf-8",
+    )
+    actual = skills_dir / "other" / "target"
+    actual.mkdir(parents=True)
+    (actual / "SKILL.md").write_text(
+        "---\nname: actual-target\ndescription: actual\n---\n\nactual body\n",
+        encoding="utf-8",
+    )
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  disabled: [other/target]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    skill_utils._raw_config_cache_clear()
+
+    selected_targets = skills_tool.resolve_skill_read_grant_targets(["local/foo"])
+    assert "other/target" not in selected_targets["local/foo"]
+    grant = skill_utils.issue_skill_read_grant(
+        list(selected_targets),
+        session_id="session-slash-poison",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=selected_targets,
+    )
+    assert grant is None
+    assert _view("local/foo")["success"] is True
+    assert _view("other/target")["success"] is False
+
+    config_path.write_text(
+        "skills:\n  disabled: [other/target, local/foo]\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    actual_targets = skills_tool.resolve_skill_read_grant_targets(["other/target"])
+    with skill_utils.skill_read_grant_scope(
+        list(actual_targets),
+        session_id="session-actual-target",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        authorization_aliases=actual_targets,
+    ):
+        assert _view("other/target")["success"] is True
+        poisoned_view = _view("local/foo")
+        assert poisoned_view["success"] is False
+        assert "selected body" not in json.dumps(poisoned_view)
+
+
+@pytest.mark.parametrize(
+    "requested",
+    ["../alpha", "/absolute/alpha", "missing", "bundle:", "alpha/../beta"],
+)
+def test_invalid_skill_identity_does_not_resolve_to_a_grant(
+    disabled_skills_home, requested
+):
+    assert skills_tool.resolve_skill_read_grant_names([requested]) == []

--- a/tests/cli/test_cli_disabled_skill_grants.py
+++ b/tests/cli/test_cli_disabled_skill_grants.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import time
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from agent import skill_utils
+from cli import HermesCLI as _ProductionHermesCLI
+from tools import skills_tool
+
+
+class _GrantAwareCLI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.session_id = "session-123"
+        self.system_prompt = "base prompt"
+        self.preloaded_skills = []
+        self.conversation_history = [
+            {"role": "user", "content": "prior-user-canary"},
+            {"role": "assistant", "content": "prior-assistant-canary"},
+        ]
+        self.prompt_during_run = ""
+        self.history_during_run = []
+
+    def run(self):
+        _ProductionHermesCLI.finalize_preloaded_skills(self)
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        assert skill_utils.is_skill_read_granted("beta") is False
+        self.prompt_during_run = self.system_prompt
+        self.history_during_run = copy.deepcopy(self.conversation_history)
+
+
+def _prepare_home(tmp_path, monkeypatch, disabled: str = "[alpha, beta]"):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        f"skills:\n  disabled: {disabled}\n",
+        encoding="utf-8",
+    )
+    skill_dir = home / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: test\n---\n\nalpha\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+    skill_utils._raw_config_cache_clear()
+    return home, config_path
+
+
+def _audit_events(home):
+    return [
+        json.loads(line)
+        for line in (home / "logs" / "skill-grants.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+
+
+def test_main_scopes_disabled_skill_grant_to_cli_session(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, config_path = _prepare_home(tmp_path, monkeypatch)
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "build")
+    skills_dir = home / "skills"
+    alpha_dir = skills_dir / "alpha"
+    alpha_dir.mkdir(parents=True, exist_ok=True)
+    (alpha_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: integration skill\n---\n\nalpha body\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    created = {}
+
+    def fake_cli(**kwargs):
+        created["cli"] = _GrantAwareCLI(**kwargs)
+        return created["cli"]
+
+    def fake_build(skills, task_id=None):
+        assert skills == ["alpha"]
+        assert task_id == "session-123"
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        loaded = json.loads(skills_tool.skill_view("alpha", preprocess=False))
+        assert loaded["success"] is True
+        assert "alpha body" in loaded["content"]
+        return "alpha prompt", ["alpha"], []
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fake_build)
+
+    cli_mod.main(skills="alpha", toolsets="safe")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert created["cli"].prompt_during_run == "base prompt\n\nalpha prompt"
+    assert created["cli"].system_prompt == created["cli"].prompt_during_run
+    assert created["cli"].history_during_run == created["cli"].conversation_history == [
+        {"role": "user", "content": "prior-user-canary"},
+        {"role": "assistant", "content": "prior-assistant-canary"},
+    ]
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+    events = _audit_events(home)
+    assert events[0]["source"] == "cli"
+    assert events[0]["session_id"] == "session-123"
+    assert events[0]["task_id"] is None
+    assert events[-1]["terminal_status"] == "completed"
+    serialized = json.dumps(events)
+    assert "prior-user-canary" not in serialized
+    assert "prior-assistant-canary" not in serialized
+
+
+def test_interactive_threads_preserve_selected_skill_grant(
+    tmp_path, monkeypatch
+):
+    import signal
+    import sys
+
+    import cli as cli_mod
+    import hermes_cli.plugins
+
+    home, _ = _prepare_home(tmp_path, monkeypatch)
+    beta_dir = home / "skills" / "beta"
+    beta_dir.mkdir(parents=True)
+    (beta_dir / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: sibling\n---\n\nbeta body\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli_mod, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_DEFER_AGENT_STARTUP", "1")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda: None)
+    monkeypatch.setattr(cli_mod, "_detect_light_mode", lambda: False)
+    monkeypatch.setattr(cli_mod, "patch_stdout", lambda: nullcontext())
+    monkeypatch.setattr(cli_mod, "_enable_extended_enter_keys", lambda *_args: False)
+    monkeypatch.setattr(signal, "signal", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.model_switch",
+        SimpleNamespace(prewarm_picker_cache_async=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.curator",
+        SimpleNamespace(maybe_run_curator=lambda **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.onboarding",
+        SimpleNamespace(
+            OPENCLAW_RESIDUE_FLAG="test-residue",
+            detect_openclaw_residue=lambda: False,
+            is_seen=lambda *_args, **_kwargs: True,
+            mark_seen=lambda *_args, **_kwargs: None,
+            openclaw_residue_hint_cli=lambda: "",
+        ),
+    )
+    plugin_manager = SimpleNamespace(_cli_ref=None)
+    monkeypatch.setattr(
+        hermes_cli.plugins,
+        "get_plugin_manager",
+        lambda: plugin_manager,
+    )
+
+    inner_started = threading.Event()
+    observations = {}
+    cli_holder = {}
+
+    class ToolCallingAgent:
+        max_iterations = 1
+        model = "unit-test-model"
+        platform = "cli"
+
+        def __init__(self):
+            self.session_id = ""
+
+        def run_conversation(self, **_kwargs):
+            observations["agent_thread"] = threading.get_ident()
+            observations["selected"] = json.loads(
+                skills_tool.skill_view("alpha", preprocess=False)
+            )
+            observations["sibling"] = json.loads(
+                skills_tool.skill_view("beta", preprocess=False)
+            )
+            inner_started.set()
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+                "failed": False,
+            }
+
+        def interrupt(self, *_args, **_kwargs):
+            return None
+
+    class InteractiveCLI(cli_mod.HermesCLI):
+        def _claim_active_session(self, *_args, **_kwargs):
+            return True
+
+        def show_banner(self):
+            return None
+
+        def _show_security_advisories(self):
+            return None
+
+        def _console_print(self, *_args, **_kwargs):
+            return None
+
+        def _install_tool_callbacks(self):
+            return None
+
+        def _ensure_tirith_security(self):
+            return None
+
+        def _check_config_mcp_changes(self):
+            return None
+
+        def _print_user_message_preview(self, *_args, **_kwargs):
+            observations["process_thread"] = threading.get_ident()
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, _message):
+            return {
+                "signature": "threaded-test-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            self.finalize_preloaded_skills()
+            return True
+
+        def _reset_stream_state(self):
+            return None
+
+        def _flush_credit_notices(self):
+            return None
+
+        def _flush_stream(self):
+            return None
+
+        def _pet_start_anim(self):
+            return None
+
+        def _pet_stop_anim(self):
+            return None
+
+        def _pet_react_turn_end(self):
+            return None
+
+        def _persist_active_session_before_close(self):
+            return None
+
+        def _print_exit_summary(self):
+            return None
+
+        def _release_active_session(self):
+            return None
+
+    agent = ToolCallingAgent()
+    cli = InteractiveCLI(
+        model="unit-test-model",
+        toolsets=["safe"],
+        provider="unit-test",
+        api_key="unit-test-placeholder",
+        base_url="http://127.0.0.1",
+        max_turns=1,
+        compact=True,
+    )
+    cli.agent = agent
+    agent.session_id = cli.session_id
+    cli._active_agent_route_signature = "threaded-test-route"
+    cli._session_db = None
+    cli_holder["cli"] = cli
+
+    class TestApplication:
+        def __init__(self, **_kwargs):
+            self.is_running = True
+            self.loop = None
+            self.output = SimpleNamespace(
+                write_raw=lambda *_args: None,
+                flush=lambda: None,
+            )
+            self.renderer = SimpleNamespace(
+                cpr_not_supported_callback=lambda: None
+            )
+            self._on_resize = lambda: None
+
+        def invalidate(self):
+            return None
+
+        def exit(self):
+            self.is_running = False
+
+        def run(self):
+            cli._pending_input.put("inspect disabled skills")
+            assert inner_started.wait(timeout=5)
+            deadline = time.monotonic() + 5
+            while cli._agent_running and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert cli._agent_running is False
+            cli._should_exit = True
+            self.is_running = False
+
+    monkeypatch.setattr(cli_mod, "Application", TestApplication)
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **_kwargs: cli_holder["cli"])
+
+    main_thread = threading.get_ident()
+    cli_mod.main(
+        skills=["alpha"],
+        toolsets="safe",
+        model="unit-test-model",
+        provider="unit-test",
+        api_key="unit-test-placeholder",
+        base_url="http://127.0.0.1",
+        max_turns=1,
+        compact=True,
+    )
+
+    assert observations["selected"]["success"] is True
+    assert "\nalpha\n" in observations["selected"]["content"]
+    assert observations["sibling"]["success"] is False
+    assert "beta body" not in json.dumps(observations["sibling"])
+    assert observations["process_thread"] != main_thread
+    assert observations["agent_thread"] not in {
+        main_thread,
+        observations["process_thread"],
+    }
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert skill_utils.is_skill_read_granted("beta") is False
+
+
+def test_main_records_kanban_task_scope_for_disabled_skill(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_PROFILE", "build")
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    events = _audit_events(home)
+    assert events[0]["source"] == "kanban"
+    assert events[0]["task_id"] == "task-123"
+    assert events[0]["profile"] == "build"
+    assert events[-1]["terminal_status"] == "completed"
+
+
+def test_preload_exception_closes_grant_immediately(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+
+    def fail_preload(*_args, **_kwargs):
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        raise RuntimeError("preload exploded")
+
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fail_preload)
+    with pytest.raises(RuntimeError, match="preload exploded"):
+        cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == "failed"
+
+
+def test_default_profile_attribution_is_not_dot_hermes(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    assert cli_mod._active_skill_grant_profile() == "default"
+
+
+def test_profile_attribution_uses_profile_home_without_env_hint(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home = tmp_path / ".hermes" / "profiles" / "build"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [alpha]\n", encoding="utf-8"
+    )
+    skill_dir = home / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: test\n---\n\nalpha\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    skill_utils._raw_config_cache_clear()
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert _audit_events(home)[0]["profile"] == "build"
+
+
+def test_interactive_cancellation_return_is_audited_as_cancelled(
+    tmp_path, monkeypatch
+):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    class CancelledCLI(_GrantAwareCLI):
+        def run(self):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            self._last_run_cancelled = True
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: CancelledCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert _audit_events(home)[-1]["terminal_status"] == "cancelled"
+
+
+def test_system_exit_130_is_audited_as_cancelled(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    @cli_mod._skill_grant_lifecycle
+    def cancelled_invocation():
+        skill_utils.issue_skill_read_grant(
+            ["alpha"],
+            session_id="quiet-session",
+            task_id="task-quiet",
+            profile="build",
+            requester="build",
+            source="kanban",
+        )
+        raise SystemExit(130)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cancelled_invocation()
+
+    assert exc_info.value.code == 130
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == "cancelled"
+
+
+def test_quiet_single_query_exit_zero_closes_grant_as_completed(
+    tmp_path, monkeypatch
+):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    class QuietCLI(_GrantAwareCLI):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id=self.session_id,
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=self._run_conversation,
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return surface == "cli" and stderr is True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            assert effective_query == "hello"
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            return True
+
+        def _run_conversation(self, *, user_message, conversation_history):
+            assert user_message == "hello"
+            assert conversation_history == self.conversation_history
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            return {"final_response": "done", "failed": False}
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", QuietCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(
+            query="hello",
+            quiet=True,
+            skills=["alpha"],
+            toolsets="safe",
+        )
+
+    assert exc_info.value.code == 0
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    closed = [event for event in _audit_events(home) if event["event"] == "closed"]
+    assert [event["terminal_status"] for event in closed] == ["completed"]

--- a/tests/cli/test_cli_disabled_skill_grants.py
+++ b/tests/cli/test_cli_disabled_skill_grants.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import time
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from agent import skill_utils
+from tools import skills_tool
+
+
+class _GrantAwareCLI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.session_id = "session-123"
+        self.system_prompt = "base prompt"
+        self.preloaded_skills = []
+        self.conversation_history = [
+            {"role": "user", "content": "prior-user-canary"},
+            {"role": "assistant", "content": "prior-assistant-canary"},
+        ]
+        self.prompt_during_run = ""
+        self.history_during_run = []
+
+    def run(self):
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        assert skill_utils.is_skill_read_granted("beta") is False
+        self.prompt_during_run = self.system_prompt
+        self.history_during_run = copy.deepcopy(self.conversation_history)
+
+
+def _prepare_home(tmp_path, monkeypatch, disabled: str = "[alpha, beta]"):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        f"skills:\n  disabled: {disabled}\n",
+        encoding="utf-8",
+    )
+    skill_dir = home / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: test\n---\n\nalpha\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+    skill_utils._raw_config_cache_clear()
+    return home, config_path
+
+
+def _audit_events(home):
+    return [
+        json.loads(line)
+        for line in (home / "logs" / "skill-grants.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+
+
+def test_main_scopes_disabled_skill_grant_to_cli_session(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, config_path = _prepare_home(tmp_path, monkeypatch)
+    original_config = config_path.read_bytes()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "build")
+    skills_dir = home / "skills"
+    alpha_dir = skills_dir / "alpha"
+    alpha_dir.mkdir(parents=True, exist_ok=True)
+    (alpha_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: integration skill\n---\n\nalpha body\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    created = {}
+
+    def fake_cli(**kwargs):
+        created["cli"] = _GrantAwareCLI(**kwargs)
+        return created["cli"]
+
+    def fake_build(skills, task_id=None):
+        assert skills == ["alpha"]
+        assert task_id == "session-123"
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        loaded = json.loads(skills_tool.skill_view("alpha", preprocess=False))
+        assert loaded["success"] is True
+        assert "alpha body" in loaded["content"]
+        return "alpha prompt", ["alpha"], []
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fake_build)
+
+    cli_mod.main(skills="alpha", toolsets="safe")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert created["cli"].prompt_during_run == "base prompt\n\nalpha prompt"
+    assert created["cli"].system_prompt == created["cli"].prompt_during_run
+    assert created["cli"].history_during_run == created["cli"].conversation_history == [
+        {"role": "user", "content": "prior-user-canary"},
+        {"role": "assistant", "content": "prior-assistant-canary"},
+    ]
+    assert config_path.read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled
+    events = _audit_events(home)
+    assert events[0]["source"] == "cli"
+    assert events[0]["session_id"] == "session-123"
+    assert events[0]["task_id"] is None
+    assert events[-1]["terminal_status"] == "completed"
+    serialized = json.dumps(events)
+    assert "prior-user-canary" not in serialized
+    assert "prior-assistant-canary" not in serialized
+
+
+def test_interactive_threads_preserve_selected_skill_grant(
+    tmp_path, monkeypatch
+):
+    import signal
+    import sys
+
+    import cli as cli_mod
+    import hermes_cli.plugins
+
+    home, _ = _prepare_home(tmp_path, monkeypatch)
+    beta_dir = home / "skills" / "beta"
+    beta_dir.mkdir(parents=True)
+    (beta_dir / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: sibling\n---\n\nbeta body\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli_mod, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_DEFER_AGENT_STARTUP", "1")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda: None)
+    monkeypatch.setattr(cli_mod, "_detect_light_mode", lambda: False)
+    monkeypatch.setattr(cli_mod, "patch_stdout", lambda: nullcontext())
+    monkeypatch.setattr(signal, "signal", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.model_switch",
+        SimpleNamespace(prewarm_picker_cache_async=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.curator",
+        SimpleNamespace(maybe_run_curator=lambda **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.onboarding",
+        SimpleNamespace(
+            OPENCLAW_RESIDUE_FLAG="test-residue",
+            detect_openclaw_residue=lambda: False,
+            is_seen=lambda *_args, **_kwargs: True,
+            mark_seen=lambda *_args, **_kwargs: None,
+            openclaw_residue_hint_cli=lambda: "",
+        ),
+    )
+    plugin_manager = SimpleNamespace(_cli_ref=None)
+    monkeypatch.setattr(
+        hermes_cli.plugins,
+        "get_plugin_manager",
+        lambda: plugin_manager,
+    )
+
+    inner_started = threading.Event()
+    observations = {}
+    cli_holder = {}
+
+    class ToolCallingAgent:
+        max_iterations = 1
+        model = "unit-test-model"
+        platform = "cli"
+
+        def __init__(self):
+            self.session_id = ""
+
+        def run_conversation(self, **_kwargs):
+            observations["agent_thread"] = threading.get_ident()
+            observations["selected"] = json.loads(
+                skills_tool.skill_view("alpha", preprocess=False)
+            )
+            observations["sibling"] = json.loads(
+                skills_tool.skill_view("beta", preprocess=False)
+            )
+            inner_started.set()
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+                "failed": False,
+            }
+
+        def interrupt(self, *_args, **_kwargs):
+            return None
+
+    class InteractiveCLI(cli_mod.HermesCLI):
+        def _claim_active_session(self, *_args, **_kwargs):
+            return True
+
+        def show_banner(self):
+            return None
+
+        def _show_security_advisories(self):
+            return None
+
+        def _console_print(self, *_args, **_kwargs):
+            return None
+
+        def _install_tool_callbacks(self):
+            return None
+
+        def _ensure_tirith_security(self):
+            return None
+
+        def _check_config_mcp_changes(self):
+            return None
+
+        def _print_user_message_preview(self, *_args, **_kwargs):
+            observations["process_thread"] = threading.get_ident()
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, _message):
+            return {
+                "signature": "threaded-test-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            return True
+
+        def _reset_stream_state(self):
+            return None
+
+        def _flush_credit_notices(self):
+            return None
+
+        def _flush_stream(self):
+            return None
+
+        def _pet_start_anim(self):
+            return None
+
+        def _pet_stop_anim(self):
+            return None
+
+        def _pet_react_turn_end(self):
+            return None
+
+        def _persist_active_session_before_close(self):
+            return None
+
+        def _print_exit_summary(self):
+            return None
+
+        def _release_active_session(self):
+            return None
+
+    agent = ToolCallingAgent()
+    cli = InteractiveCLI(
+        model="unit-test-model",
+        toolsets=["safe"],
+        provider="unit-test",
+        api_key="unit-test-placeholder",
+        base_url="http://127.0.0.1",
+        max_turns=1,
+        compact=True,
+    )
+    cli.agent = agent
+    agent.session_id = cli.session_id
+    cli._active_agent_route_signature = "threaded-test-route"
+    cli._session_db = None
+    cli_holder["cli"] = cli
+
+    class TestApplication:
+        def __init__(self, **_kwargs):
+            self.is_running = True
+            self.loop = None
+            self.renderer = SimpleNamespace(
+                cpr_not_supported_callback=lambda: None
+            )
+            self._on_resize = lambda: None
+
+        def invalidate(self):
+            return None
+
+        def exit(self):
+            self.is_running = False
+
+        def run(self):
+            cli._pending_input.put("inspect disabled skills")
+            assert inner_started.wait(timeout=5)
+            deadline = time.monotonic() + 5
+            while cli._agent_running and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert cli._agent_running is False
+            cli._should_exit = True
+            self.is_running = False
+
+    monkeypatch.setattr(cli_mod, "Application", TestApplication)
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **_kwargs: cli_holder["cli"])
+
+    main_thread = threading.get_ident()
+    cli_mod.main(
+        skills=["alpha"],
+        toolsets="safe",
+        model="unit-test-model",
+        provider="unit-test",
+        api_key="unit-test-placeholder",
+        base_url="http://127.0.0.1",
+        max_turns=1,
+        compact=True,
+    )
+
+    assert observations["selected"]["success"] is True
+    assert "\nalpha\n" in observations["selected"]["content"]
+    assert observations["sibling"]["success"] is False
+    assert "beta body" not in json.dumps(observations["sibling"])
+    assert observations["process_thread"] != main_thread
+    assert observations["agent_thread"] not in {
+        main_thread,
+        observations["process_thread"],
+    }
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert skill_utils.is_skill_read_granted("beta") is False
+
+
+def test_main_records_kanban_task_scope_for_disabled_skill(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_PROFILE", "build")
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    events = _audit_events(home)
+    assert events[0]["source"] == "kanban"
+    assert events[0]["task_id"] == "task-123"
+    assert events[0]["profile"] == "build"
+    assert events[-1]["terminal_status"] == "completed"
+
+
+def test_preload_exception_closes_grant_immediately(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+
+    def fail_preload(*_args, **_kwargs):
+        assert skill_utils.is_skill_read_granted("alpha") is True
+        raise RuntimeError("preload exploded")
+
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fail_preload)
+    with pytest.raises(RuntimeError, match="preload exploded"):
+        cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == "failed"
+
+
+def test_default_profile_attribution_is_not_dot_hermes(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    _prepare_home(tmp_path, monkeypatch, "[alpha]")
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    assert cli_mod._active_skill_grant_profile() == "default"
+
+
+def test_profile_attribution_uses_profile_home_without_env_hint(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home = tmp_path / ".hermes" / "profiles" / "build"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [alpha]\n", encoding="utf-8"
+    )
+    skill_dir = home / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: test\n---\n\nalpha\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    skill_utils._raw_config_cache_clear()
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _GrantAwareCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert _audit_events(home)[0]["profile"] == "build"
+
+
+def test_interactive_cancellation_return_is_audited_as_cancelled(
+    tmp_path, monkeypatch
+):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    class CancelledCLI(_GrantAwareCLI):
+        def run(self):
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            self._last_run_cancelled = True
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: CancelledCLI(**kwargs))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    cli_mod.main(skills=["alpha"], toolsets="safe")
+
+    assert _audit_events(home)[-1]["terminal_status"] == "cancelled"
+
+
+def test_system_exit_130_is_audited_as_cancelled(tmp_path, monkeypatch):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    @cli_mod._skill_grant_lifecycle
+    def cancelled_invocation():
+        skill_utils.issue_skill_read_grant(
+            ["alpha"],
+            session_id="quiet-session",
+            task_id="task-quiet",
+            profile="build",
+            requester="build",
+            source="kanban",
+        )
+        raise SystemExit(130)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cancelled_invocation()
+
+    assert exc_info.value.code == 130
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert _audit_events(home)[-1]["terminal_status"] == "cancelled"
+
+
+def test_quiet_single_query_exit_zero_closes_grant_as_completed(
+    tmp_path, monkeypatch
+):
+    import cli as cli_mod
+
+    home, _ = _prepare_home(tmp_path, monkeypatch, "[alpha]")
+
+    class QuietCLI(_GrantAwareCLI):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id=self.session_id,
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=self._run_conversation,
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return surface == "cli" and stderr is True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            assert effective_query == "hello"
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            return True
+
+        def _run_conversation(self, *, user_message, conversation_history):
+            assert user_message == "hello"
+            assert conversation_history == self.conversation_history
+            assert skill_utils.is_skill_read_granted("alpha") is True
+            return {"final_response": "done", "failed": False}
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", QuietCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda *_args, **_kwargs: ("alpha prompt", ["alpha"], []),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(
+            query="hello",
+            quiet=True,
+            skills=["alpha"],
+            toolsets="safe",
+        )
+
+    assert exc_info.value.code == 0
+    assert skill_utils.current_skill_read_grant() is None
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    closed = [event for event in _audit_events(home) if event["event"] == "closed"]
+    assert [event["terminal_status"] for event in closed] == ["completed"]

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -749,8 +749,116 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
 
 
+def test_spawned_worker_executes_disabled_categorized_skill_with_scoped_grant(
+    kanban_home, monkeypatch
+):
+    """Persisted task -> dispatcher argv/env -> CLI preload uses one scoped grant."""
+    import cli as cli_mod
+    from agent import skill_utils
+    from tools import skills_tool
 
+    profile_home = kanban_home / "profiles" / "build"
+    skill_dir = profile_home / "skills" / "category" / "directory-alias"
+    skill_dir.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n", encoding="utf-8"
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: integration\n---\n\nkanban body\n",
+        encoding="utf-8",
+    )
+    original_config = (profile_home / "config.yaml").read_bytes()
+    captured = {}
 
+    class FakeProc:
+        pid = 45678
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="real skill route",
+            assignee="build",
+            skills=["category/directory-alias"],
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    command = captured["cmd"]
+    skill_args = [
+        command[index + 1]
+        for index, value in enumerate(command[:-1])
+        if value == "--skills"
+    ]
+    assert skill_args == ["category/directory-alias"]
+    assert not any("SKILL_GRANT" in key for key in captured["env"])
+
+    for key, value in captured["env"].items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", profile_home / "skills")
+    skill_utils._raw_config_cache_clear()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    observed = {}
+    finalize_preloaded_skills = cli_mod.HermesCLI.finalize_preloaded_skills
+
+    class WorkerCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "kanban-session"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            self.conversation_history = [
+                {"role": "user", "content": "prior-kanban-user"},
+                {"role": "assistant", "content": "prior-kanban-assistant"},
+            ]
+
+        def run(self):
+            finalize_preloaded_skills(self)
+            observed["granted"] = skill_utils.is_skill_read_granted(
+                "category/directory-alias"
+            )
+            viewed = json.loads(skills_tool.skill_view("category/directory-alias"))
+            observed["content"] = viewed.get("content", "")
+            observed["system_prompt"] = self.system_prompt
+            observed["history"] = list(self.conversation_history)
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", WorkerCLI)
+    cli_mod.main(skills=skill_args, toolsets="safe")
+
+    assert observed["granted"] is True
+    assert observed["content"] == (
+        "---\nname: alpha\ndescription: integration\n---\n\nkanban body\n"
+    )
+    assert observed["system_prompt"].startswith("base\n\n")
+    assert observed["history"] == [
+        {"role": "user", "content": "prior-kanban-user"},
+        {"role": "assistant", "content": "prior-kanban-assistant"},
+    ]
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert (profile_home / "config.yaml").read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled == {
+        "category:directory-alias"
+    }
+    events = [
+        json.loads(line)
+        for line in (profile_home / "logs" / "skill-grants.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[0]["skill_names"] == ["category/directory-alias"]
+    assert events[0]["source"] == "kanban"
+    assert events[0]["task_id"] == task_id
+    assert events[0]["profile"] == "build"
+    assert events[-1]["terminal_status"] == "completed"
 
 
 def test_legacy_db_without_skills_column_migrates(tmp_path):
@@ -1406,5 +1514,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -749,8 +749,114 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
 
 
+def test_spawned_worker_executes_disabled_categorized_skill_with_scoped_grant(
+    kanban_home, monkeypatch
+):
+    """Persisted task -> dispatcher argv/env -> CLI preload uses one scoped grant."""
+    import cli as cli_mod
+    from agent import skill_utils
+    from tools import skills_tool
 
+    profile_home = kanban_home / "profiles" / "build"
+    skill_dir = profile_home / "skills" / "category" / "directory-alias"
+    skill_dir.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  disabled: [category:directory-alias]\n", encoding="utf-8"
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: integration\n---\n\nkanban body\n",
+        encoding="utf-8",
+    )
+    original_config = (profile_home / "config.yaml").read_bytes()
+    captured = {}
 
+    class FakeProc:
+        pid = 45678
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="real skill route",
+            assignee="build",
+            skills=["category/directory-alias"],
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    command = captured["cmd"]
+    skill_args = [
+        command[index + 1]
+        for index, value in enumerate(command[:-1])
+        if value == "--skills"
+    ]
+    assert skill_args == ["category/directory-alias"]
+    assert not any("SKILL_GRANT" in key for key in captured["env"])
+
+    for key, value in captured["env"].items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", profile_home / "skills")
+    skill_utils._raw_config_cache_clear()
+    original_disabled = skill_utils.get_disabled_skill_names()
+    observed = {}
+
+    class WorkerCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "kanban-session"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            self.conversation_history = [
+                {"role": "user", "content": "prior-kanban-user"},
+                {"role": "assistant", "content": "prior-kanban-assistant"},
+            ]
+
+        def run(self):
+            observed["granted"] = skill_utils.is_skill_read_granted(
+                "category/directory-alias"
+            )
+            viewed = json.loads(skills_tool.skill_view("category/directory-alias"))
+            observed["content"] = viewed.get("content", "")
+            observed["system_prompt"] = self.system_prompt
+            observed["history"] = list(self.conversation_history)
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", WorkerCLI)
+    cli_mod.main(skills=skill_args, toolsets="safe")
+
+    assert observed["granted"] is True
+    assert observed["content"] == (
+        "---\nname: alpha\ndescription: integration\n---\n\nkanban body\n"
+    )
+    assert observed["system_prompt"].startswith("base\n\n")
+    assert observed["history"] == [
+        {"role": "user", "content": "prior-kanban-user"},
+        {"role": "assistant", "content": "prior-kanban-assistant"},
+    ]
+    assert skill_utils.is_skill_read_granted("alpha") is False
+    assert (profile_home / "config.yaml").read_bytes() == original_config
+    assert skill_utils.get_disabled_skill_names() == original_disabled == {
+        "category:directory-alias"
+    }
+    events = [
+        json.loads(line)
+        for line in (profile_home / "logs" / "skill-grants.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[0]["skill_names"] == ["category/directory-alias"]
+    assert events[0]["source"] == "kanban"
+    assert events[0]["task_id"] == task_id
+    assert events[0]["profile"] == "build"
+    assert events[-1]["terminal_status"] == "completed"
 
 
 def test_legacy_db_without_skills_column_migrates(tmp_path):
@@ -1406,5 +1512,4 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -862,3 +862,44 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def test_background_review_suppresses_foreground_skill_grant(monkeypatch, tmp_path):
+    from agent import skill_utils
+
+    observed = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            observed["init"] = skill_utils.is_skill_read_granted("alpha")
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            observed["run"] = skill_utils.is_skill_read_granted("alpha")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(skill_utils, "get_disabled_skill_names", lambda: {"alpha"})
+
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="foreground",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        audit_path=tmp_path / "audit.jsonl",
+    ):
+        AIAgent._spawn_background_review(
+            _bare_agent(),
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+        )
+        assert skill_utils.is_skill_read_granted("alpha") is True
+
+    assert observed == {"init": False, "run": False}

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -223,3 +223,44 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def test_background_review_suppresses_foreground_skill_grant(monkeypatch, tmp_path):
+    from agent import skill_utils
+
+    observed = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            observed["init"] = skill_utils.is_skill_read_granted("alpha")
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            observed["run"] = skill_utils.is_skill_read_granted("alpha")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(skill_utils, "get_disabled_skill_names", lambda: {"alpha"})
+
+    with skill_utils.skill_read_grant_scope(
+        ["alpha"],
+        session_id="foreground",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        audit_path=tmp_path / "audit.jsonl",
+    ):
+        AIAgent._spawn_background_review(
+            _bare_agent(),
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+        )
+        assert skill_utils.is_skill_read_granted("alpha") is True
+
+    assert observed == {"init": False, "run": False}

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -57,6 +57,95 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+def test_child_agent_construction_does_not_inherit_skill_read_grant(
+    tmp_path, monkeypatch
+):
+    from agent import skill_utils
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [private-skill]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_utils._raw_config_cache_clear()
+    parent = _make_mock_parent()
+
+    def fake_agent(**kwargs):
+        assert skill_utils.is_skill_read_granted("private-skill") is False
+        return MagicMock()
+
+    with skill_utils.skill_read_grant_scope(
+        ["private-skill"],
+        session_id="parent-session",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ):
+        assert skill_utils.is_skill_read_granted("private-skill") is True
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            _build_child_agent(
+                task_index=0,
+                goal="do not inherit",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=5,
+                task_count=1,
+                parent_agent=parent,
+            )
+        assert skill_utils.is_skill_read_granted("private-skill") is True
+
+
+def test_delegate_child_execution_does_not_inherit_skill_read_grant(
+    tmp_path, monkeypatch
+):
+    from agent import skill_utils
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [private-skill]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_utils._raw_config_cache_clear()
+    for child_raises in (False, True):
+        parent = _make_mock_parent()
+        observed = []
+
+        def fake_agent(**kwargs):
+            child = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                observed.append(skill_utils.is_skill_read_granted("private-skill"))
+                if child_raises:
+                    raise RuntimeError("child failed")
+                return {"final_response": "done", "completed": True, "api_calls": 1}
+
+            child.run_conversation.side_effect = run_conversation
+            return child
+
+        with skill_utils.skill_read_grant_scope(
+            ["private-skill"],
+            session_id=f"parent-session-{child_raises}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            with patch("run_agent.AIAgent", side_effect=fake_agent):
+                result = json.loads(
+                    delegate_task(goal="nested child", parent_agent=parent)
+                )
+            assert skill_utils.is_skill_read_granted("private-skill") is True
+
+        assert observed == [False]
+        expected_status = "error" if child_raises else "completed"
+        assert result["results"][0]["status"] == expected_status
+    assert skill_utils.is_skill_read_granted("private-skill") is False
+
+
 class TestDelegateRequirements(unittest.TestCase):
 
     def test_schema_valid(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -56,6 +56,95 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+def test_child_agent_construction_does_not_inherit_skill_read_grant(
+    tmp_path, monkeypatch
+):
+    from agent import skill_utils
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [private-skill]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_utils._raw_config_cache_clear()
+    parent = _make_mock_parent()
+
+    def fake_agent(**kwargs):
+        assert skill_utils.is_skill_read_granted("private-skill") is False
+        return MagicMock()
+
+    with skill_utils.skill_read_grant_scope(
+        ["private-skill"],
+        session_id="parent-session",
+        profile="build",
+        requester="local-cli",
+        source="cli",
+        ttl_seconds=60,
+    ):
+        assert skill_utils.is_skill_read_granted("private-skill") is True
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            _build_child_agent(
+                task_index=0,
+                goal="do not inherit",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=5,
+                task_count=1,
+                parent_agent=parent,
+            )
+        assert skill_utils.is_skill_read_granted("private-skill") is True
+
+
+def test_delegate_child_execution_does_not_inherit_skill_read_grant(
+    tmp_path, monkeypatch
+):
+    from agent import skill_utils
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  disabled: [private-skill]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_utils._raw_config_cache_clear()
+    for child_raises in (False, True):
+        parent = _make_mock_parent()
+        observed = []
+
+        def fake_agent(**kwargs):
+            child = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                observed.append(skill_utils.is_skill_read_granted("private-skill"))
+                if child_raises:
+                    raise RuntimeError("child failed")
+                return {"final_response": "done", "completed": True, "api_calls": 1}
+
+            child.run_conversation.side_effect = run_conversation
+            return child
+
+        with skill_utils.skill_read_grant_scope(
+            ["private-skill"],
+            session_id=f"parent-session-{child_raises}",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            ttl_seconds=60,
+        ):
+            with patch("run_agent.AIAgent", side_effect=fake_agent):
+                result = json.loads(
+                    delegate_task(goal="nested child", parent_agent=parent)
+                )
+            assert skill_utils.is_skill_read_granted("private-skill") is True
+
+        assert observed == [False]
+        expected_status = "error" if child_raises else "completed"
+        assert result["results"][0]["status"] == expected_status
+    assert skill_utils.is_skill_read_granted("private-skill") is False
+
+
 class TestDelegateRequirements(unittest.TestCase):
 
     def test_schema_valid(self):

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -215,6 +215,36 @@ class TestRunSingleChildSchemaValidation:
         # final summary is the retried (valid) answer
         assert json.loads(entry["summary"])["city"] == "Oslo"
 
+    def test_retry_suppresses_foreground_skill_grant(self, monkeypatch, tmp_path):
+        from agent import skill_utils
+
+        observed = []
+
+        class ObservingChild(_StubChild):
+            def run_conversation(self, *args, **kwargs):
+                observed.append(skill_utils.is_skill_read_granted("alpha"))
+                return super().run_conversation(*args, **kwargs)
+
+        child = ObservingChild(["not json at all", '{"city": "Oslo"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        monkeypatch.setattr(
+            skill_utils, "get_disabled_skill_names", lambda: {"alpha"}
+        )
+
+        with skill_utils.skill_read_grant_scope(
+            ["alpha"],
+            session_id="foreground",
+            profile="build",
+            requester="local-cli",
+            source="cli",
+            audit_path=tmp_path / "skill-grants.jsonl",
+        ):
+            entry = _run(child)
+            assert skill_utils.is_skill_read_granted("alpha") is True
+
+        assert entry["schema_valid"] is True
+        assert observed == [False, False]
+
     def test_invalid_twice_surfaces_errors_and_stops(self):
         child = _StubChild(["nope", "still nope"])
         child._delegate_output_schema = ADDRESS_SCHEMA

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1959,8 +1959,12 @@ def _build_child_agent(
             child_session_db = None
 
     from agent.delegation_context import delegated_child_context
+    from agent.skill_utils import suppress_skill_read_grants
 
-    with delegated_child_context():
+    # A parent may have a CLI/Kanban-scoped exception to read an otherwise
+    # disabled skill. That privilege belongs to the parent request only and
+    # must not become ambient authority during child construction.
+    with delegated_child_context(), suppress_skill_read_grants():
         try:
             child = AIAgent(
                 base_url=effective_base_url,
@@ -2814,8 +2818,11 @@ def _run_single_child(
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
+            from agent.skill_utils import suppress_skill_read_grants
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            with delegated_child_context(
+                str(getattr(child, "session_id", "") or "")
+            ), suppress_skill_read_grants():
                 return child.run_conversation(
                     user_message=goal,
                     task_id=child_task_id,
@@ -2981,11 +2988,17 @@ def _run_single_child(
                 _schema_retries = 1
                 _retry_result = None
                 try:
-                    _retry_result = child.run_conversation(
-                        user_message=build_retry_message(_schema_errors),
-                        task_id=child_task_id,
-                        stream_callback=_relay_child_text,
-                    )
+                    from agent.delegation_context import delegated_child_context
+                    from agent.skill_utils import suppress_skill_read_grants
+
+                    with delegated_child_context(
+                        str(getattr(child, "session_id", "") or "")
+                    ), suppress_skill_read_grants():
+                        _retry_result = child.run_conversation(
+                            user_message=build_retry_message(_schema_errors),
+                            task_id=child_task_id,
+                            stream_callback=_relay_child_text,
+                        )
                 except Exception as _retry_exc:
                     logger.warning(
                         "Subagent %d schema-retry turn failed: %s",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1499,8 +1499,12 @@ def _build_child_agent(
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
     from agent.delegation_context import delegated_child_context
+    from agent.skill_utils import suppress_skill_read_grants
 
-    with delegated_child_context():
+    # A parent may have a CLI/Kanban-scoped exception to read an otherwise
+    # disabled skill. That privilege belongs to the parent request only and
+    # must not become ambient authority during child construction.
+    with delegated_child_context(), suppress_skill_read_grants():
         child = AIAgent(
             base_url=effective_base_url,
             api_key=effective_api_key,
@@ -1510,7 +1514,6 @@ def _build_child_agent(
             acp_command=effective_acp_command,
             acp_args=effective_acp_args,
             max_iterations=max_iterations,
-
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
             fallback_model=parent_fallback,
@@ -2175,8 +2178,11 @@ def _run_single_child(
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
+            from agent.skill_utils import suppress_skill_read_grants
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            with delegated_child_context(
+                str(getattr(child, "session_id", "") or "")
+            ), suppress_skill_read_grants():
                 return child.run_conversation(
                     user_message=goal,
                     task_id=child_task_id,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -83,6 +83,7 @@ from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    SKILL_SUPPORT_DIRS as _SKILL_SUPPORT_DIRS,
     is_skill_support_path as _is_skill_support_path,
 )
 
@@ -935,7 +936,11 @@ def _serve_plugin_skill(
         pass
 
     qualified_name = f"{namespace}:{bare}"
-    if _is_skill_disabled(qualified_name):
+    from agent.skill_utils import is_skill_read_granted
+
+    if _is_skill_disabled(qualified_name) and not is_skill_read_granted(
+        qualified_name
+    ):
         return json.dumps(
             {
                 "success": False,
@@ -1083,6 +1088,363 @@ def _plugin_skill_linked_files(skill_root: Path) -> Dict[str, List[str]] | None:
     return linked or None
 
 
+def _read_skill_frontmatter_only(skill_md: Path) -> Dict[str, Any]:
+    """Read only bounded frontmatter metadata, never the skill instruction body."""
+    try:
+        with skill_md.open(encoding="utf-8-sig", errors="replace") as handle:
+            first = handle.readline()
+            if first.strip() != "---":
+                return {}
+            lines = [first]
+            total = len(first)
+            for line in handle:
+                lines.append(line)
+                total += len(line)
+                if line.strip() == "---":
+                    metadata, _ = _parse_frontmatter("".join(lines))
+                    return metadata
+                if total > 256 * 1024:
+                    return {}
+    except Exception:
+        return {}
+    return {}
+
+
+def _iter_local_flat_skill_files(search_dir: Path):
+    """Yield flat skills with the same pruned, follow-link walk as packages."""
+    matches: List[Path] = []
+    for root, dirs, files in os.walk(search_dir, followlinks=True):
+        has_skill_md = "SKILL.md" in files
+        dirs[:] = sorted(
+            directory
+            for directory in dirs
+            if directory not in _EXCLUDED_SKILL_DIRS
+            and not (has_skill_md and directory in _SKILL_SUPPORT_DIRS)
+        )
+        for filename in sorted(files):
+            if filename == "SKILL.md" or not filename.endswith(".md"):
+                continue
+            flat_md = Path(root) / filename
+            if not _is_skill_support_path(flat_md):
+                matches.append(flat_md)
+    for flat_md in sorted(
+        matches, key=lambda path: str(path.relative_to(search_dir))
+    ):
+        yield flat_md
+
+
+def _same_local_skill_file(left: Path, right: Path) -> bool:
+    """Compare lexical skill paths by their physical target when possible."""
+    try:
+        return left.resolve() == right.resolve()
+    except Exception:
+        return left == right
+
+
+def _local_skill_candidates(
+    name: str,
+    local_lookup: str,
+    search_dirs: List[Path],
+) -> List[Tuple[Optional[Path], Path]]:
+    """Resolve one local selector without widening an explicit path."""
+    from agent.skill_utils import iter_skill_index_files
+
+    candidates: List[Tuple[Optional[Path], Path]] = []
+    seen: Set[Path] = set()
+
+    def _record(skill_dir: Optional[Path], skill_md: Path) -> None:
+        try:
+            key = skill_md.resolve()
+        except Exception:
+            key = skill_md
+        if key not in seen:
+            seen.add(key)
+            candidates.append((skill_dir, skill_md))
+
+    explicit_path = "/" in local_lookup
+    for search_dir in search_dirs:
+        direct = search_dir / local_lookup
+        if (
+            direct.is_dir()
+            and not _is_skill_support_path(direct)
+            and (direct / "SKILL.md").exists()
+        ):
+            _record(direct, direct / "SKILL.md")
+        elif direct.with_suffix(".md").exists() and not _is_skill_support_path(
+            direct.with_suffix(".md")
+        ):
+            _record(None, direct.with_suffix(".md"))
+
+        # A full categorized selector is already exact. Recursive leaf-name
+        # matching here would let a sibling path make that exact target appear
+        # ambiguous (or, worse, select the sibling if the direct path vanished).
+        if explicit_path:
+            continue
+
+        for skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            if skill_md.parent.name == local_lookup:
+                _record(skill_md.parent, skill_md)
+                continue
+            metadata = _read_skill_frontmatter_only(skill_md)
+            if metadata.get("name") == name:
+                _record(skill_md.parent, skill_md)
+
+        for flat_md in _iter_local_flat_skill_files(search_dir):
+            if flat_md.stem == local_lookup:
+                _record(None, flat_md)
+                continue
+            metadata = _read_skill_frontmatter_only(flat_md)
+            if metadata.get("name") == name:
+                _record(None, flat_md)
+
+    return candidates
+
+
+def _is_under_skill_roots(path: Path, roots: List[Path]) -> bool:
+    """Return whether *path* resolves beneath any trusted resolution root."""
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):
+        resolved = path
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return False
+
+
+def _prefer_project_skill_candidates(
+    candidates: List[Tuple[Optional[Path], Path]],
+    project_dirs: List[Path],
+) -> List[Tuple[Optional[Path], Path]]:
+    """Apply the same project-tier precedence used by ``skill_view``."""
+    if len(candidates) <= 1 or not project_dirs:
+        return candidates
+    project_candidates = [
+        candidate
+        for candidate in candidates
+        if _is_under_skill_roots(candidate[1], project_dirs)
+    ]
+    return project_candidates or candidates
+
+
+def _local_skill_lexical_selectors(
+    selected_skill_md: Path,
+    search_dirs: List[Path],
+) -> Set[str]:
+    """Enumerate every discovered relative selector for one physical skill."""
+    from agent.skill_utils import iter_skill_index_files
+
+    selectors: Set[str] = set()
+    for search_dir in search_dirs:
+        for skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            if not _same_local_skill_file(skill_md, selected_skill_md):
+                continue
+            try:
+                relative = skill_md.parent.relative_to(search_dir)
+            except ValueError:
+                continue
+            relative_name = relative.as_posix()
+            if relative_name and relative_name != ".":
+                selectors.add(relative_name)
+
+        for flat_md in _iter_local_flat_skill_files(search_dir):
+            if not _same_local_skill_file(flat_md, selected_skill_md):
+                continue
+            try:
+                relative = flat_md.relative_to(search_dir).with_suffix("")
+            except ValueError:
+                continue
+            relative_name = relative.as_posix()
+            if relative_name and relative_name != ".":
+                selectors.add(relative_name)
+
+    return selectors
+
+
+def _selector_maps_to_local_skill(
+    selector: str,
+    selected_skill_md: Path,
+    search_dirs: List[Path],
+) -> bool:
+    """Return whether normal selector ownership resolves to the selected file."""
+    if not selector or _skill_lookup_path_error(selector):
+        return False
+
+    local_lookup = selector
+    if ":" in selector:
+        from agent.skill_utils import (
+            is_valid_namespace,
+            parse_qualified_name,
+        )
+
+        namespace, bare = parse_qualified_name(selector)
+        if not namespace or not bare or not is_valid_namespace(namespace):
+            return False
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+        try:
+            discover_plugins()
+            manager = get_plugin_manager()
+            plugin_skill = manager.find_plugin_skill(selector)
+            plugin_skills = manager.list_plugin_skills(namespace)
+        except Exception:
+            return False
+        if plugin_skill is not None and plugin_skill.exists():
+            return False
+        if plugin_skills:
+            return False
+        local_lookup = f"{namespace}/{bare}"
+
+    candidates = _local_skill_candidates(selector, local_lookup, search_dirs)
+
+    # A shared bare canonical name is still a disabled identity advertised by
+    # every matching skill, even though invoking that bare selector remains
+    # ambiguous. Qualified selectors retain single-owner path/plugin semantics.
+    if "/" not in selector and ":" not in selector:
+        return any(
+            _same_local_skill_file(candidate_md, selected_skill_md)
+            for _, candidate_md in candidates
+        )
+    if len(candidates) != 1:
+        return False
+    return _same_local_skill_file(candidates[0][1], selected_skill_md)
+
+
+def _local_skill_authorization(
+    name: str,
+    local_lookup: str,
+    skill_md: Path,
+    search_dirs: List[Path],
+) -> Tuple[str, Set[str], Dict[str, Any]]:
+    """Return the selector-bound grant identity and its exact-target aliases."""
+    metadata = _read_skill_frontmatter_only(skill_md)
+
+    aliases = {name, local_lookup}
+    fallback_name = (
+        skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
+    )
+    canonical = str(metadata.get("name") or "").strip()
+    for candidate_alias in (canonical, fallback_name):
+        if candidate_alias and _selector_maps_to_local_skill(
+            candidate_alias, skill_md, search_dirs
+        ):
+            aliases.add(candidate_alias)
+
+    for relative_name in _local_skill_lexical_selectors(skill_md, search_dirs):
+        if _selector_maps_to_local_skill(relative_name, skill_md, search_dirs):
+            aliases.add(relative_name)
+        if "/" in relative_name:
+            from agent.skill_utils import is_valid_namespace
+
+            namespace, bare = relative_name.split("/", 1)
+            colon_name = f"{namespace}:{bare}"
+            if is_valid_namespace(namespace) and _selector_maps_to_local_skill(
+                colon_name, skill_md, search_dirs
+            ):
+                aliases.add(colon_name)
+
+    return name, {alias for alias in aliases if alias}, metadata
+
+
+def resolve_skill_read_grant_targets(names) -> Dict[str, Set[str]]:
+    """Map each unambiguous requested selector to its exact target aliases."""
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        get_project_skills_dirs,
+        is_valid_namespace,
+        parse_qualified_name,
+    )
+
+    if isinstance(names, str):
+        requested_names = [names]
+    else:
+        requested_names = list(names or [])
+    resolved_targets: Dict[str, Set[str]] = {}
+
+    for raw_name in requested_names:
+        name = str(raw_name).strip()
+        if not name or _skill_lookup_path_error(name):
+            continue
+
+        local_lookup = name
+        if ":" in name:
+            namespace, bare = parse_qualified_name(name)
+            if not namespace or not bare or not is_valid_namespace(namespace):
+                continue
+            from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+            try:
+                discover_plugins()
+                pm = get_plugin_manager()
+                plugin_skill = pm.find_plugin_skill(name)
+                active_memory_provider = None
+                try:
+                    from plugins.memory import (
+                        _get_active_memory_provider,
+                        _prune_inactive_memory_provider_skills,
+                        load_memory_provider,
+                    )
+
+                    active_memory_provider = _get_active_memory_provider()
+                    _prune_inactive_memory_provider_skills(active_memory_provider)
+                    if plugin_skill is None and namespace == active_memory_provider:
+                        load_memory_provider(namespace)
+                        plugin_skill = pm.find_plugin_skill(name)
+                except Exception:
+                    logger.debug(
+                        "Could not load memory-provider skill grant target %r",
+                        name,
+                        exc_info=True,
+                    )
+                plugin_skills = pm.list_plugin_skills(namespace)
+            except Exception:
+                logger.debug(
+                    "Could not resolve plugin skill grant target %r", name, exc_info=True
+                )
+                continue
+            if plugin_skill is not None and plugin_skill.exists():
+                resolved_targets[name] = {name}
+                continue
+            if plugin_skills:
+                # The plugin exists but the requested member does not. Do not
+                # reinterpret it as a local skill with the same spelling.
+                continue
+            local_lookup = f"{namespace}/{bare}"
+            if _skill_lookup_path_error(local_lookup):
+                continue
+
+        project_dirs = get_project_skills_dirs()
+        search_dirs: List[Path] = list(project_dirs)
+        active_skills_dir = _skills_dir()
+        if active_skills_dir.exists():
+            search_dirs.append(active_skills_dir)
+        search_dirs.extend(get_external_skills_dirs())
+        candidates = _local_skill_candidates(name, local_lookup, search_dirs)
+        candidates = _prefer_project_skill_candidates(candidates, project_dirs)
+        if len(candidates) != 1:
+            continue
+        _, skill_md = candidates[0]
+        if project_dirs and _is_under_skill_roots(skill_md, project_dirs):
+            from agent.skill_utils import is_quarantined_project_skill
+
+            if is_quarantined_project_skill(skill_md):
+                continue
+        identity, aliases, _ = _local_skill_authorization(
+            name, local_lookup, skill_md, search_dirs
+        )
+        resolved_targets[identity] = aliases
+
+    return resolved_targets
+
+
+def resolve_skill_read_grant_names(names) -> List[str]:
+    """Resolve preloads to selector-bound identities used by ``skill_view``."""
+    return list(resolve_skill_read_grant_targets(names))
+
+
 def skill_view(
     name: str,
     file_path: str = None,
@@ -1125,7 +1487,11 @@ def skill_view(
         # Names containing ':' are routed to the plugin skill registry.
         # Bare names fall through to the existing flat-tree scan below.
         if ":" in name:
-            from agent.skill_utils import is_valid_namespace, parse_qualified_name
+            from agent.skill_utils import (
+                is_skill_read_granted,
+                is_valid_namespace,
+                parse_qualified_name,
+            )
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
             namespace, bare = parse_qualified_name(name)
@@ -1136,6 +1502,18 @@ def skill_view(
                         "error": (
                             f"Invalid namespace '{namespace}' in '{name}'. "
                             f"Namespaces must match [a-zA-Z0-9_-]+."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+            if _is_skill_disabled(name) and not is_skill_read_granted(name):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Skill '{name}' is disabled. Enable it with "
+                            "`hermes skills` or inspect the files directly on disk."
                         ),
                     },
                     ensure_ascii=False,
@@ -1261,110 +1639,10 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
-        # Collision detection: collect ALL candidates across every dir using
-        # every lookup strategy (direct path, recursive by parent dir name,
-        # legacy flat <name>.md). If more than one matches, refuse and tell
-        # the caller — silent shadowing of a local skill by a same-named
-        # external skill is a real bug class (`/skills` shows one, agent
-        # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
+        local_lookup = local_category_name or name
+        candidates = _local_skill_candidates(name, local_lookup, all_dirs)
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
-        seen_md: set = set()
-
-        def _record(sd: Optional[Path], smd: Path) -> None:
-            try:
-                key = smd.resolve()
-            except Exception:
-                key = smd
-            if key in seen_md:
-                return
-            seen_md.add(key)
-            candidates.append((sd, smd))
-
-        for search_dir in all_dirs:
-            # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
-            # at the top of the dir).
-            direct_path = search_dir / name
-            if (
-                not _is_skill_support_path(direct_path)
-                and direct_path.is_dir()
-                and (direct_path / "SKILL.md").exists()
-            ):
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
-            ):
-                _record(None, direct_path.with_suffix(".md"))
-
-            # Strategy 1b: categorized form for plugin namespace fall-through
-            # (e.g., a "myplugin:explore" name with no plugin registered also
-            # tries the on-disk path "myplugin/explore").
-            if local_category_name:
-                categorized_path = search_dir / local_category_name
-                if (
-                    not _is_skill_support_path(categorized_path)
-                    and categorized_path.is_dir()
-                    and (categorized_path / "SKILL.md").exists()
-                ):
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(
-                    ".md"
-                ).exists() and not _is_skill_support_path(
-                    categorized_path.with_suffix(".md")
-                ):
-                    _record(None, categorized_path.with_suffix(".md"))
-
-            # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name),
-            # plus frontmatter `name:` lookup. `skills_list()` exposes the
-            # frontmatter name, so `skill_view(name)` must accept it too even
-            # when the on-disk directory is a shorter category/alias.
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
-                if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
-                    continue
-                try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8-sig", errors="replace")
-                    fm, _ = _parse_frontmatter(fm_content)
-                except Exception:
-                    fm = {}
-                if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
-
-            # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            # Exclude skill support docs: references/templates/assets/scripts
-            # are loaded through skill_view(skill, file_path=...) and must not
-            # shadow or collide with real skills that share the same basename.
-            for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md" and not _is_skill_support_path(
-                    found_md
-                ):
-                    _record(None, found_md)
-
-        if len(candidates) > 1 and project_dirs:
-            # Cross-tier collision resolution: a project skill intentionally
-            # overrides a same-named local/external skill, so when at least
-            # one candidate lives under a trusted project dir, narrow to
-            # those. Ambiguity WITHIN the project tier still refuses below.
-            def _in_project(smd: Path) -> bool:
-                try:
-                    resolved = smd.resolve()
-                except Exception:
-                    resolved = smd
-                for pd in project_dirs:
-                    try:
-                        resolved.relative_to(pd)
-                        return True
-                    except ValueError:
-                        continue
-                return False
-
-            project_candidates = [
-                (sd, smd) for sd, smd in candidates if _in_project(smd)
-            ]
-            if project_candidates:
-                candidates = project_candidates
+        candidates = _prefer_project_skill_candidates(candidates, project_dirs)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
@@ -1399,20 +1677,9 @@ def skill_view(
         if skill_md is not None and project_dirs:
             from agent.skill_utils import is_quarantined_project_skill
 
-            def _under_project(p: Path) -> bool:
-                try:
-                    rp = p.resolve()
-                except Exception:
-                    rp = p
-                for pd in project_dirs:
-                    try:
-                        rp.relative_to(pd)
-                        return True
-                    except ValueError:
-                        continue
-                return False
-
-            if _under_project(skill_md) and is_quarantined_project_skill(skill_md):
+            if _is_under_skill_roots(
+                skill_md, project_dirs
+            ) and is_quarantined_project_skill(skill_md):
                 return json.dumps(
                     {
                         "success": False,
@@ -1442,7 +1709,35 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Read the file once — reused for platform check and main content below
+        authorization_identity, disabled_aliases, parsed_frontmatter = (
+            _local_skill_authorization(name, local_lookup, skill_md, all_dirs)
+        )
+        from agent.skill_utils import is_skill_read_granted
+
+        is_disabled = any(_is_skill_disabled(alias) for alias in disabled_aliases)
+        if is_disabled and not is_skill_read_granted(authorization_identity):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Skill '{name}' is disabled. "
+                        "Enable it with `hermes skills` or inspect the files directly on disk."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
+        if not skill_matches_platform(parsed_frontmatter):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Skill '{name}' is not supported on this platform.",
+                    "readiness_status": SkillReadinessStatus.UNSUPPORTED.value,
+                },
+                ensure_ascii=False,
+            )
+
+        # Read full content only after the disabled-skill authorization check.
         try:
             content = skill_md.read_text(encoding="utf-8-sig", errors="replace")
         except Exception as e:
@@ -1483,36 +1778,6 @@ def skill_view(
             if _injection_detected:
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
             logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
-
-        parsed_frontmatter: Dict[str, Any] = {}
-        try:
-            parsed_frontmatter, _ = _parse_frontmatter(content)
-        except Exception:
-            parsed_frontmatter = {}
-
-        if not skill_matches_platform(parsed_frontmatter):
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": f"Skill '{name}' is not supported on this platform.",
-                    "readiness_status": SkillReadinessStatus.UNSUPPORTED.value,
-                },
-                ensure_ascii=False,
-            )
-
-        # Check if the skill is disabled by the user
-        resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
-        if _is_skill_disabled(resolved_name):
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": (
-                        f"Skill '{resolved_name}' is disabled. "
-                        "Enable it with `hermes skills` or inspect the files directly on disk."
-                    ),
-                },
-                ensure_ascii=False,
-            )
 
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -82,6 +82,7 @@ from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    SKILL_SUPPORT_DIRS as _SKILL_SUPPORT_DIRS,
     is_skill_support_path as _is_skill_support_path,
 )
 
@@ -958,6 +959,305 @@ def _serve_plugin_skill(
     )
 
 
+def _read_skill_frontmatter_only(skill_md: Path) -> Dict[str, Any]:
+    """Read only bounded frontmatter metadata, never the skill instruction body."""
+    try:
+        with skill_md.open(encoding="utf-8") as handle:
+            first = handle.readline()
+            if first.strip() != "---":
+                return {}
+            lines = [first]
+            total = len(first)
+            for line in handle:
+                lines.append(line)
+                total += len(line)
+                if line.strip() == "---":
+                    metadata, _ = _parse_frontmatter("".join(lines))
+                    return metadata
+                if total > 256 * 1024:
+                    return {}
+    except Exception:
+        return {}
+    return {}
+
+
+def _iter_local_flat_skill_files(search_dir: Path):
+    """Yield flat skills with the same pruned, follow-link walk as packages."""
+    matches: List[Path] = []
+    for root, dirs, files in os.walk(search_dir, followlinks=True):
+        has_skill_md = "SKILL.md" in files
+        dirs[:] = sorted(
+            directory
+            for directory in dirs
+            if directory not in _EXCLUDED_SKILL_DIRS
+            and not (has_skill_md and directory in _SKILL_SUPPORT_DIRS)
+        )
+        for filename in sorted(files):
+            if filename == "SKILL.md" or not filename.endswith(".md"):
+                continue
+            flat_md = Path(root) / filename
+            if not _is_skill_support_path(flat_md):
+                matches.append(flat_md)
+    for flat_md in sorted(
+        matches, key=lambda path: str(path.relative_to(search_dir))
+    ):
+        yield flat_md
+
+
+def _same_local_skill_file(left: Path, right: Path) -> bool:
+    """Compare lexical skill paths by their physical target when possible."""
+    try:
+        return left.resolve() == right.resolve()
+    except Exception:
+        return left == right
+
+
+def _local_skill_candidates(
+    name: str,
+    local_lookup: str,
+    search_dirs: List[Path],
+) -> List[Tuple[Optional[Path], Path]]:
+    """Resolve one local selector without widening an explicit path."""
+    from agent.skill_utils import iter_skill_index_files
+
+    candidates: List[Tuple[Optional[Path], Path]] = []
+    seen: Set[Path] = set()
+
+    def _record(skill_dir: Optional[Path], skill_md: Path) -> None:
+        try:
+            key = skill_md.resolve()
+        except Exception:
+            key = skill_md
+        if key not in seen:
+            seen.add(key)
+            candidates.append((skill_dir, skill_md))
+
+    explicit_path = "/" in local_lookup
+    for search_dir in search_dirs:
+        direct = search_dir / local_lookup
+        if (
+            direct.is_dir()
+            and not _is_skill_support_path(direct)
+            and (direct / "SKILL.md").exists()
+        ):
+            _record(direct, direct / "SKILL.md")
+        elif direct.with_suffix(".md").exists() and not _is_skill_support_path(
+            direct.with_suffix(".md")
+        ):
+            _record(None, direct.with_suffix(".md"))
+
+        # A full categorized selector is already exact. Recursive leaf-name
+        # matching here would let a sibling path make that exact target appear
+        # ambiguous (or, worse, select the sibling if the direct path vanished).
+        if explicit_path:
+            continue
+
+        for skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            if skill_md.parent.name == local_lookup:
+                _record(skill_md.parent, skill_md)
+                continue
+            metadata = _read_skill_frontmatter_only(skill_md)
+            if metadata.get("name") == name:
+                _record(skill_md.parent, skill_md)
+
+        for flat_md in _iter_local_flat_skill_files(search_dir):
+            if flat_md.stem == local_lookup:
+                _record(None, flat_md)
+                continue
+            metadata = _read_skill_frontmatter_only(flat_md)
+            if metadata.get("name") == name:
+                _record(None, flat_md)
+
+    return candidates
+
+
+def _local_skill_lexical_selectors(
+    selected_skill_md: Path,
+    search_dirs: List[Path],
+) -> Set[str]:
+    """Enumerate every discovered relative selector for one physical skill."""
+    from agent.skill_utils import iter_skill_index_files
+
+    selectors: Set[str] = set()
+    for search_dir in search_dirs:
+        for skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            if not _same_local_skill_file(skill_md, selected_skill_md):
+                continue
+            try:
+                relative = skill_md.parent.relative_to(search_dir)
+            except ValueError:
+                continue
+            relative_name = relative.as_posix()
+            if relative_name and relative_name != ".":
+                selectors.add(relative_name)
+
+        for flat_md in _iter_local_flat_skill_files(search_dir):
+            if not _same_local_skill_file(flat_md, selected_skill_md):
+                continue
+            try:
+                relative = flat_md.relative_to(search_dir).with_suffix("")
+            except ValueError:
+                continue
+            relative_name = relative.as_posix()
+            if relative_name and relative_name != ".":
+                selectors.add(relative_name)
+
+    return selectors
+
+
+def _selector_maps_to_local_skill(
+    selector: str,
+    selected_skill_md: Path,
+    search_dirs: List[Path],
+) -> bool:
+    """Return whether normal selector ownership resolves to the selected file."""
+    if not selector or _skill_lookup_path_error(selector):
+        return False
+
+    local_lookup = selector
+    if ":" in selector:
+        from agent.skill_utils import (
+            is_valid_namespace,
+            parse_qualified_name,
+        )
+
+        namespace, bare = parse_qualified_name(selector)
+        if not namespace or not bare or not is_valid_namespace(namespace):
+            return False
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+        try:
+            discover_plugins()
+            manager = get_plugin_manager()
+            plugin_skill = manager.find_plugin_skill(selector)
+            plugin_skills = manager.list_plugin_skills(namespace)
+        except Exception:
+            return False
+        if plugin_skill is not None and plugin_skill.exists():
+            return False
+        if plugin_skills:
+            return False
+        local_lookup = f"{namespace}/{bare}"
+
+    candidates = _local_skill_candidates(selector, local_lookup, search_dirs)
+
+    # A shared bare canonical name is still a disabled identity advertised by
+    # every matching skill, even though invoking that bare selector remains
+    # ambiguous. Qualified selectors retain single-owner path/plugin semantics.
+    if "/" not in selector and ":" not in selector:
+        return any(
+            _same_local_skill_file(candidate_md, selected_skill_md)
+            for _, candidate_md in candidates
+        )
+    if len(candidates) != 1:
+        return False
+    return _same_local_skill_file(candidates[0][1], selected_skill_md)
+
+
+def _local_skill_authorization(
+    name: str,
+    local_lookup: str,
+    skill_md: Path,
+    search_dirs: List[Path],
+) -> Tuple[str, Set[str], Dict[str, Any]]:
+    """Return the selector-bound grant identity and its exact-target aliases."""
+    metadata = _read_skill_frontmatter_only(skill_md)
+
+    aliases = {name, local_lookup}
+    fallback_name = (
+        skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
+    )
+    canonical = str(metadata.get("name") or "").strip()
+    for candidate_alias in (canonical, fallback_name):
+        if candidate_alias and _selector_maps_to_local_skill(
+            candidate_alias, skill_md, search_dirs
+        ):
+            aliases.add(candidate_alias)
+
+    for relative_name in _local_skill_lexical_selectors(skill_md, search_dirs):
+        if _selector_maps_to_local_skill(relative_name, skill_md, search_dirs):
+            aliases.add(relative_name)
+        if "/" in relative_name:
+            from agent.skill_utils import is_valid_namespace
+
+            namespace, bare = relative_name.split("/", 1)
+            colon_name = f"{namespace}:{bare}"
+            if is_valid_namespace(namespace) and _selector_maps_to_local_skill(
+                colon_name, skill_md, search_dirs
+            ):
+                aliases.add(colon_name)
+
+    return name, {alias for alias in aliases if alias}, metadata
+
+
+def resolve_skill_read_grant_targets(names) -> Dict[str, Set[str]]:
+    """Map each unambiguous requested selector to its exact target aliases."""
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        is_valid_namespace,
+        parse_qualified_name,
+    )
+
+    if isinstance(names, str):
+        requested_names = [names]
+    else:
+        requested_names = list(names or [])
+    resolved_targets: Dict[str, Set[str]] = {}
+
+    for raw_name in requested_names:
+        name = str(raw_name).strip()
+        if not name or _skill_lookup_path_error(name):
+            continue
+
+        local_lookup = name
+        if ":" in name:
+            namespace, bare = parse_qualified_name(name)
+            if not namespace or not bare or not is_valid_namespace(namespace):
+                continue
+            from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+            try:
+                discover_plugins()
+                pm = get_plugin_manager()
+                plugin_skill = pm.find_plugin_skill(name)
+                plugin_skills = pm.list_plugin_skills(namespace)
+            except Exception:
+                logger.debug(
+                    "Could not resolve plugin skill grant target %r", name, exc_info=True
+                )
+                continue
+            if plugin_skill is not None and plugin_skill.exists():
+                resolved_targets[name] = {name}
+                continue
+            if plugin_skills:
+                # The plugin exists but the requested member does not. Do not
+                # reinterpret it as a local skill with the same spelling.
+                continue
+            local_lookup = f"{namespace}/{bare}"
+            if _skill_lookup_path_error(local_lookup):
+                continue
+
+        search_dirs: List[Path] = []
+        if SKILLS_DIR.exists():
+            search_dirs.append(SKILLS_DIR)
+        search_dirs.extend(get_external_skills_dirs())
+        candidates = _local_skill_candidates(name, local_lookup, search_dirs)
+        if len(candidates) != 1:
+            continue
+        _, skill_md = candidates[0]
+        identity, aliases, _ = _local_skill_authorization(
+            name, local_lookup, skill_md, search_dirs
+        )
+        resolved_targets[identity] = aliases
+
+    return resolved_targets
+
+
+def resolve_skill_read_grant_names(names) -> List[str]:
+    """Resolve preloads to selector-bound identities used by ``skill_view``."""
+    return list(resolve_skill_read_grant_targets(names))
+
+
 def skill_view(
     name: str,
     file_path: str = None,
@@ -1000,7 +1300,11 @@ def skill_view(
         # Names containing ':' are routed to the plugin skill registry.
         # Bare names fall through to the existing flat-tree scan below.
         if ":" in name:
-            from agent.skill_utils import is_valid_namespace, parse_qualified_name
+            from agent.skill_utils import (
+                is_skill_read_granted,
+                is_valid_namespace,
+                parse_qualified_name,
+            )
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
             namespace, bare = parse_qualified_name(name)
@@ -1011,6 +1315,18 @@ def skill_view(
                         "error": (
                             f"Invalid namespace '{namespace}' in '{name}'. "
                             f"Namespaces must match [a-zA-Z0-9_-]+."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+            if _is_skill_disabled(name) and not is_skill_read_granted(name):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Skill '{name}' is disabled. Enable it with "
+                            "`hermes skills` or inspect the files directly on disk."
                         ),
                     },
                     ensure_ascii=False,
@@ -1098,86 +1414,8 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
-        # Collision detection: collect ALL candidates across every dir using
-        # every lookup strategy (direct path, recursive by parent dir name,
-        # legacy flat <name>.md). If more than one matches, refuse and tell
-        # the caller — silent shadowing of a local skill by a same-named
-        # external skill is a real bug class (`/skills` shows one, agent
-        # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
-
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
-        seen_md: set = set()
-
-        def _record(sd: Optional[Path], smd: Path) -> None:
-            try:
-                key = smd.resolve()
-            except Exception:
-                key = smd
-            if key in seen_md:
-                return
-            seen_md.add(key)
-            candidates.append((sd, smd))
-
-        for search_dir in all_dirs:
-            # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
-            # at the top of the dir).
-            direct_path = search_dir / name
-            if (
-                not _is_skill_support_path(direct_path)
-                and direct_path.is_dir()
-                and (direct_path / "SKILL.md").exists()
-            ):
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
-            ):
-                _record(None, direct_path.with_suffix(".md"))
-
-            # Strategy 1b: categorized form for plugin namespace fall-through
-            # (e.g., a "myplugin:explore" name with no plugin registered also
-            # tries the on-disk path "myplugin/explore").
-            if local_category_name:
-                categorized_path = search_dir / local_category_name
-                if (
-                    not _is_skill_support_path(categorized_path)
-                    and categorized_path.is_dir()
-                    and (categorized_path / "SKILL.md").exists()
-                ):
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(
-                    ".md"
-                ).exists() and not _is_skill_support_path(
-                    categorized_path.with_suffix(".md")
-                ):
-                    _record(None, categorized_path.with_suffix(".md"))
-
-            # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name),
-            # plus frontmatter `name:` lookup. `skills_list()` exposes the
-            # frontmatter name, so `skill_view(name)` must accept it too even
-            # when the on-disk directory is a shorter category/alias.
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
-                if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
-                    continue
-                try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8")
-                    fm, _ = _parse_frontmatter(fm_content)
-                except Exception:
-                    fm = {}
-                if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
-
-            # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            # Exclude skill support docs: references/templates/assets/scripts
-            # are loaded through skill_view(skill, file_path=...) and must not
-            # shadow or collide with real skills that share the same basename.
-            for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md" and not _is_skill_support_path(
-                    found_md
-                ):
-                    _record(None, found_md)
+        local_lookup = local_category_name or name
+        candidates = _local_skill_candidates(name, local_lookup, all_dirs)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
@@ -1218,7 +1456,35 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Read the file once — reused for platform check and main content below
+        authorization_identity, disabled_aliases, parsed_frontmatter = (
+            _local_skill_authorization(name, local_lookup, skill_md, all_dirs)
+        )
+        from agent.skill_utils import is_skill_read_granted
+
+        is_disabled = any(_is_skill_disabled(alias) for alias in disabled_aliases)
+        if is_disabled and not is_skill_read_granted(authorization_identity):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Skill '{name}' is disabled. "
+                        "Enable it with `hermes skills` or inspect the files directly on disk."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
+        if not skill_matches_platform(parsed_frontmatter):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Skill '{name}' is not supported on this platform.",
+                    "readiness_status": SkillReadinessStatus.UNSUPPORTED.value,
+                },
+                ensure_ascii=False,
+            )
+
+        # Read full content only after the disabled-skill authorization check.
         try:
             content = skill_md.read_text(encoding="utf-8")
         except Exception as e:
@@ -1258,36 +1524,6 @@ def skill_view(
             if _injection_detected:
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
             logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
-
-        parsed_frontmatter: Dict[str, Any] = {}
-        try:
-            parsed_frontmatter, _ = _parse_frontmatter(content)
-        except Exception:
-            parsed_frontmatter = {}
-
-        if not skill_matches_platform(parsed_frontmatter):
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": f"Skill '{name}' is not supported on this platform.",
-                    "readiness_status": SkillReadinessStatus.UNSUPPORTED.value,
-                },
-                ensure_ascii=False,
-            )
-
-        # Check if the skill is disabled by the user
-        resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
-        if _is_skill_disabled(resolved_name):
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": (
-                        f"Skill '{resolved_name}' is disabled. "
-                        "Enable it with `hermes skills` or inspect the files directly on disk."
-                    ),
-                },
-                ensure_ascii=False,
-            )
 
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -116,7 +116,7 @@ Common options:
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
 | `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `upstage` (alias `solar`), `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `opencode-free` (aliases `free`, `opencode_free`; keyless), `commandcode`, `commandcode-anthropic`, `ai-gateway`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
-| `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
+| `-s`, `--skills <name>` | Preload one or more skills for this session (repeat or comma-separate). For `hermes chat`, an explicitly named globally disabled skill gets an exact-name, time-bounded read grant for that invocation only; listing/discovery remain disabled. |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |
 | `--image <path>` | Attach a local image to a single query. |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -113,7 +113,7 @@ Common options:
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
 | `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `upstage` (alias `solar`), `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
-| `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
+| `-s`, `--skills <name>` | Preload one or more skills for this session (repeat or comma-separate). For `hermes chat`, an explicitly named globally disabled skill gets an exact-name, time-bounded read grant for that invocation only; listing/discovery remain disabled. |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |
 | `--image <path>` | Attach a local image to a single query. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -461,7 +461,7 @@ hermes kanban create "audit auth flow" \
 
 **From the dashboard**, type the skills comma-separated into the **skills** field of the create-task dialog.
 
-The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills that are actually installed on the assignee's profile (run `hermes skills list` to see what's available); there's no runtime install.
+The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills installed on the assignee's profile; there is no runtime install. A task may explicitly name a globally disabled skill: that worker receives a metadata-audited, exact-name read grant limited to its invocation, while the profile's disabled list and automatic discovery stay unchanged. Delegated child agents do not inherit the worker's grant.
 
 ### Per-task model override
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -455,7 +455,7 @@ hermes kanban create "audit auth flow" \
 
 **From the dashboard**, type the skills comma-separated into the **skills** field of the create-task dialog.
 
-The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills that are actually installed on the assignee's profile (run `hermes skills list` to see what's available); there's no runtime install.
+The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills installed on the assignee's profile; there is no runtime install. A task may explicitly name a globally disabled skill: that worker receives a metadata-audited, exact-name read grant limited to its invocation, while the profile's disabled list and automatic discovery stay unchanged. Delegated child agents do not inherit the worker's grant.
 
 ### Per-task model override
 


### PR DESCRIPTION
## Summary

- permit explicitly requested disabled skills only through task-scoped CLI `--skills` and Kanban `required_skills`
- resolve exact skill identities and aliases before issuing profile-scoped, audited grants
- propagate grants only through the intended task execution path while suppressing them for delegation and background review
- preserve default denial, prompt-cache construction, and profile isolation

## Security contract

- disabled skills remain denied by default
- a grant is narrow, explicit, task-scoped, and bound to the active profile
- grants do not leak into unrelated prompts, sessions, delegation, or background review
- tests do not consult live Keychain state or modify live Hermes configuration

## Validation

- focused Phase 1A tests: **330 passed**
- Ruff: passed
- Python syntax checks: passed
- diff hygiene checks: passed
- `scripts/run_tests.sh`: **23,910 passed**; 25 failures in unrelated platform/environment tests and 11 ACP collection errors caused by the absent optional ACP dependency. These failures were reviewed against the patch and were not regressions introduced by this change.

No deployment, gateway restart, session alteration, or live configuration/credential access was performed.
