### PR TITLE
chore(ci): pin ruff/ty in lint.yml to the versions from the dev extra

### DIFF
--- a/.github/actions/linter-versions/action.yml
+++ b/.github/actions/linter-versions/action.yml
@@ -1,0 +1,30 @@
+name: Resolve pinned linter versions
+description: >-
+  Read the exact ruff/ty pins out of pyproject.toml's ``dev`` extra, so CI
+  installs the same linter versions contributors get from
+  ``uv sync --extra dev``. Without this, ``uv tool install ruff`` in a
+  blocking job floats to the newest release and a linter bump can fail main
+  on code nobody touched. Fails the step if a pin is missing or inexact —
+  never falls back to floating.
+
+outputs:
+  ruff:
+    description: Version pinned for ruff in the dev extra (e.g. 0.15.10).
+    value: ${{ steps.pins.outputs.ruff }}
+  ty:
+    description: Version pinned for ty in the dev extra (e.g. 0.0.21).
+    value: ${{ steps.pins.outputs.ty }}
+
+runs:
+  using: composite
+  steps:
+    - id: pins
+      shell: bash
+      # tee so the resolved versions show up in the job log too — otherwise
+      # everything lands in $GITHUB_OUTPUT and the step looks like a no-op.
+      # ``pipefail`` is load-bearing, not decoration: tee exits 0, so without
+      # it a failed resolve would be swallowed and the install step would run
+      # with an empty version.
+      run: |
+        set -euo pipefail
+        python3 "$GITHUB_ACTION_PATH/read_pins.py" | tee -a "$GITHUB_OUTPUT"

--- a/.github/actions/linter-versions/read_pins.py
+++ b/.github/actions/linter-versions/read_pins.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Print the pinned linter versions from pyproject.toml as ``name=version`` lines.
+
+CI feeds these to ``uv tool install <name>==<version>`` so the blocking lint
+job runs the same linters ``uv sync --extra dev`` gives contributors. A bare
+``uv tool install ruff`` floats to whatever released this morning, which can
+turn main red on code nobody touched — and lets a local ruff disagree with
+CI. This repo is extra exposed to that: ``[tool.ruff] preview = true`` opts
+into preview rules, whose behavior is explicitly allowed to change between
+releases.
+
+Usage:
+    # Emit ``ruff=<version>`` / ``ty=<version>`` for $GITHUB_OUTPUT
+    python3 .github/actions/linter-versions/read_pins.py
+
+    # Read a pyproject.toml somewhere else
+    python3 .github/actions/linter-versions/read_pins.py path/to/pyproject.toml
+
+Exit status:
+    0 — every tool had exactly one exact ``==`` pin
+    1 — a pin is missing, duplicated, or not an exact version
+
+Failing loud is the point: a silent fallback to a floating install would put
+back the exact hole this closes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Tools CI installs standalone (outside the venv) and therefore has to pin
+# by hand. Both live in the ``dev`` extra.
+TOOLS = ("ruff", "ty")
+
+EXTRA = "dev"
+
+# The version is interpolated into a shell install command and pyproject.toml
+# is PR-editable, so require it to be inert as a shell word. PEP 440 versions
+# only ever use this alphabet.
+VERSION_RE = re.compile(r"\A[A-Za-z0-9._+!-]+\Z")
+
+# Distribution name of a PEP 508 requirement — everything before the extras
+# bracket, any version operator, or an environment marker. Matching on this
+# rather than on ``name==`` means ``ruff>=0.15`` is recognised as the ruff
+# requirement and rejected as inexact, instead of looking absent.
+NAME_RE = re.compile(r"\A\s*([A-Za-z0-9._-]+)")
+
+
+def pins(pyproject: Path) -> list[str]:
+    with open(pyproject, "rb") as fh:
+        data = tomllib.load(fh)
+
+    try:
+        specs = data["project"]["optional-dependencies"][EXTRA]
+    except KeyError:
+        sys.exit(
+            f"{pyproject}: no [project.optional-dependencies] {EXTRA} extra — "
+            f"cannot resolve pinned versions for {', '.join(TOOLS)}"
+        )
+
+    def name_of(spec: str) -> str:
+        found = NAME_RE.match(spec)
+        # Normalised per PEP 503 so ``Ruff`` / ``ruff`` compare equal.
+        return re.sub(r"[-_.]+", "-", found.group(1)).lower() if found else ""
+
+    lines = []
+    for tool in TOOLS:
+        matched = [s for s in specs if name_of(s) == tool]
+        if len(matched) != 1:
+            sys.exit(
+                f"{pyproject}: expected exactly one '{tool}' requirement in the "
+                f"{EXTRA} extra, found {len(matched)}: {matched}"
+            )
+
+        spec = matched[0]
+        if "==" not in spec:
+            sys.exit(
+                f"{pyproject}: '{spec}' is not an exact pin. CI installs this "
+                f"tool standalone and needs a '{tool}==<version>' pin to stay "
+                f"reproducible."
+            )
+
+        version = spec.split("==", 1)[1].strip()
+        if not VERSION_RE.match(version):
+            sys.exit(f"{pyproject}: refusing unexpected version string {version!r} for {tool}")
+
+        lines.append(f"{tool}={version}")
+
+    return lines
+
+
+def main() -> None:
+    pyproject = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("pyproject.toml")
+    if not pyproject.is_file():
+        sys.exit(f"{pyproject}: not found (run from the repository root)")
+
+    for line in pins(pyproject):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,13 @@ name: Lint (ruff + ty)
 #      Separate job so the advisory diff still runs even when enforcement
 #      fails.
 #
+# Both jobs install ruff/ty at the versions pinned in pyproject.toml's
+# ``dev`` extra, resolved by ``.github/actions/linter-versions`` — same
+# reasoning as the setup-uv pin below, applied to what uv installs. One
+# pin, one source of truth: a blocking gate must not change its verdict on
+# untouched code because a linter released, and a contributor's
+# ``uv sync --extra dev`` ruff has to agree with CI's.
+#
 # CI-sensitive file review was previously here as a ``ci-review`` job but
 # has moved to ``review-labels.yml`` so it can be rerun independently.
 
@@ -46,10 +53,22 @@ jobs:
           # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
           version: "0.9.28"
 
+      - name: Resolve pinned linter versions
+        id: pins
+        uses: ./.github/actions/linter-versions
+
       - name: Install ruff + ty
         uses: ./.github/actions/retry
         with:
-          command: uv tool install ruff && uv tool install ty
+          # Pinned so this job is reproducible over time: rerunning an old
+          # PR shouldn't produce a different advisory diff just because ruff
+          # released. It also keeps lint_diff.py's parser off ruff's release
+          # schedule — it reads ``code``/``filename``/``location.row`` from
+          # the JSON and falls back to "unknown" if a key moves, which would
+          # go wrong quietly rather than loudly.
+          command: >-
+            uv tool install ruff==${{ steps.pins.outputs.ruff }} &&
+            uv tool install ty==${{ steps.pins.outputs.ty }}
 
       - name: Determine base ref
         id: base
@@ -140,10 +159,18 @@ jobs:
           # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
           version: "0.9.28"
 
+      - name: Resolve pinned ruff version
+        id: pins
+        uses: ./.github/actions/linter-versions
+
       - name: Install ruff
         uses: ./.github/actions/retry
         with:
-          command: uv tool install ruff
+          # Pinned to pyproject.toml's dev extra. A bare ``uv tool install
+          # ruff`` here means the next ruff release can fail this blocking
+          # gate on code nobody touched — and ``preview = true`` in
+          # [tool.ruff] opts us into rules that change between releases.
+          command: uv tool install ruff==${{ steps.pins.outputs.ruff }}
 
       - name: ruff check .
         # No --exit-zero, no || true. Exit code propagates to the job,


### PR DESCRIPTION
## What

`.github/workflows/lint.yml` installs its linters with bare `uv tool install ruff` / `uv tool install ty`. Both jobs now install the exact versions pinned in `pyproject.toml`'s `dev` extra (`ruff==0.15.10`, `ty==0.0.21`), resolved by a new `.github/actions/linter-versions` composite action.

## Why

This is the same class of problem the `setup-uv` pin in this file already fixes, one level down — **we pin the installer but not what it installs:**

```yaml
# Pinned: unpinned setup-uv fetches a 'latest' manifest from
# raw.githubusercontent.com every job; transient fetch failures
# fail the job (2026-07-28 incident). Keep in sync with tests.yml.
version: "0.9.28"
...
command: uv tool install ruff && uv tool install ty   # ← floats
```

`ruff enforcement (blocking)` is a required check, and it resolves to whatever released most recently — 0.16.1 today, against a repo that pins 0.15.10 for developers. Two consequences:

- A ruff release can change the verdict on code nobody touched, at a moment nobody chose.
- Local `ruff check .` and CI's `ruff check .` are different programs, so "passes locally" means less than it should.

`[tool.ruff] preview = true` widens this: PLW1514, the one rule the gate enforces, is a **preview** rule, and preview behavior is explicitly allowed to change between releases.

**For the advisory `ruff + ty diff` job** the cost is reproducibility — rerunning an older PR can produce a different diff purely because ruff released in between. It also leaves `scripts/lint_diff.py` on ruff's release schedule. Ruff's JSON has already drifted: 0.16.1 adds a `name` field that 0.15.10 doesn't emit. That specific change is harmless, because `_normalize_ruff` reads `code` / `filename` / `location.row` — but it reads them with `e.get("code") or "unknown"`, so if a key it depends on is ever renamed, every finding collapses into one `unknown` bucket and the diff goes wrong **quietly**. Pinning means that exposure arrives when someone bumps the pin deliberately, with CI watching, instead of on release day.

**`Windows footguns (blocking)` needs no change** — I checked. It runs `scripts/check-windows-footguns.py`, a stdlib-only regex checker (`argparse`/`os`/`re`/`subprocess`/`sys`/`dataclasses`/`pathlib`), on a SHA-pinned `actions/setup-python`. No third-party linter to float.

## How

A composite action parses the pins from `pyproject.toml` with `tomllib` and exports them as step outputs; each job installs `<tool>==<pin>`. The versions are **not** duplicated into YAML — `pyproject.toml` stays the single source of truth, so bumping ruff remains a one-line change.

The resolver **fails the step** if a pin is missing, duplicated, inexact (`ruff>=0.15`), or not a plain version string. A silent fallback to a floating install would restore the exact hole this closes. `set -o pipefail` in the action is load-bearing for that: `tee` exits 0, so without it a failed resolve would be swallowed and the install would run with an empty version.

The version is interpolated into a shell command and `pyproject.toml` is PR-editable, so the resolver also rejects version strings outside the PEP 440 alphabet.

Both `setup-uv` version pins in this file are preserved untouched.

## How to test

Ran against this branch on macOS 15.

**The gate still catches violations** — clean before/after on this branch, using pinned ruff 0.15.10:

| Step | `ruff check .` |
|---|---|
| branch as-is | `exit=0` |
| + a file with `open(p, "w")` (no `encoding=`) | `exit=1`, `error[PLW1514]` |
| probe file removed | `exit=0` |

I probed with PLW1514 rather than an undefined name on purpose: `select = ["PLW1514"]`, so F821 is not enforced here and would have proven nothing.

**End-to-end install path**, simulating what the job does: resolve pin → `uv tool install ruff==0.15.10` → `ruff --version` → `ruff 0.15.10`. Before this change the same step yields 0.16.1.

**Resolver, 9 cases** — `python3 .github/actions/linter-versions/read_pins.py`:

| Case | Result |
|---|---|
| this repo's `pyproject.toml` | `exit=0` → `ruff=0.15.10 ty=0.0.21` |
| `ruff` pin absent | `exit=1` "expected exactly one 'ruff' requirement … found 0" |
| `ruff>=0.15` | `exit=1` "is not an exact pin" |
| `ruff` (no version) | `exit=1` "is not an exact pin" |
| `ruff==0.1; curl evil` | `exit=1` "refusing unexpected version string" |
| `ruff` pinned twice | `exit=1` "found 2" |
| `ruff[x]==0.15.10` | `exit=0` (extras bracket parsed) |
| no `dev` extra | `exit=1` "no [project.optional-dependencies] dev extra" |
| missing file | `exit=1` "not found" |

**Composite step plumbing**, simulated with `GITHUB_ACTION_PATH` / `GITHUB_OUTPUT`: happy path writes `ruff=0.15.10` and `ty=0.0.21`; failure path exits 1 and writes **nothing** to `$GITHUB_OUTPUT`. Control: the same pipeline without `pipefail` exits 0, confirming that line does real work.

**New files pass the repo's own gates:** `ruff check` (0.15.10) clean, `ty check` (0.0.21) clean, `check-windows-footguns.py --all` clean across 897 files.

## Scope

This is exposure, not a live break — `main` is ruff-clean today under both 0.15.10 and 0.16.1, which is the good moment to close it. Pinning only; no rule changes, no version bumps, and the `dev` extra is untouched. One logical change, per CONTRIBUTING.

Searched open and merged PRs and issues for prior art on this first; found none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
