### PR TITLE
fix(cron): 修复 Telegram topic 下 mirror_delivery 无法开启新线程的问题

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1701,7 +1701,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             and not in_channel_surface
             and runtime_adapter is not None
             and loop is not None
-            and not thread_id  # never override an explicit origin thread/topic
         ):
             new_thread_id = _open_continuable_cron_thread(
                 job, runtime_adapter, chat_id, loop,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5013,6 +5013,74 @@ class TestCronDeliveryMirror:
         mirror_mock.assert_not_called()
 
 
+    # --- Telegram topic-born jobs: fresh thread per run with mirroring ---
+
+    def test_topic_origin_with_mirror_opens_fresh_thread(self):
+        """Regression for #76548: a cron job created inside a Telegram topic
+        (origin carries a thread_id) should still open a fresh thread per run
+        when mirror_delivery is enabled. The prior guard ``and not thread_id``
+        blocked the fresh-thread branch for topic-born jobs, so every run
+        delivered back to the origin topic instead of a dedicated thread."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        adapter._session_store = MagicMock()
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            try:
+                import asyncio as _asyncio
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        # Job created inside a Telegram topic — origin has thread_id.
+        # attach_to_session=True enables the continuable mirror.
+        job = {
+            "id": "topic-job",
+            "name": "Topic Brief",
+            "deliver": "origin",
+            "attach_to_session": True,
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123456789",
+                "user_id": "987654321",
+                "thread_id": "100",  # topic-born: this was blocking the fresh-thread branch
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("cron.scheduler._open_continuable_cron_thread", return_value="42") as open_thread_mock, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            _deliver_result(
+                job, "Brief content.",
+                adapters={Platform.TELEGRAM: adapter}, loop=loop,
+            )
+
+        # The fresh-thread branch MUST be taken even though the origin pins
+        # a thread_id — that is the documented behaviour for mirror-enabled
+        # continuable cron jobs.
+        open_thread_mock.assert_called_once()
+        call_args = open_thread_mock.call_args
+        assert call_args[0][0] is job
+        assert call_args[0][1] is adapter
+        assert call_args[0][2] == "123456789"
+
+
 class TestCronContinuableSurfaceInChannel:
     """cron_continuable_surface: in_channel — deliver a continuable cron FLAT
     into a channel (no dedicated thread), so a plain channel reply continues the


### PR DESCRIPTION
## 背景

修复 #76548: cron.mirror_delivery 在 Telegram topic 下创建的 cron job 不会每次运行都开新线程，而是始终投递回 origin topic。

## 根因分析

在 cron/scheduler.py L1704，fresh-thread 分支有一个 guard `and not thread_id`，注释为 "never override an explicit origin thread/topic"。当 job 在 Telegram topic 内创建时，origin 携带 thread_id，导致 `not thread_id` 为 False，整个 fresh-thread 分支被跳过，输出始终投递回 origin topic，而非文档描述的每运行一次开一个新线程。

## 修复方式

移除 `and not thread_id` guard，因为：
- `mirror_this_target` 已经将该分支限定为仅 origin-targeted delivery（fan-out targets 的 mirror_this_target=False）
- `not in_channel_surface` 确保我们在 thread mode
- `runtime_adapter is not None` 和 `loop is not None` 确保 live gateway 上下文
- 对于 mirror-enabled 的 continuable cron jobs，无论 origin 是否携带 thread_id，开新线程都是文档规定的行为

## 验证

- [x] 新增回归测试 test_topic_origin_with_mirror_opens_fresh_thread，验证 topic-born job 的 fresh-thread 分支会被正确触发
- [x] TestCronDeliveryMirror 全部 24 个测试通过
- [x] 相关测试类（TestCronContinuableSurfaceInChannel, TestResolveOrigin, TestDeliverOriginUnresolvableIsLocal）共 50 个测试全部通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #76548