### PR TITLE
fix(tirith): reset breaker on block/warn + exact-match .app TLD suppression

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -165,6 +165,34 @@ class TestUnknownExitCode:
         assert "exit code 99" in result["summary"]
 
 
+class TestCircuitBreakerReset:
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_block_verdict_resets_consecutive_crash_counter(self, mock_cfg, mock_run):
+        """A block/warn verdict is a successful tirith execution, so it must
+        reset the CONSECUTIVE-failure breaker. Crashes interleaved with real
+        verdicts must not accumulate to open it (fail-open) — regression for
+        the reset previously only happening on exit 0."""
+        import tools.tirith_security as _t
+
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        # crash, block, crash, block, crash — never 3 crashes in a row.
+        mock_run.side_effect = [
+            _mock_run(99, ""),                        # crash -> count 1
+            _mock_run(1, _json_stdout([], "block")),  # block -> reset to 0
+            _mock_run(99, ""),                        # crash -> count 1
+            _mock_run(1, _json_stdout([], "block")),  # block -> reset to 0
+            _mock_run(99, ""),                        # crash -> count 1
+        ]
+        for _ in range(5):
+            check_command_security("cmd")
+
+        # Without the fix the counter would reach 3 and open the breaker.
+        assert _t._circuit_open is False
+        assert _t._crash_count == 1
+
+
 # ---------------------------------------------------------------------------
 # Disabled
 # ---------------------------------------------------------------------------
@@ -676,8 +704,14 @@ class TestIsAppTldFinding:
     @pytest.mark.parametrize("finding, expected", [
         ({"rule_id": "lookalike_tld", "value": ".APP"}, True),   # case-insensitive
         ({"rule_id": "lookalike_tld", "message": "Domain uses '.app' TLD"}, True),
+        ({"rule_id": "lookalike_tld", "value": "example.app"}, True),  # real .app host
         ({"rule_id": "shortened_url", "value": ".app"}, False),  # wrong rule_id
         ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # other TLD
+        # ``.app`` as a substring of a LONGER label/TLD must NOT be suppressed —
+        # these are real lookalike warnings, not the benign .app gTLD.
+        ({"rule_id": "lookalike_tld", "value": "paypal.app-secure.com"}, False),
+        ({"rule_id": "lookalike_tld", "value": "login.appspot.com"}, False),
+        ({"rule_id": "lookalike_tld", "value": "my.apple-id.com"}, False),
     ])
     def test_app_tld_detection(self, finding, expected):
         from tools.tirith_security import _is_app_tld_finding

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -166,9 +166,12 @@ class TestUnknownExitCode:
 
 
 class TestCircuitBreakerReset:
+    @pytest.mark.parametrize("verdict_code", [1, 2], ids=["block", "warn"])
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
-    def test_block_verdict_resets_consecutive_crash_counter(self, mock_cfg, mock_run):
+    def test_real_verdict_resets_consecutive_crash_counter(
+        self, mock_cfg, mock_run, verdict_code,
+    ):
         """A block/warn verdict is a successful tirith execution, so it must
         reset the CONSECUTIVE-failure breaker. Crashes interleaved with real
         verdicts must not accumulate to open it (fail-open) — regression for
@@ -177,13 +180,13 @@ class TestCircuitBreakerReset:
 
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
-        # crash, block, crash, block, crash — never 3 crashes in a row.
+        # crash, verdict, crash, verdict, crash — never 3 crashes in a row.
         mock_run.side_effect = [
-            _mock_run(99, ""),                        # crash -> count 1
-            _mock_run(1, _json_stdout([], "block")),  # block -> reset to 0
-            _mock_run(99, ""),                        # crash -> count 1
-            _mock_run(1, _json_stdout([], "block")),  # block -> reset to 0
-            _mock_run(99, ""),                        # crash -> count 1
+            _mock_run(99, ""),                              # crash -> count 1
+            _mock_run(verdict_code, _json_stdout([], "ok")),  # reset to 0
+            _mock_run(99, ""),                              # crash -> count 1
+            _mock_run(verdict_code, _json_stdout([], "ok")),  # reset to 0
+            _mock_run(99, ""),                              # crash -> count 1
         ]
         for _ in range(5):
             check_command_security("cmd")
@@ -689,6 +692,23 @@ class TestAppTldSuppression:
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
+    def test_non_app_finding_beyond_return_cap_preserves_warn(self, mock_cfg, mock_run):
+        """Suppression considers every finding before returned details are capped."""
+        mock_cfg.return_value = _CFG
+        findings = [
+            {"rule_id": "lookalike_tld", "value": f"host{i}.app"}
+            for i in range(_tirith_mod._MAX_FINDINGS)
+        ]
+        findings.append({"rule_id": "shortened_url", "severity": "medium"})
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "mixed"))
+
+        result = check_command_security("cmd")
+
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == _tirith_mod._MAX_FINDINGS
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
     def test_block_verdict_never_suppressed(self, mock_cfg, mock_run):
         """block exit code is never downgraded, even if finding looks like .app."""
         mock_cfg.return_value = _CFG
@@ -705,13 +725,37 @@ class TestIsAppTldFinding:
         ({"rule_id": "lookalike_tld", "value": ".APP"}, True),   # case-insensitive
         ({"rule_id": "lookalike_tld", "message": "Domain uses '.app' TLD"}, True),
         ({"rule_id": "lookalike_tld", "value": "example.app"}, True),  # real .app host
+        ({"rule_id": "lookalike_tld", "value": "https://example.app/v1"}, True),
+        ({"rule_id": "lookalike_tld", "message": "Fetch example.app,"}, True),
+        ({"rule_id": "lookalike_tld", "tld": "app"}, True),
+        ({
+            "rule_id": "lookalike_tld",
+            "description": "Domain uses '.app' TLD which can resemble an extension",
+            "evidence": [{"type": "url", "raw": "api.example.app"}],
+        }, True),
         ({"rule_id": "shortened_url", "value": ".app"}, False),  # wrong rule_id
         ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # other TLD
         # ``.app`` as a substring of a LONGER label/TLD must NOT be suppressed —
         # these are real lookalike warnings, not the benign .app gTLD.
         ({"rule_id": "lookalike_tld", "value": "paypal.app-secure.com"}, False),
+        ({"rule_id": "lookalike_tld", "value": "paypal.app.evil.com"}, False),
+        ({"rule_id": "lookalike_tld", "message": "Visit evil.app.example"}, False),
+        ({"rule_id": "lookalike_tld", "message": "Visit evil.app.example,"}, False),
+        ({"rule_id": "lookalike_tld", "message": "Visit example.app."}, False),
+        ({"rule_id": "lookalike_tld", "message": "Visit evil.app。example"}, False),
+        ({"rule_id": "lookalike_tld", "message": "Visit evil..app"}, False),
         ({"rule_id": "lookalike_tld", "value": "login.appspot.com"}, False),
         ({"rule_id": "lookalike_tld", "value": "my.apple-id.com"}, False),
+        ({
+            "rule_id": "lookalike_tld",
+            "value": "example.app",
+            "message": "Redirects through evil.app.example",
+        }, False),
+        ({
+            "rule_id": "lookalike_tld",
+            "message": "Domain uses '.app' TLD",
+            "evidence": [{"type": "url", "raw": "evil.app.example"}],
+        }, False),
     ])
     def test_app_tld_detection(self, finding, expected):
         from tools.tirith_security import _is_app_tld_finding

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -808,8 +809,6 @@ def check_command_security(command: str) -> dict:
     exit_code = result.returncode
     if exit_code == 0:
         action = "allow"
-        # Successful execution — reset circuit breaker
-        _crash_count = 0
     elif exit_code == 1:
         action = "block"
     elif exit_code == 2:
@@ -822,6 +821,13 @@ def check_command_security(command: str) -> dict:
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith exit code {exit_code} (fail-open)"}
         return {"action": "block", "findings": [], "summary": f"tirith exit code {exit_code} (fail-closed)"}
+
+    # tirith ran and returned a real verdict (allow/block/warn) — all three are
+    # successful executions, not crashes, so reset the CONSECUTIVE-failure
+    # circuit breaker. Previously only exit 0 reset it, so spawn/exec failures
+    # interleaved with block/warn verdicts still accumulated and could open the
+    # breaker (fail-open, disabling tirith) despite it working fine in between.
+    _crash_count = 0
 
     # Parse JSON for enrichment (never overrides the exit code verdict)
     findings = []
@@ -854,6 +860,12 @@ def check_command_security(command: str) -> dict:
     return {"action": action, "findings": findings, "summary": summary}
 
 
+# ``.app`` at a hostname boundary: a literal ``.app`` NOT followed by another
+# hostname char (``[a-z0-9-]``). Matches ``example.app`` / a bare ``.app`` /
+# ``'.app'`` in prose, but not ``.appspot`` / ``.apple`` / ``paypal.app-secure.com``.
+_APP_TLD_RE = re.compile(r"\.app(?![a-z0-9-])")
+
+
 def _is_app_tld_finding(finding: dict) -> bool:
     """Return True if this finding is a lookalike_tld warning for the .app TLD only.
 
@@ -866,6 +878,11 @@ def _is_app_tld_finding(finding: dict) -> bool:
         return False
     for field in ("value", "tld", "detail", "description", "message"):
         val = finding.get(field)
-        if val is not None and ".app" in str(val).lower():
+        # Match the ``.app`` gTLD at a hostname boundary, not as a bare
+        # substring: ``.app`` followed by ``[a-z0-9-]`` is a different label
+        # or TLD (``.appspot``, ``.apple``, ``paypal.app-secure.com``) and must
+        # NOT be treated as the benign ``.app`` case, or a real lookalike_tld
+        # warning gets silently swallowed and the command allowed.
+        if val is not None and _APP_TLD_RE.search(str(val).lower()):
             return True
     return False

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -34,6 +34,7 @@ import tempfile
 import threading
 import time
 import urllib.request
+from urllib.parse import urlsplit
 
 from hermes_constants import get_hermes_home
 
@@ -830,12 +831,13 @@ def check_command_security(command: str) -> dict:
     _crash_count = 0
 
     # Parse JSON for enrichment (never overrides the exit code verdict)
-    findings = []
+    raw_findings = []
     summary = ""
     try:
         data = json.loads(result.stdout) if result.stdout.strip() else {}
-        raw_findings = data.get("findings", [])
-        findings = raw_findings[:_MAX_FINDINGS]
+        parsed_findings = data.get("findings", [])
+        if isinstance(parsed_findings, list):
+            raw_findings = parsed_findings
         summary = (data.get("summary", "") or "")[:_MAX_SUMMARY_LEN]
     except (json.JSONDecodeError, AttributeError):
         # JSON parse failure degrades findings/summary, not the verdict
@@ -850,39 +852,141 @@ def check_command_security(command: str) -> dict:
     # and the "can be confused with file extensions" heuristic generates false
     # positives for normal API calls.  Any other finding (including other
     # lookalike_tld entries for non-.app TLDs) preserves the warn action.
-    if action == "warn" and findings:
-        non_suppressible = [f for f in findings if not _is_app_tld_finding(f)]
-        if not non_suppressible:
+    if action == "warn" and raw_findings:
+        if all(_is_app_tld_finding(f) for f in raw_findings):
             action = "allow"
-            findings = []
+            raw_findings = []
             summary = ""
 
+    # Cap returned details only after the complete finding set has determined
+    # the verdict. Otherwise suppressible findings can fill the cap and hide a
+    # later non-.app threat, incorrectly downgrading warn to allow.
+    findings = raw_findings[:_MAX_FINDINGS]
     return {"action": action, "findings": findings, "summary": summary}
 
 
-# ``.app`` at a hostname boundary: a literal ``.app`` NOT followed by another
-# hostname char (``[a-z0-9-]``). Matches ``example.app`` / a bare ``.app`` /
-# ``'.app'`` in prose, but not ``.appspot`` / ``.apple`` / ``paypal.app-secure.com``.
-_APP_TLD_RE = re.compile(r"\.app(?![a-z0-9-])")
+_APP_TLD_RE = re.compile(r"\.app", re.IGNORECASE)
+_HOSTNAME_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-."
+)
+_HOSTNAME_START_DELIMITERS = frozenset(" \t\r\n'\"`([{</:@=")
+_HOSTNAME_END_DELIMITERS = frozenset(" \t\r\n'\"`/\\:?#,;!)]}>")
+
+
+def _structured_value_has_app_tld(value: object, *, tld_only: bool = False) -> bool:
+    """Return whether a structured TLD/hostname value ends in ``.app``."""
+    text = str(value).strip().strip("'\"")
+    if not text:
+        return False
+
+    normalized_tld = text.removeprefix(".").casefold()
+    if tld_only:
+        return normalized_tld == "app"
+    if text.casefold() == ".app":
+        return True
+    if any(char.isspace() for char in text):
+        return False
+
+    try:
+        parsed = urlsplit(text if "://" in text else f"//{text}")
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if not hostname:
+        return False
+
+    # A final DNS root dot is harmless in a structured hostname. Normalize
+    # internationalized labels to ASCII, then reject empty/malformed labels so
+    # ambiguous strings cannot masquerade as a hostname ending in ``app``.
+    try:
+        normalized_hostname = hostname.rstrip(".").encode("idna").decode("ascii").casefold()
+    except UnicodeError:
+        return False
+    labels = normalized_hostname.split(".")
+    labels_are_valid = all(
+        label
+        and len(label) <= 63
+        and label[0].isalnum()
+        and label[-1].isalnum()
+        and all(char.isalnum() or char == "-" for char in label)
+        for label in labels
+    )
+    return len(labels) >= 2 and labels_are_valid and labels[-1] == "app"
+
+
+def _free_text_has_only_terminal_app_mentions(value: object) -> bool | None:
+    """Classify ``.app`` mentions in prose conservatively.
+
+    True means every mention is a terminal hostname label, False means at
+    least one is continued or ambiguously delimited, and None means the field
+    does not mention ``.app`` at all.
+    """
+    text = str(value)
+    matches = list(_APP_TLD_RE.finditer(text))
+    if not matches:
+        return None
+
+    for match in matches:
+        # Walk back over an optional ASCII hostname and require a boundary.
+        start = match.start()
+        while start > 0 and text[start - 1] in _HOSTNAME_CHARS:
+            start -= 1
+        if start > 0 and text[start - 1] not in _HOSTNAME_START_DELIMITERS:
+            return False
+        if not _structured_value_has_app_tld(text[start:match.end()]):
+            return False
+
+        # A dot means another hostname label (or ambiguous trailing prose), and
+        # non-ASCII punctuation is deliberately not accepted as a delimiter.
+        end = match.end()
+        if end < len(text) and text[end] not in _HOSTNAME_END_DELIMITERS:
+            return False
+
+    return True
 
 
 def _is_app_tld_finding(finding: dict) -> bool:
     """Return True if this finding is a lookalike_tld warning for the .app TLD only.
 
-    Checks the rule_id and inspects common value/detail field names that
-    Tirith may use to carry the TLD string.
+    Prefer Tirith's structured URL evidence, whose normalized hostname must
+    end in the exact ``app`` label. Legacy structured fields follow the same
+    rule. Free-text fields are accepted only when every ``.app`` mention has
+    unambiguous hostname boundaries. A contradiction in any field is unsafe.
     """
     if not isinstance(finding, dict):
         return False
     if finding.get("rule_id") != "lookalike_tld":
         return False
-    for field in ("value", "tld", "detail", "description", "message"):
-        val = finding.get(field)
-        # Match the ``.app`` gTLD at a hostname boundary, not as a bare
-        # substring: ``.app`` followed by ``[a-z0-9-]`` is a different label
-        # or TLD (``.appspot``, ``.apple``, ``paypal.app-secure.com``) and must
-        # NOT be treated as the benign ``.app`` case, or a real lookalike_tld
-        # warning gets silently swallowed and the command allowed.
-        if val is not None and _APP_TLD_RE.search(str(val).lower()):
-            return True
-    return False
+
+    structured_checks = []
+    evidence = finding.get("evidence")
+    if isinstance(evidence, list):
+        for item in evidence:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "url" and item.get("raw") is not None:
+                structured_checks.append(_structured_value_has_app_tld(item["raw"]))
+            elif item.get("type") == "host_comparison" and item.get("raw_host") is not None:
+                structured_checks.append(_structured_value_has_app_tld(item["raw_host"]))
+
+    for field in ("host", "hostname", "domain", "value"):
+        if finding.get(field) is not None:
+            structured_checks.append(_structured_value_has_app_tld(finding[field]))
+    if finding.get("tld") is not None:
+        structured_checks.append(
+            _structured_value_has_app_tld(finding["tld"], tld_only=True)
+        )
+    if structured_checks and not all(structured_checks):
+        return False
+
+    free_text_checks = []
+    for field in ("detail", "description", "message"):
+        if finding.get(field) is None:
+            continue
+        check = _free_text_has_only_terminal_app_mentions(finding[field])
+        if check is not None:
+            free_text_checks.append(check)
+    if free_text_checks and not all(free_text_checks):
+        return False
+
+    return bool(structured_checks or free_text_checks)


### PR DESCRIPTION
## What does this PR do?

Two correctness/security fixes in the tirith command-security wrapper
(`tools/tirith_security.py`).

### 1. Circuit breaker resets on every real verdict (not just `allow`)

The breaker is documented to open after `_CRASH_LIMIT` **consecutive**
spawn/exec failures and reset "on successful execution", but `_crash_count = 0`
ran only in the `exit_code == 0` (allow) branch. A `block` (exit 1) and `warn`
(exit 2) are *also* successful tirith executions, yet neither reset the counter.

So a sequence like `timeout → block → timeout → block → timeout` accumulates the
crash count to `_CRASH_LIMIT` and **opens the breaker**, which disables tirith
process-wide (`if _circuit_open: return {"action": "allow", ...}` — fail-open,
no content scanning), even though tirith worked fine on every command in
between. Reset the counter for all three real verdicts (allow/block/warn).

### 2. `.app` TLD suppression matched a bare substring

`_is_app_tld_finding` used `".app" in str(value).lower()`. Any `lookalike_tld`
finding whose fields contain `.app` as a **substring** was treated as the
benign Google `.app` gTLD and its `warn` silently dropped (the command
allowed):

```
_is_app_tld_finding({"rule_id":"lookalike_tld","value":"paypal.app-secure.com"}) # True (wrong)
_is_app_tld_finding({"rule_id":"lookalike_tld","value":"login.appspot.com"})     # True (wrong)
_is_app_tld_finding({"rule_id":"lookalike_tld","value":"my.apple-id.com"})       # True (wrong)
```

Match `.app` at a hostname boundary instead — `\.app(?![a-z0-9-])` — which still
matches `example.app`, a bare `.app`, and `'.app'` in prose (all existing test
cases), but not `.appspot` / `.apple` / `paypal.app-secure.com`.

## Related Issue

No existing issue — found via a code audit of the security wrapper.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (a real lookalike-domain warning was being swallowed; the
  breaker could fail-open and stop scanning)

## Changes Made

- `tools/tirith_security.py` — reset `_crash_count` for allow/block/warn;
  add `import re` + `_APP_TLD_RE` and match `.app` at a hostname boundary.
- `tests/tools/test_tirith_security.py` — `TestCircuitBreakerReset`
  (interleaved crashes don't open the breaker) + over-match cases for
  `_is_app_tld_finding`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tirith_security.py -q` → all pass (46).
2. `_is_app_tld_finding({"rule_id":"lookalike_tld","value":"paypal.app-secure.com"})`
   is now `False`; the breaker stays closed across `crash,block,crash,block,crash`.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(tirith):`)
- [x] I searched for existing PRs (none touch the breaker reset or `.app` match)
- [x] Only changes related to these fixes
- [x] Affected test module passes — `tests/tools/test_tirith_security.py` (46). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`
