### PR TITLE
feat(web): add runtime search provider fallbacks

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -353,6 +353,8 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        "search_fallback_backends": [],  # ordered fallback providers for web_search when primary fails (list or comma-separated string)
+        "fallback_backends": [],  # shared fallback for both search and extract (used when capability-specific key is absent)
     },
 
     "browser": {

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -476,6 +476,92 @@ class TestWebSearchErrorHandling:
         primary_provider.search.assert_called_once_with("test query", 3)
         fallback_provider.search.assert_called_once_with("test query", 3)
 
+    def test_search_runtime_fallback_skipped_when_interrupted(self):
+        """If the primary returns an Interrupted failure, the loop must not
+        dispatch a fallback provider (no extra network request)."""
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "Interrupted",
+        }
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        # is_interrupted returns False for the initial check, True after the
+        # primary fails (simulating a stop signal arriving mid-search).
+        interrupt_values = iter([False, True])
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", side_effect=lambda: next(interrupt_values)), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result["success"] is False
+        assert result["error"] == "Interrupted"
+        fallback_provider.search.assert_not_called()
+
+    def test_search_runtime_fallback_preserves_primary_failure_when_all_fail(self):
+        """When the primary and all fallbacks fail, the original primary
+        failure response is returned (not the last fallback's failure)."""
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "quota exhausted",
+        }
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+        fallback_provider.search.return_value = {
+            "success": False,
+            "error": "rate limited",
+        }
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result["success"] is False
+        assert result["error"] == "quota exhausted"
+        primary_provider.search.assert_called_once_with("test query", 3)
+        fallback_provider.search.assert_called_once_with("test query", 3)
+
+    def test_search_runtime_fallback_uses_shared_fallback_backends_config(self):
+        """The shared ``web.fallback_backends`` config key is used when no
+        capability-specific ``web.search_fallback_backends`` is set."""
+        from tools.web_tools import _get_capability_fallback_backends
+
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "fallback_backends": ["ddgs", "brave-free"],
+            },
+        ):
+            assert _get_capability_fallback_backends("search") == [
+                "ddgs",
+                "brave-free",
+            ]
+
 
 class TestCheckWebApiKey:
     """Test suite for check_web_api_key() unified availability check."""

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -250,6 +250,21 @@ class TestBackendSelection:
              patch("tools.web_tools._is_tool_gateway_ready", return_value=True):
             assert _get_backend() == "firecrawl"
 
+    def test_capability_fallback_backends_normalize_and_deduplicate_plugin_names(self):
+        """Fallback config accepts plugin names without a core allowlist."""
+        from tools.web_tools import _get_capability_fallback_backends
+
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "search_fallback_backends": " DDGS, custom-search,ddgs, ,CUSTOM-search "
+            },
+        ):
+            assert _get_capability_fallback_backends("search") == [
+                "ddgs",
+                "custom-search",
+            ]
+
 
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""
@@ -378,6 +393,88 @@ class TestWebSearchErrorHandling:
         assert "exception_type" not in result
         assert "exception_chain" not in result
         assert "traceback" not in result
+
+    def test_search_runtime_fallback_uses_configured_provider_after_primary_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "quota exhausted",
+        }
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Fallback result",
+                        "url": "https://example.com",
+                        "description": "ok",
+                    }
+                ]
+            },
+        }
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result["success"] is True
+        assert result["metadata"] == {
+            "fallback_from": "tavily",
+            "fallback_backend": "ddgs",
+        }
+        primary_provider.search.assert_called_once_with("test query", 3)
+        fallback_provider.search.assert_called_once_with("test query", 3)
+
+    def test_search_runtime_fallback_recovers_from_primary_exception(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.side_effect = RuntimeError("temporary outage")
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {"web": []},
+        }
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result == {
+            "success": True,
+            "data": {"web": []},
+            "metadata": {
+                "fallback_from": "tavily",
+                "fallback_backend": "ddgs",
+            },
+        }
+        primary_provider.search.assert_called_once_with("test query", 3)
+        fallback_provider.search.assert_called_once_with("test query", 3)
 
 
 class TestCheckWebApiKey:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -769,6 +769,18 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             primary_response = None
             primary_exception = None
             for index, candidate in enumerate(providers_to_try):
+                # Re-check interruption before each candidate dispatch so a
+                # stop signal during/after the primary doesn't trigger a
+                # fallback network request. A provider may return an
+                # ``Interrupted`` failure from its own internal check; without
+                # this guard the loop would proceed to the next fallback.
+                if index > 0 and is_interrupted():
+                    response_data = primary_response or {
+                        "success": False,
+                        "error": "Interrupted",
+                    }
+                    break
+
                 logger.info(
                     "Web search via %s: '%s' (limit: %d)",
                     candidate.name,

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -308,6 +308,39 @@ def _get_capability_backend(capability: str) -> str:
     return _get_backend()
 
 
+def _get_capability_fallback_backends(capability: str) -> list[str]:
+    """Return ordered runtime fallback providers for a web capability.
+
+    ``web.<capability>_fallback_backends`` takes precedence over the shared
+    ``web.fallback_backends`` setting. Both accept a YAML sequence or a
+    comma-separated string. Names are resolved by the provider registry at
+    dispatch time so plugin-contributed providers work without a core
+    allowlist.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get(f"{capability}_fallback_backends")
+    if raw is None:
+        raw = cfg.get("fallback_backends")
+
+    if isinstance(raw, str):
+        candidates = raw.split(",")
+    elif isinstance(raw, (list, tuple)):
+        candidates = raw
+    else:
+        return []
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if not isinstance(item, str):
+            continue
+        name = item.strip().lower()
+        if name and name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable.
 
@@ -715,11 +748,76 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     ),
                 }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            providers_to_try = [provider]
+            for fallback_name in _get_capability_fallback_backends("search"):
+                fallback_provider = _wsp_get_provider(fallback_name)
+                if fallback_provider is None or fallback_provider.name == provider.name:
+                    continue
+                try:
+                    if (
+                        fallback_provider.supports_search()
+                        and fallback_provider.is_available()
+                    ):
+                        providers_to_try.append(fallback_provider)
+                except Exception as exc:  # noqa: BLE001 — skip broken fallbacks
+                    logger.debug(
+                        "Web fallback provider %r is unavailable: %s",
+                        fallback_name,
+                        exc,
+                    )
+
+            primary_response = None
+            primary_exception = None
+            for index, candidate in enumerate(providers_to_try):
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    candidate.name,
+                    query,
+                    limit,
+                )
+                try:
+                    candidate_response = candidate.search(query, limit)
+                except Exception as exc:  # noqa: BLE001 — provider boundary
+                    if index == 0:
+                        primary_exception = exc
+                    logger.warning(
+                        "Web search via %s raised: %s",
+                        candidate.name,
+                        str(exc)[:200],
+                    )
+                    continue
+
+                if index == 0:
+                    primary_response = candidate_response
+                if not candidate_response.get("success"):
+                    logger.warning(
+                        "Web search via %s returned failure: %s",
+                        candidate.name,
+                        str(candidate_response.get("error", "search failed"))[:200],
+                    )
+                    continue
+
+                response_data = dict(candidate_response)
+                if index > 0:
+                    metadata = dict(response_data.get("metadata") or {})
+                    metadata.update(
+                        {
+                            "fallback_from": provider.name,
+                            "fallback_backend": candidate.name,
+                        }
+                    )
+                    response_data["metadata"] = metadata
+                break
+            else:
+                if primary_response is not None:
+                    response_data = primary_response
+                elif primary_exception is not None:
+                    raise primary_exception
+                else:  # Defensive: providers_to_try always includes the primary.
+                    response_data = {
+                        "success": False,
+                        "error": "No web search provider attempted.",
+                    }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -229,6 +229,21 @@ web:
 
 With this config, Hermes uses SearXNG for all search queries and Firecrawl for URL extraction — combining free search with high-quality extraction.
 
+#### Add runtime search fallbacks
+
+A configured provider can be available at startup and still fail later because of a quota, rate limit, or outage. Add ordered fallback providers for `web_search`:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "tavily"
+  search_fallback_backends:
+    - "ddgs"
+    - "brave-free"
+```
+
+Hermes tries these providers only after the primary search returns a failure or raises an error. Successful fallback responses include `metadata.fallback_from` and `metadata.fallback_backend`. Providers must be installed, enabled, support search, and report themselves available. The setting also accepts a comma-separated string.
+
 ---
 
 ### Tavily


### PR DESCRIPTION
## Summary
Adds ordered runtime fallback providers for `web_search` — when the primary search provider returns a failure or raises an exception, Hermes now tries configured fallback providers in order before giving up.

Based on #65129 by @Nysley, cherry-picked to preserve authorship. Follow-up commits address the sweeper review (interrupt re-check) and add the missing DEFAULT_CONFIG keys.

## Changes
- `tools/web_tools.py`: New `_get_capability_fallback_backends()` reads `web.<capability>_fallback_backends` or shared `web.fallback_backends` (list or comma-string, deduped). Modified `web_search_tool()` to try fallback providers when the primary fails. Re-checks `is_interrupted()` before each fallback dispatch so a stop signal doesn't trigger extra network requests.
- `hermes_cli/config_defaults.py`: Added `search_fallback_backends: []` and `fallback_backends: []` to DEFAULT_CONFIG.
- `tests/tools/test_web_tools_config.py`: 6 new tests — config parsing/dedup, fallback on failure, fallback recovery from exception, fallback skipped when interrupted, all-fail preserves primary failure, shared `fallback_backends` config key.
- `website/docs/user-guide/features/web-search.md`: Documentation.

## Compatibility
- No behavior change when no fallback list is configured
- Original primary failure/exception preserved when no fallback succeeds
- Unavailable, unsupported, duplicate, or unknown fallback providers are skipped
- Interrupt signal prevents fallback dispatch (no extra network request after stop)

## Validation
| | Before | After |
|---|---|---|
| Targeted tests | 41 passed | 44 passed |
| E2E smoke (18 edge cases) | — | 18/18 passed |
| Interrupt re-check | missing | covered |
| Shared fallback_backends | untested | tested |
| All-fail path | untested | tested |
| DEFAULT_CONFIG keys | missing | present |

Closes #65129
