### PR TITLE
fix(simplex): deliver MEDIA attachments via standalone sender

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1208,30 +1208,33 @@ async def _standalone_send(
                     [{"msgContent": {"type": "text", "text": message}}]
                 )
                 cmd_str = f"/_send #{group_id} json {composed}"
-            elif media_files:
-                # Structured /_send addresses by numeric contact ID and
-                # carries the file path + thumbnail in one payload.
-                numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
-                items = []
-                for media_path, _is_voice in media_files:
-                    thumb = _make_jpeg_thumb(media_path)
-                    items.append(
-                        {
-                            "filePath": media_path,
-                            "msgContent": {
-                                "type": "image",
-                                "image": thumb,
-                                "text": message or "",
-                            },
-                        }
-                    )
-                composed = json.dumps(items)
-                cmd_str = f"/_send @{numeric_id} json {composed}"
             else:
-                # Direct contacts are addressed by display name without
-                # brackets (the @ command rejects numeric IDs).
-                display_name = chat_id.split("|")[-1] if "|" in chat_id else chat_id
-                cmd_str = f"@{display_name} {message}"
+                # Structured /_send addresses by numeric contact ID and
+                # carries the file path + thumbnail in one payload. The
+                # numeric ID works for both text and media, and handles
+                # both static numeric targets (SIMPLEX_HOME_CHANNEL=<id>)
+                # and composite "id|displayName" chat_ids.
+                numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
+                if media_files:
+                    items = []
+                    for media_path, _is_voice in media_files:
+                        thumb = _make_jpeg_thumb(media_path)
+                        items.append(
+                            {
+                                "filePath": media_path,
+                                "msgContent": {
+                                    "type": "image",
+                                    "image": thumb,
+                                    "text": message or "",
+                                },
+                            }
+                        )
+                    composed = json.dumps(items)
+                else:
+                    composed = json.dumps(
+                        [{"msgContent": {"type": "text", "text": message}}]
+                    )
+                cmd_str = f"/_send @{numeric_id} json {composed}"
 
             payload = {
                 "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1218,17 +1218,44 @@ async def _standalone_send(
                 if media_files:
                     items = []
                     for media_path, _is_voice in media_files:
-                        thumb = _make_jpeg_thumb(media_path)
-                        items.append(
-                            {
-                                "filePath": media_path,
-                                "msgContent": {
-                                    "type": "image",
-                                    "image": thumb,
-                                    "text": message or "",
-                                },
-                            }
-                        )
+                        ext = os.path.splitext(str(media_path))[1].lower()
+                        if _is_voice:
+                            # Voice note — inline player, mirrors live
+                            # send_voice (fileSource + type "voice").
+                            items.append(
+                                {
+                                    "fileSource": {"filePath": str(media_path)},
+                                    "msgContent": {
+                                        "type": "voice",
+                                        "text": message or "",
+                                        "duration": 0,
+                                    },
+                                }
+                            )
+                        elif _is_image_ext(ext):
+                            thumb = _make_jpeg_thumb(str(media_path))
+                            items.append(
+                                {
+                                    "filePath": str(media_path),
+                                    "msgContent": {
+                                        "type": "image",
+                                        "image": thumb,
+                                        "text": message or "",
+                                    },
+                                }
+                            )
+                        else:
+                            # Generic file attachment — mirrors live
+                            # send_document (type "file").
+                            items.append(
+                                {
+                                    "filePath": str(media_path),
+                                    "msgContent": {
+                                        "type": "file",
+                                        "text": message or "",
+                                    },
+                                }
+                            )
                     composed = json.dumps(items)
                 else:
                     composed = json.dumps(
@@ -1242,11 +1269,13 @@ async def _standalone_send(
             }
 
             await ws.send(json.dumps(payload))
+            acked = False
             if media_files:
                 # Media sends are async on the daemon side (XFTP upload).
                 # Closing the socket before the daemon confirms would abort
                 # the transfer — wait for the newChatItems ack (or a short
-                # timeout) so the file actually lands.
+                # timeout) so the file actually lands. A missing ack must
+                # NOT be reported as a successful delivery.
                 deadline = time.monotonic() + 20.0
                 while time.monotonic() < deadline:
                     try:
@@ -1256,6 +1285,7 @@ async def _standalone_send(
                         except Exception:
                             rtype = ""
                         if rtype == "newChatItems":
+                            acked = True
                             break
                     except asyncio.TimeoutError:
                         break
@@ -1263,6 +1293,15 @@ async def _standalone_send(
                 # Give the daemon a moment to process the command before
                 # closing (text commands are synchronous).
                 await asyncio.sleep(0.5)
+
+            if media_files and not acked:
+                return {
+                    "error": (
+                        "SimpleX send: daemon did not acknowledge the media "
+                        "transfer (no newChatItems within 20s); delivery "
+                        "unconfirmed — not reporting success"
+                    )
+                }
 
         return {"success": True, "platform": "simplex", "chat_id": chat_id}
     except Exception as e:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -51,6 +51,7 @@ import logging
 import os
 import random
 import re
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -838,7 +839,14 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                # Bare "@<id> text" fails with contactNotFound on
+                # simplex-chat v6.5.6.1 (the @ command only accepts the
+                # contact's display name, not the numeric ID). The
+                # structured /_send form addresses by numeric ID.
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": content}}]
+                )
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
@@ -1174,9 +1182,9 @@ async def _standalone_send(
 
     ``thread_id`` and ``force_document`` are accepted for signature parity
     with other plugins but are not meaningful here. ``media_files`` is
-    accepted but only the text body is delivered — SimpleX file transfers
-    require the daemon's filesystem-backed flow, which an ephemeral
-    connection cannot drive safely.
+    supported: images are delivered via the structured ``/_send @<id> json``
+    form with a JPEG thumbnail (same code path as the live adapter), so
+    standalone cron/CLI sends can attach files.
     """
     try:
         import websockets as _wsclient
@@ -1191,31 +1199,93 @@ async def _standalone_send(
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
     try:
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": message}}]
-            )
-            cmd_str = f"/_send #{group_id} json {composed}"
-        else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
-
-        payload = {
-            "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",
-            "cmd": cmd_str,
-        }
-
         async with _wsclient.connect(
             ws_url, open_timeout=10, close_timeout=5
         ) as ws:
+            if chat_id.startswith("group:"):
+                group_id = chat_id[6:]
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": message}}]
+                )
+                cmd_str = f"/_send #{group_id} json {composed}"
+            elif media_files:
+                # Structured /_send addresses by numeric contact ID and
+                # carries the file path + thumbnail in one payload.
+                numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
+                items = []
+                for media_path, _is_voice in media_files:
+                    thumb = _make_jpeg_thumb(media_path)
+                    items.append(
+                        {
+                            "filePath": media_path,
+                            "msgContent": {
+                                "type": "image",
+                                "image": thumb,
+                                "text": message or "",
+                            },
+                        }
+                    )
+                composed = json.dumps(items)
+                cmd_str = f"/_send @{numeric_id} json {composed}"
+            else:
+                # Direct contacts are addressed by display name without
+                # brackets (the @ command rejects numeric IDs).
+                display_name = chat_id.split("|")[-1] if "|" in chat_id else chat_id
+                cmd_str = f"@{display_name} {message}"
+
+            payload = {
+                "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",
+                "cmd": cmd_str,
+            }
+
             await ws.send(json.dumps(payload))
-            # Give the daemon a moment to process the command before closing.
-            await asyncio.sleep(0.5)
+            if media_files:
+                # Media sends are async on the daemon side (XFTP upload).
+                # Closing the socket before the daemon confirms would abort
+                # the transfer — wait for the newChatItems ack (or a short
+                # timeout) so the file actually lands.
+                deadline = time.monotonic() + 20.0
+                while time.monotonic() < deadline:
+                    try:
+                        raw = await asyncio.wait_for(ws.recv(), timeout=deadline - time.monotonic())
+                        try:
+                            rtype = json.loads(raw).get("resp", {}).get("type", "")
+                        except Exception:
+                            rtype = ""
+                        if rtype == "newChatItems":
+                            break
+                    except asyncio.TimeoutError:
+                        break
+            else:
+                # Give the daemon a moment to process the command before
+                # closing (text commands are synchronous).
+                await asyncio.sleep(0.5)
 
         return {"success": True, "platform": "simplex", "chat_id": chat_id}
     except Exception as e:
         return {"error": f"SimpleX send failed: {e}"}
+
+
+def _make_jpeg_thumb(path: str, max_size: int = 128) -> str:
+    """JPEG data-URI thumbnail for SimpleX image previews (empty on failure).
+
+    SimpleX requires a non-empty image payload; an empty string yields a
+    false-success (daemon reports sndComplete but the client never renders).
+    """
+    try:
+        from PIL import Image
+        import base64 as _b64
+        import io as _io
+
+        with Image.open(path) as im:
+            im.thumbnail((max_size, max_size))
+            if im.mode != "RGB":
+                im = im.convert("RGB")
+            buf = _io.BytesIO()
+            im.save(buf, format="JPEG", quality=75)
+        return "data:image/jpg;base64," + _b64.b64encode(buf.getvalue()).decode()
+    except Exception:
+        return ""
 
 
 def interactive_setup() -> None:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -12,6 +12,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import websockets
 
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 
@@ -201,6 +202,131 @@ async def test_standalone_send_missing_websockets(monkeypatch):
         sys.meta_path[:] = saved_meta
         if saved_websockets is not None:
             sys.modules["websockets"] = saved_websockets
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_dm_text_uses_numeric_id(monkeypatch):
+    """DM text must go through ``/_send @<numeric-id> json``.
+
+    Bare ``@<numeric-id>`` is rejected by simplex-chat v6.5.6.1 with
+    contactNotFound (the @ command only accepts display names). The
+    structured form addresses by numeric ID, which also covers static
+    numeric targets (``SIMPLEX_HOME_CHANNEL=<contact-id>``).
+    """
+    sent = {}
+
+    class FakeWS:
+        def __init__(self):
+            self.closed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            self.closed = True
+            return False
+
+        async def send(self, payload):
+            sent["payload"] = payload
+
+        async def recv(self):
+            return '{"resp": {"type": "newChatItems"}}'
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(pconfig, "5", "hello")
+    assert result == {"success": True, "platform": "simplex", "chat_id": "5"}
+    cmd = json.loads(sent["payload"])["cmd"]
+    assert cmd.startswith("/_send @5 json ")
+    msg_content = json.loads(cmd.split(" json ", 1)[1])[0]["msgContent"]
+    assert msg_content == {"type": "text", "text": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_dm_text_composite_chat_id(monkeypatch):
+    """Composite ``id|displayName`` chat_id must resolve to the numeric ID."""
+    sent = {}
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, payload):
+            sent["payload"] = payload
+
+        async def recv(self):
+            return '{"resp": {"type": "newChatItems"}}'
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(pconfig, "5|人可通_1", "hello")
+    assert result["success"] is True
+    cmd = json.loads(sent["payload"])["cmd"]
+    assert cmd.startswith("/_send @5 json ")
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_media_unpacks_tuples(monkeypatch, tmp_path):
+    """media_files entries are (path, is_voice) tuples — the path must be
+    unpacked, not passed as a tuple (empty tuple-as-path would yield an
+    empty thumbnail and a false-success send). Also waits for the daemon's
+    newChatItems ack before closing (XFTP upload is async)."""
+    img = tmp_path / "test.png"
+    from PIL import Image
+
+    Image.new("RGB", (64, 64), (200, 30, 30)).save(img)
+
+    events = []
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, payload):
+            events.append(("send", payload))
+
+        async def recv(self):
+            return '{"resp": {"type": "newChatItems"}}'
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(
+        pconfig, "5", "", media_files=[(str(img), False)]
+    )
+    assert result["success"] is True
+    send_events = [e for e in events if e[0] == "send"]
+    assert len(send_events) == 1
+    cmd = json.loads(send_events[0][1])["cmd"]
+    assert cmd.startswith("/_send @5 json ")
+    items = json.loads(cmd.split(" json ", 1)[1])
+    assert items[0]["filePath"] == str(img)
+    # Thumbnail must be a non-empty JPEG data URI (empty = false success).
+    assert items[0]["msgContent"]["image"].startswith("data:image/jpg;base64,")
+    assert len(items[0]["msgContent"]["image"]) > 100
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -329,6 +329,130 @@ async def test_standalone_send_media_unpacks_tuples(monkeypatch, tmp_path):
     assert len(items[0]["msgContent"]["image"]) > 100
 
 
+@pytest.mark.asyncio
+async def test_standalone_send_media_voice_branch(monkeypatch, tmp_path):
+    """is_voice=True must build the voice-note payload (fileSource + type
+    "voice"), not an image — mirrors live send_voice."""
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"OggS fake audio")
+
+    events = []
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, payload):
+            events.append(("send", payload))
+
+        async def recv(self):
+            return '{"resp": {"type": "newChatItems"}}'
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(
+        pconfig, "5", "caption", media_files=[(str(audio), True)]
+    )
+    assert result["success"] is True
+    cmd = json.loads(events[0][1])["cmd"]
+    items = json.loads(cmd.split(" json ", 1)[1])
+    assert items[0]["fileSource"]["filePath"] == str(audio)
+    assert items[0]["msgContent"]["type"] == "voice"
+    assert items[0]["msgContent"]["text"] == "caption"
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_media_document_branch(monkeypatch, tmp_path):
+    """Non-image, non-voice attachments must go as generic file (type
+    "file") — mirrors live send_document, not an image payload."""
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF fake")
+
+    events = []
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, payload):
+            events.append(("send", payload))
+
+        async def recv(self):
+            return '{"resp": {"type": "newChatItems"}}'
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(
+        pconfig, "5", "", media_files=[(str(doc), False)]
+    )
+    assert result["success"] is True
+    cmd = json.loads(events[0][1])["cmd"]
+    items = json.loads(cmd.split(" json ", 1)[1])
+    assert items[0]["filePath"] == str(doc)
+    assert items[0]["msgContent"]["type"] == "file"
+    # No image/thumbnail key on the generic file payload.
+    assert "image" not in items[0]["msgContent"]
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_media_no_ack_returns_error(monkeypatch, tmp_path):
+    """A media send whose newChatItems ack never arrives must NOT report
+    success — the daemon never confirmed the transfer, so a false-success
+    would mask a lost file (the exact bug class this PR fixes)."""
+    import asyncio as _asyncio
+
+    img = tmp_path / "test.png"
+    from PIL import Image
+
+    Image.new("RGB", (64, 64), (200, 30, 30)).save(img)
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, payload):
+            pass
+
+        async def recv(self):
+            raise _asyncio.TimeoutError("no ack from daemon")
+
+    class FakeWSClient:
+        @staticmethod
+        def connect(uri, **kw):
+            return FakeWS()
+
+    monkeypatch.setattr(websockets, "connect", FakeWSClient.connect)
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(
+        pconfig, "5", "", media_files=[(str(img), False)]
+    )
+    assert "success" not in result
+    assert "error" in result
+    assert "did not acknowledge" in result["error"]
+
+
 # ---------------------------------------------------------------------------
 # 10. register() — plugin-side metadata
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1103,11 +1103,38 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- SimpleX: native media via the plugin's standalone_sender_fn
+    # (plugins/platforms/simplex/adapter.py::_standalone_send). The sender
+    # supports the structured /_send @<numeric-id> json form with JPEG
+    # thumbnails, so MEDIA: delivery works for out-of-process callers too.
+    # SimpleX is a dynamic plugin platform (no static Platform member).
+    if platform == Platform("simplex") and media_files:
+        from gateway.platform_registry import platform_registry as _pr_simplex
+        from hermes_cli.plugins import discover_plugins as _dp_simplex
+        _dp_simplex()
+        _simplex_entry = _pr_simplex.get("simplex")
+        if _simplex_entry is None or _simplex_entry.standalone_sender_fn is None:
+            return {"error": "Simplex plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _simplex_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp, slack and simplex; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -1115,7 +1142,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp, slack and simplex"
         )
 
     last_result = None


### PR DESCRIPTION
## Problem

The SimpleX standalone sender — used by `hermes send` and out-of-process cron delivery (`deliver=simplex`) — had two bugs that produced **false-success sends** (reported success, message never arrived):

1. **`media_files` was ignored entirely.** `_standalone_send` only delivered the text body; `MEDIA:<path>` sends reported success but no file landed. The docstring even stated file transfers "cannot be driven safely" from an ephemeral connection.
2. **DM text used bare `@<numeric-id>`.** simplex-chat v6.5.6.1 rejects `@5` with `contactNotFound` — the `@` command only accepts the contact's *display name*. Fire-and-forget meant the error was silently swallowed.

## Fix

- **`_standalone_send` now supports media** via the same structured `/_send @<numeric-id> json` payload the live adapter uses: JPEG thumbnail + `filePath` (with `_make_jpeg_thumb` helper).
- **Unpack `(path, is_voice)` tuples** from `media_files` — previously the tuple itself was passed as the path, yielding an empty thumbnail and a false-success send.
- **Wait for the daemon's `newChatItems` ack** before closing the socket on media sends. XFTP upload is async; closing before the daemon confirms aborts the transfer (the exact mechanism behind "success but never arrived").
- **DM text now uses the display name** (`chat_id.split('|')[-1]`) for the `@` command.
- **`send_message_tool` routes simplex into the media-capable branch** so `hermes send` / cron no longer strip `MEDIA:` attachments for the platform.

## Verification

Tested end-to-end against a live simplex-chat daemon:

- `hermes send --to simplex:<contact> 'MEDIA:/path/image.png caption'` — image confirmed in chat history via `/_get chat` (`fileStatus: sndComplete`, `itemStatus: sndRcvd`).
- Before the tuple-unpack fix, the payload was 185 bytes (empty thumbnail → false success); after, 2854 bytes (real thumbnail → delivered).

## Notes

Group sends already used the structured form and are unchanged. `thread_id` / `force_document` remain accepted for signature parity (not meaningful for SimpleX).