### PR TITLE
fix(plugins): classify pip entry-point provider plugins without importing

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1771,6 +1771,21 @@ class PluginManager:
         of its parent packages (see ``_resolve_module_source``); only
         the first 8192 chars are scanned, mirroring the directory-plugin
         heuristic. Unresolvable or non-Python modules stay ``standalone``.
+
+        Activation contract: this method only decides whether the general
+        manager imports the module — it does not activate anything.
+        Memory and model providers activate through their own systems
+        (``memory.provider`` config via ``plugins/memory`` directory
+        discovery; ``providers/`` lazy directory discovery). Both are
+        directory-based today, so a pip-only provider is recorded for
+        introspection but not activatable until those systems gain
+        entry-point discovery (tracked for memory: #40644). That is not
+        a regression: pre-change such a provider was equally
+        unactivatable — it was merely imported first, at full cost
+        (e.g. fastembed -> onnxruntime), and logged
+        ``no register() function``. Classification removes the cost
+        without changing the activation surface, and is the prerequisite
+        that prevents double-import once entry-point activation lands.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -296,6 +296,82 @@ def _detect_kind_from_source(source_text: str) -> Optional[str]:
     return None
 
 
+def _read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
+    """Read the first ``limit`` chars of a module's source file.
+
+    Returns ``""`` on any failure (callers fall back to ``standalone``).
+    ``.pyc``/``.pyo`` origins are mapped back to their source path so
+    source is still scanned when only the bytecode cache is present.
+    """
+    if not origin:
+        return ""
+    if origin.endswith((".pyc", ".pyo")):
+        try:
+            origin = importlib.util.source_from_cache(origin)
+        except Exception:
+            return ""
+    if not origin.endswith(".py"):
+        return ""
+    try:
+        return Path(origin).read_text(encoding="utf-8", errors="replace")[:limit]
+    except Exception:
+        return ""
+
+
+def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """Return the first ``limit`` chars of a module's source WITHOUT importing it.
+
+    ``importlib.util.find_spec`` on a dotted name imports the parent
+    package first (executing its ``__init__.py``), which would run
+    arbitrary package initialization during discovery and pay the very
+    import cost this classification exists to avoid — a provider whose
+    heavy imports live in ``package/__init__.py`` would still pay them.
+
+    Only the top-level name is resolved with ``find_spec`` (import-free
+    for top-level names); the remaining dotted segments are walked
+    through ``submodule_search_locations`` by hand, mirroring the file
+    layout conventions of the default PathFinder (``part.py`` module or
+    ``part/__init__.py`` package). Namespace packages, zipped modules,
+    extension modules, and anything else unexpected fall back to ``""``
+    (→ ``standalone``, the safe default).
+    """
+    parts = [p for p in module_name.split(".") if p]
+    if not parts:
+        return ""
+    try:
+        spec = importlib.util.find_spec(parts[0])
+        if spec is None or not spec.origin:
+            return ""
+        if len(parts) == 1:
+            return _read_source_from_origin(spec.origin, limit)
+
+        search_paths = spec.submodule_search_locations
+        if not search_paths:
+            return ""
+        for i, part in enumerate(parts[1:], start=2):
+            found_origin = None
+            next_paths = None
+            for base in search_paths:
+                base = Path(base)
+                pkg_init = base / part / "__init__.py"
+                if pkg_init.is_file():
+                    found_origin = str(pkg_init)
+                    next_paths = [base / part]
+                    break
+                mod_file = base / (part + ".py")
+                if mod_file.is_file():
+                    found_origin = str(mod_file)
+                    break
+            if found_origin is None:
+                return ""
+            if i == len(parts) or next_paths is None:
+                return _read_source_from_origin(found_origin, limit)
+            search_paths = next_paths
+        return ""
+    except Exception:
+        return ""
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -1691,22 +1767,16 @@ class PluginManager:
         memory-provider plugin pulling in onnxruntime via fastembed —
         ~60 MB RSS on startup).
 
-        The module is resolved with ``importlib.util.find_spec`` — no
-        import for top-level module names (for dotted names only the
-        parent package may be imported). Only the first 8192 chars of
-        source are scanned, mirroring the directory-plugin heuristic.
-        Unresolvable or non-Python modules stay ``standalone``.
+        The module source is read without importing the module or any
+        of its parent packages (see ``_resolve_module_source``); only
+        the first 8192 chars are scanned, mirroring the directory-plugin
+        heuristic. Unresolvable or non-Python modules stay ``standalone``.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()
             if not module_name:
                 return "standalone"
-            spec = importlib.util.find_spec(module_name)
-            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
-                return "standalone"
-            source_text = Path(spec.origin).read_text(
-                errors="replace", encoding="utf-8"
-            )[:8192]
+            source_text = _resolve_module_source(module_name)
             return _detect_kind_from_source(source_text) or "standalone"
         except Exception:
             return "standalone"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -277,6 +277,25 @@ def _get_enabled_plugins() -> Optional[set]:
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
 
 
+def _detect_kind_from_source(source_text: str) -> Optional[str]:
+    """Return the plugin kind implied by source markers, or ``None``.
+
+    Mirrors ``plugins/memory/__init__.py:_is_memory_provider_dir``: a
+    module that registers a memory provider (``register_memory_provider``
+    or ``MemoryProvider``) belongs to the memory-provider discovery
+    system (``exclusive``); a module that registers a model provider
+    (``register_provider`` + ``ProviderProfile``) belongs to the
+    providers discovery (``model-provider``). Applied to both directory
+    plugins and pip entry-point plugins so neither is eagerly imported
+    by the general PluginManager.
+    """
+    if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
+        return "exclusive"
+    if "register_provider" in source_text and "ProviderProfile" in source_text:
+        return "model-provider"
+    return None
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -1620,29 +1639,16 @@ class PluginManager:
                 init_file = plugin_dir / "__init__.py"
                 if init_file.exists():
                     try:
-                        source_text = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
-                        if (
-                            "register_memory_provider" in source_text
-                            or "MemoryProvider" in source_text
-                        ):
-                            kind = "exclusive"
+                        detected = _detect_kind_from_source(
+                            init_file.read_text(
+                                errors="replace", encoding="utf-8"
+                            )[:8192]
+                        )
+                        if detected:
+                            kind = detected
                             logger.debug(
-                                "Plugin %s: detected memory provider, "
-                                "treating as kind='exclusive'",
-                                key,
-                            )
-                        elif (
-                            "register_provider" in source_text
-                            and "ProviderProfile" in source_text
-                        ):
-                            # Model provider plugin (calls register_provider()
-                            # from ``providers`` with a ProviderProfile). Route
-                            # to providers/__init__.py discovery.
-                            kind = "model-provider"
-                            logger.debug(
-                                "Plugin %s: detected model provider, "
-                                "treating as kind='model-provider'",
-                                key,
+                                "Plugin %s: detected %s, treating as kind='%s'",
+                                key, detected, detected,
                             )
                     except Exception:
                         pass
@@ -1674,6 +1680,37 @@ class PluginManager:
     # Entry-point scanning
     # -----------------------------------------------------------------------
 
+    def _classify_entrypoint_kind(self, ep) -> str:
+        """Classify a pip entry-point plugin by scanning its module source.
+
+        The ``kind`` semantics are the same for pip entry points as for
+        directory plugins: memory providers (``exclusive``) and model
+        providers (``model-provider``) have their own discovery systems,
+        so importing them here registers nothing and only pays the
+        module's import cost in every Hermes process (e.g. a pip
+        memory-provider plugin pulling in onnxruntime via fastembed —
+        ~60 MB RSS on startup).
+
+        The module is resolved with ``importlib.util.find_spec`` — no
+        import for top-level module names (for dotted names only the
+        parent package may be imported). Only the first 8192 chars of
+        source are scanned, mirroring the directory-plugin heuristic.
+        Unresolvable or non-Python modules stay ``standalone``.
+        """
+        try:
+            module_name = ep.value.split(":", 1)[0].strip()
+            if not module_name:
+                return "standalone"
+            spec = importlib.util.find_spec(module_name)
+            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
+                return "standalone"
+            source_text = Path(spec.origin).read_text(
+                errors="replace", encoding="utf-8"
+            )[:8192]
+            return _detect_kind_from_source(source_text) or "standalone"
+        except Exception:
+            return "standalone"
+
     def _scan_entry_points(self) -> List[PluginManifest]:
         """Check ``importlib.metadata`` for pip-installed plugins."""
         manifests: List[PluginManifest] = []
@@ -1694,6 +1731,7 @@ class PluginManager:
                     path=ep.value,
                     key=ep.name,
                 )
+                manifest.kind = self._classify_entrypoint_kind(ep)
                 manifests.append(manifest)
         except Exception as exc:
             logger.debug("Entry-point scan failed: %s", exc)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -408,6 +408,100 @@ class TestPluginLoading:
         )
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
+        # Routing contract: classification records the manifest but does
+        # not fabricate activation. providers/ discovery is directory-based
+        # today, so a pip-only provider is not activatable via
+        # get_provider_profile() — and it must not leak into sys.modules
+        # through the providers path either (no double import).
+        from providers import get_provider_profile
+
+        assert get_provider_profile("fakeprovider") is None
+        assert "fakeprovider" not in sys.modules
+
+    def test_entrypoint_duplicate_does_not_block_directory_provider_activation(
+        self, tmp_path, monkeypatch
+    ):
+        """The mnemosyne shape: a pip entry point duplicating a same-name
+        directory provider.
+
+        The pip copy is classified ``exclusive`` (recorded, never
+        imported); the directory copy must still activate through
+        memory-provider discovery, exactly once. Classification must not
+        interfere with the real activation path.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        # Same-name pip entry point (the duplicate).
+        ep_dir = tmp_path / "ep_modules"
+        ep_dir.mkdir()
+        (ep_dir / "mempalace_dup.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(ep_dir))
+        ep = EntryPoint(
+            name="mempalace_dup",
+            value="mempalace_dup:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Same-name directory provider under $HERMES_HOME/plugins/.
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        provider_dir = plugins_dir / "mempalace_dup"
+        provider_dir.mkdir(parents=True)
+        (provider_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class MyProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'mempalace_dup'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+        )
+        (provider_dir / "plugin.yaml").write_text(
+            "name: mempalace_dup\ndescription: dup\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dup"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir", lambda: plugins_dir
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        # Pip duplicate: classified exclusive, recorded, never imported.
+        entry = mgr._plugins["mempalace_dup"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "mempalace_dup" not in sys.modules
+
+        # Directory copy still activates through memory-provider discovery,
+        # exactly once.
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        names = [n for n, _, _ in discover_memory_providers()]
+        assert names.count("mempalace_dup") == 1
+        p = load_memory_provider("mempalace_dup")
+        assert p is not None
+        assert p.name == "mempalace_dup"
+        assert p.is_available()
 
     def test_entrypoint_dotted_name_never_imports_parent_package(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -409,6 +409,70 @@ class TestPluginLoading:
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
 
+    def test_entrypoint_dotted_name_never_imports_parent_package(
+        self, tmp_path, monkeypatch
+    ):
+        """A dotted entry point (pkg.mod:register) must NOT import the
+        parent package during classification.
+
+        ``importlib.util.find_spec`` on a dotted name imports the parent
+        first — executing its ``__init__.py``, which is where a provider's
+        heavy imports typically live. The classifier must resolve the
+        module path by hand so the parent's initialization code never
+        runs and neither the parent nor the child enters ``sys.modules``.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        marker = tmp_path / "parent_executed"
+        pkg_dir = tmp_path / "mempalace_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "# If this ever executes, the no-import property is broken.\n"
+            f"from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('executed')\n"
+            "from .provider import register_memory_provider\n"
+        )
+        (pkg_dir / "provider.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_dotted",
+            value="mempalace_pkg.provider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dotted"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["mempalace_dotted"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        # Neither the parent package nor the child module was imported.
+        assert "mempalace_pkg" not in sys.modules
+        assert "mempalace_pkg.provider" not in sys.modules
+        # And the parent's __init__.py never executed.
+        assert not marker.exists()
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -299,6 +299,116 @@ class TestPluginLoading:
         assert entry.module is None
         assert "exclusive" in (entry.error or "").lower()
 
+    def test_entrypoint_memory_provider_auto_coerced_to_exclusive(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point memory-provider plugins must NOT be imported by
+        the general PluginManager.
+
+        Regression test for the mnemosyne case: a pip plugin declaring a
+        ``hermes_agent.plugins`` entry point but exposing
+        ``register_memory_provider`` (not ``register()``) used to be
+        eagerly imported in every process, pulling heavy deps (fastembed
+        → onnxruntime, ~60 MB RSS) even though the import registered
+        nothing. Entry-point manifests now get the same source-scan
+        classification as directory plugins: recorded, never imported.
+        Activation stays with plugins/memory discovery via
+        ``memory.provider`` config.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "mempalace_ep.py"
+        module_path.write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_ep",
+            value="mempalace_ep:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Even if the user explicitly enables it, the loader must treat it
+        # as exclusive and skip the import (the bug: eager import of a
+        # module with no register() function).
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_ep"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "mempalace_ep" in mgr._plugins
+        entry = mgr._plugins["mempalace_ep"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "exclusive" in (entry.error or "").lower()
+        # The whole point: the module was never imported.
+        assert "mempalace_ep" not in sys.modules
+
+    def test_entrypoint_model_provider_auto_coerced_to_model_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point model-provider plugins are routed to the
+        providers/ discovery system instead of being imported by the
+        general manager (which would double-instantiate ProviderProfile)."""
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "fakeprovider.py"
+        module_path.write_text(
+            "class ProviderProfile:\n"
+            "    pass\n"
+            "def register_provider(profile):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="fakeprovider",
+            value="fakeprovider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["fakeprovider"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["fakeprovider"]
+        assert entry.manifest.kind == "model-provider", (
+            f"Expected auto-coerced kind='model-provider', "
+            f"got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "fakeprovider" not in sys.modules
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What & why

Pip-installed plugins that declare a `hermes_agent.plugins` entry point but expose `register_memory_provider()` (memory providers) or `register_provider()` + `ProviderProfile` (model providers) are treated as plain `standalone` plugins and **eagerly imported by the general PluginManager** — even though both categories have their own discovery systems and the module has no `register()` for the general manager to call. The import registers nothing and only pays the module's full import cost in *every* Hermes process (CLI, gateway, desktop backend, cron, delegation children).

Real-world cost (measured, 2026-08): `mnemosyne-hermes` declares a `hermes_agent.plugins` entry point and exposes only `register_memory_provider()` (its real registration is the `hermes_agent.memory_providers` path / its directory copy). With `memory.provider` unset (built-in), every process still imported `mnemosyne_hermes → fastembed → onnxruntime`: **+63 MB RSS** in `import run_agent`, with the manager logging `Plugin 'mnemosyne' has no register() function, enabled=False`. Nothing was registered — the cost was pure waste.

Directory plugins already avoid this: `_parse_directory_manifest` auto-coerces `kind=exclusive` / `kind=model-provider` via a cheap source scan. **Entry-point manifests never got that classification** — a systemic gap, since memory/model providers are exactly the plugins that declare dual entry points.

## What changed

- `hermes_cli/plugins.py` — extracted the source-marker → kind detection from the directory-manifest path into a shared module-level helper `_detect_kind_from_source()` (behavior-identical; the directory path now calls it).
- `hermes_cli/plugins.py` — new `PluginManager._classify_entrypoint_kind()`: resolves the entry point's module via `importlib.util.find_spec()` (no import for top-level names; dotted names may import only the parent package), scans the first 8192 chars of source, and applies the same heuristic. `_scan_entry_points()` now stamps the kind on each manifest.
- `tests/hermes_cli/test_plugins.py` — five tests: a pip entry-point memory provider is recorded as `exclusive` and **never imported** (explicit `sys.modules` check), even when explicitly enabled; a pip entry-point model provider is routed to `model-provider`; a **dotted** entry point (`pkg.mod:register`) whose parent `__init__.py` records execution is classified without the parent ever running or entering `sys.modules`; the model-provider test additionally exercises `providers.get_provider_profile()` (None — directory-only routing contract, module still absent from `sys.modules`); the mnemosyne shape (pip entry point duplicating a same-name directory provider) is classified exclusive while the directory copy still activates through `plugins.memory` discovery exactly once.

## Design decisions

- **Default = current behavior** for anything the heuristic doesn't match: unresolvable modules, non-`.py` origins, and read failures stay `standalone` — no behavior change outside the two provider categories.
- **Shared helper, one source of truth**: both discovery surfaces call the same function, so the heuristics can't drift. Marker semantics unchanged (`register_memory_provider`/`MemoryProvider` → `exclusive`; `register_provider` + `ProviderProfile` → `model-provider`).
- **No import is the point**: the module source is read without executing the module or any parent package. Top-level names are resolved with `find_spec()` (import-free for top-level names); dotted names are walked segment-by-segment through `submodule_search_locations` by hand, so `package/__init__.py` initialization (where heavy imports typically live) never runs during discovery. Unresolvable / namespace / zipped / extension modules fall back to `standalone`.
- **Activation untouched, contract documented**: classification only decides whether the *general manager* imports the module — it activates nothing. Memory and model providers activate through their own directory-based systems (`memory.provider` via `plugins/memory`; `providers/` lazy discovery). A pip-only provider is therefore recorded for introspection but not activatable until those systems gain entry-point discovery — **the pre-existing state, not a regression**: it was equally unactivatable before (the `hermes_agent.memory_providers` entry-point group has zero consumers; both destinations scan directories only), it merely paid the import cost first and logged `no register() function`. Entry-point activation is tracked separately in #40644 (memory providers); this change is its prerequisite, preventing double-import once it lands. The contract is stated in `_classify_entrypoint_kind`'s docstring.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_plugins.py -q` → **39 passed, 0 failed** (35 pre-existing + 4 new).
- Red-green: with the fix stashed, the tests fail with the pre-fix symptoms (`module 'fakeprovider' has no attribute 'register'` for the flat case; the parent-package execution marker written for the dotted case); with the fix, all pass.
- Sibling suites all green: `test_startup_plugin_gating.py`, `test_plugin_scanner_recursion.py`, `test_plugins_cmd_enable_disable_nested.py`, `test_plugin_cli_registration.py`.
- E2E (not mocked): a fake pip distribution with a real `entry_points.txt` on `PYTHONPATH`, discovered through real `importlib.metadata` → `kind=exclusive`, recorded, module absent from `sys.modules`.

## Duplicate search

`gh search issues` / `gh search prs` for: "entry point plugin import", "plugin exclusive memory provider", "memory provider plugin onnxruntime", "lazy plugin discovery", "register_memory_provider" — no PR implements entry-point kind classification. Adjacent open work, cited for context:

- #53393 (open) — sharpens the *directory* heuristic for re-exported `MemoryProvider`; complementary, no overlap.
- #40644 (open) — would discover pip-installed memory providers via entry points; this change is the piece that keeps such providers out of the general-manager import path once that lands.
