### PR TITLE
fix(secrets): secret-scope migration wave — /compress, Matrix, model tools, cold hydration, WhatsApp (cluster salvage)

### DIFF
--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -39,16 +39,35 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+from contextvars import ContextVar, Token
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Optional, Sequence
+from typing import Dict, FrozenSet, List, MutableMapping, Optional, Sequence
 
 # Bump ONLY for breaking changes to the required contract surface
 # (abstract-method signatures, FetchResult required fields).  Additive
 # optional hooks must ship with defaults and must NOT bump this.
 SECRET_SOURCE_API_VERSION = 1
+
+_SOURCE_ENVIRONMENT: ContextVar[Optional[MutableMapping[str, str]]]
+_SOURCE_ENVIRONMENT = ContextVar("hermes_secret_source_environment", default=None)
+
+
+def set_source_environment(environ: MutableMapping[str, str]) -> Token:
+    """Install a per-fetch environment view without changing ``os.environ``."""
+    return _SOURCE_ENVIRONMENT.set(environ)
+
+
+def reset_source_environment(token: Token) -> None:
+    _SOURCE_ENVIRONMENT.reset(token)
+
+
+def get_source_environment() -> MutableMapping[str, str]:
+    """Return the active per-fetch environment, or the process environment."""
+    environ = _SOURCE_ENVIRONMENT.get()
+    return environ if environ is not None else os.environ
 
 # Timeout the orchestrator enforces around fetch() when the source's
 # config section doesn't override it.  Generous because a first run may

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -58,6 +58,7 @@ from agent.secret_sources._cache import (
     is_valid_env_name as _is_valid_env_name,
 )
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 
 logger = logging.getLogger(__name__)
 
@@ -667,10 +668,15 @@ def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
     cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
-    # bws child intentionally receives the access token; exact preservation
-    # (BWS_SERVER_URL manual overrides etc. must survive untouched).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    # bws child intentionally receives the access token.  Under a profile-local
+    # fetch it must not inherit sibling credentials from process-global env.
+    source_env = get_source_environment()
+    if source_env is os.environ:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    else:
+        env = dict(source_env)
     env["BWS_ACCESS_TOKEN"] = access_token
     # Make sure we're not echoing telemetry / colour codes into json.
     env.setdefault("NO_COLOR", "1")
@@ -908,7 +914,7 @@ class BitwardenSource(SecretSource):
         result = FetchResult()
 
         access_token_env = str(cfg.get("access_token_env") or "BWS_ACCESS_TOKEN")
-        access_token = os.environ.get(access_token_env, "").strip()
+        access_token = get_source_environment().get(access_token_env, "").strip()
         if not access_token:
             result.error = (
                 f"secrets.bitwarden.enabled is true but {access_token_env} is "

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -44,6 +44,7 @@ from typing import Dict, Optional
 # Reuse the exact result shape the bitwarden source returns so
 # hermes_cli.env_loader can consume both providers identically.
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
@@ -181,8 +182,17 @@ def _run_helper(
 
     # User-configured secret-helper command: runs with the user's full shell
     # env by design (it may need any credential to resolve the secret).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    source_env = get_source_environment()
+    if source_env is os.environ:
+        # Legacy single-profile startup intentionally preserves the existing
+        # helper contract, which may rely on the user's full environment.
+        from tools.environments.local import build_subprocess_env
+        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    else:
+        # A multiplex profile must never inherit sibling secrets from the
+        # process-global environment.  hydrate_profile_secret_sources seeds
+        # only global-safe values plus this profile's own .env.
+        env = dict(source_env)
     env["HERMES_SECRET_KEY"] = secret_key
 
     try:

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -55,6 +55,7 @@ from agent.secret_sources._cache import (
     is_valid_env_name,
 )
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 
 logger = logging.getLogger(__name__)
 
@@ -182,15 +183,16 @@ def _auth_fingerprint(token_env: str) -> str:
     previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
+    source_env = get_source_environment()
     parts: List[str] = [
-        f"token={os.environ.get(token_env, '')}",
-        f"account={os.environ.get('OP_ACCOUNT', '')}",
-        f"connect_host={os.environ.get('OP_CONNECT_HOST', '')}",
-        f"connect_token={os.environ.get('OP_CONNECT_TOKEN', '')}",
+        f"token={source_env.get(token_env, '')}",
+        f"account={source_env.get('OP_ACCOUNT', '')}",
+        f"connect_host={source_env.get('OP_CONNECT_HOST', '')}",
+        f"connect_token={source_env.get('OP_CONNECT_TOKEN', '')}",
     ]
-    for key in sorted(os.environ):
+    for key in sorted(source_env):
         if key.startswith("OP_SESSION_"):
-            parts.append(f"{key}={os.environ[key]}")
+            parts.append(f"{key}={source_env[key]}")
     material = "\n".join(parts)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
@@ -238,13 +240,14 @@ def _scrub(text: str) -> str:
 
 def _op_child_env(token_value: str) -> Dict[str, str]:
     """Build a minimal allowlisted environment for the ``op`` child process."""
+    source_env = get_source_environment()
     env: Dict[str, str] = {}
     for key in _OP_ENV_ALLOWLIST:
-        val = os.environ.get(key)
+        val = source_env.get(key)
         if val is not None:
             env[key] = val
     # Desktop / interactive session credentials.
-    for key, val in os.environ.items():
+    for key, val in source_env.items():
         if key.startswith("OP_SESSION_"):
             env[key] = val
     # `op` reads OP_SERVICE_ACCOUNT_TOKEN regardless of which env var the user
@@ -340,7 +343,7 @@ def fetch_onepassword_secrets(
     if not valid:
         return {}, warnings
 
-    token_value = os.environ.get(token_env, "").strip()
+    token_value = get_source_environment().get(token_env, "").strip()
     cache_key: _CacheKey = (
         _auth_fingerprint(token_env),
         account or "",

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -32,7 +32,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, MutableMapping, Optional
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -40,6 +40,8 @@ from agent.secret_sources.base import (
     FetchResult,
     SecretSource,
     is_valid_env_name,
+    reset_source_environment,
+    set_source_environment,
 )
 
 logger = logging.getLogger(__name__)
@@ -196,7 +198,8 @@ def _reset_registry_for_tests() -> None:
 
 
 def _fetch_with_timeout(
-    source: SecretSource, cfg: dict, home_path: Path
+    source: SecretSource, cfg: dict, home_path: Path,
+    environ: MutableMapping[str, str],
 ) -> FetchResult:
     """Run source.fetch() under a wall-clock budget; never raises.
 
@@ -211,7 +214,14 @@ def _fetch_with_timeout(
         max_workers=1, thread_name_prefix=f"secret-src-{source.name}"
     )
     try:
-        future = executor.submit(source.fetch, cfg, home_path)
+        def _fetch() -> FetchResult:
+            token = set_source_environment(environ)
+            try:
+                return source.fetch(cfg, home_path)
+            finally:
+                reset_source_environment(token)
+
+        future = executor.submit(_fetch)
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
@@ -321,7 +331,7 @@ def _profile_alias_target(var: str, profile: str) -> Optional[str]:
 
 
 def apply_all(secrets_cfg: dict, home_path: Path,
-              environ: Optional[Dict[str, str]] = None) -> ApplyReport:
+              environ: Optional[MutableMapping[str, str]] = None) -> ApplyReport:
     """Fetch from every enabled source and apply the merged result to env.
 
     ``environ`` defaults to ``os.environ``; injectable for tests.
@@ -376,7 +386,7 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     for source in ordered:
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
-        result = _fetch_with_timeout(source, cfg, home_path)
+        result = _fetch_with_timeout(source, cfg, home_path, env)
         fetches.append((source, cfg, result))
         try:
             for var in source.protected_env_vars(cfg):

--- a/contributors/emails/checo520@outlook.com
+++ b/contributors/emails/checo520@outlook.com
@@ -1,0 +1,1 @@
+sergioperezcheco

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -77,7 +77,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
-from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin, _get_wsecret
 from gateway.platforms.media_cache import ext_for_mime
 from gateway import rich_sent_store
 from hermes_constants import get_hermes_dir
@@ -265,12 +265,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         elif "allowFrom" in extra:
             self._dm_allowlist_source = "config"
             allow_raw = extra.get("allowFrom")
-        elif os.getenv("WHATSAPP_CLOUD_ALLOW_FROM"):
+        elif _get_wsecret("WHATSAPP_CLOUD_ALLOW_FROM"):
             self._dm_allowlist_source = "WHATSAPP_CLOUD_ALLOW_FROM"
-            allow_raw = os.getenv("WHATSAPP_CLOUD_ALLOW_FROM")
-        elif os.getenv("WHATSAPP_CLOUD_ALLOWED_USERS"):
+            allow_raw = _get_wsecret("WHATSAPP_CLOUD_ALLOW_FROM")
+        elif _get_wsecret("WHATSAPP_CLOUD_ALLOWED_USERS"):
             self._dm_allowlist_source = "WHATSAPP_CLOUD_ALLOWED_USERS"
-            allow_raw = os.getenv("WHATSAPP_CLOUD_ALLOWED_USERS")
+            allow_raw = _get_wsecret("WHATSAPP_CLOUD_ALLOWED_USERS")
         else:
             self._dm_allowlist_source = None
             allow_raw = None
@@ -282,7 +282,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # "allowlist" when an allowlist is configured (so it is actually
         # enforced instead of silently dropping), else "open".
         _allow_all_optin = str(
-            os.getenv("WHATSAPP_CLOUD_ALLOW_ALL_USERS", "")
+            _get_wsecret("WHATSAPP_CLOUD_ALLOW_ALL_USERS", default="") or ""
         ).strip().lower() in {"true", "1", "yes"}
         _default_dm_policy = (
             "open" if _allow_all_optin
@@ -290,20 +290,21 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
         self._dm_policy: str = str(
             extra.get("dm_policy")
-            or os.getenv("WHATSAPP_CLOUD_DM_POLICY")
-            or os.getenv("WHATSAPP_DM_POLICY")
+            or _get_wsecret("WHATSAPP_CLOUD_DM_POLICY")
+            or _get_wsecret("WHATSAPP_DM_POLICY")
             or _default_dm_policy
         ).strip().lower()
         self._group_policy: str = str(
             extra.get("group_policy")
-            or os.getenv("WHATSAPP_CLOUD_GROUP_POLICY")
-            or os.getenv("WHATSAPP_GROUP_POLICY", "open")
+            or _get_wsecret("WHATSAPP_CLOUD_GROUP_POLICY")
+            or _get_wsecret("WHATSAPP_GROUP_POLICY", default="open")
+            or "open"
         ).strip().lower()
         self._group_allow_from: set[str] = self._normalize_allow_ids(
             self._coerce_allow_list(
                 extra.get("group_allow_from")
                 or extra.get("groupAllowFrom")
-                or os.getenv("WHATSAPP_CLOUD_GROUP_ALLOW_FROM")
+                or _get_wsecret("WHATSAPP_CLOUD_GROUP_ALLOW_FROM")
             )
         )
         self._mention_patterns = self._compile_mention_patterns()
@@ -412,7 +413,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         WHATSAPP_ALLOW_ALL_USERS; the Cloud adapter's documented open-access
         opt-in is WHATSAPP_CLOUD_ALLOW_ALL_USERS, so honor it here too.
         """
-        if str(os.getenv("WHATSAPP_CLOUD_ALLOW_ALL_USERS", "")).strip().lower() in {"true", "1", "yes"}:
+        if str(_get_wsecret("WHATSAPP_CLOUD_ALLOW_ALL_USERS", default="") or "").strip().lower() in {"true", "1", "yes"}:
             return True
         return super()._open_dm_opted_in()
 

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -37,7 +37,26 @@ import os
 import re
 from typing import Any, Dict, Optional
 
-from agent.secret_scope import get_secret as _get_wsecret
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_wsecret(name, default=None):
+    """Scope-aware WHATSAPP_* read with the default-profile startup fallback.
+
+    Secondary profiles run under ``_profile_runtime_scope`` -- the scope is
+    authoritative and a scoped miss returns ``default`` (no cross-profile
+    borrow). The DEFAULT profile's adapter constructs and sends *unscoped*
+    under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash its WhatsApp path; there ``os.environ``
+    is that profile's own value, so fall back to it. Same pattern as the
+    Slack ``SLACK_APP_TOKEN`` read (#59739).
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
 
 logger = logging.getLogger(__name__)
 

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -37,6 +37,7 @@ import os
 import re
 from typing import Any, Dict, Optional
 
+from agent.secret_scope import get_secret as _get_wsecret
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +88,12 @@ class WhatsAppBehaviorMixin:
         adapter) can override this to always return ``""`` or apply a
         different policy.
         """
-        whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
+        whatsapp_mode = _get_wsecret("WHATSAPP_MODE", default="self-chat") or "self-chat"
         if whatsapp_mode != "self-chat":
             return ""
         if self._reply_prefix is not None:
             return self._reply_prefix.replace("\\n", "\n")
-        env_prefix = os.getenv("WHATSAPP_REPLY_PREFIX")
+        env_prefix = _get_wsecret("WHATSAPP_REPLY_PREFIX")
         if env_prefix is not None:
             return env_prefix.replace("\\n", "\n")
         return self.DEFAULT_REPLY_PREFIX
@@ -110,7 +111,7 @@ class WhatsAppBehaviorMixin:
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("WHATSAPP_REQUIRE_MENTION", "false").lower() in {
+        return (_get_wsecret("WHATSAPP_REQUIRE_MENTION", default="false") or "false").lower() in {
             "true",
             "1",
             "yes",
@@ -120,7 +121,7 @@ class WhatsAppBehaviorMixin:
     def _whatsapp_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
-            raw = os.getenv("WHATSAPP_FREE_RESPONSE_CHATS", "")
+            raw = _get_wsecret("WHATSAPP_FREE_RESPONSE_CHATS", default="") or ""
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
@@ -190,7 +191,7 @@ class WhatsAppBehaviorMixin:
     def _open_dm_opted_in(self) -> bool:
         if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WHATSAPP_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_get_wsecret("WHATSAPP_ALLOW_ALL_USERS", default="") or "").lower() in {"true", "1", "yes"}
 
     @staticmethod
     def _matches_whatsapp_allowlist(candidate: str, allow_from) -> bool:
@@ -271,7 +272,7 @@ class WhatsAppBehaviorMixin:
     def _compile_mention_patterns(self):
         patterns = self.config.extra.get("mention_patterns")
         if patterns is None:
-            raw = os.getenv("WHATSAPP_MENTION_PATTERNS", "").strip()
+            raw = (_get_wsecret("WHATSAPP_MENTION_PATTERNS", default="") or "").strip()
             if raw:
                 try:
                     patterns = json.loads(raw)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1822,8 +1822,10 @@ def _profile_runtime_scope(profile_home: "Path"):
         set_secret_scope,
         reset_secret_scope,
     )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
+    hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10639,8 +10639,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.warning("No adapter available for %s", _pval)
                 continue
             
-            # Set up message + fatal error handlers
-            adapter.set_message_handler(self._handle_message)
+            # Set up message + fatal error handlers. Under multiplexing the
+            # default profile needs the same whole-handler runtime scope as a
+            # secondary profile: authorization and prompt rendering both run
+            # before the narrower agent-turn scope is installed.
+            adapter.set_message_handler(self._primary_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -11741,7 +11744,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
-                    adapter.set_message_handler(self._handle_message)
+                    adapter.set_message_handler(self._primary_message_handler())
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -12890,6 +12893,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_message(event)
 
         return _handler
+
+    def _make_default_profile_message_handler(self):
+        """Scope a multiplexed default-profile message from ingress onward."""
+        profile_home = Path(get_hermes_home())
+
+        async def _handler(event):
+            with _profile_runtime_scope(profile_home):
+                return await self._handle_message(event)
+
+        return _handler
+
+    def _primary_message_handler(self):
+        """Return the correctly scoped handler for a primary adapter."""
+        if getattr(self.config, "multiplex_profiles", False):
+            return self._make_default_profile_message_handler()
+        return self._handle_message
 
     @staticmethod
     def _adapter_credential_claim(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -416,11 +416,13 @@ def _discord_tools_loaded() -> bool:
     Returns False (safe default — keeps the stale-API disclaimer) on any
     error so a bad config can't silently promise tools the agent lacks.
     """
-    if not (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
-        return False
     try:
+        from agent.secret_scope import get_secret
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
+
+        if not (get_secret("DISCORD_BOT_TOKEN", "") or "").strip():
+            return False
         cfg = load_config()
         enabled = _get_platform_tools(cfg, "discord", include_default_mcp_servers=False)
         return "discord" in enabled or "discord_admin" in enabled

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3798,6 +3798,28 @@ class GatewaySlashCommandsMixin:
         return t("gateway.footer.saved", state=state, example=example)
 
     async def _handle_compress_command(self, event: MessageEvent) -> str:
+        """Profile-scoping wrapper around manual /compress.
+
+        Multiplexed gateways resolve credentials through the fail-closed
+        per-profile secret scope (``agent.secret_scope``, Workstream A). The
+        agent turn installs it via ``_run_agent``'s wrapper, but slash-command
+        dispatch does not — so manual /compress reached the compressor's
+        provider resolution unscoped and died with ``UnscopedSecretError``
+        (``get_secret('OPENROUTER_BASE_URL') called with no profile secret
+        scope active``). Install the source profile's scope around the whole
+        handler, mirroring ``_run_agent``. Single-profile gateways skip this
+        — zero behavior change.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return await self._handle_compress_command_inner(event)
+
+        from gateway.run import _profile_runtime_scope
+
+        profile_home = self._resolve_profile_home_for_source(event.source)
+        with _profile_runtime_scope(profile_home):
+            return await self._handle_compress_command_inner(event)
+
+    async def _handle_compress_command_inner(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context.
 
         Accepts an optional focus topic: ``/compress <focus>`` guides the
@@ -3983,9 +4005,13 @@ class GatewaySlashCommandsMixin:
                 if not compressor.has_content_to_compress(head):
                     return t("gateway.compress.nothing_to_do")
 
-                loop = asyncio.get_running_loop()
-                compressed, _ = await loop.run_in_executor(
-                    None,
+                # _run_in_executor_with_context (not a bare run_in_executor):
+                # the profile secret scope installed by the wrapper is a
+                # contextvar, and the default-executor hop would drop it —
+                # the compressor's aux-client provider resolution would then
+                # read credentials unscoped and fail closed under
+                # multiplexing.
+                compressed, _ = await self._run_in_executor_with_context(
                     lambda: tmp_agent._compress_context(
                         head,
                         "",

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -208,6 +208,15 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
             if _is_global_env(name)
         }
         local_env.update(load_env_file(home / ".env"))
+        # Mirror load_hermes_dotenv()'s .op.env bootstrap: the 1Password
+        # service-account token lives in <home>/.op.env (gitignored), not
+        # .env. Without seeding it here a cold profile configured for the
+        # supported .op.env flow fails 1Password hydration (sweeper review
+        # on #74549). .env values win — never override an existing key.
+        op_env = home / ".op.env"
+        if op_env.exists():
+            for _name, _value in load_env_file(op_env).items():
+                local_env.setdefault(_name, _value)
         local_env["HERMES_HOME"] = str(home)
         report = apply_all(cfg, home, environ=local_env)
     except Exception:  # noqa: BLE001 — preserve fail-open startup behavior

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,6 +6,7 @@ import codecs
 import io
 import os
 import sys
+import threading
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -48,6 +49,7 @@ _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
 # in-process cache prevents redundant network calls, but the print, the
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
+_SECRET_SOURCE_CACHE_LOCK = threading.RLock()
 
 
 def _known_hermes_env_keys() -> set[str]:
@@ -162,6 +164,69 @@ def get_secret_source_values(
     """Return the external-secret value snapshot for ``hermes_home``."""
     home_key = str(Path(hermes_home).resolve())
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
+
+
+def hydrate_profile_secret_sources(
+    hermes_home: str | os.PathLike,
+) -> dict[str, str]:
+    """Resolve one profile's configured sources without mutating ``os.environ``.
+
+    Multiplex gateways can route a first turn to a secondary profile that has
+    never run the process-global dotenv startup path.  Resolve that profile's
+    sources against a private mapping seeded from its own ``.env`` and record
+    the usual per-home snapshot for ``build_profile_secret_scope()``.
+
+    Fail-open and once-per-home semantics intentionally mirror
+    ``_apply_external_secret_sources``.  The returned mapping contains only
+    values actually contributed by external sources, never the profile's
+    plaintext ``.env`` entries.
+    """
+    with _SECRET_SOURCE_CACHE_LOCK:
+        return _hydrate_profile_secret_sources(Path(hermes_home))
+
+
+def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
+    """Locked implementation for :func:`hydrate_profile_secret_sources`."""
+    home_key = str(home.resolve())
+    if home_key in _APPLIED_HOMES:
+        return get_secret_source_values(home)
+
+    try:
+        cfg = _load_secrets_config(home)
+    except Exception:  # noqa: BLE001 — external sources must not block routing
+        return {}
+    if not cfg:
+        return {}
+
+    try:
+        from agent.secret_scope import _is_global_env, load_env_file
+        from agent.secret_sources.registry import apply_all
+
+        local_env = {
+            name: value
+            for name, value in os.environ.items()
+            if _is_global_env(name)
+        }
+        local_env.update(load_env_file(home / ".env"))
+        local_env["HERMES_HOME"] = str(home)
+        report = apply_all(cfg, home, environ=local_env)
+    except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
+        return {}
+
+    if not report.sources:
+        return {}
+
+    _APPLIED_HOMES.add(home_key)
+    values: dict[str, str] = {}
+    for name, applied in report.provenance.items():
+        value = local_env.get(name)
+        if value is None:
+            continue
+        _SECRET_SOURCES[name] = applied.source
+        values[name] = value
+    if values:
+        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+    return dict(values)
 
 
 def reset_secret_source_cache() -> None:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -191,6 +191,16 @@ def _xai_credentials_present() -> bool:
         pass
     return bool(str(os.environ.get("XAI_API_KEY") or "").strip())
 
+
+def _homeassistant_credentials_present() -> bool:
+    """Return whether the active profile has a Home Assistant token."""
+    try:
+        from agent.secret_scope import get_secret
+
+        return bool((get_secret("HASS_TOKEN", "") or "").strip())
+    except Exception:
+        return False
+
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset
 # absent from this map is available on every platform (current behaviour).
@@ -2282,7 +2292,7 @@ def _get_platform_tools(
             default_off = set(_DEFAULT_OFF_TOOLSETS)
             if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
                 default_off.remove(platform)
-            if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+            if "homeassistant" in default_off and _homeassistant_credentials_present():
                 default_off.remove("homeassistant")
             _exempt_explicit_platform_native(
                 default_off, platform, explicitly_configured=explicitly_configured
@@ -2344,7 +2354,7 @@ def _get_platform_tools(
         # (e.g. cron) that run through _get_platform_tools without an
         # explicit saved toolset list. Without this, Norbert's HA cron jobs
         # regressed after #14798 made cron honor per-platform tool config.
-        if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+        if "homeassistant" in default_off and _homeassistant_credentials_present():
             default_off.remove("homeassistant")
         # Symmetric carve-out for x_search auto-enable (see the inject
         # block above). Without this, the default_off subtraction would

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,7 +29,13 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import discover_builtin_tools, registry, tool_error
+from tools.registry import (
+    CHECK_FN_CACHE_BYPASS,
+    check_fn_cache_scope,
+    discover_builtin_tools,
+    registry,
+    tool_error,
+)
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -317,6 +323,7 @@ def get_tool_definitions(
     # user-visible config edits that affect dynamic schemas (execute_code
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
+    cache_key = None
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -325,16 +332,19 @@ def get_tool_definitions(
             cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
-        cache_key = (
-            frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
-            frozenset(disabled_toolsets) if disabled_toolsets else None,
-            registry._generation,
-            cfg_fp,
-            bool(os.environ.get("HERMES_KANBAN_TASK")),
-            bool(skip_tool_search_assembly),
-            _is_delegated_child_context(),
-        )
-        cached = _tool_defs_cache.get(cache_key)
+        profile_scope = check_fn_cache_scope()
+        if profile_scope != CHECK_FN_CACHE_BYPASS:
+            cache_key = (
+                frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
+                frozenset(disabled_toolsets) if disabled_toolsets else None,
+                registry._generation,
+                cfg_fp,
+                bool(os.environ.get("HERMES_KANBAN_TASK")),
+                bool(skip_tool_search_assembly),
+                _is_delegated_child_context(),
+                profile_scope,
+            )
+        cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
@@ -346,7 +356,7 @@ def get_tool_definitions(
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
-    if quiet_mode:
+    if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a
@@ -360,6 +370,8 @@ def get_tool_definitions(
         if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
             _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
         _tool_defs_cache[cache_key] = result
+        return list(result)
+    if quiet_mode:
         return list(result)
     return result
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -70,6 +70,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
+from agent.secret_scope import UnscopedSecretError, get_secret
+
 try:
     from mautrix.types import (
         ContentURI,
@@ -811,6 +813,24 @@ def _handle_generated_matrix_recovery_key(mxid: str, recovery_key: str) -> None:
             "from your Matrix client before future restarts.",
             mxid,
         )
+
+
+def _scoped_recovery_key() -> str:
+    """Resolve MATRIX_RECOVERY_KEY honoring the active profile's secret scope.
+
+    Under ``gateway.multiplex_profiles`` the secret scope holds the secondary
+    profile's credentials, while ``os.environ`` may carry the default profile's
+    key — so a bare ``os.getenv`` resolves the wrong key and E2EE verification
+    fails with "Key MAC does not match" (#69090). We read through
+    :func:`get_secret`, which is scope-aware. An *unscoped* read under multiplex
+    (e.g. the default-profile startup loop) raises ``UnscopedSecretError``; in
+    that context ``os.environ`` is that profile's own value, so we fall back to
+    it — mirroring the established Slack app-token pattern (#59739).
+    """
+    try:
+        return (get_secret("MATRIX_RECOVERY_KEY") or "").strip()
+    except UnscopedSecretError:
+        return os.getenv("MATRIX_RECOVERY_KEY", "").strip()
 
 
 def _sanitize_matrix_html(html: str) -> str:
@@ -1577,7 +1597,11 @@ class MatrixAdapter(BasePlatformAdapter):
                             return False
                         logger.warning("Matrix: share_keys() warning during startup: %s", exc)
 
-                    recovery_key = os.getenv("MATRIX_RECOVERY_KEY", "").strip()
+                    # Honor the active profile's secret scope so a secondary
+                    # profile under gateway.multiplex_profiles resolves its own
+                    # recovery key instead of the default profile's (which fails
+                    # E2EE verification with "Key MAC does not match", #69090).
+                    recovery_key = _scoped_recovery_key()
                     if recovery_key:
                         try:
                             await olm.verify_with_recovery_key(recovery_key)
@@ -1875,7 +1899,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 "enabled": bool(self._encryption),
                 "deps_available": _check_e2ee_deps(),
                 "crypto_store_path": str(_CRYPTO_DB_PATH),
-                "recovery_key_configured": bool(os.getenv("MATRIX_RECOVERY_KEY", "").strip()),
+                "recovery_key_configured": bool(
+                    _scoped_recovery_key().strip()
+                ),
             },
             "policy": {
                 "allowed_user_count": len(self._allowed_user_ids),

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -43,8 +43,16 @@ def _wenv(name: str, default: str = "") -> str:
     ``get_secret`` honors the active ``_profile_runtime_scope`` so secondary
     profiles see their own credentials.
     """
-    from agent.secret_scope import get_secret
-    val = get_secret(name)
+    from agent.secret_scope import UnscopedSecretError, get_secret
+    try:
+        val = get_secret(name)
+    except UnscopedSecretError:
+        # DEFAULT profile's adapter constructs/connects outside any
+        # _profile_runtime_scope under multiplexing; os.environ is that
+        # profile's own value there. Same pattern as Slack SLACK_APP_TOKEN
+        # (#59739) and the Matrix recovery key. A *scoped* miss still
+        # returns the default (no cross-profile borrow).
+        val = os.getenv(name)
     return val if val is not None else default
 
 logger = logging.getLogger(__name__)
@@ -683,7 +691,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # (which reads process.env.WHATSAPP_MODE etc.) sees the profile's
             # own configuration instead of falling back to self-chat defaults.
             _profile_wa_mode = _wenv("WHATSAPP_MODE", "self-chat")
-            if _profile_wa_mode != "self-chat" or _profile_wa_mode:
+            if _profile_wa_mode:
                 bridge_env["WHATSAPP_MODE"] = _profile_wa_mode
             for _key in (
                 "WHATSAPP_ALLOWED_USERS", "WHATSAPP_ALLOW_FROM",
@@ -691,6 +699,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "WHATSAPP_GROUP_ALLOWED_USERS", "WHATSAPP_GROUP_ALLOW_FROM",
                 "WHATSAPP_REQUIRE_MENTION", "WHATSAPP_MENTION_PATTERNS",
                 "WHATSAPP_FREE_RESPONSE_CHATS",
+                # Full set bridge.js consumes -- without these a secondary
+                # profile's bridge silently reverts to defaults for debug,
+                # forwarding, prefixes, and send pacing.
+                "WHATSAPP_DEBUG", "WHATSAPP_FORWARD_OWNER_MESSAGES",
+                "WHATSAPP_REPLY_PREFIX", "WHATSAPP_MAX_MESSAGE_LENGTH",
+                "WHATSAPP_CHUNK_DELAY_MS", "WHATSAPP_SEND_TIMEOUT_MS",
             ):
                 _v = _wenv(_key)
                 if _v:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -34,6 +34,19 @@ from hermes_constants import (
     with_hermes_node_path,
 )
 
+def _wenv(name: str, default: str = "") -> str:
+    """Read a WHATSAPP_* env var through the profile secret scope.
+
+    Under multiplexing, ``os.getenv`` bypasses the per-profile ``.env`` and
+    returns the process-global value (often unset), causing the bridge to
+    silently fall back to ``"self-chat"`` and reject all messages.
+    ``get_secret`` honors the active ``_profile_runtime_scope`` so secondary
+    profiles see their own credentials.
+    """
+    from agent.secret_scope import get_secret
+    val = get_secret(name)
+    return val if val is not None else default
+
 logger = logging.getLogger(__name__)
 
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
@@ -407,26 +420,27 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
-        self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
+        self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
         # (setup wizard / pairing mirror). Select by key *presence* so an
         # explicit empty allow_from: [] stays authoritative and does not fall
         # through to a lower-precedence env grant. Track which source won so
-        # live DM checks preserve that precedence.
+        # live DM checks preserve that precedence. Env reads go through the
+        # profile secret scope (_wenv) so multiplexed profiles see their own.
         if "allow_from" in config.extra:
             self._dm_allowlist_source = "config"
             allow_raw = config.extra.get("allow_from")
         elif "allowFrom" in config.extra:
             self._dm_allowlist_source = "config"
             allow_raw = config.extra.get("allowFrom")
-        elif os.getenv("WHATSAPP_ALLOWED_USERS"):
+        elif _wenv("WHATSAPP_ALLOWED_USERS"):
             self._dm_allowlist_source = "WHATSAPP_ALLOWED_USERS"
-            allow_raw = os.getenv("WHATSAPP_ALLOWED_USERS")
+            allow_raw = _wenv("WHATSAPP_ALLOWED_USERS")
         else:
             self._dm_allowlist_source = None
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
-        self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
@@ -648,7 +662,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
             # messages are preserved for troubleshooting.
-            whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
+            whatsapp_mode = _wenv("WHATSAPP_MODE", "self-chat")
             self._bridge_log = self._session_path.parent / "bridge.log"
             bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
             self._bridge_log_fh = bridge_log_fh
@@ -663,6 +677,24 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            # Under multiplexing, the bridge subprocess runs with a copy of
+            # os.environ that does NOT contain the secondary profile's .env
+            # vars.  Inject the resolved WHATSAPP_* values so the Node bridge
+            # (which reads process.env.WHATSAPP_MODE etc.) sees the profile's
+            # own configuration instead of falling back to self-chat defaults.
+            _profile_wa_mode = _wenv("WHATSAPP_MODE", "self-chat")
+            if _profile_wa_mode != "self-chat" or _profile_wa_mode:
+                bridge_env["WHATSAPP_MODE"] = _profile_wa_mode
+            for _key in (
+                "WHATSAPP_ALLOWED_USERS", "WHATSAPP_ALLOW_FROM",
+                "WHATSAPP_DM_POLICY", "WHATSAPP_GROUP_POLICY",
+                "WHATSAPP_GROUP_ALLOWED_USERS", "WHATSAPP_GROUP_ALLOW_FROM",
+                "WHATSAPP_REQUIRE_MENTION", "WHATSAPP_MENTION_PATTERNS",
+                "WHATSAPP_FREE_RESPONSE_CHATS",
+            ):
+                _v = _wenv(_key)
+                if _v:
+                    bridge_env[_key] = _v
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -119,6 +119,43 @@ class TestPrimaryStartupSkipsEmptyTokenUnderMultiplex:
         assert created == []
 
 
+class TestPrimaryMessageRuntimeScope:
+    @pytest.mark.asyncio
+    async def test_default_profile_prompt_gate_sees_its_scoped_token(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+        from gateway import run as run_mod
+        from gateway.run import GatewayRunner
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".env").write_text(
+            "DISCORD_BOT_TOKEN=default-profile-token\n", encoding="utf-8"
+        )
+        (home / "config.yaml").write_text(
+            "platform_toolsets:\n  discord:\n    - discord\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: home)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "wrong-process-token")
+        secret_scope.set_multiplex_active(True)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+
+        async def _handle_message(_event):
+            from gateway.session import _discord_tools_loaded
+
+            return _discord_tools_loaded()
+
+        runner._handle_message = _handle_message  # type: ignore[method-assign]
+        handler = runner._primary_message_handler()
+
+        assert await handler(SimpleNamespace(source=SimpleNamespace(profile=None))) is True
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            secret_scope.get_secret("DISCORD_BOT_TOKEN")
+
+
 class TestReconnectDropsEmptyToken:
     @pytest.mark.asyncio
     async def test_empty_token_removed_from_queue(self):

--- a/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
+++ b/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
@@ -1,0 +1,158 @@
+"""Regression test for #75349 — WhatsApp bridge loses WHATSAPP_* vars under multiplex.
+
+Under ``_profile_runtime_scope`` (the context installed for every secondary-profile
+turn in a multiplexed gateway), ``os.getenv("WHATSAPP_MODE")`` bypasses the
+profile's secret scope and returns the process-global value (often unset),
+causing the bridge to silently fall back to ``"self-chat"`` and reject all
+inbound messages.
+
+The fix routes WHATSAPP_* reads through ``get_secret()`` (``agent.secret_scope``)
+which honours the active scope.
+"""
+import pytest
+
+from agent import secret_scope as ss
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex(monkeypatch):
+    """Ensure multiplex mode is off before and after each test."""
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+class TestWhatsAppEnvViaSecretScope:
+    """WHATSAPP_* reads must go through ``get_secret``, not ``os.getenv``."""
+
+    def test_wenv_reads_scope_under_multiplex(self, tmp_path, monkeypatch):
+        """When multiplexing is active and a scope is installed, the profile's
+        .env values are returned — not the global os.environ values."""
+        from plugins.platforms.whatsapp.adapter import _wenv
+
+        # Set a misleading value in os.environ that would be returned by
+        # os.getenv("WHATSAPP_MODE", "self-chat") if the bug was present.
+        monkeypatch.setenv("WHATSAPP_MODE", "self-chat")
+
+        ss.set_multiplex_active(True)
+
+        # Write a profile .env with bot mode
+        (tmp_path / ".env").write_text("WHATSAPP_MODE=bot\nWHATSAPP_DM_POLICY=allowlist\n")
+
+        tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            # The fix reads from the scope, not os.environ
+            mode = _wenv("WHATSAPP_MODE", "self-chat")
+            assert mode == "bot", f"Expected 'bot', got {mode!r}"
+
+            dm_policy = _wenv("WHATSAPP_DM_POLICY", "pairing")
+            assert dm_policy == "allowlist", f"Expected 'allowlist', got {dm_policy!r}"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_wenv_fallback_when_scope_absent(self, monkeypatch):
+        """When no scope is installed and multiplex is off, _wenv returns default."""
+        from plugins.platforms.whatsapp.adapter import _wenv
+
+        monkeypatch.delenv("WHATSAPP_MODE", raising=False)
+        result = _wenv("WHATSAPP_MODE", "self-chat")
+        assert result == "self-chat"
+
+    def test_wenv_does_not_leak_cross_profile(self, tmp_path, monkeypatch):
+        """Two different profiles under the same process see their own values."""
+        from plugins.platforms.whatsapp.adapter import _wenv
+
+        ss.set_multiplex_active(True)
+
+        (tmp_path / "profA").mkdir()
+        (tmp_path / "profA" / ".env").write_text("WHATSAPP_MODE=bot\n")
+        (tmp_path / "profB").mkdir()
+        (tmp_path / "profB" / ".env").write_text("WHATSAPP_MODE=self-chat\n")
+
+        tok_a = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path / "profA"))
+        try:
+            assert _wenv("WHATSAPP_MODE", "self-chat") == "bot"
+        finally:
+            ss.reset_secret_scope(tok_a)
+
+        tok_b = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path / "profB"))
+        try:
+            assert _wenv("WHATSAPP_MODE", "self-chat") == "self-chat"
+        finally:
+            ss.reset_secret_scope(tok_b)
+
+
+class TestWhatsAppCommonUsesSecretScope:
+    """The shared WhatsAppBehaviorMixin methods must also use get_secret."""
+
+    def test_effective_reply_prefix_uses_scope(self, tmp_path, monkeypatch):
+        """_effective_reply_prefix respects the profile's WHATSAPP_MODE from scope."""
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        monkeypatch.delenv("WHATSAPP_MODE", raising=False)
+        monkeypatch.delenv("WHATSAPP_REPLY_PREFIX", raising=False)
+        ss.set_multiplex_active(True)
+
+        # Set scope with bot mode (should NOT add reply prefix)
+        (tmp_path / ".env").write_text("WHATSAPP_MODE=bot\n")
+        tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            mixin = object.__new__(WhatsAppBehaviorMixin)
+            mixin.config = type("C", (), {"extra": {}})()
+            mixin.name = "test"
+            mixin._reply_prefix = None
+            mixin.MAX_MESSAGE_LENGTH = 4096
+            mixin.DEFAULT_REPLY_PREFIX = "[Reply] "
+
+            prefix = mixin._effective_reply_prefix()
+            # bot mode → no prefix
+            assert prefix == ""
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_whatsapp_require_mention_uses_scope(self, tmp_path, monkeypatch):
+        """_whatsapp_require_mention respects the profile's env from scope."""
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        monkeypatch.delenv("WHATSAPP_REQUIRE_MENTION", raising=False)
+        ss.set_multiplex_active(True)
+
+        (tmp_path / ".env").write_text("WHATSAPP_REQUIRE_MENTION=true\n")
+        tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            mixin = object.__new__(WhatsAppBehaviorMixin)
+            mixin.config = type("C", (), {"extra": {}})()
+            mixin.name = "test"
+
+            assert mixin._whatsapp_require_mention() is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+
+class TestWhatsAppCloudAdapterUsesSecretScope:
+    """The Cloud API adapter must also read WHATSAPP_* through get_secret."""
+
+    def test_cloud_dm_policy_reads_scope(self, tmp_path, monkeypatch):
+        """WhatsAppCloudAdapter._dm_policy respects profile scope."""
+        from gateway.config import PlatformConfig
+
+        monkeypatch.delenv("WHATSAPP_CLOUD_DM_POLICY", raising=False)
+        monkeypatch.delenv("WHATSAPP_DM_POLICY", raising=False)
+        ss.set_multiplex_active(True)
+
+        (tmp_path / ".env").write_text("WHATSAPP_DM_POLICY=allowlist\n")
+        tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+            cfg = type("C", (), {
+                "extra": {},
+                "enabled": True,
+            })()
+            # Cloud adapter won't fully init without creds, but we can at least
+            # verify the dm_policy assignment path doesn't crash under scope.
+            # We test via the mixin's behavior instead.
+            from gateway.platforms.whatsapp_common import _get_wsecret
+            assert _get_wsecret("WHATSAPP_DM_POLICY", default="pairing") == "allowlist"
+        finally:
+            ss.reset_secret_scope(tok)

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -309,3 +309,114 @@ async def test_compress_command_passes_tool_messages_to_compressor():
     assert any(m.get("tool_calls") for m in passed), "assistant tool_calls stub dropped"
 
 
+
+
+@pytest.mark.asyncio
+async def test_compress_command_multiplexed_runs_under_profile_secret_scope(tmp_path):
+    """Manual /compress must install the source profile's secret scope.
+
+    Multiplexed gateways resolve credentials fail-closed (Workstream A):
+    ``get_secret`` raises ``UnscopedSecretError`` on any read outside a
+    ``set_secret_scope`` block. The agent turn is scoped by ``_run_agent``'s
+    wrapper, but slash-command dispatch is not — manual /compress reached the
+    compressor's provider resolution unscoped and died with
+    ``get_secret('OPENROUTER_BASE_URL') called with no profile secret scope
+    active``. The credential read happens inside the executor hop, so this
+    also pins that the handler uses the contextvar-preserving executor
+    (``_run_in_executor_with_context``), not a bare ``run_in_executor``.
+    """
+    from agent import secret_scope as ss
+
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "compressed summary"},
+        history[-1],
+    ]
+    runner = _make_runner(history)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+        multiplex_profiles=True,
+    )
+    profile_home = tmp_path / "profiles" / "milo"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "OPENROUTER_BASE_URL=https://scoped.example/v1\n"
+    )
+    runner._resolve_profile_home_for_source = MagicMock(return_value=profile_home)
+
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.context_compressor._last_compress_aborted = False
+    agent_instance.context_compressor._last_summary_fallback_used = False
+    agent_instance.context_compressor._last_summary_dropped_count = 0
+    agent_instance.context_compressor._last_summary_error = None
+    agent_instance.context_compressor._last_aux_model_failure_model = None
+    agent_instance.context_compressor._last_aux_model_failure_error = None
+    agent_instance.session_id = "sess-1"
+    agent_instance._compression_skipped_due_to_lock = False
+
+    seen: dict[str, str | None] = {}
+
+    def _compress(*_args, **_kwargs):
+        # Runs in the executor thread — exactly where the aux client
+        # resolves provider credentials. Fail-closed get_secret raises
+        # here unless the profile scope survived the thread hop.
+        seen["base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
+        return (compressed, "")
+
+    agent_instance._compress_context.side_effect = _compress
+
+    ss.set_multiplex_active(True)
+    try:
+        with (
+            patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+            patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+            patch("run_agent.AIAgent", return_value=agent_instance),
+            patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+        ):
+            result = await runner._handle_compress_command(_make_event())
+    finally:
+        ss.set_multiplex_active(False)
+        runner._shutdown_executor()
+
+    assert "failed" not in result.lower(), result
+    assert seen["base_url"] == "https://scoped.example/v1"
+    runner._resolve_profile_home_for_source.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_compress_command_single_profile_skips_profile_resolution():
+    """Multiplexing off → the scope wrapper is a transparent pass-through.
+
+    Single-profile gateways must not pay the profile-resolution path (and
+    ``_resolve_profile_home_for_source`` assumes multiplex config exists) —
+    mirrors the gating contract of ``_run_agent``'s wrapper.
+    """
+    history = _make_history()
+    runner = _make_runner(history)
+    runner._resolve_profile_home_for_source = MagicMock()
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    runner._resolve_profile_home_for_source.assert_not_called()
+    runner._shutdown_executor()

--- a/tests/gateway/test_matrix_recovery_key_scope.py
+++ b/tests/gateway/test_matrix_recovery_key_scope.py
@@ -1,0 +1,79 @@
+"""Regression test for #69090: MATRIX_RECOVERY_KEY must honor the active
+profile's secret scope under ``gateway.multiplex_profiles`` so that a
+secondary profile resolves its own recovery key (not the default profile's),
+otherwise E2EE cross-signing verification fails with "Key MAC does not match".
+
+The fix routes the recovery-key read through ``_scoped_recovery_key()``,
+which uses :func:`agent.secret_scope.get_secret` (scope-aware) and only falls
+back to ``os.getenv`` for an *unscoped* read under multiplex — mirroring the
+established Slack app-token pattern (#59739).
+"""
+import pytest
+
+from agent import secret_scope as ss
+from plugins.platforms.matrix.adapter import _scoped_recovery_key
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    """Ensure each test starts and ends with multiplexing off (it's a global)."""
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+class TestScopedRecoveryKey:
+    def test_multiplex_inactive_reads_environ(self, monkeypatch):
+        """Default deployment: get_secret transparently reads os.environ."""
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "default-profile-key")
+        assert _scoped_recovery_key() == "default-profile-key"
+
+    def test_multiplex_active_scoped_uses_scope_not_environ(self, monkeypatch):
+        """Secondary profile under multiplex must resolve its own key.
+
+        This is the core regression: ``os.getenv`` would have returned the
+        default profile's key (from os.environ), failing verification.
+        """
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"MATRIX_RECOVERY_KEY": "secondary-profile-key"})
+        try:
+            assert _scoped_recovery_key() == "secondary-profile-key"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_multiplex_active_unscoped_falls_back_to_environ(self, monkeypatch):
+        """Default-profile startup loop under multiplex: unscoped read is fine.
+
+        An unscoped read raises ``UnscopedSecretError``; in that context
+        os.environ holds that profile's own value, so we fall back to it rather
+        than crashing startup. This matches the Slack adapter's behavior.
+        """
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        # No secret scope installed -> get_secret raises UnscopedSecretError.
+        assert _scoped_recovery_key() == "default-profile-key"
+
+    def test_multiplex_active_scoped_missing_key_is_empty(self, monkeypatch):
+        """A scope without the key must NOT fall through to another profile's env.
+
+        If the secondary profile hasn't configured a recovery key, the scope is
+        authoritative: we return empty rather than silently borrowing the
+        default profile's key (which would fail verification with a confusing
+        "Key MAC does not match").
+        """
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+        try:
+            assert _scoped_recovery_key() == ""
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "  padded-key  \n")
+        assert _scoped_recovery_key() == "padded-key"
+
+    def test_unset_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
+        assert _scoped_recovery_key() == ""

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -88,3 +88,81 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
+def test_cold_profile_hydrates_external_source_without_global_env(
+    tmp_path, monkeypatch
+):
+    """The first routed secondary turn must resolve its own source locally."""
+    import os
+
+    from agent.secret_sources.base import FetchResult
+    from agent.secret_sources.registry import AppliedVar, ApplyReport, SourceReport
+    from agent.secret_sources import registry
+    from agent.secret_scope import get_secret
+    from hermes_cli import env_loader
+    from gateway.run import _profile_runtime_scope
+
+    profile = tmp_path / "profiles" / "secondary"
+    sibling = tmp_path / "profiles" / "sibling"
+    profile.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    (profile / ".env").write_text(
+        "EXPLICIT_API_KEY=dotenv-wins\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("TEST_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("EXPLICIT_API_KEY", raising=False)
+    monkeypatch.setattr(
+        env_loader,
+        "_load_secrets_config",
+        lambda home: (
+            {"fake-source": {"enabled": True}}
+            if Path(home).resolve() == profile.resolve()
+            else {}
+        ),
+    )
+
+    calls = {"count": 0}
+
+    def _fake_apply_all(_cfg, _home, *, environ=None):
+        calls["count"] += 1
+        assert environ is not os.environ
+        assert environ is not None
+        assert environ["EXPLICIT_API_KEY"] == "dotenv-wins"
+        environ["TEST_PROVIDER_API_KEY"] = "profile-only"
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="fake-source",
+                    label="Fake Source",
+                    result=FetchResult(),
+                    applied=["TEST_PROVIDER_API_KEY"],
+                )
+            ],
+            provenance={
+                "TEST_PROVIDER_API_KEY": AppliedVar(
+                    name="TEST_PROVIDER_API_KEY",
+                    source="fake-source",
+                    shape="mapped",
+                    overrode_env=False,
+                )
+            },
+        )
+
+    monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
+    env_loader.reset_secret_source_cache()
+
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
+        assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
+        assert env_loader.get_secret_source_values(profile) == {
+            "TEST_PROVIDER_API_KEY": "profile-only"
+        }
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
+    with _profile_runtime_scope(sibling):
+        assert get_secret("TEST_PROVIDER_API_KEY") is None
+
+    assert calls["count"] == 1
+    assert "TEST_PROVIDER_API_KEY" not in os.environ
+    assert "EXPLICIT_API_KEY" not in os.environ
+
+

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -100,6 +100,20 @@ def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_tok
     assert "homeassistant" in cli_enabled
 
 
+def test_get_platform_tools_homeassistant_uses_active_profile_token(monkeypatch):
+    from agent import secret_scope
+
+    monkeypatch.delenv("HASS_TOKEN", raising=False)
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"HASS_TOKEN": "profile-token"})
+    try:
+        assert "homeassistant" in _get_platform_tools({}, "cron")
+        assert "homeassistant" in _get_platform_tools({}, "cli")
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+
 # ─── #35527: platform-restricted default-off toolsets (discord/discord_admin)
 # are stripped by _DEFAULT_OFF_TOOLSETS even when the user explicitly opts in
 # via the platform's native composite. The composite ``hermes-discord``

--- a/tests/secret_sources/test_profile_secrets.py
+++ b/tests/secret_sources/test_profile_secrets.py
@@ -123,5 +123,55 @@ def test_hyphenated_profile_name_matches_underscore_suffix():
     assert env["SLACK_APP_TOKEN"] == "xapp-1"
 
 
+def test_source_fetch_reads_injected_environment_without_global_mutation(
+    monkeypatch, tmp_path
+):
+    """Cold-profile bootstrap values reach sources through the local mapping."""
+    from agent.secret_sources.base import get_source_environment
+
+    class _BootstrapSource(SecretSource):
+        name = "bootstrap"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            result = FetchResult()
+            result.secrets = {
+                "RESOLVED_API_KEY": get_source_environment()["BOOTSTRAP_TOKEN"]
+            }
+            return result
+
+    registry.register_source(_BootstrapSource())
+    monkeypatch.delenv("BOOTSTRAP_TOKEN", raising=False)
+    env = {"BOOTSTRAP_TOKEN": "profile-token"}
+    _, applied = _apply(
+        {},
+        cfg_extra={"bootstrap": {"enabled": True}},
+        home=tmp_path,
+        env=env,
+    )
+
+    assert applied["RESOLVED_API_KEY"] == "profile-token"
+    assert "BOOTSTRAP_TOKEN" not in __import__("os").environ
+
+
+def test_empty_injected_environment_does_not_fall_back_to_process(monkeypatch, tmp_path):
+    from agent.secret_sources.base import get_source_environment
+
+    class _CanarySource(SecretSource):
+        name = "canary"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            result = FetchResult()
+            assert get_source_environment().get("LEAK_CANARY") is None
+            return result
+
+    registry.register_source(_CanarySource())
+    monkeypatch.setenv("LEAK_CANARY", "global-secret")
+    registry.apply_all(
+        {"canary": {"enabled": True}}, tmp_path, environ={}
+    )
+
+
 
 

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -35,11 +35,16 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agent.secret_sources.command import (  # noqa: E402
+    _run_helper,
     apply_command_secrets,
     get_command_secret,
     list_command_secrets,
     parse_secret_output,
     unquote_dotenv_value,
+)
+from agent.secret_sources.base import (  # noqa: E402
+    reset_source_environment,
+    set_source_environment,
 )
 from hermes_cli import env_loader  # noqa: E402
 
@@ -55,6 +60,22 @@ def _write_helper(tmp_path: Path, body: str, name: str = "helper.sh") -> Path:
     script.write_text("#!/bin/sh\n" + body + "\n", encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return script
+
+
+def test_profile_helper_does_not_inherit_process_secret(monkeypatch):
+    monkeypatch.setenv("LEAK_CANARY", "global-secret")
+    token = set_source_environment({"PROFILE_ONLY": "profile-value"})
+    try:
+        output = _run_helper(
+            'printf "%s|%s" "${LEAK_CANARY-unset}" "$PROFILE_ONLY"',
+            "",
+            1.0,
+            1024,
+        )
+    finally:
+        reset_source_environment(token)
+
+    assert output == "unset|profile-value"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -174,6 +174,78 @@ def test_cold_profile_bitwarden_uses_profile_bootstrap_without_global_env(
     assert os.environ.get("ANTHROPIC_API_KEY") is None
 
 
+def test_cold_profile_hydration_seeds_op_env_bootstrap(tmp_path, monkeypatch):
+    """The .op.env bootstrap file must feed cold-profile hydration.
+
+    load_hermes_dotenv() reads <home>/.op.env for OP_SERVICE_ACCOUNT_TOKEN
+    (the documented gitignored 1Password bootstrap); hydration must mirror
+    that or a cold profile using the supported .op.env flow fails 1Password
+    resolution (sweeper review on #74549). .env wins on conflict.
+    """
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    (tmp_path / ".env").write_text("UNRELATED=x\n", encoding="utf-8")
+    (tmp_path / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=ops_from-op-env\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    seen_env = {}
+
+    def _capture_apply_all(_cfg, home_path, environ=None):
+        from agent.secret_sources.registry import ApplyReport
+        seen_env.update(environ or {})
+        return ApplyReport(sources=[], provenance={})
+
+    monkeypatch.setattr(reg_module, "apply_all", _capture_apply_all)
+    reg_module._reset_registry_for_tests()
+
+    env_loader.hydrate_profile_secret_sources(tmp_path)
+
+    assert seen_env.get("OP_SERVICE_ACCOUNT_TOKEN") == "ops_from-op-env"
+    # Never leaked into the process env.
+    assert os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") is None
+
+
+def test_cold_profile_hydration_dotenv_wins_over_op_env(tmp_path, monkeypatch):
+    """.env takes precedence over .op.env for the same key (setdefault)."""
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    (tmp_path / ".env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=ops_from-dotenv\n", encoding="utf-8"
+    )
+    (tmp_path / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=ops_from-op-env\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    seen_env = {}
+
+    def _capture_apply_all(_cfg, home_path, environ=None):
+        from agent.secret_sources.registry import ApplyReport
+        seen_env.update(environ or {})
+        return ApplyReport(sources=[], provenance={})
+
+    monkeypatch.setattr(reg_module, "apply_all", _capture_apply_all)
+    reg_module._reset_registry_for_tests()
+
+    env_loader.hydrate_profile_secret_sources(tmp_path)
+
+    assert seen_env.get("OP_SERVICE_ACCOUNT_TOKEN") == "ops_from-dotenv"
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -135,6 +135,45 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     )
 
 
+def test_cold_profile_bitwarden_uses_profile_bootstrap_without_global_env(
+    tmp_path, monkeypatch
+):
+    """Real Bitwarden adapter reads its token from the profile-local view."""
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "BWS_ACCESS_TOKEN=profile-bootstrap\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+    from agent.secret_sources import registry as reg_module
+
+    captured = {}
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+
+    def _fake_fetch(**kwargs):
+        captured.update(kwargs)
+        return {"ANTHROPIC_API_KEY": "profile-provider-key"}, []
+
+    monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _fake_fetch)
+    reg_module._reset_registry_for_tests()
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "ANTHROPIC_API_KEY": "profile-provider-key"
+    }
+    assert captured["access_token"] == "profile-bootstrap"
+    assert os.environ.get("BWS_ACCESS_TOKEN") is None
+    assert os.environ.get("ANTHROPIC_API_KEY") is None
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 

--- a/tests/tools/test_browser_camofox_auth.py
+++ b/tests/tools/test_browser_camofox_auth.py
@@ -18,6 +18,7 @@ from tools.browser_camofox import (
     camofox_scroll,
     camofox_snapshot,
     camofox_type,
+    get_camofox_url,
 )
 
 
@@ -41,6 +42,51 @@ class TestAuthHeaders:
     def test_empty_when_key_blank(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_API_KEY", "   ")
         assert _auth_headers() == {}
+
+    def test_multiplex_scope_key_wins_over_process_environment(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"CAMOFOX_API_KEY": "secondary-profile-key"})
+        try:
+            assert _auth_headers() == {"Authorization": "Bearer secondary-profile-key"}
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_multiplex_scope_missing_key_fails_closed(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            assert _auth_headers() == {}
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_multiplex_scope_keeps_endpoint_and_key_in_same_profile(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("CAMOFOX_URL", "https://default.example")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope(
+            {
+                "CAMOFOX_URL": "https://secondary.example/",
+                "CAMOFOX_API_KEY": "secondary-profile-key",
+            }
+        )
+        try:
+            assert get_camofox_url() == "https://secondary.example"
+            assert _auth_headers() == {
+                "Authorization": "Bearer secondary-profile-key"
+            }
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
 
 
 class TestAuthHeadersSent:

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -126,6 +126,103 @@ class TestManagedPersistenceMode:
 class TestConfiguredCamofoxIdentity:
     """Externally managed Camofox sessions can provide their own identity."""
 
+    def test_multiplex_scope_identity_wins_over_process_env_and_config(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_URL", "https://default.example")
+        monkeypatch.setenv("CAMOFOX_USER_ID", "default-profile-user")
+        monkeypatch.setenv("CAMOFOX_SESSION_KEY", "default-profile-session")
+        config = {
+            "browser": {
+                "camofox": {
+                    "user_id": "secondary-config-user",
+                    "session_key": "secondary-config-session",
+                }
+            }
+        }
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope(
+            {
+                "CAMOFOX_URL": "https://secondary.example",
+                "CAMOFOX_USER_ID": "secondary-scope-user",
+                "CAMOFOX_SESSION_KEY": "secondary-scope-session",
+            }
+        )
+        try:
+            with (
+                patch("tools.browser_camofox.load_config", return_value=config),
+                patch(
+                    "tools.browser_camofox.requests.post",
+                    return_value=_mock_response(json_data={"tabId": "scoped-tab"}),
+                ) as mock_post,
+            ):
+                result = json.loads(
+                    camofox_navigate("https://example.com", task_id="scoped-precedence")
+                )
+                request_url = mock_post.call_args.args[0]
+                request_body = mock_post.call_args.kwargs["json"]
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert result["success"] is True
+        assert request_url == "https://secondary.example/tabs"
+        assert request_body["userId"] == "secondary-scope-user"
+        assert request_body["listItemId"] == "secondary-scope-session"
+
+    def test_multiplex_scope_miss_uses_profile_config_not_process_env(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_USER_ID", "default-profile-user")
+        monkeypatch.setenv("CAMOFOX_SESSION_KEY", "default-profile-session")
+        config = {
+            "browser": {
+                "camofox": {
+                    "user_id": "secondary-config-user",
+                    "session_key": "secondary-config-session",
+                }
+            }
+        }
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            with patch("tools.browser_camofox.load_config", return_value=config):
+                session = _get_session("config-fallback")
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert session["user_id"] == "secondary-config-user"
+        assert session["session_key"] == "secondary-config-session"
+
+    def test_multiplex_scope_miss_without_config_ignores_process_identity(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_USER_ID", "default-profile-user")
+        monkeypatch.setenv("CAMOFOX_SESSION_KEY", "default-profile-session")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            with patch("tools.browser_camofox.load_config", return_value={}):
+                session = _get_session("fail-closed")
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert session["user_id"].startswith("hermes_")
+        assert session["user_id"] != "default-profile-user"
+        assert session["session_key"] == "task_fail-closed"
+        assert session["managed"] is False
+
     def test_env_identity_overrides_default_identity(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -58,6 +58,64 @@ class TestCheckRequirements:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "  my-token  ")
         assert _get_bot_token() == "my-token"
 
+    def test_multiplex_scope_token_wins_over_process_environment(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "another-profile-token")
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope(
+            {"DISCORD_BOT_TOKEN": "  active-profile-token  "}
+        )
+        try:
+            assert _get_bot_token() == "active-profile-token"
+            assert check_discord_tool_requirements() is True
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_multiplex_scope_missing_token_fails_closed(self, monkeypatch):
+        from agent import secret_scope
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "another-profile-token")
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope({"UNRELATED_SECRET": "value"})
+        invalidate_check_fn_cache()
+        try:
+            assert _get_bot_token() is None
+            assert check_discord_tool_requirements() is False
+            assert registry.get_definitions({"discord", "discord_admin"}) == []
+        finally:
+            invalidate_check_fn_cache()
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_non_multiplex_scope_miss_keeps_environment_compatibility(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "process-token")
+        secret_scope.set_multiplex_active(False)
+        scope_token = secret_scope.set_secret_scope({"UNRELATED_SECRET": "value"})
+        try:
+            assert _get_bot_token() == "process-token"
+            assert check_discord_tool_requirements() is True
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+
+    def test_gateway_tool_prompt_gate_uses_active_profile_token(self, monkeypatch):
+        from agent import secret_scope
+        from gateway.session import _discord_tools_loaded
+
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "another-profile-token")
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope({"UNRELATED_SECRET": "value"})
+        try:
+            with patch("hermes_cli.config.load_config") as load_config:
+                assert _discord_tools_loaded() is False
+                load_config.assert_not_called()
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
 
 # ---------------------------------------------------------------------------
 # Channel type names

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -308,6 +308,40 @@ class TestCheckAvailable:
         monkeypatch.setenv("HASS_TOKEN", "")
         assert _check_ha_available() is False
 
+    def test_multiplex_scope_does_not_fall_back_to_another_profile(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("HASS_TOKEN", "default-profile-token")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            assert _check_ha_available() is False
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_multiplex_scope_supplies_profile_url_and_token(self, monkeypatch):
+        from agent import secret_scope
+        from tools.homeassistant_tool import _get_config
+
+        monkeypatch.setattr("tools.homeassistant_tool._HASS_URL", "")
+        monkeypatch.setattr("tools.homeassistant_tool._HASS_TOKEN", "")
+        monkeypatch.setenv("HASS_URL", "http://default-profile:8123")
+        monkeypatch.setenv("HASS_TOKEN", "default-profile-token")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({
+            "HASS_URL": "http://secondary-profile:8123/",
+            "HASS_TOKEN": "secondary-profile-token",
+        })
+        try:
+            assert _get_config() == (
+                "http://secondary-profile:8123",
+                "secondary-profile-token",
+            )
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
 
 # ---------------------------------------------------------------------------
 # Auth headers

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -134,6 +134,125 @@ class TestCheckFnTransientFailureSuppression:
         t["now"] += reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
         assert reg._check_fn_cached(probe) is False
 
+    def test_profile_scoped_availability_does_not_cross_multiplex_profiles(
+        self, tmp_path
+    ):
+        """Both availability caches must use the active profile as a key."""
+        import tools.registry as reg
+        from agent.secret_scope import (
+            get_secret,
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+        profile_a = tmp_path / "profiles" / "a"
+        profile_b = tmp_path / "profiles" / "b"
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+        tool_name = "profile_scoped_availability_probe"
+
+        def probe():
+            return bool(get_secret("PROFILE_CACHE_TEST_TOKEN"))
+
+        reg.registry.register(
+            name=tool_name,
+            toolset="profile-cache-test",
+            schema={
+                "name": tool_name,
+                "description": "test-only profile-scoped availability probe",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda _args: "ok",
+            check_fn=probe,
+        )
+        set_multiplex_active(True)
+        try:
+            home_a = set_hermes_home_override(str(profile_a))
+            secrets_a = set_secret_scope({"PROFILE_CACHE_TEST_TOKEN": "token-a"})
+            try:
+                tools_a = get_tool_definitions(
+                    enabled_toolsets=["profile-cache-test"],
+                    quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            finally:
+                reset_secret_scope(secrets_a)
+                reset_hermes_home_override(home_a)
+
+            home_b = set_hermes_home_override(str(profile_b))
+            secrets_b = set_secret_scope({})
+            try:
+                tools_b = get_tool_definitions(
+                    enabled_toolsets=["profile-cache-test"],
+                    quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            finally:
+                reset_secret_scope(secrets_b)
+                reset_hermes_home_override(home_b)
+
+            assert tool_name in {tool["function"]["name"] for tool in tools_a}
+            assert tool_name not in {tool["function"]["name"] for tool in tools_b}
+        finally:
+            set_multiplex_active(False)
+            reg.registry.deregister(tool_name)
+            reg.invalidate_check_fn_cache()
+            _clear_tool_defs_cache()
+
+    def test_unscoped_multiplex_request_bypasses_cache(self, monkeypatch):
+        """An unknown profile must never share another request's cache entry."""
+        import model_tools
+        import tools.registry as reg
+        from agent.secret_scope import set_multiplex_active
+
+        values = iter([True, False])
+        definition_calls = {"n": 0}
+
+        def probe():
+            return next(values)
+
+        def compute_definitions(*_args, **_kwargs):
+            definition_calls["n"] += 1
+            return []
+
+        set_multiplex_active(True)
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute_definitions)
+        try:
+            assert reg._check_fn_cached(probe) is True
+            assert reg._check_fn_cached(probe) is False
+            assert not reg._check_fn_cache
+
+            model_tools.get_tool_definitions(quiet_mode=True)
+            model_tools.get_tool_definitions(quiet_mode=True)
+            assert definition_calls["n"] == 2
+            assert not model_tools._tool_defs_cache
+        finally:
+            set_multiplex_active(False)
+            reg.invalidate_check_fn_cache()
+            model_tools._clear_tool_defs_cache()
+
+    def test_profile_scoped_check_cache_is_bounded(self, monkeypatch):
+        """Many multiplex profiles must not grow registry caches forever."""
+        import tools.registry as reg
+
+        scopes = iter(f"/profiles/{index}" for index in range(1_000))
+        monkeypatch.setattr(reg, "check_fn_cache_scope", lambda: next(scopes))
+
+        def available():
+            return True
+
+        for _ in range(1_000):
+            assert reg._check_fn_cached(available) is True
+
+        assert len(reg._check_fn_cache) <= reg._CHECK_FN_CACHE_MAX
+        assert len(reg._check_fn_last_good) <= reg._CHECK_FN_CACHE_MAX
+
     def test_subagent_keeps_file_tools_through_docker_flake(self, monkeypatch):
         """End-to-end: a docker probe that flakes on the 2nd build keeps the
         file/terminal toolset available for the subagent being constructed."""

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -192,12 +192,15 @@ def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, An
     so Hermes operates in the same browser profile instead of creating a
     separate private session.
     """
-    user_id = os.getenv("CAMOFOX_USER_ID", "").strip() or str(camofox_cfg.get("user_id") or "").strip()
+    user_id = (
+        (get_secret("CAMOFOX_USER_ID", "") or "").strip()
+        or str(camofox_cfg.get("user_id") or "").strip()
+    )
     if not user_id:
         return None
 
     session_key = (
-        os.getenv("CAMOFOX_SESSION_KEY", "").strip()
+        (get_secret("CAMOFOX_SESSION_KEY", "") or "").strip()
         or str(camofox_cfg.get("session_key") or "").strip()
         or f"task_{(task_id or 'default')[:16]}"
     )

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -36,6 +36,7 @@ from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import requests
 
+from agent.secret_scope import get_secret
 from hermes_cli.config import cfg_get, load_config, read_raw_config
 from tools.browser_camofox_state import get_camofox_identity
 from tools.registry import tool_error
@@ -82,7 +83,7 @@ def _get_command_timeout() -> int:
 
 def _auth_headers() -> Dict[str, str]:
     """Return Authorization header when CAMOFOX_API_KEY is set."""
-    key = os.getenv("CAMOFOX_API_KEY", "").strip()
+    key = (get_secret("CAMOFOX_API_KEY", "") or "").strip()
     if key:
         return {"Authorization": f"Bearer {key}"}
     return {}
@@ -90,7 +91,7 @@ def _auth_headers() -> Dict[str, str]:
 
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
-    return os.getenv("CAMOFOX_URL", "").rstrip("/")
+    return (get_secret("CAMOFOX_URL", "") or "").rstrip("/")
 
 
 def _config_cdp_url() -> str:

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -27,13 +27,13 @@ actionable guidance the model can relay to the user.
 
 import json
 import logging
-import os
 import threading
 import urllib.error
 import urllib.parse
 import urllib.request
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from agent.secret_scope import get_secret
 from tools.registry import registry, tool_error
 
 if TYPE_CHECKING:
@@ -72,8 +72,8 @@ def _read_limited_response_body(source: Any, limit: int, *, label: str) -> bytes
 
 
 def _get_bot_token() -> Optional[str]:
-    """Resolve the Discord bot token from environment."""
-    return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
+    """Resolve the Discord bot token under the active profile secret scope."""
+    return (get_secret("DISCORD_BOT_TOKEN", "") or "").strip() or None
 
 
 def _discord_request(

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -13,9 +13,10 @@ The HA instance URL is read from ``HASS_URL`` (default: http://homeassistant.loc
 import asyncio
 import json
 import logging
-import os
 import re
 from typing import Any, Dict, Optional
+
+from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -29,10 +30,10 @@ _HASS_TOKEN: str = ""
 
 
 def _get_config():
-    """Return (hass_url, hass_token) from env vars at call time."""
+    """Return the active profile's Home Assistant URL and token."""
     return (
-        (_HASS_URL or os.getenv("HASS_URL", "http://homeassistant.local:8123")).rstrip("/"),
-        _HASS_TOKEN or os.getenv("HASS_TOKEN", ""),
+        (_HASS_URL or get_secret("HASS_URL", "http://homeassistant.local:8123") or "").rstrip("/"),
+        _HASS_TOKEN or get_secret("HASS_TOKEN", "") or "",
     )
 
 # Regex for valid HA entity_id format (e.g. "light.living_room", "sensor.temperature_1")
@@ -343,7 +344,7 @@ def _handle_list_services(args: dict, **kw) -> str:
 
 def _check_ha_available() -> bool:
     """Tool is only available when HASS_TOKEN is set."""
-    return bool(os.getenv("HASS_TOKEN"))
+    return bool(get_secret("HASS_TOKEN"))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -218,10 +218,54 @@ _CHECK_FN_TTL_SECONDS = 30.0
 # as a flake (last-good True is served) rather than a real outage. Kept short
 # so a genuinely-down backend is reflected within a couple of turns.
 _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
-_check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
+_CHECK_FN_CACHE_MAX = 512
+_check_fn_cache: Dict[tuple[Callable, Optional[str]], tuple[float, bool]] = {}
 # Monotonic timestamp of the most recent True result per check_fn.
-_check_fn_last_good: Dict[Callable, float] = {}
+_check_fn_last_good: Dict[tuple[Callable, Optional[str]], float] = {}
 _check_fn_cache_lock = threading.Lock()
+CHECK_FN_CACHE_BYPASS = ""
+
+
+def _prune_check_fn_caches(now: float) -> None:
+    """Expire stale entries and cap profile-dimensional cache growth.
+
+    Caller must hold ``_check_fn_cache_lock``.
+    """
+    for key, (timestamp, _) in list(_check_fn_cache.items()):
+        if now - timestamp >= _CHECK_FN_TTL_SECONDS:
+            _check_fn_cache.pop(key, None)
+    for key, timestamp in list(_check_fn_last_good.items()):
+        if now - timestamp >= _CHECK_FN_FAILURE_GRACE_SECONDS:
+            _check_fn_last_good.pop(key, None)
+    while len(_check_fn_cache) >= _CHECK_FN_CACHE_MAX:
+        _check_fn_cache.pop(next(iter(_check_fn_cache)))
+    while len(_check_fn_last_good) >= _CHECK_FN_CACHE_MAX:
+        _check_fn_last_good.pop(next(iter(_check_fn_last_good)))
+
+
+def check_fn_cache_scope() -> Optional[str]:
+    """Return the active profile key when availability is profile-scoped.
+
+    Single-profile processes intentionally keep the historical process-wide
+    cache. A multiplex gateway installs a Hermes-home override for every
+    profile turn, so the canonical profile key is the stable isolation
+    boundary across repeated turns for that profile.
+    """
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        if not is_multiplex_active():
+            return None
+        from hermes_constants import get_hermes_home_override
+
+        override = get_hermes_home_override()
+        if not override:
+            return CHECK_FN_CACHE_BYPASS
+        return str(Path(override).expanduser().resolve())
+    except Exception:
+        # Fail closed: bypass both cache layers rather than aliasing requests
+        # whose multiplex profile identity could not be resolved.
+        return CHECK_FN_CACHE_BYPASS
 
 
 def _check_fn_cached(fn: Callable) -> bool:
@@ -234,8 +278,22 @@ def _check_fn_cached(fn: Callable) -> bool:
     contention, probe timeout) from silently stripping tools mid-session.
     """
     now = time.monotonic()
+    scope = check_fn_cache_scope()
+    if scope == CHECK_FN_CACHE_BYPASS:
+        try:
+            return bool(fn())
+        except Exception:
+            logger.warning(
+                "check_fn %s raised while profile cache scope was unresolved; "
+                "dependent tools will be unavailable this turn",
+                getattr(fn, "__qualname__", fn),
+                exc_info=True,
+            )
+            return False
+    cache_key = (fn, scope)
     with _check_fn_cache_lock:
-        cached = _check_fn_cache.get(fn)
+        _prune_check_fn_caches(now)
+        cached = _check_fn_cache.get(cache_key)
         if cached is not None:
             ts, value = cached
             if now - ts < _CHECK_FN_TTL_SECONDS:
@@ -249,12 +307,13 @@ def _check_fn_cached(fn: Callable) -> bool:
         raised = True
 
     with _check_fn_cache_lock:
+        _prune_check_fn_caches(now)
         if value:
-            _check_fn_last_good[fn] = now
-            _check_fn_cache[fn] = (now, True)
+            _check_fn_last_good[cache_key] = now
+            _check_fn_cache[cache_key] = (now, True)
             return True
 
-        last_good = _check_fn_last_good.get(fn)
+        last_good = _check_fn_last_good.get(cache_key)
         if last_good is not None and now - last_good < _CHECK_FN_FAILURE_GRACE_SECONDS:
             # Recent success → treat this failure as a flake. Serve last-good
             # True and do NOT cache the failure, so the next call re-probes
@@ -275,7 +334,7 @@ def _check_fn_cached(fn: Callable) -> bool:
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",
         )
-        _check_fn_cache[fn] = (now, False)
+        _check_fn_cache[cache_key] = (now, False)
         return False
 
 


### PR DESCRIPTION
## Summary
Consolidated salvage of the secret-scope migration wave: five contributor fixes land the remaining per-subsystem scope migrations, all verified against the profile-boundary rule (isolation between profiles; a profile's own children — subagents, cron, review forks, bridge subprocesses — inherit its secrets).

Every premise was re-verified on current main by parallel review before cherry-picking; contributor authorship preserved per-commit.

## Changes (in composition order)
- **/compress under profile scope** (@CocaKova, #74964, as-is): the slash handler ran outside `_profile_runtime_scope` and its `run_in_executor(None, …)` hop dropped the ContextVar scope → `UnscopedSecretError` under multiplexing. Now wraps the handler in the profile scope and uses `_run_in_executor_with_context` — scopes the spawn, no fallback, no swallowing.
- **Matrix recovery key** (@sergioperezcheco, #69110, as-is): `MATRIX_RECOVERY_KEY` read via `get_secret`; scoped miss returns empty (no cross-profile borrow); default-profile startup uses the established Slack-pattern `UnscopedSecretError→os.getenv` fallback. 6 tests.
- **Model-tool isolation** (@tachyon-r, #74023, both commits): Discord/HASS/Camofox credential reads routed through `get_secret`; `check_fn`/tool-defs caches gain a `(fn, profile_home)` key (unresolved scope ⇒ cache bypass, fail-closed); fixes the default profile's own unscoped ingress via `_primary_message_handler` scope wrap. Child-inheritance verified: cache scope rides the same ContextVar `copy_context` propagates.
- **Cold-profile hydration** (@kingrubic, #74549 + our required fix): profiles whose BWS/1Password sources were never resolved in-process now hydrate inside `_profile_runtime_scope` before scope build — profile-local env, never mutates `os.environ`. Our follow-up seeds the documented `.op.env` bootstrap (`OP_SERVICE_ACCOUNT_TOKEN`) the original missed (sweeper-flagged); 2 regression tests.
- **WhatsApp env** (@x7peeps, #75382 + our 3 fixes): `WHATSAPP_*` reads via scope-aware helpers; bridge subprocess overlay injects the routed profile's values (child inherits — correct direction). Our follow-ups: `UnscopedSecretError` fallback so the *default* profile's adapter doesn't crash (the PR's one real defect), full bridge.js env set (DEBUG/FORWARD/PREFIX/lengths/delays), dead-conditional removal. Junk commits (CI-retrigger, stray changelog) dropped from the original.

## Validation
| Path | Verified |
|---|---|
| Targeted suites (compress, matrix, registry, discord, HASS, env_loader, secret sources, multiplex isolation, whatsapp×6, camofox) | 250+ tests green |
| E2E: whatsapp `_wenv` | default-profile unscoped → own environ (no crash); secondary scoped → own value |
| E2E: matrix `_scoped_recovery_key` | scoped → profile key; scoped miss → empty (no borrow) |
| E2E: cold hydration | `.op.env` token seeded into profile-local env; `os.environ` untouched |
| Cross-PR compose | stacked merge-tree checks clean; branch based on today's main |

Credits: @CocaKova (#74964), @sergioperezcheco (#69110), @tachyon-r (#74023), @kingrubic (#74549), @x7peeps (#75382).
Closes #69090, #75349, #74317.

Cluster context: #74722 and #76199 close separately as superseded (#74340 / #76213); #70616 closes as wrong-premise (roots-into-every-profile inheritance violates the isolation contract).

## Infographic

![scope wave complete](https://v3b.fal.media/files/b/0aa4ad48/SMJh_KLJokAqOzCOv85Me_kv0nEJh1.png)
