### PR TITLE
fix(desktop): settle final reply onto interim even after message.start reset the boundary flag

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -560,25 +560,29 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (existing.interim && (responsePreviewed || finalContinuesInterim)) {
+            } else if ((interimBoundaryPending && responsePreviewed) || finalContinuesInterim) {
               // Settle the interim in place instead of creating a duplicate —
-              // the DB has one row, so the live UI must agree. Previously this
-              // was gated on `responsePreviewed` alone, so a NON-previewed
-              // tool-call turn whose final matched its sealed interim appended a
-              // second bubble (the "renders twice: partial first copy + clean
-              // final" bug, #63679). `finalContinuesInterim` closes that gap
-              // for ordinary tool-call turns while `responsePreviewed` still
-              // covers the verify-on-stop continuation-budget case even when the
-              // final text was rewritten and no longer shares a prefix.
+              // the DB has one row, so the live UI must agree. Two distinct
+              // settle paths with different boundary requirements:
               //
-              // We key on the message's OWN durable `interim` state, not the
-              // session's volatile `interimBoundaryPending` flag: the flag is
-              // reset to false by a subsequent `message.start` (a chained turn,
-              // follow-up, or mid-turn compaction). When that reset lands
-              // between this turn's `message.interim` and `message.complete`, the
-              // flag-based gate wrongly fell through to appending a duplicate
-              // bubble (#74560). The message row still says `interim`, so the
-              // continuation merges correctly regardless of the flag.
+              // • responsePreviewed covers the verify-on-stop continuation-
+              //   budget case, where the final may be a rewrite sharing no
+              //   prefix with the interim. Because there is no continuity
+              //   guarantee, it must stay gated on the session's
+              //   `interimBoundaryPending` flag: after a new `message.start`
+              //   resets the flag, a previewed final is a DISTINCT reply and
+              //   must append its own bubble, never overwrite the interim
+              //   (otherwise interim('old') → message.start →
+              //   complete({response_previewed: true, text: 'new'}) would
+              //   silently destroy 'old').
+              //
+              // • finalContinuesInterim (prefix-either-way continuity, same
+              //   text or one a prefix of the other) is safe to settle
+              //   flag-free: continuity can only hold for the SAME message,
+              //   so a `message.start` reset landing between this turn's
+              //   `message.interim` and `message.complete` must not force an
+              //   append of a duplicate bubble (#74560). This also closes the
+              //   non-previewed tool-call gap from #63679.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -560,7 +560,7 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (interimBoundaryPending && (responsePreviewed || finalContinuesInterim)) {
+            } else if (existing.interim && (responsePreviewed || finalContinuesInterim)) {
               // Settle the interim in place instead of creating a duplicate —
               // the DB has one row, so the live UI must agree. Previously this
               // was gated on `responsePreviewed` alone, so a NON-previewed
@@ -570,6 +570,15 @@ export function useMessageStream({
               // for ordinary tool-call turns while `responsePreviewed` still
               // covers the verify-on-stop continuation-budget case even when the
               // final text was rewritten and no longer shares a prefix.
+              //
+              // We key on the message's OWN durable `interim` state, not the
+              // session's volatile `interimBoundaryPending` flag: the flag is
+              // reset to false by a subsequent `message.start` (a chained turn,
+              // follow-up, or mid-turn compaction). When that reset lands
+              // between this turn's `message.interim` and `message.complete`, the
+              // flag-based gate wrongly fell through to appending a duplicate
+              // bubble (#74560). The message row still says `interim`, so the
+              // continuation merges correctly regardless of the flag.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -217,6 +217,23 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+  it('settles final onto interim even after message.start reset the boundary flag (#74560)', async () => {
+    await mountStream()
+    await start()
+    await delta('partial')
+    await interim('partial')
+    // A chained turn / follow-up re-emits message.start, which resets
+    // interimBoundaryPending to false BEFORE the same turn's message.complete.
+    // The continuation must still settle onto the interim — not append a
+    // duplicate bubble. Regression for #74560.
+    await start()
+    await complete('partial answer continued')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.includes('partial'))).toHaveLength(1)
+    expect(texts[0]).toBe('partial answer continued')
+  })
+
   it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -234,6 +234,26 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+  it('appends a distinct previewed final after a message.start reset instead of overwriting the interim', async () => {
+    await mountStream()
+    await start()
+    await interim('old interim text')
+    // A genuinely new turn begins — message.start resets interimBoundaryPending.
+    // Production ordering: mid-turn compaction-resume events do NOT include
+    // message.start (COMPACTION_RESUME_EVENT_TYPES in gateway-event.ts), and
+    // the TUI gateway emits message.complete BEFORE goal-followup starts
+    // (tui_gateway/server.py), so a previewed final arriving after the reset
+    // is a DISTINCT reply, not a rewrite of the interim. It must append its
+    // own bubble — never overwrite the old one (sweeper review on #76583).
+    await start()
+    await completePreviewed('totally new answer')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('old interim text')
+    expect(texts).toContain('totally new answer')
+    expect(texts).toHaveLength(2)
+  })
+
   it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
     await mountStream()
     await start()


### PR DESCRIPTION
## What does this PR do?

Key the interim-settle merge in use-message-stream completeAssistantMessage on the message's own interim state instead of the volatile session flag `interimBoundaryPending`.

## Related Issue

Fixes #74560 — the reported desktop double-render where a message.start resetting the interimBoundaryPending flag before the same turn's message.complete made the UI append a duplicate assistant bubble.

Root cause and the completed fix shape (key the merge on the message's own existing.interim instead of the volatile session flag) were provided by @J-10VigorousDragon in the issue, including a proposed patch; this PR implements that approach with an added regression test.

## Changes Made

- `fix/desktop-interim-double-render` — 2 file(s) changed vs base:
  - `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`
  - `apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx`

In apps/desktop/src/app/session/hooks/use-message-stream/index.ts, the merge branch now checks existing.interim (durable message state) instead of the session-scoped interimBoundaryPending flag (reset to false by a chained message.start). finalContinuesInterim still requires prefix continuity, so genuinely distinct replies append as their own bubble as before.

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: vitest regression: fixed leg 15/15 pass; reverted buggy gate fails new test (got 2 wanted 1). Full desktop ui project 379 files/3289 tests pass. tsc clean on changed files.
2. Duplicate check: 40 potential matches reviewed — none covers this change.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: vitest regression: fixed leg 15/15 pass; reverted buggy gate fails new test (got 2 wanted 1). Full desktop ui project 379 files/3289 tests pass. tsc clean on changed files.
```

