### PR TITLE
fix(doctor): honor a provider profile's models_url when base_url is empty

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -667,9 +667,15 @@ def _build_apikey_providers_list() -> list:
             )
             if not _key_vars:
                 continue
+            # ``models_url`` is the explicit models endpoint; ``base_url`` only
+            # provides the ``{base_url}/models`` fallback (providers/base.py).
+            # The ``if _pp.base_url else None`` guard must wrap only the
+            # fallback, not the whole expression — otherwise a profile that
+            # sets ``models_url`` without a ``base_url`` loses its endpoint and
+            # doctor probes ``None`` (spurious "couldn't verify").
             _models_url = (
-                (_pp.models_url or (_pp.base_url.rstrip("/") + "/models"))
-                if _pp.base_url else None
+                _pp.models_url
+                or (_pp.base_url.rstrip("/") + "/models" if _pp.base_url else None)
             )
             _hc = getattr(_pp, "supports_health_check", True)
             _static.append((_label, _key_vars, _models_url, _base_var, _hc))

--- a/tests/hermes_cli/test_doctor_apikey_models_url.py
+++ b/tests/hermes_cli/test_doctor_apikey_models_url.py
@@ -1,0 +1,56 @@
+"""Regression: hermes doctor must honor a provider profile's explicit
+``models_url`` even when it declares no ``base_url``.
+
+``ProviderProfile.models_url`` is the explicit models endpoint; ``base_url``
+only supplies the ``{base_url}/models`` fallback (providers/base.py). In
+``_build_apikey_providers_list`` the ``if base_url else None`` guard wrapped the
+whole expression, so a profile with ``models_url`` but no ``base_url`` lost its
+endpoint (``default_url=None``) and doctor probed ``None`` — a spurious yellow
+"couldn't verify" even with a valid key and a good models endpoint.
+"""
+
+from __future__ import annotations
+
+
+def test_build_apikey_providers_list_honors_models_url_without_base_url(monkeypatch):
+    from hermes_cli import doctor
+    from providers.base import ProviderProfile
+
+    stub = ProviderProfile(
+        name="foo-audit-only",          # not a known/dedicated provider name
+        display_name="Foo AI",
+        env_vars=("FOO_API_KEY",),
+        models_url="https://api.foo.ai/v1/models",
+        base_url="",                     # explicit models_url, no base_url
+        auth_type="api_key",
+    )
+    monkeypatch.setattr("providers.list_providers", lambda: [stub])
+
+    entries = doctor._build_apikey_providers_list()
+
+    # Tuple shape: (display_name, env_vars, default_url, base_env, supports_health_check)
+    foo = [e for e in entries if e[0] == "Foo AI"]
+    assert foo, f"stub provider missing from list: {sorted(e[0] for e in entries)}"
+    assert foo[0][2] == "https://api.foo.ai/v1/models", (
+        "explicit models_url must be kept even when base_url is empty; "
+        f"got default_url={foo[0][2]!r}"
+    )
+
+
+def test_build_apikey_providers_list_falls_back_to_base_url(monkeypatch):
+    """When only base_url is set, the endpoint is still {base_url}/models."""
+    from hermes_cli import doctor
+    from providers.base import ProviderProfile
+
+    stub = ProviderProfile(
+        name="bar-audit-only",
+        display_name="Bar AI",
+        env_vars=("BAR_API_KEY",),
+        base_url="https://api.bar.ai/v1",
+        auth_type="api_key",
+    )
+    monkeypatch.setattr("providers.list_providers", lambda: [stub])
+
+    entries = doctor._build_apikey_providers_list()
+    bar = [e for e in entries if e[0] == "Bar AI"]
+    assert bar and bar[0][2] == "https://api.bar.ai/v1/models"


### PR DESCRIPTION
## What does this PR do?

`_build_apikey_providers_list` computed the models-endpoint URL as:

```python
_models_url = (
    (_pp.models_url or (_pp.base_url.rstrip("/") + "/models"))
    if _pp.base_url else None
)
```

The `if _pp.base_url else None` guard wraps the **whole** expression, so a
`ProviderProfile` that sets an explicit `models_url` but no `base_url` ends up
with `default_url=None`. But `ProviderProfile.models_url` is documented as the
**explicit** models endpoint, with `base_url` only supplying the
`{base_url}/models` fallback (`providers/base.py:55`). So a valid endpoint is
silently dropped: `_probe_apikey_provider` then calls `httpx.get(None, ...)`
and doctor always shows a spurious yellow "⚠ … couldn't verify" for that
provider, even with a valid key and a perfectly good models endpoint.

## Fix

Honor `models_url` independently; the `if base_url` guard now wraps only the
fallback:

```python
_models_url = (
    _pp.models_url
    or (_pp.base_url.rstrip("/") + "/models" if _pp.base_url else None)
)
```

Orthogonal to the open #9823 (which fixes double-appending `/models` in the
probe-time `_build_models_url`) — different function, different bug.

## Related Issue

No existing issue — found via a code audit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py` — honor `models_url` when `base_url` is empty.
- `tests/hermes_cli/test_doctor_apikey_models_url.py` — regression tests for the
  models_url-only and base_url-only cases.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_doctor_apikey_models_url.py -q` → all pass.
2. A profile with `models_url` set and `base_url=""` now yields that
   `models_url` as the doctor probe URL instead of `None`.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(doctor):`)
- [x] I searched for existing PRs (orthogonal to #9823; none fix this)
- [x] Only changes related to this fix
- [x] Affected tests pass (3, incl. the adjacent dedicated-skip test). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`
