### PR TITLE
fix(tts): emit KittenTTS voice notes as OGG Opus

### DIFF
--- a/tests/tools/test_tts_kittentts.py
+++ b/tests/tools/test_tts_kittentts.py
@@ -79,6 +79,23 @@ class TestGenerateKittenTts:
         assert call_kwargs["speed"] == 1.25
         assert call_kwargs["clean_text"] is False
 
+    def test_ogg_generation_forces_opus(
+        self, tmp_path, mock_kittentts_module, monkeypatch
+    ):
+        from tools import tts_tool
+
+        run = MagicMock()
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(tts_tool.subprocess, "run", run)
+
+        output_path = str(tmp_path / "voice.ogg")
+        assert tts_tool._generate_kittentts("Hello", output_path, {}) == output_path
+
+        command = run.call_args.args[0]
+        assert command[0] == "/usr/bin/ffmpeg"
+        assert command[command.index("-c:a") + 1] == "libopus"
+        assert command[-1] == output_path
+
 
     def test_missing_kittentts_raises_import_error(self, tmp_path, monkeypatch):
         """When kittentts package is not installed, _import_kittentts raises."""
@@ -129,3 +146,34 @@ class TestDispatcherBranch:
         assert result["success"] is False
         assert "kittentts" in result["error"].lower()
         assert "hermes setup tts" in result["error"].lower()
+
+    def test_existing_ogg_is_marked_voice_compatible(self, monkeypatch, tmp_path):
+        from tools import tts_tool
+
+        output_path = tmp_path / "voice.ogg"
+        convert = MagicMock()
+
+        def fake_generate(_text, path, _config):
+            assert path == str(output_path)
+            output_path.write_bytes(b"OggS-opus")
+            return path
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(
+            tts_tool, "_load_tts_config", lambda: {"provider": "kittentts"}
+        )
+        monkeypatch.setattr(tts_tool, "_import_kittentts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_kittentts", fake_generate)
+        monkeypatch.setattr(tts_tool, "_repair_ogg_container", lambda path: path)
+        monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+        result = json.loads(
+            tts_tool.text_to_speech_tool("Hello", output_path=str(output_path))
+        )
+
+        assert result["success"] is True
+        assert result["voice_compatible"] is True
+        assert result["media_tag"] == (
+            f"[[audio_as_voice]]\nMEDIA:{output_path}"
+        )
+        convert.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2765,7 +2765,13 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
     if wav_path != output_path:
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
-            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error"]
+            # Telegram native voice bubbles require OGG/Opus. Letting ffmpeg
+            # infer the codec from a .ogg suffix chooses Vorbis, which Telegram
+            # sends as a generic audio attachment instead.
+            if output_path.lower().endswith(".ogg"):
+                conv_cmd.extend(["-c:a", "libopus", "-b:a", "48k"])
+            conv_cmd.append(output_path)
             subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
             os.remove(wav_path)
         else:
@@ -3114,12 +3120,15 @@ def text_to_speech_tool(
         elif (
             want_opus
             and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
         ):
-            opus_path = _convert_to_opus(file_str)
-            if opus_path:
-                file_str = opus_path
-                voice_compatible = True
+            if not file_str.endswith(".ogg"):
+                opus_path = _convert_to_opus(file_str)
+                if opus_path:
+                    file_str = opus_path
+            # Providers such as KittenTTS may already have written OGG/Opus
+            # directly. That is still native-voice compatible and must not be
+            # left marked false merely because no second conversion was needed.
+            voice_compatible = file_str.endswith(".ogg")
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 


### PR DESCRIPTION
## Bug Description

KittenTTS output targeting `.ogg` can be encoded as Vorbis and delivered as a generic attachment instead of a native voice bubble. Even when a provider already returns an OGG file, the routing logic can leave `voice_compatible` false because conversion is skipped.

## Root Cause

FFmpeg infers Vorbis from the `.ogg` suffix unless Opus is requested explicitly. Separately, the built-in conversion branch only marks output voice-compatible when it performs a conversion; an already-OGG output bypasses that branch.

## Fix

- Force `libopus` at 48 kbps when KittenTTS writes `.ogg`.
- Treat an existing `.ogg` result as voice-compatible on Opus voice platforms.
- Avoid an unnecessary second conversion.
- Add regression tests for codec arguments and native voice routing.

## How to Verify

1. Run `python -m pytest -q tests/tools/test_tts_kittentts.py tests/tools/test_tts_opus_routing.py`.
2. Confirm KittenTTS `.ogg` conversion invokes FFmpeg with `-c:a libopus`.
3. Confirm an existing `.ogg` result receives the `[[audio_as_voice]]` media tag without calling `_convert_to_opus`.

## Test Plan

- [x] Added codec and routing regression tests
- [x] Focused TTS suites pass: 11 tests
- [x] `git diff --check` and Python compilation pass

## Risk Assessment

Low — scoped to KittenTTS conversion and the existing Opus-compatible built-in provider routing branch.