### PR TITLE
fix(memory): skip embedding_model_dims for chroma provider (#75963)

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -190,9 +190,14 @@ class OSSBackend(Mem0Backend):
             model = embedder_config.get("model", "")
             dims = KNOWN_DIMS.get(model)
         if dims:
-            vs_config["embedding_model_dims"] = dims
+            # Only set embedding_model_dims for providers that accept it
+            # (qdrant).  Chroma's pydantic schema in mem0ai 2.0+ rejects
+            # extra fields, so adding it there causes a ValidationError.
+            provider = vector_store.get("provider", "qdrant")
+            if provider != "chroma":
+                vs_config["embedding_model_dims"] = dims
             self._recreate_collection_if_dims_changed(
-                vector_store.get("provider", "qdrant"), vs_config, dims,
+                provider, vs_config, dims,
             )
 
         vector_store["config"] = vs_config


### PR DESCRIPTION
## Summary

OSSBackend.__init__ in plugins/memory/mem0/_backend.py unconditionally sets `embedding_model_dims` in the vector_store config. This field is valid for qdrant but chromas pydantic schema in mem0ai 2.0+ rejects it as an extra field, causing a `ValidationError` on `Memory.from_config()`.

## Root Cause

Line 193 writes `vs_config["embedding_model_dims"] = dims` regardless of which vector store provider is configured. mem0ai 2.0+ uses strict pydantic validation for chroma, where allowed fields are: `tenant, port, client, path, api_key, collection_name, host` — no `embedding_model_dims`.

## Fix

Only set `embedding_model_dims` when the provider is not `chroma`. The `_recreate_collection_if_dims_changed` helper already checks for `qdrant` specifically, so the dims are still used correctly for collection recreation.

## Changes

- `plugins/memory/mem0/_backend.py`: +7/-2 lines — guard `embedding_model_dims` assignment with provider check

Fixes #75963