### PR TITLE
feat(sessions): hermes sessions cost — cache-hit and savings report (#76589)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -727,6 +727,15 @@ DEFAULT_CONFIG = {
         "cache_ttl": "5m",
     },
 
+    # Per-session cost reporting (`hermes sessions cost`): the assumed ratio
+    # of cache-read input price to cold input price, used for the
+    # "cost if cache had been 0%" counterfactual. 0.10 = cache reads are
+    # billed at 10% of the cold input rate (e.g. DeepSeek's ~10x spread).
+    # This is an estimate — the per-token price split is not persisted.
+    "cost": {
+        "cache_hit_ratio": 0.10,
+    },
+
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -39,6 +39,7 @@ Usage:
     hermes uninstall           Uninstall Hermes Agent
     hermes acp                 Run as an ACP server for editor integration
     hermes sessions browse     Interactive session picker with search
+    hermes sessions cost       Cache-hit and cost-savings report per session
 
     hermes claw migrate --dry-run  # Preview migration without changes
 """
@@ -11918,7 +11919,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, cost, rename, export, prune, delete)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -12119,6 +12120,33 @@ def main():
     sessions_delete.add_argument("session_id", help="Session ID to delete")
     sessions_delete.add_argument(
         "--yes", "-y", action="store_true", help="Skip confirmation"
+    )
+
+    sessions_cost = sessions_subparsers.add_parser(
+        "cost",
+        help="Per-session token, cache-hit and cost-savings report",
+        description=(
+            "Report each session's token usage, cache-hit rate, estimated "
+            "cost, and the counterfactual cost if the prompt cache had never "
+            "hit. The counterfactual is an ESTIMATE: it assumes cache reads "
+            "are billed at cost.cache_hit_ratio (default 0.10 = 10%) of the "
+            "cold input rate and attributes the recorded cost to the input "
+            "side in proportion to token counts."
+        ),
+    )
+    sessions_cost.add_argument(
+        "--session",
+        metavar="ID",
+        help="Session ID or unique prefix to show the full cost breakdown for",
+    )
+    sessions_cost.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max sessions to include in the table (default: 20)",
+    )
+    sessions_cost.add_argument(
+        "--source", help="Filter by source (cli, telegram, discord, etc.)"
     )
 
     sessions_prune = sessions_subparsers.add_parser(

--- a/hermes_cli/session_cost.py
+++ b/hermes_cli/session_cost.py
@@ -1,0 +1,182 @@
+"""Cost / cache-hit reporting for `hermes sessions cost`.
+
+Pure computation + formatting helpers that turn a session row (as
+returned by ``SessionDB.list_sessions_rich`` / ``get_session_rich_row``)
+into a cache-hit and savings breakdown.
+
+The counterfactual ("what would this session have cost if the prompt
+cache had never hit?") is deliberately an **estimate**: Hermes records
+the aggregate ``estimated_cost_usd`` at call time but does not persist
+the per-token price split, so the exact cold-price delta is unknowable
+after the fact. We attribute the recorded cost to the input side in
+proportion to token counts, then re-price the cache-read share as if it
+had been billed at the cold input rate:
+
+    savings = estimated_cost * (input_side / total_tokens)
+                           * (cache_read / input_side_tokens)
+                           * (1 / cache_hit_ratio - 1)
+
+The cache-to-cold price ratio is configurable via
+``cost.cache_hit_ratio`` in config.yaml (``0.10`` = cache reads are
+billed at 10% of the cold input rate, e.g. DeepSeek's ~10x spread),
+defaulting to a conservative 0.10 when unset or invalid.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+#: Default assumption: cache reads are billed at 10% of the cold input
+#: price (a conservative cross-provider default — DeepSeek ~10x, OpenAI
+#: 5x for long contexts, Anthropic ~5x for 1h TTL).
+DEFAULT_CACHE_HIT_RATIO = 0.10
+
+#: Below this cache-hit rate a session gets the ``⚠`` marker — the signal
+#: that something (workspace switch, toolset swap, compression) may have
+#: invalidated the prompt prefix.
+CACHE_HIT_WARN_THRESHOLD_PCT = 70.0
+
+_TOKEN_KEYS = (
+    "input_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "output_tokens",
+)
+
+
+def cache_hit_ratio_from_config(config: Optional[Dict[str, Any]]) -> float:
+    """Read ``cost.cache_hit_ratio`` from a loaded config dict.
+
+    Returns ``DEFAULT_CACHE_HIT_RATIO`` when the key is missing, not a
+    dict, or outside ``(0, 1]`` — a hand-edited config degrades to the
+    conservative default instead of producing nonsense counterfactuals.
+    """
+    ratio = DEFAULT_CACHE_HIT_RATIO
+    if not isinstance(config, dict):
+        return ratio
+    cost_cfg = config.get("cost")
+    if not isinstance(cost_cfg, dict):
+        return ratio
+    raw = cost_cfg.get("cache_hit_ratio")
+    if raw is None:
+        return ratio
+    try:
+        parsed = float(raw)
+    except (TypeError, ValueError):
+        return ratio
+    if 0.0 < parsed <= 1.0:
+        return parsed
+    return ratio
+
+
+def session_cost_breakdown(
+    session_row: Dict[str, Any],
+    *,
+    cache_hit_ratio: float = DEFAULT_CACHE_HIT_RATIO,
+) -> Dict[str, Any]:
+    """Compute the cache-hit + savings breakdown for one session row.
+
+    The row is a ``sessions`` table dict (any of the ``SessionDB`` list /
+    get shapes); every token column defaults to 0 and ``estimated_cost``
+    defaults to None when absent, so rows from older schemas or test
+    doubles degrade safely.
+
+    Returns a dict with:
+
+    * ``input_tokens`` / ``cache_read_tokens`` / ``cache_write_tokens`` /
+      ``output_tokens`` — the per-type totals (ints)
+    * ``input_side_tokens`` — input + cache_read + cache_write
+    * ``total_tokens`` — input_side + output
+    * ``cache_hit_pct`` — ``cache_read / input_side * 100`` (None when
+      there are no input-side tokens)
+    * ``estimated_cost`` — the recorded ``estimated_cost_usd`` (or None)
+    * ``counterfactual_cost`` — estimated cost if cache hits had been 0%
+      (None when ``estimated_cost`` is None)
+    * ``savings`` — counterfactual − estimated (0.0 when there is cost
+      but nothing to save; None when cost is unknown)
+    * ``below_threshold`` — True when ``cache_hit_pct`` is not None and
+      below ``CACHE_HIT_WARN_THRESHOLD_PCT``
+    """
+    inp = _int_or_zero(session_row.get("input_tokens"))
+    cr = _int_or_zero(session_row.get("cache_read_tokens"))
+    cw = _int_or_zero(session_row.get("cache_write_tokens"))
+    out = _int_or_zero(session_row.get("output_tokens"))
+
+    raw_cost = session_row.get("estimated_cost_usd")
+    cost: Optional[float] = None
+    if raw_cost is not None:
+        try:
+            cost = float(raw_cost)
+        except (TypeError, ValueError):
+            cost = None
+
+    input_side = inp + cr + cw
+    total = input_side + out
+    cache_hit_pct: Optional[float] = (
+        (cr / input_side * 100.0) if input_side else None
+    )
+
+    counterfactual_cost: Optional[float] = None
+    savings: Optional[float] = None
+    if cost is not None and input_side and cr:
+        ratio = cache_hit_ratio
+        if not (0.0 < ratio <= 1.0):
+            ratio = DEFAULT_CACHE_HIT_RATIO
+        input_share = input_side / total if total else 0.0
+        cache_share = cr / input_side
+        savings = cost * input_share * cache_share * (1.0 / ratio - 1.0)
+        counterfactual_cost = cost + savings
+    elif cost is not None:
+        # Cost recorded but nothing cacheable — the counterfactual is the
+        # same bill (no savings).
+        counterfactual_cost = cost
+        savings = 0.0
+
+    return {
+        "input_tokens": inp,
+        "cache_read_tokens": cr,
+        "cache_write_tokens": cw,
+        "output_tokens": out,
+        "input_side_tokens": input_side,
+        "total_tokens": total,
+        "cache_hit_pct": cache_hit_pct,
+        "estimated_cost": cost,
+        "counterfactual_cost": counterfactual_cost,
+        "savings": savings,
+        "below_threshold": (
+            cache_hit_pct is not None
+            and cache_hit_pct < CACHE_HIT_WARN_THRESHOLD_PCT
+        ),
+    }
+
+
+def format_usd(value: Optional[float]) -> str:
+    """``$1.23`` / ``$0.0040`` (4 decimals for sub-cent amounts) / ``—``."""
+    if value is None:
+        return "—"
+    if abs(value) < 0.01:
+        return f"${value:,.4f}"
+    return f"${value:,.2f}"
+
+
+def format_hit_pct(value: Optional[float]) -> str:
+    """``36.9%`` / ``—`` for unknown."""
+    if value is None:
+        return "—"
+    return f"{value:.1f}%"
+
+
+def format_tokens(value: Optional[int]) -> str:
+    """``12,345`` (thousands separator) / ``0`` / ``—`` for unknown."""
+    if value is None:
+        return "—"
+    return f"{int(value):,}"
+
+
+def _int_or_zero(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -310,6 +310,116 @@ def cmd_sessions(args, sessions_parser=None):
                 sid = s["id"]
                 print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
+    elif action == "cost":
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.session_cost import (
+            CACHE_HIT_WARN_THRESHOLD_PCT,
+            cache_hit_ratio_from_config,
+            format_hit_pct,
+            format_tokens,
+            format_usd,
+            session_cost_breakdown,
+        )
+
+        ratio = cache_hit_ratio_from_config(load_config_readonly())
+
+        session_arg = getattr(args, "session", None)
+        if session_arg:
+            full_id = db.resolve_session_id(session_arg)
+            if not full_id:
+                print(f"Session '{session_arg}' not found.")
+                db.close()
+                return
+            row = db.get_session_rich_row(full_id)
+            if not row:
+                print(f"Session '{session_arg}' not found.")
+                db.close()
+                return
+            b = session_cost_breakdown(row, cache_hit_ratio=ratio)
+            title = (row.get("title") or "—").strip() or "—"
+            model = (row.get("model") or "unknown").strip() or "unknown"
+            source = (row.get("source") or "—").strip() or "—"
+            print(f"Session {full_id}")
+            print(f"  {'Title:':<20}{title}")
+            print(f"  {'Source:':<20}{source}")
+            print(f"  {'Model:':<20}{model}")
+            print(
+                f"  {'Input tokens:':<20}"
+                f"{format_tokens(b['input_tokens'])}"
+            )
+            print(
+                f"  {'Cache read:':<20}"
+                f"{format_tokens(b['cache_read_tokens'])}"
+            )
+            print(
+                f"  {'Cache write:':<20}"
+                f"{format_tokens(b['cache_write_tokens'])}"
+            )
+            print(
+                f"  {'Output tokens:':<20}"
+                f"{format_tokens(b['output_tokens'])}"
+            )
+            hit_line = format_hit_pct(b["cache_hit_pct"])
+            if b["below_threshold"]:
+                hit_line += (
+                    f"  ⚠ below {CACHE_HIT_WARN_THRESHOLD_PCT:.0f}% — "
+                    "prompt prefix may have been invalidated"
+                )
+            print(f"  {'Cache hit:':<20}{hit_line}")
+            print(
+                f"  {'Estimated cost:':<20}"
+                f"{format_usd(b['estimated_cost'])}"
+            )
+            print(
+                f"  {'Cost if 0% cache:':<20}"
+                f"{format_usd(b['counterfactual_cost'])}"
+            )
+            print(
+                f"  {'Estimated savings:':<20}"
+                f"{format_usd(b['savings'])}"
+            )
+            print(
+                f"  (Counterfactual assumes cache reads billed at "
+                f"{ratio:.0%} of the cold input rate — config "
+                f"cost.cache_hit_ratio; estimate, not a bill.)"
+            )
+            return
+
+        sessions = db.list_sessions_rich(
+            source=args.source, exclude_sources=_exclude, limit=args.limit
+        )
+        if not sessions:
+            print("No sessions found.")
+            return
+
+        print(
+            f"{'ID':<26}{'Hit%':>7}{'Input':>12}{'CRead':>12}"
+            f"{'CWrite':>12}{'Output':>12}{'Cost':>11}"
+            f"{'No-Cache':>11}{'Saved':>11}"
+        )
+        print("─" * 114)
+        for s in sessions:
+            b = session_cost_breakdown(s, cache_hit_ratio=ratio)
+            flag = "  ⚠" if b["below_threshold"] else ""
+            print(
+                f"{s['id']:<26}"
+                f"{format_hit_pct(b['cache_hit_pct']):>7}"
+                f"{format_tokens(b['input_tokens']):>12}"
+                f"{format_tokens(b['cache_read_tokens']):>12}"
+                f"{format_tokens(b['cache_write_tokens']):>12}"
+                f"{format_tokens(b['output_tokens']):>12}"
+                f"{format_usd(b['estimated_cost']):>11}"
+                f"{format_usd(b['counterfactual_cost']):>11}"
+                f"{format_usd(b['savings']):>11}"
+                f"{flag}"
+            )
+        print()
+        print(
+            f"Counterfactual: cache reads billed at {ratio:.0%} of the "
+            "cold input rate (config cost.cache_hit_ratio) — "
+            "estimates, not a bill."
+        )
+
     elif action == "export":
         from hermes_cli.session_filters import (
             build_prune_filters,

--- a/tests/hermes_cli/test_session_cost.py
+++ b/tests/hermes_cli/test_session_cost.py
@@ -1,0 +1,207 @@
+"""Unit tests for the `hermes sessions cost` computation helpers."""
+
+import pytest
+
+from hermes_cli.session_cost import (
+    CACHE_HIT_WARN_THRESHOLD_PCT,
+    DEFAULT_CACHE_HIT_RATIO,
+    cache_hit_ratio_from_config,
+    format_hit_pct,
+    format_tokens,
+    format_usd,
+    session_cost_breakdown,
+)
+
+
+def _row(**overrides):
+    row = {
+        "input_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "output_tokens": 0,
+        "estimated_cost_usd": None,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestCacheHitPct:
+    def test_hit_pct_uses_input_side_denominator(self):
+        # hit% = cache_read / (input + cache_read + cache_write)
+        b = session_cost_breakdown(_row(input_tokens=1000, cache_read_tokens=500))
+        assert b["cache_hit_pct"] == pytest.approx(100 / 3)
+
+    def test_hit_pct_includes_cache_write_in_denominator(self):
+        b = session_cost_breakdown(
+            _row(
+                input_tokens=1000,
+                cache_read_tokens=500,
+                cache_write_tokens=100,
+            )
+        )
+        # 500 / (1000 + 500 + 100)
+        assert b["cache_hit_pct"] == pytest.approx(31.25)
+
+    def test_hit_pct_is_none_without_input_side_tokens(self):
+        b = session_cost_breakdown(_row(output_tokens=100))
+        assert b["cache_hit_pct"] is None
+        assert b["below_threshold"] is False
+
+    def test_zero_cache_read_is_zero_hit(self):
+        b = session_cost_breakdown(_row(input_tokens=1000))
+        assert b["cache_hit_pct"] == pytest.approx(0.0)
+
+
+class TestCounterfactual:
+    def test_all_cache_reads_cost_10x_at_default_ratio(self):
+        # Every input-side token is a cache read billed at 10% of cold:
+        # the 0% counterfactual is 10x the recorded cost.
+        b = session_cost_breakdown(
+            _row(cache_read_tokens=1000, estimated_cost_usd=1.0)
+        )
+        assert b["counterfactual_cost"] == pytest.approx(10.0)
+        assert b["savings"] == pytest.approx(9.0)
+
+    def test_mixed_session_attribution(self):
+        b = session_cost_breakdown(
+            _row(
+                input_tokens=3000,
+                cache_read_tokens=1000,
+                cache_write_tokens=1000,
+                output_tokens=5000,
+                estimated_cost_usd=10.0,
+            )
+        )
+        # f_in = 5000/10000 = 0.5, f_cr = 1000/5000 = 0.2
+        # savings = 10 * 0.5 * 0.2 * (1/0.1 - 1) = 9.0
+        assert b["savings"] == pytest.approx(9.0)
+        assert b["counterfactual_cost"] == pytest.approx(19.0)
+
+    def test_no_cache_reads_no_savings(self):
+        b = session_cost_breakdown(
+            _row(input_tokens=1000, estimated_cost_usd=5.0)
+        )
+        assert b["savings"] == pytest.approx(0.0)
+        assert b["counterfactual_cost"] == pytest.approx(5.0)
+
+    def test_unknown_cost_yields_unknown_counterfactual(self):
+        b = session_cost_breakdown(_row(input_tokens=1000, cache_read_tokens=500))
+        assert b["counterfactual_cost"] is None
+        assert b["savings"] is None
+
+    def test_zero_tokens_with_cost_is_pass_through(self):
+        b = session_cost_breakdown(_row(estimated_cost_usd=2.0))
+        assert b["counterfactual_cost"] == pytest.approx(2.0)
+        assert b["savings"] == pytest.approx(0.0)
+
+    def test_custom_ratio_changes_counterfactual(self):
+        b = session_cost_breakdown(
+            _row(cache_read_tokens=1000, estimated_cost_usd=1.0),
+            cache_hit_ratio=0.25,
+        )
+        # 1/0.25 - 1 = 3 -> 4x total
+        assert b["counterfactual_cost"] == pytest.approx(4.0)
+
+    def test_invalid_ratio_falls_back_to_default(self):
+        b = session_cost_breakdown(
+            _row(cache_read_tokens=1000, estimated_cost_usd=1.0),
+            cache_hit_ratio=1.5,
+        )
+        assert b["counterfactual_cost"] == pytest.approx(10.0)
+
+
+class TestWarnMarker:
+    def test_below_threshold_flagged(self):
+        b = session_cost_breakdown(
+            _row(
+                input_tokens=1000,
+                cache_read_tokens=690,
+                cache_write_tokens=310,
+            )
+        )
+        assert b["cache_hit_pct"] < CACHE_HIT_WARN_THRESHOLD_PCT
+        assert b["below_threshold"] is True
+
+    def test_at_threshold_not_flagged(self):
+        b = session_cost_breakdown(
+            _row(
+                input_tokens=30,
+                cache_read_tokens=70,
+            )
+        )
+        assert b["cache_hit_pct"] == pytest.approx(CACHE_HIT_WARN_THRESHOLD_PCT)
+        assert b["below_threshold"] is False
+
+    def test_above_threshold_not_flagged(self):
+        b = session_cost_breakdown(
+            _row(input_tokens=100, cache_read_tokens=900)
+        )
+        assert b["below_threshold"] is False
+
+    def test_no_usage_not_flagged(self):
+        b = session_cost_breakdown(_row())
+        assert b["below_threshold"] is False
+
+
+class TestTokenFields:
+    def test_missing_columns_default_to_zero(self):
+        b = session_cost_breakdown({"id": "x"})
+        assert b["input_tokens"] == 0
+        assert b["cache_read_tokens"] == 0
+        assert b["cache_write_tokens"] == 0
+        assert b["output_tokens"] == 0
+        assert b["input_side_tokens"] == 0
+        assert b["total_tokens"] == 0
+
+    def test_non_numeric_cost_becomes_none(self):
+        b = session_cost_breakdown(
+            _row(input_tokens=10, estimated_cost_usd="n/a")
+        )
+        assert b["estimated_cost"] is None
+        assert b["counterfactual_cost"] is None
+
+
+class TestCacheHitRatioFromConfig:
+    def test_missing_uses_default(self):
+        assert cache_hit_ratio_from_config({}) == DEFAULT_CACHE_HIT_RATIO
+        assert cache_hit_ratio_from_config(None) == DEFAULT_CACHE_HIT_RATIO
+
+    def test_explicit_value_wins(self):
+        assert (
+            cache_hit_ratio_from_config(
+                {"cost": {"cache_hit_ratio": 0.25}}
+            )
+            == pytest.approx(0.25)
+        )
+
+    def test_invalid_values_fall_back(self):
+        for bad in (0, -1, 1.5, 2, "x", None):
+            assert (
+                cache_hit_ratio_from_config({"cost": {"cache_hit_ratio": bad}})
+                == DEFAULT_CACHE_HIT_RATIO
+            )
+
+    def test_non_dict_cost_section_falls_back(self):
+        assert (
+            cache_hit_ratio_from_config({"cost": "oops"})
+            == DEFAULT_CACHE_HIT_RATIO
+        )
+
+
+class TestFormatting:
+    def test_format_usd(self):
+        assert format_usd(None) == "—"
+        assert format_usd(1.5) == "$1.50"
+        assert format_usd(1234.567) == "$1,234.57"
+        # sub-cent amounts keep 4 decimals so tiny sessions are not $0.00
+        assert format_usd(0.004) == "$0.0040"
+
+    def test_format_hit_pct(self):
+        assert format_hit_pct(None) == "—"
+        assert format_hit_pct(31.25) == "31.2%"
+        assert format_hit_pct(100.0) == "100.0%"
+
+    def test_format_tokens(self):
+        assert format_tokens(None) == "—"
+        assert format_tokens(0) == "0"
+        assert format_tokens(12345) == "12,345"

--- a/tests/hermes_cli/test_sessions_cost_cli.py
+++ b/tests/hermes_cli/test_sessions_cost_cli.py
@@ -1,0 +1,156 @@
+"""CLI integration tests for `hermes sessions cost`."""
+
+import sys
+
+import pytest
+
+from hermes_cli.session_cost import CACHE_HIT_WARN_THRESHOLD_PCT
+
+_SESSIONS = [
+    {
+        "id": "20260701_000000_aaaaaa",
+        "source": "cli",
+        "model": "deepseek-v4-flash",
+        "title": "api debugging",
+        "input_tokens": 1_000_000,
+        "cache_read_tokens": 900_000,
+        "cache_write_tokens": 100_000,
+        "output_tokens": 50_000,
+        "estimated_cost_usd": 0.31,
+    },
+    {
+        "id": "20260702_000000_bbbbbb",
+        "source": "cli",
+        "model": "deepseek-v4-flash",
+        "title": "cache busted",
+        "input_tokens": 1_000_000,
+        "cache_read_tokens": 100_000,
+        "cache_write_tokens": 500_000,
+        "output_tokens": 50_000,
+        "estimated_cost_usd": 0.45,
+    },
+    {
+        "id": "20260703_000000_cccccc",
+        "source": "telegram",
+        "model": "unknown",
+        "title": "no usage",
+        "input_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "output_tokens": 0,
+        "estimated_cost_usd": None,
+    },
+]
+
+
+def _run(monkeypatch, capsys, argv_tail, rows=_SESSIONS, detail=None):
+    """Run `hermes sessions cost <argv_tail>` against a FakeDB."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+    from hermes_cli import config as cfg_mod
+
+    class FakeDB:
+        def list_sessions_rich(self, source=None, exclude_sources=None, limit=20):
+            return list(rows)[:limit]
+
+        def resolve_session_id(self, session_id):
+            for s in rows:
+                if s["id"].startswith(session_id):
+                    return s["id"]
+            return None
+
+        def get_session_rich_row(self, session_id):
+            for s in rows:
+                if s["id"] == session_id:
+                    return dict(s)
+            return None
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: {"cost": {"cache_hit_ratio": 0.10}})
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "cost", *argv_tail])
+    main_mod.main()
+    return capsys.readouterr().out
+
+
+def test_cost_table_columns_and_values(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, [])
+    assert "ID" in out
+    assert "Hit%" in out
+    assert "Input" in out
+    assert "CRead" in out
+    assert "CWrite" in out
+    assert "Output" in out
+    assert "Cost" in out
+    assert "No-Cache" in out
+    assert "Saved" in out
+    # Session 1: hit = 900k / 2M = 45.0%
+    assert "45.0%" in out
+    assert "20260701_000000_aaaaaa" in out
+    # Session 2: hit = 100k / 1.6M = 6.2%
+    assert "6.2%" in out
+    assert "20260702_000000_bbbbbb" in out
+    # Session 3 has no usage -> dash placeholders
+    assert "20260703_000000_cccccc" in out
+
+
+def test_cost_table_flags_low_cache_hit(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, [])
+    # Both data sessions are below the 70% warn threshold and must carry the
+    # marker; the no-usage session must not.
+    assert out.count("⚠") == 2
+    assert "20260702_000000_bbbbbb" in out
+
+
+def test_cost_table_counterfactual_footer(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, [])
+    assert "Counterfactual: cache reads billed at 10%" in out
+    assert "cost.cache_hit_ratio" in out
+
+
+def test_cost_table_no_sessions(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, [], rows=[])
+    assert "No sessions found." in out
+
+
+def test_cost_detail_single_session(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, ["--session", "20260702_000000_bbbbbb"])
+    assert "Session 20260702_000000_bbbbbb" in out
+    assert "Title:" in out
+    assert "cache busted" in out
+    assert "Source:" in out
+    assert "Model:" in out
+    assert "deepseek-v4-flash" in out
+    assert "Input tokens:" in out
+    assert "1,000,000" in out
+    assert "Cache read:" in out
+    assert "100,000" in out
+    assert "Cache write:" in out
+    assert "500,000" in out
+    assert "Output tokens:" in out
+    assert "Cache hit:" in out
+    assert "6.2%" in out
+    assert "Estimated cost:" in out
+    assert "$0.45" in out
+    assert "Cost if 0% cache:" in out
+    assert "Estimated savings:" in out
+    assert "Counterfactual assumes cache reads billed at 10%" in out
+
+
+def test_cost_detail_resolves_unique_prefix(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, ["--session", "20260702"])
+    assert "Session 20260702_000000_bbbbbb" in out
+
+
+def test_cost_detail_unknown_session(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, ["--session", "missing-prefix"])
+    assert "Session 'missing-prefix' not found." in out
+
+
+def test_cost_detail_warn_note_on_low_hit(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, ["--session", "20260702"])
+    assert "⚠" in out
+    assert f"below {CACHE_HIT_WARN_THRESHOLD_PCT:.0f}%" in out
+    assert "prompt prefix may have been invalidated" in out


### PR DESCRIPTION
Closes #76589

## Summary

Adds a `hermes sessions cost` CLI command that reports per-session token usage, cache-hit rate, estimated cost, and the counterfactual cost if the prompt cache had never hit — surfacing data Hermes already collects (`input_tokens`, `cache_read_tokens`, `cache_write_tokens`, `output_tokens`, `estimated_cost_usd` on the `sessions` table via `update_token_counts` / `record_auxiliary_usage`).

```
hermes sessions cost                  # table across recent sessions
hermes sessions cost --session <id>   # detail for one session (id or unique prefix)
```

Per session it reports:
- `input_tokens` / `cache_read_tokens` / `cache_write_tokens` / `output_tokens`
- cache-hit % = `cache_read / (input + cache_read + cache_write)`
- estimated cost actually paid (the recorded `estimated_cost_usd`)
- estimated cost if cache had been 0% (counterfactual) and the savings delta
- a `⚠` marker when cache-hit drops below 70% — the signal that a workspace switch, toolset swap, or compression invalidated the prompt prefix

## Counterfactual estimate

Provider per-token price splits are not persisted, so the "no-cache" cost is a documented estimate: the recorded cost is attributed to the input side in proportion to token counts, then the cache-read share is re-priced as if billed at the cold input rate. The cache→cold price ratio is configurable:

```yaml
cost:
  cache_hit_ratio: 0.10   # cache reads = 10% of cold input price (default)
```

Conservative default `0.10` (e.g. DeepSeek ~10x, OpenAI/Anthropic 5x spreads); values outside `(0, 1]` fall back to the default. No new env vars, no new model tools, no provider-specific logic — pure edge expansion of the existing `sessions` command.

## Files

- `hermes_cli/session_cost.py` — new pure computation/formatting helpers (breakdown, config read, formatting)
- `hermes_cli/sessions_cmd.py` — `cost` action dispatch alongside `list`/`delete`/`export`
- `hermes_cli/main.py` — `sessions cost` subparser (`--session`, `--limit`, `--source`) + help strings
- `hermes_cli/config_defaults.py` — `cost.cache_hit_ratio` default
- `tests/hermes_cli/test_session_cost.py` — unit tests for the breakdown math, config fallback, formatting
- `tests/hermes_cli/test_sessions_cost_cli.py` — CLI integration tests (table, flags, detail, not-found)

## Test plan

- `pytest tests/hermes_cli/test_session_cost.py tests/hermes_cli/test_sessions_cost_cli.py` — 32 passed
- Existing sessions tests (`test_sessions_delete.py`, `test_sessions_size_delta_label.py`, `test_sessions_export_md_cli.py`, `test_session_filters.py`, `test_session_browse.py`, `test_aux_usage_accounting.py`) — 37 passed, no regressions
- Config suites (`test_config.py`, `test_config_validation.py`, `test_set_config_value.py`, `test_fast_command.py`) — 183 passed; the new `cost` root key is auto-accepted since `_KNOWN_ROOT_KEYS` is derived from `DEFAULT_CONFIG`
