### PR TITLE
fix(config): preserve multiline dotenv values during sanitization

### DIFF
--- a/contributors/emails/235949691+yuzilongleif-collab@users.noreply.github.com
+++ b/contributors/emails/235949691+yuzilongleif-collab@users.noreply.github.com
@@ -1,0 +1,2 @@
+yuzilongleif-collab
+# Issue #76571 contribution

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3721,23 +3721,48 @@ def invalidate_env_cache() -> None:
 
 
 def _sanitize_env_lines(lines: list) -> list:
-    """Normalize .env line endings without changing assignment semantics.
+    """Normalize safe .env formatting without changing value semantics.
 
-    Content after the first ``=`` is opaque value data. A known variable name
-    embedded in that value must never be reinterpreted as another assignment;
-    concatenated assignments are ambiguous and therefore remain on one line.
+    A quoted dotenv value may span physical lines. Every byte inside that
+    binding — including whitespace and ``#`` markers — is value content, so a
+    per-line ``strip()`` would corrupt it (#76571). Use python-dotenv's pinned
+    parser only to discover binding boundaries: preserve multiline bindings,
+    keep the existing normalization for ordinary physical lines, and fail
+    closed by leaving the whole file untouched if any binding is malformed.
+
+    Content after the first ``=`` remains opaque value data. A known variable
+    name embedded in that value must never be reinterpreted as another
+    assignment; concatenated assignments remain on one line.
     """
+    from io import StringIO
+
+    from dotenv.parser import parse_stream
+
+    bindings = list(parse_stream(StringIO("".join(lines))))
+    if any(binding.error for binding in bindings):
+        return list(lines)
+
     sanitized: list[str] = []
-    for line in lines:
-        raw = line.rstrip("\r\n")
-        stripped = raw.strip()
+    for binding in bindings:
+        physical_lines = binding.original.string.splitlines(keepends=True)
+        is_multiline_value = binding.key is not None and len(physical_lines) > 1
 
-        # Preserve blank lines and comments
-        if not stripped or stripped.startswith("#"):
-            sanitized.append(raw + "\n")
-            continue
+        for line in physical_lines:
+            raw = line.rstrip("\r\n")
+            stripped = raw.strip()
 
-        sanitized.append(stripped + "\n")
+            # A multiline binding is an indivisible value-bearing unit. Only
+            # normalize its physical line endings; preserve all other bytes.
+            if is_multiline_value:
+                sanitized.append(raw + "\n")
+                continue
+
+            # Preserve blank lines and comments.
+            if not stripped or stripped.startswith("#"):
+                sanitized.append(raw + "\n")
+                continue
+
+            sanitized.append(stripped + "\n")
 
     return sanitized
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4063,23 +4063,48 @@ def invalidate_env_cache() -> None:
 
 
 def _sanitize_env_lines(lines: list) -> list:
-    """Normalize .env line endings without changing assignment semantics.
+    """Normalize safe .env formatting without changing value semantics.
 
-    Content after the first ``=`` is opaque value data. A known variable name
-    embedded in that value must never be reinterpreted as another assignment;
-    concatenated assignments are ambiguous and therefore remain on one line.
+    A quoted dotenv value may span physical lines. Every byte inside that
+    binding — including whitespace and ``#`` markers — is value content, so a
+    per-line ``strip()`` would corrupt it (#76571). Use python-dotenv's pinned
+    parser only to discover binding boundaries: preserve multiline bindings,
+    keep the existing normalization for ordinary physical lines, and fail
+    closed by leaving the whole file untouched if any binding is malformed.
+
+    Content after the first ``=`` remains opaque value data. A known variable
+    name embedded in that value must never be reinterpreted as another
+    assignment; concatenated assignments remain on one line.
     """
+    from io import StringIO
+
+    from dotenv.parser import parse_stream
+
+    bindings = list(parse_stream(StringIO("".join(lines))))
+    if any(binding.error for binding in bindings):
+        return list(lines)
+
     sanitized: list[str] = []
-    for line in lines:
-        raw = line.rstrip("\r\n")
-        stripped = raw.strip()
+    for binding in bindings:
+        physical_lines = binding.original.string.splitlines(keepends=True)
+        is_multiline_value = binding.key is not None and len(physical_lines) > 1
 
-        # Preserve blank lines and comments
-        if not stripped or stripped.startswith("#"):
-            sanitized.append(raw + "\n")
-            continue
+        for line in physical_lines:
+            raw = line.rstrip("\r\n")
+            stripped = raw.strip()
 
-        sanitized.append(stripped + "\n")
+            # A multiline binding is an indivisible value-bearing unit. Only
+            # normalize its physical line endings; preserve all other bytes.
+            if is_multiline_value:
+                sanitized.append(raw + "\n")
+                continue
+
+            # Preserve blank lines and comments.
+            if not stripped or stripped.startswith("#"):
+                sanitized.append(raw + "\n")
+                continue
+
+            sanitized.append(stripped + "\n")
 
     return sanitized
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -464,10 +464,63 @@ class TestSanitizeEnvLines:
         result = _sanitize_env_lines(lines)
         assert result == lines, f"GLM_* lines were corrupted by suffix collision: {result}"
 
+    def test_multiline_quoted_value_is_preserved_while_sibling_is_normalized(self):
+        lines = [
+            "  MULTI='opening  \n",
+            "  continuation # value content  \n",
+            "closing'  # comment\n",
+            "  SINGLE=value  \n",
+        ]
 
+        assert _sanitize_env_lines(lines) == [
+            "  MULTI='opening  \n",
+            "  continuation # value content  \n",
+            "closing'  # comment\n",
+            "SINGLE=value\n",
+        ]
 
+    def test_double_quoted_multiline_value_with_escaped_quote_is_preserved(self):
+        lines = [
+            '  MULTI="opening  \n',
+            '  escaped \\" quote # value content  \n',
+            'closing"  # comment\n',
+        ]
 
+        assert _sanitize_env_lines(lines) == lines
 
+    def test_unclosed_quote_leaves_entire_file_untouched(self):
+        lines = [
+            "  BROKEN='opening  \n",
+            "  continuation # ambiguous  \n",
+            "  SINGLE=value  \n",
+        ]
+
+        assert _sanitize_env_lines(lines) == lines
+
+    def test_sanitize_env_file_preserves_multiline_dotenv_value(self, tmp_path):
+        from dotenv import dotenv_values
+
+        env_file = tmp_path / ".env"
+        original = (
+            "  MULTI='opening  \n"
+            "  continuation # value content  \n"
+            "closing'  # comment\n"
+            "  SINGLE=value  \n"
+        )
+        env_file.write_text(original, encoding="utf-8")
+        expected_value = dotenv_values(env_file, interpolate=False)["MULTI"]
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            fixes = sanitize_env_file()
+
+        assert fixes == 1
+        assert dotenv_values(env_file, interpolate=False)["MULTI"] == expected_value
+        assert env_file.read_text(encoding="utf-8") == (
+            "  MULTI='opening  \n"
+            "  continuation # value content  \n"
+            "closing'  # comment\n"
+            "SINGLE=value\n"
+        )
 
     def test_sanitize_env_file_does_not_rewrite_value_semantics(self, tmp_path):
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## Summary

- preserve complete multiline quoted dotenv bindings during `sanitize_env_file()`
- retain the existing whitespace normalization for ordinary single-line entries
- leave the entire file untouched when python-dotenv reports a malformed binding, rather than risking an ambiguous rewrite

Fixes #76571.

## Root cause

`_sanitize_env_lines()` called `strip()` on every non-comment physical line. For a quoted dotenv value spanning multiple physical lines, that changed value data:

- trailing whitespace on the opening line was removed
- leading/trailing whitespace on continuation lines was removed
- continuation-line `#` characters could no longer be treated as opaque value content

The fix uses the project's pinned `python-dotenv` parser only to discover binding boundaries. Valid multiline bindings are preserved byte-for-byte except for the sanitizer's existing newline normalization; ordinary single-line bindings continue through the existing normalization path. If parsing reports an error (for example an unclosed quote), sanitization becomes a no-op for the whole file.

## Tests

Regression coverage proves:

- single-quoted multiline whitespace and `#` content survive while an adjacent single-line entry is still normalized
- double-quoted multiline content with an escaped quote survives
- an unclosed quote leaves the whole file untouched
- the end-to-end file rewrite preserves the value returned by `python-dotenv`

Verification on current `main`:

- `tests/hermes_cli/test_config.py` + env-loader suites: **93 passed**
- contributor mapping tests: **7 passed**
- Ruff 0.15.10: **passed**
- `compileall` and `git diff --check`: **passed**

Compatibility check: a temporary merge with the current #76545 head was conflict-free; its config/env suites passed **105 tests**, the complete skills-tool suite passed **41 tests**, and Ruff passed on the combined tree.
