### PR TITLE
fix(notarize): restrict Apple P8 key to 0600 and surface notarize errors

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -259,7 +259,7 @@ long transcript or a busy terminal.
 
 - Every user-facing string goes through `useI18n()` (`src/i18n/context.tsx`).
   No literals in JSX.
-- **Update all locales together** — `en`, `ja`, `zh`, `zh-hant`. A string change
+- **Update all locales together** — `en`, `ja`, `zh`, `zh-hant`, `ar`. A string change
   in `en.ts` that skips the others is a regression (drifted punctuation,
   stale labels). Keep trailing-punctuation and tone consistent across all four.
 
@@ -305,7 +305,7 @@ The detailed state contract lives in the scoped
 - [ ] Hot interactions avoid broad subscriptions, layout thrash, and
       `transition-all`?
 - [ ] Keyboard ownership and single-action `Esc` behavior are correct?
-- [ ] All four locales updated for any new/changed string?
+- [ ] All five locales updated for any new/changed string?
 - [ ] `cursor-pointer`, focus ring, and `Esc`-to-close behave?
 - [ ] Touched a primitive, token, or variant? Its named-contract entry in this
       file is updated in the same change.

--- a/apps/desktop/scripts/notarize-artifact.mjs
+++ b/apps/desktop/scripts/notarize-artifact.mjs
@@ -35,7 +35,7 @@ function resolveApiKeyPath(rawValue) {
   }
 
   const tempPath = join(tmpdir(), `hermes-notary-${Date.now()}-${process.pid}.p8`)
-  writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 }))
+  writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 })
   return {
     keyPath: tempPath,
     cleanup: () => rmSync(tempPath, { force: true })

--- a/apps/desktop/scripts/notarize-artifact.mjs
+++ b/apps/desktop/scripts/notarize-artifact.mjs
@@ -35,7 +35,7 @@ function resolveApiKeyPath(rawValue) {
   }
 
   const tempPath = join(tmpdir(), `hermes-notary-${Date.now()}-${process.pid}.p8`)
-  writeFileSync(tempPath, value, 'utf8')
+  writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 }))
   return {
     keyPath: tempPath,
     cleanup: () => rmSync(tempPath, { force: true })
@@ -71,7 +71,7 @@ async function main() {
   }
 }
 
-main().catch(() => {
-  console.error('Notarization failed. Check configuration and command output in secure CI logs.')
+main().catch((err) => {
+  console.error('Notarization failed:', err?.message || err)
   process.exit(1)
 })

--- a/apps/desktop/scripts/notarize.mjs
+++ b/apps/desktop/scripts/notarize.mjs
@@ -36,7 +36,7 @@ function resolveApiKeyPath(rawValue) {
   }
 
   const tempPath = path.join(os.tmpdir(), `hermes-notary-${Date.now()}-${process.pid}.p8`)
-  fs.writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 }))
+  fs.writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 })
   return {
     keyPath: tempPath,
     cleanup: () => {

--- a/apps/desktop/scripts/notarize.mjs
+++ b/apps/desktop/scripts/notarize.mjs
@@ -36,7 +36,7 @@ function resolveApiKeyPath(rawValue) {
   }
 
   const tempPath = path.join(os.tmpdir(), `hermes-notary-${Date.now()}-${process.pid}.p8`)
-  fs.writeFileSync(tempPath, value, 'utf8')
+  fs.writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 }))
   return {
     keyPath: tempPath,
     cleanup: () => {


### PR DESCRIPTION
## Summary
- scripts/notarize.mjs + notarize-artifact.mjs: write the inline .p8 key with mode 0o600 so it is no longer world-readable in the shared temp dir
- notarize-artifact.mjs: pass the real error through .catch() instead of swallowing it, so CI shows why notarization failed
- DESIGN.md: list all five locales (incl. Arabic) in the i18n docs

## Security Impact
- **Before**: `fs.writeFileSync(tempPath, value, 'utf8')` created files with default umask (typically 0644), allowing any local user to read the Apple .p8 signing key.
- **After**: `fs.writeFileSync(tempPath, value, { encoding: 'utf8', mode: 0o600 })` restricts access to the file owner only.

## Files Changed
| File | Change |
|------|--------|
| apps/desktop/scripts/notarize-artifact.mjs | 0o600 perms + error passthrough |
| apps/desktop/scripts/notarize.mjs | 0o600 perms |
| apps/desktop/DESIGN.md | Add Arabic locale to i18n docs |

## Test Plan
- [ ] Notarization scripts still work with restricted perms
- [ ] Error messages include original failure reason
- [ ] Manual: read notarize temp file as non-owner ? permission denied

## Checklist
- [x] No changes to IPC contracts or user-facing behavior
- [x] Security-sensitive changes are defensive hardening only
- [x] Documentation-only changes pose zero risk