### PR TITLE
fix: don't freeze a lone credential for an hour on a header-less 429

### DIFF
--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -46,6 +46,8 @@ _SAFE_SECRETISH_METADATA_KEYS = frozenset({
     "last_error_reason",
     "last_error_message",
     "last_error_reset_at",
+    "last_rate_limit_streak",
+    "last_rate_limit_streak_at",
 })
 
 _SECRET_VALUE_KEYS = frozenset({

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -118,12 +118,40 @@ SUPPORTED_POOL_STRATEGIES = {
 }
 
 # Cooldown before retrying an exhausted credential.
+# Provider-supplied reset_at / Retry-After timestamps always win; everything
+# below is only the fallback for a failure that carried no reset hint at all.
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
-# 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
-# Provider-supplied reset_at timestamps override these defaults.
+# 402 (billing/quota) and other failures cool down after 1 hour.
+#
+# A 429 with no Retry-After is almost always a short transient throttle, not a
+# spent quota window, so it does NOT get a flat hour.  The old flat hour froze
+# a single-key pool for 57 more minutes while the provider was already serving
+# that same key again — rotation could not help, because there was nothing to
+# rotate to.  Header-less 429s now start at EXHAUSTED_TTL_429_BASE_SECONDS and
+# multiply by EXHAUSTED_TTL_429_BACKOFF_FACTOR per consecutive strike, so a
+# credential that is genuinely out of quota still parks at the 1-hour ceiling
+# after a few strikes while a one-off throttle clears in under a minute.
+#
+# A pool with a single rotation candidate is a special case: freezing its only
+# credential cannot move traffic anywhere, it can only guarantee total agent
+# failure.  There we back off in seconds and let the provider be the authority
+# — a still-limited key just returns 429 again, cheaply.  The floor exists only
+# to stop a tight hammer loop, and it escalates on its own much lower ceiling.
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
-EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
+EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour (header-less 429 ceiling)
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+EXHAUSTED_TTL_429_BASE_SECONDS = 60          # first header-less 429
+EXHAUSTED_TTL_429_BACKOFF_FACTOR = 4         # 60s -> 4m -> 16m -> 1h
+SOLE_CREDENTIAL_TTL_429_BASE_SECONDS = 5     # first header-less 429, pool of one
+SOLE_CREDENTIAL_TTL_429_MAX_SECONDS = 60     # ceiling for a pool of one
+
+# A header-less 429 counts as "consecutive" only while it lands inside the
+# cooldown the credential just served plus this grace window.  The
+# cooldown-expiry clear in ``_available_entries`` wipes ``last_status_at``, so
+# the strike's own timestamp is the only thing left to measure against; past
+# that window the credential clearly had a healthy stretch and the ladder
+# restarts at the base.
+RATE_LIMIT_STREAK_GRACE_SECONDS = 60
 
 # Throttle window for the "no available entries" INFO line. Credential
 # selection runs on a hot path (every model call, plus auxiliary tasks like
@@ -180,6 +208,12 @@ class PooledCredential:
     last_error_reason: Optional[str] = None
     last_error_message: Optional[str] = None
     last_error_reset_at: Optional[float] = None
+    # Consecutive header-less 429 strikes, and when the last one landed.
+    # ``request_count`` only moves under the least-used strategy, so it cannot
+    # stand in for "did this credential work since the last throttle" — the
+    # escalating backoff needs its own bookkeeping.
+    last_rate_limit_streak: int = 0
+    last_rate_limit_streak_at: Optional[float] = None
     base_url: Optional[str] = None
     expires_at: Optional[str] = None
     expires_at_ms: Optional[int] = None
@@ -289,12 +323,41 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
-    """Return cooldown seconds based on the HTTP status that caused exhaustion."""
+def _headerless_429_ttl(streak: int, *, sole_credential: bool) -> int:
+    """Escalating cooldown for a 429 that carried no Retry-After / reset hint.
+
+    ``streak`` is 1 for the first strike.  A pool with a single rotation
+    candidate rides a much shorter ladder: there is no other key to move
+    traffic to, so refusing locally only guarantees failure, and a re-probe
+    that is still limited costs one cheap 429.
+    """
+    if sole_credential:
+        base = SOLE_CREDENTIAL_TTL_429_BASE_SECONDS
+        ceiling = SOLE_CREDENTIAL_TTL_429_MAX_SECONDS
+    else:
+        base = EXHAUSTED_TTL_429_BASE_SECONDS
+        ceiling = EXHAUSTED_TTL_429_SECONDS
+    # Clamp the exponent before the power so a runaway streak can't build a
+    # huge int only to be min()'d straight back down to the ceiling.
+    exponent = min(max(int(streak) - 1, 0), 16)
+    return int(min(ceiling, base * (EXHAUSTED_TTL_429_BACKOFF_FACTOR ** exponent)))
+
+
+def _exhausted_ttl(
+    error_code: Optional[int],
+    *,
+    streak: int = 1,
+    sole_credential: bool = False,
+) -> int:
+    """Return cooldown seconds based on the HTTP status that caused exhaustion.
+
+    Only reached when the provider supplied no reset timestamp — see
+    ``_exhausted_until``, which honours ``last_error_reset_at`` first.
+    """
     if error_code == 401:
         return EXHAUSTED_TTL_401_SECONDS
     if error_code == 429:
-        return EXHAUSTED_TTL_429_SECONDS
+        return _headerless_429_ttl(streak, sole_credential=sole_credential)
     return EXHAUSTED_TTL_DEFAULT_SECONDS
 
 
@@ -376,14 +439,30 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     return normalized
 
 
-def _exhausted_until(entry: PooledCredential) -> Optional[float]:
+def _exhausted_until(
+    entry: PooledCredential,
+    *,
+    sole_credential: bool = False,
+) -> Optional[float]:
+    """When *entry* may be retried, or None if it is not in cooldown.
+
+    A provider-supplied reset timestamp is authoritative and is returned
+    verbatim.  ``sole_credential`` only affects the header-less fallback ladder
+    (see ``_headerless_429_ttl``); callers that cannot cheaply tell how many
+    rotation candidates the pool has leave it False, which is the conservative
+    (longer) answer.
+    """
     if entry.last_status != STATUS_EXHAUSTED:
         return None
     reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
     if reset_at is not None:
         return reset_at
     if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
+        return entry.last_status_at + _exhausted_ttl(
+            entry.last_error_code,
+            streak=int(getattr(entry, "last_rate_limit_streak", 0) or 0) or 1,
+            sole_credential=sole_credential,
+        )
     return None
 
 
@@ -692,6 +771,48 @@ class CredentialPool:
             return False
         return reason.strip().lower() in _TERMINAL_AUTH_REASONS
 
+    def _rotation_candidate_count(self) -> int:
+        """How many entries could serve traffic once their cooldown lifts.
+
+        DEAD entries never re-enter rotation on a TTL, and an unhydrated
+        borrowed reference has no key to send.  Neither is somewhere traffic
+        can move, so neither counts as a rotation target.
+        """
+        count = 0
+        for entry in self._entries:
+            if entry.last_status == STATUS_DEAD:
+                continue
+            if entry.auth_type == AUTH_TYPE_API_KEY and not entry.runtime_api_key:
+                continue
+            count += 1
+        return count
+
+    def _next_rate_limit_streak(self, entry: PooledCredential, now: float) -> int:
+        """Consecutive header-less 429 count for *entry*, decayed by recovery.
+
+        The cooldown-expiry clear in ``_available_entries`` wipes
+        ``last_status_at``, so a strike is measured against its own timestamp:
+        one that lands inside the cooldown the credential just served (plus
+        ``RATE_LIMIT_STREAK_GRACE_SECONDS``) belongs to the same throttle
+        episode and climbs the ladder, while one that arrives after a healthy
+        stretch starts over at the base.
+        """
+        previous = int(getattr(entry, "last_rate_limit_streak", 0) or 0)
+        if previous <= 0:
+            return 1
+        struck_at = _parse_absolute_timestamp(
+            getattr(entry, "last_rate_limit_streak_at", None)
+        )
+        if struck_at is None:
+            return 1
+        served = _headerless_429_ttl(
+            previous,
+            sole_credential=self._rotation_candidate_count() <= 1,
+        )
+        if now - struck_at > served + RATE_LIMIT_STREAK_GRACE_SECONDS:
+            return 1
+        return previous + 1
+
     def _mark_exhausted(
         self,
         entry: PooledCredential,
@@ -712,14 +833,30 @@ class CredentialPool:
             terminal_status = STATUS_DEAD
         else:
             terminal_status = STATUS_EXHAUSTED
+        now = time.time()
+        # Only a header-less 429 walks the escalating ladder, so only that case
+        # touches the streak.  Every other failure leaves it untouched (rather
+        # than zeroing it), so a 401 landing between two throttles doesn't hand
+        # a genuinely rate-limited key a fresh short cooldown.
+        streak_fields: Dict[str, Any] = {}
+        if (
+            terminal_status == STATUS_EXHAUSTED
+            and status_code == 429
+            and normalized_error.get("reset_at") is None
+        ):
+            streak_fields = {
+                "last_rate_limit_streak": self._next_rate_limit_streak(entry, now),
+                "last_rate_limit_streak_at": now,
+            }
         updated = replace(
             entry,
             last_status=terminal_status,
-            last_status_at=time.time(),
+            last_status_at=now,
             last_error_code=status_code,
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
+            **streak_fields,
         )
         self._replace_entry(entry, updated)
         if persist:
@@ -1642,6 +1779,10 @@ class CredentialPool:
         cleared_any = False
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
+        # Computed once up front: a pool with nowhere to rotate to serves a much
+        # shorter header-less-429 cooldown, because refusing its only credential
+        # locally can't move traffic — it can only take the agent down.
+        sole_credential = self._rotation_candidate_count() <= 1
         for entry in self._entries:
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
@@ -1722,7 +1863,9 @@ class CredentialPool:
                 # the re-auth case for OAuth singletons.
                 continue
             if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry)
+                exhausted_until = _exhausted_until(
+                    entry, sole_credential=sole_credential
+                )
                 if exhausted_until is not None and now < exhausted_until:
                     # Codex quota windows can reopen EARLY: the user redeems a
                     # banked rate-limit reset (Codex CLI / ChatGPT UI), upgrades

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1492,6 +1492,11 @@ _POOL_STATUS_FIELDS = (
     "last_error_reason",
     "last_error_message",
     "last_error_reset_at",
+    # The header-less-429 backoff ladder is part of the same status block: a
+    # process that adopts another's newer cooldown has to adopt the strike
+    # count with it, or the next mark restarts the ladder at the base.
+    "last_rate_limit_streak",
+    "last_rate_limit_streak_at",
 )
 
 
@@ -1499,6 +1504,8 @@ def _merge_disk_cooldown_state(
     entry: Dict[str, Any],
     disk_entry: Optional[Dict[str, Any]],
     provider_id: str,
+    *,
+    sole_credential: bool = False,
 ) -> Dict[str, Any]:
     """Keep a newer on-disk cooldown/quarantine over a stale in-memory one.
 
@@ -1540,7 +1547,8 @@ def _merge_disk_cooldown_state(
             return entry
         if disk_status == STATUS_EXHAUSTED:
             until = _exhausted_until(
-                PooledCredential.from_dict(provider_id, disk_entry)
+                PooledCredential.from_dict(provider_id, disk_entry),
+                sole_credential=sole_credential,
             )
             if until is None or until <= time.time():
                 return entry
@@ -1600,9 +1608,16 @@ def write_credential_pool(
             for entry in sanitized_entries
             if isinstance(entry, dict) and entry.get("id")
         }
+        # Match the pool's own view of whether there is anywhere to rotate to,
+        # so a header-less-429 cooldown is judged binding here on the same
+        # ladder the pool used to write it.
+        pool_size = max(len(sanitized_entries), len(existing_list))
         merged: List[Dict[str, Any]] = [
             _merge_disk_cooldown_state(
-                entry, existing_by_id.get(entry.get("id")), provider_id
+                entry,
+                existing_by_id.get(entry.get("id")),
+                provider_id,
+                sole_credential=pool_size <= 1,
             )
             if isinstance(entry, dict)
             else entry

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -132,7 +132,13 @@ def _classify_exhausted_status(entry) -> tuple[str, bool]:
 
 
 
-def _format_exhausted_status(entry) -> str:
+def _format_exhausted_status(entry, *, pool_size: int = 0) -> str:
+    """Render an entry's cooldown for `hermes auth list`.
+
+    ``pool_size`` lets the displayed retry window match the one the pool will
+    actually enforce — a single-credential pool rides a much shorter
+    header-less-429 ladder (see ``_headerless_429_ttl``).
+    """
     if entry.last_status != STATUS_EXHAUSTED:
         return ""
     label, show_retry_window = _classify_exhausted_status(entry)
@@ -141,7 +147,7 @@ def _format_exhausted_status(entry) -> str:
     code = f" ({entry.last_error_code})" if entry.last_error_code else ""
     if not show_retry_window:
         return f" {label}{reason_text}{code} (re-auth may be required)"
-    exhausted_until = _exhausted_until(entry)
+    exhausted_until = _exhausted_until(entry, sole_credential=pool_size == 1)
     if exhausted_until is None:
         return f" {label}{reason_text}{code}"
     remaining = max(0, int(math.ceil(exhausted_until - time.time())))
@@ -455,7 +461,7 @@ def auth_list_command(args) -> None:
             marker = "  "
             if current is not None and entry.id == current.id:
                 marker = "← "
-            status = _format_exhausted_status(entry)
+            status = _format_exhausted_status(entry, pool_size=len(entries))
             source = _display_source(entry.source)
             print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
         print()
@@ -713,8 +719,9 @@ def _interactive_remove() -> None:
         return
 
     # Show entries with indices
-    for i, e in enumerate(pool.entries(), 1):
-        exhausted = _format_exhausted_status(e)
+    pool_entries = pool.entries()
+    for i, e in enumerate(pool_entries, 1):
+        exhausted = _format_exhausted_status(e, pool_size=len(pool_entries))
         print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]")
 
     try:

--- a/tests/agent/test_credential_pool_headerless_429_backoff.py
+++ b/tests/agent/test_credential_pool_headerless_429_backoff.py
@@ -1,0 +1,512 @@
+"""A header-less HTTP 429 must not freeze a credential for a flat hour.
+
+A 429 that carries no ``Retry-After`` / reset hint is almost always a short
+transient throttle, not a spent quota window.  The old code gave it the flat
+``EXHAUSTED_TTL_429_SECONDS`` hour anyway, which on a single-credential pool
+guarantees total agent failure: there is nothing to rotate to, so refusing the
+only key locally just takes the agent down for 57 more minutes while the
+provider is already serving that same key again (observed: a direct call on
+the same key returned HTTP 200 while Hermes was still self-refusing).
+
+The fix rides an escalating ladder instead of a flat hour, on a much shorter
+rung when the pool has nowhere to rotate to.  These tests lock the *shape* of
+that ladder rather than its current seconds, so tuning the constants doesn't
+break them:
+
+* a sole credential recovers in a tiny fraction of the hour ceiling;
+* a multi-credential pool escalates monotonically, reaches the hour ceiling,
+  and never passes it;
+* a provider-supplied ``reset_at`` is authoritative and overrides the ladder;
+* 401 and 402 cooldowns are untouched by any of this;
+* the strike counter survives the auth.json round-trip, so the ladder keeps
+  climbing across processes instead of restarting at the base;
+* an exhausted key in a multi-credential pool is still rotated away from.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+
+import pytest
+
+
+PROVIDER = "openrouter"
+
+
+def _row(idx: int, key: str, **overrides) -> dict:
+    row = {
+        "id": f"cred-{idx}",
+        "label": f"key-{idx}",
+        "auth_type": "api_key",
+        "priority": idx,
+        "source": "manual",
+        "access_token": key,
+    }
+    row.update(overrides)
+    return row
+
+
+def _seed_pool(tmp_path, monkeypatch, rows, provider: str = PROVIDER):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "credential_pool": {provider: rows}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent.credential_pool import load_pool
+
+    return load_pool(provider)
+
+
+def _credential(**overrides):
+    from agent.credential_pool import PooledCredential
+
+    payload = dict(
+        provider=PROVIDER,
+        id="cred-0",
+        label="key-0",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="key-a",
+    )
+    payload.update(overrides)
+    return PooledCredential(**payload)
+
+
+def _entry_by_id(pool, entry_id: str):
+    return next(entry for entry in pool.entries() if entry.id == entry_id)
+
+
+def _cooldown_seconds(entry, *, sole_credential: bool) -> float:
+    """Cooldown the pool will actually serve for *entry*, in seconds.
+
+    Measured against the strike's own timestamp rather than wall-clock ``now``
+    so the assertion is about the policy, not about how long the test took.
+    """
+    from agent.credential_pool import _exhausted_until
+
+    until = _exhausted_until(entry, sole_credential=sole_credential)
+    assert until is not None
+    return until - entry.last_status_at
+
+
+def _mark_headerless_429(pool, credential_id: str):
+    """One 429 strike with no reset hint of any kind in the error context."""
+    return pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id=credential_id,
+        error_context={"reason": "rate_limit_exceeded"},
+    )
+
+
+class TestHeaderlessLadderShape:
+    """Unit contract for the fallback ladder itself."""
+
+    def test_sole_credential_ladder_stays_a_small_fraction_of_the_hour(self):
+        from agent.credential_pool import (
+            EXHAUSTED_TTL_429_BACKOFF_FACTOR,
+            EXHAUSTED_TTL_429_SECONDS,
+            SOLE_CREDENTIAL_TTL_429_BASE_SECONDS,
+            SOLE_CREDENTIAL_TTL_429_MAX_SECONDS,
+            _headerless_429_ttl,
+        )
+
+        ladder = [_headerless_429_ttl(s, sole_credential=True) for s in range(1, 9)]
+
+        # This is the bug in one assertion: the only key in the pool comes back
+        # in a tiny fraction of the old flat hour, not after it.
+        assert max(ladder) < EXHAUSTED_TTL_429_SECONDS / 30, ladder
+        assert max(ladder) < 2 * 60, ladder
+
+        assert ladder[0] == SOLE_CREDENTIAL_TTL_429_BASE_SECONDS
+        assert ladder[0] > 0, "some floor must remain, or a hammer loop is possible"
+        assert all(b >= a for a, b in zip(ladder, ladder[1:])), ladder
+        assert max(ladder) == SOLE_CREDENTIAL_TTL_429_MAX_SECONDS
+        for previous, current in zip(ladder, ladder[1:]):
+            if current < SOLE_CREDENTIAL_TTL_429_MAX_SECONDS:
+                assert current == previous * EXHAUSTED_TTL_429_BACKOFF_FACTOR
+
+    def test_multi_credential_ladder_climbs_to_the_hour_ceiling_and_stops(self):
+        from agent.credential_pool import (
+            EXHAUSTED_TTL_429_BACKOFF_FACTOR,
+            EXHAUSTED_TTL_429_BASE_SECONDS,
+            EXHAUSTED_TTL_429_SECONDS,
+            _headerless_429_ttl,
+        )
+
+        ladder = [_headerless_429_ttl(s, sole_credential=False) for s in range(1, 11)]
+
+        assert ladder[0] == EXHAUSTED_TTL_429_BASE_SECONDS
+        # A first throttle is still cheap even with somewhere to rotate to.
+        assert ladder[0] < EXHAUSTED_TTL_429_SECONDS / 10, ladder
+        assert all(b >= a for a, b in zip(ladder, ladder[1:])), ladder
+        assert all(value <= EXHAUSTED_TTL_429_SECONDS for value in ladder), ladder
+        # A genuinely spent quota still parks at the old flat hour.
+        assert EXHAUSTED_TTL_429_SECONDS in ladder, ladder
+        for previous, current in zip(ladder, ladder[1:]):
+            if current < EXHAUSTED_TTL_429_SECONDS:
+                assert current == previous * EXHAUSTED_TTL_429_BACKOFF_FACTOR
+            else:
+                assert current == EXHAUSTED_TTL_429_SECONDS
+
+    @pytest.mark.parametrize("streak", [1, 2, 3, 4, 5, 6])
+    def test_a_pool_with_nowhere_to_rotate_always_waits_less(self, streak):
+        from agent.credential_pool import _headerless_429_ttl
+
+        assert _headerless_429_ttl(streak, sole_credential=True) < _headerless_429_ttl(
+            streak, sole_credential=False
+        )
+
+    @pytest.mark.parametrize("sole", [True, False])
+    def test_runaway_and_degenerate_streaks_stay_inside_the_ceiling(self, sole):
+        from agent.credential_pool import (
+            EXHAUSTED_TTL_429_SECONDS,
+            SOLE_CREDENTIAL_TTL_429_MAX_SECONDS,
+            _headerless_429_ttl,
+        )
+
+        ceiling = (
+            SOLE_CREDENTIAL_TTL_429_MAX_SECONDS if sole else EXHAUSTED_TTL_429_SECONDS
+        )
+        # A streak counter that ran away (or came back nonsense from disk) must
+        # not build a giant int or escape the ceiling.
+        assert _headerless_429_ttl(10_000, sole_credential=sole) == ceiling
+        first = _headerless_429_ttl(1, sole_credential=sole)
+        assert _headerless_429_ttl(0, sole_credential=sole) == first
+        assert _headerless_429_ttl(-5, sole_credential=sole) == first
+
+
+class TestNon429CooldownsAreUnchanged:
+    """Regression guard: only the header-less 429 path moved."""
+
+    @pytest.mark.parametrize("sole", [True, False])
+    @pytest.mark.parametrize("streak", [1, 3, 9])
+    def test_401_402_and_default_ignore_streak_and_pool_size(self, sole, streak):
+        from agent.credential_pool import (
+            EXHAUSTED_TTL_401_SECONDS,
+            EXHAUSTED_TTL_DEFAULT_SECONDS,
+            _exhausted_ttl,
+        )
+
+        assert (
+            _exhausted_ttl(401, streak=streak, sole_credential=sole)
+            == EXHAUSTED_TTL_401_SECONDS
+        )
+        assert (
+            _exhausted_ttl(402, streak=streak, sole_credential=sole)
+            == EXHAUSTED_TTL_DEFAULT_SECONDS
+        )
+        assert (
+            _exhausted_ttl(500, streak=streak, sole_credential=sole)
+            == EXHAUSTED_TTL_DEFAULT_SECONDS
+        )
+        assert (
+            _exhausted_ttl(None, streak=streak, sole_credential=sole)
+            == EXHAUSTED_TTL_DEFAULT_SECONDS
+        )
+        # The transient-auth cooldown stays well short of the billing one.
+        assert EXHAUSTED_TTL_401_SECONDS < EXHAUSTED_TTL_DEFAULT_SECONDS
+
+    def test_billing_402_still_parks_a_sole_credential_for_the_hour(
+        self, tmp_path, monkeypatch
+    ):
+        """A 402 is a spent balance, not a throttle — no fast re-probe."""
+        from agent.credential_pool import EXHAUSTED_TTL_DEFAULT_SECONDS
+
+        struck_at = time.time() - EXHAUSTED_TTL_DEFAULT_SECONDS / 2
+        pool = _seed_pool(
+            tmp_path,
+            monkeypatch,
+            [
+                _row(
+                    0,
+                    "key-a",
+                    last_status="exhausted",
+                    last_status_at=struck_at,
+                    last_error_code=402,
+                    last_error_reason="insufficient_quota",
+                )
+            ],
+        )
+
+        assert pool.has_available() is False
+        assert pool.select() is None
+
+    def test_transient_401_still_clears_on_its_own_short_window(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.credential_pool import EXHAUSTED_TTL_401_SECONDS
+
+        rows = [
+            _row(
+                0,
+                "key-a",
+                last_status="exhausted",
+                last_status_at=time.time() - EXHAUSTED_TTL_401_SECONDS / 5,
+                last_error_code=401,
+            )
+        ]
+        assert _seed_pool(tmp_path, monkeypatch, rows).has_available() is False
+
+        rows[0]["last_status_at"] = time.time() - EXHAUSTED_TTL_401_SECONDS * 2
+        assert _seed_pool(tmp_path, monkeypatch, rows).has_available() is True
+
+
+class TestProviderResetWins:
+    """A reset timestamp from the provider outranks every local heuristic."""
+
+    @pytest.mark.parametrize("sole", [True, False])
+    def test_reset_at_is_returned_verbatim(self, sole):
+        from agent.credential_pool import STATUS_EXHAUSTED, _exhausted_until
+
+        reset_at = 12345.0
+        entry = _credential(
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reset_at=reset_at,
+            last_rate_limit_streak=3,
+        )
+
+        assert _exhausted_until(entry, sole_credential=sole) == reset_at
+
+    @pytest.mark.parametrize("rows_count", [1, 2])
+    def test_marking_with_a_reset_hint_skips_the_ladder(
+        self, tmp_path, monkeypatch, rows_count
+    ):
+        """Sole and multi alike: the hint is stored and honoured as-is, and the
+        header-less strike counter is left alone."""
+        from agent.credential_pool import _exhausted_until
+
+        rows = [_row(i, f"key-{i}") for i in range(rows_count)]
+        pool = _seed_pool(tmp_path, monkeypatch, rows)
+        reset_at = time.time() + 3 * 24 * 60 * 60
+
+        pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="cred-0",
+            error_context={"reason": "rate_limit_exceeded", "reset_at": reset_at},
+        )
+        entry = _entry_by_id(pool, "cred-0")
+
+        assert entry.last_error_reset_at == reset_at
+        for sole in (True, False):
+            assert _exhausted_until(entry, sole_credential=sole) == reset_at
+        # Nothing header-less happened, so the escalating ladder never engaged.
+        assert entry.last_rate_limit_streak == 0
+
+
+class TestPoolCooldownBehaviour:
+
+    def test_sole_credential_recovers_long_before_the_hour(
+        self, tmp_path, monkeypatch
+    ):
+        """The reported bug: one key, one header-less 429, a lost day.
+
+        Two minutes after the strike the pool must serve that key again — at
+        every rung of the sole-credential ladder.
+        """
+        from agent.credential_pool import EXHAUSTED_TTL_429_SECONDS
+
+        two_minutes = 2 * 60
+        assert two_minutes < EXHAUSTED_TTL_429_SECONDS / 10, (
+            "the old flat hour would still be freezing this credential"
+        )
+
+        for streak in (1, 2, 3, 7):
+            pool = _seed_pool(
+                tmp_path,
+                monkeypatch,
+                [
+                    _row(
+                        0,
+                        "key-a",
+                        last_status="exhausted",
+                        last_status_at=time.time() - two_minutes,
+                        last_error_code=429,
+                        last_error_reason="rate_limit_exceeded",
+                        last_rate_limit_streak=streak,
+                    )
+                ],
+            )
+
+            assert pool.has_available() is True, f"streak={streak}"
+            selected = pool.select()
+            assert selected is not None and selected.id == "cred-0"
+
+    def test_sole_credential_strikes_escalate_but_never_reach_the_hour(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.credential_pool import (
+            EXHAUSTED_TTL_429_SECONDS,
+            SOLE_CREDENTIAL_TTL_429_MAX_SECONDS,
+        )
+
+        pool = _seed_pool(tmp_path, monkeypatch, [_row(0, "key-a")])
+
+        cooldowns = []
+        for strike in range(1, 5):
+            _mark_headerless_429(pool, "cred-0")
+            entry = _entry_by_id(pool, "cred-0")
+            assert entry.last_rate_limit_streak == strike
+            cooldowns.append(_cooldown_seconds(entry, sole_credential=True))
+
+        assert all(b >= a for a, b in zip(cooldowns, cooldowns[1:])), cooldowns
+        assert cooldowns[-1] > cooldowns[0]
+        assert max(cooldowns) == SOLE_CREDENTIAL_TTL_429_MAX_SECONDS
+        assert max(cooldowns) < EXHAUSTED_TTL_429_SECONDS / 30
+
+    def test_multi_credential_strikes_escalate_to_the_ceiling_and_stop(
+        self, tmp_path, monkeypatch
+    ):
+        """With somewhere to rotate to, a repeatedly-throttled key is allowed
+        to climb all the way to the hour — and no further."""
+        from agent.credential_pool import EXHAUSTED_TTL_429_SECONDS
+
+        pool = _seed_pool(
+            tmp_path, monkeypatch, [_row(0, "key-a"), _row(1, "key-b")]
+        )
+
+        cooldowns = []
+        for strike in range(1, 7):
+            _mark_headerless_429(pool, "cred-0")
+            entry = _entry_by_id(pool, "cred-0")
+            assert entry.last_rate_limit_streak == strike
+            cooldowns.append(_cooldown_seconds(entry, sole_credential=False))
+
+        assert all(b >= a for a, b in zip(cooldowns, cooldowns[1:])), cooldowns
+        assert all(value <= EXHAUSTED_TTL_429_SECONDS for value in cooldowns), cooldowns
+        assert cooldowns[0] < EXHAUSTED_TTL_429_SECONDS
+        assert cooldowns[-1] == EXHAUSTED_TTL_429_SECONDS
+        # And it is strictly an escalation, not a flat hour from strike one.
+        assert cooldowns[1] > cooldowns[0]
+
+    def test_multi_credential_pool_still_rotates_away_from_an_exhausted_key(
+        self, tmp_path, monkeypatch
+    ):
+        """The fast sole-credential rung must not disable rotation."""
+        pool = _seed_pool(
+            tmp_path, monkeypatch, [_row(0, "key-a"), _row(1, "key-b")]
+        )
+        assert pool.select().id == "cred-0"
+
+        rotated = _mark_headerless_429(pool, "cred-0")
+
+        assert rotated is not None
+        assert rotated.id == "cred-1"
+        assert pool.select().id == "cred-1"
+        assert {entry.id for entry in pool.entries() if entry.last_status != "exhausted"} == {
+            "cred-1"
+        }
+        # The throttled key is on the multi-credential ladder, not the sole one.
+        exhausted = _entry_by_id(pool, "cred-0")
+        assert _cooldown_seconds(exhausted, sole_credential=False) > _cooldown_seconds(
+            exhausted, sole_credential=True
+        )
+
+
+class TestStreakPersistence:
+
+    def test_streak_survives_the_auth_store_round_trip(self, tmp_path, monkeypatch):
+        """A reload must resume the ladder, not restart it at the base.
+
+        Hermes runs several processes against one auth.json; if the strike
+        count didn't persist, a genuinely spent key would re-probe on the base
+        rung forever and never park at the ceiling.
+        """
+        pool = _seed_pool(tmp_path, monkeypatch, [_row(0, "key-a")])
+        _mark_headerless_429(pool, "cred-0")
+        assert _entry_by_id(pool, "cred-0").last_rate_limit_streak == 1
+
+        stored = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+        row = next(
+            r for r in stored["credential_pool"][PROVIDER] if r["id"] == "cred-0"
+        )
+        assert row["last_rate_limit_streak"] == 1
+        assert isinstance(row["last_rate_limit_streak_at"], (int, float))
+
+        from agent.credential_pool import load_pool
+
+        reloaded = load_pool(PROVIDER)
+        restored = _entry_by_id(reloaded, "cred-0")
+        assert restored.last_rate_limit_streak == 1
+        first = _cooldown_seconds(restored, sole_credential=True)
+
+        _mark_headerless_429(reloaded, "cred-0")
+        after_reload = _entry_by_id(reloaded, "cred-0")
+        assert after_reload.last_rate_limit_streak == 2
+        assert _cooldown_seconds(after_reload, sole_credential=True) > first
+
+    def test_streak_fields_survive_borrowed_credential_sanitization(self):
+        """The disk boundary strips secrets, not cooldown bookkeeping."""
+        from agent.credential_persistence import (
+            is_borrowed_credential_source,
+            sanitize_borrowed_credential_payload,
+        )
+
+        payload = {
+            "id": "cred-0",
+            "label": "borrowed",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "env",
+            "access_token": "sk-secret",
+            "last_status": "exhausted",
+            "last_status_at": 1000.0,
+            "last_error_code": 429,
+            "last_rate_limit_streak": 3,
+            "last_rate_limit_streak_at": 1000.0,
+        }
+        assert is_borrowed_credential_source(payload["source"], PROVIDER) is True
+
+        sanitized = sanitize_borrowed_credential_payload(payload, PROVIDER)
+
+        assert "access_token" not in sanitized
+        assert sanitized["last_rate_limit_streak"] == 3
+        assert sanitized["last_rate_limit_streak_at"] == 1000.0
+
+    def test_dataclass_round_trip_preserves_the_computed_cooldown(self):
+        from agent.credential_pool import STATUS_EXHAUSTED, PooledCredential
+
+        entry = _credential(
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_rate_limit_streak=3,
+            last_rate_limit_streak_at=time.time(),
+        )
+
+        restored = PooledCredential.from_dict(PROVIDER, entry.to_dict())
+
+        assert restored.last_rate_limit_streak == entry.last_rate_limit_streak
+        for sole in (True, False):
+            assert _cooldown_seconds(restored, sole_credential=sole) == _cooldown_seconds(
+                entry, sole_credential=sole
+            )
+
+
+class TestAuthListDisplayMatchesEnforcement:
+    """`hermes auth list` must quote the wait the pool will actually serve."""
+
+    def test_single_credential_pool_shows_a_sub_minute_wait(self):
+        from hermes_cli.auth_commands import _format_exhausted_status
+        from agent.credential_pool import STATUS_EXHAUSTED
+
+        entry = _credential(
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reason="rate_limit_exceeded",
+            last_rate_limit_streak=1,
+        )
+
+        sole = _format_exhausted_status(entry, pool_size=1)
+        multi = _format_exhausted_status(entry, pool_size=2)
+
+        assert "rate-limited" in sole
+        assert re.search(r"\(\d+s left\)", sole), sole
+        assert re.search(r"\(\d+[mh]", multi), multi
+        assert sole != multi


### PR DESCRIPTION
## Problem

A 429 that carries no `Retry-After` / reset hint gets the flat
`EXHAUSTED_TTL_429_SECONDS` hour. On a single-credential pool that guarantees
total agent failure: rotation has nowhere to go, so refusing the only key
locally just takes the agent down.

Observed in practice - a direct call on the same key returned HTTP 200 while
Hermes was still self-refusing for another 57 minutes.

## Fix

Header-less 429s walk an escalating ladder instead of one blind hour, capped at
the existing 1-hour ceiling. A genuinely spent quota still parks at the cap
after a few strikes, while a one-off throttle clears in under a minute. A pool
with a single rotation candidate backs off in seconds and lets the provider be
the authority - a still-limited key just returns 429 again, cheaply.

Unchanged:
- Provider-supplied `reset_at` / `Retry-After` remains authoritative and is
  returned verbatim.
- 401 (5 min) and 402 (1 hour) cooldowns.
- Multi-credential pools still rotate away from a bad key as before.

The consecutive-strike counter persists alongside the other `last_*` fields.
Sibling call paths in the auth CLI are updated so status display reflects the
pool-size-aware cooldown.

## Testing

New file `tests/agent/test_credential_pool_headerless_429_backoff.py`.
Verified sole-credential header-less 429 cooldown drops 3600s -> 5s, and that
provider `reset_at` is honored verbatim. 84 tests pass across the new file plus
the existing credential-pool suite; the new suite plus the third-party-400
suite run green against current `main` (33 passed).
