### PR TITLE
fix(file): accurate denial reason for outside-safe-root (#76594)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -99,7 +99,15 @@ def get_safe_write_roots() -> set[str]:
 
 
 def _classify_write_denial(path: str) -> Optional[str]:
-    """Return ``'credential'``, ``'safe_root'``, or ``None`` if writes are allowed."""
+    """Return ``'credential'``, ``'sensitive_path'``, ``'safe_root'``, or
+    ``None`` if writes are allowed.
+
+    ``'credential'`` means the path matches an explicit credential/system
+    denylist entry; ``'sensitive_path'`` means the path is application-owned
+    state (session transcripts) that agent file tools must not rewrite;
+    ``'safe_root'`` means the path is simply outside ``HERMES_WRITE_SAFE_ROOT``
+    and is not otherwise protected.
+    """
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
@@ -126,10 +134,10 @@ def _classify_write_denial(path: str) -> Optional[str]:
         # falsify conversation history and invalidate resume/compression state.
         try:
             if resolved == os.path.realpath(os.path.join(base_real, "state.db")):
-                return True
+                return "sensitive_path"
             sessions_real = os.path.realpath(os.path.join(base_real, "sessions"))
             if resolved == sessions_real or resolved.startswith(sessions_real + os.sep):
-                return True
+                return "sensitive_path"
         except Exception:
             pass
         try:
@@ -173,6 +181,11 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
         return (
             f"{verb} denied: '{path}' is outside HERMES_WRITE_SAFE_ROOT "
             f"({roots_display}). Unset the variable or add this path's directory prefix."
+        )
+    if denial == "sensitive_path":
+        return (
+            f"{verb} denied: '{path}' is protected Hermes session/system "
+            "state and cannot be rewritten by file tools."
         )
     return f"{verb} denied: '{path}' is a protected system/credential file."
 

--- a/tests/agent/test_file_safety_session_state.py
+++ b/tests/agent/test_file_safety_session_state.py
@@ -45,6 +45,41 @@ def test_session_state_paths_are_write_denied(fake_homes, relative):
     assert is_write_denied(str(target)) is True
 
 
+@pytest.mark.parametrize("relative", ["state.db", "sessions/session_abc.json"])
+def test_session_state_denial_classifies_as_sensitive_path(fake_homes, relative):
+    """Session transcripts must be classified as protected application state
+    ('sensitive_path'), not as a safe-root escape or a credential file
+    (regression for #76594)."""
+    from agent.file_safety import _classify_write_denial, get_write_denied_error
+
+    _root, profile = fake_homes
+    target = profile / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("existing transcript", encoding="utf-8")
+
+    assert _classify_write_denial(str(target)) == "sensitive_path"
+
+    err = get_write_denied_error(str(target))
+    assert err is not None
+    assert "session/system state" in err
+    assert "outside HERMES_WRITE_SAFE_ROOT" not in err
+    assert "credential file" not in err
+
+
+def test_session_state_denial_message_uses_verb(fake_homes):
+    """The sensitive-path message honors the requested verb."""
+    from agent.file_safety import get_write_denied_error
+
+    _root, profile = fake_homes
+    target = profile / "state.db"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("existing transcript", encoding="utf-8")
+
+    err = get_write_denied_error(str(target), verb="Delete")
+    assert err is not None
+    assert err.startswith("Delete denied:")
+
+
 
 
 

--- a/tests/tools/test_tts_path_traversal.py
+++ b/tests/tools/test_tts_path_traversal.py
@@ -48,7 +48,7 @@ def test_output_path_rejects_hermes_oauth_store(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "credential" in result["error"]
     assert not target.exists()
 
 
@@ -69,5 +69,53 @@ def test_output_path_rejects_mcp_token_directory(tmp_path, monkeypatch):
     ))
 
     assert result["success"] is False
-    assert "protected credential" in result["error"]
+    assert "credential" in result["error"]
+    assert not target.exists()
+
+
+def test_output_path_outside_safe_root_names_safe_root(tmp_path, monkeypatch):
+    """TTS output_path outside HERMES_WRITE_SAFE_ROOT must not be mislabeled
+    as a protected credential/system file (regression for #76594)."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    safe_root = tmp_path / "workspace"
+    safe_root.mkdir()
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+    outside = tmp_path / "audio-out" / "clip.mp3"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(outside),
+    ))
+
+    assert result["success"] is False
+    assert "outside HERMES_WRITE_SAFE_ROOT" in result["error"]
+    assert "credential" not in result["error"]
+    assert not outside.exists()
+
+
+def test_output_path_session_state_names_session_state(tmp_path, monkeypatch):
+    """TTS output_path targeting session transcripts must be reported as
+    protected session/system state, not as a credential file."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    sessions_dir = hermes_home / "sessions"
+    sessions_dir.mkdir(parents=True)
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    target = sessions_dir / "session_abc.json"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(target),
+    ))
+
+    assert result["success"] is False
+    assert "session/system state" in result["error"]
     assert not target.exists()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2894,15 +2894,13 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
-        from agent.file_safety import is_write_denied
+        from agent.file_safety import get_write_denied_error
 
-        if is_write_denied(str(file_path)):
+        denied = get_write_denied_error(str(file_path))
+        if denied:
             return json.dumps({
                 "success": False,
-                "error": (
-                    f"output_path targets a protected credential or system path: "
-                    f"{file_path}. Choose a normal audio output location."
-                ),
+                "error": denied,
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")


### PR DESCRIPTION
Closes #76594

## Summary

`agent.file_safety` already distinguishes `safe_root` denials from credential blocks (from #64347), but two gaps remained that still mislabeled denials:

1. **`_classify_write_denial()` returned a bare `True` for session-transcript paths** (`state.db`, `sessions/`) instead of a string category, violating its own docstring contract. Those paths now return a distinct `'sensitive_path'` category, and `get_write_denied_error()` renders an accurate message ("protected Hermes session/system state") instead of falling through to the credential-file wording.

2. **`tools/tts_tool.py` still used the boolean `is_write_denied()`** and emitted a hard-coded "output_path targets a protected credential or system path" error for *every* denial — including plain outside-safe-root paths. It now calls `get_write_denied_error()` so the reason matches the cause.

## Changes

- `agent/file_safety.py`: return `'sensitive_path'` for session-transcript paths; add a dedicated message branch in `get_write_denied_error()`; update docstring.
- `tools/tts_tool.py`: route output-path denials through `get_write_denied_error()`.
- Tests: cover the `'sensitive_path'` classification/message, the verb-aware message, and TTS output-path denials for all three reason classes (credential, outside-safe-root, session state).

## Behavior

- Fail-closed behavior is unchanged — every previously denied path is still denied.
- Messages are now accurate per cause:
  - credential/system denylist → "protected system/credential file"
  - session transcripts → "protected Hermes session/system state"
  - outside `HERMES_WRITE_SAFE_ROOT` → names the variable and allowed roots
