### PR TITLE
fix(gateway): accept a scalar events: in HOOK.yaml

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -111,6 +111,15 @@ class HookRegistry:
 
                 hook_name = manifest.get("name", hook_dir.name)
                 events = manifest.get("events", [])
+                # A single-event shorthand (`events: agent:start`) is a YAML
+                # scalar, not a list. Wrap it so it isn't iterated
+                # character-by-character (which would register the handler under
+                # 'a','g','e',… and silently never fire).
+                if isinstance(events, str):
+                    events = [events]
+                if not isinstance(events, list):
+                    print(f"[hooks] Skipping {hook_name}: 'events' must be a string or list", flush=True)
+                    continue
                 if not events:
                     print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)
                     continue

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -46,6 +46,23 @@ class TestDiscoverAndLoad:
         assert "agent:start" in reg.loaded_hooks[0]["events"]
 
 
+    def test_loads_hook_with_scalar_events(self, tmp_path):
+        # `events: agent:start` (a single-event YAML scalar, not a list) must
+        # register the handler under the whole event name — not iterated
+        # character-by-character under 'a','g','e',… (which silently never fires).
+        _create_hook(tmp_path, "scalar-hook", "agent:start",
+                      "def handle(event_type, context):\n    pass\n")
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert len(reg.loaded_hooks) == 1
+        assert "agent:start" in reg._handlers
+        assert "a" not in reg._handlers  # not registered per-character
+        assert reg.loaded_hooks[0]["events"] == ["agent:start"]
+
+
     def test_skips_no_events(self, tmp_path):
         hook_dir = tmp_path / "empty-hook"
         hook_dir.mkdir()


### PR DESCRIPTION
## What does this PR do?

`HookRegistry.discover_and_load` read `events = manifest.get("events", [])` and
iterated it directly. A single-event shorthand — the natural
`events: agent:start` (a YAML **scalar**, not a list) — passes the
`if not events:` guard as a non-empty string and is then iterated
**character-by-character**, so the handler is registered under `'a'`, `'g'`,
`'e'`, … instead of `"agent:start"`.

Worse, the load log then prints a false `Loaded hook '…' for events: agent:start`
success, and a later `emit("agent:start")` finds nothing registered — the hook
**silently never fires** and nothing is logged. (The empty-events case is
already handled gracefully; only the scalar case misbehaves.)

## Fix

Normalize a scalar to a one-element list, and skip with a clear message when
`events` is neither a string nor a list.

## Related Issue

No existing issue — found via a code audit of hook discovery.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/hooks.py` — wrap a scalar `events` into a list; guard non-list types.
- `tests/gateway/test_hooks.py` — regression test asserting a scalar `events:`
  registers under the full event name (and not per-character).

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_hooks.py -q` → all pass (8).
2. A hook with `events: agent:start` now registers under `"agent:start"`;
   pre-fix, `"a"` (and other single chars) were the registered handler keys.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs (none touch scalar `events` handling)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/gateway/test_hooks.py` (8). Full suite not run locally.
- [x] Added a regression test
- [x] Tested on: Ubuntu (WSL2), against current `main`
