### PR TITLE
fix(gateway): refresh Buzz profile for renamed mentions

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1032,9 +1032,16 @@ class BuzzAdapter(BasePlatformAdapter):
         is_dm = state["chat_type"] == "dm"
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
-            return
+        # A self p-tag is a stable signal that the text may target this identity;
+        # refresh the cached profile before deciding so live display-name changes
+        # do not silently drop mentions. DMs always dispatch.
+        if not is_dm and self.require_mention:
+            is_mentioned = self._is_mentioned(content)
+            if not is_mentioned and self._is_self_ptagged(event):
+                await self._refresh_self_profile()
+                is_mentioned = self._is_mentioned(content)
+            if not is_mentioned:
+                return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
@@ -1099,6 +1106,37 @@ class BuzzAdapter(BasePlatformAdapter):
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description
 
+    async def _refresh_self_profile(self) -> bool:
+        """Refresh mutable profile fields used for channel mention matching."""
+        code, out, _err = await self._run_cli(["users", "get"])
+        if code != 0:
+            return False
+        profiles = _parse_json_list(out)
+        if not profiles:
+            return False
+        profile = profiles[0]
+        pubkey = str(profile.get("pubkey") or "").lower()
+        if pubkey != self._self_pubkey:
+            return False
+        self._display_name = str(profile.get("display_name") or "").strip()
+        self._self_npub = hex_to_npub(self._self_pubkey) or ""
+        return True
+
+    def _is_self_ptagged(self, event: dict) -> bool:
+        """True when the event explicitly addresses this identity by pubkey."""
+        if not self._self_pubkey:
+            return False
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return False
+        return any(
+            isinstance(tag, (list, tuple))
+            and len(tag) > 1
+            and tag[0] == "p"
+            and str(tag[1]).lower() == self._self_pubkey
+            for tag in tags
+        )
+
     def _is_direct_message_event(self, channel_id: str, event: dict) -> bool:
         """True when ``event`` is shaped like a direct message to us: a chat
         message from another user, p-tagged to our pubkey, whose content does
@@ -1111,17 +1149,7 @@ class BuzzAdapter(BasePlatformAdapter):
         pubkey = str(event.get("pubkey") or "").lower()
         if not pubkey or pubkey == self._self_pubkey:
             return False
-        tags = event.get("tags")
-        if not isinstance(tags, list):
-            return False
-        p_tagged_to_self = any(
-            isinstance(tag, (list, tuple))
-            and len(tag) > 1
-            and tag[0] == "p"
-            and str(tag[1]).lower() == self._self_pubkey
-            for tag in tags
-        )
-        if not p_tagged_to_self:
+        if not self._is_self_ptagged(event):
             return False
         content = event.get("content")
         return isinstance(content, str) and not self._is_mentioned(content)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,27 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_self_ptag_dispatches_after_profile_rename(self, adapter):
+        adapter._display_name = "Old Agent Name"
+        adapter.channels = [CHANNEL]
+        adapter._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL,
+            "name": "coordination",
+            "description": "Shared agent coordination",
+        }
+        event = _event("e1", content="@RenamedAgent can you help?", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [event])
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY, "display_name": "RenamedAgent"}])
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(CHANNEL)
+
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._display_name == "RenamedAgent"
+
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):


### PR DESCRIPTION
## Summary
- refresh the current Buzz profile when a self-addressed channel event no longer matches the cached display name
- re-evaluate the visible mention after refresh so live profile renames do not silently drop messages
- reuse a single helper for self `p`-tag detection while preserving DM classification
- add regression coverage for the stale-name/profile-rename scenario

## Root cause
The Buzz adapter cached its display name at gateway startup. If the profile was renamed while the gateway remained running, channel events could carry a valid self `p` tag while their visible `@name` matched the new profile rather than the cached name. The mention gate rejected those events before dispatch.

The self `p` tag is used only as a signal to refresh mutable profile data; the adapter still requires a visible mention after refresh. This preserves existing behavior for unmentioned `p`-tagged events in real channels.

## Test plan
- [x] New regression test fails before the adapter change
- [x] `pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q --tb=short -n 0`
- [x] 28 tests passed
- [x] Independent fingerprint-bound review passed
