### PR TITLE
fix(dashboard): send Authorization header in gateway health probe (#76051)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1566,6 +1566,7 @@ def _apply_main_model_assignment(
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 _GATEWAY_HEALTH_TIMEOUT_MAX = 1.0
 _GATEWAY_HEALTH_ROUTE_TIMEOUT = 1.0
+_GATEWAY_API_KEY = os.getenv("API_SERVER_KEY", "").strip()
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "1"))
 except (ValueError, TypeError):
@@ -1631,6 +1632,8 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     for path in (f"{base}/health/detailed", f"{base}/health"):
         try:
             req = urllib.request.Request(path, method="GET")
+            if _GATEWAY_API_KEY:
+                req.add_header("Authorization", f"Bearer {_GATEWAY_API_KEY}")
             with urllib.request.urlopen(req, timeout=_GATEWAY_HEALTH_TIMEOUT) as resp:
                 if resp.status == 200:
                     body = json.loads(resp.read())


### PR DESCRIPTION
## Summary

`_probe_gateway_health()` in `web_server.py` sends `GET /health/detailed` without any `Authorization` header. When `API_SERVER_KEY` is set on the gateway, every probe is rejected with 401, flooding gateway logs with:

```
WARNING gateway.platforms.api_server: API server rejected invalid API key: remote='127.0.0.1' method='GET' path='/health/detailed'
```

Functionality is unaffected (dashboard silently falls back to `/health`), but the warning repeats on every status poll.

## Fix

- Read `API_SERVER_KEY` at module level into `_GATEWAY_API_KEY`
- In `_probe_gateway_health()`, add `Authorization: Bearer <key>` header when the key is present

When the key is absent, no header is sent — preserving existing behavior for unauthenticated setups.

## Changes

- `hermes_cli/web_server.py`: +3 lines — module-level key read + conditional header injection

Fixes #76051