### PR TITLE
fix(discord): validate destinations and verify received messages

### DIFF
--- a/docs/specs/discord-delivery-acceptance-contract.md
+++ b/docs/specs/discord-delivery-acceptance-contract.md
@@ -1,0 +1,171 @@
+# Discord delivery acceptance — review contract (packet-provable)
+
+Companion to `docs/specs/discord-delivery-acceptance.md`. That document says
+what the code must do; this one says how a reviewer proves it, using only the
+commit packet: **the diff, the test files, and the recorded test/static-check
+output**. No criterion below requires a live Discord connection, a running
+gateway, a deployment, or CI.
+
+Base commit: `3f497e2b4f92ef83f45a98c02f7cb47c12ee069e`.
+Spec sections referenced as §N are sections of the normative spec.
+
+## How to read a criterion
+
+Each criterion has an id (`C-nn`), the requirement, and the **proof** — the
+exact artifact in the packet that discharges it. A criterion is met only when
+the named proof exists and shows the stated result. "Test named X" means a
+test function whose failure would be caused by the requirement being violated
+(the reviewer should confirm the assertion, not just the name).
+
+---
+
+## Group 1 — Scope and containment
+
+- **C-01** The implementation commit changes only
+  `plugins/platforms/discord/adapter.py`, files under `tests/` that exercise
+  the Discord adapter, and files under `docs/specs/`.
+  *Proof:* `git show --stat <impl sha>`.
+- **C-02** No file under `gateway/`, no other platform adapter, and no
+  packaging/config/CI file is modified.
+  *Proof:* same stat listing.
+- **C-03** The two spec documents were committed alone, before the
+  implementation, and are unmodified by the implementation commit.
+  *Proof:* `git log --oneline` order plus `git show --stat` of both commits.
+
+## Group 2 — Strict id validation (§2)
+
+- **C-04** A single predicate defines validity and is the only gate in front
+  of every `int()` used for a channel/thread id on the delivery path. Grepping
+  the changed functions shows no `int(chat_id)` / `int(thread_id)` that is not
+  preceded by the predicate.
+  *Proof:* diff of `send()` / `edit_message()` / the new helper; grep output.
+- **C-05** The predicate rejects, and the delivery path fails without posting,
+  for every row A1–A12 of matrix §6a, and accepts A13–A14.
+  *Proof:* a parametrised test covering all 14 rows, passing.
+- **C-06** Rejection of a non-name-shaped invalid id produces
+  `SendResult(success=False)` and no `channel.send` call.
+  *Proof:* assertion on `success is False` and `channel.send.await_count == 0`
+  in the A-row test.
+- **C-07** `metadata["thread_id"]` is validated by the same predicate as
+  `chat_id` (not a second, weaker copy).
+  *Proof:* test asserting an invalid `thread_id` fails without posting, plus
+  the diff showing one shared call site.
+
+## Group 3 — Name resolution (§3)
+
+- **C-08** Resolution is exact and case-sensitive; rows B1–B4 of §6b hold.
+  *Proof:* tests for `#name` hit, bare `name` hit, case miss, absent miss.
+- **C-09** Ambiguity fails loudly and never picks a winner; rows B5 and B9
+  hold, and the diagnostic contains the competing channel ids.
+  *Proof:* tests asserting `success is False`, `channel.send` never awaited,
+  and both ids present in the captured error record.
+- **C-10** A name is never passed to `int()` (row B7). The proof must be
+  positive, not incidental: the test installs a client whose
+  `get_channel`/`fetch_channel` raise if called with anything that is not an
+  `int`, and asserts the name path never reaches them.
+  *Proof:* named test with that guard.
+- **C-11** The candidate set is exactly the one in §3.2 (guild
+  `text_channels`, `forums` when present, `threads`), and objects lacking
+  `name` are skipped without raising.
+  *Proof:* diff of the resolver plus a test with a mixed-candidate guild
+  including a nameless object.
+- **C-12** A client without `guilds` (row B8) and the degenerate `"#"` input
+  (row B6) both fail loudly with no post.
+  *Proof:* two tests.
+- **C-13** A resolved-by-name channel object is used directly for the post —
+  no second lookup, no `int()` round trip.
+  *Proof:* test asserting the object posted to is the same object the guild
+  scan returned (`is` identity).
+
+## Group 4 — Loud failure and secret-free diagnostics (§4)
+
+- **C-14** Rows C1–C4 of §6c each yield `SendResult(success=False)`.
+  *Proof:* four tests.
+- **C-15** Each of those failures emits at least one `ERROR`-level record from
+  the adapter logger; none of them is reported only at `DEBUG`/`TRACE`.
+  *Proof:* tests capturing the adapter logger and asserting on record levels.
+- **C-16** For every row in C1–C4 (row C5), neither the captured log records
+  nor `SendResult.error` contains `http://`, `https://`, the bot token value,
+  or the message content body. The test drives content and an exception text
+  that both embed a URL and a token-shaped string, so a regression is caught
+  rather than assumed.
+  *Proof:* named secret-free test.
+- **C-17** New error-level delivery diagnostics do not pass `exc_info=True`.
+  *Proof:* diff inspection of the added `logger.error` calls.
+- **C-18** A partial multi-chunk failure (row C4) preserves the ids of chunks
+  that landed in `raw_response["message_ids"]`.
+  *Proof:* test asserting the exact list.
+
+## Group 5 — Received-message acceptance (§5)
+
+- **C-19** The success path performs a read-back per posted chunk and requires
+  an id match (row D1); a passing single-chunk success test asserts
+  `fetch_message` was awaited with the posted id.
+  *Proof:* named test.
+- **C-20** Rows D2–D5 (absence, mismatch, read exception, no `fetch_message`)
+  each produce `success=False`.
+  *Proof:* four tests.
+- **C-21** In every D2–D5 case, `SendResult.message_id` still carries the
+  posted id and `raw_response["message_ids"]` lists every posted id —
+  repair evidence is preserved, not discarded.
+  *Proof:* assertions inside the same four tests.
+- **C-22** In every D2–D5 case the adapter performs no additional
+  `channel.send` — the side effect is never retried by the adapter.
+  *Proof:* `channel.send.await_count` assertions in the same four tests.
+- **C-23** `raw_response["delivery_acceptance"]` carries a machine-readable
+  reason, the unverified id, and the verified ids.
+  *Proof:* assertion on the dict shape in at least one D test.
+- **C-24** Multi-chunk acceptance (row D6): all posted chunks are verified in
+  order, the call fails on the first unverified chunk, and verification stops
+  there.
+  *Proof:* test asserting failure plus the exact `fetch_message` call sequence.
+- **C-25** Thread targeting (row D8): the read-back is performed on the
+  resolved thread object, not the parent channel.
+  *Proof:* test with distinct parent/thread mocks asserting which one received
+  `fetch_message`.
+- **C-26** Row D7: driving the same acceptance failure through
+  `_send_with_retry` leaves the total `channel.send` await count equal to the
+  count from the single `send()` call — the base-class retry/plain-text
+  fallback does not duplicate a message that already landed.
+  *Proof:* named test asserting the await count before/after and that the
+  returned result is the original acceptance failure.
+- **C-27** `retryable` is `False` on acceptance failures.
+  *Proof:* assertion in a D test.
+
+## Group 6 — Non-regression (§7)
+
+- **C-28** The pre-existing reply-reference retry behavior
+  (`test_send_retries_without_reference_when_reply_target_is_deleted`) still
+  passes, updated only to model the read-back that §5 now requires.
+  *Proof:* recorded run of `tests/gateway/test_discord_send.py`.
+- **C-29** Every other Discord test touched by this change is updated only to
+  supply a read-back-capable channel mock; no assertion about pre-existing
+  behavior is weakened or deleted.
+  *Proof:* diff of the touched test files.
+- **C-30** Forum sends, edits, and attachment senders keep their current
+  semantics (they are out of scope per §1).
+  *Proof:* diff shows no acceptance logic added to `_send_to_forum`,
+  `_forum_post_file`, `_edit_overflow_split`, `_send_file_attachment`; the
+  existing forum/edit tests still pass in the recorded run.
+
+## Group 7 — Evidence discipline
+
+- **C-31** The packet records the RED run: the new tests were executed against
+  the pre-fix adapter and failed for the specified reason, before the
+  implementation commit.
+  *Proof:* the recorded pre-fix output in the session summary (assertion text
+  quoted, not paraphrased).
+- **C-32** The packet records the GREEN run of the same focused command plus
+  the adjacent Discord suites, with pass/fail counts.
+  *Proof:* recorded output.
+- **C-33** The packet records which static checks were run
+  (`python -m py_compile` / AST parse of each changed file) and their result.
+  *Proof:* recorded output.
+- **C-34** Any test that could NOT be executed in this environment (missing
+  runner or plugin) is named explicitly, with the reason, rather than being
+  silently omitted or reported as passing.
+  *Proof:* an explicit "not executed" list in the summary.
+- **C-35** No criterion in this contract is discharged by a claim of live
+  Discord behavior, a deployment, or a CI run. A reviewer who has only the
+  diff and the recorded output can decide every criterion above.
+  *Proof:* self-evident from the criteria; violation is a contract defect.

--- a/docs/specs/discord-delivery-acceptance.md
+++ b/docs/specs/discord-delivery-acceptance.md
@@ -1,0 +1,284 @@
+# Discord delivery acceptance — normative spec
+
+Status: normative for `plugins/platforms/discord/adapter.py` (the outbound
+delivery path: `DiscordAdapter.send`, plus the target-resolution helpers it
+shares with `DiscordAdapter.edit_message`).
+
+Base commit this spec was written against: `3f497e2b4f92ef83f45a98c02f7cb47c12ee069e`.
+
+Terminology in this document follows RFC 2119: MUST / MUST NOT / SHOULD / MAY.
+
+---
+
+## 0. Problem statement (observed on the base commit)
+
+`DiscordAdapter.send()` resolves its target with a bare `int()`:
+
+```python
+channel = self._client.get_channel(int(thread_id))     # adapter.py:2983
+channel = self._client.get_channel(int(chat_id))       # adapter.py:2990
+```
+
+Three consequences, all reachable from configuration a user can legitimately
+write today (`DISCORD_HOME_CHANNEL=#general`, a channel name in a routing
+table, an id pasted with stray characters):
+
+1. **No id validation.** `int()` accepts values that are not Discord
+   snowflakes: `"+123"`, `"1_2"`, `" 123 "`, `"١٢٣"` (non-ASCII decimal
+   digits). These produce an int that addresses a *different* channel or no
+   channel at all, and the failure surfaces — if at all — as a generic
+   "not found".
+2. **No name resolution.** A channel *name* (`"#general"`, `"general"`) is
+   passed straight into `int()`, which raises `ValueError`. The value lands in
+   the catch-all handler and is reported as an opaque send failure rather than
+   as "that name does not resolve".
+3. **No delivery acceptance.** `channel.send()` returning without raising is
+   treated as proof of delivery. A post that Discord accepted but that is not
+   subsequently readable in the target channel/thread is indistinguishable
+   from a clean send, and a multi-chunk send that fails midway discards the
+   ids of the chunks that *did* land, so nothing downstream can repair the
+   partial state.
+
+This spec closes all three. It is a delivery-path spec: it defines behavior
+that is provable from unit tests against a mocked Discord client. It makes no
+claim about live Discord behavior (see §8).
+
+---
+
+## 1. Scope
+
+**In scope** — `plugins/platforms/discord/adapter.py`:
+
+- `DiscordAdapter.send()` — target resolution, post, delivery acceptance.
+- `DiscordAdapter.edit_message()` — target resolution only (§2, §3). Edits are
+  not posts and are NOT subject to §5 acceptance.
+- New module-level helpers for id validation, name resolution and diagnostic
+  sanitisation.
+- The adapter-local `_send_with_retry` override that enforces §5.6.
+
+**Out of scope** (explicitly, so the boundary is finite and reviewable):
+
+- `_send_to_forum()` / `_forum_post_file()`. Forum posts create a thread and a
+  starter message atomically, and the returned `message_id` legitimately falls
+  back to the *thread* id when the API response carries no starter message
+  (`adapter.py:3127`). "Read back the message id" is therefore not
+  well-defined for that path. Forum sends keep their current semantics.
+- `_edit_overflow_split()` continuation sends (they are edits' recovery path,
+  not the delivery path).
+- File/voice/image attachment senders (`_send_file_attachment`, voice, etc.).
+- `gateway/platforms/base.py` and every other platform adapter. No file
+  outside the Discord adapter, its tests, and `docs/specs/` changes.
+
+---
+
+## 2. Snowflake identifiers — strict validation
+
+A **valid Discord id** is defined here, exhaustively, as:
+
+- a `str` which, after exactly one `.strip()`, matches the regular expression
+  `^[1-9][0-9]{0,19}$` (ASCII decimal digits only, no leading zero, no sign,
+  no separators, no internal whitespace, at most 20 digits); or
+- an `int` (excluding `bool`) that is `> 0`.
+
+Everything else is invalid. Rationale for each restriction:
+
+| Restriction | Why |
+| --- | --- |
+| ASCII digits only | `int()` accepts other Unicode decimal digits (`"١٢٣"` → 123); a target id must be byte-exact. |
+| no `+`/`-` sign | `int("+123")` succeeds and silently normalises. |
+| no `_` separators | `int("1_2")` succeeds (PEP 515) and yields 12. |
+| no surrounding-whitespace acceptance beyond one strip; no internal whitespace | `int(" 1 2 ")` raises, but `int("\n123\t")` succeeds; one explicit strip is the documented normalisation, nothing more. |
+| no leading zero, and `"0"` invalid | Snowflakes are positive and canonical; `"0123"` is a typo, not an address. |
+| ≤ 20 digits | A snowflake is a 64-bit unsigned integer (max 20 decimal digits). |
+
+**Rules**
+
+- 2.1 The delivery path MUST validate a candidate id with this predicate
+  BEFORE any `int()` call, and MUST NOT call `int()` on a value that fails it.
+- 2.2 An invalid value that is *name-shaped* (§3) MUST be routed to name
+  resolution.
+- 2.3 An invalid value that is neither a valid id nor name-shaped MUST fail
+  loudly (§4) with no post attempted.
+
+## 3. Channel/thread name resolution — deterministic and exact
+
+A **name-shaped** target is a non-empty string that is not a valid id (§2) and
+whose value, after one `.strip()` and after removing at most one leading `#`,
+is a non-empty string containing no whitespace-only content.
+
+**Rules**
+
+- 3.1 Resolution MUST be by **exact, case-sensitive** equality against the
+  candidate's `name` attribute. No prefix, substring, fuzzy, or
+  case-insensitive matching. Discord lowercases text-channel names on
+  creation; a user who writes `#General` where only `general` exists gets a
+  loud miss, never a guess.
+- 3.2 The candidate set is deterministic and consists of, for every guild in
+  `client.guilds`, in guild order then per-collection order: `text_channels`,
+  `forums` (when the attribute exists), `threads`. Candidates without a
+  `name` attribute are skipped. No other object (category, voice channel,
+  DM) participates.
+- 3.3 Exactly one match → that channel object is the resolved target. The
+  resolved object MUST be used directly; the delivery path MUST NOT round-trip
+  it through `int()` or a second lookup.
+- 3.4 Zero matches → loud failure (§4). MUST NOT fall back to a partial match,
+  to the first guild's default channel, or to `int()`.
+- 3.5 Two or more matches → **ambiguous** → loud failure (§4). MUST NOT pick
+  one. The diagnostic MUST include the matching channel ids so an operator can
+  disambiguate by id.
+- 3.6 A client with no `guilds` attribute, or an empty guild list, yields zero
+  matches → 3.4.
+- 3.7 Name resolution MUST NOT be attempted for a value that is a valid id
+  (§2); ids never fall through to a name scan.
+
+## 4. Loud failure — no silent or debug-only degradation
+
+- 4.1 Every failure defined in §2, §3, §5 and every exception raised by the
+  Discord API during target resolution or posting (explicitly including HTTP
+  404 "Unknown Channel" / "Unknown Message", and 403 Forbidden) MUST produce
+  `SendResult(success=False)` with a non-empty `error`.
+- 4.2 Each such failure MUST emit exactly one `logger.error(...)` record from
+  the delivery path. `logger.debug` / `logger.trace`-only reporting of a
+  delivery failure is forbidden. (Non-failure fallbacks that recover — e.g.
+  dropping a stale reply reference — keep their existing lower level.)
+- 4.3 No path may return `success=True` for a post that raised, that was not
+  attempted, or that failed acceptance (§5).
+- 4.4 **Secret-free diagnostics.** Log records and `SendResult.error` strings
+  produced by the code added under this spec MUST NOT contain: the bot token
+  or any credential, any URL (`http://` / `https://`), or the message content
+  body. They MAY contain: channel/thread/message ids, the requested target
+  string, exception type names, HTTP status and Discord error codes, and
+  counts. Provider exception text MUST be passed through a sanitiser that
+  replaces URL-shaped substrings and bounds the length. New error-level
+  delivery diagnostics MUST NOT pass `exc_info=True` (a rendered traceback is
+  an unbounded, unsanitised channel).
+
+## 5. Received-message acceptance
+
+"Posted" means `channel.send(...)` returned a message object. "Accepted"
+means the posted id was subsequently read back from the *same* target
+channel/thread object and matched. Only accepted posts are successes.
+
+- 5.1 After each successful `channel.send()` in `send()`, the adapter MUST
+  read the posted message back from the resolved target via
+  `channel.fetch_message(<posted id>)` and MUST require that the returned
+  object's `id` equals the posted id (string comparison).
+- 5.2 Acceptance failure is any of: the read returns `None`; the read returns
+  an object whose `id` differs from the posted id; the read raises any
+  exception; the resolved target exposes no callable `fetch_message`. Each of
+  these MUST make the whole `send()` call return `success=False`.
+- 5.3 On acceptance failure the result MUST preserve repair evidence:
+  `SendResult.message_id` is the first posted id (unchanged from the success
+  shape) and `raw_response["message_ids"]` lists every id posted by this call,
+  in send order. `raw_response` MUST also carry a machine-readable
+  `delivery_acceptance` record containing the failure reason, the unverified
+  id, and the verified ids.
+- 5.4 The adapter MUST NOT re-post, re-send, delete, or otherwise mutate the
+  channel in response to an acceptance failure. The side effect stands; the
+  result reports it as unverified.
+- 5.5 For a multi-chunk send, every posted chunk MUST be verified. The call
+  fails on the first chunk that fails acceptance; verification of later chunks
+  is not attempted, and the already-posted ids are still reported per 5.3.
+- 5.6 A caller that routes through the base-class recovery wrapper
+  (`_send_with_retry`) MUST NOT cause a second post after an acceptance
+  failure. The base wrapper's plain-text fallback and retry loop both call
+  `send()` again, which would duplicate a message that is already in the
+  channel; the adapter MUST short-circuit those re-entrant calls and return
+  the original acceptance failure without posting.
+- 5.7 Acceptance applies to the thread target when `metadata["thread_id"]` is
+  present: the read-back MUST use the resolved thread object, not the parent
+  channel.
+- 5.8 Bookkeeping that records what is *in the channel*
+  (`_last_self_message_id`, `_nonconversational_messages`) reflects what was
+  posted and is unaffected by acceptance outcome — the messages are really
+  there.
+
+## 6. Failure-mode matrix (finite enumeration of §2–§5 "every/all")
+
+Every "every"/"all" above is discharged by this table. `send()` is called with
+a mocked client; "no post" means `channel.send` await count is 0.
+
+### 6a. Id validation (applies to `chat_id` and to `metadata["thread_id"]`)
+
+| # | Input | Required outcome |
+| --- | --- | --- |
+| A1 | `""` / `"   "` | fail loud, no `int()`, no post |
+| A2 | `"0"` | fail loud, no post |
+| A3 | `"-123"` | fail loud, no post |
+| A4 | `"+123"` | fail loud, no post |
+| A5 | `"1_2"` | fail loud, no post |
+| A6 | `"١٢٣"` (non-ASCII digits) | fail loud, no post |
+| A7 | `"12.0"` | fail loud, no post |
+| A8 | `"0123"` (leading zero) | fail loud, no post |
+| A9 | `"1 2"` (internal space) | fail loud, no post |
+| A10 | `None` | fail loud, no post |
+| A11 | `True` (bool) | fail loud, no post |
+| A12 | 21+ digits | fail loud, no post |
+| A13 | `" 123 "` | valid → id 123 (single strip) |
+| A14 | `123` (int) | valid → id 123 |
+
+### 6b. Name resolution
+
+| # | Input / world | Required outcome |
+| --- | --- | --- |
+| B1 | `"#general"`, one exact match | resolved to that object, post proceeds |
+| B2 | `"general"`, one exact match | resolved, post proceeds |
+| B3 | `"#General"`, only `general` exists | fail loud (case-sensitive), no post |
+| B4 | `"nope"`, no match | fail loud, no post |
+| B5 | `"general"` in two guilds | fail loud (ambiguous), ids in diagnostic, no post |
+| B6 | `"#"` | fail loud, no post |
+| B7 | any name | `int()` never called with a name; `get_channel`/`fetch_channel` never called with a non-id |
+| B8 | client without `guilds` | fail loud, no post |
+| B9 | `"general"` matching one text channel and one thread | fail loud (ambiguous) |
+
+### 6c. API failure
+
+| # | Condition | Required outcome |
+| --- | --- | --- |
+| C1 | `fetch_channel` raises 404 Unknown Channel | `success=False`, one error-level record, no `success=True` |
+| C2 | `get_channel` → `None` and `fetch_channel` → `None` | `success=False`, error-level record |
+| C3 | `channel.send` raises 403 Forbidden | `success=False`, error-level record |
+| C4 | `channel.send` raises on chunk 2 of 3 | `success=False`, `raw_response["message_ids"] == [<chunk1 id>]` |
+| C5 | any of C1–C4 | log records and `error` contain no URL, no token, no message body |
+
+### 6d. Delivery acceptance
+
+| # | Condition | Required outcome |
+| --- | --- | --- |
+| D1 | read-back returns matching id | `success=True` (unchanged shape) |
+| D2 | read-back returns `None` | `success=False`, `message_id` preserved, no second post |
+| D3 | read-back returns a different id | `success=False`, `message_id` preserved, no second post |
+| D4 | read-back raises | `success=False`, sanitised error-level record, no second post |
+| D5 | target has no `fetch_message` | `success=False`, no second post |
+| D6 | 3 chunks, chunk 2 unverified | `success=False`, all posted ids in `raw_response`, chunk 3 not verified |
+| D7 | acceptance failure under `_send_with_retry` | total `channel.send` await count is unchanged after the wrapper returns |
+| D8 | `metadata["thread_id"]` set | read-back is performed on the thread object |
+
+## 7. Non-goals / preserved behavior
+
+- The reply-reference retry (`error code: 10008` / `50035`) keeps its current
+  behavior, including its `logger.warning` level — it is a recovery, not a
+  delivery failure.
+- Chunking, formatting, forum detection, `_record_discord_response` ledger
+  writes and their offloading to a thread are unchanged.
+- `SendResult.retryable` stays `False` for acceptance failures: the post
+  landed, so a transport-level retry is exactly the wrong response.
+- `SendResult.error_kind` is left unset for acceptance failures — the existing
+  vocabulary (`SEND_ERROR_KINDS`) has no member for "posted but unverified",
+  and inventing one would change a shared cross-adapter contract.
+
+## 8. Verification boundary
+
+Everything in this spec is provable from unit tests against a mocked Discord
+client, static syntax checks, and the diff. Nothing here asserts behavior
+against live Discord, a running gateway, or CI. Any claim of live acceptance
+is out of this spec's scope and MUST NOT be inferred from a passing packet.
+
+## 9. Known consequence (flagged, not silently absorbed)
+
+Making read-back mandatory adds one `fetch_message` API call per posted chunk
+and converts a class of previously-silent conditions into visible failures. In
+particular, a bot lacking permission to read the target's history will now
+report every send as failed (§5.2). §5.6 keeps that from turning into
+duplicate user-visible messages, but the visible-failure change is real and
+intended: a post that cannot be read back has not been shown to be delivered.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3102,7 +3102,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception as e:
                     return None, (
                         f"{kind} {channel_id} lookup failed: "
-                        f"{_sanitize_delivery_error(e)}"
+                        f"{_sanitize_delivery_error(e, self._delivery_redactions(None))}"
                     )
             if not channel:
                 return None, f"{kind} {channel_id} not found"
@@ -3282,13 +3282,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
         try:
             # Determine target channel: thread_id in metadata takes precedence.
-            thread_id = None
-            if metadata and metadata.get("thread_id"):
-                thread_id = metadata["thread_id"]
+            has_thread_target = isinstance(metadata, dict) and "thread_id" in metadata
+            thread_id = metadata.get("thread_id") if isinstance(metadata, dict) else None
             nonconversational = _metadata_marks_nonconversational(metadata)
             final_delivery = bool(metadata and metadata.get("notify"))
 
-            if thread_id:
+            if has_thread_target:
                 # Threads are addressed by their own ID (or name).
                 channel, resolve_error = await self._resolve_delivery_target(
                     thread_id, kind="Thread",
@@ -3595,9 +3594,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+            channel, resolve_error = await self._resolve_delivery_target(
+                chat_id, kind="Channel",
+            )
+            if channel is None:
+                return self._fail_delivery(
+                    resolve_error or "Discord channel resolution failed"
+                )
             msg = await channel.fetch_message(int(message_id))
             formatted = self.format_message(content)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -10,6 +10,7 @@ Uses discord.py library for:
 """
 
 import asyncio
+import contextvars
 import datetime as dt
 import hashlib
 import inspect
@@ -326,6 +327,134 @@ def _looks_like_nonconversational_history_message(content: str) -> bool:
     """Fallback recognizer for legacy status bumps missing persisted IDs."""
     text = content or ""
     return any(pattern.match(text) for pattern in _DISCORD_NONCONVERSATIONAL_HISTORY_MESSAGE_PATTERNS)
+
+
+# ── delivery-path target validation (docs/specs/discord-delivery-acceptance.md) ──
+# A Discord snowflake is a positive 64-bit integer written in ASCII decimal
+# digits.  ``int()`` is far more permissive than that: it accepts a sign
+# ("+123"), PEP 515 separators ("1_2" -> 12), surrounding whitespace
+# ("\n123\t") and non-ASCII decimal digits ("١٢٣" -> 123).  Each of those
+# addresses a DIFFERENT channel than the operator typed, so the delivery path
+# validates with this pattern BEFORE any int() (spec §2).
+_DISCORD_SNOWFLAKE_RE = re.compile(r"[1-9][0-9]{0,19}")
+# URL-shaped substrings are stripped from provider errors before they reach a
+# log record or SendResult.error: a Discord API error routinely embeds the
+# request URL, and a request URL can carry credentials (spec §4.4).
+_DISCORD_URL_IN_ERROR_RE = re.compile(r"(?i)\b[a-z][a-z0-9+.\-]*://\S+")
+# Caller-supplied literals (bot token, message body) are redacted from error
+# text only when at least this long — replacing a one-character chunk would
+# shred the diagnostic itself.
+_DISCORD_MIN_REDACTABLE_LEN = 12
+_DISCORD_ERROR_MAX_LEN = 300
+_DISCORD_TARGET_REPR_MAX_LEN = 80
+# Re-entrancy guard for the base-class recovery wrapper (spec §5.6).  A
+# ContextVar rather than an instance attribute: asyncio tasks copy the context
+# at creation, so concurrent sends on other tasks cannot see each other's
+# state, and there is nothing to clean up if a task is cancelled.
+_discord_acceptance_guard: contextvars.ContextVar = contextvars.ContextVar(
+    "discord_delivery_acceptance_guard", default=None,
+)
+
+
+def _valid_discord_id(value: Any) -> Optional[int]:
+    """Return ``value`` as an id when it is a valid snowflake, else ``None``.
+
+    Accepts a positive ``int`` (``bool`` excluded — ``True`` is not channel 1)
+    or a string that, after exactly one ``strip()``, is ASCII decimal digits
+    with no leading zero and at most 20 digits.  Everything else is invalid
+    and must never reach ``int()``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str):
+        candidate = value.strip()
+        if _DISCORD_SNOWFLAKE_RE.fullmatch(candidate):
+            return int(candidate)
+    return None
+
+
+def _discord_channel_name_target(value: Any) -> Optional[str]:
+    """Return the bare channel name of a name-shaped target, else ``None``.
+
+    Name-shaped means: a string that is not a valid id (spec §2) and that,
+    after one ``strip()`` and removing at most one leading ``#``, is neither
+    empty nor whitespace-only.  ``"#"`` alone is therefore NOT name-shaped.
+    """
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or _valid_discord_id(candidate) is not None:
+        return None
+    if candidate.startswith("#"):
+        candidate = candidate[1:]
+    if not candidate.strip():
+        return None
+    return candidate
+
+
+def _iter_discord_name_candidates(client: Any):
+    """Yield the deterministic candidate set for name resolution (spec §3.2).
+
+    Guild order, then per-collection order: ``text_channels``, ``forums``
+    (when the attribute exists), ``threads``.  Categories, voice channels and
+    DMs never participate.
+    """
+    guilds = getattr(client, "guilds", None)
+    if not guilds:
+        return
+    for guild in guilds:
+        for collection in ("text_channels", "forums", "threads"):
+            for candidate in getattr(guild, collection, None) or ():
+                yield candidate
+
+
+def _match_discord_channels_by_name(client: Any, name: str) -> List[Any]:
+    """Exact, case-sensitive name matches across the candidate set (spec §3.1).
+
+    No prefix, substring, fuzzy or case-insensitive matching: Discord
+    lowercases text-channel names on creation, so ``#General`` where only
+    ``general`` exists is a loud miss, never a guess.  Candidates without a
+    ``name`` attribute are skipped.
+    """
+    return [
+        candidate
+        for candidate in _iter_discord_name_candidates(client)
+        if getattr(candidate, "name", None) == name
+    ]
+
+
+def _sanitize_delivery_error(err: Any, redactions: Tuple[Any, ...] = ()) -> str:
+    """Render a provider error safely for a log record / ``SendResult.error``.
+
+    Strips URL-shaped substrings, redacts caller-supplied literals (bot token,
+    the message body a provider may echo back), collapses whitespace and
+    bounds the length (spec §4.4).  Callers pass the rendered string to
+    ``logger.error`` WITHOUT ``exc_info`` — a traceback is an unbounded,
+    unsanitised channel.
+    """
+    if isinstance(err, BaseException):
+        text = f"{type(err).__name__}: {err}"
+    else:
+        text = str(err)
+    text = _standalone_sanitize_error(text)
+    for secret in redactions:
+        if isinstance(secret, str) and len(secret) >= _DISCORD_MIN_REDACTABLE_LEN:
+            text = text.replace(secret, "<redacted>")
+    text = _DISCORD_URL_IN_ERROR_RE.sub("<url>", text)
+    text = " ".join(text.split())
+    if len(text) > _DISCORD_ERROR_MAX_LEN:
+        text = text[:_DISCORD_ERROR_MAX_LEN] + _DISCORD_ELLIPSIS
+    return text
+
+
+def _discord_target_repr(target: Any) -> str:
+    """Bounded repr of a requested target for diagnostics (spec §4.4)."""
+    text = repr(target)
+    if len(text) > _DISCORD_TARGET_REPR_MAX_LEN:
+        text = text[:_DISCORD_TARGET_REPR_MAX_LEN] + _DISCORD_ELLIPSIS
+    return text
 
 
 def _clean_discord_id(entry: str) -> str:
@@ -2952,6 +3081,167 @@ class DiscordAdapter(BasePlatformAdapter):
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
 
+    async def _resolve_delivery_target(
+        self, target: Any, *, kind: str,
+    ) -> Tuple[Any, Optional[str]]:
+        """Resolve a channel/thread target to a channel object (spec §2/§3).
+
+        Returns ``(channel, None)`` on success and ``(None, error)`` on every
+        failure, so the caller reports it once and loudly.  A valid snowflake
+        is looked up by id; a name-shaped target is resolved by an exact,
+        case-sensitive scan of the connected guilds and the resolved object is
+        used directly (no ``int()`` round trip, no second lookup); anything
+        else is rejected before ``int()`` ever sees it.
+        """
+        channel_id = _valid_discord_id(target)
+        if channel_id is not None:
+            channel = self._client.get_channel(channel_id)
+            if not channel:
+                try:
+                    channel = await self._client.fetch_channel(channel_id)
+                except Exception as e:
+                    return None, (
+                        f"{kind} {channel_id} lookup failed: "
+                        f"{_sanitize_delivery_error(e)}"
+                    )
+            if not channel:
+                return None, f"{kind} {channel_id} not found"
+            return channel, None
+
+        name = _discord_channel_name_target(target)
+        if name is None:
+            return None, (
+                f"Invalid Discord {kind.lower()} target {_discord_target_repr(target)}: "
+                "not a snowflake id and not a channel name"
+            )
+        matches = _match_discord_channels_by_name(self._client, name)
+        if not matches:
+            return None, (
+                f"No Discord channel or thread named {name!r} (exact, case-sensitive) "
+                f"in any connected guild — requested {kind.lower()} target "
+                f"{_discord_target_repr(target)}"
+            )
+        if len(matches) > 1:
+            ids = ", ".join(str(getattr(match, "id", "?")) for match in matches)
+            return None, (
+                f"Ambiguous Discord {kind.lower()} target {name!r}: {len(matches)} "
+                f"channels/threads share that name (ids: {ids}) — address it by id"
+            )
+        return matches[0], None
+
+    async def _verify_posted_message(
+        self, channel: Any, posted_id: Any,
+    ) -> Optional[Tuple[str, str]]:
+        """Read a just-posted message back from ``channel`` (spec §5.1/§5.2).
+
+        Returns ``None`` when the target hands back a message whose id equals
+        the posted id, else ``(reason, detail)``.  Never re-posts, deletes or
+        otherwise mutates the channel: the side effect stands, the caller
+        reports it as unverified.
+        """
+        fetch = getattr(channel, "fetch_message", None)
+        if not callable(fetch):
+            return ("no_read_back_capability", "target exposes no callable fetch_message")
+        try:
+            fetched = await fetch(posted_id)
+        except Exception as e:
+            return ("read_back_error", _sanitize_delivery_error(e))
+        if fetched is None:
+            return ("read_back_absent", "target returned no message for the posted id")
+        fetched_id = getattr(fetched, "id", None)
+        if str(fetched_id) != str(posted_id):
+            return ("read_back_id_mismatch", f"target returned id {fetched_id}")
+        return None
+
+    async def _post_chunk(
+        self, channel: Any, chunk: str, reference: Any, reply_to: Optional[str],
+    ) -> Tuple[Any, bool]:
+        """Post one chunk, retrying once without a rejected reply reference.
+
+        Returns ``(message, reference_dropped)``.  The reply-reference retry is
+        a recovery, not a delivery failure, so it keeps its warning level
+        (spec §7).
+        """
+        try:
+            return await channel.send(content=chunk, reference=reference), False
+        except Exception as e:
+            err_text = str(e)
+            if (
+                reference is not None
+                and (
+                    (
+                        "error code: 50035" in err_text
+                        and "Cannot reply to a system message" in err_text
+                    )
+                    or "error code: 10008" in err_text
+                )
+            ):
+                logger.warning(
+                    "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
+                    self.name,
+                    reply_to,
+                )
+                return await channel.send(content=chunk, reference=None), True
+            raise
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """Base recovery wrapper, made safe for delivery acceptance (spec §5.6).
+
+        The base wrapper reacts to a failed send by calling ``send()`` again
+        (retry loop and plain-text fallback).  After an acceptance failure the
+        message is ALREADY in the channel, so a second call would duplicate a
+        user-visible message.  Arming this guard makes those re-entrant calls
+        short-circuit and return the original acceptance failure.
+        """
+        token = _discord_acceptance_guard.set({"result": None})
+        try:
+            return await super()._send_with_retry(
+                chat_id,
+                content,
+                reply_to=reply_to,
+                metadata=metadata,
+                max_retries=max_retries,
+                base_delay=base_delay,
+            )
+        finally:
+            _discord_acceptance_guard.reset(token)
+
+    def _delivery_redactions(self, content: Optional[str]) -> Tuple[Any, ...]:
+        """Literals that must never appear in a delivery diagnostic (spec §4.4).
+
+        Provider errors echo back both the request URL (which can carry the bot
+        token) and, for validation errors, the message body.
+        """
+        return (getattr(self.config, "token", None), content)
+
+    def _fail_delivery(
+        self,
+        error: str,
+        *,
+        message_id: Optional[str] = None,
+        raw_response: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Report a delivery failure exactly once, at ERROR level (spec §4).
+
+        No ``exc_info``: ``error`` is already sanitised and bounded, whereas a
+        rendered traceback is an unbounded, unsanitised channel.
+        """
+        logger.error("[%s] %s", self.name, error)
+        return SendResult(
+            success=False,
+            error=error,
+            message_id=message_id,
+            raw_response=raw_response,
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -2966,9 +3256,29 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Forum channels (type 15) reject direct messages — a thread post is
         created automatically.
+
+        The target is resolved by strict snowflake validation or exact
+        channel-name lookup, and every posted chunk is read back from the
+        target before the send is reported as a success
+        (docs/specs/discord-delivery-acceptance.md).
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        # §5.6: the base recovery wrapper re-enters send() after a failure.
+        # An acceptance failure means the message already landed, so posting
+        # again would duplicate it — return the original failure instead.
+        # Reported at warning level: the failure itself already emitted its
+        # one ERROR record (§4.2), and this is the same failure, not a new one.
+        guard = _discord_acceptance_guard.get()
+        if guard is not None and guard.get("result") is not None:
+            logger.warning(
+                "[%s] Suppressing re-entrant send after unverified delivery of message %s "
+                "— the post already landed; re-sending would duplicate it",
+                self.name,
+                guard["result"].message_id,
+            )
+            return guard["result"]
 
         try:
             # Determine target channel: thread_id in metadata takes precedence.
@@ -2979,19 +3289,16 @@ class DiscordAdapter(BasePlatformAdapter):
             final_delivery = bool(metadata and metadata.get("notify"))
 
             if thread_id:
-                # Fetch the thread directly — threads are addressed by their own ID.
-                channel = self._client.get_channel(int(thread_id))
-                if not channel:
-                    channel = await self._client.fetch_channel(int(thread_id))
-                if not channel:
-                    return SendResult(success=False, error=f"Thread {thread_id} not found")
+                # Threads are addressed by their own ID (or name).
+                channel, resolve_error = await self._resolve_delivery_target(
+                    thread_id, kind="Thread",
+                )
             else:
-                # Get the parent channel
-                channel = self._client.get_channel(int(chat_id))
-                if not channel:
-                    channel = await self._client.fetch_channel(int(chat_id))
-                if not channel:
-                    return SendResult(success=False, error=f"Channel {chat_id} not found")
+                channel, resolve_error = await self._resolve_delivery_target(
+                    chat_id, kind="Channel",
+                )
+            if channel is None:
+                return self._fail_delivery(resolve_error)
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
@@ -3009,8 +3316,12 @@ class DiscordAdapter(BasePlatformAdapter):
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-            message_ids = []
+            message_ids: List[str] = []
+            verified_ids: List[str] = []
+            acceptance: Optional[Dict[str, Any]] = None
+            send_error: Optional[str] = None
             reference = None
+            redactions = self._delivery_redactions(content)
 
             if reply_to and self._reply_to_mode != "off":
                 try:
@@ -3028,38 +3339,40 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
+                    msg, reference_dropped = await self._post_chunk(
+                        channel, chunk, chunk_reference, reply_to,
                     )
                 except Exception as e:
-                    err_text = str(e)
-                    if (
-                        chunk_reference is not None
-                        and (
-                            (
-                                "error code: 50035" in err_text
-                                and "Cannot reply to a system message" in err_text
-                            )
-                            or "error code: 10008" in err_text
-                        )
-                    ):
-                        logger.warning(
-                            "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
-                            self.name,
-                            reply_to,
-                        )
-                        reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
-                    else:
-                        raise
-                message_ids.append(str(msg.id))
+                    send_error = (
+                        f"Discord send failed on chunk {i + 1}/{len(chunks)} to "
+                        f"{_discord_target_repr(thread_id or chat_id)}: "
+                        f"{_sanitize_delivery_error(e, redactions)}"
+                    )
+                    break
+                if reference_dropped:
+                    reference = None
+                posted_id = str(msg.id)
+                message_ids.append(posted_id)
+
+                # §5: posted is not delivered.  Read the id back from the same
+                # target before counting the chunk as accepted, and stop at the
+                # first chunk that fails (§5.5) — never re-post (§5.4).
+                failure = await self._verify_posted_message(channel, msg.id)
+                if failure is not None:
+                    reason, detail = failure
+                    acceptance = {
+                        "reason": reason,
+                        "detail": detail,
+                        "unverified_message_id": posted_id,
+                        "verified_message_ids": list(verified_ids),
+                    }
+                    break
+                verified_ids.append(posted_id)
 
             # Track the last message we sent in this channel for history
             # backfill — avoids a full channel.history() scan on hot paths.
+            # §5.8: this records what is really IN the channel, so it reflects
+            # what was posted regardless of the acceptance outcome.
             if message_ids:
                 _target_id = thread_id or chat_id
                 if nonconversational:
@@ -3067,11 +3380,31 @@ class DiscordAdapter(BasePlatformAdapter):
                 elif not _looks_like_nonconversational_history_message(content):
                     self._last_self_message_id[_target_id] = message_ids[-1]
 
-            result = SendResult(
-                success=True,
-                message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
-            )
+            if send_error is not None:
+                result = self._fail_delivery(
+                    send_error, raw_response={"message_ids": message_ids},
+                )
+            elif acceptance is not None:
+                result = self._fail_delivery(
+                    f"Discord accepted message {acceptance['unverified_message_id']} but it "
+                    f"could not be read back from "
+                    f"{_discord_target_repr(thread_id or chat_id)} "
+                    f"({acceptance['reason']}: {acceptance['detail']}) — delivery unverified",
+                    # Repair evidence (§5.3): the posted ids survive the failure.
+                    message_id=message_ids[0],
+                    raw_response={
+                        "message_ids": message_ids,
+                        "delivery_acceptance": acceptance,
+                    },
+                )
+                if guard is not None and guard.get("result") is None:
+                    guard["result"] = result
+            else:
+                result = SendResult(
+                    success=True,
+                    message_id=message_ids[0] if message_ids else None,
+                    raw_response={"message_ids": message_ids}
+                )
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,
@@ -3082,8 +3415,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return result
 
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
-            result = SendResult(success=False, error=str(e))
+            error = (
+                "Failed to send Discord message: "
+                f"{_sanitize_delivery_error(e, self._delivery_redactions(content))}"
+            )
+            logger.error("[%s] %s", self.name, error)
+            result = SendResult(success=False, error=error)
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,

--- a/tests/gateway/test_discord_delivery_acceptance.py
+++ b/tests/gateway/test_discord_delivery_acceptance.py
@@ -201,8 +201,6 @@ async def test_invalid_channel_id_fails_loud_without_posting(bad_id):
 @pytest.mark.asyncio
 async def test_invalid_thread_id_fails_loud_without_posting(bad_id):
     """C-07 — thread_id goes through the same predicate as chat_id."""
-    if bad_id in (None, "", "   "):
-        pytest.skip("empty thread_id means 'no thread' and falls back to chat_id")
     channel = _channel()
     adapter = _adapter(channel)
     with _Recorder() as log:
@@ -520,3 +518,34 @@ async def test_send_with_retry_never_reposts_after_acceptance_failure():
     assert channel.send.await_count == 1, (
         "the message already landed; retry/plain-text fallback must not post again"
     )
+
+
+@pytest.mark.asyncio
+async def test_edit_message_uses_the_shared_exact_name_resolver():
+    """C-04 — edits use the same strict id/name target contract as sends."""
+    message = SimpleNamespace(id=42, edit=AsyncMock())
+    channel = _channel(channel_id=555, name="general")
+    channel.fetch_message = AsyncMock(return_value=message)
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+
+    result = await adapter.edit_message("general", "42", "updated")
+
+    assert result.success is True
+    message.edit.assert_awaited_once()
+    assert adapter._client.get_channel.call_count == 0
+    assert adapter._client.fetch_channel.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_scrubs_the_configured_bot_token():
+    """C-16 — provider lookup diagnostics cannot echo the configured token."""
+    adapter = _adapter(None)
+    adapter._client.fetch_channel = AsyncMock(
+        side_effect=RuntimeError(f"lookup rejected Authorization: Bot {TOKEN}")
+    )
+    with _Recorder() as log:
+        result = await adapter.send("555", "harmless body")
+
+    assert result.success is False
+    assert TOKEN not in (result.error or "")
+    assert TOKEN not in log.text

--- a/tests/gateway/test_discord_delivery_acceptance.py
+++ b/tests/gateway/test_discord_delivery_acceptance.py
@@ -1,0 +1,522 @@
+"""Discord delivery path: id validation, name resolution, acceptance.
+
+Contract: docs/specs/discord-delivery-acceptance.md (matrix 6a-6d) and
+docs/specs/discord-delivery-acceptance-contract.md (C-04..C-27).
+
+Every test here drives ``DiscordAdapter.send`` against a mocked client; none
+of them requires a live Discord connection.
+"""
+
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord import adapter as discord_adapter  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+TOKEN = "MTIzNDU2Nzg5.SUPER-SECRET-BOT-TOKEN"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+class _Recorder(logging.Handler):
+    """Capture records emitted by the Discord adapter module logger."""
+
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def __enter__(self):
+        discord_adapter.logger.addHandler(self)
+        self._prev_level = discord_adapter.logger.level
+        self._prev_prop = discord_adapter.logger.propagate
+        discord_adapter.logger.setLevel(logging.DEBUG)
+        discord_adapter.logger.propagate = False
+        return self
+
+    def __exit__(self, *exc):
+        discord_adapter.logger.removeHandler(self)
+        discord_adapter.logger.setLevel(self._prev_level)
+        discord_adapter.logger.propagate = self._prev_prop
+        return False
+
+    @property
+    def text(self):
+        return "\n".join(r.getMessage() for r in self.records)
+
+    def errors(self):
+        return [r for r in self.records if r.levelno >= logging.ERROR]
+
+
+def _message(msg_id):
+    return SimpleNamespace(id=msg_id)
+
+
+def _channel(channel_id=555, *, posted_ids=(1001, 1002, 1003), readable=True,
+             read_result="match", name=None):
+    """A channel mock that posts ``posted_ids`` in order and reads them back.
+
+    ``read_result``: "match" | "none" | "mismatch" | "raise".
+    """
+    posted = list(posted_ids)
+    state = {"i": 0}
+
+    async def _send(content=None, reference=None, **kwargs):
+        i = state["i"]
+        state["i"] += 1
+        return _message(posted[i] if i < len(posted) else posted[-1])
+
+    async def _fetch_message(message_id):
+        if read_result == "none":
+            return None
+        if read_result == "mismatch":
+            return _message(int(message_id) + 7)
+        if read_result == "raise":
+            raise RuntimeError("404 Not Found (error code: 10008): Unknown Message")
+        return _message(int(message_id))
+
+    chan = SimpleNamespace(
+        id=channel_id,
+        send=AsyncMock(side_effect=_send),
+        fetch_message=AsyncMock(side_effect=_fetch_message),
+    )
+    if name is not None:
+        chan.name = name
+    if not readable:
+        del chan.fetch_message
+    return chan
+
+
+def _adapter(channel=None, *, guilds=None, strict_lookup=True):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token=TOKEN))
+
+    def get_channel(channel_id):
+        if strict_lookup and not isinstance(channel_id, int):
+            raise AssertionError(f"get_channel called with non-int {channel_id!r}")
+        if channel is None:
+            return None
+        return channel if channel_id == getattr(channel, "id", None) else None
+
+    async def fetch_channel(channel_id):
+        if strict_lookup and not isinstance(channel_id, int):
+            raise AssertionError(f"fetch_channel called with non-int {channel_id!r}")
+        if channel is None or channel_id != getattr(channel, "id", None):
+            raise RuntimeError("404 Not Found (error code: 10003): Unknown Channel")
+        return channel
+
+    client = SimpleNamespace(
+        get_channel=MagicMock(side_effect=get_channel),
+        fetch_channel=AsyncMock(side_effect=fetch_channel),
+    )
+    if guilds is not None:
+        client.guilds = guilds
+    adapter._client = client
+    return adapter
+
+
+def _guild(text_channels=(), threads=(), forums=None):
+    g = SimpleNamespace(text_channels=list(text_channels), threads=list(threads))
+    if forums is not None:
+        g.forums = list(forums)
+    return g
+
+
+# ── 6a. strict snowflake validation (C-04..C-07) ─────────────────────────
+INVALID_IDS = [
+    "",             # A1
+    "   ",          # A1
+    "0",            # A2
+    "-123",         # A3
+    "+123",         # A4
+    "1_2",          # A5
+    "١٢٣",  # A6 non-ASCII decimal digits
+    "12.0",         # A7
+    "0123",         # A8
+    "1 2",          # A9
+    None,           # A10
+    True,           # A11
+    "1" * 21,       # A12
+]
+
+
+@pytest.mark.parametrize("bad_id", INVALID_IDS)
+@pytest.mark.asyncio
+async def test_invalid_channel_id_fails_loud_without_posting(bad_id):
+    channel = _channel()
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send(bad_id, "hello")
+    assert result.success is False, f"{bad_id!r} must not be accepted as a channel id"
+    assert result.error
+    assert channel.send.await_count == 0
+    # The value must be rejected BEFORE any lookup — int() must never see it.
+    assert adapter._client.get_channel.call_count == 0, f"{bad_id!r} reached get_channel"
+    assert adapter._client.fetch_channel.await_count == 0
+    assert log.errors(), f"{bad_id!r} must be reported at ERROR level"
+
+
+@pytest.mark.parametrize("bad_id", INVALID_IDS)
+@pytest.mark.asyncio
+async def test_invalid_thread_id_fails_loud_without_posting(bad_id):
+    """C-07 — thread_id goes through the same predicate as chat_id."""
+    if bad_id in (None, "", "   "):
+        pytest.skip("empty thread_id means 'no thread' and falls back to chat_id")
+    channel = _channel()
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello", metadata={"thread_id": bad_id})
+    assert result.success is False
+    assert channel.send.await_count == 0
+    assert adapter._client.get_channel.call_count == 0, f"{bad_id!r} reached get_channel"
+    assert log.errors()
+
+
+@pytest.mark.parametrize("good_id", [" 555 ", 555])
+@pytest.mark.asyncio
+async def test_valid_ids_are_accepted(good_id):
+    """A13/A14 — one strip, and a positive int."""
+    channel = _channel()
+    adapter = _adapter(channel)
+    result = await adapter.send(good_id, "hello")
+    assert result.success is True
+    assert result.message_id == "1001"
+
+
+# ── 6b. name resolution (C-08..C-13) ─────────────────────────────────────
+@pytest.mark.parametrize("target", ["#general", "general"])
+@pytest.mark.asyncio
+async def test_exact_channel_name_resolves(target):
+    channel = _channel(channel_id=555, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+    result = await adapter.send(target, "hello")
+    # C-13: the object found by the guild scan is the object posted to.
+    assert result.success is True
+    assert channel.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_name_match_is_case_sensitive():
+    channel = _channel(channel_id=555, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+    with _Recorder() as log:
+        result = await adapter.send("#General", "hello")
+    assert result.success is False
+    assert channel.send.await_count == 0
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_unknown_channel_name_fails_loud():
+    channel = _channel(channel_id=555, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+    with _Recorder() as log:
+        result = await adapter.send("nope", "hello")
+    assert result.success is False
+    assert channel.send.await_count == 0
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_channel_name_across_guilds_fails_loud_with_ids():
+    a = _channel(channel_id=111, name="general")
+    b = _channel(channel_id=222, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[a]), _guild(text_channels=[b])])
+    with _Recorder() as log:
+        result = await adapter.send("#general", "hello")
+    assert result.success is False
+    assert a.send.await_count == 0 and b.send.await_count == 0
+    blob = log.text + (result.error or "")
+    assert "111" in blob and "222" in blob, "ambiguity diagnostic must name the competing ids"
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_channel_and_thread_name_fails_loud():
+    chan = _channel(channel_id=111, name="general")
+    thread = _channel(channel_id=333, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[chan], threads=[thread])])
+    result = await adapter.send("general", "hello")
+    assert result.success is False
+    assert chan.send.await_count == 0 and thread.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_bare_hash_target_fails_loud():
+    adapter = _adapter(None, guilds=[_guild()])
+    with _Recorder() as log:
+        result = await adapter.send("#", "hello")
+    assert result.success is False
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_client_without_guilds_fails_loud_on_name():
+    adapter = _adapter(None)  # no guilds attribute at all
+    with _Recorder() as log:
+        result = await adapter.send("#general", "hello")
+    assert result.success is False
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_name_is_never_passed_to_int_or_channel_lookup():
+    """C-10 — the lookup mocks raise if handed anything that is not an int."""
+    channel = _channel(channel_id=555, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+    result = await adapter.send("#general", "hello")
+    assert result.success is True
+    assert adapter._client.fetch_channel.await_count == 0
+    assert adapter._client.get_channel.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_nameless_candidates_are_skipped():
+    """C-11 — a candidate without .name must not raise or match."""
+    nameless = SimpleNamespace(id=999)
+    channel = _channel(channel_id=555, name="general")
+    forum = _channel(channel_id=777, name="forum-a")
+    adapter = _adapter(
+        None,
+        guilds=[_guild(text_channels=[nameless, channel], forums=[forum])],
+    )
+    result = await adapter.send("general", "hello")
+    assert result.success is True
+    assert channel.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolved_name_target_is_the_scanned_object():
+    """C-13 — identity, not a second lookup."""
+    channel = _channel(channel_id=555, name="general")
+    adapter = _adapter(None, guilds=[_guild(text_channels=[channel])])
+    result = await adapter.send("general", "hi")
+    assert result.success is True
+    assert channel.fetch_message.await_count == 1
+
+
+# ── 6c. loud API failures (C-14..C-18) ───────────────────────────────────
+@pytest.mark.asyncio
+async def test_fetch_channel_404_fails_loud():
+    adapter = _adapter(None)  # every fetch_channel raises 404
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert log.errors(), "a 404 must be reported at ERROR level, not debug/trace"
+
+
+@pytest.mark.asyncio
+async def test_channel_lookup_returning_none_fails_loud():
+    async def fetch_channel(channel_id):
+        return None
+
+    adapter = _adapter(None)
+    adapter._client.fetch_channel = AsyncMock(side_effect=fetch_channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_forbidden_send_fails_loud():
+    channel = _channel()
+    channel.send = AsyncMock(
+        side_effect=RuntimeError("403 Forbidden (error code: 50013): Missing Permissions")
+    )
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_mid_chunk_failure_preserves_landed_ids():
+    """C-18 / row C4 — chunk 1 landed; its id is repair evidence."""
+    channel = _channel()
+    calls = {"n": 0}
+
+    async def _send(content=None, reference=None, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("500 Internal Server Error")
+        return _message(1000 + calls["n"])
+
+    channel.send = AsyncMock(side_effect=_send)
+    adapter = _adapter(channel)
+    adapter.truncate_message = lambda content, max_len, **kw: ["a", "b", "c"]
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert (result.raw_response or {}).get("message_ids") == ["1001"]
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_failure_diagnostics_are_secret_free():
+    """C-16 — no URL, no token, no message body in logs or in error."""
+    body = "TOP-SECRET-MESSAGE-BODY-2f4a"
+    channel = _channel()
+    channel.send = AsyncMock(
+        side_effect=RuntimeError(
+            f"400 Bad Request https://discord.com/api/v10/channels/555/messages"
+            f"?token={TOKEN} body={body}"
+        )
+    )
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", body)
+    assert result.success is False
+    blob = log.text + "\n" + (result.error or "")
+    assert "https://" not in blob and "http://" not in blob
+    assert TOKEN not in blob
+    assert body not in blob
+
+
+# ── 6d. received-message acceptance (C-19..C-27) ─────────────────────────
+@pytest.mark.asyncio
+async def test_successful_send_reads_the_posted_message_back():
+    channel = _channel()
+    adapter = _adapter(channel)
+    result = await adapter.send("555", "hello")
+    assert result.success is True
+    assert result.message_id == "1001"
+    channel.fetch_message.assert_awaited_once_with(1001)
+
+
+@pytest.mark.parametrize("mode", ["none", "mismatch", "raise"])
+@pytest.mark.asyncio
+async def test_unverified_post_is_a_failure_with_evidence(mode):
+    channel = _channel(read_result=mode)
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert result.message_id == "1001", "posted id must survive as repair evidence"
+    assert (result.raw_response or {}).get("message_ids") == ["1001"]
+    acceptance = (result.raw_response or {}).get("delivery_acceptance")
+    assert isinstance(acceptance, dict)
+    assert acceptance.get("unverified_message_id") == "1001"
+    assert acceptance.get("reason")
+    assert "verified_message_ids" in acceptance
+    assert result.retryable is False
+    assert channel.send.await_count == 1, "the side effect must never be retried"
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_target_without_read_back_capability_fails():
+    channel = _channel(readable=False)
+    adapter = _adapter(channel)
+    with _Recorder() as log:
+        result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert result.message_id == "1001"
+    assert channel.send.await_count == 1
+    assert log.errors()
+
+
+@pytest.mark.asyncio
+async def test_multi_chunk_stops_at_first_unverified_chunk():
+    """Row D6 — chunk 2 fails read-back: no chunk 3, evidence kept."""
+    channel = _channel()
+    posted = {"n": 0}
+    fetched = []
+
+    async def _send(content=None, reference=None, **kwargs):
+        posted["n"] += 1
+        return _message(1000 + posted["n"])
+
+    async def _fetch_message(message_id):
+        fetched.append(message_id)
+        if message_id == 1002:
+            return None
+        return _message(message_id)
+
+    channel.send = AsyncMock(side_effect=_send)
+    channel.fetch_message = AsyncMock(side_effect=_fetch_message)
+    adapter = _adapter(channel)
+    adapter.truncate_message = lambda content, max_len, **kw: ["a", "b", "c"]
+
+    result = await adapter.send("555", "hello")
+    assert result.success is False
+    assert result.message_id == "1001"
+    assert (result.raw_response or {}).get("message_ids") == ["1001", "1002"]
+    assert fetched == [1001, 1002]
+    assert channel.send.await_count == 2, "chunk 3 must not be posted"
+
+
+@pytest.mark.asyncio
+async def test_thread_target_is_read_back_on_the_thread():
+    """Row D8 — the read-back must hit the thread, not the parent."""
+    parent = _channel(channel_id=555)
+    thread = _channel(channel_id=999, posted_ids=(2001,))
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token=TOKEN))
+    lookup = {555: parent, 999: thread}
+    adapter._client = SimpleNamespace(
+        get_channel=lambda cid: lookup.get(cid),
+        fetch_channel=AsyncMock(side_effect=AssertionError("unexpected fetch")),
+    )
+
+    result = await adapter.send("555", "hello", metadata={"thread_id": "999"})
+    assert result.success is True
+    assert thread.fetch_message.await_count == 1
+    assert parent.fetch_message.await_count == 0
+    assert parent.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_never_reposts_after_acceptance_failure():
+    """C-26 / row D7 — base-class recovery must not duplicate a landed post."""
+    channel = _channel(read_result="mismatch")
+    adapter = _adapter(channel)
+
+    result = await adapter._send_with_retry("555", "hello", max_retries=2, base_delay=0)
+    assert result.success is False
+    assert result.message_id == "1001"
+    assert channel.send.await_count == 1, (
+        "the message already landed; retry/plain-text fallback must not post again"
+    )

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -89,8 +89,13 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
             )
         return sent_msgs[len(send_calls) - 2]
 
+    async def fake_fetch(message_id):
+        if message_id == 99:
+            return ref_msg
+        return next(msg for msg in sent_msgs if msg.id == message_id)
+
     channel = SimpleNamespace(
-        fetch_message=AsyncMock(return_value=ref_msg),
+        fetch_message=AsyncMock(side_effect=fake_fetch),
         send=AsyncMock(side_effect=fake_send),
     )
     adapter._client = SimpleNamespace(
@@ -103,7 +108,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
 
     assert result.success is True
     assert result.message_id == "1001"
-    assert channel.fetch_message.await_count == 1
+    assert channel.fetch_message.await_count == 3
     assert channel.send.await_count == 3
     ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
     assert send_calls[0]["reference"] is reference_obj


### PR DESCRIPTION
## Scope

Fixes the Discord gateway delivery path:

- accepts only strict positive decimal channel/thread IDs;
- resolves channel names by deterministic, exact, case-sensitive guild scan;
- fails loudly on missing or ambiguous names and API/404 failures;
- treats a post as successful only after every returned message ID is read back from the same destination and matches;
- preserves posted IDs as repair evidence while preventing acceptance-failure reposts;
- keeps provider errors and logs free of bot tokens, URLs, and message bodies.

## Contract-first evidence

- Base: `3f497e2b4f92ef83f45a98c02f7cb47c12ee069e`
- Contract-first commit: `cdc0296388a907fbec4aa67ad06bd3117ecc88e6`
- Exact reviewed head: `c1b1500b81f16e9059830e5de5eb768315b76d7c`
- Normative spec: `docs/specs/discord-delivery-acceptance.md`
- Review contract: `docs/specs/discord-delivery-acceptance-contract.md`

## Exercise evidence

At the exact reviewed head:

- 71 passed across the focused acceptance suite, existing gateway send tests, and Discord adapter e2e tests;
- Python bytecode compilation passed for all changed Python files;
- no test performs a live Discord send.

## Independent review

Initial Codex review: **FAIL**, identifying three contract gaps: `edit_message` had not adopted the shared resolver; explicit blank/None `thread_id` values still fell back to the parent; and channel-lookup exceptions did not scrub the configured bot token.

All three were repaired with regression coverage. Exact-head Codex re-review at `c1b1500b81f16e9059830e5de5eb768315b76d7c`: **PASS**, C-01–C-35 satisfied, findings none.

## Custody

Born held as a draft PR. Do not merge until operator approval. The upstream repository has no `hold` or `awaiting-operator-merge` labels, so draft state is the available custody control.

No installation, deployment, gateway restart, credential access, or live Discord send was performed.
