### PR TITLE
fix(mcp): retain OAuth tokens across transient failures (#76590)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11987,7 +11987,16 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
 
                         reconnect_mcp_server(flow.server_name)
                 except Exception:
-                    storage.restore(backup, only_if_absent=True)
+                    # #76590: roll the failed re-auth back UNCONDITIONALLY.
+                    # The MCP SDK commonly writes partial state (client.json
+                    # via RFC 7591 registration, meta.json from discovery)
+                    # before the flow dies — e.g. a non-interactive probe or
+                    # a transient connection failure. With only_if_absent=True
+                    # that partial file made the restore skip, leaving the
+                    # previously-valid tokens deleted from disk with no way to
+                    # recover headlessly. A failed re-auth must never destroy
+                    # working credentials, so restore over any partial state.
+                    storage.restore(backup, only_if_absent=False)
                     manager.restore_entry(
                         flow.server_name,
                         previous_entry,

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -401,6 +401,54 @@ class TestRemoveOAuthTokens:
         assert not (d / "myserver.client.json").exists()
 
 
+class TestOAuthRollback:
+    """#76590: a failed re-auth must restore the pre-flow OAuth state even
+    when the aborted flow left partial files behind (client.json / meta.json
+    written by RFC 7591 registration and metadata discovery before the flow
+    dies). only_if_absent would see that partial state and skip the rollback,
+    leaving the previously-valid tokens deleted from disk."""
+
+    def _write_state(self, storage, *, tokens: str = "TOKEN_OLD", client: bool = True):
+        storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+        storage._tokens_path().write_text(
+            '{"access_token":"%s","token_type":"Bearer","expires_in":3600}' % tokens
+        )
+        if client:
+            storage._client_info_path().write_text('{"client_id":"old-client"}')
+
+    def test_restore_rolls_back_over_partial_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("myserver")
+        self._write_state(storage)
+
+        backup = storage.snapshot()
+        storage.remove()  # re-auth wipes disk state…
+        # …then the aborted flow leaves a partial client registration behind,
+        # exactly like a probe that died before the browser step completed.
+        storage._client_info_path().write_text('{"client_id":"partial-client"}')
+
+        storage.restore(backup, only_if_absent=False)
+
+        assert "TOKEN_OLD" in storage._tokens_path().read_text()
+        assert "old-client" in storage._client_info_path().read_text()
+
+    def test_restore_only_if_absent_skips_partial_state(self, tmp_path, monkeypatch):
+        """Document the hazard: the old only_if_absent=True call skipped the
+        rollback whenever ANY state file existed, leaving tokens deleted."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("myserver")
+        self._write_state(storage)
+
+        backup = storage.snapshot()
+        storage.remove()
+        storage._client_info_path().write_text('{"client_id":"partial-client"}')
+
+        storage.restore(backup, only_if_absent=True)
+
+        assert not storage._tokens_path().exists()
+        assert "partial-client" in storage._client_info_path().read_text()
+
+
 # ---------------------------------------------------------------------------
 # Non-interactive / startup-safety tests
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -62,6 +62,74 @@ def test_manager_restore_entry_preserves_newer_concurrent_entry(tmp_path, monkey
     assert manager.get_or_build_provider("shared", "https://new.example", {}) is new_provider
     assert new_provider is not old_provider
 
+
+def test_evict_preserves_tokens_on_disk(tmp_path, monkeypatch):
+    """#76590: the soft evict() path drops the in-memory provider but must
+    NEVER delete the persisted OAuth tokens — only remove() touches disk.
+
+    The MCP runtime calls evict() when an OAuth server is parked after
+    transient connection failures; deleting the tokens there would take the
+    integration down on a headless gateway until a manual re-login.
+    """
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("shared")
+    storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+    storage._tokens_path().write_text(
+        '{"access_token":"TOKEN_KEEP","token_type":"Bearer","expires_in":3600}'
+    )
+
+    manager = MCPOAuthManager()
+    provider = manager.get_or_build_provider("shared", "https://mcp.example/mcp", {})
+    assert provider is not None
+
+    manager.evict("shared")
+
+    # In-memory provider is dropped (a fresh one is built next time)…
+    assert (
+        manager.get_or_build_provider("shared", "https://mcp.example/mcp", {})
+        is not provider
+    )
+    # …but the persisted tokens are untouched.
+    assert storage.has_cached_tokens()
+    assert "TOKEN_KEEP" in storage._tokens_path().read_text()
+
+
+def test_remove_delete_tokens_false_keeps_disk_state(tmp_path, monkeypatch):
+    """#76590: remove(delete_tokens=False) gives the in-memory eviction plus
+    the returned entry WITHOUT the destructive disk step, so a caller that
+    restores the entry after a failed re-auth never loses the tokens."""
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    storage = HermesTokenStorage("shared")
+    storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+    storage._tokens_path().write_text(
+        '{"access_token":"TOKEN_KEEP","token_type":"Bearer","expires_in":3600}'
+    )
+
+    manager = MCPOAuthManager()
+    provider = manager.get_or_build_provider("shared", "https://mcp.example/mcp", {})
+    assert provider is not None
+
+    entry = manager.remove("shared", delete_tokens=False)
+
+    assert entry is not None
+    assert storage.has_cached_tokens()
+    assert "TOKEN_KEEP" in storage._tokens_path().read_text()
+    # Evicted from cache: a new provider is built on the next call.
+    assert (
+        manager.get_or_build_provider("shared", "https://mcp.example/mcp", {})
+        is not provider
+    )
+
 pytest.importorskip(
     "mcp.client.auth.oauth2",
     reason="MCP SDK 1.26.0+ required for OAuth support",

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -592,21 +592,31 @@ class MCPOAuthManager:
         server_name: str,
         *,
         hermes_home: str | Path | None = None,
+        delete_tokens: bool = True,
     ) -> _ProviderEntry | None:
         """Evict the provider from cache AND delete tokens from disk.
 
         Called by ``hermes mcp remove <name>`` and (indirectly) by
         ``hermes mcp login <name>`` during forced re-auth.
+
+        This is the ONLY disk-deleting operation on the manager. It must
+        never be invoked from the automatic reconnect/parking machinery —
+        a transient connection failure must use :meth:`evict` instead so
+        the persisted OAuth tokens survive (see #76590). ``delete_tokens``
+        is exposed so a caller that wants the in-memory eviction plus the
+        returned entry (e.g. to restore it after a failed re-auth) can opt
+        out of the destructive disk step explicitly.
         """
         with self._entries_lock:
             entry = self._entries.pop(self._key(server_name, hermes_home), None)
 
-        from tools.mcp_oauth import remove_oauth_tokens
-        remove_oauth_tokens(server_name, hermes_home=hermes_home)
-        logger.info(
-            "MCP OAuth '%s': evicted from cache and removed from disk",
-            server_name,
-        )
+        if delete_tokens:
+            from tools.mcp_oauth import remove_oauth_tokens
+            remove_oauth_tokens(server_name, hermes_home=hermes_home)
+            logger.info(
+                "MCP OAuth '%s': evicted from cache and removed from disk",
+                server_name,
+            )
         return entry
 
     def restore_entry(
@@ -628,7 +638,13 @@ class MCPOAuthManager:
         *,
         hermes_home: str | Path | None = None,
     ) -> None:
-        """Drop only the in-process provider, preserving persisted OAuth state."""
+        """Drop only the in-process provider, preserving persisted OAuth state.
+
+        The soft path for transient connection failures: the MCP runtime
+        calls this when a server is parked after failed reconnects, so the
+        revival rebuilds the provider fresh from the still-persisted tokens.
+        Unlike :meth:`remove`, this NEVER touches disk (see #76590).
+        """
         with self._entries_lock:
             self._entries.pop(self._key(server_name, hermes_home), None)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2352,7 +2352,27 @@ class MCPServerTask:
             request or self-probe timeout). The reconnect event is cleared
             before returning so the next park cycle starts from a fresh
             signal. Shutdown takes precedence.
+
+        Note:
+            Entering the park is a *transient connection failure*, not an
+            auth failure — so it must never delete this server's OAuth
+            tokens from disk. We drop only the in-memory provider via
+            ``MCPOAuthManager.evict()`` (the soft path); the revival path
+            rebuilds the provider fresh from the still-persisted tokens.
+            The disk-deleting ``MCPOAuthManager.remove()`` stays reserved
+            for explicit ``hermes mcp remove`` / ``hermes mcp login`` /
+            dashboard re-auth. See #76590.
         """
+        # #76590: evict the in-memory OAuth provider (soft path) so the
+        # parked server's revival rebuilds it from the persisted tokens.
+        # Best-effort: a missing manager or entry is not an error.
+        if self._auth_type == "oauth":
+            try:
+                from tools.mcp_oauth_manager import get_manager
+
+                get_manager().evict(self.name)
+            except Exception:  # pragma: no cover — defensive, must not throw
+                pass
         shutdown_task = asyncio.ensure_future(self._shutdown_event.wait())
         reconnect_task = asyncio.ensure_future(self._reconnect_event.wait())
         try:


### PR DESCRIPTION
Closes #76590

## Problem

MCP OAuth tokens get **deleted from disk** after a transient connection failure — a slow/timed-out tool call, connection reset, or exhausted reconnect budget — even though nothing about the failure indicated the tokens were invalid. On a headless surface (gateway/WhatsApp/Telegram) this leaves the server unusable until an operator manually runs `hermes mcp login` from an interactive terminal, and the stored token file was observed gone for ~8 minutes until it self-recovered.

Per the code comments, `MCPOAuthManager.remove()` (which deletes tokens from disk) was only meant to be called by explicit `hermes mcp remove` / `hermes mcp login` / dashboard re-auth. The automatic reconnect machinery was never supposed to invoke it, and the soft `evict()` path (in-memory only) existed but was **dead code** — nothing in the runtime called it.

## Root cause analysis

Two concrete failure modes were found:

1. **Dashboard re-auth could permanently delete tokens on a failed flow.** `_run_dashboard_mcp_oauth` snapshots the pre-flow state, calls `manager.remove()` (disk deletion), then probes. If the probe fails (non-interactive env, transient network error), the rollback used `storage.restore(backup, only_if_absent=True)`. The MCP SDK commonly writes **partial state** before the flow dies — `client.json` via RFC 7591 dynamic client registration, `meta.json` from metadata discovery — so `only_if_absent=True` saw "state exists" and **skipped the rollback**, leaving the previously-valid tokens deleted. This matches the reported log sequence exactly: `OAuth tokens removed for 'Composio'` + `evicted from cache and removed from disk`, followed by repeated `non-interactive environment and no cached tokens found`.

2. **The runtime reconnect path had no soft-eviction hook.** `MCPOAuthManager.evict()` (drop in-memory provider, keep on-disk tokens) was never called anywhere. When a server is parked after exhausted reconnect attempts, the stale in-memory provider (with SDK auth state that may have been cleared in-memory by a failed refresh) stays cached; the revival path reuses it instead of rebuilding fresh from the persisted tokens.

## Fix

- **`hermes_cli/web_server.py`** — a failed dashboard re-auth now rolls back **unconditionally** (`only_if_absent=False`): a failed re-auth must never destroy working credentials, and the per-server transaction lock already serializes flows.
- **`tools/mcp_tool.py`** — when an OAuth server is parked after transient connection failures (`_wait_for_reconnect_or_shutdown`), evict the in-memory provider via the soft `MCPOAuthManager.evict()` path. The revival rebuilds the provider fresh from the still-persisted tokens. Disk is never touched.
- **`tools/mcp_oauth_manager.py`** — `remove()` gains an explicit `delete_tokens: bool = True` parameter so the destructive disk step is an explicit opt-in; docstrings now document that `remove()` is the *only* disk-deleting operation and must never be called from the automatic reconnect machinery (see #76590).

## Tests

- `test_evict_preserves_tokens_on_disk` — `evict()` drops the in-memory provider but never touches the persisted tokens.
- `test_remove_delete_tokens_false_keeps_disk_state` — `remove(delete_tokens=False)` evicts in-memory without disk deletion.
- `TestOAuthRollback::test_restore_rolls_back_over_partial_state` — a failed re-auth restores the pre-flow tokens even when partial `client.json` state was left behind.
- `TestOAuthRollback::test_restore_only_if_absent_skips_partial_state` — documents the old hazard (rollback skipped, tokens gone).

All OAuth/manager/park/reconnect test suites pass (`tests/tools/test_mcp_oauth*.py`, `test_mcp_parked_self_probe.py`, `test_mcp_circuit_breaker.py`, `test_mcp_failure_classification.py`, `test_mcp_initial_connect_shutdown.py`, `test_mcp_dashboard_oauth.py`).
