### PR TITLE
fix(desktop): preserve update handoff with background mode

### DIFF
--- a/apps/desktop/electron/close-to-background.test.ts
+++ b/apps/desktop/electron/close-to-background.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldHideMainWindowOnClose } from './close-to-background'
+
+describe('shouldHideMainWindowOnClose', () => {
+  it('keeps the desktop running for a normal close when the preference is enabled', () => {
+    expect(
+      shouldHideMainWindowOnClose({
+        enabled: true,
+        quitRequested: false,
+        updateHandoff: false
+      })
+    ).toBe(true)
+  })
+
+  it('does not intercept close when the preference is disabled', () => {
+    expect(
+      shouldHideMainWindowOnClose({
+        enabled: false,
+        quitRequested: false,
+        updateHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('does not intercept an explicit application quit', () => {
+    expect(
+      shouldHideMainWindowOnClose({
+        enabled: true,
+        quitRequested: true,
+        updateHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('does not intercept an updater handoff', () => {
+    expect(
+      shouldHideMainWindowOnClose({
+        enabled: true,
+        quitRequested: false,
+        updateHandoff: true
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/electron/close-to-background.ts
+++ b/apps/desktop/electron/close-to-background.ts
@@ -1,0 +1,20 @@
+export interface CloseToBackgroundDecision {
+  enabled: boolean
+  quitRequested: boolean
+  updateHandoff: boolean
+}
+
+/**
+ * Return true only for a user-initiated main-window close that should hide the
+ * window while leaving Electron and its Hermes backend alive.
+ *
+ * Explicit app quits and updater handoffs must always reach Electron's normal
+ * teardown path so processes and files are released cleanly.
+ */
+export function shouldHideMainWindowOnClose({
+  enabled,
+  quitRequested,
+  updateHandoff
+}: CloseToBackgroundDecision): boolean {
+  return enabled && !quitRequested && !updateHandoff
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -49,6 +50,7 @@ import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from '
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
+import { shouldHideMainWindowOnClose } from './close-to-background'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
   authModeFromStatus,
@@ -189,6 +191,7 @@ import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
+import { isUpdateOperationBusy, updateHandoffExitMode } from './update-handoff-state'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -206,7 +209,12 @@ import {
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker
 } from './updater-process'
-import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
+import {
+  formatBlockerMessage,
+  formatProbeFailedMessage,
+  partitionDesktopUpdateBlockers,
+  scanVenvBlockers
+} from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import {
@@ -1048,6 +1056,9 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let backgroundTray = null
+let closeToBackgroundEnabled = false
+let appQuitRequested = false
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -1768,7 +1779,12 @@ const UPDATE_HANDOFF_DWELL_MS = 2500
 function updateGateDeps() {
   return {
     hasLiveMarker: () => Boolean(readLiveUpdateMarker(HERMES_HOME)),
-    isUpdateInFlight: () => updateInFlight
+    // Keep the backend parked for the whole detached hand-off. Older staged
+    // installers do not write their marker until several seconds after spawn,
+    // so updateInFlight alone leaves a window where a reconnect can relaunch
+    // the backend and re-lock the venv before the updater reaches Rust.
+    isUpdateInFlight: () =>
+      isUpdateOperationBusy({ updateInFlight, handoffInFlight: updateHandoffInFlight })
   }
 }
 
@@ -2598,6 +2614,11 @@ async function readCommitLog(cwd, branch) {
 }
 
 let updateInFlight = false
+// Unlike updateInFlight, this latch stays set after the detached updater has
+// spawned. It must remain true until this Electron process exits: older staged
+// installers do not write the on-disk marker immediately, and a renderer
+// reconnect in that gap must not start another backend or a second updater.
+let updateHandoffInFlight = false
 
 // Set to true when the desktop is about to quit so a detached swap/install/
 // uninstall script can take over. On macOS, app.quit() closes windows but
@@ -2608,6 +2629,18 @@ let updateInFlight = false
 // set, window-all-closed calls app.quit() on every platform so the process
 // actually dies and the hand-off script can proceed immediately.
 let isQuittingForHandoff = false
+
+// Windows update handoff already stopped every backend owned by this process
+// and waited for the venv shim to unlock. Use a hard Electron exit so tray,
+// window-all-closed, SSH teardown, or other quit hooks cannot keep the process
+// alive while the detached updater is waiting for its PID to disappear.
+function exitAfterUpdateHandoff() {
+  if (updateHandoffExitMode(IS_WINDOWS) === 'hard') {
+    app.exit(0)
+  } else {
+    app.quit()
+  }
+}
 
 // Quit-guard latches: one while the confirmation is on screen (a second
 // Cmd-Q must not stack dialogs), one after the user has said "quit anyway"
@@ -2840,7 +2873,7 @@ async function releaseBackendLock(updateRoot, tag) {
 // Detection (checkUpdates / commit changelog / "N behind") stays in the UI;
 // only this apply action changed.
 async function applyUpdates(opts = {}) {
-  if (updateInFlight) {
+  if (updateInFlight || updateHandoffInFlight) {
     throw new Error('An update is already in progress.')
   }
 
@@ -2967,13 +3000,29 @@ async function applyUpdates(opts = {}) {
       const scanOutcome = await scanVenvBlockers(updateRoot)
 
       if (scanOutcome.kind === 'blocked') {
-        const message = formatBlockerMessage(scanOutcome.result)
+        // `hermes update` itself pauses and resumes installed Windows Gateway
+        // runners. Do not abort the desktop handoff for that known managed
+        // holder; retain the hard stop for every other process, which the CLI
+        // cannot safely assume it owns.
+        const { blockingProcesses, deferredGatewayProcesses } = partitionDesktopUpdateBlockers(
+          scanOutcome.result.processes
+        )
 
-        rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
+        if (deferredGatewayProcesses.length > 0) {
+          rememberLog(
+            `[updates] deferring ${deferredGatewayProcesses.length} managed gateway process(es) to CLI updater pause/resume`
+          )
+        }
 
-        return { ok: false, error: 'venv-blocked', message }
+        if (blockingProcesses.length > 0) {
+          const message = formatBlockerMessage({ blocked: true, processes: blockingProcesses })
+
+          rememberLog(`[updates] venv-blocked: ${blockingProcesses.length} process(es) hold the install`)
+          emitUpdateProgress({ stage: 'error', message, percent: null })
+          startHermes().catch(() => {})
+
+          return { ok: false, error: 'venv-blocked', message }
+        }
       }
 
       if (scanOutcome.kind === 'probe-failure') {
@@ -2999,6 +3048,11 @@ async function applyUpdates(opts = {}) {
       detached: true,
       stdio: 'ignore'
     })
+
+    // The updater now owns the handoff. Keep both the backend gate and the
+    // duplicate-click guard closed until this process exits, rather than
+    // clearing everything in the finally block below.
+    updateHandoffInFlight = true
 
     // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
     // quit dwell. The Tauri updater won't write its own marker for several
@@ -3032,7 +3086,7 @@ async function applyUpdates(opts = {}) {
     // and lured users into the #50238 relaunch loop.)
     isQuittingForHandoff = true
     setTimeout(() => {
-      app.quit()
+      exitAfterUpdateHandoff()
     }, UPDATE_HANDOFF_DWELL_MS)
 
     return { ok: true, handedOff: true, updater }
@@ -3044,6 +3098,10 @@ async function applyUpdates(opts = {}) {
 async function handOffWindowsBootstrapRecovery(reason) {
   if (!IS_WINDOWS || !IS_PACKAGED) {
     return false
+  }
+
+  if (updateHandoffInFlight) {
+    return true
   }
 
   const updater = resolveUpdaterBinary()
@@ -3062,9 +3120,10 @@ async function handOffWindowsBootstrapRecovery(reason) {
     // it finishes, so treat this the same as a successful hand-off instead
     // of clobbering it with our own.
     rememberLog(`[bootstrap] refusing recovery hand-off: ${handoffConflict.message}`)
+    updateHandoffInFlight = true
     isQuittingForHandoff = true
     setTimeout(() => {
-      app.quit()
+      exitAfterUpdateHandoff()
     }, UPDATE_HANDOFF_DWELL_MS)
 
     return true
@@ -3105,6 +3164,8 @@ async function handOffWindowsBootstrapRecovery(reason) {
     stdio: 'ignore'
   })
 
+  updateHandoffInFlight = true
+
   // Same marker pre-write as applyUpdates — see comment there. The recovery
   // hand-off has the same window where the renderer can respawn a backend
   // before the updater writes its own marker, and the same stale-updater
@@ -3126,7 +3187,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
   // a crash and provoke a mid-recovery relaunch.
   isQuittingForHandoff = true
   setTimeout(() => {
-    app.quit()
+    exitAfterUpdateHandoff()
   }, UPDATE_HANDOFF_DWELL_MS)
 
   return true
@@ -5304,6 +5365,80 @@ function registerPowerResumeListeners() {
 
 function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
+}
+
+const CLOSE_TO_BACKGROUND_CONFIG_PATH = path.join(app.getPath('userData'), 'close-to-background.json')
+
+function readCloseToBackgroundEnabled() {
+  try {
+    return JSON.parse(fs.readFileSync(CLOSE_TO_BACKGROUND_CONFIG_PATH, 'utf8'))?.enabled === true
+  } catch {
+    return false
+  }
+}
+
+function writeCloseToBackgroundEnabled(enabled) {
+  try {
+    fs.mkdirSync(path.dirname(CLOSE_TO_BACKGROUND_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(CLOSE_TO_BACKGROUND_CONFIG_PATH, JSON.stringify({ enabled }, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[background] preference write failed: ${error?.message || error}`)
+  }
+}
+
+function showMainWindowFromBackground() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    createWindow()
+
+    return
+  }
+
+  focusWindow(mainWindow)
+}
+
+function refreshBackgroundTrayMenu() {
+  if (!backgroundTray || backgroundTray.isDestroyed()) {
+    return
+  }
+
+  backgroundTray.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Open Hermes',
+        click: showMainWindowFromBackground
+      },
+      { type: 'separator' },
+      {
+        label: 'Keep running when the main window closes',
+        type: 'checkbox',
+        checked: closeToBackgroundEnabled,
+        click: menuItem => {
+          closeToBackgroundEnabled = menuItem.checked
+          writeCloseToBackgroundEnabled(closeToBackgroundEnabled)
+          refreshBackgroundTrayMenu()
+        }
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit Hermes',
+        click: () => app.quit()
+      }
+    ])
+  )
+}
+
+function createBackgroundTray() {
+  if (process.platform === 'darwin' || backgroundTray) {
+    return
+  }
+
+  const icon = getAppIconPath()
+
+  backgroundTray = new Tray(icon || nativeImage.createEmpty())
+  backgroundTray.setToolTip('Hermes')
+  backgroundTray.on('click', showMainWindowFromBackground)
+  backgroundTray.on('double-click', showMainWindowFromBackground)
+  refreshBackgroundTrayMenu()
 }
 
 function sendOpenUpdatesRequested() {
@@ -9338,7 +9473,21 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+
+    if (
+      shouldHideMainWindowOnClose({
+        enabled: closeToBackgroundEnabled,
+        quitRequested: appQuitRequested,
+        updateHandoff: isQuittingForHandoff
+      })
+    ) {
+      event.preventDefault()
+      mainWindow?.hide()
+      rememberLog('[background] main window hidden; desktop backend remains running')
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -11824,6 +11973,8 @@ app.whenReady().then(() => {
   configureSpellChecker()
   registerPowerResumeListeners()
   keepAwake.set(readPersistedKeepAwake())
+  closeToBackgroundEnabled = readCloseToBackgroundEnabled()
+  createBackgroundTray()
   // Quick Entry's global chord — registered on ready so a cold launch restores
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
@@ -11934,6 +12085,10 @@ app.on('before-quit', event => {
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  // A real app quit (tray menu, OS shutdown, updater handoff, Cmd/Ctrl+Q)
+  // must bypass the main-window close-to-background handler below.
+  appQuitRequested = true
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()

--- a/apps/desktop/electron/update-handoff-state.test.ts
+++ b/apps/desktop/electron/update-handoff-state.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { isUpdateOperationBusy, updateHandoffExitMode } from './update-handoff-state'
+
+test('the backend gate stays closed after detached handoff starts', () => {
+  assert.equal(isUpdateOperationBusy({ updateInFlight: false, handoffInFlight: true }), true)
+  assert.equal(isUpdateOperationBusy({ updateInFlight: true, handoffInFlight: false }), true)
+  assert.equal(isUpdateOperationBusy({ updateInFlight: false, handoffInFlight: false }), false)
+})
+
+test('a handoff latch prevents a second updater after the first spawn', () => {
+  const state = { updateInFlight: false, handoffInFlight: true }
+
+  assert.equal(isUpdateOperationBusy(state), true)
+  assert.equal(isUpdateOperationBusy(state), true)
+})
+
+test('Windows handoff uses a hard exit while POSIX keeps graceful quit', () => {
+  assert.equal(updateHandoffExitMode(true), 'hard')
+  assert.equal(updateHandoffExitMode(false), 'graceful')
+})

--- a/apps/desktop/electron/update-handoff-state.ts
+++ b/apps/desktop/electron/update-handoff-state.ts
@@ -1,0 +1,23 @@
+export interface UpdateHandoffState {
+  updateInFlight: boolean
+  handoffInFlight: boolean
+}
+
+/**
+ * The update gate must stay closed after the detached updater is spawned.
+ * Older staged installers do not write their marker until several seconds
+ * into startup, so the process-local handoff latch covers that gap.
+ */
+export function isUpdateOperationBusy(state: UpdateHandoffState): boolean {
+  return state.updateInFlight || state.handoffInFlight
+}
+
+export type UpdateHandoffExitMode = 'hard' | 'graceful'
+
+/**
+ * Windows must bypass Electron quit hooks after the updater owns the handoff;
+ * POSIX keeps the existing graceful quit path.
+ */
+export function updateHandoffExitMode(isWindows: boolean): UpdateHandoffExitMode {
+  return isWindows ? 'hard' : 'graceful'
+}

--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -18,6 +18,7 @@ import {
   formatBlockerMessage,
   formatProbeFailedMessage,
   parseVenvBlockerScanOutput,
+  partitionDesktopUpdateBlockers,
   resolveVenvPython,
   scanVenvBlockers
 } from './venv-blocker-scan'
@@ -65,6 +66,44 @@ describe('formatBlockerMessage', () => {
     assert.ok(msg.includes('remote backend'))
     assert.ok(msg.includes('retry'))
     assert.ok(!msg.includes('force-venv'))
+  })
+})
+
+describe('partitionDesktopUpdateBlockers', () => {
+  it('defers only managed gateway runners to the detached updater', () => {
+    const result = partitionDesktopUpdateBlockers([
+      {
+        pid: 12016,
+        name: 'python.exe',
+        cmdline: 'C:\\Hermes\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+      },
+      {
+        pid: 9804,
+        name: 'python.exe',
+        cmdline: 'C:\\Hermes\\venv\\Scripts\\python.exe -m hermes_cli.main serve --host 127.0.0.1 --port 0'
+      }
+    ])
+
+    assert.deepEqual(result.deferredGatewayProcesses.map(proc => proc.pid), [12016])
+    assert.deepEqual(result.blockingProcesses.map(proc => proc.pid), [9804])
+  })
+
+  it('keeps quoted gateway text and non-Python lookalikes as blockers', () => {
+    const result = partitionDesktopUpdateBlockers([
+      {
+        pid: 12017,
+        name: 'python.exe',
+        cmdline: 'C:\\Hermes\\venv\\Scripts\\python.exe -m hermes_cli.main serve --label "gateway run"'
+      },
+      {
+        pid: 12018,
+        name: 'node.exe',
+        cmdline: 'node -m hermes_cli.main gateway run'
+      }
+    ])
+
+    assert.deepEqual(result.deferredGatewayProcesses, [])
+    assert.deepEqual(result.blockingProcesses.map(proc => proc.pid), [12017, 12018])
   })
 })
 

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -29,6 +29,65 @@ export interface VenvBlockerScanResult {
   processes: VenvBlockerProcess[]
 }
 
+/**
+ * The CLI updater has a Windows-specific pause/resume path for its installed
+ * Gateway. Desktop must let that updater own these runners; otherwise its
+ * preflight rejects the very gateway that the detached updater will stop.
+ */
+export interface DesktopUpdateBlockerPartition {
+  blockingProcesses: VenvBlockerProcess[]
+  deferredGatewayProcesses: VenvBlockerProcess[]
+}
+
+const PYTHON_PROCESS_NAMES = new Set(['python', 'python.exe', 'python3', 'python3.exe'])
+
+function commandLineTokens(cmdline: string): string[] {
+  const tokens = cmdline.match(/"[^"]*"|'[^']*'|[^\s]+/g) || []
+
+  return tokens.map(token => token.replace(/^(?:"|')|(?:"|')$/g, ''))
+}
+
+function isManagedGatewayRunner(process: VenvBlockerProcess): boolean {
+  if (!PYTHON_PROCESS_NAMES.has(process.name.trim().toLowerCase())) {
+    return false
+  }
+
+  const tokens = commandLineTokens(process.cmdline)
+
+  const moduleIndex = tokens.findIndex(
+    (token, index) => token === '-m' && tokens[index + 1]?.toLowerCase() === 'hermes_cli.main'
+  )
+
+  // Fail closed: only the exact long-lived CLI command is deferred to the
+  // detached updater. Arguments or quoted text that merely resemble it stay
+  // in the blocker list.
+  return (
+    moduleIndex > 0 &&
+    tokens.length === moduleIndex + 4 &&
+    tokens[moduleIndex + 2]?.toLowerCase() === 'gateway' &&
+    tokens[moduleIndex + 3]?.toLowerCase() === 'run'
+  )
+}
+
+export function partitionDesktopUpdateBlockers(
+  processes: VenvBlockerProcess[]
+): DesktopUpdateBlockerPartition {
+  const blockingProcesses: VenvBlockerProcess[] = []
+  const deferredGatewayProcesses: VenvBlockerProcess[] = []
+
+  for (const process of processes) {
+    // Require both the Hermes module and the exact long-lived gateway command;
+    // unrelated programs that merely contain the word "gateway" remain blockers.
+    if (isManagedGatewayRunner(process)) {
+      deferredGatewayProcesses.push(process)
+    } else {
+      blockingProcesses.push(process)
+    }
+  }
+
+  return { blockingProcesses, deferredGatewayProcesses }
+}
+
 export type ScanOutcome =
   | { kind: 'clear'; result: VenvBlockerScanResult }
   | { kind: 'blocked'; result: VenvBlockerScanResult }


### PR DESCRIPTION
## Summary

Fix Windows Desktop one-click update handoff:

- explicit Quit and updater handoff bypass close-to-tray hiding;
- managed `hermes_cli.main gateway run` processes are deferred to the CLI updater pause/resume path; unrelated venv holders remain blockers;
- keep the backend gate and duplicate-update guard closed for the entire detached handoff, including old staged installers that write their marker late;
- use a hard Windows Electron exit after the updater is spawned so tray/quit hooks cannot keep the Desktop PID alive;
- the existing updater relaunches Hermes after a successful update.

## Verification

- Electron focused Vitest: 61 passed
- TypeScript typecheck: passed
- Desktop build: passed
- ESLint: 0 errors (existing warnings only)
- `git diff --check`: passed

## Root cause

The Desktop cleared its in-process update flag before the detached updater had reached its marker-writing stage. A renderer reconnect could start the backend again, and a second click could start another updater. On Windows, graceful `app.quit()` could also remain in Electron quit hooks while the updater waited for the PID to disappear.