### PR TITLE
feat(plugins): make extension registration transactional

### DIFF
--- a/agent/browser_registry.py
+++ b/agent/browser_registry.py
@@ -41,16 +41,21 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.browser_provider import BrowserProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
 
 _providers: Dict[str, BrowserProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("browser", _providers, _lock)
 
 
-def register_provider(provider: BrowserProvider) -> None:
-    """Register a cloud browser provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: BrowserProvider,
+) -> str:
+    """Validate and register into a live registry or isolated transaction view.
 
     Re-registration (same ``name``) overwrites the previous entry and logs
     a debug message — makes hot-reload scenarios (tests, dev loops) behave
@@ -64,9 +69,7 @@ def register_provider(provider: BrowserProvider) -> None:
     name = provider.name
     if not isinstance(name, str) or not name.strip():
         raise ValueError("Browser provider .name must be a non-empty string")
-    with _lock:
-        existing = _providers.get(name)
-        _providers[name] = provider
+    _added, existing = target.put(name, provider)
     if existing is not None:
         logger.debug(
             "Browser provider '%s' re-registered (was %r)",
@@ -77,12 +80,23 @@ def register_provider(provider: BrowserProvider) -> None:
             "Registered browser provider '%s' (%s)",
             name, type(provider).__name__,
         )
+    return name
+
+
+def register_provider(provider: BrowserProvider) -> None:
+    """Register a cloud browser provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[BrowserProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -90,8 +104,7 @@ def get_provider(name: str) -> Optional[BrowserProvider]:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
-    with _lock:
-        return _providers.get(name.strip())
+    return _registry_state.get(name.strip())
 
 
 # ---------------------------------------------------------------------------
@@ -143,8 +156,7 @@ def _resolve(configured: Optional[str]) -> Optional[BrowserProvider]:
     matches the legacy preference; the dispatcher then falls back to local
     browser mode.
     """
-    with _lock:
-        snapshot = dict(_providers)
+    snapshot = dict(_registry_state.items_snapshot())
 
     def _is_available_safe(p: BrowserProvider) -> bool:
         """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
@@ -188,5 +200,4 @@ def _resolve(configured: Optional[str]) -> Optional[BrowserProvider]:
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -25,16 +25,21 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.image_gen_provider import ImageGenProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
 
 _providers: Dict[str, ImageGenProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("image_gen", _providers, _lock)
 
 
-def register_provider(provider: ImageGenProvider) -> None:
-    """Register an image generation provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: ImageGenProvider,
+) -> str:
+    """Validate and register into a live registry or isolated transaction view.
 
     Re-registration (same ``name``) overwrites the previous entry and logs
     a debug message — this makes hot-reload scenarios (tests, dev loops)
@@ -48,19 +53,28 @@ def register_provider(provider: ImageGenProvider) -> None:
     name = provider.name
     if not isinstance(name, str) or not name.strip():
         raise ValueError("Image gen provider .name must be a non-empty string")
-    with _lock:
-        existing = _providers.get(name)
-        _providers[name] = provider
+    _added, existing = target.put(name, provider)
     if existing is not None:
         logger.debug("Image gen provider '%s' re-registered (was %r)", name, type(existing).__name__)
     else:
         logger.debug("Registered image gen provider '%s' (%s)", name, type(provider).__name__)
+    return name
+
+
+def register_provider(provider: ImageGenProvider) -> None:
+    """Register an image generation provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[ImageGenProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -68,8 +82,7 @@ def get_provider(name: str) -> Optional[ImageGenProvider]:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
-    with _lock:
-        return _providers.get(name.strip())
+    return _registry_state.get(name.strip())
 
 
 def get_active_provider() -> Optional[ImageGenProvider]:
@@ -102,8 +115,7 @@ def get_active_provider() -> Optional[ImageGenProvider]:
     except Exception as exc:
         logger.debug("Could not read image_gen.provider from config: %s", exc)
 
-    with _lock:
-        snapshot = dict(_providers)
+    snapshot = dict(_registry_state.items_snapshot())
 
     def _is_available_safe(p: ImageGenProvider) -> bool:
         """Wrap ``is_available()`` so a buggy provider doesn't kill resolution."""
@@ -141,5 +153,4 @@ def get_active_provider() -> Optional[ImageGenProvider]:
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -169,6 +169,12 @@ class _SecretTransactionSurface:
         )
         _BUILTINS_LOADED = prepared._builtins_loaded
 
+    def restore_snapshot_locked(self, snapshot) -> None:
+        global _BUILTINS_LOADED
+        self._validate_snapshot(snapshot)
+        _registry_state.restore_snapshot_locked(snapshot._mapping)
+        _BUILTINS_LOADED = snapshot._builtins_loaded
+
 
 _plugin_transaction = _SecretTransactionSurface()
 

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, MutableMapping, Optional
@@ -43,6 +44,7 @@ from agent.secret_sources.base import (
     reset_source_environment,
     set_source_environment,
 )
+from registry_transaction import MappingRegistry, RegistryTransactionConflict
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,125 @@ logger = logging.getLogger(__name__)
 # insertion order, which doubles as the default apply order.
 _SOURCES: Dict[str, SecretSource] = {}
 _BUILTINS_LOADED = False
+_lock = threading.RLock()
+_registry_state = MappingRegistry("secret", _SOURCES, _lock)
+_BUILTINS_LOADING = False
+_BUILTINS_LOADING_THREAD: Optional[int] = None
+_BUILTINS_READY = threading.Event()
+
+
+class _SecretSnapshot:
+    __slots__ = ("_owner", "_mapping", "_builtins_loaded")
+
+    def __init__(self, owner, mapping, builtins_loaded: bool) -> None:
+        self._owner = owner
+        self._mapping = mapping
+        self._builtins_loaded = builtins_loaded
+
+
+class _SecretView:
+    __slots__ = ("_owner", "_snapshot", "registry", "builtins_loaded")
+
+    def __init__(self, owner, snapshot, registry, builtins_loaded: bool) -> None:
+        self._owner = owner
+        self._snapshot = snapshot
+        self.registry = registry
+        self.builtins_loaded = builtins_loaded
+
+
+class _PreparedSecretState:
+    __slots__ = ("_owner", "_snapshot", "_mapping", "_builtins_loaded")
+
+    def __init__(self, owner, snapshot, mapping, builtins_loaded: bool) -> None:
+        self._owner = owner
+        self._snapshot = snapshot
+        self._mapping = mapping
+        self._builtins_loaded = builtins_loaded
+
+
+class _SecretTransactionSurface:
+    surface = "secret"
+
+    @property
+    def lock(self):
+        return _registry_state.lock
+
+    def take_snapshot(self):
+        with _registry_state.lock:
+            return _SecretSnapshot(
+                self,
+                _registry_state.take_snapshot(),
+                _BUILTINS_LOADED,
+            )
+
+    def _validate_snapshot(self, snapshot) -> None:
+        if not isinstance(snapshot, _SecretSnapshot) or snapshot._owner is not self:
+            raise ValueError(
+                "transaction snapshot belongs to a different secret registry"
+            )
+
+    def create_view(self, snapshot, *, remove_keys=()):
+        self._validate_snapshot(snapshot)
+        return _SecretView(
+            self,
+            snapshot,
+            _registry_state.create_view(
+                snapshot._mapping,
+                remove_keys=remove_keys,
+            ),
+            snapshot._builtins_loaded,
+        )
+
+    def register(self, staged, source) -> Optional[str]:
+        if not isinstance(staged, _SecretView) or staged._owner is not self:
+            raise ValueError("transaction view belongs to a different secret registry")
+        return _register_source_in(staged.registry, source)
+
+    def prepare(self, snapshot, staged):
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(staged, _SecretView)
+            or staged._owner is not self
+            or staged._snapshot is not snapshot
+        ):
+            raise ValueError("transaction view belongs to a different secret registry")
+        return _PreparedSecretState(
+            self,
+            snapshot,
+            _registry_state.prepare(snapshot._mapping, staged.registry),
+            staged.builtins_loaded,
+        )
+
+    def validate_prepared_locked(self, snapshot, prepared) -> None:
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(prepared, _PreparedSecretState)
+            or prepared._owner is not self
+            or prepared._snapshot is not snapshot
+        ):
+            raise ValueError("prepared state belongs to a different secret registry")
+        if _BUILTINS_LOADED != snapshot._builtins_loaded:
+            raise RegistryTransactionConflict(
+                self.surface,
+                snapshot._mapping._generation,
+                _registry_state._generation,
+            )
+        _registry_state.validate_prepared_locked(
+            snapshot._mapping,
+            prepared._mapping,
+        )
+
+    def install_prepared_locked(self, snapshot, prepared) -> None:
+        global _BUILTINS_LOADED
+        self.validate_prepared_locked(snapshot, prepared)
+        _registry_state.install_prepared_locked(
+            snapshot._mapping,
+            prepared._mapping,
+        )
+        _BUILTINS_LOADED = prepared._builtins_loaded
+
+
+_plugin_transaction = _SecretTransactionSurface()
 
 
 @dataclass
@@ -94,8 +215,13 @@ class ApplyReport:
 # ---------------------------------------------------------------------------
 
 
-def register_source(source: SecretSource, *, replace: bool = False) -> bool:
-    """Register a secret source.  Returns True on success.
+def _register_source_in(
+    target: MappingRegistry,
+    source: SecretSource,
+    *,
+    replace: bool = False,
+) -> Optional[str]:
+    """Validate and register into a live registry or isolated transaction view.
 
     Rejections are logged, never raised — a bad plugin must not take
     down startup.  ``replace`` allows tests / user plugins to override
@@ -108,88 +234,145 @@ def register_source(source: SecretSource, *, replace: bool = False) -> bool:
             "Ignoring secret source %r: does not inherit from SecretSource",
             source,
         )
-        return False
+        return None
     name = getattr(source, "name", "") or ""
     if not name or not name.replace("_", "").isalnum() or name != name.lower():
         logger.warning("Ignoring secret source with invalid name %r", name)
-        return False
+        return None
     if getattr(source, "api_version", None) != SECRET_SOURCE_API_VERSION:
         logger.warning(
             "Ignoring secret source '%s': built against secret-source API v%s, "
             "this Hermes speaks v%s",
             name, getattr(source, "api_version", "?"), SECRET_SOURCE_API_VERSION,
         )
-        return False
+        return None
     if getattr(source, "shape", None) not in ("mapped", "bulk"):
         logger.warning(
             "Ignoring secret source '%s': shape must be 'mapped' or 'bulk', got %r",
             name, getattr(source, "shape", None),
         )
-        return False
-    if name in _SOURCES and not replace:
-        logger.warning("Secret source '%s' already registered; ignoring duplicate", name)
-        return False
+        return None
     scheme = getattr(source, "scheme", None)
-    if scheme:
-        for other_name, other in _SOURCES.items():
-            if other_name != name and getattr(other, "scheme", None) == scheme:
+    while True:
+        snapshot = target.take_snapshot()
+        items = target.snapshot_items(snapshot)
+        if not replace and any(other_name == name for other_name, _other in items):
+            logger.warning("Secret source '%s' already registered; ignoring duplicate", name)
+            return None
+        if scheme:
+            collision = next(
+                (
+                    other_name
+                    for other_name, other in items
+                    if other_name != name
+                    and getattr(other, "scheme", None) == scheme
+                ),
+                None,
+            )
+            if collision is not None:
                 logger.warning(
                     "Ignoring secret source '%s': scheme '%s://' is already "
                     "owned by source '%s'",
-                    name, scheme, other_name,
+                    name, scheme, collision,
                 )
-                return False
-    _SOURCES[name] = source
-    return True
+                return None
+        try:
+            added, _existing = target.put_if_snapshot(
+                snapshot,
+                name,
+                source,
+                replace=replace,
+            )
+        except RegistryTransactionConflict:
+            continue
+        return name if added else None
+
+
+def register_source(source: SecretSource, *, replace: bool = False) -> bool:
+    """Register a secret source.  Returns True on success."""
+    return _register_source_in(
+        _registry_state,
+        source,
+        replace=replace,
+    ) is not None
 
 
 def get_source(name: str) -> Optional[SecretSource]:
     _ensure_builtin_sources()
-    return _SOURCES.get(name)
+    return _registry_state.get(name)
 
 
 def list_sources() -> List[SecretSource]:
     _ensure_builtin_sources()
-    return list(_SOURCES.values())
+    return _registry_state.values()
 
 
 def _ensure_builtin_sources() -> None:
-    """Idempotently register the bundled sources.
-
-    Lazy so importing this module stays cheap and so a broken bundled
-    source can never break registration of the others.
-    """
-    global _BUILTINS_LOADED
-    if _BUILTINS_LOADED:
+    """Resolve bundled sources once without imports or constructors under lock."""
+    global _BUILTINS_LOADED, _BUILTINS_LOADING, _BUILTINS_LOADING_THREAD
+    with _lock:
+        if _BUILTINS_LOADED:
+            return
+        if _BUILTINS_LOADING:
+            if _BUILTINS_LOADING_THREAD == threading.get_ident():
+                return
+            ready = _BUILTINS_READY
+            should_load = False
+        else:
+            _BUILTINS_LOADING = True
+            _BUILTINS_LOADING_THREAD = threading.get_ident()
+            _BUILTINS_READY.clear()
+            ready = _BUILTINS_READY
+            should_load = True
+    if not should_load:
+        ready.wait()
         return
-    _BUILTINS_LOADED = True
-    try:
-        from agent.secret_sources.bitwarden import BitwardenSource
 
-        register_source(BitwardenSource())
-    except Exception:  # noqa: BLE001 — never block startup
-        logger.warning("Failed to register bundled Bitwarden secret source",
-                       exc_info=True)
     try:
-        from agent.secret_sources.onepassword import OnePasswordSource
+        try:
+            from agent.secret_sources.bitwarden import BitwardenSource
 
-        register_source(OnePasswordSource())
-    except Exception:  # noqa: BLE001 — never block startup
-        logger.warning("Failed to register bundled 1Password secret source",
-                       exc_info=True)
-    try:
-        from agent.secret_sources.command import CommandSource
+            register_source(BitwardenSource())
+        except Exception:
+            logger.warning(
+                "Failed to register bundled Bitwarden secret source",
+                exc_info=True,
+            )
+        try:
+            from agent.secret_sources.onepassword import OnePasswordSource
 
-        register_source(CommandSource())
-    except Exception:  # noqa: BLE001 — never block startup
-        logger.warning("Failed to register bundled command secret source",
-                       exc_info=True)
+            register_source(OnePasswordSource())
+        except Exception:
+            logger.warning(
+                "Failed to register bundled 1Password secret source",
+                exc_info=True,
+            )
+        try:
+            from agent.secret_sources.command import CommandSource
+
+            register_source(CommandSource())
+        except Exception:
+            logger.warning(
+                "Failed to register bundled command secret source",
+                exc_info=True,
+            )
+    finally:
+        with _lock:
+            _BUILTINS_LOADED = True
+            _BUILTINS_LOADING = False
+            _BUILTINS_LOADING_THREAD = None
+            _registry_state._generation += 1
+            ready.set()
 
 
 def _reset_registry_for_tests() -> None:
-    global _BUILTINS_LOADED
-    _SOURCES.clear()
-    _BUILTINS_LOADED = False
+    global _BUILTINS_LOADED, _BUILTINS_LOADING, _BUILTINS_LOADING_THREAD
+    _registry_state.clear()
+    with _lock:
+        _BUILTINS_LOADED = False
+        _BUILTINS_LOADING = False
+        _BUILTINS_LOADING_THREAD = None
+        _BUILTINS_READY.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -261,27 +444,28 @@ def _ordered_enabled_sources(secrets_cfg: dict) -> List[SecretSource]:
     precedence is applied on top of this order by :func:`apply_all`.
     """
     _ensure_builtin_sources()
+    sources = dict(_registry_state.items_snapshot())
 
     explicit = secrets_cfg.get("sources")
     order: List[str] = []
     if isinstance(explicit, list):
         for entry in explicit:
-            if isinstance(entry, str) and entry in _SOURCES and entry not in order:
+            if isinstance(entry, str) and entry in sources and entry not in order:
                 order.append(entry)
         unknown = [e for e in explicit
-                   if isinstance(e, str) and e not in _SOURCES]
+                   if isinstance(e, str) and e not in sources]
         if unknown:
             logger.warning(
                 "secrets.sources names unknown source(s): %s (known: %s)",
-                ", ".join(unknown), ", ".join(_SOURCES) or "none",
+                ", ".join(unknown), ", ".join(sources) or "none",
             )
-    for name in _SOURCES:
+    for name in sources:
         if name not in order:
             order.append(name)
 
     enabled: List[SecretSource] = []
     for name in order:
-        source = _SOURCES[name]
+        source = sources[name]
         cfg = secrets_cfg.get(name)
         cfg = cfg if isinstance(cfg, dict) else {}
         try:

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -24,6 +24,7 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.transcription_provider import TranscriptionProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
@@ -50,11 +51,15 @@ _BUILTIN_NAMES = frozenset({
 
 
 _providers: Dict[str, TranscriptionProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("stt", _providers, _lock)
 
 
-def register_provider(provider: TranscriptionProvider) -> None:
-    """Register a transcription provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: TranscriptionProvider,
+) -> Optional[str]:
+    """Validate and register into a live registry or isolated transaction view.
 
     Rejects:
 
@@ -84,9 +89,7 @@ def register_provider(provider: TranscriptionProvider) -> None:
             key, ", ".join(sorted(_BUILTIN_NAMES)),
         )
         return
-    with _lock:
-        existing = _providers.get(key)
-        _providers[key] = provider
+    _added, existing = target.put(key, provider)
     if existing is not None:
         logger.debug(
             "Transcription provider '%s' re-registered (was %r)",
@@ -97,12 +100,23 @@ def register_provider(provider: TranscriptionProvider) -> None:
             "Registered transcription provider '%s' (%s)",
             key, type(provider).__name__,
         )
+    return key
+
+
+def register_provider(provider: TranscriptionProvider) -> None:
+    """Register a transcription provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[TranscriptionProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -115,10 +129,9 @@ def get_provider(name: str) -> Optional[TranscriptionProvider]:
     """
     if not isinstance(name, str):
         return None
-    return _providers.get(name.strip().lower())
+    return _registry_state.get(name.strip().lower())
 
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -33,6 +33,7 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.tts_provider import TTSProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +62,15 @@ _BUILTIN_NAMES = frozenset({
 
 
 _providers: Dict[str, TTSProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("tts", _providers, _lock)
 
 
-def register_provider(provider: TTSProvider) -> None:
-    """Register a TTS provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: TTSProvider,
+) -> Optional[str]:
+    """Validate and register into a live registry or isolated transaction view.
 
     Rejects:
 
@@ -94,9 +99,7 @@ def register_provider(provider: TTSProvider) -> None:
             key, ", ".join(sorted(_BUILTIN_NAMES)),
         )
         return
-    with _lock:
-        existing = _providers.get(key)
-        _providers[key] = provider
+    _added, existing = target.put(key, provider)
     if existing is not None:
         logger.debug(
             "TTS provider '%s' re-registered (was %r)",
@@ -107,12 +110,23 @@ def register_provider(provider: TTSProvider) -> None:
             "Registered TTS provider '%s' (%s)",
             key, type(provider).__name__,
         )
+    return key
+
+
+def register_provider(provider: TTSProvider) -> None:
+    """Register a TTS provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[TTSProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -125,10 +139,9 @@ def get_provider(name: str) -> Optional[TTSProvider]:
     """
     if not isinstance(name, str):
         return None
-    return _providers.get(name.strip().lower())
+    return _registry_state.get(name.strip().lower())
 
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -29,16 +29,21 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.video_gen_provider import VideoGenProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
 
 _providers: Dict[str, VideoGenProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("video_gen", _providers, _lock)
 
 
-def register_provider(provider: VideoGenProvider) -> None:
-    """Register a video generation provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: VideoGenProvider,
+) -> str:
+    """Validate and register into a live registry or isolated transaction view.
 
     Re-registration (same ``name``) overwrites the previous entry and logs
     a debug message — this makes hot-reload scenarios (tests, dev loops)
@@ -52,19 +57,28 @@ def register_provider(provider: VideoGenProvider) -> None:
     name = provider.name
     if not isinstance(name, str) or not name.strip():
         raise ValueError("Video gen provider .name must be a non-empty string")
-    with _lock:
-        existing = _providers.get(name)
-        _providers[name] = provider
+    _added, existing = target.put(name, provider)
     if existing is not None:
         logger.debug("Video gen provider '%s' re-registered (was %r)", name, type(existing).__name__)
     else:
         logger.debug("Registered video gen provider '%s' (%s)", name, type(provider).__name__)
+    return name
+
+
+def register_provider(provider: VideoGenProvider) -> None:
+    """Register a video generation provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[VideoGenProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -72,8 +86,7 @@ def get_provider(name: str) -> Optional[VideoGenProvider]:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
-    with _lock:
-        return _providers.get(name.strip())
+    return _registry_state.get(name.strip())
 
 
 def get_active_provider() -> Optional[VideoGenProvider]:
@@ -95,8 +108,7 @@ def get_active_provider() -> Optional[VideoGenProvider]:
     except Exception as exc:
         logger.debug("Could not read video_gen.provider from config: %s", exc)
 
-    with _lock:
-        snapshot = dict(_providers)
+    snapshot = dict(_registry_state.items_snapshot())
 
     if configured:
         provider = snapshot.get(configured)
@@ -129,5 +141,4 @@ def get_active_provider() -> Optional[VideoGenProvider]:
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -37,16 +37,21 @@ import threading
 from typing import Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 logger = logging.getLogger(__name__)
 
 
 _providers: Dict[str, WebSearchProvider] = {}
-_lock = threading.Lock()
+_lock = threading.RLock()
+_registry_state = MappingRegistry("web", _providers, _lock)
 
 
-def register_provider(provider: WebSearchProvider) -> None:
-    """Register a web search/extract provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: WebSearchProvider,
+) -> str:
+    """Validate and register into a live registry or isolated transaction view.
 
     Re-registration (same ``name``) overwrites the previous entry and logs
     a debug message — makes hot-reload scenarios (tests, dev loops) behave
@@ -60,9 +65,7 @@ def register_provider(provider: WebSearchProvider) -> None:
     name = provider.name
     if not isinstance(name, str) or not name.strip():
         raise ValueError("Web provider .name must be a non-empty string")
-    with _lock:
-        existing = _providers.get(name)
-        _providers[name] = provider
+    _added, existing = target.put(name, provider)
     if existing is not None:
         logger.debug(
             "Web provider '%s' re-registered (was %r)",
@@ -73,12 +76,23 @@ def register_provider(provider: WebSearchProvider) -> None:
             "Registered web provider '%s' (%s)",
             name, type(provider).__name__,
         )
+    return name
+
+
+def register_provider(provider: WebSearchProvider) -> None:
+    """Register a web search/extract provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def list_providers() -> List[WebSearchProvider]:
     """Return all registered providers, sorted by name."""
-    with _lock:
-        items = list(_providers.values())
+    items = _registry_state.values()
     return sorted(items, key=lambda p: p.name)
 
 
@@ -86,8 +100,7 @@ def get_provider(name: str) -> Optional[WebSearchProvider]:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
-    with _lock:
-        return _providers.get(name.strip())
+    return _registry_state.get(name.strip())
 
 
 # ---------------------------------------------------------------------------
@@ -160,8 +173,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     matches the legacy preference; the dispatcher then returns a "set up a
     provider" error to the user.
     """
-    with _lock:
-        snapshot = dict(_providers)
+    snapshot = dict(_registry_state.items_snapshot())
 
     def _capable(p: WebSearchProvider) -> bool:
         if capability == "search":
@@ -300,5 +312,4 @@ def get_active_extract_provider() -> Optional[WebSearchProvider]:
 
 def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -29,8 +29,11 @@ Usage (gateway side):
 """
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
+
+from registry_transaction import RegistryTransactionConflict
 
 logger = logging.getLogger(__name__)
 
@@ -159,14 +162,57 @@ class PlatformEntry:
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
 
 
-class PlatformRegistry:
-    """Central registry of platform adapters.
+class _PlatformSnapshot:
+    __slots__ = ("_owner", "_entries", "_deferred", "_resolving", "_generation")
 
-    Thread-safe for reads (dict lookups are atomic under GIL).
-    Writes happen at startup during sequential discovery.
-    """
+    def __init__(
+        self,
+        owner: "PlatformRegistry",
+        entries: tuple,
+        deferred: tuple,
+        resolving: tuple,
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._entries = entries
+        self._deferred = deferred
+        self._resolving = resolving
+        self._generation = generation
+
+
+class _PreparedPlatformState:
+    __slots__ = ("_owner", "_snapshot", "_entries", "_deferred", "_generation")
+
+    def __init__(
+        self,
+        owner: "PlatformRegistry",
+        snapshot: _PlatformSnapshot,
+        entries: dict,
+        deferred: dict,
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._snapshot = snapshot
+        self._entries = entries
+        self._deferred = deferred
+        self._generation = generation
+
+
+class _DeferredResolution:
+    __slots__ = ("event", "owner_thread")
 
     def __init__(self) -> None:
+        self.event = threading.Event()
+        self.owner_thread = threading.get_ident()
+
+
+class PlatformRegistry:
+    """Thread-safe central registry of platform adapters."""
+
+    surface = "platform"
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
         self._entries: dict[str, PlatformEntry] = {}
         # Deferred platform loaders: name -> zero-arg callable that imports the
         # owning plugin module (which calls register() and populates _entries).
@@ -181,6 +227,139 @@ class PlatformRegistry:
         # actually asks for that platform (gateway start, cron delivery,
         # `hermes setup`/`gateway status`, send_message).
         self._deferred: dict[str, Callable[[], None]] = {}
+        self._resolving: dict[str, _DeferredResolution] = {}
+        self._generation = 0
+        self._frozen = False
+        self._transaction_owner: Optional[PlatformRegistry] = None
+        self._transaction_snapshot: Optional[_PlatformSnapshot] = None
+
+    @property
+    def lock(self) -> threading.RLock:
+        return self._lock
+
+    # -- opaque transaction API -------------------------------------------
+
+    def take_snapshot(self) -> _PlatformSnapshot:
+        with self._lock:
+            return _PlatformSnapshot(
+                self,
+                tuple(self._entries.items()),
+                tuple(self._deferred.items()),
+                tuple(self._resolving.items()),
+                self._generation,
+            )
+
+    def _validate_snapshot(self, snapshot: _PlatformSnapshot) -> None:
+        if not isinstance(snapshot, _PlatformSnapshot) or snapshot._owner is not self:
+            raise ValueError(
+                "transaction snapshot belongs to a different PlatformRegistry"
+            )
+
+    def create_view(
+        self,
+        snapshot: _PlatformSnapshot,
+        *,
+        remove_keys=(),
+    ) -> "PlatformRegistry":
+        self._validate_snapshot(snapshot)
+        removed = frozenset(remove_keys)
+        staged = PlatformRegistry()
+        staged._entries = {
+            name: entry
+            for name, entry in snapshot._entries
+            if name not in removed
+        }
+        staged._deferred = {
+            name: loader
+            for name, loader in snapshot._deferred
+            if name not in removed
+        }
+        staged._generation = snapshot._generation
+        staged._transaction_owner = self
+        staged._transaction_snapshot = snapshot
+        return staged
+
+    def prepare(
+        self,
+        snapshot: _PlatformSnapshot,
+        staged: "PlatformRegistry",
+    ) -> _PreparedPlatformState:
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(staged, PlatformRegistry)
+            or staged._transaction_owner is not self
+            or staged._transaction_snapshot is not snapshot
+        ):
+            raise ValueError(
+                "transaction view belongs to a different PlatformRegistry"
+            )
+        with staged._lock:
+            prepared = _PreparedPlatformState(
+                self,
+                snapshot,
+                dict(staged._entries),
+                dict(staged._deferred),
+                staged._generation,
+            )
+            staged._frozen = True
+            return prepared
+
+    def _matches_snapshot_locked(self, snapshot: _PlatformSnapshot) -> bool:
+        return (
+            self._generation == snapshot._generation
+            and len(self._entries) == len(snapshot._entries)
+            and all(
+                name in self._entries and self._entries[name] is entry
+                for name, entry in snapshot._entries
+            )
+            and len(self._deferred) == len(snapshot._deferred)
+            and all(
+                name in self._deferred and self._deferred[name] is loader
+                for name, loader in snapshot._deferred
+            )
+            and len(self._resolving) == len(snapshot._resolving)
+            and all(
+                name in self._resolving
+                and self._resolving[name] is resolution
+                for name, resolution in snapshot._resolving
+            )
+        )
+
+    def validate_prepared_locked(
+        self,
+        snapshot: _PlatformSnapshot,
+        prepared: _PreparedPlatformState,
+    ) -> None:
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(prepared, _PreparedPlatformState)
+            or prepared._owner is not self
+            or prepared._snapshot is not snapshot
+        ):
+            raise ValueError(
+                "prepared state belongs to a different PlatformRegistry"
+            )
+        current_thread = threading.get_ident()
+        foreign_resolution = any(
+            resolution.owner_thread != current_thread
+            for _name, resolution in snapshot._resolving
+        )
+        if foreign_resolution or not self._matches_snapshot_locked(snapshot):
+            raise RegistryTransactionConflict(
+                self.surface,
+                snapshot._generation,
+                self._generation,
+            )
+
+    def install_prepared_locked(
+        self,
+        snapshot: _PlatformSnapshot,
+        prepared: _PreparedPlatformState,
+    ) -> None:
+        self.validate_prepared_locked(snapshot, prepared)
+        self._entries = prepared._entries
+        self._deferred = prepared._deferred
+        self._generation = max(self._generation, prepared._generation) + 1
 
     # -- deferred loading ----------------------------------------------------
 
@@ -194,16 +373,41 @@ class PlatformRegistry:
         registered directly (e.g. a built-in) takes precedence -- the deferred
         loader is then dropped.
         """
-        if name in self._entries:
-            # Already concretely registered; no need to defer.
-            return
-        self._deferred[name] = loader
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError("platform transaction view is frozen")
+            if name in self._entries:
+                return
+            self._deferred[name] = loader
+            self._generation += 1
 
     def _resolve(self, name: str) -> None:
         """Run the deferred loader for *name* if one is pending."""
-        loader = self._deferred.pop(name, None)
-        if loader is None:
-            return
+        resolution: Optional[_DeferredResolution] = None
+        loader: Optional[Callable[[], None]] = None
+        while True:
+            with self._lock:
+                if name in self._entries:
+                    return
+                active = self._resolving.get(name)
+                if active is not None:
+                    if active.owner_thread == threading.get_ident():
+                        return
+                    wait_event = active.event
+                else:
+                    loader = self._deferred.pop(name, None)
+                    if loader is None:
+                        return
+                    resolution = _DeferredResolution()
+                    self._resolving[name] = resolution
+                    self._generation += 1
+                    wait_event = None
+            if wait_event is None:
+                break
+            wait_event.wait()
+
+        assert loader is not None
+        assert resolution is not None
         try:
             loader()
         except Exception as e:
@@ -213,6 +417,11 @@ class PlatformRegistry:
                 e,
                 exc_info=True,
             )
+        finally:
+            with self._lock:
+                if self._resolving.get(name) is resolution:
+                    self._resolving.pop(name, None)
+                resolution.event.set()
 
     def _resolve_all(self) -> None:
         """Run every pending deferred loader.
@@ -222,11 +431,24 @@ class PlatformRegistry:
         gateway startup, ``hermes setup``/``gateway status``, channel
         directory.  CLI chat never iterates the full set.
         """
-        if not self._deferred:
+        while True:
+            current_thread = threading.get_ident()
+            with self._lock:
+                pending = list(self._deferred)
+                active = [
+                    resolution.event
+                    for resolution in self._resolving.values()
+                    if resolution.owner_thread != current_thread
+                ]
+            if pending:
+                for name in pending:
+                    self._resolve(name)
+                continue
+            if active:
+                for event in active:
+                    event.wait()
+                continue
             return
-        # Snapshot keys -- loaders mutate _deferred as they resolve.
-        for name in list(self._deferred):
-            self._resolve(name)
 
     def register(self, entry: PlatformEntry) -> None:
         """Register a platform adapter entry.
@@ -234,46 +456,65 @@ class PlatformRegistry:
         If an entry with the same name exists, it is replaced (last writer
         wins -- this lets plugins override built-in adapters if desired).
         """
-        # A concrete registration supersedes any pending deferred loader.
-        self._deferred.pop(entry.name, None)
-        if entry.name in self._entries:
-            prev = self._entries[entry.name]
+        name = entry.name
+        source = entry.source
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError("platform transaction view is frozen")
+            self._deferred.pop(name, None)
+            prev = self._entries.get(name)
+            self._entries[name] = entry
+            self._generation += 1
+        if prev is not None:
             logger.info(
                 "Platform '%s' re-registered (was %s, now %s)",
-                entry.name,
+                name,
                 prev.source,
-                entry.source,
+                source,
             )
-        self._entries[entry.name] = entry
-        logger.debug("Registered platform adapter: %s (%s)", entry.name, entry.source)
+        logger.debug("Registered platform adapter: %s (%s)", name, source)
 
     def unregister(self, name: str) -> bool:
         """Remove a platform entry.  Returns True if it existed."""
-        self._deferred.pop(name, None)
-        return self._entries.pop(name, None) is not None
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError("platform transaction view is frozen")
+            deferred = self._deferred.pop(name, None)
+            entry = self._entries.pop(name, None)
+            if deferred is not None or entry is not None:
+                self._generation += 1
+            return entry is not None
 
     def get(self, name: str) -> Optional[PlatformEntry]:
         """Look up a platform entry by name."""
-        if name not in self._entries:
-            self._resolve(name)
-        return self._entries.get(name)
+        self._resolve(name)
+        with self._lock:
+            return self._entries.get(name)
 
     def all_entries(self) -> list[PlatformEntry]:
         """Return all registered platform entries."""
         self._resolve_all()
-        return list(self._entries.values())
+        with self._lock:
+            return list(self._entries.values())
 
     def plugin_entries(self) -> list[PlatformEntry]:
         """Return only plugin-registered platform entries."""
         self._resolve_all()
-        return [e for e in self._entries.values() if e.source == "plugin"]
+        with self._lock:
+            entries = list(self._entries.values())
+        return [entry for entry in entries if entry.source == "plugin"]
 
     def is_registered(self, name: str) -> bool:
         # A deferred (not-yet-imported) platform still counts as registered --
         # the loader will materialize it on first real use.  This keeps cheap
         # membership checks (toolset resolution, webhook deliver-target checks)
         # from triggering a heavy import.
-        return name in self._entries or name in self._deferred
+        with self._lock:
+            return (
+                name in self._entries
+                or name in self._deferred
+                or name in self._resolving
+            )
 
     def create_adapter(self, name: str, config: Any) -> Optional[Any]:
         """Create an adapter instance for the given platform name.
@@ -284,9 +525,7 @@ class PlatformRegistry:
         - validate_config() returns False (misconfigured)
         - The factory raises an exception
         """
-        if name not in self._entries:
-            self._resolve(name)
-        entry = self._entries.get(name)
+        entry = self.get(name)
         if entry is None:
             return None
 

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -365,6 +365,14 @@ class PlatformRegistry:
         self._deferred = prepared._deferred
         self._generation = max(self._generation, prepared._generation) + 1
 
+    def restore_snapshot_locked(self, snapshot: _PlatformSnapshot) -> None:
+        """Restore an opaque snapshot exactly while the registry lock is held."""
+        self._validate_snapshot(snapshot)
+        self._entries = dict(snapshot._entries)
+        self._deferred = dict(snapshot._deferred)
+        self._resolving = dict(snapshot._resolving)
+        self._generation = snapshot._generation
+
     # -- deferred loading ----------------------------------------------------
 
     def register_deferred(self, name: str, loader: Callable[[], None]) -> None:

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -228,6 +228,10 @@ class PlatformRegistry:
         # `hermes setup`/`gateway status`, send_message).
         self._deferred: dict[str, Callable[[], None]] = {}
         self._resolving: dict[str, _DeferredResolution] = {}
+        # Current cross-thread deferred-loader waits.  Tracking this graph lets
+        # re-entrant loaders break only cyclic waits while ordinary readers
+        # still wait for the owning loader's final entry (or failure).
+        self._waiting: dict[int, _DeferredResolution] = {}
         self._generation = 0
         self._frozen = False
         self._transaction_owner: Optional[PlatformRegistry] = None
@@ -393,7 +397,7 @@ class PlatformRegistry:
                 if active is not None:
                     if active.owner_thread == threading.get_ident():
                         return
-                    wait_event = active.event
+                    wait_resolution = active
                 else:
                     loader = self._deferred.pop(name, None)
                     if loader is None:
@@ -401,10 +405,11 @@ class PlatformRegistry:
                     resolution = _DeferredResolution()
                     self._resolving[name] = resolution
                     self._generation += 1
-                    wait_event = None
-            if wait_event is None:
+                    wait_resolution = None
+            if wait_resolution is None:
                 break
-            wait_event.wait()
+            if not self._wait_for_resolution(wait_resolution):
+                return
 
         assert loader is not None
         assert resolution is not None
@@ -423,6 +428,41 @@ class PlatformRegistry:
                     self._resolving.pop(name, None)
                 resolution.event.set()
 
+    def _wait_for_resolution(self, resolution: _DeferredResolution) -> bool:
+        """Wait for *resolution*, unless that wait would close a loader cycle.
+
+        Returns ``False`` only when the caller must treat the still-provisional
+        resolution as unavailable so its own loader can finish and unblock the
+        cycle.  The registry lock is never held while waiting.
+        """
+        current_thread = threading.get_ident()
+        with self._lock:
+            if resolution.event.is_set():
+                return True
+
+            owner_thread = resolution.owner_thread
+            seen = set()
+            while owner_thread not in seen:
+                if owner_thread == current_thread:
+                    return False
+                seen.add(owner_thread)
+                owner_wait = self._waiting.get(owner_thread)
+                if owner_wait is None:
+                    self._waiting[current_thread] = resolution
+                    break
+                owner_thread = owner_wait.owner_thread
+            else:
+                # Defensive fallback for an already-cyclic dependency graph.
+                return False
+
+        try:
+            resolution.event.wait()
+        finally:
+            with self._lock:
+                if self._waiting.get(current_thread) is resolution:
+                    self._waiting.pop(current_thread, None)
+        return True
+
     def _resolve_all(self) -> None:
         """Run every pending deferred loader.
 
@@ -436,7 +476,7 @@ class PlatformRegistry:
             with self._lock:
                 pending = list(self._deferred)
                 active = [
-                    resolution.event
+                    resolution
                     for resolution in self._resolving.values()
                     if resolution.owner_thread != current_thread
                 ]
@@ -445,9 +485,15 @@ class PlatformRegistry:
                     self._resolve(name)
                 continue
             if active:
-                for event in active:
-                    event.wait()
-                continue
+                waited = False
+                for resolution in active:
+                    waited = self._wait_for_resolution(resolution) or waited
+                if waited:
+                    continue
+                # Every remaining foreign resolution depends (possibly
+                # transitively) on this loader.  Returning exposes only already
+                # committed entries and lets this loader release the cycle.
+                return
             return
 
     def register(self, entry: PlatformEntry) -> None:

--- a/hermes_cli/dashboard_auth/registry.py
+++ b/hermes_cli/dashboard_auth/registry.py
@@ -14,42 +14,58 @@ from hermes_cli.dashboard_auth.base import (
     DashboardAuthProvider,
     assert_protocol_compliance,
 )
+from registry_transaction import MappingRegistry, RegistryTransactionSurface
 
 _log = logging.getLogger(__name__)
-_lock = threading.Lock()
+_lock = threading.RLock()
 _providers: dict[str, DashboardAuthProvider] = {}
+_registry_state = MappingRegistry("dashboard", _providers, _lock)
 
 
-def register_provider(provider: DashboardAuthProvider) -> None:
-    """Register a provider.
+def _register_provider_in(
+    target: MappingRegistry,
+    provider: DashboardAuthProvider,
+) -> str:
+    """Validate and register into a live registry or isolated transaction view.
 
     Raises:
         TypeError: on protocol violation.
         ValueError: if a provider with the same name is already registered.
     """
     assert_protocol_compliance(type(provider))
-    with _lock:
-        if provider.name in _providers:
-            raise ValueError(
-                f"dashboard-auth provider already registered: {provider.name!r}"
-            )
-        _providers[provider.name] = provider
+    name = provider.name
+    display_name = provider.display_name
+    added, _existing = target.put(name, provider, replace=False)
+    if not added:
+        raise ValueError(
+            f"dashboard-auth provider already registered: {name!r}"
+        )
     _log.info(
         "dashboard-auth: registered provider %r (%s)",
-        provider.name, provider.display_name,
+        name, display_name,
     )
+    return name
+
+
+def register_provider(provider: DashboardAuthProvider) -> None:
+    """Register a provider."""
+    _register_provider_in(_registry_state, provider)
+
+
+_plugin_transaction = RegistryTransactionSurface(
+    _registry_state,
+    _register_provider_in,
+)
 
 
 def get_provider(name: str) -> Optional[DashboardAuthProvider]:
     """Return the registered provider for ``name``, or None if unknown."""
-    with _lock:
-        return _providers.get(name)
+    return _registry_state.get(name)
 
 
 def list_providers() -> List[DashboardAuthProvider]:
     """All registered providers, in registration order."""
-    with _lock:
-        return list(_providers.values())
+    return _registry_state.values()
 
 
 def list_token_providers() -> List[DashboardAuthProvider]:
@@ -62,8 +78,8 @@ def list_token_providers() -> List[DashboardAuthProvider]:
     no token provider is registered — a token-authable route then fails
     closed (401), never open.
     """
-    with _lock:
-        return [p for p in _providers.values() if getattr(p, "supports_token", False)]
+    providers = _registry_state.values()
+    return [p for p in providers if getattr(p, "supports_token", False)]
 
 
 def list_session_providers() -> List[DashboardAuthProvider]:
@@ -71,11 +87,10 @@ def list_session_providers() -> List[DashboardAuthProvider]:
     sessions). The login page, /auth/login, and the gate's verify/refresh loops
     consult only these. Mirror of list_token_providers.
     """
-    with _lock:
-        return [p for p in _providers.values() if getattr(p, "supports_session", True)]
+    providers = _registry_state.values()
+    return [p for p in providers if getattr(p, "supports_session", True)]
 
 
 def clear_providers() -> None:
     """Test-only: drop all registrations."""
-    with _lock:
-        _providers.clear()
+    _registry_state.clear()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11635,7 +11635,7 @@ def main():
             # so its register_cli_command side effect runs before we read
             # _cli_commands (issue #54678).
             _resolve_deferred_platform_cli_command(_first_positional_argv())
-            for cmd_info in get_plugin_manager()._cli_commands.values():
+            for cmd_info in get_plugin_manager().get_cli_commands().values():
                 if cmd_info["name"] in seen_plugin_commands:
                     continue
                 plugin_parser = subparsers.add_parser(

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -248,7 +248,12 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    manager = get_plugin_manager()
+    accessor = getattr(manager, "get_middleware_callbacks", None)
+    if accessor is not None:
+        return accessor(kind)
+    # Backward-compatible duck typing for embedded hosts and test doubles.
+    return list(getattr(manager, "_middleware", {}).get(kind, []))
 
 
 def _run_execution_chain(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -527,6 +527,20 @@ class _PluginRegistrationView:
         self._frozen = True
 
 
+class _PluginPublicationCapability:
+    """Host-owned, fail-closed authority for one managed publication."""
+
+    __slots__ = ("_published",)
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_published", False)
+
+    def _activate(self) -> None:
+        # This is the final, non-failing publication point. Bypass plugin-
+        # controlled attribute hooks so activation can never be ambiguous.
+        object.__setattr__(self, "_published", True)
+
+
 @dataclass(frozen=True)
 class _PluginContextBinding:
     """One coherent authority target captured by a registration mutation."""
@@ -535,6 +549,7 @@ class _PluginContextBinding:
     manager: Any
     external_registries: Any
     managed_generation: Optional[int]
+    publication_capability: Optional[_PluginPublicationCapability] = None
 
 
 class _RegistrationTransaction:
@@ -661,9 +676,7 @@ class _RegistrationTransaction:
             if self.replace_owned
             else None
         )
-        context_locks = [
-            context._registration_lock for context in self.contexts
-        ]
+        context_locks = [self.manager._context_registration_lock]
         live_registry_locks = [
             self.manager._lock,
             self.tool_registry._lock,
@@ -675,6 +688,8 @@ class _RegistrationTransaction:
         acquired_locks: List[Any] = []
         revocation_started = False
         publication_started = False
+        publication_committed = False
+        publication_capability = _PluginPublicationCapability()
         context_bindings_before: List[
             tuple[PluginContext, _PluginContextBinding]
         ] = []
@@ -684,7 +699,13 @@ class _RegistrationTransaction:
             # registry lock. This blocks retained contexts before publication
             # can swap or restore their single coherent authority reference.
             for lock in context_locks:
-                lock.acquire()
+                # A registration callback may wait for this commit thread.
+                # Never wait back while it owns the shared context lock: abort
+                # this candidate and let the live registration complete.
+                if not lock.acquire(blocking=False):
+                    raise _ForceSweepAbort(
+                        "plugin publication conflicted with an active registration"
+                    )
                 acquired_locks.append(lock)
             if revoke_generation is not None:
                 # Claim cleanup before the call: an injected BaseException may
@@ -733,10 +754,13 @@ class _RegistrationTransaction:
                     manager=self.manager,
                     external_registries=None,
                     managed_generation=self.context_generation,
+                    publication_capability=publication_capability,
                 )
             self.manager._install_owned_state_locked(next_manager)
+            publication_capability._activate()
+            publication_committed = True
         except BaseException as primary:
-            if publication_started:
+            if publication_started and not publication_committed:
                 rollback_errors: List[BaseException] = []
                 rollback_steps = [
                     (
@@ -820,7 +844,11 @@ class PluginContext:
     ):
         self.manifest = manifest
         self._manager = manager
-        self._registration_lock = threading.RLock()
+        # Every context owned by this manager, including staged transaction
+        # contexts, shares the live manager's reentrant registration lock.
+        # Cross-context callback nesting is therefore same-thread re-entry,
+        # never independent-lock acquisition in an opposing order.
+        self._registration_lock = manager._context_registration_lock
         # Managed discovery supplies isolated registry transaction views.
         # Direct/runtime contexts leave them unset and target live registries.
         self._registration_binding = _PluginContextBinding(
@@ -832,6 +860,16 @@ class PluginContext:
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+
+    def _registration_binding_locked(self) -> _PluginContextBinding:
+        """Read and validate the one authority binding under its owner lock."""
+        binding = self._registration_binding
+        capability = binding.publication_capability
+        if capability is not None and not capability._published:
+            raise RuntimeError(
+                f"Plugin context for {self.manifest.name!r} is not published"
+            )
+        return binding
 
     def _ensure_live_locked(
         self,
@@ -996,7 +1034,7 @@ class PluginContext:
             )
 
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target_registry = binding.registry
             if target_registry is None:
                 from tools.registry import registry as target_registry
@@ -1103,7 +1141,7 @@ class PluginContext:
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
         as the default dispatch function via ``set_defaults(func=...)``."""
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1171,7 +1209,7 @@ class PluginContext:
             pass  # If commands module isn't available, skip the check
 
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1244,7 +1282,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1288,7 +1326,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             self._register_external_value(
                 binding, "image_gen", provider, register_provider
             )
@@ -1325,7 +1363,7 @@ class PluginContext:
             return
         try:
             with self._registration_lock:
-                binding = self._registration_binding
+                binding = self._registration_binding_locked()
                 name = self._register_external_value(
                     binding,
                     "dashboard",
@@ -1368,7 +1406,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             self._register_external_value(
                 binding,
                 "video_gen",
@@ -1403,7 +1441,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             self._register_external_value(
                 binding, "web", provider, _register_web_provider
             )
@@ -1439,7 +1477,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             self._register_external_value(
                 binding,
                 "browser",
@@ -1493,7 +1531,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             registered = self._register_external_value(
                 binding, "secret", source, register_source
             )
@@ -1536,7 +1574,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             name = self._register_external_value(
                 binding,
                 "tts",
@@ -1589,7 +1627,7 @@ class PluginContext:
             )
             return
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             name = self._register_external_value(
                 binding,
                 "stt",
@@ -1652,7 +1690,7 @@ class PluginContext:
             **entry_kwargs,
         )
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             targets = binding.external_registries
             if targets is None:
                 release_live = self._acquire_live_lease(binding)
@@ -1724,7 +1762,7 @@ class PluginContext:
                 f"action handler with an empty action_id."
             )
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1835,7 +1873,7 @@ class PluginContext:
                 merged_defaults[k] = v
 
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1883,7 +1921,7 @@ class PluginContext:
                 ", ".join(sorted(VALID_HOOKS)),
             )
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1914,7 +1952,7 @@ class PluginContext:
                 ", ".join(sorted(VALID_MIDDLEWARE)),
             )
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1963,7 +2001,7 @@ class PluginContext:
 
         qualified = f"{self.manifest.name}:{name}"
         with self._registration_lock:
-            binding = self._registration_binding
+            binding = self._registration_binding_locked()
             target = binding.manager
             release_live = self._acquire_live_lease(binding)
             try:
@@ -1995,6 +2033,7 @@ class PluginManager:
         # Discovery writers serialize here while readers keep using the live
         # generation. Plugin callbacks are never invoked under registry locks.
         self._discovery_lock = threading.RLock()
+        self._context_registration_lock = threading.RLock()
         self._lock = threading.RLock()
         self._generation = 0
         self._plugins: Dict[str, LoadedPlugin] = {}
@@ -2147,9 +2186,11 @@ class PluginManager:
         """Load plugins, publishing a force reload as one complete generation."""
         if force:
             self._reject_reentrant_force_reload(self._live_context_generation)
+            self._force_discover_and_load()
+            return
         with self._discovery_lock:
             with self._lock:
-                if self._discovered and not force:
+                if self._discovered:
                     return
             if env_var_enabled("HERMES_SAFE_MODE"):
                 logger.info("HERMES_SAFE_MODE=1 - plugin discovery skipped")
@@ -2158,7 +2199,33 @@ class PluginManager:
                     self._generation += 1
                 return
 
-            if force:
+            with self._lock:
+                self._discovered = True
+                self._generation += 1
+            try:
+                self._discover_and_load_inner()
+            except BaseException:
+                with self._lock:
+                    self._discovered = False
+                    self._generation += 1
+                raise
+
+    def _force_discover_and_load(self) -> None:
+        """Stage and publish a force generation while owning shared authority."""
+        # Acquire before discovery invokes any candidate callback. If a live
+        # registration owns the lock, fail closed without waiting back on a
+        # callback that may itself be waiting for this reload.
+        if not self._context_registration_lock.acquire(blocking=False):
+            return
+        try:
+            with self._discovery_lock:
+                if env_var_enabled("HERMES_SAFE_MODE"):
+                    logger.info("HERMES_SAFE_MODE=1 - plugin discovery skipped")
+                    with self._lock:
+                        self._discovered = True
+                        self._generation += 1
+                    return
+
                 transaction = _RegistrationTransaction(
                     self,
                     replace_owned=True,
@@ -2182,18 +2249,8 @@ class PluginManager:
                 except BaseException:
                     _restore_module_namespace(_NS_PARENT, module_snapshot)
                     raise
-                return
-
-            with self._lock:
-                self._discovered = True
-                self._generation += 1
-            try:
-                self._discover_and_load_inner()
-            except BaseException:
-                with self._lock:
-                    self._discovered = False
-                    self._generation += 1
-                raise
+        finally:
+            self._context_registration_lock.release()
 
     def _discover_and_load_inner(
         self,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -649,8 +649,6 @@ class _RegistrationTransaction:
             if self.replace_owned
             else None
         )
-        if revoke_generation is not None:
-            self.manager._begin_live_context_revocation(revoke_generation)
         locks = [
             self.manager._lock,
             self.tool_registry._lock,
@@ -659,9 +657,13 @@ class _RegistrationTransaction:
                 for surface in _EXTERNAL_COMMIT_SURFACES
             ),
         ]
-        for lock in locks:
-            lock.acquire()
+        acquired_locks: List[Any] = []
         try:
+            if revoke_generation is not None:
+                self.manager._begin_live_context_revocation(revoke_generation)
+            for lock in locks:
+                lock.acquire()
+                acquired_locks.append(lock)
             if self.manager._generation != self.manager_before._generation:
                 raise RegistryTransactionConflict(
                     "manager",
@@ -696,7 +698,7 @@ class _RegistrationTransaction:
                 context._managed_generation = self.context_generation
             self.manager._install_owned_state_locked(next_manager)
         finally:
-            for lock in reversed(locks):
+            for lock in reversed(acquired_locks):
                 lock.release()
             if revoke_generation is not None:
                 self.manager._cancel_live_context_revocation(revoke_generation)
@@ -1831,6 +1833,7 @@ class PluginManager:
         self._live_context_generation = 0
         self._live_context_condition = threading.Condition(threading.RLock())
         self._live_context_active: Dict[int, int] = {}
+        self._live_context_active_by_thread: Dict[tuple[int, int], int] = {}
         self._live_context_revoking: set[int] = set()
 
     def _record_external_registration(self, surface: str, name: str) -> None:
@@ -1844,6 +1847,8 @@ class PluginManager:
         plugin_name: str,
         generation: int,
     ) -> Callable[[], None]:
+        owner_thread_id = threading.get_ident()
+        owner_key = (generation, owner_thread_id)
         with self._live_context_condition:
             if (
                 self._live_context_generation != generation
@@ -1854,6 +1859,9 @@ class PluginManager:
                 )
             self._live_context_active[generation] = (
                 self._live_context_active.get(generation, 0) + 1
+            )
+            self._live_context_active_by_thread[owner_key] = (
+                self._live_context_active_by_thread.get(owner_key, 0) + 1
             )
 
         released = False
@@ -1870,14 +1878,32 @@ class PluginManager:
                     self._live_context_condition.notify_all()
                 else:
                     self._live_context_active[generation] = active - 1
+                thread_active = self._live_context_active_by_thread.get(owner_key, 0)
+                if thread_active <= 1:
+                    self._live_context_active_by_thread.pop(owner_key, None)
+                else:
+                    self._live_context_active_by_thread[owner_key] = thread_active - 1
 
         return release
 
+    def _reject_reentrant_force_reload(self, generation: int) -> None:
+        with self._live_context_condition:
+            if self._live_context_active_by_thread.get(
+                (generation, threading.get_ident()),
+                0,
+            ):
+                raise RuntimeError(
+                    "force reload cannot run from a live plugin registration"
+                )
+
     def _begin_live_context_revocation(self, generation: int) -> None:
         with self._live_context_condition:
+            self._reject_reentrant_force_reload(generation)
+            if self._live_context_active.get(generation, 0):
+                raise _ForceSweepAbort(
+                    "plugin force reload conflicted with an active live registration"
+                )
             self._live_context_revoking.add(generation)
-            while self._live_context_active.get(generation, 0):
-                self._live_context_condition.wait()
 
     def _cancel_live_context_revocation(self, generation: int) -> None:
         with self._live_context_condition:
@@ -1909,6 +1935,8 @@ class PluginManager:
 
     def discover_and_load(self, force: bool = False) -> None:
         """Load plugins, publishing a force reload as one complete generation."""
+        if force:
+            self._reject_reentrant_force_reload(self._live_context_generation)
         with self._discovery_lock:
             with self._lock:
                 if self._discovered and not force:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -550,9 +550,11 @@ class _RegistrationTransaction:
                 for surface in _EXTERNAL_COMMIT_SURFACES
             ),
         ]
-        for lock in locks:
-            lock.acquire()
+        acquired_locks: List[Any] = []
         try:
+            for lock in locks:
+                lock.acquire()
+                acquired_locks.append(lock)
             self.manager_before = _PluginManagerState(manager)
             self.tool_snapshot = tool_registry._take_transaction_snapshot()
             self.external_snapshots = {
@@ -560,7 +562,7 @@ class _RegistrationTransaction:
                 for surface in _EXTERNAL_COMMIT_SURFACES
             }
         finally:
-            for lock in reversed(locks):
+            for lock in reversed(acquired_locks):
                 lock.release()
 
         self.manager_view = _PluginRegistrationView(
@@ -658,6 +660,25 @@ class _RegistrationTransaction:
             ),
         ]
         acquired_locks: List[Any] = []
+        publication_started = False
+        context_bindings_before = [
+            (
+                context,
+                context._registration_registry,
+                context._registration_manager,
+                context._registration_external_registries,
+                context._managed_generation,
+            )
+            for context in self.contexts
+        ]
+
+        def restore_context_binding(binding: tuple[Any, ...]) -> None:
+            context, registry, manager, external_registries, generation = binding
+            context._registration_registry = registry
+            context._registration_manager = manager
+            context._registration_external_registries = external_registries
+            context._managed_generation = generation
+
         try:
             if revoke_generation is not None:
                 self.manager._begin_live_context_revocation(revoke_generation)
@@ -681,6 +702,7 @@ class _RegistrationTransaction:
                     prepared_external[surface],
                 )
 
+            publication_started = True
             self.tool_registry._install_prepared_transaction_locked(
                 self.tool_snapshot,
                 prepared_tools,
@@ -697,6 +719,59 @@ class _RegistrationTransaction:
                 context._registration_external_registries = None
                 context._managed_generation = self.context_generation
             self.manager._install_owned_state_locked(next_manager)
+        except BaseException as primary:
+            if publication_started:
+                rollback_errors: List[BaseException] = []
+                rollback_steps = [
+                    (
+                        "tool",
+                        lambda: self.tool_registry._restore_transaction_snapshot_exact_locked(
+                            self.tool_snapshot,
+                        ),
+                    ),
+                    *(
+                        (
+                            surface,
+                            lambda surface=surface: self.external_transactions[
+                                surface
+                            ].restore_snapshot_locked(
+                                self.external_snapshots[surface],
+                            ),
+                        )
+                        for surface in _EXTERNAL_COMMIT_SURFACES
+                    ),
+                    *(
+                        (
+                            f"context[{index}]",
+                            lambda binding=binding: restore_context_binding(binding),
+                        )
+                        for index, binding in enumerate(context_bindings_before)
+                    ),
+                    (
+                        "manager",
+                        lambda: self.manager._restore_owned_state_locked(
+                            self.manager_before,
+                        ),
+                    ),
+                ]
+                for surface, restore in rollback_steps:
+                    try:
+                        restore()
+                    except BaseException as rollback_exc:
+                        logger.critical(
+                            "Plugin publication rollback failed for %s after %s",
+                            surface,
+                            type(primary).__name__,
+                            exc_info=True,
+                        )
+                        rollback_errors.append(rollback_exc)
+                if rollback_errors:
+                    primary.__notes__ = getattr(primary, "__notes__", []) + [
+                        "Plugin publication rollback failed; process-local "
+                        "registries may be partially published. Check logs "
+                        "for every rollback failure."
+                    ]
+            raise
         finally:
             for lock in reversed(acquired_locks):
                 lock.release()
@@ -737,6 +812,8 @@ class PluginContext:
         self._subagent_lifecycle: Any = None
 
     def _ensure_live_locked(self, target: Any) -> None:
+        if getattr(target, "_frozen", False):
+            raise RuntimeError("plugin registration view is frozen")
         generation = self._managed_generation
         if generation is None or not isinstance(target, PluginManager):
             return
@@ -1932,6 +2009,24 @@ class PluginManager:
         self._discovered = state._discovered
         self._live_context_generation = state._live_context_generation
         self._generation = max(self._generation, state._generation) + 1
+
+    def _restore_owned_state_locked(self, state: Any) -> None:
+        """Restore a transaction checkpoint exactly while ``_lock`` is held."""
+        self._plugins = state._plugins
+        self._hooks = state._hooks
+        self._middleware = state._middleware
+        self._plugin_tool_names = state._plugin_tool_names
+        self._plugin_platform_names = state._plugin_platform_names
+        self._plugin_external_names = state._plugin_external_names
+        self._cli_commands = state._cli_commands
+        self._context_engine = state._context_engine
+        self._plugin_commands = state._plugin_commands
+        self._plugin_skills = state._plugin_skills
+        self._aux_tasks = state._aux_tasks
+        self._slack_action_handlers = state._slack_action_handlers
+        self._discovered = state._discovered
+        self._live_context_generation = state._live_context_generation
+        self._generation = state._generation
 
     def discover_and_load(self, force: bool = False) -> None:
         """Load plugins, publishing a force reload as one complete generation."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -439,6 +439,7 @@ class _PluginManagerState:
         self._slack_action_handlers = list(manager._slack_action_handlers)
         self._discovered = manager._discovered
         self._generation = manager._generation
+        self._live_context_generation = manager._live_context_generation
 
 
 class _PluginRegistrationView:
@@ -485,6 +486,7 @@ class _PluginRegistrationView:
         self._slack_action_handlers = list(state._slack_action_handlers)
         self._discovered = state._discovered
         self._generation = state._generation
+        self._live_context_generation = state._live_context_generation
         self._cli_ref = cli_ref
         self._lock = threading.RLock()
         self._transaction_tools_registered: List[str] = []
@@ -537,7 +539,30 @@ class _RegistrationTransaction:
         from tools.registry import registry as tool_registry
 
         self.manager = manager
-        self.manager_before = manager._snapshot_owned_state()
+        self.replace_owned = replace_owned
+        self.tool_registry = tool_registry
+        self.external_transactions = _external_registry_transactions()
+        locks = [
+            manager._lock,
+            tool_registry._lock,
+            *(
+                self.external_transactions[surface].lock
+                for surface in _EXTERNAL_COMMIT_SURFACES
+            ),
+        ]
+        for lock in locks:
+            lock.acquire()
+        try:
+            self.manager_before = _PluginManagerState(manager)
+            self.tool_snapshot = tool_registry._take_transaction_snapshot()
+            self.external_snapshots = {
+                surface: self.external_transactions[surface].take_snapshot()
+                for surface in _EXTERNAL_COMMIT_SURFACES
+            }
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
         self.manager_view = _PluginRegistrationView(
             self.manager_before,
             manager._cli_ref,
@@ -559,8 +584,6 @@ class _RegistrationTransaction:
             self.manager_view._slack_action_handlers = []
         self.manager_view._discovered = True
 
-        self.tool_registry = tool_registry
-        self.tool_snapshot = tool_registry._take_transaction_snapshot()
         removed_tool_names = (
             self.manager_before._plugin_tool_names if replace_owned else set()
         )
@@ -579,11 +602,6 @@ class _RegistrationTransaction:
             remove_policy_names=removed_policy_names,
         )
 
-        self.external_transactions = _external_registry_transactions()
-        self.external_snapshots = {
-            surface: transaction.take_snapshot()
-            for surface, transaction in self.external_transactions.items()
-        }
         self.external_views = {}
         for surface, transaction in self.external_transactions.items():
             remove_keys = (
@@ -596,6 +614,11 @@ class _RegistrationTransaction:
                 remove_keys=remove_keys,
             )
         self.contexts: List["PluginContext"] = []
+        self.context_generation = (
+            self.manager_before._live_context_generation + 1
+            if replace_owned
+            else self.manager_before._live_context_generation
+        )
 
     def context_targets(self) -> Dict[str, tuple[Any, Any]]:
         return {
@@ -617,9 +640,17 @@ class _RegistrationTransaction:
             for surface, transaction in self.external_transactions.items()
         }
         with self.manager_view._lock:
+            self.manager_view._live_context_generation = self.context_generation
             next_manager = _PluginManagerState(self.manager_view)
             self.manager_view._freeze()
 
+        revoke_generation = (
+            self.manager_before._live_context_generation
+            if self.replace_owned
+            else None
+        )
+        if revoke_generation is not None:
+            self.manager._begin_live_context_revocation(revoke_generation)
         locks = [
             self.manager._lock,
             self.tool_registry._lock,
@@ -662,10 +693,13 @@ class _RegistrationTransaction:
                 context._registration_registry = self.tool_registry
                 context._registration_manager = self.manager
                 context._registration_external_registries = None
+                context._managed_generation = self.context_generation
             self.manager._install_owned_state_locked(next_manager)
         finally:
             for lock in reversed(locks):
                 lock.release()
+            if revoke_generation is not None:
+                self.manager._cancel_live_context_revocation(revoke_generation)
 
 
 class _ForceSweepAbort(RuntimeError):
@@ -695,15 +729,32 @@ class PluginContext:
         # Direct/runtime contexts leave this unset and target the live registry.
         self._registration_registry = registration_registry
         self._registration_external_registries = registration_external_registries
+        self._managed_generation: Optional[int] = None
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+
+    def _ensure_live_locked(self, target: Any) -> None:
+        generation = self._managed_generation
+        if generation is None or not isinstance(target, PluginManager):
+            return
+        if target._live_context_generation != generation:
+            raise RuntimeError(
+                f"Plugin context for {self.manifest.name!r} is no longer live"
+            )
+
+    def _acquire_live_lease(self, target: Any) -> Callable[[], None]:
+        generation = self._managed_generation
+        if generation is None or not isinstance(target, PluginManager):
+            return lambda: None
+        return target._acquire_live_context_lease(self.manifest.name, generation)
 
     def _record_external_registration(self, surface: str, name: str) -> None:
         target = self._registration_manager
         recorder = getattr(target, "_record_external_registration", None)
         if recorder is not None:
             with target._lock:
+                self._ensure_live_locked(target)
                 recorder(surface, name)
 
     def _register_external_value(
@@ -713,15 +764,22 @@ class PluginContext:
         live_register: Callable[[Any], Any],
     ) -> Optional[str]:
         targets = self._registration_external_registries
+        target = self._registration_manager
         if targets is None:
-            result = live_register(value)
-            if surface == "secret" and not result:
-                return None
-            name = value.name
+            release_live = self._acquire_live_lease(target)
+            try:
+                result = live_register(value)
+                if surface == "secret" and not result:
+                    return None
+                name = value.name
+                if name:
+                    self._record_external_registration(surface, name)
+            finally:
+                release_live()
         else:
             transaction, staged = targets[surface]
             name = transaction.register(staged, value)
-        if name:
+        if targets is not None and name:
             self._record_external_registration(surface, name)
         return name
 
@@ -827,27 +885,33 @@ class PluginContext:
         if target_registry is None:
             from tools.registry import registry as target_registry
 
-        target_registry.register(
-            name=name,
-            toolset=toolset,
-            schema=schema,
-            handler=handler,
-            check_fn=check_fn,
-            requires_env=requires_env,
-            is_async=is_async,
-            description=description,
-            emoji=emoji,
-            override=override,
-        )
         target = self._registration_manager
-        with target._lock:
-            target._plugin_tool_names.add(name)
-            registered = getattr(
-                target, "_transaction_tools_registered", None
+        resolved_description = description or schema.get("description", "")
+        release_live = self._acquire_live_lease(target)
+        try:
+            target_registry.register(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                check_fn=check_fn,
+                requires_env=requires_env,
+                is_async=is_async,
+                description=resolved_description,
+                emoji=emoji,
+                override=override,
             )
-            if registered is not None and name not in registered:
-                registered.append(name)
-            target._generation += 1
+            with target._lock:
+                self._ensure_live_locked(target)
+                target._plugin_tool_names.add(name)
+                registered = getattr(
+                    target, "_transaction_tools_registered", None
+                )
+                if registered is not None and name not in registered:
+                    registered.append(name)
+                target._generation += 1
+        finally:
+            release_live()
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
@@ -924,6 +988,7 @@ class PluginContext:
         as the default dispatch function via ``set_defaults(func=...)``."""
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._cli_commands[name] = {
                 "name": name,
                 "help": help,
@@ -985,6 +1050,7 @@ class PluginContext:
 
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._plugin_commands[clean] = {
                 "handler": handler,
                 "description": description or "Plugin command",
@@ -1051,6 +1117,7 @@ class PluginContext:
             return
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             if getattr(target, "_frozen", False):
                 raise RuntimeError("plugin registration transaction is frozen")
             if target._context_engine is not None:
@@ -1426,11 +1493,17 @@ class PluginContext:
         )
         targets = self._registration_external_registries
         if targets is None:
-            platform_registry.register(entry)
+            target = self._registration_manager
+            release_live = self._acquire_live_lease(target)
+            try:
+                platform_registry.register(entry)
+                self._record_external_registration("platform", name)
+            finally:
+                release_live()
         else:
             _transaction, staged = targets["platform"]
             staged.register(entry)
-        self._record_external_registration("platform", name)
+            self._record_external_registration("platform", name)
         logger.debug(
             "Plugin %s registered platform: %s",
             self.manifest.name,
@@ -1488,6 +1561,7 @@ class PluginContext:
             )
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._slack_action_handlers.append(
                 (action_id, callback, self.manifest.name)
             )
@@ -1602,6 +1676,7 @@ class PluginContext:
                 merged_defaults[k] = v
 
         with target._lock:
+            self._ensure_live_locked(target)
             target._aux_tasks[key] = {
                 "key": key,
                 "display_name": display_name,
@@ -1633,6 +1708,7 @@ class PluginContext:
             )
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._hooks.setdefault(hook_name, []).append(callback)
             target._generation += 1
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
@@ -1657,6 +1733,7 @@ class PluginContext:
             )
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._middleware.setdefault(kind, []).append(callback)
             target._generation += 1
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
@@ -1699,6 +1776,7 @@ class PluginContext:
         qualified = f"{self.manifest.name}:{name}"
         target = self._registration_manager
         with target._lock:
+            self._ensure_live_locked(target)
             target._plugin_skills[qualified] = {
                 "path": path,
                 "plugin": self.manifest.name,
@@ -1750,12 +1828,61 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        self._live_context_generation = 0
+        self._live_context_condition = threading.Condition(threading.RLock())
+        self._live_context_active: Dict[int, int] = {}
+        self._live_context_revoking: set[int] = set()
 
     def _record_external_registration(self, surface: str, name: str) -> None:
         self._plugin_external_names.setdefault(surface, set()).add(name)
         if surface == "platform":
             self._plugin_platform_names.add(name)
         self._generation += 1
+
+    def _acquire_live_context_lease(
+        self,
+        plugin_name: str,
+        generation: int,
+    ) -> Callable[[], None]:
+        with self._live_context_condition:
+            if (
+                self._live_context_generation != generation
+                or generation in self._live_context_revoking
+            ):
+                raise RuntimeError(
+                    f"Plugin context for {plugin_name!r} is no longer live"
+                )
+            self._live_context_active[generation] = (
+                self._live_context_active.get(generation, 0) + 1
+            )
+
+        released = False
+
+        def release() -> None:
+            nonlocal released
+            if released:
+                return
+            released = True
+            with self._live_context_condition:
+                active = self._live_context_active.get(generation, 0)
+                if active <= 1:
+                    self._live_context_active.pop(generation, None)
+                    self._live_context_condition.notify_all()
+                else:
+                    self._live_context_active[generation] = active - 1
+
+        return release
+
+    def _begin_live_context_revocation(self, generation: int) -> None:
+        with self._live_context_condition:
+            self._live_context_revoking.add(generation)
+            while self._live_context_active.get(generation, 0):
+                self._live_context_condition.wait()
+
+    def _cancel_live_context_revocation(self, generation: int) -> None:
+        with self._live_context_condition:
+            self._live_context_revoking.discard(generation)
+            self._live_context_condition.notify_all()
 
     def _snapshot_owned_state(self) -> _PluginManagerState:
         """Take a non-aliasing checkpoint under the manager state lock."""
@@ -1777,6 +1904,7 @@ class PluginManager:
         self._aux_tasks = state._aux_tasks
         self._slack_action_handlers = state._slack_action_handlers
         self._discovered = state._discovered
+        self._live_context_generation = state._live_context_generation
         self._generation = max(self._generation, state._generation) + 1
 
     def discover_and_load(self, force: bool = False) -> None:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -45,7 +45,7 @@ import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
@@ -541,6 +541,44 @@ class _PluginPublicationCapability:
         object.__setattr__(self, "_published", True)
 
 
+def _run_cleanup_actions(
+    actions: Iterable[tuple[str, Callable[[], None]]],
+    *,
+    primary: Optional[BaseException] = None,
+    note: str = "Plugin registration cleanup failed",
+) -> None:
+    """Run every cleanup action, preserving an active primary exception."""
+    failures: List[tuple[str, BaseException]] = []
+    for label, action in actions:
+        try:
+            action()
+        except BaseException as exc:
+            logger.error("%s for %s", note, label, exc_info=True)
+            failures.append((label, exc))
+    if not failures:
+        return
+    if primary is not None:
+        primary.add_note(
+            f"{note}; attempted all cleanup actions. First failure: "
+            f"{failures[0][0]}: {type(failures[0][1]).__name__}: {failures[0][1]}"
+        )
+        for label, exc in failures[1:]:
+            primary.add_note(
+                f"Additional cleanup failure: {label}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+        return
+    first_label, first_failure = failures[0]
+    for label, exc in failures[1:]:
+        first_failure.add_note(
+            f"Additional cleanup failure: {label}: {type(exc).__name__}: {exc}"
+        )
+    first_failure.add_note(
+        f"{note}; attempted all cleanup actions. First failure at {first_label}."
+    )
+    raise first_failure
+
+
 @dataclass(frozen=True)
 class _PluginContextBinding:
     """One coherent authority target captured by a registration mutation."""
@@ -566,6 +604,7 @@ class _RegistrationTransaction:
         self.manager = manager
         self.replace_owned = replace_owned
         self.tool_registry = tool_registry
+        self.registration_lock = threading.RLock()
         self.external_transactions = _external_registry_transactions()
         locks = [
             manager._lock,
@@ -587,8 +626,13 @@ class _RegistrationTransaction:
                 for surface in _EXTERNAL_COMMIT_SURFACES
             }
         finally:
-            for lock in reversed(acquired_locks):
-                lock.release()
+            _run_cleanup_actions(
+                [
+                    (f"constructor lock[{index}]", lock.release)
+                    for index, lock in enumerate(reversed(acquired_locks))
+                ],
+                primary=sys.exc_info()[1],
+            )
 
         self.manager_view = _PluginRegistrationView(
             self.manager_before,
@@ -677,6 +721,9 @@ class _RegistrationTransaction:
             else None
         )
         context_locks = [self.manager._context_registration_lock]
+        context_locks.extend(
+            dict.fromkeys(context._registration_lock for context in self.contexts)
+        )
         live_registry_locks = [
             self.manager._lock,
             self.tool_registry._lock,
@@ -688,11 +735,11 @@ class _RegistrationTransaction:
         acquired_locks: List[Any] = []
         revocation_started = False
         publication_started = False
-        publication_committed = False
         publication_capability = _PluginPublicationCapability()
         context_bindings_before: List[
             tuple[PluginContext, _PluginContextBinding]
         ] = []
+        active_primary: Optional[BaseException] = None
 
         try:
             # Binding locks always precede every live manager/tool/external
@@ -758,9 +805,9 @@ class _RegistrationTransaction:
                 )
             self.manager._install_owned_state_locked(next_manager)
             publication_capability._activate()
-            publication_committed = True
         except BaseException as primary:
-            if publication_started and not publication_committed:
+            active_primary = primary
+            if publication_started and not publication_capability._published:
                 rollback_errors: List[BaseException] = []
                 rollback_steps = [
                     (
@@ -815,10 +862,23 @@ class _RegistrationTransaction:
                     ]
             raise
         finally:
-            for lock in reversed(acquired_locks):
-                lock.release()
+            cleanup_actions: List[tuple[str, Callable[[], None]]] = [
+                (f"commit lock[{index}]", lock.release)
+                for index, lock in enumerate(reversed(acquired_locks))
+            ]
             if revocation_started:
-                self.manager._cancel_live_context_revocation(revoke_generation)
+                cleanup_actions.append(
+                    (
+                        "live context revocation",
+                        lambda: self.manager._cancel_live_context_revocation(
+                            revoke_generation
+                        ),
+                    )
+                )
+            _run_cleanup_actions(
+                cleanup_actions,
+                primary=sys.exc_info()[1] or active_primary,
+            )
 
 
 class _ForceSweepAbort(RuntimeError):
@@ -841,14 +901,13 @@ class PluginContext:
         registration_manager: Any = None,
         registration_registry: Any = None,
         registration_external_registries: Any = None,
+        registration_lock: Any = None,
     ):
         self.manifest = manifest
         self._manager = manager
-        # Every context owned by this manager, including staged transaction
-        # contexts, shares the live manager's reentrant registration lock.
-        # Cross-context callback nesting is therefore same-thread re-entry,
-        # never independent-lock acquisition in an opposing order.
-        self._registration_lock = manager._context_registration_lock
+        # Live contexts share the manager lock; staged transaction contexts use
+        # a transaction-local lock and join the live ordering only at commit.
+        self._registration_lock = registration_lock or manager._context_registration_lock
         # Managed discovery supplies isolated registry transaction views.
         # Direct/runtime contexts leave them unset and target live registries.
         self._registration_binding = _PluginContextBinding(
@@ -2211,46 +2270,38 @@ class PluginManager:
                 raise
 
     def _force_discover_and_load(self) -> None:
-        """Stage and publish a force generation while owning shared authority."""
-        # Acquire before discovery invokes any candidate callback. If a live
-        # registration owns the lock, fail closed without waiting back on a
-        # callback that may itself be waiting for this reload.
-        if not self._context_registration_lock.acquire(blocking=False):
-            return
-        try:
-            with self._discovery_lock:
-                if env_var_enabled("HERMES_SAFE_MODE"):
-                    logger.info("HERMES_SAFE_MODE=1 - plugin discovery skipped")
-                    with self._lock:
-                        self._discovered = True
-                        self._generation += 1
-                    return
+        """Stage and publish a force generation under discovery serialization."""
+        with self._discovery_lock:
+            if env_var_enabled("HERMES_SAFE_MODE"):
+                logger.info("HERMES_SAFE_MODE=1 - plugin discovery skipped")
+                with self._lock:
+                    self._discovered = True
+                    self._generation += 1
+                return
 
-                transaction = _RegistrationTransaction(
-                    self,
-                    replace_owned=True,
-                )
-                module_snapshot = _snapshot_module_namespace(_NS_PARENT)
-                try:
-                    self._discover_and_load_inner(transaction)
-                    transaction.commit()
-                except (_ForceSweepAbort, RegistryTransactionConflict) as exc:
-                    _restore_module_namespace(_NS_PARENT, module_snapshot)
-                    if isinstance(exc, RegistryTransactionConflict):
-                        logger.warning(
-                            "Plugin force-reload commit conflict: "
-                            "surface=%s expected_generation=%d "
-                            "actual_generation=%d; retaining prior generation",
-                            exc.surface,
-                            exc.expected_generation,
-                            exc.actual_generation,
-                        )
-                    return
-                except BaseException:
-                    _restore_module_namespace(_NS_PARENT, module_snapshot)
-                    raise
-        finally:
-            self._context_registration_lock.release()
+            transaction = _RegistrationTransaction(
+                self,
+                replace_owned=True,
+            )
+            module_snapshot = _snapshot_module_namespace(_NS_PARENT)
+            try:
+                self._discover_and_load_inner(transaction)
+                transaction.commit()
+            except (_ForceSweepAbort, RegistryTransactionConflict) as exc:
+                _restore_module_namespace(_NS_PARENT, module_snapshot)
+                if isinstance(exc, RegistryTransactionConflict):
+                    logger.warning(
+                        "Plugin force-reload commit conflict: "
+                        "surface=%s expected_generation=%d "
+                        "actual_generation=%d; retaining prior generation",
+                        exc.surface,
+                        exc.expected_generation,
+                        exc.actual_generation,
+                    )
+                return
+            except BaseException:
+                _restore_module_namespace(_NS_PARENT, module_snapshot)
+                raise
 
     def _discover_and_load_inner(
         self,
@@ -2734,6 +2785,7 @@ class PluginManager:
             registration_manager=transaction.manager_view,
             registration_registry=transaction.tool_view,
             registration_external_registries=transaction.context_targets(),
+            registration_lock=transaction.registration_lock,
         )
         try:
             transaction.tool_view.register_plugin_override_policy(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import importlib.metadata
 import importlib.util
 import inspect
@@ -219,6 +220,125 @@ ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 _NS_PARENT = "hermes_plugins"
 
 
+def _snapshot_module_namespace(root: str) -> Dict[str, types.ModuleType]:
+    """Capture module identities for *root* and all descendants."""
+    prefix = f"{root}."
+    return {
+        name: module
+        for name, module in sys.modules.items()
+        if name == root or name.startswith(prefix)
+    }
+
+
+def _restore_module_namespace(
+    root: str,
+    snapshot: Dict[str, types.ModuleType],
+) -> None:
+    """Remove modules created in an attempt, then restore prior identities."""
+    prefix = f"{root}."
+    for name in list(sys.modules):
+        if name == root or name.startswith(prefix):
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _directory_module_name(manifest: "PluginManifest") -> str:
+    key = manifest.key or manifest.name
+    slug = key.replace("/", "__").replace("-", "_")
+    return f"{_NS_PARENT}.{slug}"
+
+
+class _ExternalRegistrySnapshot:
+    """Opaque checkpoint for one legacy external registration surface."""
+
+    __slots__ = ("_surface", "_owner", "_items", "_extra")
+
+    def __init__(
+        self,
+        surface: str,
+        owner: Any,
+        items: tuple,
+        extra: Any = None,
+    ) -> None:
+        self._surface = surface
+        self._owner = owner
+        self._items = items
+        self._extra = extra
+
+
+_PROVIDER_REGISTRY_MODULES = {
+    "image_gen": "agent.image_gen_registry",
+    "video_gen": "agent.video_gen_registry",
+    "web": "agent.web_search_registry",
+    "browser": "agent.browser_registry",
+    "tts": "agent.tts_registry",
+    "stt": "agent.transcription_registry",
+    "dashboard": "hermes_cli.dashboard_auth.registry",
+}
+_EXTERNAL_REGISTRY_SURFACES = (
+    "platform",
+    "image_gen",
+    "video_gen",
+    "web",
+    "browser",
+    "secret",
+    "tts",
+    "stt",
+    "dashboard",
+)
+
+
+def _take_external_registry_snapshot(surface: str) -> _ExternalRegistrySnapshot:
+    """Checkpoint a traced PluginContext external surface without exposing maps."""
+    if surface == "platform":
+        from gateway.platform_registry import platform_registry
+
+        return _ExternalRegistrySnapshot(
+            surface,
+            platform_registry,
+            tuple(platform_registry._entries.items()),
+            tuple(platform_registry._deferred.items()),
+        )
+    if surface == "secret":
+        module = importlib.import_module("agent.secret_sources.registry")
+        return _ExternalRegistrySnapshot(
+            surface,
+            module,
+            tuple(module._SOURCES.items()),
+            module._BUILTINS_LOADED,
+        )
+    module_name = _PROVIDER_REGISTRY_MODULES.get(surface)
+    if module_name is None:
+        raise ValueError(f"unsupported external plugin registry surface: {surface}")
+    module = importlib.import_module(module_name)
+    with module._lock:
+        items = tuple(module._providers.items())
+    return _ExternalRegistrySnapshot(surface, module, items)
+
+
+def _restore_external_registry_snapshot(
+    snapshot: _ExternalRegistrySnapshot,
+) -> None:
+    """Restore an external checkpoint; no plugin callback is invoked."""
+    if snapshot._surface == "platform":
+        registry = snapshot._owner
+        registry._entries.clear()
+        registry._entries.update(snapshot._items)
+        registry._deferred.clear()
+        registry._deferred.update(snapshot._extra)
+        return
+    if snapshot._surface == "secret":
+        module = snapshot._owner
+        module._SOURCES.clear()
+        module._SOURCES.update(snapshot._items)
+        module._BUILTINS_LOADED = snapshot._extra
+        return
+    module = snapshot._owner
+    with module._lock:
+        module._providers.clear()
+        module._providers.update(snapshot._items)
+
+
 def _env_enabled(name: str) -> bool:
     """Return True when an env var is set to a truthy opt-in value."""
     return env_var_enabled(name)
@@ -332,6 +452,101 @@ class LoadedPlugin:
     deferred: bool = False
 
 
+class _PluginManagerState:
+    """Host-private, identity-preserving snapshot of manager-owned state."""
+
+    def __init__(self, manager: "PluginManager") -> None:
+        self._plugins = dict(manager._plugins)
+        self._hooks = {
+            name: list(callbacks) for name, callbacks in manager._hooks.items()
+        }
+        self._middleware = {
+            name: list(callbacks)
+            for name, callbacks in manager._middleware.items()
+        }
+        self._plugin_tool_names = set(manager._plugin_tool_names)
+        self._plugin_platform_names = set(manager._plugin_platform_names)
+        self._cli_commands = {
+            name: dict(entry) for name, entry in manager._cli_commands.items()
+        }
+        self._context_engine = manager._context_engine
+        self._plugin_commands = {
+            name: dict(entry) for name, entry in manager._plugin_commands.items()
+        }
+        self._plugin_skills = {
+            name: dict(entry) for name, entry in manager._plugin_skills.items()
+        }
+        self._aux_tasks = {
+            name: {
+                **entry,
+                "defaults": dict(entry.get("defaults", {})),
+            }
+            for name, entry in manager._aux_tasks.items()
+        }
+        self._slack_action_handlers = list(manager._slack_action_handlers)
+        self._discovered = manager._discovered
+
+
+class _PluginRegistrationView:
+    """Isolated manager facade populated while arbitrary plugin code runs."""
+
+    def __init__(
+        self,
+        state: _PluginManagerState,
+        cli_ref: Any,
+    ) -> None:
+        # Clone every list/dict again: the rollback checkpoint and staging view
+        # must never alias one another.
+        self._plugins = dict(state._plugins)
+        self._hooks = {
+            name: list(callbacks) for name, callbacks in state._hooks.items()
+        }
+        self._middleware = {
+            name: list(callbacks)
+            for name, callbacks in state._middleware.items()
+        }
+        self._plugin_tool_names = set(state._plugin_tool_names)
+        self._plugin_platform_names = set(state._plugin_platform_names)
+        self._cli_commands = {
+            name: dict(entry) for name, entry in state._cli_commands.items()
+        }
+        self._context_engine = state._context_engine
+        self._plugin_commands = {
+            name: dict(entry) for name, entry in state._plugin_commands.items()
+        }
+        self._plugin_skills = {
+            name: dict(entry) for name, entry in state._plugin_skills.items()
+        }
+        self._aux_tasks = {
+            name: {
+                **entry,
+                "defaults": dict(entry.get("defaults", {})),
+            }
+            for name, entry in state._aux_tasks.items()
+        }
+        self._slack_action_handlers = list(state._slack_action_handlers)
+        self._discovered = state._discovered
+        self._cli_ref = cli_ref
+        self._lock = threading.RLock()
+        self._transaction_tools_registered: List[str] = []
+        self._transaction_commands_registered: List[str] = []
+        self._external_registry_snapshots: Dict[
+            str, _ExternalRegistrySnapshot
+        ] = {}
+
+    def _checkpoint_external_registry(self, surface: str) -> None:
+        if surface not in self._external_registry_snapshots:
+            self._external_registry_snapshots[surface] = (
+                _take_external_registry_snapshot(surface)
+            )
+
+    def _rollback_external_registries(self) -> None:
+        for snapshot in reversed(
+            list(self._external_registry_snapshots.values())
+        ):
+            _restore_external_registry_snapshot(snapshot)
+
+
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
@@ -339,12 +554,33 @@ class LoadedPlugin:
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
 
-    def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
+    def __init__(
+        self,
+        manifest: PluginManifest,
+        manager: "PluginManager",
+        *,
+        registration_manager: Any = None,
+        registration_registry: Any = None,
+    ):
         self.manifest = manifest
         self._manager = manager
+        self._registration_manager = registration_manager or manager
+        # Managed discovery supplies an isolated ToolRegistry transaction view.
+        # Direct/runtime contexts leave this unset and target the live registry.
+        self._registration_registry = registration_registry
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+
+    def _checkpoint_external_registry(self, surface: str) -> None:
+        """Lazily journal an external surface during managed plugin loading."""
+        checkpoint = getattr(
+            self._registration_manager,
+            "_checkpoint_external_registry",
+            None,
+        )
+        if checkpoint is not None:
+            checkpoint(surface)
 
     # -- host-owned LLM access ----------------------------------------------
 
@@ -444,9 +680,11 @@ class PluginContext:
                 f"in config.yaml to allow this plugin to replace built-in tools."
             )
 
-        from tools.registry import registry
+        target_registry = self._registration_registry
+        if target_registry is None:
+            from tools.registry import registry as target_registry
 
-        registry.register(
+        target_registry.register(
             name=name,
             toolset=toolset,
             schema=schema,
@@ -458,7 +696,14 @@ class PluginContext:
             emoji=emoji,
             override=override,
         )
-        self._manager._plugin_tool_names.add(name)
+        target = self._registration_manager
+        with target._lock:
+            target._plugin_tool_names.add(name)
+            registered = getattr(
+                target, "_transaction_tools_registered", None
+            )
+            if registered is not None and name not in registered:
+                registered.append(name)
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
@@ -533,14 +778,16 @@ class PluginContext:
         The *setup_fn* receives an argparse subparser and should add any
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
         as the default dispatch function via ``set_defaults(func=...)``."""
-        self._manager._cli_commands[name] = {
-            "name": name,
-            "help": help,
-            "description": description,
-            "setup_fn": setup_fn,
-            "handler_fn": handler_fn,
-            "plugin": self.manifest.name,
-        }
+        target = self._registration_manager
+        with target._lock:
+            target._cli_commands[name] = {
+                "name": name,
+                "help": help,
+                "description": description,
+                "setup_fn": setup_fn,
+                "handler_fn": handler_fn,
+                "plugin": self.manifest.name,
+            }
         logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
 
     # -- slash command registration -------------------------------------------
@@ -591,12 +838,19 @@ class PluginContext:
         except Exception:
             pass  # If commands module isn't available, skip the check
 
-        self._manager._plugin_commands[clean] = {
-            "handler": handler,
-            "description": description or "Plugin command",
-            "plugin": self.manifest.name,
-            "args_hint": (args_hint or "").strip(),
-        }
+        target = self._registration_manager
+        with target._lock:
+            target._plugin_commands[clean] = {
+                "handler": handler,
+                "description": description or "Plugin command",
+                "plugin": self.manifest.name,
+                "args_hint": (args_hint or "").strip(),
+            }
+            registered = getattr(
+                target, "_transaction_commands_registered", None
+            )
+            if registered is not None and clean not in registered:
+                registered.append(clean)
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
     # -- tool dispatch -------------------------------------------------------
@@ -640,13 +894,6 @@ class PluginContext:
 
         The engine must be an instance of ``agent.context_engine.ContextEngine``.
         """
-        if self._manager._context_engine is not None:
-            logger.warning(
-                "Plugin '%s' tried to register a context engine, but one is "
-                "already registered. Only one context engine plugin is allowed.",
-                self.manifest.name,
-            )
-            return
         # Defer the import to avoid circular deps at module level
         from agent.context_engine import ContextEngine
         if not isinstance(engine, ContextEngine):
@@ -656,7 +903,16 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._manager._context_engine = engine
+        target = self._registration_manager
+        with target._lock:
+            if target._context_engine is not None:
+                logger.warning(
+                    "Plugin '%s' tried to register a context engine, but one is "
+                    "already registered. Only one context engine plugin is allowed.",
+                    self.manifest.name,
+                )
+                return
+            target._context_engine = engine
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -683,6 +939,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("image_gen")
         register_provider(provider)
         logger.info(
             "Plugin '%s' registered image_gen provider: %s",
@@ -715,6 +972,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("dashboard")
         try:
             register_provider(provider)
         except (TypeError, ValueError) as e:
@@ -750,6 +1008,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("video_gen")
         _register_video_provider(provider)
         logger.info(
             "Plugin '%s' registered video_gen provider: %s",
@@ -778,6 +1037,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("web")
         _register_web_provider(provider)
         logger.info(
             "Plugin '%s' registered web provider: %s",
@@ -810,6 +1070,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("browser")
         _register_browser_provider(provider)
         logger.info(
             "Plugin '%s' registered browser provider: %s",
@@ -857,6 +1118,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("secret")
         if register_source(source):
             logger.info(
                 "Plugin '%s' registered secret source: %s",
@@ -895,6 +1157,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("tts")
         _register_tts_provider(provider)
         logger.info(
             "Plugin '%s' registered TTS provider: %s",
@@ -939,6 +1202,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
+        self._checkpoint_external_registry("stt")
         _register_stt_provider(provider)
         logger.info(
             "Plugin '%s' registered transcription provider: %s",
@@ -993,8 +1257,11 @@ class PluginContext:
             source="plugin",
             **entry_kwargs,
         )
+        self._checkpoint_external_registry("platform")
         platform_registry.register(entry)
-        self._manager._plugin_platform_names.add(name)
+        target = self._registration_manager
+        with target._lock:
+            target._plugin_platform_names.add(name)
         logger.debug(
             "Plugin %s registered platform: %s",
             self.manifest.name,
@@ -1050,9 +1317,11 @@ class PluginContext:
                 f"Plugin '{self.manifest.name}' tried to register a Slack "
                 f"action handler with an empty action_id."
             )
-        self._manager._slack_action_handlers.append(
-            (action_id, callback, self.manifest.name)
-        )
+        target = self._registration_manager
+        with target._lock:
+            target._slack_action_handlers.append(
+                (action_id, callback, self.manifest.name)
+            )
         logger.debug(
             "Plugin %s registered Slack action handler: %s",
             self.manifest.name,
@@ -1138,7 +1407,9 @@ class PluginContext:
             )
 
         # Reject duplicate registrations across plugins
-        existing = self._manager._aux_tasks.get(key)
+        target = self._registration_manager
+        with target._lock:
+            existing = target._aux_tasks.get(key)
         if existing is not None and existing.get("plugin") != self.manifest.name:
             raise ValueError(
                 f"Plugin '{self.manifest.name}' cannot register auxiliary task "
@@ -1160,13 +1431,14 @@ class PluginContext:
             for k, v in defaults.items():
                 merged_defaults[k] = v
 
-        self._manager._aux_tasks[key] = {
-            "key": key,
-            "display_name": display_name,
-            "description": description,
-            "defaults": merged_defaults,
-            "plugin": self.manifest.name,
-        }
+        with target._lock:
+            target._aux_tasks[key] = {
+                "key": key,
+                "display_name": display_name,
+                "description": description,
+                "defaults": merged_defaults,
+                "plugin": self.manifest.name,
+            }
         logger.debug(
             "Plugin %s registered auxiliary task: %s (%s)",
             self.manifest.name,
@@ -1188,7 +1460,9 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
-        self._manager._hooks.setdefault(hook_name, []).append(callback)
+        target = self._registration_manager
+        with target._lock:
+            target._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -1209,7 +1483,9 @@ class PluginContext:
                 kind,
                 ", ".join(sorted(VALID_MIDDLEWARE)),
             )
-        self._manager._middleware.setdefault(kind, []).append(callback)
+        target = self._registration_manager
+        with target._lock:
+            target._middleware.setdefault(kind, []).append(callback)
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
 
     # -- skill registration -------------------------------------------------
@@ -1248,12 +1524,14 @@ class PluginContext:
             raise FileNotFoundError(f"SKILL.md not found at {path}")
 
         qualified = f"{self.manifest.name}:{name}"
-        self._manager._plugin_skills[qualified] = {
-            "path": path,
-            "plugin": self.manifest.name,
-            "bare_name": name,
-            "description": description,
-        }
+        target = self._registration_manager
+        with target._lock:
+            target._plugin_skills[qualified] = {
+                "path": path,
+                "plugin": self.manifest.name,
+                "bare_name": name,
+                "description": description,
+            }
         logger.debug(
             "Plugin %s registered skill: %s",
             self.manifest.name, qualified,
@@ -1268,6 +1546,10 @@ class PluginManager:
     """Central manager that discovers, loads, and invokes plugins."""
 
     def __init__(self) -> None:
+        # Lock order when both registries are touched is always:
+        # ToolRegistry first, then PluginManager. Plugin callbacks are never
+        # invoked while this state lock is held.
+        self._lock = threading.RLock()
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
@@ -1290,6 +1572,167 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+    def _snapshot_owned_state(self) -> _PluginManagerState:
+        """Take a non-aliasing checkpoint under the manager state lock."""
+        with self._lock:
+            return _PluginManagerState(self)
+
+    def _replace_owned_state(self, state: Any) -> None:
+        """Atomically replace every manager-owned registration surface."""
+        with self._lock:
+            self._install_owned_state_locked(state)
+
+    def _install_owned_state_locked(self, state: Any) -> None:
+        """Install already-independent manager state while ``_lock`` is held."""
+        self._plugins = state._plugins
+        self._hooks = state._hooks
+        self._middleware = state._middleware
+        self._plugin_tool_names = state._plugin_tool_names
+        self._plugin_platform_names = state._plugin_platform_names
+        self._cli_commands = state._cli_commands
+        self._context_engine = state._context_engine
+        self._plugin_commands = state._plugin_commands
+        self._plugin_skills = state._plugin_skills
+        self._aux_tasks = state._aux_tasks
+        self._slack_action_handlers = state._slack_action_handlers
+        self._discovered = state._discovered
+
+    def _clear_owned_state_for_discovery(self) -> None:
+        """Install one coherent empty discovery state under the lock."""
+        with self._lock:
+            self._plugins = {}
+            self._hooks = {}
+            self._middleware = {}
+            self._plugin_tool_names = set()
+            self._plugin_platform_names = set()
+            self._cli_commands = {}
+            self._plugin_commands = {}
+            self._plugin_skills = {}
+            self._aux_tasks = {}
+            self._slack_action_handlers = []
+            self._context_engine = None
+
+    def _commit_registration_view(
+        self,
+        before: _PluginManagerState,
+        staged: _PluginRegistrationView,
+        plugin_id: str,
+        loaded: LoadedPlugin,
+        tool_registry: Any,
+        tool_snapshot: Any,
+        staged_tool_registry: Any,
+        context: PluginContext,
+    ) -> None:
+        """Atomically commit staged tool and manager state.
+
+        The fixed live-lock order is ToolRegistry then PluginManager. Tool
+        state is conflict-checked against the exact baseline before either
+        registry changes. Both next states are built independently first, so
+        an error cannot expose a half-applied registration.
+        """
+        prepared_tools = tool_registry._prepare_transaction_commit(
+            tool_snapshot,
+            staged_tool_registry,
+        )
+
+        tool_registry._lock.acquire()
+        manager_locked = False
+        install_attempted = False
+        manager_at_commit = None
+        try:
+            self._lock.acquire()
+            manager_locked = True
+            tool_registry._validate_prepared_transaction_locked(
+                tool_snapshot,
+                prepared_tools,
+            )
+            manager_at_commit = _PluginManagerState(self)
+            next_manager = self._build_committed_state_locked(
+                before,
+                staged,
+                plugin_id,
+                loaded,
+            )
+            try:
+                install_attempted = True
+                tool_registry._install_prepared_transaction_locked(
+                    tool_snapshot,
+                    prepared_tools,
+                )
+                self._install_owned_state_locked(next_manager)
+                # Callbacks may retain ctx. Flip both registration targets
+                # before readers can observe the committed manager state.
+                context._registration_registry = tool_registry
+                context._registration_manager = self
+            except BaseException:
+                if install_attempted:
+                    tool_registry._restore_transaction_snapshot_locked(
+                        tool_snapshot
+                    )
+                if manager_at_commit is not None:
+                    self._install_owned_state_locked(manager_at_commit)
+                raise
+        finally:
+            # Publish tools first. A tool reader that immediately asks for
+            # manager attribution blocks until the new manager state is ready.
+            tool_registry._lock.release()
+            if manager_locked:
+                self._lock.release()
+
+    def _build_committed_state_locked(
+        self,
+        before: _PluginManagerState,
+        staged: _PluginRegistrationView,
+        plugin_id: str,
+        loaded: LoadedPlugin,
+    ) -> _PluginManagerState:
+        """Build the merged manager state without mutating the live manager."""
+        if staged._context_engine is not before._context_engine:
+            if self._context_engine is not before._context_engine:
+                raise RuntimeError(
+                    "context engine changed during plugin registration"
+                )
+
+        committed = _PluginManagerState(self)
+        for name, callbacks in staged._hooks.items():
+            baseline_count = len(before._hooks.get(name, []))
+            additions = callbacks[baseline_count:]
+            if additions:
+                committed._hooks.setdefault(name, []).extend(additions)
+        for name, callbacks in staged._middleware.items():
+            baseline_count = len(before._middleware.get(name, []))
+            additions = callbacks[baseline_count:]
+            if additions:
+                committed._middleware.setdefault(name, []).extend(additions)
+
+        committed._plugin_tool_names.update(
+            staged._plugin_tool_names - before._plugin_tool_names
+        )
+        committed._plugin_platform_names.update(
+            staged._plugin_platform_names - before._plugin_platform_names
+        )
+
+        for attr in (
+            "_cli_commands",
+            "_plugin_commands",
+            "_plugin_skills",
+            "_aux_tasks",
+        ):
+            committed_map = getattr(committed, attr)
+            before_map = getattr(before, attr)
+            staged_map = getattr(staged, attr)
+            for name, entry in staged_map.items():
+                if name not in before_map or entry != before_map[name]:
+                    committed_map[name] = dict(entry)
+
+        slack_additions = staged._slack_action_handlers[
+            len(before._slack_action_handlers):
+        ]
+        committed._slack_action_handlers.extend(slack_additions)
+        if staged._context_engine is not before._context_engine:
+            committed._context_engine = staged._context_engine
+        committed._plugins[plugin_id] = loaded
+        return committed
 
     # -----------------------------------------------------------------------
     # Public
@@ -1302,35 +1745,54 @@ class PluginManager:
         changes or newly-added bundled backends become visible in long-lived
         sessions without requiring a full agent restart.
         """
-        if self._discovered and not force:
-            return
+        with self._lock:
+            if self._discovered and not force:
+                return
         if env_var_enabled("HERMES_SAFE_MODE"):
             logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
-            self._discovered = True
+            with self._lock:
+                self._discovered = True
             return
+        previous_state = self._snapshot_owned_state() if force else None
+        tool_snapshot = None
+        module_snapshot = None
+        external_snapshots: List[_ExternalRegistrySnapshot] = []
         if force:
-            self._plugins.clear()
-            self._hooks.clear()
-            self._middleware.clear()
-            self._plugin_tool_names.clear()
-            self._plugin_platform_names.clear()
-            self._cli_commands.clear()
-            self._plugin_commands.clear()
-            self._plugin_skills.clear()
-            self._aux_tasks.clear()
-            self._slack_action_handlers.clear()
-            self._context_engine = None
+            from tools.registry import registry as _registry
+
+            tool_snapshot = _registry._take_transaction_snapshot()
+            external_snapshots = [
+                _take_external_registry_snapshot(surface)
+                for surface in _EXTERNAL_REGISTRY_SURFACES
+            ]
+            module_snapshot = _snapshot_module_namespace(_NS_PARENT)
+            self._clear_owned_state_for_discovery()
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty
         # registry" — callers swallow the exception and would otherwise be
         # permanently stranded on the early-return above (the "No web provider
         # configured" class of failures).
-        self._discovered = True
+        with self._lock:
+            self._discovered = True
         try:
             self._discover_and_load_inner()
         except BaseException:
-            self._discovered = False
+            if force:
+                from tools.registry import registry as _registry
+
+                assert previous_state is not None
+                assert tool_snapshot is not None
+                assert module_snapshot is not None
+                # Fixed rollback order: ToolRegistry, module cache, manager.
+                _registry._restore_transaction_snapshot(tool_snapshot)
+                for snapshot in reversed(external_snapshots):
+                    _restore_external_registry_snapshot(snapshot)
+                _restore_module_namespace(_NS_PARENT, module_snapshot)
+                self._replace_owned_state(previous_state)
+            else:
+                with self._lock:
+                    self._discovered = False
             raise
 
     def _discover_and_load_inner(self) -> None:
@@ -1401,6 +1863,7 @@ class PluginManager:
         winners: Dict[str, PluginManifest] = {}
         for manifest in manifests:
             winners[manifest.key or manifest.name] = manifest
+
         for manifest in winners.values():
             lookup_key = manifest.key or manifest.name
 
@@ -1409,7 +1872,8 @@ class PluginManager:
             if lookup_key in disabled or manifest.name in disabled:
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
                 loaded.error = "disabled via config"
-                self._plugins[lookup_key] = loaded
+                with self._lock:
+                    self._plugins[lookup_key] = loaded
                 logger.debug("Skipping disabled plugin '%s'", lookup_key)
                 continue
 
@@ -1421,7 +1885,8 @@ class PluginManager:
                 loaded.error = (
                     "exclusive plugin — activate via <category>.provider config"
                 )
-                self._plugins[lookup_key] = loaded
+                with self._lock:
+                    self._plugins[lookup_key] = loaded
                 logger.debug(
                     "Skipping '%s' (exclusive, handled by category discovery)",
                     lookup_key,
@@ -1436,7 +1901,8 @@ class PluginManager:
             # override semantics between bundled and user plugins.
             if manifest.kind == "model-provider":
                 loaded = LoadedPlugin(manifest=manifest, enabled=True)
-                self._plugins[lookup_key] = loaded
+                with self._lock:
+                    self._plugins[lookup_key] = loaded
                 logger.debug(
                     "Skipping '%s' (model-provider, handled by providers/ discovery)",
                     lookup_key,
@@ -1480,7 +1946,8 @@ class PluginManager:
                     "not enabled in config (run `hermes plugins enable {}` to activate)"
                     .format(lookup_key)
                 )
-                self._plugins[lookup_key] = loaded
+                with self._lock:
+                    self._plugins[lookup_key] = loaded
                 logger.debug(
                     "Skipping '%s' (not in plugins.enabled)", lookup_key
                 )
@@ -1488,10 +1955,15 @@ class PluginManager:
             self._load_plugin(manifest)
 
         if manifests:
+            with self._lock:
+                found_count = len(self._plugins)
+                enabled_count = sum(
+                    1 for plugin in self._plugins.values() if plugin.enabled
+                )
             logger.info(
                 "Plugin discovery complete: %d found, %d enabled",
-                len(self._plugins),
-                sum(1 for p in self._plugins.values() if p.enabled),
+                found_count,
+                enabled_count,
             )
 
     # -----------------------------------------------------------------------
@@ -1740,7 +2212,8 @@ class PluginManager:
         # (tools/hooks/commands attribution) when the loader fires.
         loaded = LoadedPlugin(manifest=manifest, enabled=True)
         loaded.deferred = True
-        self._plugins[lookup_key] = loaded
+        with self._lock:
+            self._plugins[lookup_key] = loaded
 
         def _loader(_manifest: PluginManifest = manifest) -> None:
             self._load_plugin(_manifest)
@@ -1773,80 +2246,110 @@ class PluginManager:
         )
 
         from tools.registry import registry as _registry
-        _plugin_id = manifest.key or manifest.name
-        _slug = _plugin_id.replace("/", "__").replace("-", "_")
-        _registry.register_plugin_override_policy(
-            f"{_NS_PARENT}.{_slug}",
-            PluginContext(manifest, self)._tool_override_allowed(""),
+
+        plugin_id = manifest.key or manifest.name
+        module_root = (
+            _directory_module_name(manifest)
+            if manifest.source in {"user", "project", "bundled"}
+            else None
+        )
+        manager_before = self._snapshot_owned_state()
+        registration_view = _PluginRegistrationView(
+            manager_before,
+            self._cli_ref,
+        )
+        tool_before = _registry._take_transaction_snapshot()
+        tool_registration_view = _registry._create_transaction_view(tool_before)
+        modules_before = (
+            _snapshot_module_namespace(module_root) if module_root else {}
+        )
+        phase = "import"
+        context = PluginContext(
+            manifest,
+            self,
+            registration_manager=registration_view,
+            registration_registry=tool_registration_view,
         )
         try:
+            tool_registration_view.register_plugin_override_policy(
+                module_root or plugin_id,
+                context._tool_override_allowed(""),
+            )
             if manifest.source in {"user", "project", "bundled"}:
                 module = self._load_directory_module(manifest)
             else:
                 module = self._load_entrypoint_module(manifest)
 
             loaded.module = module
-
-            # Call register()
             register_fn = getattr(module, "register", None)
             if register_fn is None:
-                loaded.error = "no register() function"
-                logger.warning("Plugin '%s' has no register() function", manifest.name)
-            else:
-                ctx = PluginContext(manifest, self)
-                # Snapshot registry state BEFORE register() so each registry's
-                # attribution counts only what THIS plugin actually added.
-                # The previous approach diffed names against all already-loaded
-                # plugins, which mis-credited a plugin that registered a hook /
-                # middleware / tool name an earlier plugin had already used:
-                # the shared name was attributed to the first plugin only, so
-                # later plugins under-reported in `hermes plugins list`.
-                _tools_before = set(self._plugin_tool_names)
-                _hook_counts_before = {
-                    h: len(cbs) for h, cbs in self._hooks.items()
-                }
-                _mw_counts_before = {
-                    kind: len(cbs) for kind, cbs in self._middleware.items()
-                }
-                register_fn(ctx)
-                loaded.tools_registered = [
-                    t for t in self._plugin_tool_names
-                    if t not in _tools_before
-                ]
-                loaded.hooks_registered = [
-                    h
-                    for h, cbs in self._hooks.items()
-                    if len(cbs) > _hook_counts_before.get(h, 0)
-                ]
-                loaded.middleware_registered = [
-                    kind
-                    for kind, cbs in self._middleware.items()
-                    if len(cbs) > _mw_counts_before.get(kind, 0)
-                ]
-                loaded.commands_registered = [
-                    c for c in self._plugin_commands
-                    if self._plugin_commands[c].get("plugin") == manifest.name
-                ]
-                loaded.enabled = True
-                logger.debug(
-                    "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
-                    len(loaded.tools_registered),
-                    len(loaded.hooks_registered),
-                    len(loaded.middleware_registered),
-                    len(loaded.commands_registered),
-                    sum(
-                        1 for c in self._cli_commands
-                        if self._cli_commands[c].get("plugin") == manifest.name
-                    ),
-                )
+                raise RuntimeError("plugin has no register function")
 
-        except Exception as exc:
-            loaded.error = str(exc)
+            phase = "registration"
+            register_fn(context)
+            loaded.tools_registered = list(
+                registration_view._transaction_tools_registered
+            )
+            loaded.hooks_registered = [
+                name
+                for name, callbacks in registration_view._hooks.items()
+                if len(callbacks) > len(manager_before._hooks.get(name, []))
+            ]
+            loaded.middleware_registered = [
+                name
+                for name, callbacks in registration_view._middleware.items()
+                if len(callbacks) > len(manager_before._middleware.get(name, []))
+            ]
+            loaded.commands_registered = list(
+                registration_view._transaction_commands_registered
+            )
+            loaded.enabled = True
+            phase = "commit"
+            self._commit_registration_view(
+                manager_before,
+                registration_view,
+                plugin_id,
+                loaded,
+                _registry,
+                tool_before,
+                tool_registration_view,
+                context,
+            )
+            logger.debug(
+                "  registered: %d tool(s), %d hook(s), %d middleware, "
+                "%d slash command(s), %d CLI command(s)",
+                len(loaded.tools_registered),
+                len(loaded.hooks_registered),
+                len(loaded.middleware_registered),
+                len(loaded.commands_registered),
+                sum(
+                    1
+                    for entry in registration_view._cli_commands.values()
+                    if entry.get("plugin") == manifest.name
+                ),
+            )
+            return
+
+        except BaseException as exc:
+            # Live tools and manager registrations were never touched unless
+            # the atomic commit completed. External registries retain their
+            # existing explicit journals.
+            registration_view._rollback_external_registries()
+            if module_root:
+                _restore_module_namespace(module_root, modules_before)
+            loaded.enabled = False
+            loaded.module = None
+            if not isinstance(exc, Exception):
+                raise
+
+            loaded.error = f"{type(exc).__name__}: plugin {phase} failed"
             logger.warning(
                 "Failed to load plugin '%s': %s",
-                manifest.name, exc, exc_info=_PLUGINS_DEBUG,
+                manifest.name,
+                loaded.error,
             )
-        self._plugins[manifest.key or manifest.name] = loaded
+            with self._lock:
+                self._plugins[plugin_id] = loaded
 
     def _load_directory_module(self, manifest: PluginManifest) -> types.ModuleType:
         """Import a directory-based plugin as ``hermes_plugins.<slug>``.
@@ -1868,9 +2371,10 @@ class PluginManager:
             ns_pkg.__package__ = _NS_PARENT
             sys.modules[_NS_PARENT] = ns_pkg
 
-        key = manifest.key or manifest.name
-        slug = key.replace("/", "__").replace("-", "_")
-        module_name = f"{_NS_PARENT}.{slug}"
+        module_name = _directory_module_name(manifest)
+        # A force reload must execute against a clean package tree. The caller
+        # already captured prior identities and will restore them on failure.
+        _restore_module_namespace(module_name, {})
         spec = importlib.util.spec_from_file_location(
             module_name,
             init_file,
@@ -1929,7 +2433,8 @@ class PluginManager:
         persisted to session DB.
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
-        callbacks = self._hooks.get(hook_name, [])
+        with self._lock:
+            callbacks = list(self._hooks.get(hook_name, []))
         results: List[Any] = []
         for cb in callbacks:
             try:
@@ -1947,11 +2452,13 @@ class PluginManager:
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
-        return bool(self._hooks.get(hook_name))
+        with self._lock:
+            return bool(self._hooks.get(hook_name))
 
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
-        return bool(self._middleware.get(kind))
+        with self._lock:
+            return bool(self._middleware.get(kind))
 
     def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
         """Call registered middleware callbacks for *kind*.
@@ -1960,7 +2467,8 @@ class PluginManager:
         path. Middleware that wants to change behavior must return the shape
         documented by the caller-specific contract.
         """
-        callbacks = self._middleware.get(kind, [])
+        with self._lock:
+            callbacks = list(self._middleware.get(kind, []))
         results: List[Any] = []
         for cb in callbacks:
             try:
@@ -1990,7 +2498,8 @@ class PluginManager:
         Plugins register handlers via
         :meth:`PluginContext.register_slack_action_handler`.
         """
-        return list(self._slack_action_handlers)
+        with self._lock:
+            return list(self._slack_action_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection
@@ -1998,8 +2507,10 @@ class PluginManager:
 
     def list_plugins(self) -> List[Dict[str, Any]]:
         """Return a list of info dicts for all discovered plugins."""
+        with self._lock:
+            plugins = sorted(self._plugins.items())
         result: List[Dict[str, Any]] = []
-        for key, loaded in sorted(self._plugins.items()):
+        for key, loaded in plugins:
             result.append(
                 {
                     "name": loaded.manifest.name,
@@ -2024,22 +2535,68 @@ class PluginManager:
 
     def find_plugin_skill(self, qualified_name: str) -> Optional[Path]:
         """Return the ``Path`` to a plugin skill's SKILL.md, or ``None``."""
-        entry = self._plugin_skills.get(qualified_name)
+        with self._lock:
+            entry = self._plugin_skills.get(qualified_name)
         return entry["path"] if entry else None
 
     def list_plugin_skills(self, plugin_name: str) -> List[str]:
         """Return sorted bare names of all skills registered by *plugin_name*."""
         prefix = f"{plugin_name}:"
-        return sorted(
-            e["bare_name"]
-            for qn, e in self._plugin_skills.items()
-            if qn.startswith(prefix)
-        )
+        with self._lock:
+            return sorted(
+                e["bare_name"]
+                for qn, e in self._plugin_skills.items()
+                if qn.startswith(prefix)
+            )
 
     def remove_plugin_skill(self, qualified_name: str) -> None:
         """Remove a stale registry entry (silently ignores missing keys)."""
-        self._plugin_skills.pop(qualified_name, None)
+        with self._lock:
+            self._plugin_skills.pop(qualified_name, None)
 
+    def get_context_engine(self) -> Any:
+        with self._lock:
+            return self._context_engine
+
+    def get_plugin_command(self, name: str) -> Optional[dict]:
+        with self._lock:
+            entry = self._plugin_commands.get(name)
+            return dict(entry) if entry else None
+
+    def get_plugin_commands(self) -> Dict[str, dict]:
+        with self._lock:
+            return {
+                name: dict(entry)
+                for name, entry in self._plugin_commands.items()
+            }
+
+    def get_cli_commands(self) -> Dict[str, dict]:
+        with self._lock:
+            return {
+                name: dict(entry) for name, entry in self._cli_commands.items()
+            }
+
+    def get_auxiliary_tasks(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [
+                {
+                    **self._aux_tasks[key],
+                    "defaults": dict(
+                        self._aux_tasks[key].get("defaults", {})
+                    ),
+                }
+                for key in sorted(self._aux_tasks)
+            ]
+
+    def get_middleware_callbacks(self, kind: str) -> List[Callable]:
+        with self._lock:
+            return list(self._middleware.get(kind, []))
+
+    def get_tool_state_snapshot(
+        self,
+    ) -> tuple[Set[str], Dict[str, LoadedPlugin]]:
+        with self._lock:
+            return set(self._plugin_tool_names), dict(self._plugins)
 
 # ---------------------------------------------------------------------------
 # Module-level singleton & convenience functions
@@ -2358,12 +2915,12 @@ def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
 
 def get_plugin_context_engine():
     """Return the plugin-registered context engine, or None."""
-    return _ensure_plugins_discovered()._context_engine
+    return _ensure_plugins_discovered().get_context_engine()
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
-    entry = _ensure_plugins_discovered()._plugin_commands.get(name)
+    entry = _ensure_plugins_discovered().get_plugin_command(name)
     return entry["handler"] if entry else None
 
 
@@ -2422,7 +2979,7 @@ def get_plugin_commands() -> Dict[str, dict]:
     Triggers idempotent plugin discovery so callers can use plugin commands
     before any explicit discover_plugins() call.
     """
-    return _ensure_plugins_discovered()._plugin_commands
+    return _ensure_plugins_discovered().get_plugin_commands()
 
 
 def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
@@ -2436,8 +2993,7 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
     before any explicit ``discover_plugins()`` call. Sorted by ``key`` for
     deterministic ordering in pickers and tests.
     """
-    manager = _ensure_plugins_discovered()
-    return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
+    return _ensure_plugins_discovered().get_auxiliary_tasks()
 
 
 def get_plugin_toolsets() -> List[tuple]:
@@ -2447,7 +3003,8 @@ def get_plugin_toolsets() -> List[tuple]:
     alongside the built-in ones and can be toggled on/off per platform.
     """
     manager = get_plugin_manager()
-    if not manager._plugin_tool_names:
+    plugin_tool_names, loaded_plugins = manager.get_tool_state_snapshot()
+    if not plugin_tool_names:
         return []
 
     try:
@@ -2458,7 +3015,7 @@ def get_plugin_toolsets() -> List[tuple]:
     # Group plugin tool names by their toolset
     toolset_tools: Dict[str, List[str]] = {}
     toolset_plugin: Dict[str, LoadedPlugin] = {}
-    for tool_name in manager._plugin_tool_names:
+    for tool_name in plugin_tool_names:
         entry = registry.get_entry(tool_name)
         if not entry:
             continue
@@ -2466,7 +3023,7 @@ def get_plugin_toolsets() -> List[tuple]:
         toolset_tools.setdefault(ts, []).append(entry.name)
 
     # Map toolsets back to the plugin that registered them
-    for _name, loaded in manager._plugins.items():
+    for _name, loaded in loaded_plugins.items():
         for tool_name in loaded.tools_registered:
             entry = registry.get_entry(tool_name)
             if entry and entry.toolset in toolset_tools:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -65,6 +65,8 @@ def get_bundled_plugins_dir() -> Path:
         return Path(env_override)
     return Path(__file__).resolve().parent.parent / "plugins"
 
+from registry_transaction import RegistryTransactionConflict
+
 try:
     import yaml
 except ImportError:  # pragma: no cover – yaml is optional at import time
@@ -248,24 +250,6 @@ def _directory_module_name(manifest: "PluginManifest") -> str:
     return f"{_NS_PARENT}.{slug}"
 
 
-class _ExternalRegistrySnapshot:
-    """Opaque checkpoint for one legacy external registration surface."""
-
-    __slots__ = ("_surface", "_owner", "_items", "_extra")
-
-    def __init__(
-        self,
-        surface: str,
-        owner: Any,
-        items: tuple,
-        extra: Any = None,
-    ) -> None:
-        self._surface = surface
-        self._owner = owner
-        self._items = items
-        self._extra = extra
-
-
 _PROVIDER_REGISTRY_MODULES = {
     "image_gen": "agent.image_gen_registry",
     "video_gen": "agent.video_gen_registry",
@@ -275,68 +259,33 @@ _PROVIDER_REGISTRY_MODULES = {
     "stt": "agent.transcription_registry",
     "dashboard": "hermes_cli.dashboard_auth.registry",
 }
-_EXTERNAL_REGISTRY_SURFACES = (
+_EXTERNAL_COMMIT_SURFACES = (
     "platform",
+    "browser",
+    "dashboard",
     "image_gen",
+    "secret",
+    "stt",
+    "tts",
     "video_gen",
     "web",
-    "browser",
-    "secret",
-    "tts",
-    "stt",
-    "dashboard",
 )
 
 
-def _take_external_registry_snapshot(surface: str) -> _ExternalRegistrySnapshot:
-    """Checkpoint a traced PluginContext external surface without exposing maps."""
-    if surface == "platform":
-        from gateway.platform_registry import platform_registry
+def _external_registry_transactions() -> Dict[str, Any]:
+    """Return opaque registry-owned transaction surfaces in commit order."""
+    from gateway.platform_registry import platform_registry
 
-        return _ExternalRegistrySnapshot(
-            surface,
-            platform_registry,
-            tuple(platform_registry._entries.items()),
-            tuple(platform_registry._deferred.items()),
+    transactions: Dict[str, Any] = {"platform": platform_registry}
+    for surface in _EXTERNAL_COMMIT_SURFACES[1:]:
+        module_name = (
+            "agent.secret_sources.registry"
+            if surface == "secret"
+            else _PROVIDER_REGISTRY_MODULES[surface]
         )
-    if surface == "secret":
-        module = importlib.import_module("agent.secret_sources.registry")
-        return _ExternalRegistrySnapshot(
-            surface,
-            module,
-            tuple(module._SOURCES.items()),
-            module._BUILTINS_LOADED,
-        )
-    module_name = _PROVIDER_REGISTRY_MODULES.get(surface)
-    if module_name is None:
-        raise ValueError(f"unsupported external plugin registry surface: {surface}")
-    module = importlib.import_module(module_name)
-    with module._lock:
-        items = tuple(module._providers.items())
-    return _ExternalRegistrySnapshot(surface, module, items)
-
-
-def _restore_external_registry_snapshot(
-    snapshot: _ExternalRegistrySnapshot,
-) -> None:
-    """Restore an external checkpoint; no plugin callback is invoked."""
-    if snapshot._surface == "platform":
-        registry = snapshot._owner
-        registry._entries.clear()
-        registry._entries.update(snapshot._items)
-        registry._deferred.clear()
-        registry._deferred.update(snapshot._extra)
-        return
-    if snapshot._surface == "secret":
-        module = snapshot._owner
-        module._SOURCES.clear()
-        module._SOURCES.update(snapshot._items)
-        module._BUILTINS_LOADED = snapshot._extra
-        return
-    module = snapshot._owner
-    with module._lock:
-        module._providers.clear()
-        module._providers.update(snapshot._items)
+        module = importlib.import_module(module_name)
+        transactions[surface] = module._plugin_transaction
+    return transactions
 
 
 def _env_enabled(name: str) -> bool:
@@ -466,6 +415,10 @@ class _PluginManagerState:
         }
         self._plugin_tool_names = set(manager._plugin_tool_names)
         self._plugin_platform_names = set(manager._plugin_platform_names)
+        self._plugin_external_names = {
+            surface: set(names)
+            for surface, names in manager._plugin_external_names.items()
+        }
         self._cli_commands = {
             name: dict(entry) for name, entry in manager._cli_commands.items()
         }
@@ -485,6 +438,7 @@ class _PluginManagerState:
         }
         self._slack_action_handlers = list(manager._slack_action_handlers)
         self._discovered = manager._discovered
+        self._generation = manager._generation
 
 
 class _PluginRegistrationView:
@@ -507,6 +461,10 @@ class _PluginRegistrationView:
         }
         self._plugin_tool_names = set(state._plugin_tool_names)
         self._plugin_platform_names = set(state._plugin_platform_names)
+        self._plugin_external_names = {
+            surface: set(names)
+            for surface, names in state._plugin_external_names.items()
+        }
         self._cli_commands = {
             name: dict(entry) for name, entry in state._cli_commands.items()
         }
@@ -526,25 +484,192 @@ class _PluginRegistrationView:
         }
         self._slack_action_handlers = list(state._slack_action_handlers)
         self._discovered = state._discovered
+        self._generation = state._generation
         self._cli_ref = cli_ref
         self._lock = threading.RLock()
         self._transaction_tools_registered: List[str] = []
         self._transaction_commands_registered: List[str] = []
-        self._external_registry_snapshots: Dict[
-            str, _ExternalRegistrySnapshot
-        ] = {}
+        self._frozen = False
 
-    def _checkpoint_external_registry(self, surface: str) -> None:
-        if surface not in self._external_registry_snapshots:
-            self._external_registry_snapshots[surface] = (
-                _take_external_registry_snapshot(surface)
+    def _record_external_registration(self, surface: str, name: str) -> None:
+        self._plugin_external_names.setdefault(surface, set()).add(name)
+        if surface == "platform":
+            self._plugin_platform_names.add(name)
+        self._generation += 1
+
+    def _freeze(self) -> None:
+        """Make every staged manager container reject late registrations."""
+        self._plugins = types.MappingProxyType(dict(self._plugins))
+        self._hooks = types.MappingProxyType(
+            {name: tuple(callbacks) for name, callbacks in self._hooks.items()}
+        )
+        self._middleware = types.MappingProxyType(
+            {
+                name: tuple(callbacks)
+                for name, callbacks in self._middleware.items()
+            }
+        )
+        self._plugin_tool_names = frozenset(self._plugin_tool_names)
+        self._plugin_platform_names = frozenset(self._plugin_platform_names)
+        self._plugin_external_names = types.MappingProxyType(
+            {
+                surface: frozenset(names)
+                for surface, names in self._plugin_external_names.items()
+            }
+        )
+        self._cli_commands = types.MappingProxyType(dict(self._cli_commands))
+        self._plugin_commands = types.MappingProxyType(dict(self._plugin_commands))
+        self._plugin_skills = types.MappingProxyType(dict(self._plugin_skills))
+        self._aux_tasks = types.MappingProxyType(dict(self._aux_tasks))
+        self._slack_action_handlers = tuple(self._slack_action_handlers)
+        self._frozen = True
+
+
+class _RegistrationTransaction:
+    """One isolated plugin registration or complete force-reload candidate."""
+
+    def __init__(
+        self,
+        manager: "PluginManager",
+        *,
+        replace_owned: bool = False,
+    ) -> None:
+        from tools.registry import registry as tool_registry
+
+        self.manager = manager
+        self.manager_before = manager._snapshot_owned_state()
+        self.manager_view = _PluginRegistrationView(
+            self.manager_before,
+            manager._cli_ref,
+        )
+        if replace_owned:
+            self.manager_view._plugins = {}
+            self.manager_view._hooks = {}
+            self.manager_view._middleware = {}
+            self.manager_view._plugin_tool_names = set()
+            self.manager_view._plugin_platform_names = set()
+            self.manager_view._plugin_external_names = {
+                surface: set() for surface in _EXTERNAL_COMMIT_SURFACES
+            }
+            self.manager_view._cli_commands = {}
+            self.manager_view._context_engine = None
+            self.manager_view._plugin_commands = {}
+            self.manager_view._plugin_skills = {}
+            self.manager_view._aux_tasks = {}
+            self.manager_view._slack_action_handlers = []
+        self.manager_view._discovered = True
+
+        self.tool_registry = tool_registry
+        self.tool_snapshot = tool_registry._take_transaction_snapshot()
+        removed_tool_names = (
+            self.manager_before._plugin_tool_names if replace_owned else set()
+        )
+        removed_policy_names = set()
+        if replace_owned:
+            for loaded in self.manager_before._plugins.values():
+                manifest = loaded.manifest
+                plugin_id = manifest.key or manifest.name
+                if manifest.source in {"user", "project", "bundled"}:
+                    removed_policy_names.add(_directory_module_name(manifest))
+                else:
+                    removed_policy_names.add(plugin_id)
+        self.tool_view = tool_registry._create_transaction_view(
+            self.tool_snapshot,
+            remove_names=removed_tool_names,
+            remove_policy_names=removed_policy_names,
+        )
+
+        self.external_transactions = _external_registry_transactions()
+        self.external_snapshots = {
+            surface: transaction.take_snapshot()
+            for surface, transaction in self.external_transactions.items()
+        }
+        self.external_views = {}
+        for surface, transaction in self.external_transactions.items():
+            remove_keys = (
+                self.manager_before._plugin_external_names.get(surface, set())
+                if replace_owned
+                else set()
             )
+            self.external_views[surface] = transaction.create_view(
+                self.external_snapshots[surface],
+                remove_keys=remove_keys,
+            )
+        self.contexts: List["PluginContext"] = []
 
-    def _rollback_external_registries(self) -> None:
-        for snapshot in reversed(
-            list(self._external_registry_snapshots.values())
-        ):
-            _restore_external_registry_snapshot(snapshot)
+    def context_targets(self) -> Dict[str, tuple[Any, Any]]:
+        return {
+            surface: (transaction, self.external_views[surface])
+            for surface, transaction in self.external_transactions.items()
+        }
+
+    def commit(self) -> None:
+        """Validate every baseline, then install all surfaces under one lock set."""
+        prepared_tools = self.tool_registry._prepare_transaction_commit(
+            self.tool_snapshot,
+            self.tool_view,
+        )
+        prepared_external = {
+            surface: transaction.prepare(
+                self.external_snapshots[surface],
+                self.external_views[surface],
+            )
+            for surface, transaction in self.external_transactions.items()
+        }
+        with self.manager_view._lock:
+            next_manager = _PluginManagerState(self.manager_view)
+            self.manager_view._freeze()
+
+        locks = [
+            self.manager._lock,
+            self.tool_registry._lock,
+            *(
+                self.external_transactions[surface].lock
+                for surface in _EXTERNAL_COMMIT_SURFACES
+            ),
+        ]
+        for lock in locks:
+            lock.acquire()
+        try:
+            if self.manager._generation != self.manager_before._generation:
+                raise RegistryTransactionConflict(
+                    "manager",
+                    self.manager_before._generation,
+                    self.manager._generation,
+                )
+            self.tool_registry._validate_prepared_transaction_locked(
+                self.tool_snapshot,
+                prepared_tools,
+            )
+            for surface in _EXTERNAL_COMMIT_SURFACES:
+                transaction = self.external_transactions[surface]
+                transaction.validate_prepared_locked(
+                    self.external_snapshots[surface],
+                    prepared_external[surface],
+                )
+
+            self.tool_registry._install_prepared_transaction_locked(
+                self.tool_snapshot,
+                prepared_tools,
+            )
+            for surface in _EXTERNAL_COMMIT_SURFACES:
+                transaction = self.external_transactions[surface]
+                transaction.install_prepared_locked(
+                    self.external_snapshots[surface],
+                    prepared_external[surface],
+                )
+            for context in self.contexts:
+                context._registration_registry = self.tool_registry
+                context._registration_manager = self.manager
+                context._registration_external_registries = None
+            self.manager._install_owned_state_locked(next_manager)
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
+
+class _ForceSweepAbort(RuntimeError):
+    """Internal sentinel: a force candidate failed and must not publish."""
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +686,7 @@ class PluginContext:
         *,
         registration_manager: Any = None,
         registration_registry: Any = None,
+        registration_external_registries: Any = None,
     ):
         self.manifest = manifest
         self._manager = manager
@@ -568,19 +694,36 @@ class PluginContext:
         # Managed discovery supplies an isolated ToolRegistry transaction view.
         # Direct/runtime contexts leave this unset and target the live registry.
         self._registration_registry = registration_registry
+        self._registration_external_registries = registration_external_registries
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
 
-    def _checkpoint_external_registry(self, surface: str) -> None:
-        """Lazily journal an external surface during managed plugin loading."""
-        checkpoint = getattr(
-            self._registration_manager,
-            "_checkpoint_external_registry",
-            None,
-        )
-        if checkpoint is not None:
-            checkpoint(surface)
+    def _record_external_registration(self, surface: str, name: str) -> None:
+        target = self._registration_manager
+        recorder = getattr(target, "_record_external_registration", None)
+        if recorder is not None:
+            with target._lock:
+                recorder(surface, name)
+
+    def _register_external_value(
+        self,
+        surface: str,
+        value: Any,
+        live_register: Callable[[Any], Any],
+    ) -> Optional[str]:
+        targets = self._registration_external_registries
+        if targets is None:
+            result = live_register(value)
+            if surface == "secret" and not result:
+                return None
+            name = value.name
+        else:
+            transaction, staged = targets[surface]
+            name = transaction.register(staged, value)
+        if name:
+            self._record_external_registration(surface, name)
+        return name
 
     # -- host-owned LLM access ----------------------------------------------
 
@@ -704,6 +847,7 @@ class PluginContext:
             )
             if registered is not None and name not in registered:
                 registered.append(name)
+            target._generation += 1
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
@@ -788,6 +932,7 @@ class PluginContext:
                 "handler_fn": handler_fn,
                 "plugin": self.manifest.name,
             }
+            target._generation += 1
         logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
 
     # -- slash command registration -------------------------------------------
@@ -851,6 +996,7 @@ class PluginContext:
             )
             if registered is not None and clean not in registered:
                 registered.append(clean)
+            target._generation += 1
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
     # -- tool dispatch -------------------------------------------------------
@@ -905,6 +1051,8 @@ class PluginContext:
             return
         target = self._registration_manager
         with target._lock:
+            if getattr(target, "_frozen", False):
+                raise RuntimeError("plugin registration transaction is frozen")
             if target._context_engine is not None:
                 logger.warning(
                     "Plugin '%s' tried to register a context engine, but one is "
@@ -913,6 +1061,7 @@ class PluginContext:
                 )
                 return
             target._context_engine = engine
+            target._generation += 1
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -939,8 +1088,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("image_gen")
-        register_provider(provider)
+        self._register_external_value("image_gen", provider, register_provider)
         logger.info(
             "Plugin '%s' registered image_gen provider: %s",
             self.manifest.name, provider.name,
@@ -972,15 +1120,20 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("dashboard")
         try:
-            register_provider(provider)
+            name = self._register_external_value(
+                "dashboard",
+                provider,
+                register_provider,
+            )
         except (TypeError, ValueError) as e:
             logger.warning(
                 "Plugin '%s' failed to register dashboard-auth provider "
                 "%r: %s",
                 self.manifest.name, getattr(provider, "name", "?"), e,
             )
+            return
+        if name is None:
             return
         logger.info(
             "Plugin '%s' registered dashboard-auth provider: %s (%s)",
@@ -1008,8 +1161,11 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("video_gen")
-        _register_video_provider(provider)
+        self._register_external_value(
+            "video_gen",
+            provider,
+            _register_video_provider,
+        )
         logger.info(
             "Plugin '%s' registered video_gen provider: %s",
             self.manifest.name, provider.name,
@@ -1037,8 +1193,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("web")
-        _register_web_provider(provider)
+        self._register_external_value("web", provider, _register_web_provider)
         logger.info(
             "Plugin '%s' registered web provider: %s",
             self.manifest.name, provider.name,
@@ -1070,8 +1225,11 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("browser")
-        _register_browser_provider(provider)
+        self._register_external_value(
+            "browser",
+            provider,
+            _register_browser_provider,
+        )
         logger.info(
             "Plugin '%s' registered browser provider: %s",
             self.manifest.name, provider.name,
@@ -1118,8 +1276,7 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("secret")
-        if register_source(source):
+        if self._register_external_value("secret", source, register_source):
             logger.info(
                 "Plugin '%s' registered secret source: %s",
                 self.manifest.name, source.name,
@@ -1157,8 +1314,13 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("tts")
-        _register_tts_provider(provider)
+        name = self._register_external_value(
+            "tts",
+            provider,
+            _register_tts_provider,
+        )
+        if name is None:
+            return
         logger.info(
             "Plugin '%s' registered TTS provider: %s",
             self.manifest.name, provider.name,
@@ -1202,8 +1364,13 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._checkpoint_external_registry("stt")
-        _register_stt_provider(provider)
+        name = self._register_external_value(
+            "stt",
+            provider,
+            _register_stt_provider,
+        )
+        if name is None:
+            return
         logger.info(
             "Plugin '%s' registered transcription provider: %s",
             self.manifest.name, provider.name,
@@ -1257,11 +1424,13 @@ class PluginContext:
             source="plugin",
             **entry_kwargs,
         )
-        self._checkpoint_external_registry("platform")
-        platform_registry.register(entry)
-        target = self._registration_manager
-        with target._lock:
-            target._plugin_platform_names.add(name)
+        targets = self._registration_external_registries
+        if targets is None:
+            platform_registry.register(entry)
+        else:
+            _transaction, staged = targets["platform"]
+            staged.register(entry)
+        self._record_external_registration("platform", name)
         logger.debug(
             "Plugin %s registered platform: %s",
             self.manifest.name,
@@ -1322,6 +1491,7 @@ class PluginContext:
             target._slack_action_handlers.append(
                 (action_id, callback, self.manifest.name)
             )
+            target._generation += 1
         logger.debug(
             "Plugin %s registered Slack action handler: %s",
             self.manifest.name,
@@ -1439,6 +1609,7 @@ class PluginContext:
                 "defaults": merged_defaults,
                 "plugin": self.manifest.name,
             }
+            target._generation += 1
         logger.debug(
             "Plugin %s registered auxiliary task: %s (%s)",
             self.manifest.name,
@@ -1463,6 +1634,7 @@ class PluginContext:
         target = self._registration_manager
         with target._lock:
             target._hooks.setdefault(hook_name, []).append(callback)
+            target._generation += 1
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -1486,6 +1658,7 @@ class PluginContext:
         target = self._registration_manager
         with target._lock:
             target._middleware.setdefault(kind, []).append(callback)
+            target._generation += 1
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
 
     # -- skill registration -------------------------------------------------
@@ -1532,6 +1705,7 @@ class PluginContext:
                 "bare_name": name,
                 "description": description,
             }
+            target._generation += 1
         logger.debug(
             "Plugin %s registered skill: %s",
             self.manifest.name, qualified,
@@ -1546,15 +1720,19 @@ class PluginManager:
     """Central manager that discovers, loads, and invokes plugins."""
 
     def __init__(self) -> None:
-        # Lock order when both registries are touched is always:
-        # ToolRegistry first, then PluginManager. Plugin callbacks are never
-        # invoked while this state lock is held.
+        # Discovery writers serialize here while readers keep using the live
+        # generation. Plugin callbacks are never invoked under registry locks.
+        self._discovery_lock = threading.RLock()
         self._lock = threading.RLock()
+        self._generation = 0
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
+        self._plugin_external_names: Dict[str, Set[str]] = {
+            surface: set() for surface in _EXTERNAL_COMMIT_SURFACES
+        }
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
@@ -1572,15 +1750,17 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+
+    def _record_external_registration(self, surface: str, name: str) -> None:
+        self._plugin_external_names.setdefault(surface, set()).add(name)
+        if surface == "platform":
+            self._plugin_platform_names.add(name)
+        self._generation += 1
+
     def _snapshot_owned_state(self) -> _PluginManagerState:
         """Take a non-aliasing checkpoint under the manager state lock."""
         with self._lock:
             return _PluginManagerState(self)
-
-    def _replace_owned_state(self, state: Any) -> None:
-        """Atomically replace every manager-owned registration surface."""
-        with self._lock:
-            self._install_owned_state_locked(state)
 
     def _install_owned_state_locked(self, state: Any) -> None:
         """Install already-independent manager state while ``_lock`` is held."""
@@ -1589,6 +1769,7 @@ class PluginManager:
         self._middleware = state._middleware
         self._plugin_tool_names = state._plugin_tool_names
         self._plugin_platform_names = state._plugin_platform_names
+        self._plugin_external_names = state._plugin_external_names
         self._cli_commands = state._cli_commands
         self._context_engine = state._context_engine
         self._plugin_commands = state._plugin_commands
@@ -1596,208 +1777,65 @@ class PluginManager:
         self._aux_tasks = state._aux_tasks
         self._slack_action_handlers = state._slack_action_handlers
         self._discovered = state._discovered
-
-    def _clear_owned_state_for_discovery(self) -> None:
-        """Install one coherent empty discovery state under the lock."""
-        with self._lock:
-            self._plugins = {}
-            self._hooks = {}
-            self._middleware = {}
-            self._plugin_tool_names = set()
-            self._plugin_platform_names = set()
-            self._cli_commands = {}
-            self._plugin_commands = {}
-            self._plugin_skills = {}
-            self._aux_tasks = {}
-            self._slack_action_handlers = []
-            self._context_engine = None
-
-    def _commit_registration_view(
-        self,
-        before: _PluginManagerState,
-        staged: _PluginRegistrationView,
-        plugin_id: str,
-        loaded: LoadedPlugin,
-        tool_registry: Any,
-        tool_snapshot: Any,
-        staged_tool_registry: Any,
-        context: PluginContext,
-    ) -> None:
-        """Atomically commit staged tool and manager state.
-
-        The fixed live-lock order is ToolRegistry then PluginManager. Tool
-        state is conflict-checked against the exact baseline before either
-        registry changes. Both next states are built independently first, so
-        an error cannot expose a half-applied registration.
-        """
-        prepared_tools = tool_registry._prepare_transaction_commit(
-            tool_snapshot,
-            staged_tool_registry,
-        )
-
-        tool_registry._lock.acquire()
-        manager_locked = False
-        install_attempted = False
-        manager_at_commit = None
-        try:
-            self._lock.acquire()
-            manager_locked = True
-            tool_registry._validate_prepared_transaction_locked(
-                tool_snapshot,
-                prepared_tools,
-            )
-            manager_at_commit = _PluginManagerState(self)
-            next_manager = self._build_committed_state_locked(
-                before,
-                staged,
-                plugin_id,
-                loaded,
-            )
-            try:
-                install_attempted = True
-                tool_registry._install_prepared_transaction_locked(
-                    tool_snapshot,
-                    prepared_tools,
-                )
-                self._install_owned_state_locked(next_manager)
-                # Callbacks may retain ctx. Flip both registration targets
-                # before readers can observe the committed manager state.
-                context._registration_registry = tool_registry
-                context._registration_manager = self
-            except BaseException:
-                if install_attempted:
-                    tool_registry._restore_transaction_snapshot_locked(
-                        tool_snapshot
-                    )
-                if manager_at_commit is not None:
-                    self._install_owned_state_locked(manager_at_commit)
-                raise
-        finally:
-            # Publish tools first. A tool reader that immediately asks for
-            # manager attribution blocks until the new manager state is ready.
-            tool_registry._lock.release()
-            if manager_locked:
-                self._lock.release()
-
-    def _build_committed_state_locked(
-        self,
-        before: _PluginManagerState,
-        staged: _PluginRegistrationView,
-        plugin_id: str,
-        loaded: LoadedPlugin,
-    ) -> _PluginManagerState:
-        """Build the merged manager state without mutating the live manager."""
-        if staged._context_engine is not before._context_engine:
-            if self._context_engine is not before._context_engine:
-                raise RuntimeError(
-                    "context engine changed during plugin registration"
-                )
-
-        committed = _PluginManagerState(self)
-        for name, callbacks in staged._hooks.items():
-            baseline_count = len(before._hooks.get(name, []))
-            additions = callbacks[baseline_count:]
-            if additions:
-                committed._hooks.setdefault(name, []).extend(additions)
-        for name, callbacks in staged._middleware.items():
-            baseline_count = len(before._middleware.get(name, []))
-            additions = callbacks[baseline_count:]
-            if additions:
-                committed._middleware.setdefault(name, []).extend(additions)
-
-        committed._plugin_tool_names.update(
-            staged._plugin_tool_names - before._plugin_tool_names
-        )
-        committed._plugin_platform_names.update(
-            staged._plugin_platform_names - before._plugin_platform_names
-        )
-
-        for attr in (
-            "_cli_commands",
-            "_plugin_commands",
-            "_plugin_skills",
-            "_aux_tasks",
-        ):
-            committed_map = getattr(committed, attr)
-            before_map = getattr(before, attr)
-            staged_map = getattr(staged, attr)
-            for name, entry in staged_map.items():
-                if name not in before_map or entry != before_map[name]:
-                    committed_map[name] = dict(entry)
-
-        slack_additions = staged._slack_action_handlers[
-            len(before._slack_action_handlers):
-        ]
-        committed._slack_action_handlers.extend(slack_additions)
-        if staged._context_engine is not before._context_engine:
-            committed._context_engine = staged._context_engine
-        committed._plugins[plugin_id] = loaded
-        return committed
-
-    # -----------------------------------------------------------------------
-    # Public
-    # -----------------------------------------------------------------------
+        self._generation = max(self._generation, state._generation) + 1
 
     def discover_and_load(self, force: bool = False) -> None:
-        """Scan all plugin sources and load each plugin found.
-
-        When ``force`` is true, clear cached discovery state first so config
-        changes or newly-added bundled backends become visible in long-lived
-        sessions without requiring a full agent restart.
-        """
-        with self._lock:
-            if self._discovered and not force:
+        """Load plugins, publishing a force reload as one complete generation."""
+        with self._discovery_lock:
+            with self._lock:
+                if self._discovered and not force:
+                    return
+            if env_var_enabled("HERMES_SAFE_MODE"):
+                logger.info("HERMES_SAFE_MODE=1 - plugin discovery skipped")
+                with self._lock:
+                    self._discovered = True
+                    self._generation += 1
                 return
-        if env_var_enabled("HERMES_SAFE_MODE"):
-            logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
+
+            if force:
+                transaction = _RegistrationTransaction(
+                    self,
+                    replace_owned=True,
+                )
+                module_snapshot = _snapshot_module_namespace(_NS_PARENT)
+                try:
+                    self._discover_and_load_inner(transaction)
+                    transaction.commit()
+                except (_ForceSweepAbort, RegistryTransactionConflict) as exc:
+                    _restore_module_namespace(_NS_PARENT, module_snapshot)
+                    if isinstance(exc, RegistryTransactionConflict):
+                        logger.warning(
+                            "Plugin force-reload commit conflict: "
+                            "surface=%s expected_generation=%d "
+                            "actual_generation=%d; retaining prior generation",
+                            exc.surface,
+                            exc.expected_generation,
+                            exc.actual_generation,
+                        )
+                    return
+                except BaseException:
+                    _restore_module_namespace(_NS_PARENT, module_snapshot)
+                    raise
+                return
+
             with self._lock:
                 self._discovered = True
-            return
-        previous_state = self._snapshot_owned_state() if force else None
-        tool_snapshot = None
-        module_snapshot = None
-        external_snapshots: List[_ExternalRegistrySnapshot] = []
-        if force:
-            from tools.registry import registry as _registry
-
-            tool_snapshot = _registry._take_transaction_snapshot()
-            external_snapshots = [
-                _take_external_registry_snapshot(surface)
-                for surface in _EXTERNAL_REGISTRY_SURFACES
-            ]
-            module_snapshot = _snapshot_module_namespace(_NS_PARENT)
-            self._clear_owned_state_for_discovery()
-        # Set the flag up front as a re-entrancy guard (a plugin's register()
-        # can transitively trigger discovery again), but reset it if the sweep
-        # raises so a failed scan is NOT cached as "discovered with an empty
-        # registry" — callers swallow the exception and would otherwise be
-        # permanently stranded on the early-return above (the "No web provider
-        # configured" class of failures).
-        with self._lock:
-            self._discovered = True
-        try:
-            self._discover_and_load_inner()
-        except BaseException:
-            if force:
-                from tools.registry import registry as _registry
-
-                assert previous_state is not None
-                assert tool_snapshot is not None
-                assert module_snapshot is not None
-                # Fixed rollback order: ToolRegistry, module cache, manager.
-                _registry._restore_transaction_snapshot(tool_snapshot)
-                for snapshot in reversed(external_snapshots):
-                    _restore_external_registry_snapshot(snapshot)
-                _restore_module_namespace(_NS_PARENT, module_snapshot)
-                self._replace_owned_state(previous_state)
-            else:
+                self._generation += 1
+            try:
+                self._discover_and_load_inner()
+            except BaseException:
                 with self._lock:
                     self._discovered = False
-            raise
+                    self._generation += 1
+                raise
 
-    def _discover_and_load_inner(self) -> None:
+    def _discover_and_load_inner(
+        self,
+        transaction: Optional[_RegistrationTransaction] = None,
+    ) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""
         manifests: List[PluginManifest] = []
+        target = transaction.manager_view if transaction is not None else self
 
         # 1. Bundled plugins (<repo>/plugins/<name>/)
         #
@@ -1872,8 +1910,9 @@ class PluginManager:
             if lookup_key in disabled or manifest.name in disabled:
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
                 loaded.error = "disabled via config"
-                with self._lock:
-                    self._plugins[lookup_key] = loaded
+                with target._lock:
+                    target._plugins[lookup_key] = loaded
+                    target._generation += 1
                 logger.debug("Skipping disabled plugin '%s'", lookup_key)
                 continue
 
@@ -1885,8 +1924,9 @@ class PluginManager:
                 loaded.error = (
                     "exclusive plugin — activate via <category>.provider config"
                 )
-                with self._lock:
-                    self._plugins[lookup_key] = loaded
+                with target._lock:
+                    target._plugins[lookup_key] = loaded
+                    target._generation += 1
                 logger.debug(
                     "Skipping '%s' (exclusive, handled by category discovery)",
                     lookup_key,
@@ -1901,8 +1941,9 @@ class PluginManager:
             # override semantics between bundled and user plugins.
             if manifest.kind == "model-provider":
                 loaded = LoadedPlugin(manifest=manifest, enabled=True)
-                with self._lock:
-                    self._plugins[lookup_key] = loaded
+                with target._lock:
+                    target._plugins[lookup_key] = loaded
+                    target._generation += 1
                 logger.debug(
                     "Skipping '%s' (model-provider, handled by providers/ discovery)",
                     lookup_key,
@@ -1914,7 +1955,7 @@ class PluginManager:
             # services calls) is driven by ``<category>.provider`` config,
             # enforced by the tool wrapper.
             if manifest.source == "bundled" and manifest.kind == "backend":
-                self._load_plugin(manifest)
+                self._load_plugin(manifest, transaction=transaction)
                 continue
 
             # Bundled platform plugins (gateway adapters: telegram, discord,
@@ -1929,7 +1970,10 @@ class PluginManager:
             # path actually asks for that platform. Every platform Hermes ships
             # remains available out of the box — it just loads on first use.
             if manifest.source == "bundled" and manifest.kind == "platform":
-                self._register_deferred_platform(manifest)
+                self._register_deferred_platform(
+                    manifest,
+                    transaction=transaction,
+                )
                 continue
 
             # Everything else (standalone, user-installed backends,
@@ -1946,19 +1990,20 @@ class PluginManager:
                     "not enabled in config (run `hermes plugins enable {}` to activate)"
                     .format(lookup_key)
                 )
-                with self._lock:
-                    self._plugins[lookup_key] = loaded
+                with target._lock:
+                    target._plugins[lookup_key] = loaded
+                    target._generation += 1
                 logger.debug(
                     "Skipping '%s' (not in plugins.enabled)", lookup_key
                 )
                 continue
-            self._load_plugin(manifest)
+            self._load_plugin(manifest, transaction=transaction)
 
         if manifests:
-            with self._lock:
-                found_count = len(self._plugins)
+            with target._lock:
+                found_count = len(target._plugins)
                 enabled_count = sum(
-                    1 for plugin in self._plugins.values() if plugin.enabled
+                    1 for plugin in target._plugins.values() if plugin.enabled
                 )
             logger.info(
                 "Plugin discovery complete: %d found, %d enabled",
@@ -2195,71 +2240,67 @@ class PluginManager:
             return Path(manifest.path).name
         return name
 
-    def _register_deferred_platform(self, manifest: PluginManifest) -> None:
-        """Register a lazy loader for a bundled platform plugin.
-
-        The platform adapter module is imported only when the gateway / cron /
-        setup / send_message path first asks the ``platform_registry`` for this
-        platform. Until then we record a lightweight ``LoadedPlugin`` so
-        ``hermes plugins list`` still shows the platform as available, and we
-        hand the registry a loader that runs the normal eager-load path.
-        """
+    def _register_deferred_platform(
+        self,
+        manifest: PluginManifest,
+        transaction: Optional[_RegistrationTransaction] = None,
+    ) -> None:
+        """Stage a bundled platform loader with its manager attribution."""
+        own_transaction = transaction is None
+        transaction = transaction or _RegistrationTransaction(self)
+        target = transaction.manager_view
         lookup_key = manifest.key or manifest.name
         platform_name = self._platform_name_from_manifest(manifest)
 
-        # Record an enabled placeholder for introspection (`hermes plugins
-        # list`). The real module load swaps in a fully-populated LoadedPlugin
-        # (tools/hooks/commands attribution) when the loader fires.
         loaded = LoadedPlugin(manifest=manifest, enabled=True)
         loaded.deferred = True
-        with self._lock:
-            self._plugins[lookup_key] = loaded
+        with target._lock:
+            target._plugins[lookup_key] = loaded
+            target._record_external_registration("platform", platform_name)
 
         def _loader(_manifest: PluginManifest = manifest) -> None:
             self._load_plugin(_manifest)
 
-        try:
-            from gateway.platform_registry import platform_registry
-
-            platform_registry.register_deferred(platform_name, _loader)
-            logger.debug(
-                "Registered deferred platform loader: %s (plugin=%s)",
-                platform_name,
-                lookup_key,
-            )
-        except Exception:
-            # If the registry import fails for any reason, fall back to eager
-            # loading so the platform is never silently lost.
-            logger.debug(
-                "Deferred platform registration failed for '%s'; eager-loading",
-                lookup_key,
-                exc_info=True,
-            )
-            self._load_plugin(manifest)
-
-    def _load_plugin(self, manifest: PluginManifest) -> None:
-        """Import a plugin module and call its ``register(ctx)`` function."""
-        loaded = LoadedPlugin(manifest=manifest)
+        transaction.external_views["platform"].register_deferred(
+            platform_name,
+            _loader,
+        )
+        if own_transaction:
+            transaction.commit()
         logger.debug(
-            "Loading plugin '%s' (source=%s, kind=%s, path=%s)",
-            manifest.key or manifest.name, manifest.source, manifest.kind, manifest.path,
+            "Registered deferred platform loader: %s (plugin=%s)",
+            platform_name,
+            lookup_key,
         )
 
-        from tools.registry import registry as _registry
+    def _load_plugin(
+        self,
+        manifest: PluginManifest,
+        transaction: Optional[_RegistrationTransaction] = None,
+    ) -> None:
+        """Stage one plugin and publish only through the ordered transaction."""
+        with self._discovery_lock:
+            self._load_plugin_serialized(manifest, transaction)
 
+    def _load_plugin_serialized(
+        self,
+        manifest: PluginManifest,
+        transaction: Optional[_RegistrationTransaction],
+    ) -> None:
+        own_transaction = transaction is None
+        transaction = transaction or _RegistrationTransaction(self)
+        loaded = LoadedPlugin(manifest=manifest)
         plugin_id = manifest.key or manifest.name
         module_root = (
             _directory_module_name(manifest)
             if manifest.source in {"user", "project", "bundled"}
             else None
         )
-        manager_before = self._snapshot_owned_state()
-        registration_view = _PluginRegistrationView(
-            manager_before,
-            self._cli_ref,
+        manager_before = _PluginManagerState(transaction.manager_view)
+        tools_start = len(transaction.manager_view._transaction_tools_registered)
+        commands_start = len(
+            transaction.manager_view._transaction_commands_registered
         )
-        tool_before = _registry._take_transaction_snapshot()
-        tool_registration_view = _registry._create_transaction_view(tool_before)
         modules_before = (
             _snapshot_module_namespace(module_root) if module_root else {}
         )
@@ -2267,11 +2308,12 @@ class PluginManager:
         context = PluginContext(
             manifest,
             self,
-            registration_manager=registration_view,
-            registration_registry=tool_registration_view,
+            registration_manager=transaction.manager_view,
+            registration_registry=transaction.tool_view,
+            registration_external_registries=transaction.context_targets(),
         )
         try:
-            tool_registration_view.register_plugin_override_policy(
+            transaction.tool_view.register_plugin_override_policy(
                 module_root or plugin_id,
                 context._tool_override_allowed(""),
             )
@@ -2287,69 +2329,73 @@ class PluginManager:
 
             phase = "registration"
             register_fn(context)
+            staged = transaction.manager_view
             loaded.tools_registered = list(
-                registration_view._transaction_tools_registered
+                staged._transaction_tools_registered[tools_start:]
             )
             loaded.hooks_registered = [
                 name
-                for name, callbacks in registration_view._hooks.items()
+                for name, callbacks in staged._hooks.items()
                 if len(callbacks) > len(manager_before._hooks.get(name, []))
             ]
             loaded.middleware_registered = [
                 name
-                for name, callbacks in registration_view._middleware.items()
+                for name, callbacks in staged._middleware.items()
                 if len(callbacks) > len(manager_before._middleware.get(name, []))
             ]
             loaded.commands_registered = list(
-                registration_view._transaction_commands_registered
+                staged._transaction_commands_registered[commands_start:]
             )
             loaded.enabled = True
+            with staged._lock:
+                staged._plugins[plugin_id] = loaded
+                staged._generation += 1
+            transaction.contexts.append(context)
             phase = "commit"
-            self._commit_registration_view(
-                manager_before,
-                registration_view,
-                plugin_id,
-                loaded,
-                _registry,
-                tool_before,
-                tool_registration_view,
-                context,
-            )
+            if own_transaction:
+                transaction.commit()
             logger.debug(
-                "  registered: %d tool(s), %d hook(s), %d middleware, "
-                "%d slash command(s), %d CLI command(s)",
+                "Plugin '%s' staged %d tool(s), %d hook(s), %d middleware, "
+                "%d slash command(s)",
+                plugin_id,
                 len(loaded.tools_registered),
                 len(loaded.hooks_registered),
                 len(loaded.middleware_registered),
                 len(loaded.commands_registered),
-                sum(
-                    1
-                    for entry in registration_view._cli_commands.values()
-                    if entry.get("plugin") == manifest.name
-                ),
             )
             return
-
         except BaseException as exc:
-            # Live tools and manager registrations were never touched unless
-            # the atomic commit completed. External registries retain their
-            # existing explicit journals.
-            registration_view._rollback_external_registries()
             if module_root:
                 _restore_module_namespace(module_root, modules_before)
             loaded.enabled = False
             loaded.module = None
             if not isinstance(exc, Exception):
                 raise
-
-            loaded.error = f"{type(exc).__name__}: plugin {phase} failed"
-            logger.warning(
-                "Failed to load plugin '%s': %s",
-                manifest.name,
-                loaded.error,
+            loaded.error = (
+                "RuntimeError: plugin commit failed"
+                if phase == "commit"
+                else f"{type(exc).__name__}: plugin {phase} failed"
             )
+            if isinstance(exc, RegistryTransactionConflict):
+                logger.warning(
+                    "Plugin commit conflict: plugin=%s surface=%s "
+                    "expected_generation=%d actual_generation=%d",
+                    plugin_id,
+                    exc.surface,
+                    exc.expected_generation,
+                    exc.actual_generation,
+                )
+            else:
+                logger.warning(
+                    "Failed to load plugin '%s': %s",
+                    manifest.name,
+                    loaded.error,
+                )
+            if not own_transaction:
+                raise _ForceSweepAbort() from None
             with self._lock:
                 self._plugins[plugin_id] = loaded
+                self._generation += 1
 
     def _load_directory_module(self, manifest: PluginManifest) -> types.ModuleType:
         """Import a directory-based plugin as ``hermes_plugins.<slug>``.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -527,6 +527,16 @@ class _PluginRegistrationView:
         self._frozen = True
 
 
+@dataclass(frozen=True)
+class _PluginContextBinding:
+    """One coherent authority target captured by a registration mutation."""
+
+    registry: Any
+    manager: Any
+    external_registries: Any
+    managed_generation: Optional[int]
+
+
 class _RegistrationTransaction:
     """One isolated plugin registration or complete force-reload candidate."""
 
@@ -651,7 +661,10 @@ class _RegistrationTransaction:
             if self.replace_owned
             else None
         )
-        locks = [
+        context_locks = [
+            context._registration_lock for context in self.contexts
+        ]
+        live_registry_locks = [
             self.manager._lock,
             self.tool_registry._lock,
             *(
@@ -660,31 +673,32 @@ class _RegistrationTransaction:
             ),
         ]
         acquired_locks: List[Any] = []
+        revocation_started = False
         publication_started = False
-        context_bindings_before = [
-            (
-                context,
-                context._registration_registry,
-                context._registration_manager,
-                context._registration_external_registries,
-                context._managed_generation,
-            )
-            for context in self.contexts
-        ]
-
-        def restore_context_binding(binding: tuple[Any, ...]) -> None:
-            context, registry, manager, external_registries, generation = binding
-            context._registration_registry = registry
-            context._registration_manager = manager
-            context._registration_external_registries = external_registries
-            context._managed_generation = generation
+        context_bindings_before: List[
+            tuple[PluginContext, _PluginContextBinding]
+        ] = []
 
         try:
-            if revoke_generation is not None:
-                self.manager._begin_live_context_revocation(revoke_generation)
-            for lock in locks:
+            # Binding locks always precede every live manager/tool/external
+            # registry lock. This blocks retained contexts before publication
+            # can swap or restore their single coherent authority reference.
+            for lock in context_locks:
                 lock.acquire()
                 acquired_locks.append(lock)
+            if revoke_generation is not None:
+                # Claim cleanup before the call: an injected BaseException may
+                # occur after the manager adds the marker but before returning.
+                revocation_started = True
+                self.manager._begin_live_context_revocation(revoke_generation)
+            for lock in live_registry_locks:
+                lock.acquire()
+                acquired_locks.append(lock)
+
+            context_bindings_before = [
+                (context, context._registration_binding)
+                for context in self.contexts
+            ]
             if self.manager._generation != self.manager_before._generation:
                 raise RegistryTransactionConflict(
                     "manager",
@@ -714,10 +728,12 @@ class _RegistrationTransaction:
                     prepared_external[surface],
                 )
             for context in self.contexts:
-                context._registration_registry = self.tool_registry
-                context._registration_manager = self.manager
-                context._registration_external_registries = None
-                context._managed_generation = self.context_generation
+                context._registration_binding = _PluginContextBinding(
+                    registry=self.tool_registry,
+                    manager=self.manager,
+                    external_registries=None,
+                    managed_generation=self.context_generation,
+                )
             self.manager._install_owned_state_locked(next_manager)
         except BaseException as primary:
             if publication_started:
@@ -743,7 +759,9 @@ class _RegistrationTransaction:
                     *(
                         (
                             f"context[{index}]",
-                            lambda binding=binding: restore_context_binding(binding),
+                            lambda binding=binding: setattr(
+                                binding[0], "_registration_binding", binding[1]
+                            ),
                         )
                         for index, binding in enumerate(context_bindings_before)
                     ),
@@ -775,7 +793,7 @@ class _RegistrationTransaction:
         finally:
             for lock in reversed(acquired_locks):
                 lock.release()
-            if revoke_generation is not None:
+            if revocation_started:
                 self.manager._cancel_live_context_revocation(revoke_generation)
 
 
@@ -786,6 +804,7 @@ class _ForceSweepAbort(RuntimeError):
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
+
 
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
@@ -801,20 +820,27 @@ class PluginContext:
     ):
         self.manifest = manifest
         self._manager = manager
-        self._registration_manager = registration_manager or manager
-        # Managed discovery supplies an isolated ToolRegistry transaction view.
-        # Direct/runtime contexts leave this unset and target the live registry.
-        self._registration_registry = registration_registry
-        self._registration_external_registries = registration_external_registries
-        self._managed_generation: Optional[int] = None
+        self._registration_lock = threading.RLock()
+        # Managed discovery supplies isolated registry transaction views.
+        # Direct/runtime contexts leave them unset and target live registries.
+        self._registration_binding = _PluginContextBinding(
+            registry=registration_registry,
+            manager=registration_manager or manager,
+            external_registries=registration_external_registries,
+            managed_generation=None,
+        )
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
 
-    def _ensure_live_locked(self, target: Any) -> None:
+    def _ensure_live_locked(
+        self,
+        binding: _PluginContextBinding,
+        target: Any,
+    ) -> None:
         if getattr(target, "_frozen", False):
             raise RuntimeError("plugin registration view is frozen")
-        generation = self._managed_generation
+        generation = binding.managed_generation
         if generation is None or not isinstance(target, PluginManager):
             return
         if target._live_context_generation != generation:
@@ -822,44 +848,53 @@ class PluginContext:
                 f"Plugin context for {self.manifest.name!r} is no longer live"
             )
 
-    def _acquire_live_lease(self, target: Any) -> Callable[[], None]:
-        generation = self._managed_generation
+    def _acquire_live_lease(
+        self,
+        binding: _PluginContextBinding,
+    ) -> Callable[[], None]:
+        target = binding.manager
+        generation = binding.managed_generation
         if generation is None or not isinstance(target, PluginManager):
             return lambda: None
         return target._acquire_live_context_lease(self.manifest.name, generation)
 
-    def _record_external_registration(self, surface: str, name: str) -> None:
-        target = self._registration_manager
+    def _record_external_registration(
+        self,
+        binding: _PluginContextBinding,
+        surface: str,
+        name: str,
+    ) -> None:
+        target = binding.manager
         recorder = getattr(target, "_record_external_registration", None)
         if recorder is not None:
             with target._lock:
-                self._ensure_live_locked(target)
+                self._ensure_live_locked(binding, target)
                 recorder(surface, name)
 
     def _register_external_value(
         self,
+        binding: _PluginContextBinding,
         surface: str,
         value: Any,
         live_register: Callable[[Any], Any],
     ) -> Optional[str]:
-        targets = self._registration_external_registries
-        target = self._registration_manager
+        targets = binding.external_registries
         if targets is None:
-            release_live = self._acquire_live_lease(target)
+            release_live = self._acquire_live_lease(binding)
             try:
                 result = live_register(value)
                 if surface == "secret" and not result:
                     return None
                 name = value.name
                 if name:
-                    self._record_external_registration(surface, name)
+                    self._record_external_registration(binding, surface, name)
             finally:
                 release_live()
         else:
             transaction, staged = targets[surface]
             name = transaction.register(staged, value)
-        if targets is not None and name:
-            self._record_external_registration(surface, name)
+            if name:
+                self._record_external_registration(binding, surface, name)
         return name
 
     # -- host-owned LLM access ----------------------------------------------
@@ -960,37 +995,39 @@ class PluginContext:
                 f"in config.yaml to allow this plugin to replace built-in tools."
             )
 
-        target_registry = self._registration_registry
-        if target_registry is None:
-            from tools.registry import registry as target_registry
+        with self._registration_lock:
+            binding = self._registration_binding
+            target_registry = binding.registry
+            if target_registry is None:
+                from tools.registry import registry as target_registry
 
-        target = self._registration_manager
-        resolved_description = description or schema.get("description", "")
-        release_live = self._acquire_live_lease(target)
-        try:
-            target_registry.register(
-                name=name,
-                toolset=toolset,
-                schema=schema,
-                handler=handler,
-                check_fn=check_fn,
-                requires_env=requires_env,
-                is_async=is_async,
-                description=resolved_description,
-                emoji=emoji,
-                override=override,
-            )
-            with target._lock:
-                self._ensure_live_locked(target)
-                target._plugin_tool_names.add(name)
-                registered = getattr(
-                    target, "_transaction_tools_registered", None
+            target = binding.manager
+            resolved_description = description or schema.get("description", "")
+            release_live = self._acquire_live_lease(binding)
+            try:
+                target_registry.register(
+                    name=name,
+                    toolset=toolset,
+                    schema=schema,
+                    handler=handler,
+                    check_fn=check_fn,
+                    requires_env=requires_env,
+                    is_async=is_async,
+                    description=resolved_description,
+                    emoji=emoji,
+                    override=override,
                 )
-                if registered is not None and name not in registered:
-                    registered.append(name)
-                target._generation += 1
-        finally:
-            release_live()
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._plugin_tool_names.add(name)
+                    registered = getattr(
+                        target, "_transaction_tools_registered", None
+                    )
+                    if registered is not None and name not in registered:
+                        registered.append(name)
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
@@ -1065,18 +1102,24 @@ class PluginContext:
         The *setup_fn* receives an argparse subparser and should add any
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
         as the default dispatch function via ``set_defaults(func=...)``."""
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._cli_commands[name] = {
-                "name": name,
-                "help": help,
-                "description": description,
-                "setup_fn": setup_fn,
-                "handler_fn": handler_fn,
-                "plugin": self.manifest.name,
-            }
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._cli_commands[name] = {
+                        "name": name,
+                        "help": help,
+                        "description": description,
+                        "setup_fn": setup_fn,
+                        "handler_fn": handler_fn,
+                        "plugin": self.manifest.name,
+                    }
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
 
     # -- slash command registration -------------------------------------------
@@ -1127,21 +1170,27 @@ class PluginContext:
         except Exception:
             pass  # If commands module isn't available, skip the check
 
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._plugin_commands[clean] = {
-                "handler": handler,
-                "description": description or "Plugin command",
-                "plugin": self.manifest.name,
-                "args_hint": (args_hint or "").strip(),
-            }
-            registered = getattr(
-                target, "_transaction_commands_registered", None
-            )
-            if registered is not None and clean not in registered:
-                registered.append(clean)
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._plugin_commands[clean] = {
+                        "handler": handler,
+                        "description": description or "Plugin command",
+                        "plugin": self.manifest.name,
+                        "args_hint": (args_hint or "").strip(),
+                    }
+                    registered = getattr(
+                        target, "_transaction_commands_registered", None
+                    )
+                    if registered is not None and clean not in registered:
+                        registered.append(clean)
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
     # -- tool dispatch -------------------------------------------------------
@@ -1194,20 +1243,24 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            if getattr(target, "_frozen", False):
-                raise RuntimeError("plugin registration transaction is frozen")
-            if target._context_engine is not None:
-                logger.warning(
-                    "Plugin '%s' tried to register a context engine, but one is "
-                    "already registered. Only one context engine plugin is allowed.",
-                    self.manifest.name,
-                )
-                return
-            target._context_engine = engine
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    if target._context_engine is not None:
+                        logger.warning(
+                            "Plugin '%s' tried to register a context engine, but one is "
+                            "already registered. Only one context engine plugin is allowed.",
+                            self.manifest.name,
+                        )
+                        return
+                    target._context_engine = engine
+                    target._generation += 1
+            finally:
+                release_live()
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -1234,7 +1287,11 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._register_external_value("image_gen", provider, register_provider)
+        with self._registration_lock:
+            binding = self._registration_binding
+            self._register_external_value(
+                binding, "image_gen", provider, register_provider
+            )
         logger.info(
             "Plugin '%s' registered image_gen provider: %s",
             self.manifest.name, provider.name,
@@ -1267,11 +1324,14 @@ class PluginContext:
             )
             return
         try:
-            name = self._register_external_value(
-                "dashboard",
-                provider,
-                register_provider,
-            )
+            with self._registration_lock:
+                binding = self._registration_binding
+                name = self._register_external_value(
+                    binding,
+                    "dashboard",
+                    provider,
+                    register_provider,
+                )
         except (TypeError, ValueError) as e:
             logger.warning(
                 "Plugin '%s' failed to register dashboard-auth provider "
@@ -1307,11 +1367,14 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._register_external_value(
-            "video_gen",
-            provider,
-            _register_video_provider,
-        )
+        with self._registration_lock:
+            binding = self._registration_binding
+            self._register_external_value(
+                binding,
+                "video_gen",
+                provider,
+                _register_video_provider,
+            )
         logger.info(
             "Plugin '%s' registered video_gen provider: %s",
             self.manifest.name, provider.name,
@@ -1339,7 +1402,11 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._register_external_value("web", provider, _register_web_provider)
+        with self._registration_lock:
+            binding = self._registration_binding
+            self._register_external_value(
+                binding, "web", provider, _register_web_provider
+            )
         logger.info(
             "Plugin '%s' registered web provider: %s",
             self.manifest.name, provider.name,
@@ -1371,11 +1438,14 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        self._register_external_value(
-            "browser",
-            provider,
-            _register_browser_provider,
-        )
+        with self._registration_lock:
+            binding = self._registration_binding
+            self._register_external_value(
+                binding,
+                "browser",
+                provider,
+                _register_browser_provider,
+            )
         logger.info(
             "Plugin '%s' registered browser provider: %s",
             self.manifest.name, provider.name,
@@ -1422,7 +1492,12 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        if self._register_external_value("secret", source, register_source):
+        with self._registration_lock:
+            binding = self._registration_binding
+            registered = self._register_external_value(
+                binding, "secret", source, register_source
+            )
+        if registered:
             logger.info(
                 "Plugin '%s' registered secret source: %s",
                 self.manifest.name, source.name,
@@ -1460,11 +1535,14 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        name = self._register_external_value(
-            "tts",
-            provider,
-            _register_tts_provider,
-        )
+        with self._registration_lock:
+            binding = self._registration_binding
+            name = self._register_external_value(
+                binding,
+                "tts",
+                provider,
+                _register_tts_provider,
+            )
         if name is None:
             return
         logger.info(
@@ -1510,11 +1588,14 @@ class PluginContext:
                 self.manifest.name,
             )
             return
-        name = self._register_external_value(
-            "stt",
-            provider,
-            _register_stt_provider,
-        )
+        with self._registration_lock:
+            binding = self._registration_binding
+            name = self._register_external_value(
+                binding,
+                "stt",
+                provider,
+                _register_stt_provider,
+            )
         if name is None:
             return
         logger.info(
@@ -1570,19 +1651,23 @@ class PluginContext:
             source="plugin",
             **entry_kwargs,
         )
-        targets = self._registration_external_registries
-        if targets is None:
-            target = self._registration_manager
-            release_live = self._acquire_live_lease(target)
-            try:
-                platform_registry.register(entry)
-                self._record_external_registration("platform", name)
-            finally:
-                release_live()
-        else:
-            _transaction, staged = targets["platform"]
-            staged.register(entry)
-            self._record_external_registration("platform", name)
+        with self._registration_lock:
+            binding = self._registration_binding
+            targets = binding.external_registries
+            if targets is None:
+                release_live = self._acquire_live_lease(binding)
+                try:
+                    platform_registry.register(entry)
+                    self._record_external_registration(
+                        binding, "platform", name
+                    )
+                finally:
+                    release_live()
+            else:
+                _transaction, staged = targets["platform"]
+                staged.register(entry)
+                self._record_external_registration(binding, "platform", name)
+
         logger.debug(
             "Plugin %s registered platform: %s",
             self.manifest.name,
@@ -1638,13 +1723,19 @@ class PluginContext:
                 f"Plugin '{self.manifest.name}' tried to register a Slack "
                 f"action handler with an empty action_id."
             )
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._slack_action_handlers.append(
-                (action_id, callback, self.manifest.name)
-            )
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._slack_action_handlers.append(
+                        (action_id, callback, self.manifest.name)
+                    )
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug(
             "Plugin %s registered Slack action handler: %s",
             self.manifest.name,
@@ -1729,17 +1820,6 @@ class PluginContext:
                 f"Pick a plugin-namespaced key (e.g. '{self.manifest.name}_{key}')."
             )
 
-        # Reject duplicate registrations across plugins
-        target = self._registration_manager
-        with target._lock:
-            existing = target._aux_tasks.get(key)
-        if existing is not None and existing.get("plugin") != self.manifest.name:
-            raise ValueError(
-                f"Plugin '{self.manifest.name}' cannot register auxiliary task "
-                f"{key!r} — already registered by plugin "
-                f"'{existing.get('plugin')}'"
-            )
-
         # Normalize defaults — plugin owns the schema, but we ensure routing
         # fields exist with sensible types so consumers don't crash.
         merged_defaults: Dict[str, Any] = {
@@ -1754,16 +1834,33 @@ class PluginContext:
             for k, v in defaults.items():
                 merged_defaults[k] = v
 
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._aux_tasks[key] = {
-                "key": key,
-                "display_name": display_name,
-                "description": description,
-                "defaults": merged_defaults,
-                "plugin": self.manifest.name,
-            }
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    existing = target._aux_tasks.get(key)
+                    if (
+                        existing is not None
+                        and existing.get("plugin") != self.manifest.name
+                    ):
+                        raise ValueError(
+                            f"Plugin '{self.manifest.name}' cannot register auxiliary task "
+                            f"{key!r} — already registered by plugin "
+                            f"'{existing.get('plugin')}'"
+                        )
+                    target._aux_tasks[key] = {
+                        "key": key,
+                        "display_name": display_name,
+                        "description": description,
+                        "defaults": merged_defaults,
+                        "plugin": self.manifest.name,
+                    }
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug(
             "Plugin %s registered auxiliary task: %s (%s)",
             self.manifest.name,
@@ -1785,11 +1882,17 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._hooks.setdefault(hook_name, []).append(callback)
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._hooks.setdefault(hook_name, []).append(callback)
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -1810,11 +1913,17 @@ class PluginContext:
                 kind,
                 ", ".join(sorted(VALID_MIDDLEWARE)),
             )
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._middleware.setdefault(kind, []).append(callback)
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._middleware.setdefault(kind, []).append(callback)
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
 
     # -- skill registration -------------------------------------------------
@@ -1853,16 +1962,22 @@ class PluginContext:
             raise FileNotFoundError(f"SKILL.md not found at {path}")
 
         qualified = f"{self.manifest.name}:{name}"
-        target = self._registration_manager
-        with target._lock:
-            self._ensure_live_locked(target)
-            target._plugin_skills[qualified] = {
-                "path": path,
-                "plugin": self.manifest.name,
-                "bare_name": name,
-                "description": description,
-            }
-            target._generation += 1
+        with self._registration_lock:
+            binding = self._registration_binding
+            target = binding.manager
+            release_live = self._acquire_live_lease(binding)
+            try:
+                with target._lock:
+                    self._ensure_live_locked(binding, target)
+                    target._plugin_skills[qualified] = {
+                        "path": path,
+                        "plugin": self.manifest.name,
+                        "bare_name": name,
+                        "description": description,
+                    }
+                    target._generation += 1
+            finally:
+                release_live()
         logger.debug(
             "Plugin %s registered skill: %s",
             self.manifest.name, qualified,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,7 @@ exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = 
 py-modules = [
   "run_agent",
   "model_tools",
+  "registry_transaction",
   "toolsets",
   "batch_runner",
   "trajectory_compressor",

--- a/registry_transaction.py
+++ b/registry_transaction.py
@@ -261,6 +261,13 @@ class MappingRegistry:
         self._items.update(prepared._items)
         self._generation = max(self._generation, prepared._generation) + 1
 
+    def restore_snapshot_locked(self, snapshot: _MappingSnapshot) -> None:
+        """Restore an opaque snapshot exactly while the registry lock is held."""
+        self._validate_snapshot(snapshot)
+        self._items.clear()
+        self._items.update(dict(snapshot._items))
+        self._generation = snapshot._generation
+
 
 class RegistryTransactionSurface:
     """Opaque plugin transaction API owned by one module registry."""
@@ -312,3 +319,6 @@ class RegistryTransactionSurface:
         prepared: _PreparedMapping,
     ) -> None:
         self._state.install_prepared_locked(snapshot, prepared)
+
+    def restore_snapshot_locked(self, snapshot: _MappingSnapshot) -> None:
+        self._state.restore_snapshot_locked(snapshot)

--- a/registry_transaction.py
+++ b/registry_transaction.py
@@ -1,0 +1,314 @@
+"""Host-private copy-on-write primitives for process-local registries.
+
+The plugin manager uses these objects only for short prepare/validate/install
+cycles.  Arbitrary provider and plugin callbacks run while populating isolated
+views, never while a live registry lock is held.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Iterable, Optional
+
+
+class RegistryTransactionConflict(RuntimeError):
+    """A live registry changed after a transaction captured its baseline."""
+
+    def __init__(
+        self,
+        surface: str,
+        expected_generation: int,
+        actual_generation: int,
+    ) -> None:
+        self.surface = surface
+        self.expected_generation = expected_generation
+        self.actual_generation = actual_generation
+        super().__init__(
+            f"{surface} registry changed during plugin registration "
+            f"(generation {expected_generation} -> {actual_generation}); "
+            "refusing commit"
+        )
+
+
+class _MappingSnapshot:
+    __slots__ = ("_owner", "_items", "_generation")
+
+    def __init__(
+        self,
+        owner: "MappingRegistry",
+        items: tuple[tuple[str, Any], ...],
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._items = items
+        self._generation = generation
+
+
+class _PreparedMapping:
+    __slots__ = ("_owner", "_snapshot", "_items", "_generation")
+
+    def __init__(
+        self,
+        owner: "MappingRegistry",
+        snapshot: _MappingSnapshot,
+        items: dict[str, Any],
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._snapshot = snapshot
+        self._items = items
+        self._generation = generation
+
+
+class MappingRegistry:
+    """Thread-safe string-keyed registry with opaque transaction views."""
+
+    def __init__(
+        self,
+        surface: str,
+        items: Optional[dict[str, Any]] = None,
+        lock: Optional[threading.RLock] = None,
+    ) -> None:
+        self.surface = surface
+        self._items = items if items is not None else {}
+        self._lock = lock if lock is not None else threading.RLock()
+        self._generation = 0
+        self._frozen = False
+        self._transaction_owner: Optional[MappingRegistry] = None
+        self._transaction_snapshot: Optional[_MappingSnapshot] = None
+
+    @property
+    def lock(self) -> threading.RLock:
+        return self._lock
+
+    def get(self, key: str) -> Any:
+        with self._lock:
+            return self._items.get(key)
+
+    def values(self) -> list[Any]:
+        with self._lock:
+            return list(self._items.values())
+
+    def items_snapshot(self) -> tuple[tuple[str, Any], ...]:
+        with self._lock:
+            return tuple(self._items.items())
+
+    def put(
+        self,
+        key: str,
+        value: Any,
+        *,
+        replace: bool = True,
+    ) -> tuple[bool, Any]:
+        """Atomically add *value* after callers finish validation callbacks."""
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError(f"{self.surface} transaction view is frozen")
+            existing = self._items.get(key)
+            if existing is not None and not replace:
+                return False, existing
+            self._items[key] = value
+            self._generation += 1
+            return True, existing
+
+    def remove(self, key: str) -> bool:
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError(f"{self.surface} transaction view is frozen")
+            if key not in self._items:
+                return False
+            del self._items[key]
+            self._generation += 1
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError(f"{self.surface} transaction view is frozen")
+            self._items.clear()
+            self._generation += 1
+
+    def take_snapshot(self) -> _MappingSnapshot:
+        with self._lock:
+            return _MappingSnapshot(
+                self,
+                tuple(self._items.items()),
+                self._generation,
+            )
+
+    def snapshot_items(
+        self,
+        snapshot: _MappingSnapshot,
+    ) -> tuple[tuple[str, Any], ...]:
+        self._validate_snapshot(snapshot)
+        return snapshot._items
+
+    def put_if_snapshot(
+        self,
+        snapshot: _MappingSnapshot,
+        key: str,
+        value: Any,
+        *,
+        replace: bool = True,
+    ) -> tuple[bool, Any]:
+        """Put only if the exact callback-free validation baseline is live."""
+        self._validate_snapshot(snapshot)
+        with self._lock:
+            if self._frozen:
+                raise RuntimeError(f"{self.surface} transaction view is frozen")
+            if not self.matches_locked(snapshot):
+                raise RegistryTransactionConflict(
+                    self.surface,
+                    snapshot._generation,
+                    self._generation,
+                )
+            existing = self._items.get(key)
+            if existing is not None and not replace:
+                return False, existing
+            self._items[key] = value
+            self._generation += 1
+            return True, existing
+
+    def _validate_snapshot(self, snapshot: _MappingSnapshot) -> None:
+        if not isinstance(snapshot, _MappingSnapshot) or snapshot._owner is not self:
+            raise ValueError(
+                f"transaction snapshot belongs to a different {self.surface} registry"
+            )
+
+    def create_view(
+        self,
+        snapshot: _MappingSnapshot,
+        *,
+        remove_keys: Iterable[str] = (),
+    ) -> "MappingRegistry":
+        self._validate_snapshot(snapshot)
+        removed = frozenset(remove_keys)
+        staged = MappingRegistry(
+            self.surface,
+            {
+                key: value
+                for key, value in snapshot._items
+                if key not in removed
+            },
+        )
+        staged._generation = snapshot._generation
+        staged._transaction_owner = self
+        staged._transaction_snapshot = snapshot
+        return staged
+
+    def prepare(
+        self,
+        snapshot: _MappingSnapshot,
+        staged: "MappingRegistry",
+    ) -> _PreparedMapping:
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(staged, MappingRegistry)
+            or staged._transaction_owner is not self
+            or staged._transaction_snapshot is not snapshot
+        ):
+            raise ValueError(
+                f"transaction view belongs to a different {self.surface} registry"
+            )
+        with staged._lock:
+            prepared = _PreparedMapping(
+                self,
+                snapshot,
+                dict(staged._items),
+                staged._generation,
+            )
+            staged._frozen = True
+            return prepared
+
+    def matches_locked(self, snapshot: _MappingSnapshot) -> bool:
+        return (
+            self._generation == snapshot._generation
+            and len(self._items) == len(snapshot._items)
+            and all(
+                key in self._items and self._items[key] is value
+                for key, value in snapshot._items
+            )
+        )
+
+    def validate_prepared_locked(
+        self,
+        snapshot: _MappingSnapshot,
+        prepared: _PreparedMapping,
+    ) -> None:
+        self._validate_snapshot(snapshot)
+        if (
+            not isinstance(prepared, _PreparedMapping)
+            or prepared._owner is not self
+            or prepared._snapshot is not snapshot
+        ):
+            raise ValueError(
+                f"prepared state belongs to a different {self.surface} registry"
+            )
+        if not self.matches_locked(snapshot):
+            raise RegistryTransactionConflict(
+                self.surface,
+                snapshot._generation,
+                self._generation,
+            )
+
+    def install_prepared_locked(
+        self,
+        snapshot: _MappingSnapshot,
+        prepared: _PreparedMapping,
+    ) -> None:
+        self.validate_prepared_locked(snapshot, prepared)
+        self._items.clear()
+        self._items.update(prepared._items)
+        self._generation = max(self._generation, prepared._generation) + 1
+
+
+class RegistryTransactionSurface:
+    """Opaque plugin transaction API owned by one module registry."""
+
+    def __init__(
+        self,
+        state: MappingRegistry,
+        register_fn: Callable[[MappingRegistry, Any], Optional[str]],
+    ) -> None:
+        self.surface = state.surface
+        self._state = state
+        self._register_fn = register_fn
+
+    @property
+    def lock(self) -> threading.RLock:
+        return self._state.lock
+
+    def take_snapshot(self) -> _MappingSnapshot:
+        return self._state.take_snapshot()
+
+    def create_view(
+        self,
+        snapshot: _MappingSnapshot,
+        *,
+        remove_keys: Iterable[str] = (),
+    ) -> MappingRegistry:
+        return self._state.create_view(snapshot, remove_keys=remove_keys)
+
+    def register(self, staged: MappingRegistry, value: Any) -> Optional[str]:
+        return self._register_fn(staged, value)
+
+    def prepare(
+        self,
+        snapshot: _MappingSnapshot,
+        staged: MappingRegistry,
+    ) -> _PreparedMapping:
+        return self._state.prepare(snapshot, staged)
+
+    def validate_prepared_locked(
+        self,
+        snapshot: _MappingSnapshot,
+        prepared: _PreparedMapping,
+    ) -> None:
+        self._state.validate_prepared_locked(snapshot, prepared)
+
+    def install_prepared_locked(
+        self,
+        snapshot: _MappingSnapshot,
+        prepared: _PreparedMapping,
+    ) -> None:
+        self._state.install_prepared_locked(snapshot, prepared)

--- a/registry_transaction.py
+++ b/registry_transaction.py
@@ -257,15 +257,13 @@ class MappingRegistry:
         prepared: _PreparedMapping,
     ) -> None:
         self.validate_prepared_locked(snapshot, prepared)
-        self._items.clear()
-        self._items.update(prepared._items)
+        self._items = dict(prepared._items)
         self._generation = max(self._generation, prepared._generation) + 1
 
     def restore_snapshot_locked(self, snapshot: _MappingSnapshot) -> None:
         """Restore an opaque snapshot exactly while the registry lock is held."""
         self._validate_snapshot(snapshot)
-        self._items.clear()
-        self._items.update(dict(snapshot._items))
+        self._items = dict(snapshot._items)
         self._generation = snapshot._generation
 
 

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -1,6 +1,7 @@
 """Tests for the platform adapter registry and dynamic Platform enum."""
 
 import os
+import threading
 import pytest
 from unittest.mock import MagicMock
 
@@ -98,6 +99,119 @@ class TestPlatformRegistry:
         )
         reg.register(entry)
         assert reg.create_adapter("novalidate", MagicMock()) is mock_adapter
+
+    def test_deferred_loader_is_resolved_once_under_concurrency(self):
+        reg = PlatformRegistry()
+        entry, _ = self._make_entry("deferred-once")
+        loader_entered = threading.Event()
+        release_loader = threading.Event()
+        second_attempted = threading.Event()
+        second_done = threading.Event()
+        loader_calls = 0
+        loader_calls_lock = threading.Lock()
+
+        def _loader():
+            nonlocal loader_calls
+            with loader_calls_lock:
+                loader_calls += 1
+            loader_entered.set()
+            assert release_loader.wait(timeout=5)
+            reg.register(entry)
+
+        reg.register_deferred(entry.name, _loader)
+        results = []
+
+        def _read(*, second=False):
+            if second:
+                second_attempted.set()
+            results.append(reg.get(entry.name))
+            if second:
+                second_done.set()
+
+        first = threading.Thread(target=_read, daemon=True)
+        first.start()
+        assert loader_entered.wait(timeout=5)
+
+        second = threading.Thread(target=_read, kwargs={"second": True}, daemon=True)
+        second.start()
+        assert second_attempted.wait(timeout=5)
+        second_done.wait(timeout=2)
+        release_loader.set()
+
+        first.join(timeout=5)
+        second.join(timeout=5)
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert loader_calls == 1
+        assert results == [entry, entry]
+
+    @pytest.mark.parametrize("callback_name", ["check", "validate", "factory"])
+    def test_adapter_callbacks_run_without_registry_lock_held(self, callback_name):
+        reg = PlatformRegistry()
+        worker_finished = threading.Event()
+        worker_threads = []
+
+        def _callback_result(result):
+            def _callback(*args, **kwargs):
+                worker = threading.Thread(
+                    target=lambda: (
+                        reg.register(self._make_entry("callback-write")[0]),
+                        worker_finished.set(),
+                    ),
+                    daemon=True,
+                )
+                worker_threads.append(worker)
+                worker.start()
+                assert worker_finished.wait(timeout=5)
+                return result
+
+            return _callback
+
+        check_fn = _callback_result(True) if callback_name == "check" else lambda: True
+        validate_fn = (
+            _callback_result(True) if callback_name == "validate" else lambda config: True
+        )
+        factory_fn = (
+            _callback_result("adapter")
+            if callback_name == "factory"
+            else lambda config: "adapter"
+        )
+        reg.register(
+            PlatformEntry(
+                name="callback-source",
+                label="Callback source",
+                adapter_factory=factory_fn,
+                check_fn=check_fn,
+                validate_config=validate_fn,
+            )
+        )
+
+        assert reg.create_adapter("callback-source", object()) == "adapter"
+        worker_threads[0].join(timeout=5)
+        assert not worker_threads[0].is_alive()
+
+    def test_deferred_loader_runs_without_registry_lock_held(self):
+        reg = PlatformRegistry()
+        entry, _ = self._make_entry("loader-unlocked")
+        worker_finished = threading.Event()
+
+        def _loader():
+            worker = threading.Thread(
+                target=lambda: (
+                    reg.register(self._make_entry("loader-side-write")[0]),
+                    worker_finished.set(),
+                ),
+                daemon=True,
+            )
+            worker.start()
+            assert worker_finished.wait(timeout=5)
+            worker.join(timeout=5)
+            assert not worker.is_alive()
+            reg.register(entry)
+
+        reg.register_deferred(entry.name, _loader)
+
+        assert reg.get(entry.name) is entry
 
 
 # ── GatewayConfig integration ────────────────────────────────────────────

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -145,6 +145,98 @@ class TestPlatformRegistry:
         assert loader_calls == 1
         assert results == [entry, entry]
 
+    @pytest.mark.parametrize("accessor_name", ["all_entries", "plugin_entries"])
+    def test_concurrent_deferred_loaders_can_reenter_iterating_accessor(
+        self, accessor_name
+    ):
+        reg = PlatformRegistry()
+        entries = {
+            name: self._make_entry(name)[0]
+            for name in ("reentrant-alpha", "reentrant-beta")
+        }
+        loaders_ready = threading.Barrier(2)
+        nested_results = {}
+        outer_results = {}
+        failures = []
+
+        def _loader(name):
+            try:
+                loaders_ready.wait(timeout=5)
+                nested_results[name] = getattr(reg, accessor_name)()
+                reg.register(entries[name])
+            except BaseException as exc:
+                failures.append(exc)
+                raise
+
+        for name in entries:
+            reg.register_deferred(name, lambda name=name: _loader(name))
+
+        def _resolve(name):
+            outer_results[name] = reg.get(name)
+
+        threads = [
+            threading.Thread(target=_resolve, args=(name,), daemon=True)
+            for name in entries
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert failures == []
+        assert outer_results == entries
+        assert set(nested_results) == set(entries)
+
+    def test_concurrent_deferred_loaders_can_cross_get_each_other(self):
+        reg = PlatformRegistry()
+        entries = {
+            name: self._make_entry(name)[0]
+            for name in ("cross-alpha", "cross-beta")
+        }
+        peers = {
+            "cross-alpha": "cross-beta",
+            "cross-beta": "cross-alpha",
+        }
+        loaders_ready = threading.Barrier(2)
+        nested_results = {}
+        outer_results = {}
+        failures = []
+
+        def _loader(name):
+            try:
+                loaders_ready.wait(timeout=5)
+                nested_results[name] = reg.get(peers[name])
+                reg.register(entries[name])
+            except BaseException as exc:
+                failures.append(exc)
+                raise
+
+        for name in entries:
+            reg.register_deferred(name, lambda name=name: _loader(name))
+
+        def _resolve(name):
+            outer_results[name] = reg.get(name)
+
+        threads = [
+            threading.Thread(target=_resolve, args=(name,), daemon=True)
+            for name in entries
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert failures == []
+        assert outer_results == entries
+        nested_values = list(nested_results.values())
+        assert nested_values.count(None) == 1
+        assert any(
+            observed is entries[peers[name]]
+            for name, observed in nested_results.items()
+        )
+
     @pytest.mark.parametrize("callback_name", ["check", "validate", "factory"])
     def test_adapter_callbacks_run_without_registry_lock_held(self, callback_name):
         reg = PlatformRegistry()

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -145,6 +145,48 @@ class TestPlatformRegistry:
         assert loader_calls == 1
         assert results == [entry, entry]
 
+    def test_failing_deferred_loader_unblocks_all_waiters_without_retry(self):
+        reg = PlatformRegistry()
+        name = "deferred-failure"
+        loader_entered = threading.Event()
+        release_loader = threading.Event()
+        loader_calls = 0
+        loader_calls_lock = threading.Lock()
+
+        def _loader():
+            nonlocal loader_calls
+            with loader_calls_lock:
+                loader_calls += 1
+            loader_entered.set()
+            assert release_loader.wait(timeout=5)
+            raise RuntimeError("planned deferred loader failure")
+
+        reg.register_deferred(name, _loader)
+        results = []
+        failures = []
+
+        def _read():
+            try:
+                results.append(reg.get(name))
+            except BaseException as exc:  # pragma: no cover - asserted below
+                failures.append(exc)
+
+        threads = [threading.Thread(target=_read, daemon=True) for _ in range(4)]
+        threads[0].start()
+        assert loader_entered.wait(timeout=5)
+        for thread in threads[1:]:
+            thread.start()
+        release_loader.set()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert failures == []
+        assert results == [None, None, None, None]
+        assert loader_calls == 1
+        assert reg.get(name) is None
+        assert loader_calls == 1
+
     @pytest.mark.parametrize("accessor_name", ["all_entries", "plugin_entries"])
     def test_concurrent_deferred_loaders_can_reenter_iterating_accessor(
         self, accessor_name

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -5,6 +5,8 @@ art).
 """
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from hermes_cli.dashboard_auth import clear_providers, get_provider
@@ -46,6 +48,11 @@ class _MinimalManager:
     _cli_ref = None
     _context_engine = None
     _tools: dict = {}
+
+    def __init__(self) -> None:
+        # PluginContext's authority lock is manager-owned so every context for
+        # one manager participates in the same registration lock order.
+        self._context_registration_lock = threading.RLock()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -985,6 +985,191 @@ def test_failed_initial_publication_restores_candidate_context_targets(
     assert late_hook not in manager._hooks.get("post_tool_call", [])
 
 
+def _mutate_retained_candidate(context, surface: str, name: str) -> None:
+    if surface == "tool":
+        context.register_tool(
+            name,
+            "h1_transaction",
+            {
+                "name": name,
+                "description": "concurrent retained candidate",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            lambda args, **kwargs: "concurrent",
+        )
+        return
+    if surface == "hook":
+        context.register_hook(name, lambda *args, **kwargs: "concurrent")
+        return
+    context.register_platform(
+        name=name,
+        label="Concurrent retained candidate",
+        adapter_factory=lambda config: "concurrent",
+        check_fn=lambda: True,
+    )
+
+
+@pytest.mark.parametrize("surface", ["tool", "platform", "hook"])
+def test_initial_publication_hides_tentative_binding_from_retained_candidate_mutation(
+    tmp_path, monkeypatch, isolated_registries, surface
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", f"atomic-success-{surface}")
+    support = _support(values, "candidate", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    publication_paused = threading.Event()
+    release_publication = threading.Event()
+    original_install = manager._install_owned_state_locked
+
+    def pause_before_manager_install(state) -> None:
+        publication_paused.set()
+        assert release_publication.wait(timeout=5)
+        original_install(state)
+
+    monkeypatch.setattr(manager, "_install_owned_state_locked", pause_before_manager_install)
+    discovery_thread, discovery_done, discovery_failures = _start_discovery(manager)
+    assert publication_paused.wait(timeout=5)
+    context = support.saved_context
+    binding_captured = threading.Event()
+    mutation_started = threading.Event()
+    mutation_done = threading.Event()
+    mutation_failures: list[BaseException] = []
+    original_acquire = context._acquire_live_lease
+
+    def observe_binding_capture(*args, **kwargs):
+        binding_captured.set()
+        return original_acquire(*args, **kwargs)
+
+    monkeypatch.setattr(context, "_acquire_live_lease", observe_binding_capture)
+    name = f"h1_atomic_success_{surface}"
+
+    def mutate() -> None:
+        mutation_started.set()
+        try:
+            _mutate_retained_candidate(context, surface, name)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            mutation_failures.append(exc)
+        finally:
+            mutation_done.set()
+
+    mutation_thread = threading.Thread(target=mutate, daemon=True)
+    mutation_thread.start()
+    assert mutation_started.wait(timeout=5)
+    captured_before_publication = binding_captured.wait(timeout=0.2)
+    release_publication.set()
+    _join(discovery_thread, discovery_done)
+    assert mutation_done.wait(timeout=5)
+    mutation_thread.join(timeout=1)
+
+    assert not captured_before_publication
+    assert discovery_failures == []
+    assert mutation_failures == []
+    assert not mutation_thread.is_alive()
+    if surface == "tool":
+        assert registry.get_entry(name) is not None
+        assert name in manager._plugin_tool_names
+    elif surface == "platform":
+        assert isolated_registries.get(name) is not None
+        assert name in manager._plugin_external_names["platform"]
+    else:
+        assert len(manager._hooks.get(name, [])) == 1
+
+
+@pytest.mark.parametrize("surface", ["tool", "platform", "hook"])
+def test_failed_initial_publication_restores_binding_before_retained_candidate_mutation(
+    tmp_path, monkeypatch, isolated_registries, surface
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", f"atomic-rollback-{surface}")
+    support = _support(values, "candidate", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    rollback_paused = threading.Event()
+    release_rollback = threading.Event()
+    original_install = manager._install_owned_state_locked
+
+    def install_then_pause_and_interrupt(state) -> None:
+        original_install(state)
+        rollback_paused.set()
+        assert release_rollback.wait(timeout=5)
+        raise KeyboardInterrupt("injected after manager install")
+
+    monkeypatch.setattr(
+        manager,
+        "_install_owned_state_locked",
+        install_then_pause_and_interrupt,
+    )
+    discovery_thread, discovery_done, discovery_failures = _start_discovery(manager)
+    assert rollback_paused.wait(timeout=5)
+    context = support.saved_context
+    binding_captured = threading.Event()
+    mutation_started = threading.Event()
+    mutation_done = threading.Event()
+    mutation_failures: list[BaseException] = []
+    original_acquire = context._acquire_live_lease
+
+    def observe_binding_capture(*args, **kwargs):
+        binding_captured.set()
+        return original_acquire(*args, **kwargs)
+
+    monkeypatch.setattr(context, "_acquire_live_lease", observe_binding_capture)
+    name = f"h1_atomic_rollback_{surface}"
+
+    def mutate() -> None:
+        mutation_started.set()
+        try:
+            _mutate_retained_candidate(context, surface, name)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            mutation_failures.append(exc)
+        finally:
+            mutation_done.set()
+
+    mutation_thread = threading.Thread(target=mutate, daemon=True)
+    mutation_thread.start()
+    assert mutation_started.wait(timeout=5)
+    captured_before_rollback = binding_captured.wait(timeout=0.2)
+    release_rollback.set()
+    _join(discovery_thread, discovery_done)
+    assert mutation_done.wait(timeout=5)
+    mutation_thread.join(timeout=1)
+
+    assert not captured_before_rollback
+    assert len(discovery_failures) == 1
+    assert isinstance(discovery_failures[0], KeyboardInterrupt)
+    assert len(mutation_failures) == 1
+    assert "frozen" in str(mutation_failures[0])
+    assert not mutation_thread.is_alive()
+    if surface == "tool":
+        assert registry.get_entry(name) is None
+        assert name not in manager._plugin_tool_names
+    elif surface == "platform":
+        assert isolated_registries.get(name) is None
+        assert name not in manager._plugin_external_names["platform"]
+    else:
+        assert name not in manager._hooks
+
+
 def test_retained_context_live_registration_does_not_validate_under_live_locks(
     tmp_path, monkeypatch, isolated_registries
 ):

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -1,0 +1,689 @@
+"""Concurrency contracts for transactional plugin registration."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from agent.browser_provider import BrowserProvider
+from agent.image_gen_provider import ImageGenProvider
+from agent.secret_sources.base import FetchResult, SecretSource
+from agent.transcription_provider import TranscriptionProvider
+from agent.tts_provider import TTSProvider
+from agent.video_gen_provider import VideoGenProvider
+from agent.web_search_provider import WebSearchProvider
+from gateway.platform_registry import PlatformEntry, PlatformRegistry
+from hermes_cli.dashboard_auth import DashboardAuthProvider
+from hermes_cli.plugins import PluginManager
+from tools.registry import registry
+
+
+_SUPPORT_MODULE = "h1_transaction_test_support"
+_TOOL_NAME = "h1_transaction_generation_tool"
+_PLUGIN_NAME = "h1-transaction-concurrency"
+
+
+class _ImageProvider(ImageGenProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def generate(self, prompt: str, aspect_ratio: str = "landscape", **kwargs: Any) -> dict:
+        return {"marker": self.marker}
+
+
+class _VideoProvider(VideoGenProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def generate(self, prompt: str, **kwargs: Any) -> dict:
+        return {"marker": self.marker}
+
+
+class _WebProvider(WebSearchProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> dict:
+        return {"marker": self.marker}
+
+
+class _BrowserProvider(BrowserProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def create_session(self, task_id: str) -> dict:
+        return {"marker": self.marker}
+
+    def close_session(self, session_id: str) -> bool:
+        return True
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        return None
+
+
+class _TTSProvider(TTSProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def synthesize(self, text: str, output_path: str, **kwargs: Any) -> str:
+        return output_path
+
+
+class _STTProvider(TranscriptionProvider):
+    def __init__(self, name: str, marker: str) -> None:
+        self._name = name
+        self.marker = marker
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def transcribe(self, file_path: str, **kwargs: Any) -> dict:
+        return {"success": True, "transcript": self.marker, "provider": self.name}
+
+
+class _DashboardProvider(DashboardAuthProvider):
+    name = "h1-dashboard-test"
+    display_name = "H1 dashboard test"
+
+    def __init__(self, name: str, marker: str) -> None:
+        self.name = name
+        self.display_name = marker
+        self.marker = marker
+
+    def start_login(self, *, redirect_uri: str):
+        raise NotImplementedError
+
+    def complete_login(self, **kwargs: Any):
+        raise NotImplementedError
+
+    def verify_session(self, *, access_token: str):
+        return None
+
+    def refresh_session(self, *, refresh_token: str):
+        raise NotImplementedError
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        return None
+
+
+class _SecretProvider(SecretSource):
+    shape = "mapped"
+
+    def __init__(self, name: str, marker: str) -> None:
+        self.name = name
+        self.label = marker
+        self.marker = marker
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        return FetchResult()
+
+
+def _external_values(marker: str, namespace: str) -> dict[str, Any]:
+    names = {
+        surface: f"h1-{namespace}-{surface.replace('_', '-')}"
+        for surface in (
+            "image_gen",
+            "video_gen",
+            "web",
+            "browser",
+            "secret",
+            "tts",
+            "stt",
+            "dashboard",
+            "platform",
+        )
+    }
+    names["secret"] = f"h1_{namespace.replace('-', '_')}_secret"
+    return {
+        "image_gen": _ImageProvider(names["image_gen"], marker),
+        "video_gen": _VideoProvider(names["video_gen"], marker),
+        "web": _WebProvider(names["web"], marker),
+        "browser": _BrowserProvider(names["browser"], marker),
+        "secret": _SecretProvider(names["secret"], marker),
+        "tts": _TTSProvider(names["tts"], marker),
+        "stt": _STTProvider(names["stt"], marker),
+        "dashboard": _DashboardProvider(names["dashboard"], marker),
+        "platform": PlatformEntry(
+            name=names["platform"],
+            label=marker,
+            adapter_factory=lambda config, value=marker: value,
+            check_fn=lambda: True,
+            source="plugin",
+            plugin_name=_PLUGIN_NAME,
+        ),
+    }
+
+
+def _write_plugin(home: Path) -> None:
+    plugin_dir = home / "plugins" / _PLUGIN_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": _PLUGIN_NAME, "version": "1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        f'''import {_SUPPORT_MODULE} as support
+
+def register(ctx):
+    values = support.values
+    ctx.register_image_gen_provider(values["image_gen"])
+    ctx.register_video_gen_provider(values["video_gen"])
+    ctx.register_web_search_provider(values["web"])
+    ctx.register_browser_provider(values["browser"])
+    ctx.register_secret_source(values["secret"])
+    ctx.register_tts_provider(values["tts"])
+    ctx.register_transcription_provider(values["stt"])
+    ctx.register_dashboard_auth_provider(values["dashboard"])
+    platform = values["platform"]
+    ctx.register_platform(
+        name=platform.name,
+        label=platform.label,
+        adapter_factory=platform.adapter_factory,
+        check_fn=platform.check_fn,
+    )
+    if support.register_generation_state:
+        ctx.register_tool(
+            {_TOOL_NAME!r},
+            "h1_transaction",
+            {{
+                "name": {_TOOL_NAME!r},
+                "description": support.marker,
+                "parameters": {{"type": "object", "properties": {{}}}},
+            }},
+            support.tool_handler,
+        )
+        ctx.register_hook("post_tool_call", support.hook)
+    support.started.set()
+    if not support.release.wait(timeout=5):
+        raise RuntimeError("test release timeout")
+    if support.fail:
+        raise RuntimeError("planned registration failure")
+''',
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": [_PLUGIN_NAME]}}),
+        encoding="utf-8",
+    )
+
+
+def _support(
+    values: dict[str, Any],
+    marker: str,
+    *,
+    released: bool = False,
+    fail: bool = False,
+    register_generation_state: bool = False,
+) -> types.ModuleType:
+    module = types.ModuleType(_SUPPORT_MODULE)
+    module.values = values
+    module.marker = marker
+    module.started = threading.Event()
+    module.release = threading.Event()
+    if released:
+        module.release.set()
+    module.fail = fail
+    module.register_generation_state = register_generation_state
+    module.tool_handler = lambda args, **kwargs: marker
+    module.hook = lambda **kwargs: marker
+    sys.modules[_SUPPORT_MODULE] = module
+    return module
+
+
+def _start_discovery(
+    manager: PluginManager,
+    *,
+    force: bool = False,
+) -> tuple[threading.Thread, threading.Event, list[BaseException]]:
+    done = threading.Event()
+    failures: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            manager.discover_and_load(force=force)
+        except BaseException as exc:  # pragma: no cover - asserted by callers
+            failures.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    return thread, done, failures
+
+
+def _join(thread: threading.Thread, done: threading.Event) -> None:
+    assert done.wait(timeout=5), "plugin discovery did not finish"
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+
+def _external_readers(platform_registry: PlatformRegistry) -> dict[str, Any]:
+    from agent import (
+        browser_registry,
+        image_gen_registry,
+        transcription_registry,
+        tts_registry,
+        video_gen_registry,
+        web_search_registry,
+    )
+    from agent.secret_sources import registry as secret_registry
+    from hermes_cli.dashboard_auth import get_provider as get_dashboard_provider
+
+    return {
+        "image_gen": image_gen_registry.get_provider,
+        "video_gen": video_gen_registry.get_provider,
+        "web": web_search_registry.get_provider,
+        "browser": browser_registry.get_provider,
+        "secret": secret_registry.get_source,
+        "tts": tts_registry.get_provider,
+        "stt": transcription_registry.get_provider,
+        "dashboard": get_dashboard_provider,
+        "platform": platform_registry.get,
+    }
+
+
+def _read_external_generation(
+    values: dict[str, Any],
+    platform_registry: PlatformRegistry,
+) -> dict[str, Any]:
+    readers = _external_readers(platform_registry)
+    return {
+        surface: readers[surface](value.name)
+        for surface, value in values.items()
+    }
+
+
+def _register_external_direct(
+    surface: str,
+    value: Any,
+    platform_registry: PlatformRegistry,
+) -> None:
+    from agent import (
+        browser_registry,
+        image_gen_registry,
+        transcription_registry,
+        tts_registry,
+        video_gen_registry,
+        web_search_registry,
+    )
+    from agent.secret_sources import registry as secret_registry
+    from hermes_cli.dashboard_auth import register_provider as register_dashboard
+
+    registrations = {
+        "image_gen": image_gen_registry.register_provider,
+        "video_gen": video_gen_registry.register_provider,
+        "web": web_search_registry.register_provider,
+        "browser": browser_registry.register_provider,
+        "secret": secret_registry.register_source,
+        "tts": tts_registry.register_provider,
+        "stt": transcription_registry.register_provider,
+        "dashboard": register_dashboard,
+        "platform": platform_registry.register,
+    }
+    registrations[surface](value)
+
+
+@pytest.fixture(autouse=True)
+def isolated_registries(tmp_path, monkeypatch):
+    from agent import (
+        browser_registry,
+        image_gen_registry,
+        transcription_registry,
+        tts_registry,
+        video_gen_registry,
+        web_search_registry,
+    )
+    from agent.secret_sources import registry as secret_registry
+    from gateway import platform_registry as platform_module
+    from hermes_cli.dashboard_auth import clear_providers
+
+    provider_modules = (
+        image_gen_registry,
+        video_gen_registry,
+        web_search_registry,
+        browser_registry,
+        tts_registry,
+        transcription_registry,
+    )
+    for module in provider_modules:
+        module._reset_for_tests()
+    clear_providers()
+    secret_registry._reset_registry_for_tests()
+    monkeypatch.setattr(secret_registry, "_ensure_builtin_sources", lambda: None)
+    isolated_platform_registry = PlatformRegistry()
+    monkeypatch.setattr(
+        platform_module,
+        "platform_registry",
+        isolated_platform_registry,
+    )
+
+    with registry._lock:
+        tool_state = (
+            dict(registry._tools),
+            dict(registry._toolset_checks),
+            dict(registry._toolset_aliases),
+            dict(registry._plugin_override_policy),
+            registry._generation,
+        )
+
+    bundled = tmp_path / "empty-bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    yield isolated_platform_registry
+
+    with registry._lock:
+        (
+            registry._tools,
+            registry._toolset_checks,
+            registry._toolset_aliases,
+            registry._plugin_override_policy,
+            old_generation,
+        ) = tool_state
+        registry._generation = max(registry._generation, old_generation) + 1
+    sys.modules.pop(_SUPPORT_MODULE, None)
+    for name in list(sys.modules):
+        if name.startswith("hermes_plugins.h1_transaction_concurrency"):
+            sys.modules.pop(name, None)
+
+
+def test_provider_and_platform_readers_never_observe_provisional_registration(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", "visibility-success")
+    support = _support(values, "candidate")
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, done, failures = _start_discovery(manager)
+    assert support.started.wait(timeout=5)
+
+    blocked_observation = _read_external_generation(values, isolated_registries)
+    support.release.set()
+    _join(thread, done)
+    assert failures == []
+    assert all(observed is None for observed in blocked_observation.values())
+    assert _read_external_generation(values, isolated_registries) == values
+
+
+def test_failed_provider_and_platform_registration_never_becomes_visible(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", "visibility-failure")
+    support = _support(values, "candidate", fail=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, done, failures = _start_discovery(manager)
+    assert support.started.wait(timeout=5)
+
+    blocked_observation = _read_external_generation(values, isolated_registries)
+    support.release.set()
+    _join(thread, done)
+
+    assert failures == []
+    assert all(observed is None for observed in blocked_observation.values())
+    assert all(
+        observed is None
+        for observed in _read_external_generation(values, isolated_registries).values()
+    )
+    assert manager._plugins[_PLUGIN_NAME].enabled is False
+
+
+def test_force_reload_readers_observe_old_generation_until_atomic_swap(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "force")
+    support = _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_tool = registry.get_entry(_TOOL_NAME)
+    assert old_tool is not None
+
+    new_values = _external_values("generation-b", "force")
+    support = _support(
+        new_values,
+        "generation-b",
+        register_generation_state=True,
+    )
+    thread, done, failures = _start_discovery(manager, force=True)
+    assert support.started.wait(timeout=5)
+
+    blocked_hook = manager.invoke_hook("post_tool_call")
+    blocked_tool = registry.get_entry(_TOOL_NAME)
+    blocked_external = _read_external_generation(old_values, isolated_registries)
+
+    support.release.set()
+    _join(thread, done)
+    assert failures == []
+    assert blocked_hook == ["generation-a"]
+    assert blocked_tool is old_tool
+    assert blocked_external == old_values
+    assert manager.invoke_hook("post_tool_call") == ["generation-b"]
+    assert registry.get_entry(_TOOL_NAME).handler is support.tool_handler
+    assert _read_external_generation(new_values, isolated_registries) == new_values
+
+
+def test_force_reload_failure_preserves_old_generation_without_empty_window(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "force-failure")
+    _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_tool = registry.get_entry(_TOOL_NAME)
+    assert old_tool is not None
+
+    new_values = _external_values("generation-b", "force-failure")
+    support = _support(
+        new_values,
+        "generation-b",
+        fail=True,
+        register_generation_state=True,
+    )
+    thread, done, failures = _start_discovery(manager, force=True)
+    assert support.started.wait(timeout=5)
+
+    blocked_hook = manager.invoke_hook("post_tool_call")
+    blocked_tool = registry.get_entry(_TOOL_NAME)
+    blocked_external = _read_external_generation(old_values, isolated_registries)
+
+    support.release.set()
+    _join(thread, done)
+    assert failures == []
+    assert blocked_hook == ["generation-a"]
+    assert blocked_tool is old_tool
+    assert blocked_external == old_values
+    assert manager.invoke_hook("post_tool_call") == ["generation-a"]
+    assert registry.get_entry(_TOOL_NAME) is old_tool
+    observed = _read_external_generation(old_values, isolated_registries)
+    assert observed == old_values
+    assert {
+        getattr(value, "marker", getattr(value, "label", None))
+        for value in observed.values()
+    } == {"generation-a"}
+
+
+def test_force_reload_removes_registrations_absent_from_new_generation(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "force-remove")
+    _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert registry.get_entry(_TOOL_NAME) is not None
+    assert _read_external_generation(old_values, isolated_registries) == old_values
+    module_namespace = f"hermes_plugins.{_PLUGIN_NAME.replace('-', '_')}"
+    with registry._lock:
+        assert module_namespace in registry._plugin_override_policy
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": []}}),
+        encoding="utf-8",
+    )
+    manager.discover_and_load(force=True)
+
+    assert manager.invoke_hook("post_tool_call") == []
+    assert registry.get_entry(_TOOL_NAME) is None
+    assert all(
+        observed is None
+        for observed in _read_external_generation(
+            old_values,
+            isolated_registries,
+        ).values()
+    )
+    assert manager._plugin_tool_names == set()
+    assert all(not names for names in manager._plugin_external_names.values())
+    assert manager._plugins[_PLUGIN_NAME].enabled is False
+    with registry._lock:
+        assert module_namespace not in registry._plugin_override_policy
+
+
+@pytest.mark.parametrize(
+    "conflict_surface",
+    [
+        "platform",
+        "browser",
+        "dashboard",
+        "image_gen",
+        "secret",
+        "stt",
+        "tts",
+        "video_gen",
+        "web",
+    ],
+)
+def test_external_registry_commit_conflict_preserves_concurrent_writer(
+    tmp_path, monkeypatch, isolated_registries, conflict_surface
+):
+    home = tmp_path / "hermes-home"
+    candidate_values = _external_values("candidate", "conflict")
+    support = _support(candidate_values, "candidate")
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, done, failures = _start_discovery(manager)
+    assert support.started.wait(timeout=5)
+
+    concurrent_values = _external_values(
+        "concurrent-writer",
+        "conflict-writer",
+    )
+    _register_external_direct(
+        conflict_surface,
+        concurrent_values[conflict_surface],
+        isolated_registries,
+    )
+
+    support.release.set()
+    _join(thread, done)
+    assert failures == []
+    observed_concurrent = _read_external_generation(
+        concurrent_values,
+        isolated_registries,
+    )
+    assert observed_concurrent[conflict_surface] is concurrent_values[conflict_surface]
+    assert all(
+        observed is None
+        for observed in _read_external_generation(
+            candidate_values,
+            isolated_registries,
+        ).values()
+    )
+    assert manager._plugins[_PLUGIN_NAME].enabled is False
+    assert manager._plugins[_PLUGIN_NAME].error == "RuntimeError: plugin commit failed"
+
+
+def test_context_retained_after_commit_targets_live_external_registries(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("initial", "retained-context")
+    support = _support(values, "initial", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    late = _ImageProvider("h1-retained-context-late", "late")
+    support.saved_context.register_image_gen_provider(late)
+
+    from agent.image_gen_registry import get_provider
+
+    assert get_provider(late.name) is late

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -20,6 +20,7 @@ from agent.video_gen_provider import VideoGenProvider
 from agent.web_search_provider import WebSearchProvider
 from gateway.platform_registry import PlatformEntry, PlatformRegistry
 from hermes_cli.dashboard_auth import DashboardAuthProvider
+import hermes_cli.plugins as plugins_module
 from hermes_cli.plugins import PluginManager
 from tools.registry import registry
 
@@ -605,6 +606,137 @@ def test_force_reload_removes_registrations_absent_from_new_generation(
         assert module_namespace not in registry._plugin_override_policy
 
 
+def test_force_reload_preserves_same_key_external_replacement_after_manager_snapshot(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    namespace = "same-key-replacement"
+    old_values = _external_values("generation-a", namespace)
+    _support(old_values, "generation-a", released=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    replacement_values = _external_values("direct-replacement", namespace)
+    new_values = _external_values("generation-b", namespace)
+    _support(new_values, "generation-b", released=True)
+    replacement_written = threading.Event()
+    snapshot_entered = threading.Event()
+    original_transactions = plugins_module._external_registry_transactions
+
+    class _ImageSnapshotBarrier:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+            self._started = False
+
+        def __getattr__(self, name: str):
+            return getattr(self._wrapped, name)
+
+        def take_snapshot(self):
+            if not self._started:
+                self._started = True
+                snapshot_entered.set()
+
+                def write_replacement() -> None:
+                    _register_external_direct(
+                        "image_gen",
+                        replacement_values["image_gen"],
+                        isolated_registries,
+                    )
+                    replacement_written.set()
+
+                writer = threading.Thread(target=write_replacement, daemon=True)
+                writer.start()
+                replacement_written.wait(timeout=0.2)
+            return self._wrapped.take_snapshot()
+
+    def transactions_with_barrier():
+        transactions = original_transactions()
+        transactions["image_gen"] = _ImageSnapshotBarrier(transactions["image_gen"])
+        return transactions
+
+    monkeypatch.setattr(
+        plugins_module,
+        "_external_registry_transactions",
+        transactions_with_barrier,
+    )
+
+    manager.discover_and_load(force=True)
+
+    assert snapshot_entered.is_set()
+    assert replacement_written.is_set()
+    observed = _read_external_generation(replacement_values, isolated_registries)
+    assert observed["image_gen"] is replacement_values["image_gen"]
+
+
+def test_force_reload_preserves_same_key_tool_replacement_after_manager_snapshot(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "same-key-tool")
+    _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    new_values = _external_values("generation-b", "same-key-tool")
+    _support(
+        new_values,
+        "generation-b",
+        released=True,
+        register_generation_state=True,
+    )
+    replacement_written = threading.Event()
+    snapshot_calls = 0
+    original_snapshot = registry._take_transaction_snapshot
+
+    def replacement_handler(args, **kwargs):
+        return "direct-replacement"
+
+    def write_replacement() -> None:
+        registry.register(
+            name=_TOOL_NAME,
+            toolset="h1_transaction",
+            schema={
+                "name": _TOOL_NAME,
+                "description": "direct replacement",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=replacement_handler,
+        )
+        replacement_written.set()
+
+    def snapshot_with_barrier():
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        if snapshot_calls == 1:
+            writer = threading.Thread(target=write_replacement, daemon=True)
+            writer.start()
+            assert not replacement_written.wait(timeout=0.2)
+        else:
+            assert replacement_written.wait(timeout=5)
+        return original_snapshot()
+
+    monkeypatch.setattr(
+        registry,
+        "_take_transaction_snapshot",
+        snapshot_with_barrier,
+    )
+
+    manager.discover_and_load(force=True)
+
+    assert snapshot_calls >= 1
+    assert replacement_written.wait(timeout=5)
+    assert registry.get_entry(_TOOL_NAME).handler is replacement_handler
+
+
 @pytest.mark.parametrize(
     "conflict_surface",
     [
@@ -687,3 +819,206 @@ def test_context_retained_after_commit_targets_live_external_registries(
     from agent.image_gen_registry import get_provider
 
     assert get_provider(late.name) is late
+
+
+def test_retained_context_live_registration_does_not_validate_under_live_locks(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("initial", "lock-validation")
+    support = _support(values, "initial", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    from agent import image_gen_registry
+
+    observations: list[tuple[str, bool, bool, bool]] = []
+
+    def observe(label: str) -> None:
+        observations.append(
+            (
+                label,
+                manager._lock._is_owned(),
+                registry._lock._is_owned(),
+                image_gen_registry._lock._is_owned(),
+            )
+        )
+
+    class _ObservedImageProvider(_ImageProvider):
+        @property
+        def name(self) -> str:
+            observe("provider.name")
+            return super().name
+
+    class _ObservedSchema(dict):
+        def get(self, key, default=None):
+            if key == "description":
+                observe("schema.get")
+            return super().get(key, default)
+
+    provider = _ObservedImageProvider("h1-lock-validation-late-image", "late")
+    support.saved_context.register_image_gen_provider(provider)
+    support.saved_context.register_tool(
+        "h1_lock_validation_late_tool",
+        "h1_transaction",
+        _ObservedSchema(
+            {
+                "name": "h1_lock_validation_late_tool",
+                "description": "late",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ),
+        lambda args, **kwargs: "late",
+    )
+
+    assert observations
+    assert all(
+        not any((manager_locked, tool_locked, external_locked))
+        for _, manager_locked, tool_locked, external_locked in observations
+    ), observations
+
+
+def test_successful_force_reload_revokes_prior_retained_context_before_mutation(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "revoked-context")
+    support = _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    support.saved_contexts = []
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_contexts.append(ctx)\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_context = support.saved_contexts[-1]
+
+    new_values = _external_values(
+        "generation-b",
+        "revoked-context",
+    )
+    support = _support(
+        new_values,
+        "generation-b",
+        released=True,
+        register_generation_state=True,
+    )
+    support.saved_contexts = []
+    manager.discover_and_load(force=True)
+    new_context = support.saved_contexts[-1]
+    assert manager._live_context_revoking == set()
+
+    stale_external = _ImageProvider("h1-revoked-context-late-image", "stale")
+    stale_tool_name = "h1_revoked_context_late_tool"
+    stale_platform_name = "h1-revoked-context-late-platform"
+    stale_hook = lambda **kwargs: "stale"
+
+    with pytest.raises(RuntimeError, match="no longer live"):
+        old_context.register_image_gen_provider(stale_external)
+    with pytest.raises(RuntimeError, match="no longer live"):
+        old_context.register_tool(
+            stale_tool_name,
+            "h1_transaction",
+            {
+                "name": stale_tool_name,
+                "description": "stale",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            lambda args, **kwargs: "stale",
+        )
+    with pytest.raises(RuntimeError, match="no longer live"):
+        old_context.register_hook("post_tool_call", stale_hook)
+    with pytest.raises(RuntimeError, match="no longer live"):
+        old_context.register_platform(
+            name=stale_platform_name,
+            label="Stale",
+            adapter_factory=lambda config: "stale",
+            check_fn=lambda: True,
+        )
+
+    from agent.image_gen_registry import get_provider
+
+    assert get_provider(stale_external.name) is None
+    assert registry.get_entry(stale_tool_name) is None
+    assert isolated_registries.get(stale_platform_name) is None
+    assert stale_hook not in manager._hooks.get("post_tool_call", [])
+
+    live_external = _ImageProvider("h1-revoked-context-live-image", "live")
+    live_tool_name = "h1_revoked_context_live_tool"
+    live_hook = lambda **kwargs: "live"
+    new_context.register_image_gen_provider(live_external)
+    new_context.register_tool(
+        live_tool_name,
+        "h1_transaction",
+        {
+            "name": live_tool_name,
+            "description": "live",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        lambda args, **kwargs: "live",
+    )
+    new_context.register_hook("post_tool_call", live_hook)
+
+    assert get_provider(live_external.name) is live_external
+    assert registry.get_entry(live_tool_name) is not None
+    assert live_hook in manager._hooks["post_tool_call"]
+
+
+def test_failed_force_reload_keeps_prior_retained_context_live(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "failed-force-context")
+    support = _support(old_values, "generation-a", released=True)
+    support.saved_contexts = []
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_contexts.append(ctx)\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_context = support.saved_contexts[-1]
+
+    new_values = _external_values("generation-b", "failed-force-context")
+    support = _support(new_values, "generation-b", released=True, fail=True)
+    support.saved_contexts = []
+    manager.discover_and_load(force=True)
+
+    retained_external = _ImageProvider("h1-failed-force-live-image", "retained")
+    retained_hook = lambda **kwargs: "retained"
+    old_context.register_image_gen_provider(retained_external)
+    old_context.register_hook("post_tool_call", retained_hook)
+
+    from agent.image_gen_registry import get_provider
+
+    assert support.saved_contexts
+    assert get_provider(retained_external.name) is retained_external
+    assert retained_hook in manager._hooks["post_tool_call"]

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -30,6 +30,10 @@ _TOOL_NAME = "h1_transaction_generation_tool"
 _PLUGIN_NAME = "h1-transaction-concurrency"
 
 
+class _InjectedBaseException(BaseException):
+    pass
+
+
 class _ImageProvider(ImageGenProvider):
     def __init__(self, name: str, marker: str) -> None:
         self._name = name
@@ -332,6 +336,21 @@ def _read_external_generation(
     }
 
 
+def _surface_generations(manager: PluginManager) -> dict[str, int]:
+    transactions = plugins_module._external_registry_transactions()
+    return {
+        "manager": manager._generation,
+        "manager_context": manager._live_context_generation,
+        "tool": registry._generation,
+        **{
+            surface: transaction.take_snapshot()._generation
+            for surface, transaction in transactions.items()
+            if hasattr(transaction.take_snapshot(), "_generation")
+        },
+        "secret": transactions["secret"].take_snapshot()._mapping._generation,
+    }
+
+
 def _register_external_direct(
     surface: str,
     value: Any,
@@ -560,6 +579,90 @@ def test_force_reload_failure_preserves_old_generation_without_empty_window(
         getattr(value, "marker", getattr(value, "label", None))
         for value in observed.values()
     } == {"generation-a"}
+
+
+def test_force_reload_baseexception_after_tool_install_rolls_back_all_surfaces(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "tool-install-interrupt")
+    _support(old_values, "generation-a", released=True, register_generation_state=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_tool = registry.get_entry(_TOOL_NAME)
+    old_generations = _surface_generations(manager)
+
+    new_values = _external_values("generation-b", "tool-install-interrupt")
+    _support(new_values, "generation-b", released=True, register_generation_state=True)
+    original_install = registry._install_prepared_transaction_locked
+
+    def install_then_interrupt(snapshot, prepared):
+        original_install(snapshot, prepared)
+        raise _InjectedBaseException("injected after tool install")
+
+    monkeypatch.setattr(registry, "_install_prepared_transaction_locked", install_then_interrupt)
+
+    with pytest.raises(_InjectedBaseException, match="injected after tool install"):
+        manager.discover_and_load(force=True)
+
+    assert _surface_generations(manager) == old_generations
+    assert manager._live_context_revoking == set()
+    assert manager.invoke_hook("post_tool_call") == ["generation-a"]
+    assert registry.get_entry(_TOOL_NAME) is old_tool
+    assert _read_external_generation(old_values, isolated_registries) == old_values
+    assert _read_external_generation(new_values, isolated_registries) == old_values
+
+
+def test_force_reload_baseexception_after_external_install_rolls_back_all_surfaces(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "external-install-interrupt")
+    _support(old_values, "generation-a", released=True, register_generation_state=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_tool = registry.get_entry(_TOOL_NAME)
+    old_generations = _surface_generations(manager)
+
+    new_values = _external_values("generation-b", "external-install-interrupt")
+    _support(new_values, "generation-b", released=True, register_generation_state=True)
+    original_transactions = plugins_module._external_registry_transactions
+
+    class _InterruptingSurface:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str):
+            return getattr(self._wrapped, name)
+
+        def install_prepared_locked(self, snapshot, prepared) -> None:
+            self._wrapped.install_prepared_locked(snapshot, prepared)
+            raise _InjectedBaseException("injected after external install")
+
+    def transactions_with_interrupt():
+        transactions = original_transactions()
+        transactions["platform"] = _InterruptingSurface(transactions["platform"])
+        return transactions
+
+    monkeypatch.setattr(
+        plugins_module,
+        "_external_registry_transactions",
+        transactions_with_interrupt,
+    )
+
+    with pytest.raises(_InjectedBaseException, match="injected after external install"):
+        manager.discover_and_load(force=True)
+
+    assert _surface_generations(manager) == old_generations
+    assert manager._live_context_revoking == set()
+    assert manager.invoke_hook("post_tool_call") == ["generation-a"]
+    assert registry.get_entry(_TOOL_NAME) is old_tool
+    assert _read_external_generation(old_values, isolated_registries) == old_values
+    assert _read_external_generation(new_values, isolated_registries) == old_values
 
 
 def test_force_reload_removes_registrations_absent_from_new_generation(
@@ -819,6 +922,67 @@ def test_context_retained_after_commit_targets_live_external_registries(
     from agent.image_gen_registry import get_provider
 
     assert get_provider(late.name) is late
+
+
+def test_failed_initial_publication_restores_candidate_context_targets(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", "context-rollback")
+    support = _support(values, "candidate", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    original_install = manager._install_owned_state_locked
+
+    def interrupt_after_manager_install(state):
+        original_install(state)
+        raise KeyboardInterrupt("injected after manager install")
+
+    monkeypatch.setattr(
+        manager,
+        "_install_owned_state_locked",
+        interrupt_after_manager_install,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="injected after manager install"):
+        manager.discover_and_load()
+
+    candidate_context = support.saved_context
+    late = _ImageProvider("h1-failed-context-retarget-image", "late")
+    late_tool = "h1_failed_context_retarget_tool"
+    late_hook = lambda **kwargs: "late"
+
+    with pytest.raises(RuntimeError, match="transaction view is frozen"):
+        candidate_context.register_image_gen_provider(late)
+    with pytest.raises(RuntimeError, match="transaction view is frozen"):
+        candidate_context.register_tool(
+            late_tool,
+            "h1_transaction",
+            {
+                "name": late_tool,
+                "description": "late",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            lambda args, **kwargs: "late",
+        )
+    with pytest.raises(RuntimeError, match="registration view is frozen"):
+        candidate_context.register_hook("post_tool_call", late_hook)
+
+    from agent.image_gen_registry import get_provider
+
+    assert get_provider(late.name) is None
+    assert registry.get_entry(late_tool) is None
+    assert late_hook not in manager._hooks.get("post_tool_call", [])
 
 
 def test_retained_context_live_registration_does_not_validate_under_live_locks(
@@ -1225,6 +1389,64 @@ def test_force_reload_interrupt_after_revocation_keeps_old_context_live(
     )
     assert registry.get_entry(retained_tool) is not None
     assert isolated_registries.get(retained_platform) is not None
+
+
+def test_registration_transaction_constructor_lock_interrupt_releases_prior_locks(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("generation-a", "constructor-lock-interrupt")
+    _support(values, "generation-a", released=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    original_tool_lock = registry._lock
+    attempted_tool_acquire = threading.Event()
+
+    class _InterruptingToolLock:
+        def acquire(self, *args, **kwargs):
+            attempted_tool_acquire.set()
+            raise _InjectedBaseException("injected constructor acquisition failure")
+
+        def release(self) -> None:  # pragma: no cover - must not release unacquired lock
+            original_tool_lock.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            self.release()
+
+    monkeypatch.setattr(registry, "_lock", _InterruptingToolLock())
+
+    with pytest.raises(_InjectedBaseException, match="injected constructor acquisition failure"):
+        plugins_module._RegistrationTransaction(manager)
+
+    assert attempted_tool_acquire.is_set()
+    monkeypatch.setattr(registry, "_lock", original_tool_lock)
+
+    acquired = threading.Event()
+    released = threading.Event()
+
+    def acquire_manager_lock_from_other_thread() -> None:
+        with manager._lock:
+            acquired.set()
+            released.wait(timeout=5)
+
+    thread = threading.Thread(target=acquire_manager_lock_from_other_thread, daemon=True)
+    thread.start()
+    assert acquired.wait(timeout=5), "constructor leaked the manager lock"
+    released.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+    with original_tool_lock:
+        assert True
+    for transaction in plugins_module._external_registry_transactions().values():
+        with transaction.lock:
+            assert True
 
 
 def test_force_reload_lock_acquisition_interrupt_releases_prior_locks(

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -351,6 +351,48 @@ def _surface_generations(manager: PluginManager) -> dict[str, int]:
     }
 
 
+def _assert_lock_acquirable_from_other_thread(label: str, lock: Any) -> None:
+    acquired = threading.Event()
+    release = threading.Event()
+    failures: list[BaseException] = []
+
+    def acquire_lock() -> None:
+        try:
+            lock.acquire()
+            acquired.set()
+            assert release.wait(timeout=5), f"{label} release gate timed out"
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+        finally:
+            if acquired.is_set():
+                lock.release()
+
+    thread = threading.Thread(
+        target=acquire_lock,
+        name=f"h1-assert-lock-free-{label}",
+        daemon=True,
+    )
+    thread.start()
+    assert acquired.wait(timeout=5), f"{label} lock was leaked"
+    release.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive(), f"{label} lock holder did not exit"
+    assert failures == []
+
+
+def _assert_all_registration_locks_acquirable_from_other_threads(
+    manager: PluginManager,
+    *,
+    context_locks: list[Any] | None = None,
+) -> None:
+    _assert_lock_acquirable_from_other_thread("manager", manager._lock)
+    _assert_lock_acquirable_from_other_thread("tool", registry._lock)
+    for surface, transaction in plugins_module._external_registry_transactions().items():
+        _assert_lock_acquirable_from_other_thread(surface, transaction.lock)
+    for index, lock in enumerate(context_locks or []):
+        _assert_lock_acquirable_from_other_thread(f"context[{index}]", lock)
+
+
 def _register_external_direct(
     surface: str,
     value: Any,
@@ -663,6 +705,252 @@ def test_force_reload_baseexception_after_external_install_rolls_back_all_surfac
     assert registry.get_entry(_TOOL_NAME) is old_tool
     assert _read_external_generation(old_values, isolated_registries) == old_values
     assert _read_external_generation(new_values, isolated_registries) == old_values
+
+
+def test_force_reload_baseexception_after_activation_keeps_published_generation(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "activation-interrupt")
+    _support(old_values, "generation-a", released=True, register_generation_state=True)
+    _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    new_values = _external_values("generation-b", "activation-interrupt")
+    _support(new_values, "generation-b", released=True, register_generation_state=True)
+    original_activate = plugins_module._PluginPublicationCapability._activate
+    rollback_attempted = threading.Event()
+    original_restore = registry._restore_transaction_snapshot_exact_locked
+
+    def activate_then_interrupt(self):
+        original_activate(self)
+        raise _InjectedBaseException("injected after publication activation")
+
+    def observe_rollback(snapshot):
+        rollback_attempted.set()
+        original_restore(snapshot)
+
+    monkeypatch.setattr(
+        plugins_module._PluginPublicationCapability,
+        "_activate",
+        activate_then_interrupt,
+    )
+    monkeypatch.setattr(
+        registry,
+        "_restore_transaction_snapshot_exact_locked",
+        observe_rollback,
+    )
+
+    with pytest.raises(
+        _InjectedBaseException,
+        match="injected after publication activation",
+    ):
+        manager.discover_and_load(force=True)
+
+    assert not rollback_attempted.is_set()
+    assert manager._live_context_revoking == set()
+    assert manager.invoke_hook("post_tool_call") == ["generation-b"]
+    assert registry.get_entry(_TOOL_NAME).handler({}) == "generation-b"
+    assert _read_external_generation(new_values, isolated_registries) == new_values
+
+
+def test_force_reload_mid_cleanup_release_failure_preserves_primary_and_cancels_revocation(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "cleanup-release")
+    support = _support(
+        old_values,
+        "generation-a",
+        released=True,
+        register_generation_state=True,
+    )
+    support.saved_contexts = []
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_contexts.append(ctx)\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    new_values = _external_values("generation-b", "cleanup-release")
+    support = _support(
+        new_values,
+        "generation-b",
+        released=True,
+        register_generation_state=True,
+    )
+    support.saved_contexts = []
+    primary = _InjectedBaseException("injected after all publication locks")
+    release_failure = _InjectedBaseException("injected mid cleanup release failure")
+    original_tool_validate = registry._validate_prepared_transaction_locked
+    original_tool_lock = registry._lock
+    fail_release = threading.Event()
+    revocation_observed = threading.Event()
+
+    class _FailingReleaseLock:
+        def acquire(self, *args, **kwargs):
+            return original_tool_lock.acquire(*args, **kwargs)
+
+        def release(self):
+            original_tool_lock.release()
+            if fail_release.is_set():
+                raise release_failure
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.release()
+
+    def validate_then_interrupt(snapshot, prepared) -> None:
+        original_tool_validate(snapshot, prepared)
+        assert manager._live_context_revoking == {manager._live_context_generation}
+        revocation_observed.set()
+        fail_release.set()
+        raise primary
+
+    monkeypatch.setattr(registry, "_validate_prepared_transaction_locked", validate_then_interrupt)
+    monkeypatch.setattr(registry, "_lock", _FailingReleaseLock())
+
+    with pytest.raises(_InjectedBaseException) as exc_info:
+        manager.discover_and_load(force=True)
+
+    assert exc_info.value is primary
+    assert revocation_observed.is_set()
+    assert any("cleanup" in note.lower() for note in primary.__notes__)
+    assert any("mid cleanup release failure" in note for note in primary.__notes__)
+    assert manager._live_context_revoking == set()
+    monkeypatch.setattr(registry, "_lock", original_tool_lock)
+    _assert_all_registration_locks_acquirable_from_other_threads(
+        manager,
+        context_locks=[
+            manager._context_registration_lock,
+            *(context._registration_lock for context in support.saved_contexts),
+        ],
+    )
+    assert manager.invoke_hook("post_tool_call") == ["generation-a"]
+    assert registry.get_entry(_TOOL_NAME).handler({}) == "generation-a"
+    assert _read_external_generation(old_values, isolated_registries) == old_values
+
+
+def test_registration_transaction_constructor_attempts_all_lock_cleanup(monkeypatch):
+    manager = PluginManager()
+    original_manager_lock = manager._lock
+    original_tool_lock = registry._lock
+    external_transactions = plugins_module._external_registry_transactions()
+    external_lock_slots: dict[str, tuple[Any, str, Any]] = {}
+    external_surfaces = list(external_transactions)
+    for surface, transaction in external_transactions.items():
+        if surface == "platform":
+            owner = transaction
+        elif surface == "secret":
+            from agent.secret_sources import registry as secret_registry
+
+            owner = secret_registry._registry_state
+        else:
+            owner = transaction._state
+        external_lock_slots[surface] = (owner, "_lock", owner._lock)
+    first_failure = _InjectedBaseException("injected constructor release failure 0")
+    second_failure = _InjectedBaseException("injected constructor release failure 1")
+    first_cleanup_index = 2 + external_surfaces.index("web")
+    later_cleanup_index = 2 + external_surfaces.index("stt")
+    failures = {first_cleanup_index: first_failure, later_cleanup_index: second_failure}
+
+    class _ReleaseWrapper:
+        def __init__(self, lock, index: int) -> None:
+            self._lock = lock
+            self._index = index
+            self._release_count = 0
+
+        def acquire(self, *args, **kwargs):
+            return self._lock.acquire(*args, **kwargs)
+
+        def release(self):
+            self._lock.release()
+            self._release_count += 1
+            if self._index in failures and self._release_count > 1:
+                raise failures[self._index]
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.release()
+
+    monkeypatch.setattr(manager, "_lock", _ReleaseWrapper(original_manager_lock, 0))
+    monkeypatch.setattr(registry, "_lock", _ReleaseWrapper(original_tool_lock, 1))
+    for index, (surface, (owner, attr, original_lock)) in enumerate(
+        external_lock_slots.items(),
+        start=2,
+    ):
+        monkeypatch.setattr(owner, attr, _ReleaseWrapper(original_lock, index))
+
+    with pytest.raises(_InjectedBaseException) as exc_info:
+        plugins_module._RegistrationTransaction(manager)
+
+    monkeypatch.setattr(manager, "_lock", original_manager_lock)
+    monkeypatch.setattr(registry, "_lock", original_tool_lock)
+    for owner, attr, original_lock in external_lock_slots.values():
+        monkeypatch.setattr(owner, attr, original_lock)
+
+    assert exc_info.value is first_failure
+    assert first_failure.__notes__ == [
+        "Additional cleanup failure: constructor lock[3]: "
+        "_InjectedBaseException: injected constructor release failure 1",
+        "Plugin registration cleanup failed; attempted all cleanup actions. "
+        "First failure at constructor lock[0].",
+    ]
+    _assert_all_registration_locks_acquirable_from_other_threads(manager)
+
+
+def test_force_reload_candidate_callback_worker_registration_does_not_deadlock(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("generation-a", "worker-callback")
+    support = _support(values, "generation-a", released=True)
+    support.worker_started = threading.Event()
+    support.worker_done = threading.Event()
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        f'''import threading
+import {_SUPPORT_MODULE} as support
+
+def register(ctx):
+    def worker():
+        support.worker_started.set()
+        ctx.register_hook("h1_worker_callback_hook", lambda **kwargs: support.marker)
+        support.worker_done.set()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    if not support.worker_started.wait(timeout=5):
+        raise RuntimeError("worker did not start")
+    if not support.worker_done.wait(timeout=5):
+        raise RuntimeError("worker registration deadlocked")
+    thread.join(timeout=1)
+''',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    manager.discover_and_load(force=True)
+
+    assert support.worker_done.is_set()
+    assert manager.invoke_hook("h1_worker_callback_hook") == ["generation-a"]
 
 
 def test_force_reload_removes_registrations_absent_from_new_generation(

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -985,6 +985,112 @@ def test_failed_initial_publication_restores_candidate_context_targets(
     assert late_hook not in manager._hooks.get("post_tool_call", [])
 
 
+def test_failed_binding_rollback_leaves_retained_candidate_without_live_authority(
+    tmp_path, monkeypatch, isolated_registries, caplog
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("candidate", "binding-rollback-failure")
+    support = _support(values, "candidate", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    primary = _InjectedBaseException("injected after tentative live binding")
+    rollback_failure = _InjectedBaseException("injected binding rollback failure")
+    original_install = manager._install_owned_state_locked
+
+    def install_then_interrupt(state) -> None:
+        original_install(state)
+        raise primary
+
+    monkeypatch.setattr(manager, "_install_owned_state_locked", install_then_interrupt)
+    original_setattr = plugins_module.PluginContext.__setattr__
+    binding_assignments = 0
+
+    def fail_binding_rollback(self, name, value) -> None:
+        nonlocal binding_assignments
+        if self is support.saved_context and name == "_registration_binding":
+            binding_assignments += 1
+            if binding_assignments == 2:
+                raise rollback_failure
+        original_setattr(self, name, value)
+
+    monkeypatch.setattr(plugins_module.PluginContext, "__setattr__", fail_binding_rollback)
+
+    with pytest.raises(_InjectedBaseException) as raised:
+        manager.discover_and_load()
+
+    assert raised.value is primary
+    assert binding_assignments == 2
+    assert any(
+        "Plugin publication rollback failed for context[0]" in record.message
+        for record in caplog.records
+    )
+    assert any("rollback failed" in note.lower() for note in primary.__notes__)
+
+    candidate_context = support.saved_context
+    escaped_tool = "h1_failed_rollback_escape_tool"
+    escaped_platform = "h1-failed-rollback-escape-platform"
+    escaped_hook = "h1_failed_rollback_escape_hook"
+    escaped_command = "h1-failed-rollback-escape-command"
+    mutations = [
+        lambda: candidate_context.register_tool(
+            escaped_tool,
+            "h1_transaction",
+            {
+                "name": escaped_tool,
+                "description": "must not escape",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            lambda args, **kwargs: "escaped",
+        ),
+        lambda: candidate_context.register_platform(
+            name=escaped_platform,
+            label="Must not escape",
+            adapter_factory=lambda config: "escaped",
+            check_fn=lambda: True,
+        ),
+        lambda: candidate_context.register_hook(escaped_hook, lambda **kwargs: "escaped"),
+        lambda: candidate_context.register_command(
+            escaped_command,
+            lambda raw_args: "escaped",
+        ),
+    ]
+    escaped_surfaces = []
+    for surface, mutate in zip(
+        ("tool", "platform", "hook", "command"),
+        mutations,
+        strict=True,
+    ):
+        try:
+            mutate()
+        except RuntimeError as exc:
+            assert "not published" in str(exc)
+        else:  # pragma: no cover - deterministic RED assertion on the base
+            escaped_surfaces.append(surface)
+
+    assert escaped_surfaces == []
+
+    binding = candidate_context._registration_binding
+    assert binding.manager is manager
+    assert binding.managed_generation == manager._live_context_generation
+    assert binding.publication_capability is not None
+    assert binding.publication_capability._published is False
+
+    assert registry.get_entry(escaped_tool) is None
+    assert isolated_registries.get(escaped_platform) is None
+    assert escaped_hook not in manager._hooks
+    assert escaped_command not in manager._plugin_commands
+
+
 def _mutate_retained_candidate(context, surface: str, name: str) -> None:
     if surface == "tool":
         context.register_tool(
@@ -1168,6 +1274,126 @@ def test_failed_initial_publication_restores_binding_before_retained_candidate_m
         assert name not in manager._plugin_external_names["platform"]
     else:
         assert name not in manager._hooks
+
+
+def test_commit_does_not_deadlock_reverse_nested_candidate_context_registration(
+    isolated_registries,
+):
+    manager = PluginManager()
+    transaction = plugins_module._RegistrationTransaction(manager)
+    manifest_a = plugins_module.PluginManifest(name="h1-lock-a")
+    manifest_b = plugins_module.PluginManifest(name="h1-lock-b")
+    context_kwargs = {
+        "registration_manager": transaction.manager_view,
+        "registration_registry": transaction.tool_view,
+        "registration_external_registries": transaction.context_targets(),
+    }
+    context_a = plugins_module.PluginContext(manifest_a, manager, **context_kwargs)
+    context_b = plugins_module.PluginContext(manifest_b, manager, **context_kwargs)
+    transaction.contexts.extend((context_a, context_b))
+
+    commit_attempted_context_lock = threading.Event()
+    commit_ident: list[int] = []
+
+    class _ObservedRLock:
+        def __init__(self, lock) -> None:
+            self._lock = lock
+
+        def acquire(self, *args, **kwargs):
+            if commit_ident and threading.get_ident() == commit_ident[0]:
+                commit_attempted_context_lock.set()
+            return self._lock.acquire(*args, **kwargs)
+
+        def release(self) -> None:
+            self._lock.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            self.release()
+
+    wrappers = {}
+    for context in (context_a, context_b):
+        lock = context._registration_lock
+        wrapper = wrappers.setdefault(id(lock), _ObservedRLock(lock))
+        context._registration_lock = wrapper
+    if hasattr(manager, "_context_registration_lock"):
+        lock = manager._context_registration_lock
+        manager._context_registration_lock = wrappers.setdefault(
+            id(lock), _ObservedRLock(lock)
+        )
+
+    callback_entered = threading.Event()
+    registration_done = threading.Event()
+    registration_failures: list[BaseException] = []
+
+    class _ReverseNestedSchema(dict):
+        def get(self, key, default=None):
+            if key == "description":
+                callback_entered.set()
+                assert commit_attempted_context_lock.wait(timeout=5)
+                context_a.register_hook(
+                    "h1_reverse_nested_hook",
+                    lambda **kwargs: "must not publish",
+                )
+            return super().get(key, default)
+
+    def register_from_context_b() -> None:
+        try:
+            context_b.register_tool(
+                "h1_reverse_nested_tool",
+                "h1_transaction",
+                _ReverseNestedSchema(
+                    {
+                        "name": "h1_reverse_nested_tool",
+                        "description": "must not publish",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ),
+                lambda args, **kwargs: "must not publish",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            registration_failures.append(exc)
+        finally:
+            registration_done.set()
+
+    registration_thread = threading.Thread(
+        target=register_from_context_b,
+        daemon=True,
+    )
+    registration_thread.start()
+    assert callback_entered.wait(timeout=5)
+
+    commit_done = threading.Event()
+    commit_failures: list[BaseException] = []
+
+    def commit() -> None:
+        commit_ident.append(threading.get_ident())
+        try:
+            transaction.commit()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            commit_failures.append(exc)
+        finally:
+            commit_done.set()
+
+    commit_thread = threading.Thread(target=commit, daemon=True)
+    commit_thread.start()
+
+    assert commit_attempted_context_lock.wait(timeout=5)
+    assert registration_done.wait(timeout=5), "reverse nested registration deadlocked"
+    assert commit_done.wait(timeout=5), "commit deadlocked on reverse context order"
+    registration_thread.join(timeout=1)
+    commit_thread.join(timeout=1)
+    assert not registration_thread.is_alive()
+    assert not commit_thread.is_alive()
+    assert len(commit_failures) == 1
+    assert isinstance(commit_failures[0], plugins_module._ForceSweepAbort)
+    assert len(registration_failures) == 1
+    assert "frozen" in str(registration_failures[0])
+    assert registry.get_entry("h1_reverse_nested_tool") is None
+    assert "h1_reverse_nested_hook" not in manager._hooks
 
 
 def test_retained_context_live_registration_does_not_validate_under_live_locks(

--- a/tests/hermes_cli/test_plugin_registration_concurrency.py
+++ b/tests/hermes_cli/test_plugin_registration_concurrency.py
@@ -889,6 +889,143 @@ def test_retained_context_live_registration_does_not_validate_under_live_locks(
     ), observations
 
 
+def test_retained_context_reentrant_force_reload_during_validation_fails_closed(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    values = _external_values("initial", "reentrant-force")
+    support = _support(values, "initial", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    provider_name = "h1-reentrant-force-validation-image"
+
+    class _ReentrantImageProvider(_ImageProvider):
+        @property
+        def name(self) -> str:
+            manager.discover_and_load(force=True)
+            return super().name
+
+    failures: list[BaseException] = []
+    done = threading.Event()
+
+    def register_from_retained_context() -> None:
+        try:
+            support.saved_context.register_image_gen_provider(
+                _ReentrantImageProvider(provider_name, "late")
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=register_from_retained_context, daemon=True)
+    thread.start()
+
+    assert done.wait(timeout=5), "reentrant force reload self-deadlocked"
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert len(failures) == 1
+    assert isinstance(failures[0], RuntimeError)
+    assert "force reload cannot run from a live plugin registration" in str(failures[0])
+
+    from agent.image_gen_registry import get_provider
+
+    assert get_provider(provider_name) is None
+
+
+def test_force_reload_fails_closed_instead_of_waiting_on_live_validation(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "lease-cycle")
+    support = _support(old_values, "generation-a", released=True)
+    support.saved_context = None
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_context = ctx\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_context = support.saved_context
+
+    validation_started = threading.Event()
+    force_done = threading.Event()
+    registration_done = threading.Event()
+    registration_failures: list[BaseException] = []
+
+    class _WaitingImageProvider(_ImageProvider):
+        @property
+        def name(self) -> str:
+            validation_started.set()
+            if not force_done.wait(timeout=5):
+                raise RuntimeError("force reload did not finish")
+            return super().name
+
+    provider_name = "h1-live-validation-waits-for-force"
+
+    def register_provider() -> None:
+        try:
+            old_context.register_image_gen_provider(
+                _WaitingImageProvider(provider_name, "late")
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            registration_failures.append(exc)
+        finally:
+            registration_done.set()
+
+    registration_thread = threading.Thread(target=register_provider, daemon=True)
+    registration_thread.start()
+    assert validation_started.wait(timeout=5)
+
+    new_values = _external_values("generation-b", "lease-cycle")
+    support = _support(new_values, "generation-b", released=True)
+    force_failures: list[BaseException] = []
+
+    def force_reload() -> None:
+        try:
+            manager.discover_and_load(force=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            force_failures.append(exc)
+        finally:
+            force_done.set()
+
+    force_thread = threading.Thread(target=force_reload, daemon=True)
+    force_thread.start()
+
+    assert force_done.wait(timeout=5), "force reload waited on live validation"
+    assert registration_done.wait(timeout=5), "live validation did not resume"
+    force_thread.join(timeout=1)
+    registration_thread.join(timeout=1)
+    assert not force_thread.is_alive()
+    assert not registration_thread.is_alive()
+    assert force_failures == []
+    assert registration_failures == []
+    assert manager._live_context_generation == 0
+    assert manager._live_context_revoking == set()
+
+    from agent.image_gen_registry import get_provider
+
+    assert get_provider(provider_name) is not None
+
+
 def test_successful_force_reload_revokes_prior_retained_context_before_mutation(
     tmp_path, monkeypatch, isolated_registries
 ):
@@ -1022,3 +1159,160 @@ def test_failed_force_reload_keeps_prior_retained_context_live(
     assert support.saved_contexts
     assert get_provider(retained_external.name) is retained_external
     assert retained_hook in manager._hooks["post_tool_call"]
+
+
+def test_force_reload_interrupt_after_revocation_keeps_old_context_live(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "revocation-interrupt")
+    support = _support(old_values, "generation-a", released=True)
+    support.saved_contexts = []
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_contexts.append(ctx)\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_context = support.saved_contexts[-1]
+
+    support = _support(
+        _external_values("generation-b", "revocation-interrupt"),
+        "generation-b",
+        released=True,
+    )
+    support.saved_contexts = []
+    original_begin = manager._begin_live_context_revocation
+
+    def interrupt_after_begin(generation: int) -> None:
+        original_begin(generation)
+        raise KeyboardInterrupt("injected after revocation")
+
+    monkeypatch.setattr(
+        manager,
+        "_begin_live_context_revocation",
+        interrupt_after_begin,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="injected after revocation"):
+        manager.discover_and_load(force=True)
+
+    assert manager._live_context_generation == 0
+    assert manager._live_context_revoking == set()
+    retained_tool = "h1_revocation_interrupt_tool"
+    retained_platform = "h1-revocation-interrupt-platform"
+    old_context.register_tool(
+        retained_tool,
+        "h1_transaction",
+        {
+            "name": retained_tool,
+            "description": "retained",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        lambda args, **kwargs: "retained",
+    )
+    old_context.register_platform(
+        name=retained_platform,
+        label="Retained",
+        adapter_factory=lambda config: "retained",
+        check_fn=lambda: True,
+    )
+    assert registry.get_entry(retained_tool) is not None
+    assert isolated_registries.get(retained_platform) is not None
+
+
+def test_force_reload_lock_acquisition_interrupt_releases_prior_locks(
+    tmp_path, monkeypatch, isolated_registries
+):
+    home = tmp_path / "hermes-home"
+    old_values = _external_values("generation-a", "lock-interrupt")
+    support = _support(old_values, "generation-a", released=True)
+    support.saved_contexts = []
+    _write_plugin(home)
+    plugin_file = home / "plugins" / _PLUGIN_NAME / "__init__.py"
+    plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace(
+            "values = support.values",
+            "support.saved_contexts.append(ctx)\n    values = support.values",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    old_context = support.saved_contexts[-1]
+
+    from agent import image_gen_registry
+
+    original_lock = image_gen_registry._registry_state._lock
+
+    class _InterruptingLock:
+        def __init__(self) -> None:
+            self.acquire_count = 0
+
+        def acquire(self, *args, **kwargs):
+            self.acquire_count += 1
+            if self.acquire_count == 2:
+                raise KeyboardInterrupt("injected lock acquisition failure")
+            return original_lock.acquire(*args, **kwargs)
+
+        def release(self) -> None:
+            original_lock.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            self.release()
+
+    interrupting_lock = _InterruptingLock()
+    monkeypatch.setattr(image_gen_registry._registry_state, "_lock", interrupting_lock)
+    support = _support(
+        _external_values("generation-b", "lock-interrupt"),
+        "generation-b",
+        released=True,
+    )
+    support.saved_contexts = []
+
+    with pytest.raises(KeyboardInterrupt, match="injected lock acquisition failure"):
+        manager.discover_and_load(force=True)
+
+    assert interrupting_lock.acquire_count == 2
+    assert manager._live_context_generation == 0
+    assert manager._live_context_revoking == set()
+
+    retained_tool = "h1_lock_interrupt_tool"
+    done = threading.Event()
+    failures: list[BaseException] = []
+
+    def register_from_other_thread() -> None:
+        try:
+            old_context.register_tool(
+                retained_tool,
+                "h1_transaction",
+                {
+                    "name": retained_tool,
+                    "description": "retained",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                lambda args, **kwargs: "retained",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=register_from_other_thread, daemon=True)
+    thread.start()
+    assert done.wait(timeout=5), "previously acquired commit lock was leaked"
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert failures == []
+    assert registry.get_entry(retained_tool) is not None

--- a/tests/hermes_cli/test_plugin_registration_transactions.py
+++ b/tests/hermes_cli/test_plugin_registration_transactions.py
@@ -1,0 +1,886 @@
+"""Transactional plugin registration through the public discovery path."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugins import PluginManager
+from tools.registry import registry
+
+
+_OVERRIDE_TOOL = "transaction_override_target"
+
+
+def _schema(name: str, description: str = "transaction test tool") -> dict:
+    return {
+        "name": name,
+        "description": description,
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _manager_registration_state(manager: PluginManager) -> dict:
+    """Identity-preserving view of every PluginManager registration surface."""
+    return {
+        "hooks": {name: tuple(callbacks) for name, callbacks in manager._hooks.items()},
+        "middleware": {
+            name: tuple(callbacks) for name, callbacks in manager._middleware.items()
+        },
+        "tool_names": frozenset(manager._plugin_tool_names),
+        "platform_names": frozenset(manager._plugin_platform_names),
+        "cli_commands": {
+            name: dict(entry) for name, entry in manager._cli_commands.items()
+        },
+        "slash_commands": {
+            name: dict(entry) for name, entry in manager._plugin_commands.items()
+        },
+        "skills": {
+            name: dict(entry) for name, entry in manager._plugin_skills.items()
+        },
+        "aux_tasks": {
+            name: {**entry, "defaults": dict(entry.get("defaults", {}))}
+            for name, entry in manager._aux_tasks.items()
+        },
+        "slack_handlers": tuple(manager._slack_action_handlers),
+        "context_engine": manager._context_engine,
+    }
+
+
+@pytest.fixture
+def isolated_tool_registry():
+    """Restore the process-global registry even while the RED tests fail."""
+    with registry._lock:
+        before = (
+            dict(registry._tools),
+            dict(registry._toolset_checks),
+            dict(registry._toolset_aliases),
+            dict(registry._plugin_override_policy),
+            registry._generation,
+        )
+    try:
+        yield
+    finally:
+        with registry._lock:
+            (
+                registry._tools,
+                registry._toolset_checks,
+                registry._toolset_aliases,
+                registry._plugin_override_policy,
+                old_generation,
+            ) = before
+            registry._generation = max(registry._generation, old_generation) + 1
+        for module_name in list(sys.modules):
+            if module_name.startswith("hermes_plugins.transaction_"):
+                sys.modules.pop(module_name, None)
+
+
+@pytest.fixture(autouse=True)
+def no_bundled_plugins(tmp_path, monkeypatch):
+    """Keep each public discovery sweep scoped to its temporary user plugins."""
+    empty_bundled = tmp_path / "empty-bundled-plugins"
+    empty_bundled.mkdir()
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(empty_bundled))
+
+
+def _write_config(home: Path, enabled: list[str], *, allow_override: str | None = None) -> None:
+    plugins: dict = {"enabled": enabled}
+    if allow_override is not None:
+        plugins["entries"] = {allow_override: {"allow_tool_override": True}}
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins}), encoding="utf-8"
+    )
+
+
+def _write_plugin(home: Path, name: str, source: str, *, submodule: str | None = None) -> Path:
+    plugin_dir = home / "plugins" / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": name, "version": "1.0"}), encoding="utf-8"
+    )
+    (plugin_dir / "__init__.py").write_text(source, encoding="utf-8")
+    (plugin_dir / "SKILL.md").write_text("# Transaction skill\n", encoding="utf-8")
+    if submodule is not None:
+        (plugin_dir / "child.py").write_text(submodule, encoding="utf-8")
+    return plugin_dir
+
+
+def _all_surfaces_source(*, raise_line: str = "") -> str:
+    return f'''from pathlib import Path
+from agent.context_engine import ContextEngine
+from . import child
+
+register_calls = 0
+
+class TransactionEngine(ContextEngine):
+    @property
+    def name(self):
+        return "transaction-engine"
+
+    def update_from_response(self, usage):
+        return None
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+        return messages
+
+def _tool(args, **kwargs):
+    return "plugin-tool"
+
+def _override(args, **kwargs):
+    return "plugin-override"
+
+def register(ctx):
+    global register_calls
+    register_calls += 1
+    ctx.register_tool("transaction_new_tool", "transaction_plugin", {repr(_schema("transaction_new_tool"))}, _tool)
+    ctx.register_tool({_OVERRIDE_TOOL!r}, "transaction_plugin", {repr(_schema(_OVERRIDE_TOOL))}, _override, override=True)
+    ctx.register_hook("post_tool_call", lambda **kwargs: "plugin-hook")
+    ctx.register_middleware("llm_request", lambda **kwargs: {{"plugin": True}})
+    ctx.register_command("transaction-slash", lambda raw: "plugin-slash", "transaction slash")
+    ctx.register_cli_command("transaction-cli", "transaction cli", lambda parser: None, lambda args: "plugin-cli")
+    ctx.register_skill("transaction-skill", Path(__file__).parent / "SKILL.md", "transaction skill")
+    ctx.register_auxiliary_task(key="transaction_aux", display_name="Transaction aux", description="transaction task")
+    ctx.register_slack_action_handler("transaction_action", lambda **kwargs: "plugin-slack")
+    ctx.register_context_engine(TransactionEngine())
+    {raise_line or "return None"}
+'''
+
+
+def _register_builtin_override_target() -> object:
+    def _builtin(args, **kwargs):
+        return "built-in"
+
+    registry.register(
+        name=_OVERRIDE_TOOL,
+        toolset="transaction_builtin",
+        schema=_schema(_OVERRIDE_TOOL, "original built-in"),
+        handler=_builtin,
+    )
+    entry = registry.get_entry(_OVERRIDE_TOOL)
+    assert entry is not None
+    return entry
+
+
+def _concurrent_tool_source(*, fail_after_release: bool = False) -> str:
+    final_line = (
+        "raise RuntimeError('sensitive-concurrent-registration-detail')"
+        if fail_after_release
+        else "return None"
+    )
+    return f'''import threading
+
+started = threading.Event()
+release = threading.Event()
+
+def _new_tool(args, **kwargs):
+    return "committed-new-tool"
+
+def _override(args, **kwargs):
+    return "committed-override"
+
+def register(ctx):
+    ctx.register_tool("transaction_concurrent_new", "transaction_plugin", {repr(_schema("transaction_concurrent_new"))}, _new_tool)
+    ctx.register_tool({_OVERRIDE_TOOL!r}, "transaction_plugin", {repr(_schema(_OVERRIDE_TOOL, "committed override"))}, _override, override=True)
+    ctx.register_hook("post_tool_call", lambda **kwargs: "committed-hook")
+    started.set()
+    if not release.wait(timeout=5):
+        raise RuntimeError("test release timeout")
+    {final_line}
+'''
+
+
+def _start_discovery(manager: PluginManager) -> tuple[threading.Thread, list[BaseException]]:
+    failures: list[BaseException] = []
+
+    def _load() -> None:
+        try:
+            manager.discover_and_load()
+        except BaseException as exc:  # pragma: no cover - asserted by callers
+            failures.append(exc)
+
+    thread = threading.Thread(target=_load, daemon=True)
+    thread.start()
+    return thread, failures
+
+
+def _wait_for_plugin_module(plugin_name: str):
+    module_name = f"hermes_plugins.{plugin_name}"
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, "started"):
+            assert module.started.wait(timeout=5)
+            return module
+        time.sleep(0.005)
+    raise AssertionError(f"plugin module {module_name!r} did not start registration")
+
+
+def _assert_live_tools_are_preload_state(original_entry: object) -> None:
+    assert registry.get_entry("transaction_concurrent_new") is None
+    assert registry.get_entry(_OVERRIDE_TOOL) is original_entry
+    assert registry.get_entry(_OVERRIDE_TOOL).handler is original_entry.handler
+    definitions = registry.get_definitions(
+        {"transaction_concurrent_new", _OVERRIDE_TOOL}
+    )
+    assert [item["function"]["name"] for item in definitions] == [
+        _OVERRIDE_TOOL
+    ]
+    assert definitions[0]["function"]["description"] == "original built-in"
+    assert "Unknown tool" in registry.dispatch("transaction_concurrent_new", {})
+    assert registry.dispatch(_OVERRIDE_TOOL, {}) == "built-in"
+
+
+def test_tool_readers_observe_preload_state_until_atomic_successful_commit(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_concurrent_success"
+    original_entry = _register_builtin_override_target()
+    _write_plugin(home, plugin_name, _concurrent_tool_source())
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, failures = _start_discovery(manager)
+    module = _wait_for_plugin_module(plugin_name)
+
+    _assert_live_tools_are_preload_state(original_entry)
+    tool_names, loaded_plugins = manager.get_tool_state_snapshot()
+    assert tool_names == set()
+    assert loaded_plugins == {}
+    assert manager.has_hook("post_tool_call") is False
+
+    module.release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert failures == []
+
+    new_entry = registry.get_entry("transaction_concurrent_new")
+    override_entry = registry.get_entry(_OVERRIDE_TOOL)
+    assert new_entry is not None
+    assert override_entry is not None
+    assert new_entry.handler is module._new_tool
+    assert override_entry.handler is module._override
+    assert registry.dispatch("transaction_concurrent_new", {}) == "committed-new-tool"
+    assert registry.dispatch(_OVERRIDE_TOOL, {}) == "committed-override"
+    assert {
+        item["function"]["name"]
+        for item in registry.get_definitions(
+            {"transaction_concurrent_new", _OVERRIDE_TOOL}
+        )
+    } == {"transaction_concurrent_new", _OVERRIDE_TOOL}
+    tool_names, loaded_plugins = manager.get_tool_state_snapshot()
+    assert {"transaction_concurrent_new", _OVERRIDE_TOOL} <= tool_names
+    assert loaded_plugins[plugin_name].tools_registered == [
+        "transaction_concurrent_new",
+        _OVERRIDE_TOOL,
+    ]
+    assert manager.invoke_hook("post_tool_call") == ["committed-hook"]
+
+
+def test_failed_concurrent_registration_never_exposes_provisional_tools(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_concurrent_failure"
+    original_entry = _register_builtin_override_target()
+    _write_plugin(
+        home,
+        plugin_name,
+        _concurrent_tool_source(fail_after_release=True),
+    )
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, failures = _start_discovery(manager)
+    module = _wait_for_plugin_module(plugin_name)
+    observations: list[tuple[object, object]] = []
+    stop_observer = threading.Event()
+
+    def _observe() -> None:
+        while not stop_observer.is_set():
+            observations.append(
+                (
+                    registry.get_entry("transaction_concurrent_new"),
+                    registry.get_entry(_OVERRIDE_TOOL),
+                )
+            )
+
+    observer = threading.Thread(target=_observe, daemon=True)
+    observer.start()
+    try:
+        _assert_live_tools_are_preload_state(original_entry)
+        module.release.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+    finally:
+        stop_observer.set()
+        observer.join(timeout=5)
+
+    assert failures == []
+    assert observations
+    assert all(new is None for new, _override in observations)
+    assert all(override is original_entry for _new, override in observations)
+    _assert_live_tools_are_preload_state(original_entry)
+    assert manager._plugin_tool_names == set()
+    assert manager.has_hook("post_tool_call") is False
+    loaded = manager._plugins[plugin_name]
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert loaded.error == "RuntimeError: plugin registration failed"
+    assert f"hermes_plugins.{plugin_name}" not in sys.modules
+
+
+def test_commit_fails_closed_if_live_tool_registry_changed_since_snapshot(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_concurrent_conflict"
+    original_entry = _register_builtin_override_target()
+    _write_plugin(home, plugin_name, _concurrent_tool_source())
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    thread, failures = _start_discovery(manager)
+    module = _wait_for_plugin_module(plugin_name)
+
+    def _concurrent_handler(args, **kwargs):
+        return "concurrent-change"
+
+    registry.register(
+        name="transaction_concurrent_winner",
+        toolset="transaction_concurrent_writer",
+        schema=_schema("transaction_concurrent_winner"),
+        handler=_concurrent_handler,
+    )
+    concurrent_entry = registry.get_entry("transaction_concurrent_winner")
+    assert concurrent_entry is not None
+
+    module.release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert failures == []
+
+    assert registry.get_entry("transaction_concurrent_winner") is concurrent_entry
+    assert registry.dispatch("transaction_concurrent_winner", {}) == "concurrent-change"
+    _assert_live_tools_are_preload_state(original_entry)
+    assert manager._plugin_tool_names == set()
+    assert manager.has_hook("post_tool_call") is False
+    loaded = manager._plugins[plugin_name]
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert loaded.error == "RuntimeError: plugin commit failed"
+    assert f"hermes_plugins.{plugin_name}" not in sys.modules
+
+
+def test_tool_and_manager_readers_block_inside_the_atomic_commit_section(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_commit_reader_blocking"
+    _register_builtin_override_target()
+    _write_plugin(home, plugin_name, _concurrent_tool_source())
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    commit_started = threading.Event()
+    release_commit = threading.Event()
+    original_install = manager._install_owned_state_locked
+
+    def _pause_manager_install(state) -> None:
+        if plugin_name in state._plugins:
+            commit_started.set()
+            if not release_commit.wait(timeout=5):
+                raise RuntimeError("test commit release timeout")
+        original_install(state)
+
+    monkeypatch.setattr(manager, "_install_owned_state_locked", _pause_manager_install)
+    load_thread, failures = _start_discovery(manager)
+    module = _wait_for_plugin_module(plugin_name)
+    module.release.set()
+    assert commit_started.wait(timeout=5)
+
+    tool_result: list[object] = []
+    manager_result: list[object] = []
+    tool_done = threading.Event()
+    manager_done = threading.Event()
+
+    def _read_tool() -> None:
+        tool_result.append(registry.get_entry("transaction_concurrent_new"))
+        tool_done.set()
+
+    def _read_manager() -> None:
+        manager_result.append(manager.get_tool_state_snapshot())
+        manager_done.set()
+
+    tool_reader = threading.Thread(target=_read_tool, daemon=True)
+    manager_reader = threading.Thread(target=_read_manager, daemon=True)
+    tool_reader.start()
+    manager_reader.start()
+    assert not tool_done.wait(timeout=0.1)
+    assert not manager_done.wait(timeout=0.1)
+
+    release_commit.set()
+    load_thread.join(timeout=5)
+    tool_reader.join(timeout=5)
+    manager_reader.join(timeout=5)
+    assert not load_thread.is_alive()
+    assert not tool_reader.is_alive()
+    assert not manager_reader.is_alive()
+    assert failures == []
+    assert tool_result[0] is registry.get_entry("transaction_concurrent_new")
+    tool_names, plugins = manager_result[0]
+    assert "transaction_concurrent_new" in tool_names
+    assert plugins[plugin_name].enabled is True
+
+
+def test_context_retained_callback_targets_live_registries_after_commit(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_runtime_context"
+    _write_plugin(
+        home,
+        plugin_name,
+        '''saved_ctx = None
+
+def _initial(args, **kwargs):
+    return "initial"
+
+def _late(args, **kwargs):
+    return "late"
+
+def register(ctx):
+    global saved_ctx
+    saved_ctx = ctx
+    ctx.register_tool("transaction_runtime_initial", "transaction_runtime", {"name": "transaction_runtime_initial", "description": "initial", "parameters": {"type": "object", "properties": {}}}, _initial)
+
+def register_late():
+    saved_ctx.register_tool("transaction_runtime_late", "transaction_runtime", {"name": "transaction_runtime_late", "description": "late", "parameters": {"type": "object", "properties": {}}}, _late)
+''',
+    )
+    _write_config(home, [plugin_name])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    manager.discover_and_load()
+    module = sys.modules[f"hermes_plugins.{plugin_name}"]
+    assert registry.get_entry("transaction_runtime_late") is None
+
+    module.register_late()
+
+    assert registry.dispatch("transaction_runtime_late", {}) == "late"
+    tool_names, _plugins = manager.get_tool_state_snapshot()
+    assert "transaction_runtime_late" in tool_names
+
+
+def test_failed_registration_rolls_back_every_supported_surface_and_modules(
+    tmp_path, monkeypatch, caplog, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_failure"
+    old_entry = _register_builtin_override_target()
+    previous_same_name = type(sys)("hermes_plugins.transaction_failure")
+    sys.modules["hermes_plugins.transaction_failure"] = previous_same_name
+    _write_plugin(
+        home,
+        plugin_name,
+        _all_surfaces_source(
+            raise_line="raise RuntimeError('sensitive-registration-detail')"
+        ),
+        submodule="VALUE = 'created during failed import'\n",
+    )
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    manager = PluginManager()
+    before_manager = _manager_registration_state(manager)
+    with registry._lock:
+        before_tools = dict(registry._tools)
+        before_checks = dict(registry._toolset_checks)
+        before_aliases = dict(registry._toolset_aliases)
+        before_policy = dict(registry._plugin_override_policy)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        manager.discover_and_load()
+
+    assert _manager_registration_state(manager) == before_manager
+    with registry._lock:
+        assert registry._tools == before_tools
+        assert registry._toolset_checks == before_checks
+        assert registry._toolset_aliases == before_aliases
+        assert registry._plugin_override_policy == before_policy
+    assert registry.get_entry(_OVERRIDE_TOOL) is old_entry
+    assert registry.get_entry("transaction_new_tool") is None
+    assert manager.invoke_hook("post_tool_call") == []
+    assert manager.invoke_middleware("llm_request") == []
+    assert manager.find_plugin_skill(f"{plugin_name}:transaction-skill") is None
+    assert manager.get_slack_action_handlers() == []
+    assert "transaction-slash" not in manager._plugin_commands
+    assert "transaction-cli" not in manager._cli_commands
+    assert "transaction_aux" not in manager._aux_tasks
+    assert manager._context_engine is None
+
+    loaded = manager._plugins[plugin_name]
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert loaded.error
+    assert "registration failed" in loaded.error.lower()
+    assert "sensitive-registration-detail" not in loaded.error
+    assert "sensitive-registration-detail" not in caplog.text
+    assert sys.modules["hermes_plugins.transaction_failure"] is previous_same_name
+    assert "hermes_plugins.transaction_failure.child" not in sys.modules
+
+
+def test_import_failure_removes_plugin_module_tree_and_records_safe_error(
+    tmp_path, monkeypatch, caplog, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_import_failure"
+    _write_plugin(
+        home,
+        plugin_name,
+        '''from . import child
+raise RuntimeError("sensitive-import-detail")
+''',
+        submodule="VALUE = 'temporary import child'\n",
+    )
+    _write_config(home, [plugin_name])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        manager.discover_and_load()
+
+    loaded = manager._plugins[plugin_name]
+    assert loaded.enabled is False
+    assert loaded.module is None
+    assert loaded.error == "RuntimeError: plugin import failed"
+    assert "sensitive-import-detail" not in caplog.text
+    root = "hermes_plugins.transaction_import_failure"
+    assert root not in sys.modules
+    assert f"{root}.child" not in sys.modules
+
+
+def test_success_commits_once_with_attribution_and_normal_discovery_is_idempotent(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_success"
+    _register_builtin_override_target()
+    _write_plugin(
+        home,
+        plugin_name,
+        _all_surfaces_source(),
+        submodule="VALUE = 'success'\n",
+    )
+    _write_config(home, [plugin_name], allow_override=plugin_name)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    first_state = _manager_registration_state(manager)
+    module = sys.modules["hermes_plugins.transaction_success"]
+    manager.discover_and_load()
+
+    assert module.register_calls == 1
+    assert _manager_registration_state(manager) == first_state
+    loaded = manager._plugins[plugin_name]
+    assert loaded.enabled is True
+    assert loaded.error is None
+    assert loaded.module is module
+    assert set(loaded.tools_registered) == {
+        "transaction_new_tool",
+        _OVERRIDE_TOOL,
+    }
+    assert loaded.hooks_registered == ["post_tool_call"]
+    assert loaded.middleware_registered == ["llm_request"]
+    assert loaded.commands_registered == ["transaction-slash"]
+    assert len(manager._hooks["post_tool_call"]) == 1
+    assert len(manager._middleware["llm_request"]) == 1
+    assert len(manager._slack_action_handlers) == 1
+    assert manager._cli_commands["transaction-cli"]["plugin"] == plugin_name
+    assert manager._plugin_commands["transaction-slash"]["plugin"] == plugin_name
+    assert manager._plugin_skills[f"{plugin_name}:transaction-skill"]["plugin"] == plugin_name
+    assert manager._aux_tasks["transaction_aux"]["plugin"] == plugin_name
+    assert manager._slack_action_handlers[0][2] == plugin_name
+    assert manager._context_engine.name == "transaction-engine"
+    assert registry.dispatch("transaction_new_tool", {}) == "plugin-tool"
+    assert registry.dispatch(_OVERRIDE_TOOL, {}) == "plugin-override"
+
+
+def test_manager_readers_do_not_observe_a_half_registration(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = "transaction_reader_isolation"
+    _write_plugin(
+        home,
+        plugin_name,
+        '''import threading
+
+started = threading.Event()
+release = threading.Event()
+
+def register(ctx):
+    ctx.register_hook("post_tool_call", lambda **kwargs: "committed-hook")
+    started.set()
+    if not release.wait(timeout=5):
+        raise RuntimeError("test release timeout")
+    ctx.register_middleware("llm_request", lambda **kwargs: {"committed": True})
+''',
+    )
+    _write_config(home, [plugin_name])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    failures: list[BaseException] = []
+
+    def _load() -> None:
+        try:
+            manager.discover_and_load()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    thread = threading.Thread(target=_load, daemon=True)
+    thread.start()
+    module_name = "hermes_plugins.transaction_reader_isolation"
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, "started"):
+            break
+        thread.join(timeout=0.01)
+    module = sys.modules[module_name]
+    assert module.started.wait(timeout=5)
+
+    assert manager.has_hook("post_tool_call") is False
+    assert manager.has_middleware("llm_request") is False
+    assert manager.list_plugins() == []
+
+    module.release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert failures == []
+    assert manager.has_hook("post_tool_call") is True
+    assert manager.has_middleware("llm_request") is True
+    assert manager._plugins[plugin_name].enabled is True
+
+
+def test_failed_plugin_after_success_does_not_roll_back_success(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    success = "transaction_a_success"
+    failure = "transaction_z_failure"
+    _write_plugin(
+        home,
+        success,
+        '''def _tool(args, **kwargs):
+    return "success-still-present"
+
+def register(ctx):
+    ctx.register_tool("transaction_preserved_tool", "transaction_success", {"name": "transaction_preserved_tool", "description": "preserved", "parameters": {"type": "object", "properties": {}}}, _tool)
+    ctx.register_hook("post_tool_call", lambda **kwargs: "preserved-hook")
+''',
+    )
+    _write_plugin(
+        home,
+        failure,
+        '''def register(ctx):
+    ctx.register_hook("post_tool_call", lambda **kwargs: "leaked-hook")
+    raise RuntimeError("failure after success")
+''',
+    )
+    _write_config(home, [success, failure])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert manager._plugins[success].enabled is True
+    assert manager._plugins[failure].enabled is False
+    assert registry.dispatch("transaction_preserved_tool", {}) == "success-still-present"
+    assert manager.invoke_hook("post_tool_call") == ["preserved-hook"]
+    assert len(manager._hooks["post_tool_call"]) == 1
+
+
+def test_failed_registration_restores_platform_and_legacy_provider_registries(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    from agent.image_gen_provider import ImageGenProvider
+    from agent.image_gen_registry import get_provider, register_provider
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    class OriginalProvider(ImageGenProvider):
+        @property
+        def name(self):
+            return "transaction-image"
+
+        def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+            return {"owner": "original"}
+
+    original_provider = OriginalProvider()
+    original_platform = PlatformEntry(
+        name="transaction-platform",
+        label="Original platform",
+        adapter_factory=lambda config: "original-platform",
+        check_fn=lambda: True,
+        source="plugin",
+    )
+    register_provider(original_provider)
+    platform_registry.register(original_platform)
+    try:
+        home = tmp_path / "hermes-home"
+        plugin_name = "transaction_external_failure"
+        _write_plugin(
+            home,
+            plugin_name,
+            '''from agent.image_gen_provider import ImageGenProvider
+
+class ReplacementProvider(ImageGenProvider):
+    @property
+    def name(self):
+        return "transaction-image"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {"owner": "replacement"}
+
+def register(ctx):
+    ctx.register_platform(
+        name="transaction-platform",
+        label="Replacement platform",
+        adapter_factory=lambda config: "replacement-platform",
+        check_fn=lambda: True,
+    )
+    ctx.register_image_gen_provider(ReplacementProvider())
+    raise RuntimeError("external rollback")
+''',
+        )
+        _write_config(home, [plugin_name])
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        assert manager._plugins[plugin_name].enabled is False
+        assert get_provider("transaction-image") is original_provider
+        assert platform_registry.get("transaction-platform") is original_platform
+        assert "transaction-platform" not in manager._plugin_platform_names
+    finally:
+        from agent import image_gen_registry
+
+        with image_gen_registry._lock:
+            image_gen_registry._providers.pop("transaction-image", None)
+        platform_registry.unregister("transaction-platform")
+
+
+@pytest.mark.parametrize(
+    ("exception_name", "exception_text"),
+    [("KeyboardInterrupt", "stop-now"), ("SystemExit", "stop-now")],
+)
+def test_base_exception_rolls_back_then_propagates(
+    tmp_path,
+    monkeypatch,
+    isolated_tool_registry,
+    exception_name,
+    exception_text,
+):
+    home = tmp_path / "hermes-home"
+    plugin_name = f"transaction_{exception_name.lower()}"
+    _write_plugin(
+        home,
+        plugin_name,
+        f'''from . import child
+
+def _tool(args, **kwargs):
+    return "must-not-leak"
+
+def register(ctx):
+    ctx.register_tool("{plugin_name}_tool", "transaction_base_exception", {{"name": "{plugin_name}_tool", "description": "must not leak", "parameters": {{"type": "object", "properties": {{}}}}}}, _tool)
+    ctx.register_hook("post_tool_call", lambda **kwargs: "must-not-leak")
+    raise {exception_name}({exception_text!r})
+''',
+        submodule="VALUE = 'temporary'\n",
+    )
+    _write_config(home, [plugin_name])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+
+    with pytest.raises((KeyboardInterrupt, SystemExit), match=exception_text):
+        manager.discover_and_load()
+
+    assert manager.invoke_hook("post_tool_call") == []
+    assert registry.get_entry(f"{plugin_name}_tool") is None
+    assert f"{plugin_name}_tool" not in manager._plugin_tool_names
+    root = f"hermes_plugins.{plugin_name}"
+    assert root not in sys.modules
+    assert f"{root}.child" not in sys.modules
+
+
+def test_force_rediscovery_base_exception_restores_previous_coherent_state(
+    tmp_path, monkeypatch, isolated_tool_registry
+):
+    home = tmp_path / "hermes-home"
+    success = "transaction_a_coherent"
+    interrupting = "transaction_z_interrupt"
+    _write_plugin(
+        home,
+        success,
+        '''from . import child
+
+def _tool(args, **kwargs):
+    return "coherent"
+
+def register(ctx):
+    ctx.register_tool("transaction_coherent_tool", "transaction_coherent", {"name": "transaction_coherent_tool", "description": "coherent", "parameters": {"type": "object", "properties": {}}}, _tool)
+    ctx.register_hook("post_tool_call", lambda **kwargs: "coherent-hook")
+''',
+        submodule="VALUE = 'old coherent module'\n",
+    )
+    _write_config(home, [success])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    before_manager = _manager_registration_state(manager)
+    before_entry = registry.get_entry("transaction_coherent_tool")
+    before_module = sys.modules["hermes_plugins.transaction_a_coherent"]
+    before_child = sys.modules["hermes_plugins.transaction_a_coherent.child"]
+
+    _write_plugin(
+        home,
+        interrupting,
+        '''from . import child
+
+def register(ctx):
+    ctx.register_hook("post_tool_call", lambda **kwargs: "partial")
+    raise KeyboardInterrupt("force sweep interrupted")
+''',
+        submodule="VALUE = 'temporary interrupt module'\n",
+    )
+    _write_config(home, [success, interrupting])
+
+    with pytest.raises(KeyboardInterrupt, match="force sweep interrupted"):
+        manager.discover_and_load(force=True)
+
+    assert manager._discovered is True
+    assert _manager_registration_state(manager) == before_manager
+    assert registry.get_entry("transaction_coherent_tool") is before_entry
+    assert registry.dispatch("transaction_coherent_tool", {}) == "coherent"
+    assert manager.invoke_hook("post_tool_call") == ["coherent-hook"]
+    assert sys.modules["hermes_plugins.transaction_a_coherent"] is before_module
+    assert sys.modules["hermes_plugins.transaction_a_coherent.child"] is before_child
+    assert "hermes_plugins.transaction_z_interrupt" not in sys.modules
+    assert "hermes_plugins.transaction_z_interrupt.child" not in sys.modules

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -187,16 +187,16 @@ class TestPluginDiscovery:
 
 
 
-    def test_force_rediscover_clears_all_plugin_registries(self, monkeypatch):
-        """force=True must clear every plugin-populated registry.
+    def test_force_rediscover_replaces_all_plugin_registries(self, monkeypatch):
+        """force=True must publish a clean replacement generation.
 
         Regression: ``_plugin_platform_names`` was populated by
         ``register_platform`` but omitted from the ``discover_and_load(force=True)``
-        clear block, so a platform plugin disabled between force-rediscovers
+        replacement, so a platform plugin disabled between force-rediscovers
         left a stale entry behind forever (the set diverged from the real
-        platform_registry / _plugins truth). This asserts the clear block
-        empties the full set of per-plugin registries so no future addition
-        silently leaks across a force pass either.
+        platform_registry / _plugins truth). This asserts the committed
+        candidate replaces the full set of per-plugin registries so no future
+        addition silently leaks across a force pass either.
         """
         mgr = PluginManager()
 
@@ -208,6 +208,7 @@ class TestPluginDiscovery:
         mgr._middleware["llm_request"] = [lambda **_: None]
         mgr._plugin_tool_names.add("some_tool")
         mgr._plugin_platform_names.add("irc")
+        mgr._plugin_external_names["platform"].add("irc")
         mgr._cli_commands["c"] = {"plugin": "p"}
         mgr._plugin_commands["cmd"] = {"plugin": "p"}
         mgr._plugin_skills["p:skill"] = {}
@@ -215,7 +216,11 @@ class TestPluginDiscovery:
         mgr._slack_action_handlers.append(("aid", lambda **_: None, "p"))
         mgr._discovered = True
 
-        monkeypatch.setattr(PluginManager, "_discover_and_load_inner", lambda self_inner: None)
+        monkeypatch.setattr(
+            PluginManager,
+            "_discover_and_load_inner",
+            lambda self_inner, transaction=None: None,
+        )
         mgr.discover_and_load(force=True)
 
         assert mgr._plugins == {}
@@ -225,6 +230,7 @@ class TestPluginDiscovery:
         assert mgr._plugin_platform_names == set(), (
             "_plugin_platform_names was not cleared on force-rediscover"
         )
+        assert all(not names for names in mgr._plugin_external_names.values())
         assert mgr._cli_commands == {}
         assert mgr._plugin_commands == {}
         assert mgr._plugin_skills == {}

--- a/tests/test_registry_transaction.py
+++ b/tests/test_registry_transaction.py
@@ -1,0 +1,40 @@
+from registry_transaction import MappingRegistry
+
+
+def test_install_prepared_locked_publishes_fresh_items_without_mutating_retained_reference():
+    original = object()
+    installed = object()
+    registry = MappingRegistry("unit", {"old": original})
+    retained_items = registry._items
+
+    snapshot = registry.take_snapshot()
+    staged = registry.create_view(snapshot)
+    staged.put("new", installed)
+    prepared = registry.prepare(snapshot, staged)
+
+    with registry.lock:
+        registry.install_prepared_locked(snapshot, prepared)
+
+    assert retained_items == {"old": original}
+    assert retained_items is not registry._items
+    assert registry.items_snapshot() == (("old", original), ("new", installed))
+
+    prepared._items["late"] = object()
+    assert "late" not in dict(registry.items_snapshot())
+
+
+def test_restore_snapshot_locked_restores_fresh_items_without_mutating_retained_reference():
+    original = object()
+    transient = object()
+    registry = MappingRegistry("unit", {"old": original})
+    snapshot = registry.take_snapshot()
+
+    registry.put("transient", transient)
+    retained_items = registry._items
+
+    with registry.lock:
+        registry.restore_snapshot_locked(snapshot)
+
+    assert retained_items == {"old": original, "transient": transient}
+    assert retained_items is not registry._items
+    assert registry.items_snapshot() == (("old", original),)

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -6,7 +6,15 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-from tools.registry import ToolRegistry, _module_registers_tools, discover_builtin_tools
+import pytest
+
+from tools.registry import (
+    ToolRegistry,
+    _check_fn_cache,
+    _check_fn_last_good,
+    _module_registers_tools,
+    discover_builtin_tools,
+)
 
 
 def _dummy_handler(args, **kwargs):
@@ -84,6 +92,150 @@ class TestRegisterAndDispatch:
             and "mcp__foo_bar__search" in record.message
             for record in caplog.records
         )
+
+
+class TestHostPrivateTransactions:
+    def test_staging_view_is_isolated_until_commit_and_invalidates_caches(self):
+        reg = ToolRegistry()
+
+        def original(args, **kwargs):
+            return "original"
+
+        def staged_handler(args, **kwargs):
+            return "staged"
+
+        def check():
+            return True
+
+        reg.register(
+            name="original",
+            toolset="original_set",
+            schema=_make_schema("original"),
+            handler=original,
+        )
+        snapshot = reg._take_transaction_snapshot()
+        staged = reg._create_transaction_view(snapshot)
+        staged.register(
+            name="staged",
+            toolset="staged_set",
+            schema=_make_schema("staged"),
+            handler=staged_handler,
+            check_fn=check,
+        )
+        staged_entry = staged.get_entry("staged")
+
+        assert staged_entry is not None
+        assert reg.get_entry("staged") is None
+        generation_before_commit = reg._generation
+        with patch.dict(_check_fn_cache, {check: (0.0, True)}, clear=True), patch.dict(
+            _check_fn_last_good, {check: 0.0}, clear=True
+        ):
+            reg._commit_transaction_view(snapshot, staged)
+            assert _check_fn_cache == {}
+            assert _check_fn_last_good == {}
+
+        assert reg.get_entry("staged") is staged_entry
+        assert reg.dispatch("staged", {}) == "staged"
+        assert reg._generation > generation_before_commit
+
+    def test_staging_view_and_snapshot_are_bound_to_the_source_registry(self):
+        first = ToolRegistry()
+        second = ToolRegistry()
+        snapshot = first._take_transaction_snapshot()
+        staged = first._create_transaction_view(snapshot)
+
+        with pytest.raises(ValueError, match="different ToolRegistry"):
+            second._create_transaction_view(snapshot)
+        with pytest.raises(ValueError, match="different ToolRegistry"):
+            second._commit_transaction_view(snapshot, staged)
+
+    def test_transaction_commit_preserves_a_conflicting_live_change(self):
+        reg = ToolRegistry()
+        snapshot = reg._take_transaction_snapshot()
+        staged = reg._create_transaction_view(snapshot)
+        staged.register(
+            name="provisional",
+            toolset="staged_set",
+            schema=_make_schema("provisional"),
+            handler=_dummy_handler,
+        )
+
+        def concurrent(args, **kwargs):
+            return "concurrent"
+
+        reg.register(
+            name="concurrent",
+            toolset="concurrent_set",
+            schema=_make_schema("concurrent"),
+            handler=concurrent,
+        )
+        concurrent_entry = reg.get_entry("concurrent")
+
+        with pytest.raises(RuntimeError, match="changed during plugin registration"):
+            reg._commit_transaction_view(snapshot, staged)
+
+        assert reg.get_entry("concurrent") is concurrent_entry
+        assert reg.get_entry("provisional") is None
+
+    def test_restore_covers_all_mutable_state_and_advances_generation(self):
+        reg = ToolRegistry()
+
+        def original(args, **kwargs):
+            return "original"
+
+        def check():
+            return True
+
+        reg.register(
+            name="original",
+            toolset="original_set",
+            schema=_make_schema("original"),
+            handler=original,
+            check_fn=check,
+        )
+        reg.register_toolset_alias("original_alias", "original_set")
+        reg.register_plugin_override_policy("hermes_plugins.original", True)
+        original_entry = reg.get_entry("original")
+        snapshot = reg._take_transaction_snapshot()
+
+        assert not any(
+            isinstance(getattr(snapshot, attr), dict)
+            for attr in getattr(snapshot, "__slots__", ())
+        ), "host-private snapshots must not expose mutable dictionaries"
+
+        reg.register(
+            name="temporary",
+            toolset="temporary_set",
+            schema=_make_schema("temporary"),
+            handler=_dummy_handler,
+            check_fn=check,
+        )
+        reg.register_toolset_alias("temporary_alias", "temporary_set")
+        reg.register_plugin_override_policy("hermes_plugins.temporary", False)
+        generation_before_restore = reg._generation
+        with patch.dict(_check_fn_cache, {check: (0.0, True)}, clear=True), patch.dict(
+            _check_fn_last_good, {check: 0.0}, clear=True
+        ):
+            reg._restore_transaction_snapshot(snapshot)
+            assert _check_fn_cache == {}
+            assert _check_fn_last_good == {}
+
+        assert reg.get_entry("original") is original_entry
+        assert reg.get_entry("temporary") is None
+        assert reg.get_registered_toolset_aliases() == {
+            "original_alias": "original_set"
+        }
+        assert reg._toolset_checks == {"original_set": check}
+        assert reg._plugin_override_policy == {"hermes_plugins.original": True}
+        assert reg._generation == generation_before_restore + 1
+
+    def test_snapshot_belongs_to_the_registry_that_created_it(self):
+        first = ToolRegistry()
+        second = ToolRegistry()
+        snapshot = first._take_transaction_snapshot()
+
+        with pytest.raises(ValueError, match="different ToolRegistry"):
+            second._restore_transaction_snapshot(snapshot)
 
 class TestGetDefinitions:
     def test_returns_openai_format(self):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -29,6 +29,39 @@ def _make_schema(name="test_tool"):
     }
 
 
+class _ObservingRLock:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.held = False
+
+    def acquire(self, *args, **kwargs):
+        acquired = self._lock.acquire(*args, **kwargs)
+        if acquired:
+            self.held = True
+        return acquired
+
+    def release(self):
+        self.held = False
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.release()
+
+
+class _LockCheckingSchema(dict):
+    def __init__(self, lock: _ObservingRLock, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._observed_lock = lock
+
+    def get(self, key, default=None):
+        assert not self._observed_lock.held, "schema.get ran under tool registry lock"
+        return super().get(key, default)
+
+
 class TestRegisterAndDispatch:
     def test_register_and_dispatch(self):
         reg = ToolRegistry()
@@ -92,6 +125,60 @@ class TestRegisterAndDispatch:
             and "mcp__foo_bar__search" in record.message
             for record in caplog.records
         )
+
+    def test_empty_description_schema_fallback_resolves_before_live_lock(self):
+        reg = ToolRegistry()
+        observing_lock = _ObservingRLock()
+        reg._lock = observing_lock
+        schema = _LockCheckingSchema(
+            observing_lock,
+            {
+                "name": "empty_desc",
+                "description": "schema fallback",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        )
+
+        reg.register(
+            name="empty_desc",
+            toolset="plugin",
+            schema=schema,
+            handler=_dummy_handler,
+            description="",
+        )
+
+        assert reg.get_entry("empty_desc").description == "schema fallback"
+
+    def test_override_handler_globals_resolves_before_live_lock(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="protected",
+            toolset="terminal",
+            schema=_make_schema("protected"),
+            handler=_dummy_handler,
+        )
+        reg.register_plugin_override_policy("hermes_plugins.allowed", True)
+        observing_lock = _ObservingRLock()
+        reg._lock = observing_lock
+
+        class _Handler:
+            @property
+            def __globals__(self):
+                assert not observing_lock.held, "handler.__globals__ ran under tool registry lock"
+                return {"__name__": "hermes_plugins.allowed"}
+
+            def __call__(self, args, **kwargs):
+                return "override"
+
+        reg.register(
+            name="protected",
+            toolset="plugin",
+            schema=_make_schema("protected"),
+            handler=_Handler(),
+            override=True,
+        )
+
+        assert reg.get_entry("protected").handler({}) == "override"
 
 
 class TestHostPrivateTransactions:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -597,11 +597,25 @@ class ToolRegistry:
         snapshot: _ToolRegistrySnapshot,
     ) -> None:
         """Restore a valid checkpoint while ``self._lock`` is held."""
+        self._validate_transaction_snapshot(snapshot)
         self._tools = dict(snapshot._tools)
         self._toolset_checks = dict(snapshot._toolset_checks)
         self._toolset_aliases = dict(snapshot._toolset_aliases)
         self._plugin_override_policy = dict(snapshot._plugin_override_policy)
         self._generation = max(self._generation, snapshot._generation) + 1
+        invalidate_check_fn_cache()
+
+    def _restore_transaction_snapshot_exact_locked(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+    ) -> None:
+        """Restore a transaction checkpoint exactly while ``self._lock`` is held."""
+        self._validate_transaction_snapshot(snapshot)
+        self._tools = dict(snapshot._tools)
+        self._toolset_checks = dict(snapshot._toolset_checks)
+        self._toolset_aliases = dict(snapshot._toolset_aliases)
+        self._plugin_override_policy = dict(snapshot._plugin_override_policy)
+        self._generation = snapshot._generation
         invalidate_check_fn_cache()
 
     def _restore_transaction_snapshot(self, snapshot: _ToolRegistrySnapshot) -> None:
@@ -766,13 +780,16 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        prepared_owner = self._plugin_owner_of(handler)
+        prepared_requires_env = requires_env or []
+        prepared_description = description or schema.get("description", "")
         with self._lock:
             if self._transaction_frozen:
                 raise RuntimeError("tool transaction view is frozen")
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
                 if override:
-                    _owner = self._plugin_owner_of(handler)
+                    _owner = prepared_owner
                     if _owner is not None and not self._plugin_override_policy.get(_owner, False):
                         logger.error(
                             "Tool registration REJECTED: plugin %r attempted to "
@@ -812,9 +829,9 @@ class ToolRegistry:
                 schema=schema,
                 handler=handler,
                 check_fn=check_fn,
-                requires_env=requires_env or [],
+                requires_env=prepared_requires_env,
                 is_async=is_async,
-                description=description or schema.get("description", ""),
+                description=prepared_description,
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -189,6 +189,71 @@ class ToolEntry:
         self.dynamic_schema_overrides = dynamic_schema_overrides
 
 
+class _ToolRegistrySnapshot:
+    """Opaque, host-private checkpoint for one :class:`ToolRegistry`.
+
+    State is stored as immutable tuples so callers cannot obtain a mutable
+    dictionary and edit the live registry through a transaction token.
+    """
+
+    __slots__ = (
+        "_owner",
+        "_tools",
+        "_toolset_checks",
+        "_toolset_aliases",
+        "_plugin_override_policy",
+        "_generation",
+    )
+
+    def __init__(
+        self,
+        owner: "ToolRegistry",
+        tools: tuple,
+        toolset_checks: tuple,
+        toolset_aliases: tuple,
+        plugin_override_policy: tuple,
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._tools = tools
+        self._toolset_checks = toolset_checks
+        self._toolset_aliases = toolset_aliases
+        self._plugin_override_policy = plugin_override_policy
+        self._generation = generation
+
+
+class _PreparedToolRegistryState:
+    """Host-private, registry-bound state ready for a live atomic install."""
+
+    __slots__ = (
+        "_owner",
+        "_snapshot",
+        "_tools",
+        "_toolset_checks",
+        "_toolset_aliases",
+        "_plugin_override_policy",
+        "_generation",
+    )
+
+    def __init__(
+        self,
+        owner: "ToolRegistry",
+        snapshot: _ToolRegistrySnapshot,
+        tools: Dict[str, ToolEntry],
+        toolset_checks: Dict[str, Callable],
+        toolset_aliases: Dict[str, str],
+        plugin_override_policy: Dict[str, bool],
+        generation: int,
+    ) -> None:
+        self._owner = owner
+        self._snapshot = snapshot
+        self._tools = tools
+        self._toolset_checks = toolset_checks
+        self._toolset_aliases = toolset_aliases
+        self._plugin_override_policy = plugin_override_policy
+        self._generation = generation
+
+
 # ---------------------------------------------------------------------------
 # check_fn TTL cache
 #
@@ -353,9 +418,9 @@ class ToolRegistry:
         self._tools: Dict[str, ToolEntry] = {}
         # Durable map: plugin module namespace (handler.__globals__["__name__"])
         # -> operator opt-in for built-in override. Populated at plugin load and
-        # never cleared, so a plugin's override authorization is bound to the
-        # code that defined the handler, independent of WHEN the register() call
-        # happens (sync during load, or a delayed/threaded callback afterwards).
+        # durable once that load commits (failed load transactions restore the
+        # checkpoint), so authorization is bound to the code that defined the
+        # handler independent of WHEN registration happens.
         self._plugin_override_policy: Dict[str, bool] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
@@ -369,6 +434,150 @@ class ToolRegistry:
         # against it: a cache entry keyed on the generation is valid for as
         # long as the generation hasn't changed.
         self._generation: int = 0
+        # Set only on isolated transaction registries. The opaque source
+        # snapshot binds a staging view to one live registry and one baseline.
+        self._transaction_owner: Optional["ToolRegistry"] = None
+        self._transaction_snapshot: Optional[_ToolRegistrySnapshot] = None
+
+    def _take_transaction_snapshot(self) -> _ToolRegistrySnapshot:
+        """Return an opaque host-private checkpoint under the registry lock."""
+        with self._lock:
+            return _ToolRegistrySnapshot(
+                owner=self,
+                tools=tuple(self._tools.items()),
+                toolset_checks=tuple(self._toolset_checks.items()),
+                toolset_aliases=tuple(self._toolset_aliases.items()),
+                plugin_override_policy=tuple(self._plugin_override_policy.items()),
+                generation=self._generation,
+            )
+
+    def _validate_transaction_snapshot(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+    ) -> None:
+        if (
+            not isinstance(snapshot, _ToolRegistrySnapshot)
+            or snapshot._owner is not self
+        ):
+            raise ValueError("transaction snapshot belongs to a different ToolRegistry")
+
+    def _create_transaction_view(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+    ) -> "ToolRegistry":
+        """Create an isolated registry seeded only from an opaque checkpoint."""
+        self._validate_transaction_snapshot(snapshot)
+        staged = ToolRegistry()
+        staged._tools = dict(snapshot._tools)
+        staged._toolset_checks = dict(snapshot._toolset_checks)
+        staged._toolset_aliases = dict(snapshot._toolset_aliases)
+        staged._plugin_override_policy = dict(snapshot._plugin_override_policy)
+        staged._generation = snapshot._generation
+        staged._transaction_owner = self
+        staged._transaction_snapshot = snapshot
+        return staged
+
+    def _prepare_transaction_commit(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+        staged: "ToolRegistry",
+    ) -> _PreparedToolRegistryState:
+        """Freeze one staging view without touching or locking live state."""
+        self._validate_transaction_snapshot(snapshot)
+        if (
+            not isinstance(staged, ToolRegistry)
+            or staged._transaction_owner is not self
+            or staged._transaction_snapshot is not snapshot
+        ):
+            raise ValueError("transaction view belongs to a different ToolRegistry")
+        with staged._lock:
+            return _PreparedToolRegistryState(
+                owner=self,
+                snapshot=snapshot,
+                tools=dict(staged._tools),
+                toolset_checks=dict(staged._toolset_checks),
+                toolset_aliases=dict(staged._toolset_aliases),
+                plugin_override_policy=dict(staged._plugin_override_policy),
+                generation=staged._generation,
+            )
+
+    def _matches_transaction_snapshot_locked(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+    ) -> bool:
+        """Return whether live state is still the exact captured baseline."""
+        return (
+            self._generation == snapshot._generation
+            and tuple(self._tools.items()) == snapshot._tools
+            and tuple(self._toolset_checks.items()) == snapshot._toolset_checks
+            and tuple(self._toolset_aliases.items()) == snapshot._toolset_aliases
+            and tuple(self._plugin_override_policy.items())
+            == snapshot._plugin_override_policy
+        )
+
+    def _validate_prepared_transaction_locked(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+        prepared: _PreparedToolRegistryState,
+    ) -> None:
+        self._validate_transaction_snapshot(snapshot)
+        if (
+            not isinstance(prepared, _PreparedToolRegistryState)
+            or prepared._owner is not self
+            or prepared._snapshot is not snapshot
+        ):
+            raise ValueError("transaction view belongs to a different ToolRegistry")
+        if not self._matches_transaction_snapshot_locked(snapshot):
+            raise RuntimeError(
+                "tool registry changed during plugin registration; refusing commit"
+            )
+
+    def _install_prepared_transaction_locked(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+        prepared: _PreparedToolRegistryState,
+    ) -> None:
+        """Validate and install prepared state while ``self._lock`` is held."""
+        self._validate_prepared_transaction_locked(snapshot, prepared)
+        self._tools = prepared._tools
+        self._toolset_checks = prepared._toolset_checks
+        self._toolset_aliases = prepared._toolset_aliases
+        self._plugin_override_policy = prepared._plugin_override_policy
+        self._generation = max(self._generation, prepared._generation) + 1
+        invalidate_check_fn_cache()
+
+    def _commit_transaction_view(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+        staged: "ToolRegistry",
+    ) -> None:
+        """Conflict-check and atomically install an isolated staging view."""
+        prepared = self._prepare_transaction_commit(snapshot, staged)
+        with self._lock:
+            self._install_prepared_transaction_locked(snapshot, prepared)
+
+    def _restore_transaction_snapshot_locked(
+        self,
+        snapshot: _ToolRegistrySnapshot,
+    ) -> None:
+        """Restore a valid checkpoint while ``self._lock`` is held."""
+        self._tools = dict(snapshot._tools)
+        self._toolset_checks = dict(snapshot._toolset_checks)
+        self._toolset_aliases = dict(snapshot._toolset_aliases)
+        self._plugin_override_policy = dict(snapshot._plugin_override_policy)
+        self._generation = max(self._generation, snapshot._generation) + 1
+        invalidate_check_fn_cache()
+
+    def _restore_transaction_snapshot(self, snapshot: _ToolRegistrySnapshot) -> None:
+        """Restore a host checkpoint and invalidate every derived cache.
+
+        The generation never moves backwards: restoration is itself a new
+        mutation, so memoizers observing any state from the failed attempt are
+        forced to refresh.
+        """
+        self._validate_transaction_snapshot(snapshot)
+        with self._lock:
+            self._restore_transaction_snapshot_locked(snapshot)
 
     def _snapshot_state(self) -> tuple[List[ToolEntry], Dict[str, Callable]]:
         """Return a coherent snapshot of registry entries and toolset checks."""
@@ -447,12 +656,14 @@ class ToolRegistry:
 
     def register_plugin_override_policy(self, module_namespace: str, allowed: bool) -> None:
         """Bind a plugin module namespace to its operator opt-in for built-in
-        override. Called once per plugin at load time. Durable: never cleared,
-        so later (even threaded/delayed) register() calls from that module are
-        still gated by the same policy.
+        override. Called once per plugin at load time. Durable after a
+        successful load, so later (even threaded/delayed) register() calls
+        from that module are still gated by the same policy. Failed plugin
+        transactions restore the previous policy checkpoint.
         """
         with self._lock:
             self._plugin_override_policy[module_namespace] = bool(allowed)
+            self._generation += 1
 
     def _plugin_owner_of(self, handler: Callable) -> Optional[str]:
         """Return the plugin module namespace that defined *handler*, or None

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -24,6 +24,8 @@ import time
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
+from registry_transaction import RegistryTransactionConflict
+
 logger = logging.getLogger(__name__)
 
 
@@ -438,6 +440,7 @@ class ToolRegistry:
         # snapshot binds a staging view to one live registry and one baseline.
         self._transaction_owner: Optional["ToolRegistry"] = None
         self._transaction_snapshot: Optional[_ToolRegistrySnapshot] = None
+        self._transaction_frozen = False
 
     def _take_transaction_snapshot(self) -> _ToolRegistrySnapshot:
         """Return an opaque host-private checkpoint under the registry lock."""
@@ -464,14 +467,34 @@ class ToolRegistry:
     def _create_transaction_view(
         self,
         snapshot: _ToolRegistrySnapshot,
+        *,
+        remove_names: Set[str] | None = None,
+        remove_policy_names: Set[str] | None = None,
     ) -> "ToolRegistry":
         """Create an isolated registry seeded only from an opaque checkpoint."""
         self._validate_transaction_snapshot(snapshot)
+        removed = remove_names or set()
         staged = ToolRegistry()
-        staged._tools = dict(snapshot._tools)
-        staged._toolset_checks = dict(snapshot._toolset_checks)
-        staged._toolset_aliases = dict(snapshot._toolset_aliases)
-        staged._plugin_override_policy = dict(snapshot._plugin_override_policy)
+        staged._tools = {
+            name: entry for name, entry in snapshot._tools if name not in removed
+        }
+        remaining_toolsets = {entry.toolset for entry in staged._tools.values()}
+        staged._toolset_checks = {
+            name: check
+            for name, check in snapshot._toolset_checks
+            if name in remaining_toolsets
+        }
+        staged._toolset_aliases = {
+            alias: target
+            for alias, target in snapshot._toolset_aliases
+            if target in remaining_toolsets
+        }
+        removed_policies = remove_policy_names or set()
+        staged._plugin_override_policy = {
+            name: allowed
+            for name, allowed in snapshot._plugin_override_policy
+            if name not in removed_policies
+        }
         staged._generation = snapshot._generation
         staged._transaction_owner = self
         staged._transaction_snapshot = snapshot
@@ -491,7 +514,7 @@ class ToolRegistry:
         ):
             raise ValueError("transaction view belongs to a different ToolRegistry")
         with staged._lock:
-            return _PreparedToolRegistryState(
+            prepared = _PreparedToolRegistryState(
                 owner=self,
                 snapshot=snapshot,
                 tools=dict(staged._tools),
@@ -500,6 +523,8 @@ class ToolRegistry:
                 plugin_override_policy=dict(staged._plugin_override_policy),
                 generation=staged._generation,
             )
+            staged._transaction_frozen = True
+            return prepared
 
     def _matches_transaction_snapshot_locked(
         self,
@@ -508,8 +533,17 @@ class ToolRegistry:
         """Return whether live state is still the exact captured baseline."""
         return (
             self._generation == snapshot._generation
-            and tuple(self._tools.items()) == snapshot._tools
-            and tuple(self._toolset_checks.items()) == snapshot._toolset_checks
+            and len(self._tools) == len(snapshot._tools)
+            and all(
+                name in self._tools and self._tools[name] is entry
+                for name, entry in snapshot._tools
+            )
+            and len(self._toolset_checks) == len(snapshot._toolset_checks)
+            and all(
+                name in self._toolset_checks
+                and self._toolset_checks[name] is check
+                for name, check in snapshot._toolset_checks
+            )
             and tuple(self._toolset_aliases.items()) == snapshot._toolset_aliases
             and tuple(self._plugin_override_policy.items())
             == snapshot._plugin_override_policy
@@ -528,8 +562,10 @@ class ToolRegistry:
         ):
             raise ValueError("transaction view belongs to a different ToolRegistry")
         if not self._matches_transaction_snapshot_locked(snapshot):
-            raise RuntimeError(
-                "tool registry changed during plugin registration; refusing commit"
+            raise RegistryTransactionConflict(
+                "tool",
+                snapshot._generation,
+                self._generation,
             )
 
     def _install_prepared_transaction_locked(
@@ -662,6 +698,8 @@ class ToolRegistry:
         transactions restore the previous policy checkpoint.
         """
         with self._lock:
+            if self._transaction_frozen:
+                raise RuntimeError("tool transaction view is frozen")
             self._plugin_override_policy[module_namespace] = bool(allowed)
             self._generation += 1
 
@@ -729,6 +767,8 @@ class ToolRegistry:
         toolset are rejected to prevent accidental overwrites.
         """
         with self._lock:
+            if self._transaction_frozen:
+                raise RuntimeError("tool transaction view is frozen")
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
                 if override:
@@ -806,6 +846,8 @@ class ToolRegistry:
         every refresh and has no plugin-override concept.
         """
         with self._lock:
+            if self._transaction_frozen:
+                raise RuntimeError("tool transaction view is frozen")
             entry = self._tools.get(name)
             if entry is None:
                 return


### PR DESCRIPTION
## Summary

- stage plugin-owned ToolRegistry and extension registrations outside live state;
- atomically commit manager and tool state under fixed lock order;
- roll back tools, manager state, module namespace, and sanctioned external registration surfaces on failure;
- prevent concurrent readers from seeing provisional tools.

## Why generic

No business-specific classification, provider, endpoint, credential, or plugin appears. This is host infrastructure for any extension requiring atomic registration.

## Activation / live impact

Deploying commit `2b5b72692b649fb746096799cca8c1c3f83cbe39` changes process-local plugin discovery only. It configures no plugin or MCP server and cannot affect external or live business records.

## Verification

- registration and registry suites: 46 tests passed;
- concurrent provisional-visibility, commit-conflict, rollback, and external-surface regressions included;
- final composed governed matrix: 375 passed, 0 failed;
- `git diff --check` passed.

## Risk

Concurrency and rollback behavior. The tests cover failed registration, conflicting commits, sanctioned external registries, and concurrent readers.

This is H1 of a four-PR generic host stack. It is draft for line-by-line review; nothing is merged, installed, configured, or enabled.