### PR TITLE
feat(providers): add AvalAI model-provider plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@
 # NOVITA_BASE_URL=https://api.novita.ai/openai/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (AvalAI)
+# =============================================================================
+# AvalAI — OpenAI-compatible gateway for OpenAI, Anthropic, Gemini and open models
+# Get your key at: https://chat.avalai.ir/platform/api-keys
+# AVALAI_API_KEY=
+# AVALAI_BASE_URL=https://api.avalai.ir/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Google AI Studio / Gemini)
 # =============================================================================
 # Native Gemini API via Google's OpenAI-compatible endpoint.

--- a/plugins/model-providers/avalai/__init__.py
+++ b/plugins/model-providers/avalai/__init__.py
@@ -1,0 +1,36 @@
+"""AvalAI provider profile.
+
+AvalAI (avalai.ir) is an OpenAI-compatible AI gateway that fronts models
+from OpenAI, Anthropic, Google, DeepSeek and other vendors behind a single
+API key and endpoint. Chat inference and the model catalog are served from
+``https://api.avalai.ir/v1`` with standard Bearer auth.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+avalai = ProviderProfile(
+    name="avalai",
+    aliases=("aval-ai", "avalai-ir"),
+    display_name="AvalAI",
+    description="AvalAI — OpenAI-compatible gateway for OpenAI, Anthropic, Gemini and open models",
+    signup_url="https://chat.avalai.ir/platform/api-keys",
+    env_vars=("AVALAI_API_KEY", "AVALAI_BASE_URL"),
+    base_url="https://api.avalai.ir/v1",
+    auth_type="api_key",
+    # The catalog spans upstream vendors with different output limits;
+    # omit a provider-wide default so AvalAI applies its per-model cap.
+    default_max_tokens=None,
+    # Cheap/fast model for auxiliary tasks (compression, session search,
+    # vision fallback). Aux resolution is synchronous, so one model is
+    # pinned here; everything else is discovered live from /models.
+    default_aux_model="gpt-4o-mini",
+    # ``fallback_models`` deliberately empty — the gateway's catalog
+    # changes as upstream vendors ship models, so the live ``/models``
+    # fetch is the source of truth. When the live fetch fails, the picker
+    # shows no options rather than routing to a retired model.
+    fallback_models=(),
+)
+
+register_provider(avalai)

--- a/plugins/model-providers/avalai/plugin.yaml
+++ b/plugins/model-providers/avalai/plugin.yaml
@@ -1,0 +1,5 @@
+name: avalai-provider
+kind: model-provider
+version: 1.0.0
+description: AvalAI — OpenAI-compatible gateway for OpenAI, Anthropic, Gemini and open models
+author: Rick Sanchez

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -23,6 +23,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
+| **AvalAI** | `AVALAI_API_KEY` in `~/.hermes/.env` (provider: `avalai`; aliases: `aval-ai`, `avalai-ir`; OpenAI-compatible gateway for OpenAI, Anthropic, Gemini and open models) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -324,6 +325,29 @@ model:
 ```
 
 Get your API key at [novita.ai/settings/key-management](https://novita.ai/settings/key-management). The base URL can be overridden with `NOVITA_BASE_URL`.
+
+### AvalAI
+
+[AvalAI](https://avalai.ir) is an OpenAI-compatible AI gateway that fronts models from OpenAI, Anthropic, Google, DeepSeek and other vendors behind a single API key and endpoint. Hermes discovers the available models live from the gateway's `/models` catalog.
+
+```bash
+# Use any available model
+hermes chat --provider avalai --model gpt-4o-mini
+# Requires: AVALAI_API_KEY in ~/.hermes/.env
+
+# Short alias
+hermes chat --provider aval-ai --model gemini-2.5-flash
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "avalai"
+  default: "gpt-4o-mini"
+  base_url: "https://api.avalai.ir/v1"
+```
+
+Get your API key at [chat.avalai.ir/platform/api-keys](https://chat.avalai.ir/platform/api-keys). The base URL can be overridden with `AVALAI_BASE_URL`.
 
 ### Ollama Cloud — Managed Ollama Models, OAuth + API Key
 


### PR DESCRIPTION
## Summary

Adds [AvalAI](https://avalai.ir) as a bundled model-provider plugin. AvalAI is an OpenAI-compatible AI gateway that fronts models from OpenAI, Anthropic, Google, DeepSeek and other vendors behind a single API key and endpoint (`https://api.avalai.ir/v1`).

## Changes

- `plugins/model-providers/avalai/` — new `ProviderProfile` (`api_key` auth, `AVALAI_API_KEY` / `AVALAI_BASE_URL`, live `/models` catalog discovery, `gpt-4o-mini` as the aux model). `fallback_models` is deliberately empty — the gateway's catalog changes as upstream vendors ship models, so the live fetch is the source of truth (same approach as the DeepInfra profile).
- `.env.example` — AvalAI section with key signup link.
- `website/docs/integrations/providers.md` — provider table row + dedicated section with usage examples.

No changes outside the plugin dir + docs/env-example — auth, health check, model picker, and URL detection all auto-wire from the provider registry.

## Testing

- Verified the profile registers and resolves via aliases (`aval-ai`, `avalai-ir`), appears in `CANONICAL_PROVIDERS` and the auth `PROVIDER_REGISTRY`, and derives hostname `api.avalai.ir`.
- Probed `https://api.avalai.ir/v1/models` — OpenAI-compatible, Bearer auth confirmed.
- `pytest tests/hermes_cli/test_api_key_providers.py tests/providers` — 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)