### PR TITLE
fix(cli): install model-provider plugins under model-providers/ subdirectory (#76372)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -502,8 +502,17 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
             subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
         )
 
+        # Model-provider plugins must live under the ``model-providers/``
+        # subdirectory so the Provider Registry can discover them.
+        kind = manifest.get("kind", "")
+        if kind == "model-provider":
+            install_dir = plugins_dir / "model-providers"
+            install_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            install_dir = plugins_dir
+
         try:
-            target = _sanitize_plugin_name(plugin_name, plugins_dir)
+            target = _sanitize_plugin_name(plugin_name, install_dir)
         except ValueError as e:
             raise PluginOperationError(str(e)) from e
 


### PR DESCRIPTION
## Summary

`hermes plugins install` clones all plugins into `~/.hermes/plugins/<name>/` regardless of their `kind` field. The Provider Registry only scans `~/.hermes/plugins/model-providers/<name>/`, so model-provider plugins installed via CLI are invisible to `hermes model`.

## Root Cause

Two discovery systems disagree on where user-installed model-provider plugins live:

1. **`_install_plugin_core()`** in `plugins_cmd.py` — clones into `~/.hermes/plugins/<manifest_name>/` (flat, based on the `name` field from `plugin.yaml`). No special handling for `kind: model-provider`.

2. **`_discover_providers()`** in `providers/__init__.py` — scans only `~/.hermes/plugins/model-providers/<name>/`.

Result: the general plugin loader knows about the manifest but won't import it (defers to provider system); the provider loader would import it but can't find it.

## Fix

After reading the manifest in `_install_plugin_core`, check for `kind: model-provider`. If present, install into `plugins_dir / "model-providers"` instead of `plugins_dir` directly. This aligns the install path with the existing Provider Registry discovery contract.

## Changes

- `hermes_cli/plugins_cmd.py`: +10/-1 lines — detect `kind: model-provider` and route to `model-providers/` subdirectory

Fixes #76372