### PR TITLE
fix(provider): distinguish idle local endpoints from crashes (#76597)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -64,6 +64,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
+    is_local_endpoint,
     is_output_cap_error,
     parse_available_output_tokens_from_error,
     save_context_length,
@@ -78,6 +79,8 @@ from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
+    local_endpoint_wakeup_retry_ceiling,
+    should_eagerly_fallback,
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
@@ -4343,9 +4346,34 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
-                _should_fallback = (
-                    is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                # ── Local endpoint idle/sleep handling (Fixes #76597) ────
+                # LM Studio (``--sleep-idle-seconds``), Ollama, and other local
+                # servers close the TCP socket while intentionally idle.  A
+                # connection reset on a local endpoint is indistinguishable
+                # from a crash at the socket level (``ECONNRESET`` /
+                # ``WinError 10053``), so do NOT eagerly fail over to remote
+                # fallback providers — which are typically rate-limited or dead
+                # and exhaust in seconds.  Instead give the endpoint a
+                # wake-up window: raise the retry ceiling so the backoff
+                # schedule has room to run (see
+                # ``local_endpoint_wakeup_retry_ceiling``), and surface a
+                # distinct "may be sleeping" status once.  Only after the
+                # window elapses (terminal branch below) is the endpoint
+                # treated as a hard failure, with dedicated guidance.
+                _is_local_endpoint = bool(agent.base_url) and is_local_endpoint(agent.base_url)
+                if _is_local_endpoint and _is_transport_failure:
+                    max_retries = max(max_retries, local_endpoint_wakeup_retry_ceiling())
+                    if not _retry.local_idle_hint_shown:
+                        _retry.local_idle_hint_shown = True
+                        agent._buffer_status(
+                            "💤 Local endpoint appears to be idle/sleeping — "
+                            "retrying to wake it before considering fallback..."
+                        )
+                _should_fallback = should_eagerly_fallback(
+                    is_rate_limited=is_rate_limited,
+                    is_transport_failure=_is_transport_failure,
+                    retry_count=retry_count,
+                    is_local_endpoint=_is_local_endpoint,
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -5230,6 +5258,23 @@ def run_conversation(
                         )
                     elif is_rate_limited:
                         agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
+                    elif _is_local_endpoint and _is_transport_failure:
+                        # Local endpoint gave its wake-up window and stayed
+                        # down — this is now a hard failure, but the user needs
+                        # to know the endpoint may simply be asleep (and that
+                        # fallback providers were intentionally NOT burned on a
+                        # sleeping server).  Fixes #76597.
+                        agent._emit_status(
+                            f"❌ Local endpoint connection lost after {max_retries} retries — "
+                            f"{_final_summary}"
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The local endpoint (LM Studio / Ollama / "
+                            f"llama.cpp) may be sleeping or crashed. Wake it (or restart it) "
+                            f"and retry — a sleeping endpoint recovers, a crashed one needs "
+                            f"attention.",
+                            force=True,
+                        )
                     else:
                         agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
                     agent._vprint(f"{agent.log_prefix}   💀 Final error: {_final_summary}", force=True)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -206,3 +206,60 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
     """
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+# ── Local endpoint idle/sleep handling (Fixes #76597) ──────────────────────
+# Local LLM servers (LM Studio with ``--sleep-idle-seconds``, Ollama, llama.cpp,
+# oMLX) close the TCP socket while in intentional idle/sleep mode.  At the
+# socket level a sleeping endpoint is indistinguishable from a crashed one
+# (``ECONNRESET`` / ``WinError 10053``).  ``should_eagerly_fallback`` keeps the
+# turn loop from treating a sleeping local endpoint as a hard failure and
+# eagerly switching to remote fallback providers, and
+# ``local_endpoint_wakeup_retry_ceiling`` extends the retry budget so the
+# endpoint gets a real wake-up window before the terminal branch declares it
+# down.
+_LOCAL_WAKEUP_RETRY_CEILING = 6
+
+
+def local_endpoint_wakeup_retry_ceiling() -> int:
+    """Retry-loop ceiling for local endpoints on transport failures.
+
+    The default ``agent.api_max_retries`` (3) exhausts in seconds — far too
+    fast for a sleeping LM Studio/Ollama instance to wake up.  Raise the
+    ceiling so the backoff schedule (``jittered_backoff`` grows toward its 60s
+    max) gives the endpoint a ~2-3 minute wake-up window.  After the window
+    elapses with the endpoint still refusing connections, the terminal branch
+    treats it as a hard failure and surfaces dedicated guidance.
+    """
+    return _LOCAL_WAKEUP_RETRY_CEILING
+
+
+def should_eagerly_fallback(
+    *,
+    is_rate_limited: bool,
+    is_transport_failure: bool,
+    retry_count: int,
+    is_local_endpoint: bool,
+) -> bool:
+    """Whether the turn loop should eagerly switch to a fallback provider.
+
+    Rate limits and billing switch immediately (the primary provider won't
+    recover within the retry window).  Transport failures allow one retry
+    (transient hiccups recover), then fall back if the provider is truly
+    unreachable — UNLESS the provider is a local endpoint.
+
+    Local endpoints (LM Studio, Ollama, llama.cpp) drop the TCP socket while
+    intentionally idle/sleeping; a connection reset there is a "wake me up"
+    signal, not a crash.  Eagerly failing over to remote fallback providers
+    (often rate-limited or dead, exhausting in seconds) is exactly wrong: the
+    sleeping endpoint would recover if Hermes simply waited and retried.  For
+    local endpoints, transport failures fall through to the retry/backoff path
+    instead (with the ceiling raised by
+    ``local_endpoint_wakeup_retry_ceiling``), and the terminal branch reports
+    a distinct "endpoint may be sleeping or crashed" message.  Fixes #76597.
+    """
+    if is_rate_limited:
+        return True
+    if is_transport_failure and retry_count >= 2 and not is_local_endpoint:
+        return True
+    return False

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -66,6 +66,12 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
+    # Local endpoints (LM Studio, Ollama, llama.cpp) drop the TCP socket
+    # while intentionally idle/sleeping; a connection reset there is a
+    # "wake me up" signal, not a crash.  Fires the one-shot "local endpoint
+    # may be sleeping" status hint so the user sees WHY Hermes is retrying
+    # instead of failing over (Fixes #76597).
+    local_idle_hint_shown: bool = False
 
     # ── Auth-failure provider failover ───────────────────────────────────
     # Set once we've escalated a persistent 401/403 (after the per-provider

--- a/tests/run_agent/test_76597_local_endpoint_idle.py
+++ b/tests/run_agent/test_76597_local_endpoint_idle.py
@@ -1,0 +1,108 @@
+"""Regression guard for #76597: local endpoints in idle/sleep mode must NOT be
+treated as crashed (and must not eagerly fail over to remote fallback
+providers).
+
+LM Studio (``--sleep-idle-seconds``), Ollama, and other local servers close the
+TCP socket while intentionally idle.  At the socket level a sleeping endpoint
+is indistinguishable from a crashed one (``ECONNRESET`` / ``WinError 10053``).
+Before this fix, Hermes:
+
+  1. classified the connection reset as a transport failure,
+  2. after 1 retry, eagerly switched to fallback providers (often
+     rate-limited/dead — exhausting in seconds),
+  3. crashed the gateway process once retries + fallbacks were exhausted.
+
+The fix keeps the eager-fallback gate from firing for local endpoints on
+transport failures, raises the retry ceiling so the endpoint gets a wake-up
+window, and surfaces a distinct "endpoint may be sleeping" message.  These
+tests mirror the decision helper (``should_eagerly_fallback`` /
+``local_endpoint_wakeup_retry_ceiling``) that the turn loop now uses, in
+lock-step with the source per tests/run_agent convention.
+"""
+from __future__ import annotations
+
+from agent.retry_utils import (
+    local_endpoint_wakeup_retry_ceiling,
+    should_eagerly_fallback,
+)
+from agent.turn_retry_state import TurnRetryState
+
+
+class TestLocalEndpointDoesNotEagerlyFallback:
+    """Transport failures on local endpoints retry (wake-up), never fail over."""
+
+    def test_local_transport_failure_never_eagerly_falls_back(self):
+        """Sleeping local endpoint: even at retry_count >= 2, do NOT fall back."""
+        for retry_count in (0, 1, 2, 5):
+            assert not should_eagerly_fallback(
+                is_rate_limited=False,
+                is_transport_failure=True,
+                retry_count=retry_count,
+                is_local_endpoint=True,
+            ), (
+                f"Local endpoint transport failure at retry_count={retry_count} "
+                "must retry (wake-up window) instead of eagerly failing over — #76597"
+            )
+
+    def test_non_local_transport_failure_still_falls_back(self):
+        """Cloud endpoint behavior is unchanged: 1 retry, then fall back."""
+        assert not should_eagerly_fallback(
+            is_rate_limited=False,
+            is_transport_failure=True,
+            retry_count=1,
+            is_local_endpoint=False,
+        ), "Transient hiccup on a cloud endpoint deserves its single retry"
+        assert should_eagerly_fallback(
+            is_rate_limited=False,
+            is_transport_failure=True,
+            retry_count=2,
+            is_local_endpoint=False,
+        ), "Unreachable cloud provider must still fail over after 1 retry"
+
+    def test_rate_limit_falls_back_even_for_local(self):
+        """A 429 from a local server is a real condition — fall back as usual."""
+        assert should_eagerly_fallback(
+            is_rate_limited=True,
+            is_transport_failure=True,
+            retry_count=0,
+            is_local_endpoint=True,
+        )
+
+    def test_no_fallback_on_success_or_unrelated_errors(self):
+        """Rate limit + transport are the only eager-fallback triggers."""
+        assert not should_eagerly_fallback(
+            is_rate_limited=False,
+            is_transport_failure=False,
+            retry_count=9,
+            is_local_endpoint=False,
+        )
+
+
+class TestLocalEndpointWakeUpWindow:
+    """The retry ceiling must exceed api_max_retries (default 3) so the
+    backoff schedule has room to give a sleeping endpoint time to wake."""
+
+    def test_wakeup_ceiling_exceeds_default_retries(self):
+        assert local_endpoint_wakeup_retry_ceiling() > 3, (
+            "Wake-up ceiling must exceed the default api_max_retries (3) so "
+            "the backoff schedule can actually run — #76597"
+        )
+
+    def test_wakeup_ceiling_is_reasonable(self):
+        # ~2-3 minutes of jittered backoff (base 2s → max 60s) — enough for
+        # LM Studio/Ollama to come back from sleep, not so long that a truly
+        # crashed endpoint stalls the user forever.
+        assert 5 <= local_endpoint_wakeup_retry_ceiling() <= 8
+
+
+class TestTurnRetryStateIdleHint:
+    """One-shot status hint so the user sees WHY Hermes is retrying."""
+
+    def test_idle_hint_defaults_to_false(self):
+        state = TurnRetryState()
+        assert state.local_idle_hint_shown is False
+
+    def test_idle_hint_is_one_shot(self):
+        state = TurnRetryState()
+        state.local_idle_hint_shown = True
+        assert state.local_idle_hint_shown is True


### PR DESCRIPTION
Closes #76597

## Problem

When a local LLM endpoint (LM Studio with `--sleep-idle-seconds`, Ollama, llama.cpp) is in intentional idle/sleep mode, Hermes could not distinguish it from a crashed endpoint. Both surface as `ECONNRESET` / `WinError 10053`. The turn loop classified the connection reset as a transport failure, eagerly failed over to remote fallback providers (often rate-limited/dead — exhausting in seconds), and eventually crashed the gateway process once retries + fallbacks were exhausted. A sleeping endpoint would have recovered if Hermes had simply waited.

## Fix

For **local endpoints** (`is_local_endpoint()` on the active `base_url`), transport failures (connection reset / timeout / overloaded) are now treated as a "wake me up" signal, not a crash:

1. **No eager fallback** — `should_eagerly_fallback()` (new helper in `agent/retry_utils.py`) never returns True for a local endpoint on a transport failure. Cloud endpoint behavior is unchanged (1 retry, then fail over).
2. **Wake-up window** — `local_endpoint_wakeup_retry_ceiling()` raises the retry ceiling from the default 3 to 6, giving the jittered backoff schedule (~2-3 minutes, growing to 60s waits) room to let a sleeping LM Studio/Ollama wake up.
3. **Distinct user-facing messages** — a one-shot `💤 Local endpoint appears to be idle/sleeping — retrying to wake it...` status fires instead of `Provider unreachable — switching to fallback provider...`. If the wake-up window elapses with the endpoint still down, the terminal branch reports `Local endpoint connection lost... may be sleeping or crashed` with guidance, instead of a generic `API failed after N retries`.

## Files changed

- `agent/retry_utils.py` — `should_eagerly_fallback()`, `local_endpoint_wakeup_retry_ceiling()`
- `agent/conversation_loop.py` — uses the new helpers; local-endpoint wake-up status + terminal guidance
- `agent/turn_retry_state.py` — one-shot `local_idle_hint_shown` guard
- `tests/run_agent/test_76597_local_endpoint_idle.py` — regression tests (8 tests, mirror-predicate convention)

## Verification

- 8 new tests pass; 109 targeted tests pass (existing local-endpoint timeout, fallback, and error-classifier suites unaffected)
- `agent.conversation_loop` imports cleanly
