### PR TITLE
fix(simplex): send DMs by numeric contact ID

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -811,12 +811,12 @@ class SimplexAdapter(BasePlatformAdapter):
         tools to signal file attachments), they are stripped from the text
         body and sent as native voice notes or documents.
 
-        Groups use the structured ``/_send #<id> json [...]`` form
-        because the bracket chat-command syntax (``#[<id>] text``) is
-        parsed by the daemon as a display-name lookup, which silently
-        drops when the group's display name isn't the literal ID. DMs
-        use the simple ``@<id> text`` form which has always worked in
-        production.
+        Both groups and DMs use the structured ``/_send`` JSON form.  The
+        human-friendly ``@<name> text`` command resolves its target as a
+        display name in simplex-chat 6.5.6, so passing Hermes' stable numeric
+        contact ID there fails with ``contactNotFound``.  ``/_send @<id>``
+        addresses the numeric contact ID directly and also safely preserves
+        newlines and other special characters through ``json.dumps``.
 
         The call is fire-and-forget at the WebSocket level: the daemon
         doesn't always return a corrId reply for chat commands, and
@@ -830,15 +830,15 @@ class SimplexAdapter(BasePlatformAdapter):
 
         if content:
             corr_id = self._make_corr_id()
+            # Structured form addresses by numeric ID, and json.dumps escapes
+            # newlines + special characters correctly.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": content}}]
+            )
             if chat_id.startswith("group:"):
-                # Structured form: addresses by numeric ID, and json.dumps
-                # escapes newlines + special chars correctly.
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": content}}]
-                )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
@@ -1191,15 +1191,14 @@ async def _standalone_send(
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
     try:
+        composed = json.dumps(
+            [{"msgContent": {"type": "text", "text": message}}]
+        )
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": message}}]
-            )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -133,6 +133,26 @@ def test_corr_id_pending_set_self_trims():
 # 7. Outbound send (mocked WS)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.asyncio
+async def test_send_dm():
+    """DMs use structured ``/_send @<id>`` numeric addressing."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("42", "Hello,\nSimpleX!")
+    mock_ws.send.assert_called_once()
+    payload = json.loads(mock_ws.send.call_args[0][0])
+    assert payload["cmd"].startswith("/_send @42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello,\nSimpleX!"}
+    assert payload["corrId"].startswith(_CORR_PREFIX)
+    assert result.success is True
 
 @pytest.mark.asyncio
 async def test_send_group():
@@ -202,6 +222,41 @@ async def test_standalone_send_missing_websockets(monkeypatch):
         if saved_websockets is not None:
             sys.modules["websockets"] = saved_websockets
 
+
+@pytest.mark.asyncio
+async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
+    monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+    pconfig = MagicMock()
+    pconfig.extra = {}
+
+    sent_payloads = []
+
+    class DummyWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send(self, payload):
+            sent_payloads.append(json.loads(payload))
+
+    def fake_connect(url, **kwargs):
+        assert url == "ws://127.0.0.1:5225"
+        assert kwargs["open_timeout"] == 10
+        assert kwargs["close_timeout"] == 5
+        return DummyWs()
+
+    import websockets
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    result = await _standalone_send(pconfig, "42", "hi")
+    assert result == {"success": True, "platform": "simplex", "chat_id": "42"}
+    assert sent_payloads[0]["cmd"].startswith("/_send @42 json ")
+    msg_content = json.loads(sent_payloads[0]["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "hi"}
 
 # ---------------------------------------------------------------------------
 # 10. register() — plugin-side metadata


### PR DESCRIPTION
## Bug Description

SimpleX direct-message replies can fail with `contactNotFound` when Hermes passes the stable numeric contact ID through the human-friendly `@<name> text` command. Multiline text also relies on chat-command parsing rather than structured JSON escaping.

## Root Cause

In simplex-chat 6.5.6, the bare `@<value> text` form resolves `<value>` as a display name. Hermes stores the numeric `contactId`, so that command does not reliably address the intended contact. Group sends and attachment sends already use the structured numeric-ID form.

## Fix

- Send DM text with `/_send @<contact-id> json [...]`.
- Use the same structured JSON payload for in-process and standalone sends.
- Preserve newlines and special characters through `json.dumps`.
- Add regression coverage for both send paths.

## How to Verify

1. Run `python -m pytest -q tests/gateway/test_simplex_plugin.py`.
2. Confirm DM payloads use `/_send @42 json ...`.
3. Confirm multiline text round-trips through the JSON payload.

## Test Plan

- [x] Added regression tests for in-process and standalone DM sending
- [x] Focused SimpleX suite passes: 12 tests
- [x] `git diff --check` and Python compilation pass

## Risk Assessment

Low — changes only SimpleX text command construction and aligns DMs with the structured numeric-ID mechanism already used by groups and attachments.