### PR TITLE
fix: scope auxiliary provider key_env reads

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -109,6 +109,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.secret_scope import get_secret
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -5721,7 +5722,7 @@ def resolve_provider_client(
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                custom_key = (get_secret(custom_key_env) or "").strip()
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(
@@ -7004,7 +7005,7 @@ def _resolve_task_provider_model(
                 task_config.get("key_env") or task_config.get("api_key_env") or ""
             ).strip()
             if cfg_key_env:
-                cfg_api_key = os.getenv(cfg_key_env, "").strip() or None
+                cfg_api_key = (get_secret(cfg_key_env) or "").strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -107,6 +107,33 @@ class TestAuxiliaryMaxTokensParam:
 
 
 class TestResolveTaskProviderModel:
+    def test_key_env_uses_active_profile_secret_scope(self, monkeypatch):
+        """Task-specific key_env must not read another profile's process env."""
+        from agent import secret_scope
+
+        monkeypatch.setenv("AUX_TEST_PROFILE_KEY", "wrong-profile-key")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "provider": "custom",
+                "model": "test-model",
+                "base_url": "https://example.test/v1",
+                "key_env": "AUX_TEST_PROFILE_KEY",
+            },
+        )
+        previous_multiplex = secret_scope.is_multiplex_active()
+        token = secret_scope.set_secret_scope(
+            {"AUX_TEST_PROFILE_KEY": "right-profile-key"}
+        )
+        secret_scope.set_multiplex_active(True)
+        try:
+            _, _, _, api_key, _ = _resolve_task_provider_model(task="vision")
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(previous_multiplex)
+
+        assert api_key == "right-profile-key"
+
     @pytest.mark.parametrize(
         "provider",
         [

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -96,6 +96,37 @@ class TestResolveProviderClientMainAlias:
 class TestResolveProviderClientNamedCustom:
     """resolve_provider_client should resolve named custom providers directly."""
 
+    def test_key_env_uses_active_profile_secret_scope(self, monkeypatch):
+        """Named custom providers must not read another profile's process env."""
+        from agent import secret_scope
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.setenv("NAMED_TEST_PROFILE_KEY", "wrong-profile-key")
+        previous_multiplex = secret_scope.is_multiplex_active()
+        token = secret_scope.set_secret_scope(
+            {"NAMED_TEST_PROFILE_KEY": "right-profile-key"}
+        )
+        secret_scope.set_multiplex_active(True)
+        try:
+            with (
+                patch(
+                    "hermes_cli.runtime_provider._get_named_custom_provider",
+                    return_value={
+                        "name": "beans",
+                        "base_url": "https://beans.test/v1",
+                        "key_env": "NAMED_TEST_PROFILE_KEY",
+                    },
+                ),
+                patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            ):
+                mock_openai.return_value = MagicMock()
+                resolve_provider_client("beans", "test-model")
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(previous_multiplex)
+
+        assert mock_openai.call_args.kwargs["api_key"] == "right-profile-key"
+
     def test_named_custom_provider(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "test-model"},


### PR DESCRIPTION
## Summary

- resolve auxiliary custom-provider and task-specific `key_env` values through the active profile secret scope
- preserve legacy process-environment fallback for single-profile deployments
- add multiplex regressions proving the active profile key wins over a different process-global value

Addresses the `agent/auxiliary_client.py` residual gap in #76574.

## Verification

- RED: both regressions selected the decoy process-global key before the production change
- GREEN: 196 relevant tests passed across auxiliary-client and secret-scope suites
- `ruff check` passed for all changed files
- `git diff --check` and Python byte-compilation passed

The canonical runner retried one unrelated timing-sensitive Codex timeout test; its retry and subsequent isolated runs passed.