### PR TITLE
fix(plugin-llm): forward the trusted agent_id override to the completion

### DIFF
--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -654,6 +654,7 @@ class PluginLlm:
             provider_override=eff_provider,
             model_override=eff_model,
             profile_override=eff_profile,
+            agent_id_override=eff_agent,
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
@@ -739,6 +740,7 @@ class PluginLlm:
             provider_override=eff_provider,
             model_override=eff_model,
             profile_override=eff_profile,
+            agent_id_override=eff_agent,
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
@@ -801,6 +803,7 @@ class PluginLlm:
             provider_override=eff_provider,
             model_override=eff_model,
             profile_override=eff_profile,
+            agent_id_override=eff_agent,
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
@@ -866,6 +869,7 @@ class PluginLlm:
             provider_override=eff_provider,
             model_override=eff_model,
             profile_override=eff_profile,
+            agent_id_override=eff_agent,
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
@@ -923,6 +927,7 @@ class PluginLlm:
         provider_override: Optional[str],
         model_override: Optional[str],
         profile_override: Optional[str],
+        agent_id_override: Optional[str] = None,
         temperature: Optional[float],
         max_tokens: Optional[int],
         timeout: Optional[float],
@@ -937,6 +942,7 @@ class PluginLlm:
                 provider_override=provider_override,
                 model_override=model_override,
                 profile_override=profile_override,
+                agent_id_override=agent_id_override,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 timeout=timeout,
@@ -946,6 +952,8 @@ class PluginLlm:
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
+        if agent_id_override:
+            merged_extra.setdefault("metadata", {})["agent_id"] = agent_id_override
         response = call_llm(
             task=None,
             provider=provider_override,
@@ -970,6 +978,7 @@ class PluginLlm:
         provider_override: Optional[str],
         model_override: Optional[str],
         profile_override: Optional[str],
+        agent_id_override: Optional[str] = None,
         temperature: Optional[float],
         max_tokens: Optional[int],
         timeout: Optional[float],
@@ -981,6 +990,7 @@ class PluginLlm:
                 provider_override=provider_override,
                 model_override=model_override,
                 profile_override=profile_override,
+                agent_id_override=agent_id_override,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 timeout=timeout,
@@ -990,6 +1000,8 @@ class PluginLlm:
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
+        if agent_id_override:
+            merged_extra.setdefault("metadata", {})["agent_id"] = agent_id_override
         response = await async_call_llm(
             task=None,
             provider=provider_override,

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -324,9 +324,39 @@ class TestPluginLlmFacade:
         assert captured["provider_override"] == "anthropic"
         assert captured["model_override"] == "claude-3-opus"
         assert captured["profile_override"] == "work"
+        # agent_id must actually reach the caller — not just be recorded on the
+        # result. Regression: eff_agent was validated + written to result.agent_id
+        # but never forwarded, so the completion ran against the default agent.
+        assert captured["agent_id_override"] == "ada"
+        assert result.agent_id == "ada"
         assert captured["temperature"] == 0.0
         assert captured["max_tokens"] == 128
         assert captured["timeout"] == 10.0
+
+    def test_complete_threads_agent_id_into_call_llm_metadata(self, monkeypatch):
+        # Without an injected caller (real call_llm path), agent_id is threaded
+        # into request metadata the same way auth_profile is.
+        captured: dict = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return _fake_response("ok")
+
+        monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="my-plugin",
+            policy=_trusted_policy("my-plugin"),
+        )
+        llm.complete(
+            [{"role": "user", "content": "hi"}],
+            agent_id="ada",
+            profile="work",
+            temperature=0.0,
+        )
+        metadata = (captured.get("extra_body") or {}).get("metadata") or {}
+        assert metadata.get("agent_id") == "ada"
+        assert metadata.get("auth_profile") == "work"
 
     def test_complete_structured_returns_parsed_json(self):
         def fake_caller(**_kwargs):


### PR DESCRIPTION
## What does this PR do?

`PluginLlm.complete` / `acomplete` / `complete_structured` /
`acomplete_structured` validate the `agent_id` override in `_check_overrides`,
record it on `result.agent_id` and in the audit — but never **forward**
`eff_agent` to `_invoke_sync` / `_invoke_async`.

So a plugin granted `allow_agent_id_override` calling
`complete(..., agent_id="ada")` gets a result that *claims* `agent_id == "ada"`,
while the underlying request is byte-for-byte identical to `agent_id=None` — it
runs against the **default** agent. That contradicts the trust-gate, whose
error text ("cannot run completions against a non-default agent id") makes clear
the override is meant to change the completion target.

The sibling `profile` override is threaded through correctly
(`merged_extra["metadata"]["auth_profile"]`); `agent_id` (`eff_agent`) was
simply dropped after validation.

## Fix

Thread `agent_id_override` through both invoke paths exactly like `profile`:
forward it to the injected caller, and on the real `call_llm` path set
`merged_extra["metadata"]["agent_id"]`. The request now carries the requested
agent identity, matching what the result reports.

## Related Issue

No existing issue — found via a code audit of the plugin auxiliary-LLM path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/plugin_llm.py` — add `agent_id_override` to `_invoke_sync` /
  `_invoke_async` (forwarded to the injected caller and threaded into request
  metadata); pass `eff_agent` from all four completion methods.
- `tests/agent/test_plugin_llm.py` — assert the caller receives `agent_id`
  (extended the trusted-override test) + a real-path test asserting it lands in
  request metadata.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_plugin_llm.py -q` → all pass (27).
2. With a trusted `allow_agent_id_override` policy, `complete(..., agent_id="ada")`
   now forwards `agent_id_override="ada"` to the caller and sets
   `request metadata.agent_id == "ada"` (previously dropped).

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(plugin-llm):`)
- [x] I searched for existing PRs (none touch agent_id forwarding)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/agent/test_plugin_llm.py` (27). Full suite not run locally.
- [x] Added/extended regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`
