### PR TITLE
fix(delegation): stall monitor and completions survive a busy state.db

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -15,6 +15,11 @@ DEFAULT_CONFIG = {
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).
     "database": {
         "journal_mode": "wal",
+        # How long a writer waits for a busy state.db before giving up. A
+        # long-lived gateway with a large WAL and several concurrent writers
+        # (sessions, delegations, delivery) routinely exceeds a few seconds;
+        # every such timeout surfaces as a failed durable write.
+        "busy_timeout_seconds": 30,
         # Optional WAL sizing pragmas, applied when set to integers.
         # None = SQLite defaults (autocheckpoint 1000 pages, no size limit).
         "wal_autocheckpoint": None,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -562,6 +562,35 @@ def resolve_journal_mode() -> str:
     return mode if mode in ("wal", "delete") else "wal"
 
 
+DEFAULT_BUSY_TIMEOUT_SECONDS = 30.0
+
+
+def resolve_busy_timeout_seconds() -> float:
+    """Return the configured SQLite busy timeout, in seconds.
+
+    ``database.busy_timeout_seconds`` in config.yaml is the canonical operator
+    setting: how long a writer waits for a contended state.db before raising
+    ``database is locked``. Operators with a large WAL or many concurrent
+    writers may need to raise it. Missing, malformed, or non-positive values
+    fail safely to the default rather than leaving writers with no wait
+    budget at all.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        database = config.get("database", {})
+        if not isinstance(database, dict):
+            return DEFAULT_BUSY_TIMEOUT_SECONDS
+        raw = database.get("busy_timeout_seconds", DEFAULT_BUSY_TIMEOUT_SECONDS)
+    except Exception:
+        return DEFAULT_BUSY_TIMEOUT_SECONDS
+
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return DEFAULT_BUSY_TIMEOUT_SECONDS
+    return float(raw) if raw > 0 else DEFAULT_BUSY_TIMEOUT_SECONDS
+
+
 class WalUnsupportedError(sqlite3.OperationalError):
     """Raised by :func:`apply_wal_with_fallback` when ``require_wal=True`` and
     the filesystem cannot provide WAL journal mode.

--- a/tests/test_journal_mode_config.py
+++ b/tests/test_journal_mode_config.py
@@ -226,3 +226,43 @@ def test_real_db_openers_honor_configured_delete(monkeypatch, tmp_path):
         "holographic": "delete",
         "response_store": "delete",
     }
+
+
+# --- database.busy_timeout_seconds ------------------------------------------
+
+
+def _configure_busy_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, value: object
+) -> None:
+    _write_config(
+        monkeypatch, tmp_path, {"database": {"busy_timeout_seconds": value}}
+    )
+
+
+def test_database_busy_timeout_has_a_canonical_default():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["database"]["busy_timeout_seconds"] == 30
+
+
+def test_resolve_busy_timeout_uses_real_database_config(monkeypatch, tmp_path):
+    from hermes_state import resolve_busy_timeout_seconds
+
+    _configure_busy_timeout(monkeypatch, tmp_path, 90)
+    assert resolve_busy_timeout_seconds() == 90.0
+
+
+def test_resolve_busy_timeout_defaults_when_unset(monkeypatch, tmp_path):
+    from hermes_state import resolve_busy_timeout_seconds
+
+    _write_config(monkeypatch, tmp_path, {"database": {}})
+    assert resolve_busy_timeout_seconds() == 30.0
+
+
+@pytest.mark.parametrize("bad", ["nonsense", -5, 0, None, {"a": 1}])
+def test_resolve_busy_timeout_rejects_unusable_values(monkeypatch, tmp_path, bad):
+    """A malformed operator setting must not leave writers with no wait budget."""
+    from hermes_state import resolve_busy_timeout_seconds
+
+    _configure_busy_timeout(monkeypatch, tmp_path, bad)
+    assert resolve_busy_timeout_seconds() == 30.0

--- a/tests/test_journal_mode_config.py
+++ b/tests/test_journal_mode_config.py
@@ -239,10 +239,31 @@ def _configure_busy_timeout(
     )
 
 
-def test_database_busy_timeout_has_a_canonical_default():
-    from hermes_cli.config import DEFAULT_CONFIG
+def test_database_busy_timeout_default_matches_the_resolver_fallback():
+    """The shipped config and the resolver must agree on the default.
 
-    assert DEFAULT_CONFIG["database"]["busy_timeout_seconds"] == 30
+    Asserted as a relationship, not a literal, so tuning the default is a
+    one-line change instead of a test-churn exercise.
+    """
+    from hermes_cli.config import DEFAULT_CONFIG
+    from hermes_state import DEFAULT_BUSY_TIMEOUT_SECONDS
+
+    assert (
+        DEFAULT_CONFIG["database"]["busy_timeout_seconds"]
+        == DEFAULT_BUSY_TIMEOUT_SECONDS
+    )
+
+
+def test_default_busy_timeout_is_a_usable_wait_budget():
+    """Guards the relationship tests above from passing vacuously.
+
+    Every fallback assertion compares against this constant, so a default of
+    0 or a negative would satisfy all of them while leaving writers with no
+    wait budget at all.
+    """
+    from hermes_state import DEFAULT_BUSY_TIMEOUT_SECONDS
+
+    assert DEFAULT_BUSY_TIMEOUT_SECONDS > 0
 
 
 def test_resolve_busy_timeout_uses_real_database_config(monkeypatch, tmp_path):
@@ -255,14 +276,19 @@ def test_resolve_busy_timeout_uses_real_database_config(monkeypatch, tmp_path):
 def test_resolve_busy_timeout_defaults_when_unset(monkeypatch, tmp_path):
     from hermes_state import resolve_busy_timeout_seconds
 
+    from hermes_state import DEFAULT_BUSY_TIMEOUT_SECONDS
+
     _write_config(monkeypatch, tmp_path, {"database": {}})
-    assert resolve_busy_timeout_seconds() == 30.0
+    assert resolve_busy_timeout_seconds() == DEFAULT_BUSY_TIMEOUT_SECONDS
 
 
 @pytest.mark.parametrize("bad", ["nonsense", -5, 0, None, {"a": 1}])
 def test_resolve_busy_timeout_rejects_unusable_values(monkeypatch, tmp_path, bad):
     """A malformed operator setting must not leave writers with no wait budget."""
-    from hermes_state import resolve_busy_timeout_seconds
+    from hermes_state import (
+        DEFAULT_BUSY_TIMEOUT_SECONDS,
+        resolve_busy_timeout_seconds,
+    )
 
     _configure_busy_timeout(monkeypatch, tmp_path, bad)
-    assert resolve_busy_timeout_seconds() == 30.0
+    assert resolve_busy_timeout_seconds() == DEFAULT_BUSY_TIMEOUT_SECONDS

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -8,6 +8,7 @@ formatting, capacity rejection, and crash handling.
 import json
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -729,3 +730,104 @@ def test_gateway_cli_origin_event_left_unrouted():
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
 
+
+
+# --- Stale-monitor resilience to durable-store failures (#76xxx) -------------
+#
+# Regression guard for a production hang: a `database is locked` raised by
+# _persist_completion inside _finalize_stalled propagated out of
+# _stale_monitor_loop and killed the monitor thread. Because
+# _persist_completion runs BEFORE the queue put, the owning session never
+# heard the terminal event either — the delegation stayed 'running' forever
+# and the parent blocked on a child that would never report.
+
+
+def test_stalled_finalization_survives_persistence_failure(monkeypatch):
+    """A locked durable store must not swallow the terminal stall event.
+
+    Persistence is best-effort bookkeeping; the in-memory completion queue is
+    what unblocks the waiting parent. If the DB write fails, the event must
+    still be delivered.
+    """
+    _fast_stale_monitor(monkeypatch)
+
+    def _boom(event, result):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(ad, "_persist_completion", _boom)
+
+    gate = threading.Event()
+
+    def stuck_runner():
+        gate.wait(timeout=10)
+        return {"status": "completed", "summary": "too late"}
+
+    res = ad.dispatch_async_delegation(
+        goal="stuck child", context=None, toolsets=None, role="leaf",
+        model="m", session_key="", runner=stuck_runner,
+        max_async_children=1,
+        progress_fn=lambda: ((0, None), False),
+    )
+    assert res["status"] == "dispatched"
+
+    evt = _drain_for(res["delegation_id"], timeout=5.0)
+    try:
+        assert evt is not None, (
+            "terminal stall event was lost because the durable write failed"
+        )
+        assert evt["status"] == "stalled"
+        assert evt["delegation_id"] == res["delegation_id"]
+    finally:
+        gate.set()
+
+
+def test_stale_monitor_keeps_sweeping_after_persistence_failure(monkeypatch):
+    """One failing finalization must not kill the monitor for everyone else.
+
+    The monitor is a single module-level thread shared by every dispatch. An
+    exception escaping the sweep loop takes down stall detection for all
+    in-flight delegations, not just the one that failed.
+    """
+    _fast_stale_monitor(monkeypatch)
+
+    real_persist = ad._persist_completion
+    calls = {"n": 0}
+
+    def _boom_once(event, result):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return real_persist(event, result)
+
+    monkeypatch.setattr(ad, "_persist_completion", _boom_once)
+
+    gate = threading.Event()
+
+    def stuck_runner():
+        gate.wait(timeout=10)
+        return {"status": "completed", "summary": "too late"}
+
+    first = ad.dispatch_async_delegation(
+        goal="first stuck child", context=None, toolsets=None, role="leaf",
+        model="m", session_key="", runner=stuck_runner,
+        max_async_children=2,
+        progress_fn=lambda: ((0, None), False),
+    )
+    assert _drain_for(first["delegation_id"], timeout=5.0) is not None
+
+    # Second delegation stalls after the monitor already hit the DB error.
+    second = ad.dispatch_async_delegation(
+        goal="second stuck child", context=None, toolsets=None, role="leaf",
+        model="m", session_key="", runner=stuck_runner,
+        max_async_children=2,
+        progress_fn=lambda: ((0, None), False),
+    )
+    try:
+        evt = _drain_for(second["delegation_id"], timeout=5.0)
+        assert evt is not None, (
+            "monitor thread died on the first failure; the second stalled "
+            "delegation was never finalized"
+        )
+        assert evt["status"] == "stalled"
+    finally:
+        gate.set()

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -831,3 +831,21 @@ def test_stale_monitor_keeps_sweeping_after_persistence_failure(monkeypatch):
         assert evt["status"] == "stalled"
     finally:
         gate.set()
+
+
+def test_connect_applies_configured_busy_timeout(tmp_path, monkeypatch):
+    """Writers must wait out a busy store instead of failing in seconds.
+
+    A gateway with a large WAL and several concurrent writers exhausts a
+    short budget routinely, and every such timeout costs a completion. The
+    budget is an operator setting (database.busy_timeout_seconds), so
+    _connect must read it rather than hardcode one.
+    """
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(ad, "resolve_busy_timeout_seconds", lambda: 45.0)
+    conn = ad._connect()
+    try:
+        busy_ms = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    finally:
+        conn.close()
+    assert busy_ms == 45_000

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -282,6 +282,28 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def _persist_durable_completion(
+    event: Dict[str, Any], result: Dict[str, Any], delegation_id: Any
+) -> None:
+    """Persist a completion, degrading to in-memory-only if the store fails.
+
+    The durable row is a redelivery aid; the completion QUEUE is what actually
+    unblocks the waiting parent. Letting a store failure propagate inverts
+    that priority — it aborts the queue put that follows, so a transient
+    ``database is locked`` costs the session its result entirely and the
+    delegation is left looking permanently ``running``.
+    """
+    try:
+        _persist_completion(event, result)
+    except Exception as exc:  # noqa: BLE001 — durable store is best-effort
+        logger.error(
+            "Async delegation %s: durable completion write failed (%s); "
+            "delivering in-memory only — the result reaches the session but "
+            "will not survive a gateway restart.",
+            delegation_id, exc,
+        )
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -865,7 +887,7 @@ def _push_completion_event(
     ):
         if _k in result:
             evt[_k] = result[_k]
-    _persist_completion(evt, result)
+    _persist_durable_completion(evt, result, record.get("delegation_id"))
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1074,7 +1096,7 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
+    _persist_durable_completion(evt, combined, event_record.get("delegation_id"))
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1123,78 +1145,94 @@ def _stale_monitor_loop() -> None:
       runner return after that is ignored by ``_begin_finalization``.
     """
     while not _monitor_stop.wait(_STALE_CHECK_INTERVAL):
-        now = time.time()
-        stalled: List[tuple] = []  # (delegation_id, is_batch, quiet_for, in_tool)
-        expired: List[str] = []  # stalling past grace → force-finalize
-        any_monitorable = False
-        with _records_lock:
-            for record in _records.values():
-                status = record.get("status")
-                if status == "stalling":
-                    any_monitorable = True
-                    interrupted_at = record.get("_interrupted_at") or now
-                    if now - interrupted_at >= _STALL_GRACE_SECONDS:
-                        expired.append(record["delegation_id"])
-                    continue
-                if status != "running":
-                    continue
-                progress_fn = record.get("progress_fn")
-                if progress_fn is None:
-                    continue
-                any_monitorable = True
-                try:
-                    token, in_tool = progress_fn()
-                except Exception:
-                    # An unreadable child must not look permanently healthy —
-                    # keep the last timestamp running instead of refreshing it.
-                    token, in_tool = record.get("_progress_token"), False
-                if token != record.get("_progress_token"):
-                    record["_progress_token"] = token
-                    record["_progress_ts"] = now
-                    continue
-                quiet_for = now - (record.get("_progress_ts") or now)
-                limit = (
-                    _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
-                )
-                if quiet_for >= limit:
-                    record["status"] = "stalling"
-                    record["_interrupted_at"] = now
-                    # Structured stall context for the terminal event and
-                    # status listings (#51690): how long progress was frozen,
-                    # which threshold applied, and whether the child was
-                    # inside a tool when it went quiet.
-                    record["_stall_quiet_seconds"] = round(quiet_for, 2)
-                    record["_stall_threshold_seconds"] = limit
-                    record["_stall_in_tool"] = bool(in_tool)
-                    stalled.append(
-                        (
-                            record["delegation_id"],
-                            bool(record.get("is_batch")),
-                            quiet_for,
-                            in_tool,
-                        )
-                    )
-        for delegation_id, _is_batch, quiet_for, in_tool in stalled:
-            logger.warning(
-                "Async delegation %s made no progress for %.0fs "
-                "(in_tool=%s) — interrupting; grace window %.0fs",
-                delegation_id, quiet_for, in_tool, _STALL_GRACE_SECONDS,
+        try:
+            any_monitorable = _stale_monitor_sweep()
+        except Exception:  # noqa: BLE001 — the monitor must outlive any sweep
+            # One monitor thread serves every dispatch, so an escaping
+            # exception disables stall detection process-wide: in-flight
+            # delegations that later wedge are never force-finalized and
+            # their parents wait forever. Log and keep sweeping instead.
+            logger.exception(
+                "Stale-delegation sweep failed; monitor continues"
             )
-            with _records_lock:
-                record = _records.get(delegation_id)
-                fn = record.get("interrupt_fn") if record else None
-            if callable(fn):
-                try:
-                    fn()
-                except Exception as exc:
-                    logger.debug(
-                        "Async delegation %s stall interrupt failed: %s",
-                        delegation_id, exc,
-                    )
-        for delegation_id in expired:
-            _finalize_stalled(delegation_id)
+            continue
         if not any_monitorable:
             return
+
+
+def _stale_monitor_sweep() -> bool:
+    """Run one sweep. Returns whether any record is still worth monitoring."""
+    now = time.time()
+    stalled: List[tuple] = []  # (delegation_id, is_batch, quiet_for, in_tool)
+    expired: List[str] = []  # stalling past grace → force-finalize
+    any_monitorable = False
+    with _records_lock:
+        for record in _records.values():
+            status = record.get("status")
+            if status == "stalling":
+                any_monitorable = True
+                interrupted_at = record.get("_interrupted_at") or now
+                if now - interrupted_at >= _STALL_GRACE_SECONDS:
+                    expired.append(record["delegation_id"])
+                continue
+            if status != "running":
+                continue
+            progress_fn = record.get("progress_fn")
+            if progress_fn is None:
+                continue
+            any_monitorable = True
+            try:
+                token, in_tool = progress_fn()
+            except Exception:
+                # An unreadable child must not look permanently healthy —
+                # keep the last timestamp running instead of refreshing it.
+                token, in_tool = record.get("_progress_token"), False
+            if token != record.get("_progress_token"):
+                record["_progress_token"] = token
+                record["_progress_ts"] = now
+                continue
+            quiet_for = now - (record.get("_progress_ts") or now)
+            limit = (
+                _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
+            )
+            if quiet_for >= limit:
+                record["status"] = "stalling"
+                record["_interrupted_at"] = now
+                # Structured stall context for the terminal event and
+                # status listings (#51690): how long progress was frozen,
+                # which threshold applied, and whether the child was
+                # inside a tool when it went quiet.
+                record["_stall_quiet_seconds"] = round(quiet_for, 2)
+                record["_stall_threshold_seconds"] = limit
+                record["_stall_in_tool"] = bool(in_tool)
+                stalled.append(
+                    (
+                        record["delegation_id"],
+                        bool(record.get("is_batch")),
+                        quiet_for,
+                        in_tool,
+                    )
+                )
+    for delegation_id, _is_batch, quiet_for, in_tool in stalled:
+        logger.warning(
+            "Async delegation %s made no progress for %.0fs "
+            "(in_tool=%s) — interrupting; grace window %.0fs",
+            delegation_id, quiet_for, in_tool, _STALL_GRACE_SECONDS,
+        )
+        with _records_lock:
+            record = _records.get(delegation_id)
+            fn = record.get("interrupt_fn") if record else None
+        if callable(fn):
+            try:
+                fn()
+            except Exception as exc:
+                logger.debug(
+                    "Async delegation %s stall interrupt failed: %s",
+                    delegation_id, exc,
+                )
+    for delegation_id in expired:
+        _finalize_stalled(delegation_id)
+    return any_monitorable
 
 
 def _finalize_stalled(delegation_id: str) -> None:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_state import resolve_busy_timeout_seconds
 from tools.daemon_pool import DaemonThreadPoolExecutor
 from tools.thread_context import propagate_context_to_thread
 
@@ -123,8 +124,13 @@ def _db_path():
 def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path, timeout=10)
+    busy_timeout = resolve_busy_timeout_seconds()
+    conn = sqlite3.connect(path, timeout=busy_timeout)
     try:
+        # connect(timeout=) already seeds busy_timeout, but stating the pragma
+        # keeps the wait budget greppable next to the other state.db openers
+        # and survives any future connection-factory swap.
+        conn.execute(f"PRAGMA busy_timeout = {int(busy_timeout * 1000)}")
         _initialize_schema(conn)
     except Exception:
         # A PRAGMA/DDL failure after a successful connect() must not leak the


### PR DESCRIPTION
## What breaks today

A gateway with several concurrent sessions writing to `state.db` hits
`sqlite3.OperationalError: database is locked` inside `_persist_completion`.
That exception propagates out of `_stale_monitor_loop` and kills the
module-level monitor thread:

```
Exception in thread async-delegate-stale-monitor:
  tools/async_delegation.py:1165 in _stale_monitor_loop
  tools/async_delegation.py:1213 in _finalize_stalled
  tools/async_delegation.py:1047 in _push_batch_completion_event
  tools/async_delegation.py:276  in _persist_completion
sqlite3.OperationalError: database is locked
```

Two independent defects line up to make this unrecoverable:

**1. A failed durable write also kills the in-memory delivery.**
`_push_completion_event` calls `_persist_completion(evt, result)` *before*
`process_registry.completion_queue.put(evt)`. When the persist raises, the
queue put never runs. Its own docstring already states the intended contract
— *"Best-effort: a failure here must not crash the worker"* — but the call
itself does not honour it. Since `_begin_finalization` has already claimed
the record, nothing retries. The delegation stays `running` forever and the
parent session blocks on a child that can no longer report.

**2. The sweep loop has no exception guard.**
One monitor thread serves every dispatch, so an escaping exception disables
stall detection process-wide. `_ensure_stale_monitor()` respawns the thread on
the next dispatch, but the respawned thread hits the same wall on the next
stalled record.

Reproduced on a busy gateway: the same crash recurred five times over one
evening, each occurrence orphaning one delegation. Six were left `running`,
the oldest for 6.5 hours. From the user's side the agent is simply hung —
sessions wait on subagents that will never return.

## The fix

**Commit 1 — keep the monitor alive.**
- `_persist_durable_completion()` wraps the persist in a total guard, logs
  loudly, and lets delivery proceed. The durable row is a redelivery aid; the
  queue is what unblocks the parent. The current ordering inverts that
  priority.
- `_stale_monitor_sweep()` extracts the sweep body so `_stale_monitor_loop`
  can wrap one iteration in a guard and keep sweeping. This accounts for most
  of the line count in the diff — the sweep logic is unchanged, only
  re-indented.

**Commit 2 — make the wait budget configurable.**
`_connect()` opened `state.db` with a hardcoded `timeout=10`, which is both
thin for a large WAL and untunable. Adds `database.busy_timeout_seconds`
(default 30) next to the existing `database.journal_mode`, resolved by
`resolve_busy_timeout_seconds()` in `hermes_state`. Missing, malformed, or
non-positive values fall back to the default rather than leaving writers with
no wait budget at all.

Commit 1 alone fixes the hang; commit 2 makes the timeout less likely to fire
at all. They are separable if you want only one.

## Tests

Regression tests, all verified failing against `main` before the fix:

| Test | Fails on main with |
|---|---|
| `test_stalled_finalization_survives_persistence_failure` | terminal stall event lost — reproduces the traceback above |
| `test_stale_monitor_keeps_sweeping_after_persistence_failure` | second stalled delegation never finalized |
| `test_connect_applies_configured_busy_timeout` | `AttributeError` — no resolver to configure |
| `test_database_busy_timeout_has_a_canonical_default` + 7 resolver cases | `KeyError` / `ImportError` |

Suites run green (247 in the final pass, 347 across the full set):

```
tests/tools/test_async_delegation.py
tests/tools/test_async_delegation_fd_leak.py
tests/tools/test_restored_delegation_ownership.py
tests/tools/test_delegation_live_log.py
tests/tools/test_delegate.py
tests/tools/test_delegate_apiserver_background.py
tests/tools/test_delegate_subagent_timeout_diagnostic.py
tests/cli/test_cli_async_delegation_delivery.py
tests/cli/test_cli_background_status_indicator.py
tests/tui_gateway/test_delegation_session_lifecycle.py
tests/tools/test_process_registry.py
tests/gateway/test_async_delivery_capability.py
tests/test_journal_mode_config.py
tests/test_hermes_state.py
```

`ruff check` clean on all touched files.

Note: `tests/hermes_cli/ -k config` has 5 failures on this branch, but they
reproduce identically on `main` at `8ced76d61` and pass in isolation — a
pre-existing ordering issue, unrelated to this change.

## Notes

- Behaviour change worth calling out: when the durable write fails, the
  completion now reaches the session but **does not survive a gateway
  restart**. That is a deliberate downgrade from "lost entirely" to
  "delivered but not replayable", and it is logged at ERROR.
- `resolve_busy_timeout_seconds()` is applied only to the async-delegation
  opener here, to keep this PR scoped to the hang. Adopting it in the other
  `state.db` openers is a natural follow-up.
- Related but not addressed: the `state.db` growth that makes locks likely in
  the first place (multi-GB file, two FTS indexes, WAL that never checkpoints
  while a long-lived reader is attached). That needs a retention policy —
  separate PR.
