### PR TITLE
fix: replace assert statements with runtime guards (4 files)

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1238,7 +1238,10 @@ def recover_session_database(
         output_path=output_path,
         work_dir=work_dir,
     )
-    assert output is not None
+    if output is None:
+        raise SessionRecoverySafetyError(
+            "output_path is required for session recovery"
+        )
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -104,7 +104,10 @@ def _load_nostr_auth():
 
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Cannot load nostr_auth module from {path}"
+            )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module

--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -478,7 +478,11 @@ class CuaTypedBrowserRoute:
         )
         if refusal is not None:
             return refusal
-        assert selected_tab is not None and self.state.target_id is not None
+        if selected_tab is None or self.state.target_id is None:
+            return _refusal(
+                "browser_state_inconsistent",
+                "Internal error: mutation pre-checks passed but tab or target_id is missing.",
+            )
 
         ref = call_args.get("ref")
         supports_trust_choice = tool in {"browser_click", "browser_pointer"}

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -223,7 +223,10 @@ def _open_mcp(binary: str) -> subprocess.Popen:
 
 def _mcp_rpc(proc: subprocess.Popen, msg_id: int, method: str, params: Any = None) -> Dict[str, Any]:
     """Write one JSON-RPC request and read one response line."""
-    assert proc.stdin is not None and proc.stdout is not None
+    if proc.stdin is None or proc.stdout is None:
+        raise RuntimeError(
+            "_mcp_rpc called with subprocess that has no stdin or stdout pipe"
+        )
     payload: Dict[str, Any] = {"jsonrpc": "2.0", "id": msg_id, "method": method}
     if params is not None:
         payload["params"] = params


### PR DESCRIPTION
## Summary

Converts `assert` statements to explicit runtime checks in 4 production files. `assert` is silently stripped by `python -O`, eliminating invariant checks in optimized builds.

## Changes

| File | Line | Old | New |
|------|------|-----|-----|
| `tools/computer_use/browser_route.py` | 481 | `assert selected_tab is not None...` | `if ...: return _refusal(...)` |
| `tools/computer_use/doctor.py` | 226 | `assert proc.stdin is not None...` | `if ...: raise RuntimeError(...)` |
| `hermes_cli/session_recovery.py` | 1241 | `assert output is not None` | `if ...: raise SessionRecoverySafetyError(...)` |
| `plugins/platforms/buzz/adapter.py` | 107 | `assert spec is not None...` | `if ...: raise ImportError(...)` |

## Why

With `python -O`, all `assert` statements are removed. If any of these invariants are violated at runtime, the code would crash with confusing `AttributeError` or `TypeError` instead of clear, actionable error messages. Each replacement preserves the original intent while surviving optimization.

## Test Plan

- [x] `ast.parse()` passes on all 4 files
- [ ] Existing tests pass (no behavioral change for non-optimized Python)
