### PR TITLE
fix(curator): consolidation is not prune (#76588)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -665,9 +665,15 @@ def _classify_removed_skills(
         parsed_calls.append(args)
 
     # Build a set of "destination" skill names: anything still present after
-    # the run plus anything newly added this run. A removed skill being
-    # referenced from one of these is the consolidation signal.
-    destinations = set(after_names) | set(added or [])
+    # the run, anything newly added this run, plus anything created/modified
+    # during the run per the tool calls (a same-run-created umbrella may not
+    # survive into the after snapshot). A removed skill being referenced from
+    # one of these is the consolidation signal.
+    destinations = (
+        set(after_names)
+        | set(added or [])
+        | _same_run_skill_targets(tool_calls)
+    )
 
     for name in removed:
         if not name:
@@ -871,6 +877,57 @@ def _extract_absorbed_into_declarations(
     return out
 
 
+def _same_run_skill_targets(tool_calls: List[Dict[str, Any]]) -> Set[str]:
+    """Names of skills created/modified during this run, from tool calls.
+
+    A ``skill_manage`` call with a mutating action (``create``,
+    ``write_file``, ``patch``, ``edit``) only succeeds if the target skill
+    exists at call time — it was created earlier in this run, or it already
+    existed. Either way the target is a real, surviving skill, so it is a
+    valid consolidation destination even when the post-run ``after_names``
+    snapshot misses it (the umbrella was created and consumed entirely
+    within the run, or the snapshot omits brand-new skills).
+
+    Without this seed, a same-run-created umbrella is absent from
+    ``destinations``, every ``absorbed_into=<umbrella>`` delete declaration
+    fails the ``into_claim in destinations`` check in
+    ``_reconcile_classification``, and the model's authoritative
+    consolidation is downgraded to a prune (#76588).
+    """
+    targets: Set[str] = set()
+    for tc in tool_calls or []:
+        if not isinstance(tc, dict):
+            continue
+        if tc.get("name") != "skill_manage":
+            continue
+        raw = tc.get("arguments") or ""
+        args: Dict[str, Any] = {}
+        if isinstance(raw, dict):
+            args = raw
+        elif isinstance(raw, str):
+            try:
+                args = json.loads(raw)
+            except Exception:
+                # Truncated JSON (the report truncates long argument
+                # payloads): fall back to a targeted regex so a truncated
+                # `create`/`write_file` call still seeds its target.
+                m = re.search(
+                    r'"action"\s*:\s*"(?:create|write_file|patch|edit)"', raw
+                )
+                n = re.search(r'"name"\s*:\s*"([^"]+)"', raw)
+                if m and n:
+                    targets.add(n.group(1))
+                continue
+        if not isinstance(args, dict):
+            continue
+        if args.get("action") not in ("create", "write_file", "patch", "edit"):
+            continue
+        name = args.get("name")
+        if isinstance(name, str) and name.strip():
+            targets.add(name.strip())
+    return targets
+
+
 def _reconcile_classification(
     removed: List[str],
     heuristic: Dict[str, List[Dict[str, Any]]],
@@ -888,8 +945,9 @@ def _reconcile_classification(
       pruned. ``into != ""`` but target doesn't exist → hallucination; fall
       through to the usual signals.
     - Model-declared consolidation wins when its ``into`` target exists
-      in ``destinations`` (survived or newly-created). This gives the
-      model authority over intent + rationale.
+      in ``destinations`` (survived, newly-created, or created earlier in
+      this same run per the tool calls — see ``_same_run_skill_targets``).
+      This gives the model authority over intent + rationale.
     - Model-declared consolidation whose ``into`` target does NOT exist is
       downgraded: the model hallucinated an umbrella. We prefer the
       heuristic's finding for that skill, or fall back to pruned.
@@ -1044,7 +1102,7 @@ def _build_rename_summary(
         tool_calls=tool_calls,
     )
     model_block = _parse_structured_summary(model_final)
-    destinations = set(after_names) | set(added)
+    destinations = set(after_names) | set(added) | _same_run_skill_targets(tool_calls)
     absorbed_declarations = _extract_absorbed_into_declarations(tool_calls)
     classification = _reconcile_classification(
         removed=removed,
@@ -1132,6 +1190,18 @@ def _write_run_report(
     after_names = set(after_by_name.keys())
     removed = sorted(before_names - after_names)   # archived during this run
     added = sorted(after_names - before_names)     # new skills this run
+    # A skill created and consumed entirely within this run (umbrella
+    # created, sources absorbed, umbrella kept) may not survive into the
+    # after snapshot — or the snapshot may omit brand-new skills. Seed
+    # `added` from the run's tool calls so the report reliably reflects
+    # every skill the model created, not just the snapshot diff (#76588).
+    added = sorted(
+        set(added)
+        | (
+            _same_run_skill_targets(llm_meta.get("tool_calls", []) or [])
+            - before_names
+        )
+    )
     before_by_name = {r.get("name"): r for r in before_report if isinstance(r, dict)}
 
     # State transitions between the two snapshots (e.g. active -> stale)
@@ -1169,7 +1239,11 @@ def _write_run_report(
         tool_calls=llm_meta.get("tool_calls", []) or [],
     )
     model_block = _parse_structured_summary(llm_meta.get("final", "") or "")
-    destinations = set(after_names) | set(added or [])
+    destinations = (
+        set(after_names)
+        | set(added or [])
+        | _same_run_skill_targets(llm_meta.get("tool_calls", []) or [])
+    )
     # Authoritative signal: extract per-delete `absorbed_into` declarations
     # from this run's tool calls. These beat both the YAML summary block and
     # the substring heuristic — the model is telling us directly, at the

--- a/tests/agent/test_curator_classification.py
+++ b/tests/agent/test_curator_classification.py
@@ -404,6 +404,172 @@ def test_reconcile_mixed_declarations_and_legacy_calls(curator_env):
 
 
 # ---------------------------------------------------------------------------
+# #76588 — same-run-created umbrella must seed `destinations`
+# ---------------------------------------------------------------------------
+
+
+def test_same_run_skill_targets_parses_mutating_calls(curator_env):
+    """create/write_file/patch/edit targets are destinations; delete/view are not."""
+    targets = curator_env._same_run_skill_targets([
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "create", "name": "external-coding-agents",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "write_file", "name": "external-coding-agents",
+            "file_path": "references/claude-code.md",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "patch", "name": "external-coding-agents",
+            "old_string": "a", "new_string": "b",
+        })},
+        # Non-mutating / destructive calls are not destinations:
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "claude-code",
+            "absorbed_into": "external-coding-agents",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "view", "name": "claude-code",
+        })},
+        {"name": "other_tool", "arguments": json.dumps({
+            "action": "create", "name": "not-a-skill",
+        })},
+    ])
+    assert targets == {"external-coding-agents"}
+
+
+def test_same_run_skill_targets_survives_truncated_args(curator_env):
+    """A 400-char-truncated create call still seeds its target name (#76588)."""
+    raw = '{"action": "create", "name": "kanban-workflow", "content": "' + "x" * 500
+    targets = curator_env._same_run_skill_targets([
+        {"name": "skill_manage", "arguments": raw},
+    ])
+    assert targets == {"kanban-workflow"}
+
+
+def test_write_run_report_same_run_umbrella_not_pruned(curator_env):
+    """#76588 regression: absorbed_into a same-run-created umbrella is
+    classified as consolidated, never pruned — even when the after snapshot
+    omits the umbrella and the snapshot diff yields ``added: []``.
+
+    Mirrors the real-world run from the issue: the model creates the
+    umbrella, writes its reference files, and deletes the sources with
+    ``absorbed_into=<umbrella>`` — but the umbrella is absent from the
+    post-run ``after_names``, so the old ``destinations`` gate starved and
+    every declaration fell through to ``fallback (model named missing
+    umbrella, no tool-call evidence)`` → prune.
+    """
+    curator = curator_env
+    start = datetime.now(timezone.utc)
+
+    before = [
+        {"name": "claude-code", "state": "active", "pinned": False},
+        {"name": "codex", "state": "active", "pinned": False},
+        {"name": "opencode", "state": "active", "pinned": False},
+        {"name": "keeper", "state": "active", "pinned": False},
+    ]
+    # The freshly-created umbrella does NOT survive into the after snapshot
+    # (the issue's `added: []` case).
+    after = [{"name": "keeper", "state": "active", "pinned": False}]
+
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "create", "name": "external-coding-agents",
+            "content": "# External coding agents umbrella",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "write_file", "name": "external-coding-agents",
+            "file_path": "references/claude-code.md",
+            "file_content": "# Claude Code\n...",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "write_file", "name": "external-coding-agents",
+            "file_path": "references/codex.md",
+            "file_content": "# Codex\n...",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "write_file", "name": "external-coding-agents",
+            "file_path": "references/opencode.md",
+            "file_content": "# OpenCode\n...",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "claude-code",
+            "absorbed_into": "external-coding-agents",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "codex",
+            "absorbed_into": "external-coding-agents",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "opencode",
+            "absorbed_into": "external-coding-agents",
+        })},
+    ]
+
+    run_dir = curator._write_run_report(
+        started_at=start,
+        elapsed_seconds=60.0,
+        auto_counts={"checked": 4, "marked_stale": 0, "archived": 0, "reactivated": 0},
+        auto_summary="no auto changes",
+        before_report=before,
+        before_names={r["name"] for r in before},
+        after_report=after,
+        llm_meta={
+            "final": "",
+            "summary": "consolidated 3 into external-coding-agents",
+            "model": "m",
+            "provider": "p",
+            "error": None,
+            "tool_calls": tool_calls,
+        },
+    )
+
+    payload = json.loads((run_dir / "run.json").read_text())
+
+    cons_by_name = {e["name"]: e for e in payload["consolidated"]}
+    assert set(cons_by_name) == {"claude-code", "codex", "opencode"}
+    for n in ("claude-code", "codex", "opencode"):
+        assert cons_by_name[n]["into"] == "external-coding-agents"
+        # The authoritative absorbed_into declaration path won, not a fallback
+        assert "absorbed_into" in cons_by_name[n]["source"]
+    # Nothing was misclassified as a prune
+    assert payload["pruned"] == []
+    assert payload["counts"]["consolidated_this_run"] == 3
+    assert payload["counts"]["pruned_this_run"] == 0
+    # The same-run-created umbrella is reported as added (#76588 bookkeeping)
+    assert "external-coding-agents" in payload["added"]
+
+    md = (run_dir / "REPORT.md").read_text()
+    assert "`claude-code` → merged into `external-coding-agents`" in md
+    assert "Pruned — archived for staleness" not in md
+
+
+def test_rename_summary_same_run_umbrella_consolidation(curator_env):
+    """#76588: the user-visible rename map shows `→ umbrella` (not pruned)
+    when the umbrella was created earlier in the same run and is absent
+    from the after snapshot."""
+    result = curator_env._build_rename_summary(
+        before_names={"claude-code", "keeper"},
+        after_report=[{"name": "keeper", "state": "active"}],
+        tool_calls=[
+            {"name": "skill_manage", "arguments": json.dumps({
+                "action": "create", "name": "external-coding-agents",
+            })},
+            {"name": "skill_manage", "arguments": json.dumps({
+                "action": "write_file", "name": "external-coding-agents",
+                "file_path": "references/claude-code.md",
+            })},
+            {"name": "skill_manage", "arguments": json.dumps({
+                "action": "delete", "name": "claude-code",
+                "absorbed_into": "external-coding-agents",
+            })},
+        ],
+        model_final="",
+    )
+    assert "claude-code → external-coding-agents" in result
+    assert "pruned (stale)" not in result
+
+
+# ---------------------------------------------------------------------------
 # _build_rename_summary — surfaces the "where did my skills go?" map to the
 # user-visible curator summary (gateway 💾 line, CLI Rich panel,
 # `hermes curator status`). The full data has always been in REPORT.md on


### PR DESCRIPTION
Closes #76588

## Problem

When the curator's LLM consolidation pass creates an umbrella skill **and** deletes the source skills in the same run, the reconciled classification can misclassify every one of those consolidations as a **prune**, permanently removing the standalone skills and recording nothing under `.archive/`.

Root cause: `destinations` (the set of valid consolidation targets) was computed purely from the post-run snapshot:

```python
destinations = set(after_names) | set(added or [])
```

When the freshly-created umbrella does not appear in `after_names` (the snapshot omits brand-new skills, or the umbrella was created and consumed entirely within the run) **and** `added` comes back empty, the umbrella is absent from `destinations`. Every `absorbed_into=<umbrella>` delete declaration then fails the `into_claim in destinations` check in `_reconcile_classification`, the model is judged to have "named a missing umbrella", and — with no heuristic evidence — classification falls to the `fallback (model named missing umbrella, no tool-call evidence)` **prune** branch. The same gate also starved the tool-call heuristic in `_classify_removed_skills` (`target not in destinations`).

## Fix

1. **New helper `_same_run_skill_targets(tool_calls)`** — parses this run's `skill_manage` calls and returns the names of skills targeted by mutating actions (`create`, `write_file`, `patch`, `edit`). Those calls only succeed if the target skill exists, so the target is a real, surviving skill — a valid consolidation destination even when the after snapshot missed it. Handles truncated argument payloads (the report truncates long args at 400 chars) with a targeted regex fallback.

2. **Seed `destinations`** with `_same_run_skill_targets(...)` at all three computation sites:
   - `_classify_removed_skills` (heuristic gate `target not in destinations`)
   - `_build_rename_summary` (user-visible "where did my skills go?" map)
   - `_write_run_report` (run.json / REPORT.md classification)

3. **`added` bookkeeping** — `_write_run_report` now seeds `added` from the run's tool calls (minus `before_names`), so the report reliably reflects every skill the model created, not just the snapshot diff. This addresses the issue's `added: []` defect: a same-run-created umbrella is reported under "New skills this run" and feeds `counts.added_this_run` even when it didn't survive into the after snapshot.

Non-destructiveness note: the `fallback (model named missing umbrella, no tool-call evidence)` prune branch can still fire for a genuinely hallucinated umbrella (no `create`/`write_file`/`patch`/`edit` call for the claimed target), but the classification-level fix ensures same-run consolidations — the case where the model demonstrably created the umbrella — are never downgraded to a prune. Deletions already route through `.archive/` (recoverable) since #26655; misclassification previously also caused cron references to be **dropped** instead of **rewritten** to the umbrella, which this fix prevents.

## Tests

Added 4 regression tests in `tests/agent/test_curator_classification.py`:

- `test_same_run_skill_targets_parses_mutating_calls` — create/write_file/patch targets seed destinations; delete/view and non-skill_manage calls do not.
- `test_same_run_skill_targets_survives_truncated_args` — a 400-char-truncated `create` call still seeds its target name.
- `test_write_run_report_same_run_umbrella_not_pruned` — end-to-end mirror of the issue's run: umbrella created + reference files written + sources deleted with `absorbed_into=<umbrella>`, umbrella absent from the after snapshot. Asserts all three skills are `consolidated` (source contains `absorbed_into`), `pruned` is empty, and the umbrella appears in `added`.
- `test_rename_summary_same_run_umbrella_consolidation` — the user-visible rename map shows `claude-code → external-coding-agents`, not `pruned (stale)`.

All 52 curator tests + 45 skill_manager_tool tests pass.
