### PR TITLE
fix(tts): per-sentence prefetch pipeline with PortAudio resilience (salvage #71084)

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -221,3 +221,574 @@ def test_stream_cap_truncates_runaway_upstream(monkeypatch):
     out = list(ts._capped(_endless(), "test"))
     assert len(out) == 1  # 64 ok, 128 > cap → stop
     assert sum(len(c) for c in out) <= 100
+
+
+# ── Dispatch: chunked streamer path (regression tests) ───────────────────
+
+
+def test_streamer_path_handles_misaligned_pcm_chunks(monkeypatch):
+    """Regression: PCM chunks with odd byte counts must not be dropped.
+
+    OpenAI's streaming PCM API yields HTTP chunks on arbitrary byte
+    boundaries that are not aligned to the int16 frame width (2 bytes).
+    The old code called numpy.frombuffer directly on each chunk, which
+    raised "buffer size must be a multiple of element size" on any
+    odd-length chunk and silently dropped it — producing scattered
+    audio fragments. The fix carries leftover bytes into the next chunk.
+    """
+    from tools import tts_tool
+
+    class _OddChunkProvider(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            # Deliberately yield chunks with odd byte counts so the
+            # int16 frame boundary falls between chunks.
+            yield b"\x01\x00\x02"       # 3 bytes — odd, would crash old code
+            yield b"\x00\x03\x00\x04"   # 4 bytes — even, old code OK
+            yield b"\x00\x05\x00"       # 3 bytes — odd, would crash old code
+
+    sd, out = _sd_mock()
+    q = _drain_queue(["A complete sentence for testing."])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_OddChunkProvider({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    # Every chunk must have been written — no drops from misalignment.
+    assert out.write.called, "expected PCM chunks written despite odd byte counts"
+    # Collect all bytes the output stream received across all write calls.
+    written_bytes = b""
+    for call_args in out.write.call_args_list:
+        arr = call_args[0][0]
+        written_bytes += arr.tobytes()
+    # The provider yielded 3 + 4 + 3 = 10 bytes total; all should arrive.
+    assert len(written_bytes) == 10, (
+        f"expected 10 bytes of PCM data, got {len(written_bytes)} — "
+        "misaligned chunks were likely dropped"
+    )
+    assert done.is_set()
+
+
+def test_streamer_path_survives_portaudio_write_error(monkeypatch):
+    """Regression: a transient PortAudio error on output_stream.write must
+    not kill the playback thread or hang the pipeline join.
+
+    PortAudio/Core Audio can raise errors mid-stream (e.g. PaErrorCode -9986
+    "Internal PortAudio error" on macOS device state changes).  The worker
+    must log and break, not crash — otherwise _playback_done never fires.
+    """
+    from tools import tts_tool
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 50
+            yield b"\x02\x00" * 50
+
+    sd, out = _sd_mock()
+    out.write.side_effect = OSError("Internal PortAudio error [PaErrorCode -9986]")
+    q = _drain_queue(["A complete sentence for testing."])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Fake({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert out.write.called, "expected at least one write attempt"
+    assert done.is_set(), "done event must fire even after PortAudio error"
+
+
+def test_streamer_reinit_after_portaudio_error_plays_remaining_sentences(monkeypatch):
+    """Regression: after a PortAudio error the worker must reinit the stream
+    and continue playing remaining sentences instead of dropping them.
+
+    Simulates two sentences where the first triggers a PortAudio -9986 error
+    on write.  The mock sounddevice returns a *fresh* OutputStream on the
+    second call to ``OutputStream()`` (the reinit).  The second sentence must
+    be written to that fresh stream, proving the pipeline recovered.
+    """
+    from tools import tts_tool
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 50
+            yield b"\x02\x00" * 50
+
+    # First OutputStream fails on write; second (reinit) succeeds.
+    sd = MagicMock()
+    broken_out = MagicMock()
+    fresh_out = MagicMock()
+    out_pool = [broken_out, fresh_out]
+    broken_out.write.side_effect = OSError(
+        "Internal PortAudio error [PaErrorCode -9986]"
+    )
+
+    def _make_stream(*args, **kwargs):
+        return out_pool.pop(0) if out_pool else MagicMock()
+
+    sd.OutputStream.side_effect = _make_stream
+
+    q = _drain_queue([
+        "First sentence triggers PortAudio error here. ",
+        "Second sentence must still play after reinit. ",
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Fake({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert broken_out.write.called, "first stream should have received a write"
+    assert fresh_out.write.called, (
+        "second (reinit) stream should have received writes for the "
+        "remaining sentence — proves the pipeline recovered"
+    )
+    assert done.is_set(), "done event must fire after recovery"
+
+
+def test_streamer_tempfile_fallback_after_reinit_exhausted(monkeypatch):
+    """Regression: after 3 failed reinits, remaining sentences must play
+    via the temp-file fallback, not be silently dropped.
+    """
+    from tools import tts_tool
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 50
+
+    # Every OutputStream fails on write — reinit will keep failing.
+    sd = MagicMock()
+    out = MagicMock()
+    sd.OutputStream.return_value = out
+    out.write.side_effect = OSError(
+        "Internal PortAudio error [PaErrorCode -9986]"
+    )
+
+    # Patch play_audio_file so the tempfile fallback doesn't actually
+    # try to play audio — just count that it was called.
+    play_calls: list[str] = []
+
+    def _fake_play(path):
+        play_calls.append(path)
+
+    q = _drain_queue([
+        "First sentence triggers PortAudio error. ",
+        "Second sentence fails after first reinit. ",
+        "Third sentence fails after second reinit. ",
+        "Fourth sentence fails after third reinit. ",
+        "Fifth sentence plays via tempfile fallback. ",
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Fake({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"), \
+         patch("tools.voice_mode.play_audio_file", side_effect=_fake_play):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    # The stream was created 4 times: initial + 3 reinit attempts.
+    assert sd.OutputStream.call_count == 4, (
+        f"expected 4 OutputStream calls (initial + 3 reinits), "
+        f"got {sd.OutputStream.call_count}"
+    )
+    assert done.is_set(), "done event must fire even after reinit exhaustion"
+    assert len(play_calls) >= 1, (
+        "tempfile fallback should have been invoked for remaining "
+        "sentences after reinit exhaustion"
+    )
+
+
+
+# ── Dispatch: hybrid batch-prefetch path ──────────────────────────────────
+
+def test_hybrid_first_sentence_streamed_individually(monkeypatch):
+    """The first sentence must get its own stream() call for low TTFA."""
+    from tools import tts_tool
+
+    stream_calls: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_calls.append(text)
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    q = _drain_queue(["This is the first complete sentence."])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert len(stream_calls) == 1, (
+        f"single sentence should trigger 1 stream() call, got {stream_calls}"
+    )
+    assert done.is_set()
+
+
+def test_hybrid_subsequent_sentences_prefetched_individually(monkeypatch):
+    """Every sentence should get its own stream() call — per-sentence
+    prefetch fires the HTTP request the moment each sentence completes,
+    eliminating inter-sentence gaps."""
+    from tools import tts_tool
+
+    stream_calls: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_calls.append(text)
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    # Four sentences — each gets its own stream() call.
+    sentences = [
+        "This is the very first sentence here. ",
+        "This is the second complete sentence. ",
+        "This is the third complete sentence. ",
+        "This is the fourth complete sentence. ",
+    ]
+    q = _drain_queue(sentences)
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    # Exactly 4 calls: one per sentence.
+    assert len(stream_calls) == 4, (
+        f"expected 4 stream() calls (1 per sentence), "
+        f"got {len(stream_calls)}: {stream_calls}"
+    )
+    # Each call contains its corresponding sentence's text.
+    assert "first sentence" in stream_calls[0]
+    assert "second" in stream_calls[1].lower()
+    assert "third" in stream_calls[2].lower()
+    assert "fourth" in stream_calls[3].lower()
+    assert done.is_set()
+
+
+def test_hybrid_short_sentences_each_get_own_call(monkeypatch):
+    """Short sentences should each get their own stream() call — no batching,
+    no waiting for a threshold or end-of-text."""
+    from tools import tts_tool
+
+    stream_calls: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_calls.append(text)
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    # Two short sentences — each gets its own stream() call.
+    q = _drain_queue([
+        "This is the first sentence. ",
+        "Short second one. ",
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert len(stream_calls) == 2, (
+        f"expected 2 stream() calls (1 per sentence), "
+        f"got {len(stream_calls)}: {stream_calls}"
+    )
+    assert "first" in stream_calls[0].lower()
+    assert "second" in stream_calls[1].lower()
+    assert done.is_set()
+
+
+def test_hybrid_done_event_waits_for_prefetch(monkeypatch):
+    """The done event must not fire until the prefetch thread has finished,
+    otherwise continuous voice mode could overlap turns."""
+    from tools import tts_tool
+
+    prefetch_done = threading.Event()
+
+    class _Blocking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            # For the batch call (second stream() invocation), block until
+            # the test signals. The first call returns immediately.
+            yield b"\x00\x00" * 10
+            # Small delay to ensure the prefetch thread is running when
+            # the main loop hits end-of-text.
+            import time as _time
+            _time.sleep(0.3)
+            prefetch_done.set()
+
+    sd, out = _sd_mock()
+    sentences = [
+        "This is the first sentence here. ",
+        "This is the second sentence here. ",
+        "This is the third sentence here. ",
+    ]
+    q = _drain_queue(sentences)
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Blocking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    # done.is_set() is true — but only after the prefetch joined.
+    assert done.is_set()
+    # The prefetch thread should have completed before done was set.
+    assert prefetch_done.is_set(), (
+        "done event fired before the prefetch thread finished — "
+        "this would cause audio overlap in continuous voice mode"
+    )
+
+
+def test_hybrid_single_sentence_still_works(monkeypatch):
+    """A single-sentence reply should stream immediately with no batch."""
+    from tools import tts_tool
+
+    stream_calls: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_calls.append(text)
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    q = _drain_queue(["Just one complete sentence."])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert len(stream_calls) == 1, (
+        f"single sentence should trigger exactly 1 stream() call, got {stream_calls}"
+    )
+    assert done.is_set()
+
+
+def test_hybrid_playback_serialized_no_overlap(monkeypatch):
+    """Multiple batch flushes must not overlap on the output stream.
+
+    The playback lock serializes write calls so audio segments play in
+    order. We verify by tracking concurrent playback — at most one thread
+    should be inside _play_pcm_chunks at any time.
+    """
+    from tools import tts_tool
+
+    active_plays = [0]
+    max_concurrent = [0]
+    play_order: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            # Yield enough data to exercise the write loop.
+            for _ in range(5):
+                yield b"\x00\x00" * 20
+
+    sd = MagicMock()
+    out = MagicMock()
+
+    def _mock_write(_data):
+        active_plays[0] += 1
+        max_concurrent[0] = max(max_concurrent[0], active_plays[0])
+        # Track which batch is playing by the data pattern (not text,
+        # since we can't access it from the write callback).
+        play_order.append("play")
+        active_plays[0] -= 1
+
+    out.write.side_effect = _mock_write
+    sd.OutputStream.return_value = out
+
+    # Many sentences to force multiple batch flushes.
+    sentences = [f"This is sentence number {i} here. " for i in range(10)]
+    q = _drain_queue(sentences)
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert done.is_set()
+    assert max_concurrent[0] <= 1, (
+        f"playback threads overlapped: max concurrent writes = {max_concurrent[0]}"
+    )
+
+
+def test_hybrid_prefetch_fires_http_immediately(monkeypatch):
+    """The prefetch thread must start consuming the generator (firing the
+    HTTP request) the moment _enqueue_audio is called, NOT when the
+    playback worker gets to it.
+
+    We verify by recording the wall-clock time when stream() first yields
+    and asserting that the second call's first yield happens before the
+    first call's playback completes.
+    """
+    import time
+    from tools import tts_tool
+
+    stream_start_times: list[float] = []
+    playback_done_times: list[float] = []
+    block_first_playback = threading.Event()
+
+    class _BlockingFirst(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_start_times.append(time.monotonic())
+            # First sentence: block until the test signals playback to proceed.
+            # This simulates a long audio segment still playing.
+            if len(stream_start_times) == 1:
+                block_first_playback.wait(timeout=5.0)
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    write_count = [0]
+
+    def _mock_write(_data):
+        write_count[0] += 1
+        if write_count[0] == 1:
+            # First write of first sentence — unblock so playback can finish.
+            block_first_playback.set()
+
+    out.write.side_effect = _mock_write
+
+    # Two sentences: first blocks, second should prefetch while first plays.
+    q = _drain_queue(["First sentence here. ", "Second sentence here. "])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_BlockingFirst({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert done.is_set()
+    assert len(stream_start_times) == 2, (
+        f"expected 2 stream() calls, got {len(stream_start_times)}"
+    )
+    # The second stream() call must have started (HTTP fired) while the
+    # first was still blocked/playing. Since the first blocks until
+    # playback starts, and the second is enqueued immediately after,
+    # the second's start time should be very close to the first's.
+    # We just assert both fired (the timing is inherently tested by the
+    # fact that block_first_playback was needed to unblock the first).
+    assert stream_start_times[1] > stream_start_times[0], (
+        "second stream() should start after the first"
+    )
+
+
+def test_display_callback_not_called_when_streaming_enabled(monkeypatch):
+    """When streaming is enabled, display_callback must NOT be passed to
+    the TTS consumer — the token stream already renders text. This
+    prevents duplicate rendering (fix #1).
+
+    This is a CLI-level test simulated at the tts_tool level: the key
+    invariant is that stream_tts_to_speaker with display_callback=None
+    still works correctly (no crash, no display).
+    """
+    from tools import tts_tool
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x00\x00" * 10
+
+    sd, out = _sd_mock()
+    q = _drain_queue(["A sentence for the no-callback path. "])
+    stop, done = threading.Event(), threading.Event()
+
+    # display_callback=None simulates the streaming_enabled=True case.
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Fake({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done, display_callback=None)
+
+    assert done.is_set()
+    # No assertion on display — the point is no crash and done is set.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -52,7 +52,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, Iterator, Optional
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -3418,8 +3418,251 @@ def stream_tts_to_speaker(
         queue_timeout = 0.5
         _spoken_sentences: list[str] = []  # track spoken sentences to skip duplicates
 
+        # --- Per-sentence prefetch pipeline ---
+        # Every sentence gets its own streamer.stream() call the moment it's
+        # complete. A background prefetch thread fires the HTTP request
+        # immediately, buffering PCM chunks into a per-segment queue. The
+        # single playback worker drains these queues in FIFO order. This
+        # means sentence N+1's HTTP request fires WHILE sentence N is still
+        # playing, so by the time the worker reaches it, audio is already
+        # arriving — no inter-sentence gap.
+        _audio_queue: queue.Queue[Optional[queue.Queue[Optional[bytes]]]] = queue.Queue()
+        _playback_done = threading.Event()
+        _prefetch_threads: list[threading.Thread] = []
+        # Limit concurrent prefetch threads so a long reply with many sentences
+        # doesn't spawn an unbounded number of HTTP connections / RAM buffers.
+        # The playback worker drains segments in FIFO order, so capping
+        # in-flight prefetches to 3 still keeps sentence N+1's audio warm
+        # while N plays, without letting a 100-sentence reply reserve 100
+        # threads + 100 unbounded queues up front.
+        _prefetch_sem = threading.Semaphore(3)
+        # Bound each per-sentence chunk queue so a slow playback worker
+        # can't let a fast prefetch thread buffer an entire sentence's
+        # audio in RAM.  ~64 chunks ≈ 64 KB of int16 PCM at 2 bytes/frame
+        # — enough headroom for smooth playback without unbounded growth.
+        _CHUNK_QUEUE_MAX = 64
+
+        def _consume_to_queue(
+            audio_iter: Iterator[bytes],
+            chunk_queue: "queue.Queue[Optional[bytes]]",
+        ) -> None:
+            """Consume a generator into a thread-safe queue.
+
+            Fires the HTTP request immediately (the generator's first
+            iteration triggers it) and buffers every chunk so the playback
+            worker can drain without waiting for synthesis.
+            """
+            try:
+                for chunk in audio_iter:
+                    if stop_event.is_set():
+                        logger.info(
+                            "TTS CUT: prefetch cancelled (stop_event set "
+                            "mid-sentence) — partial audio only"
+                        )
+                        break
+                    chunk_queue.put(chunk, timeout=30.0)
+            except Exception as exc:
+                logger.warning(
+                    "TTS CUT: streaming TTS prefetch failed mid-sentence "
+                    "(partial audio only): %s",
+                    exc,
+                )
+            finally:
+                chunk_queue.put(None)  # sentinel: no more chunks
+                _prefetch_sem.release()  # free a prefetch slot
+
+        def _reinit_output_stream():
+            """Close the broken PortAudio stream and try to create a fresh one.
+
+            Returns the new stream on success, ``None`` on failure.  Updates
+            the enclosing ``output_stream`` so the finally block in
+            ``stream_tts_to_speaker`` closes the *current* stream, not the
+            stale broken one.
+            """
+            nonlocal output_stream
+            if output_stream is not None:
+                try:
+                    output_stream.stop()
+                    output_stream.close()
+                except Exception:
+                    pass
+            try:
+                sd = _import_sounddevice()
+                new_stream = sd.OutputStream(
+                    samplerate=streamer.sample_rate,
+                    channels=streamer.channels,
+                    dtype="int16",
+                )
+                new_stream.start()
+                output_stream = new_stream
+                logger.info(
+                    "TTS: PortAudio output stream reinitialized after error"
+                )
+                return new_stream
+            except Exception as exc:
+                logger.warning(
+                    "TTS: PortAudio stream reinit failed: %s", exc
+                )
+                output_stream = None
+                return None
+
+        def _playback_worker() -> None:
+            """Single consumer: play audio segments from the queue in order.
+
+            When PortAudio raises a transient error (e.g. PaErrorCode -9986
+            on macOS device state changes), the worker attempts to
+            reinitialize the output stream (up to ``_max_reinit`` times).
+            If reinit fails it falls back to temp-file playback for the
+            remaining sentences instead of dropping them silently.
+            """
+            assert streamer is not None
+            if output_stream is not None:
+                import numpy as _np
+                _max_reinit = 3
+                _reinit_count = 0
+                _current_stream = output_stream
+                while True:
+                    chunk_queue = _audio_queue.get()
+                    if chunk_queue is None:
+                        break
+                    if stop_event.is_set():
+                        continue
+                    # If the stream died and reinit is exhausted, fall back
+                    # to temp-file playback for all remaining sentences.
+                    if _current_stream is None:
+                        _chunks = []
+                        while True:
+                            chunk = chunk_queue.get()
+                            if chunk is None:
+                                break
+                            _chunks.append(chunk)
+                        _play_via_tempfile(
+                            iter(_chunks), stop_event, streamer.sample_rate
+                        )
+                        continue
+                    _pcm_leftover = b""
+                    while True:
+                        chunk = chunk_queue.get()
+                        if chunk is None:
+                            break
+                        if stop_event.is_set():
+                            break
+                        _buf = _pcm_leftover + chunk
+                        _aligned_len = len(_buf) - (len(_buf) % 2)
+                        if _aligned_len >= 2:
+                            try:
+                                _current_stream.write(
+                                    _np.frombuffer(
+                                        _buf[:_aligned_len], dtype="<i2"
+                                    ).reshape(-1, 1)
+                                )
+                            except Exception as write_exc:
+                                # PortAudio/Core Audio can raise transient
+                                # errors (e.g. PaErrorCode -9986 "Internal
+                                # PortAudio error" on macOS device state
+                                # changes or buffer underruns).  Try to
+                                # reinit the stream so remaining sentences
+                                # survive; if reinit is exhausted, fall
+                                # back to temp-file playback.
+                                logger.warning(
+                                    "PortAudio write failed, attempting "
+                                    "stream reinit: %s",
+                                    write_exc,
+                                )
+                                if _reinit_count < _max_reinit:
+                                    _reinit_count += 1
+                                    _current_stream = _reinit_output_stream()
+                                    if _current_stream is not None:
+                                        # Reinit succeeded — re-attempt
+                                        # the failed write on the fresh
+                                        # stream instead of skipping the
+                                        # chunk.  The old `continue` jumped
+                                        # back to chunk_queue.get(), losing
+                                        # the chunk that triggered the
+                                        # error — audible as a missing
+                                        # syllable mid-sentence.
+                                        try:
+                                            _current_stream.write(
+                                                _np.frombuffer(
+                                                    _buf[:_aligned_len],
+                                                    dtype="<i2",
+                                                ).reshape(-1, 1)
+                                            )
+                                        except Exception:
+                                            # Fresh stream also rejected
+                                            # the write — don't loop;
+                                            # fall through to the next
+                                            # chunk so we don't hang.
+                                            pass
+                                        continue
+                                else:
+                                    logger.warning(
+                                        "TTS: PortAudio reinit exhausted "
+                                        "after %d attempts, falling back "
+                                        "to tempfile for remaining "
+                                        "sentences",
+                                        _max_reinit,
+                                    )
+                                    _current_stream = None
+                                break
+                        _pcm_leftover = (
+                            _buf[_aligned_len:] if _aligned_len < len(_buf) else b""
+                        )
+            else:
+                while True:
+                    chunk_queue = _audio_queue.get()
+                    if chunk_queue is None:
+                        break
+                    if stop_event.is_set():
+                        continue
+                    # Materialize the prefetched chunks for the temp-file path.
+                    _chunks = []
+                    while True:
+                        chunk = chunk_queue.get()
+                        if chunk is None:
+                            break
+                        _chunks.append(chunk)
+                    _play_via_tempfile(
+                        iter(_chunks), stop_event, streamer.sample_rate
+                    )
+            _playback_done.set()
+
+        def _enqueue_audio(text_to_speak: str) -> None:
+            """Synthesize *text_to_speak* and start prefetching immediately.
+
+            A background thread begins consuming the generator (firing the
+            HTTP request) the moment this is called, buffering PCM chunks
+            into a per-segment queue. The queue is placed on the audio
+            queue for ordered playback by the worker thread.
+            """
+            assert streamer is not None
+            try:
+                audio_iter = streamer.stream(text_to_speak)
+            except Exception as exc:
+                logger.warning("Streaming TTS synthesis failed: %s", exc)
+                return
+            # Block until a prefetch slot is free — caps concurrent
+            # in-flight synthesis threads so a long reply doesn't
+            # reserve one thread + one queue per sentence up front.
+            _prefetch_sem.acquire()
+            chunk_queue: "queue.Queue[Optional[bytes]]" = queue.Queue(maxsize=_CHUNK_QUEUE_MAX)
+            _audio_queue.put(chunk_queue)
+            t = threading.Thread(
+                target=_consume_to_queue,
+                args=(audio_iter, chunk_queue),
+                daemon=True,
+            )
+            _prefetch_threads.append(t)
+            t.start()
+
+        # Start the single playback worker (only when we have a streamer).
+        _worker_thread: Optional[threading.Thread] = None
+        if streamer is not None:
+            _worker_thread = threading.Thread(target=_playback_worker, daemon=True)
+            _worker_thread.start()
+
         def _speak_sentence(sentence: str):
-            """Display sentence and optionally generate + play audio."""
+            """Display sentence and route to the appropriate audio path."""
             if stop_event.is_set():
                 return
             cleaned = _strip_markdown_for_tts(sentence).strip()
@@ -3441,33 +3684,10 @@ def stream_tts_to_speaker(
             # Truncate very long sentences to the provider's per-request cap.
             if stream_max_len and len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]
-            try:
-                audio_iter = streamer.stream(cleaned)
-                if output_stream is not None:
-                    import numpy as _np
-
-                    # Flag real speaker output for the duration of this
-                    # sentence so ambient cues (thinking sound) stay quiet.
-                    # Fail-open: stubbed/partial voice_mode modules (tests)
-                    # must never break sentence playback.
-                    try:
-                        from tools.voice_mode import mark_audio_output_active
-                    except Exception:
-                        def mark_audio_output_active(_active):
-                            return None
-                    mark_audio_output_active(True)
-                    try:
-                        for chunk in audio_iter:
-                            if stop_event.is_set():
-                                break
-                            output_stream.write(_np.frombuffer(chunk, dtype=_np.int16).reshape(-1, 1))
-                    finally:
-                        mark_audio_output_active(False)
-                else:
-                    # No audio device: buffer chunks to a temp WAV and play it.
-                    _play_via_tempfile(audio_iter, stop_event, streamer.sample_rate)
-            except Exception as exc:
-                logger.warning("Streaming TTS sentence failed: %s", exc)
+            # Every sentence gets its own prefetch thread — the HTTP request
+            # fires the moment the sentence boundary is detected, so audio for
+            # sentence N+1 is already buffering while sentence N plays.
+            _enqueue_audio(cleaned)
 
         def _speak_via_sync(cleaned: str):
             """Synthesize one sentence via the proven sync tool, then block on
@@ -3493,8 +3713,15 @@ def stream_tts_to_speaker(
                         pass
 
         def _play_via_tempfile(audio_iter, stop_evt, sample_rate=24000):
-            """Write PCM chunks to a temp WAV file and play it."""
-            tmp = None
+            """Write PCM chunks to a temp WAV file and play it.
+
+            Applies int16 (2-byte) frame alignment before writing: streaming
+            providers can yield chunks on arbitrary byte boundaries, and
+            ``wave.writeframes`` fed a half-sample at a chunk boundary would
+            produce a corrupted click.  Leftover bytes are carried into the
+            next chunk so every frame written is whole — same carry logic as
+            the live playback path.
+            """
             tmp_path = None
             try:
                 import wave
@@ -3504,10 +3731,21 @@ def stream_tts_to_speaker(
                     wf.setnchannels(1)
                     wf.setsampwidth(2)  # 16-bit
                     wf.setframerate(sample_rate)
+                    pcm_leftover = b""
                     for chunk in audio_iter:
                         if stop_evt.is_set():
                             break
-                        wf.writeframes(chunk)
+                        buf = pcm_leftover + chunk
+                        aligned_len = len(buf) - (len(buf) % 2)
+                        if aligned_len >= 2:
+                            wf.writeframes(buf[:aligned_len])
+                        pcm_leftover = (
+                            buf[aligned_len:] if aligned_len < len(buf) else b""
+                        )
+                    # Flush any trailing byte as silence (can't write half a
+                    # sample, but a single leftover byte is inaudible).
+                    if pcm_leftover:
+                        wf.writeframes(b"\x00")
                 # wave.open() given a file object flushes but does NOT close it
                 # (it only closes files it opened itself, by name), so the OS
                 # handle to tmp stays open.  On Windows an open write handle
@@ -3557,6 +3795,30 @@ def stream_tts_to_speaker(
                 text_queue.get_nowait()
             except queue.Empty:
                 break
+
+        # Signal the playback worker that no more audio is coming, then wait
+        # for it to finish playing everything in the queue. This ensures
+        # continuous voice mode doesn't start the next turn while audio is
+        # still playing.
+        #
+        # The timeout must be generous: a 1 000-character response is ~70 s
+        # of audio at 15 chars/s.  The old 30-second timeout was too short
+        # for anything beyond a few sentences — the join would expire
+        # mid-playback, the finally block would close the output stream
+        # out from under the still-running worker, and the worker's next
+        # write would hit PortAudio -9986 on the closed stream.  300 s
+        # gives even the longest responses room to finish; the sentinel
+        # on the audio queue is the real exit signal, the timeout is just
+        # a safety net against a wedged worker.
+        if streamer is not None and _worker_thread is not None:
+            _audio_queue.put(None)
+            _worker_thread.join(timeout=300.0)
+
+        # Join prefetch threads so in-flight HTTP requests complete before
+        # the pipeline exits (prevents orphaned connections on rapid turn
+        # changes).
+        for t in _prefetch_threads:
+            t.join(timeout=10.0)
 
         # output_stream is closed in the finally block below
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3375,6 +3375,10 @@ def stream_tts_to_speaker(
 
     try:
         output_stream = None
+        streamer = None  # type: ignore[assignment]
+        _worker_thread = None
+        _audio_queue = None  # type: ignore[assignment]
+        _prefetch_threads = []
         tts_config = _load_tts_config()
 
         # Prefer a chunked streamer for low time-to-first-audio; fall back to
@@ -3427,31 +3431,26 @@ def stream_tts_to_speaker(
         # playing, so by the time the worker reaches it, audio is already
         # arriving — no inter-sentence gap.
         _audio_queue: queue.Queue[Optional[queue.Queue[Optional[bytes]]]] = queue.Queue()
-        _playback_done = threading.Event()
         _prefetch_threads: list[threading.Thread] = []
-        # Limit concurrent prefetch threads so a long reply with many sentences
-        # doesn't spawn an unbounded number of HTTP connections / RAM buffers.
-        # The playback worker drains segments in FIFO order, so capping
-        # in-flight prefetches to 3 still keeps sentence N+1's audio warm
-        # while N plays, without letting a 100-sentence reply reserve 100
-        # threads + 100 unbounded queues up front.
         _prefetch_sem = threading.Semaphore(3)
-        # Bound each per-sentence chunk queue so a slow playback worker
-        # can't let a fast prefetch thread buffer an entire sentence's
-        # audio in RAM.  ~64 chunks ≈ 64 KB of int16 PCM at 2 bytes/frame
-        # — enough headroom for smooth playback without unbounded growth.
         _CHUNK_QUEUE_MAX = 64
+
+        def _create_output_stream():
+            """Create and start a fresh PortAudio OutputStream."""
+            sd = _import_sounddevice()
+            new_stream = sd.OutputStream(
+                samplerate=streamer.sample_rate,
+                channels=streamer.channels,
+                dtype="int16",
+            )
+            new_stream.start()
+            return new_stream
 
         def _consume_to_queue(
             audio_iter: Iterator[bytes],
             chunk_queue: "queue.Queue[Optional[bytes]]",
         ) -> None:
-            """Consume a generator into a thread-safe queue.
-
-            Fires the HTTP request immediately (the generator's first
-            iteration triggers it) and buffers every chunk so the playback
-            worker can drain without waiting for synthesis.
-            """
+            """Consume a generator into a thread-safe queue."""
             try:
                 for chunk in audio_iter:
                     if stop_event.is_set():
@@ -3472,13 +3471,7 @@ def stream_tts_to_speaker(
                 _prefetch_sem.release()  # free a prefetch slot
 
         def _reinit_output_stream():
-            """Close the broken PortAudio stream and try to create a fresh one.
-
-            Returns the new stream on success, ``None`` on failure.  Updates
-            the enclosing ``output_stream`` so the finally block in
-            ``stream_tts_to_speaker`` closes the *current* stream, not the
-            stale broken one.
-            """
+            """Close the broken PortAudio stream and try to create a fresh one."""
             nonlocal output_stream
             if output_stream is not None:
                 try:
@@ -3487,13 +3480,7 @@ def stream_tts_to_speaker(
                 except Exception:
                     pass
             try:
-                sd = _import_sounddevice()
-                new_stream = sd.OutputStream(
-                    samplerate=streamer.sample_rate,
-                    channels=streamer.channels,
-                    dtype="int16",
-                )
-                new_stream.start()
+                new_stream = _create_output_stream()
                 output_stream = new_stream
                 logger.info(
                     "TTS: PortAudio output stream reinitialized after error"
@@ -3507,107 +3494,95 @@ def stream_tts_to_speaker(
                 return None
 
         def _playback_worker() -> None:
-            """Single consumer: play audio segments from the queue in order.
-
-            When PortAudio raises a transient error (e.g. PaErrorCode -9986
-            on macOS device state changes), the worker attempts to
-            reinitialize the output stream (up to ``_max_reinit`` times).
-            If reinit fails it falls back to temp-file playback for the
-            remaining sentences instead of dropping them silently.
-            """
+            """Single consumer: play audio segments from the queue in order."""
             assert streamer is not None
             if output_stream is not None:
                 import numpy as _np
-                _max_reinit = 3
-                _reinit_count = 0
-                _current_stream = output_stream
-                while True:
-                    chunk_queue = _audio_queue.get()
-                    if chunk_queue is None:
-                        break
-                    if stop_event.is_set():
-                        continue
-                    # If the stream died and reinit is exhausted, fall back
-                    # to temp-file playback for all remaining sentences.
-                    if _current_stream is None:
-                        _chunks = []
+
+                try:
+                    from tools.voice_mode import mark_audio_output_active
+                except Exception:
+                    def mark_audio_output_active(_active):
+                        return None
+
+                mark_audio_output_active(True)
+                try:
+                    _max_reinit = 3
+                    _reinit_count = 0
+                    _current_stream = output_stream
+                    while True:
+                        chunk_queue = _audio_queue.get()
+                        if chunk_queue is None:
+                            break
+                        if stop_event.is_set():
+                            continue
+                        if _current_stream is None:
+                            _chunks = []
+                            while True:
+                                chunk = chunk_queue.get()
+                                if chunk is None:
+                                    break
+                                _chunks.append(chunk)
+                            _play_via_tempfile(
+                                iter(_chunks), stop_event, streamer.sample_rate
+                            )
+                            continue
+                        _pcm_leftover = b""
                         while True:
                             chunk = chunk_queue.get()
                             if chunk is None:
                                 break
-                            _chunks.append(chunk)
-                        _play_via_tempfile(
-                            iter(_chunks), stop_event, streamer.sample_rate
-                        )
-                        continue
-                    _pcm_leftover = b""
-                    while True:
-                        chunk = chunk_queue.get()
-                        if chunk is None:
-                            break
-                        if stop_event.is_set():
-                            break
-                        _buf = _pcm_leftover + chunk
-                        _aligned_len = len(_buf) - (len(_buf) % 2)
-                        if _aligned_len >= 2:
-                            try:
-                                _current_stream.write(
-                                    _np.frombuffer(
-                                        _buf[:_aligned_len], dtype="<i2"
-                                    ).reshape(-1, 1)
-                                )
-                            except Exception as write_exc:
-                                # PortAudio/Core Audio can raise transient
-                                # errors (e.g. PaErrorCode -9986 "Internal
-                                # PortAudio error" on macOS device state
-                                # changes or buffer underruns).  Try to
-                                # reinit the stream so remaining sentences
-                                # survive; if reinit is exhausted, fall
-                                # back to temp-file playback.
-                                logger.warning(
-                                    "PortAudio write failed, attempting "
-                                    "stream reinit: %s",
-                                    write_exc,
-                                )
-                                if _reinit_count < _max_reinit:
-                                    _reinit_count += 1
-                                    _current_stream = _reinit_output_stream()
-                                    if _current_stream is not None:
-                                        # Reinit succeeded — re-attempt
-                                        # the failed write on the fresh
-                                        # stream instead of skipping the
-                                        # chunk.  The old `continue` jumped
-                                        # back to chunk_queue.get(), losing
-                                        # the chunk that triggered the
-                                        # error — audible as a missing
-                                        # syllable mid-sentence.
-                                        try:
-                                            _current_stream.write(
-                                                _np.frombuffer(
-                                                    _buf[:_aligned_len],
-                                                    dtype="<i2",
-                                                ).reshape(-1, 1)
-                                            )
-                                        except Exception:
-                                            # Fresh stream also rejected
-                                            # the write — don't loop;
-                                            # fall through to the next
-                                            # chunk so we don't hang.
-                                            pass
-                                        continue
-                                else:
-                                    logger.warning(
-                                        "TTS: PortAudio reinit exhausted "
-                                        "after %d attempts, falling back "
-                                        "to tempfile for remaining "
-                                        "sentences",
-                                        _max_reinit,
-                                    )
-                                    _current_stream = None
+                            if stop_event.is_set():
                                 break
-                        _pcm_leftover = (
-                            _buf[_aligned_len:] if _aligned_len < len(_buf) else b""
-                        )
+                            _buf = _pcm_leftover + chunk
+                            _aligned_len = len(_buf) - (len(_buf) % 2)
+                            if _aligned_len >= 2:
+                                try:
+                                    _current_stream.write(
+                                        _np.frombuffer(
+                                            _buf[:_aligned_len], dtype="<i2"
+                                        ).reshape(-1, 1)
+                                    )
+                                except Exception as write_exc:
+                                    logger.warning(
+                                        "PortAudio write failed, attempting "
+                                        "stream reinit: %s",
+                                        write_exc,
+                                    )
+                                    if _reinit_count < _max_reinit:
+                                        _reinit_count += 1
+                                        _current_stream = _reinit_output_stream()
+                                        if _current_stream is not None:
+                                            try:
+                                                _current_stream.write(
+                                                    _np.frombuffer(
+                                                        _buf[:_aligned_len],
+                                                        dtype="<i2",
+                                                    ).reshape(-1, 1)
+                                                )
+                                            except Exception:
+                                                pass
+                                            _pcm_leftover = (
+                                                _buf[_aligned_len:]
+                                                if _aligned_len < len(_buf)
+                                                else b""
+                                            )
+                                            continue
+                                    else:
+                                        logger.warning(
+                                            "TTS: PortAudio reinit exhausted "
+                                            "after %d attempts, falling back "
+                                            "to tempfile for remaining "
+                                            "sentences",
+                                            _max_reinit,
+                                        )
+                                        _current_stream = None
+                                    break
+                            _pcm_leftover = (
+                                _buf[_aligned_len:] if _aligned_len < len(_buf) else b""
+                            )
+                finally:
+                    mark_audio_output_active(False)
             else:
                 while True:
                     chunk_queue = _audio_queue.get()
@@ -3615,7 +3590,6 @@ def stream_tts_to_speaker(
                         break
                     if stop_event.is_set():
                         continue
-                    # Materialize the prefetched chunks for the temp-file path.
                     _chunks = []
                     while True:
                         chunk = chunk_queue.get()
@@ -3625,25 +3599,15 @@ def stream_tts_to_speaker(
                     _play_via_tempfile(
                         iter(_chunks), stop_event, streamer.sample_rate
                     )
-            _playback_done.set()
 
         def _enqueue_audio(text_to_speak: str) -> None:
-            """Synthesize *text_to_speak* and start prefetching immediately.
-
-            A background thread begins consuming the generator (firing the
-            HTTP request) the moment this is called, buffering PCM chunks
-            into a per-segment queue. The queue is placed on the audio
-            queue for ordered playback by the worker thread.
-            """
+            """Synthesize *text_to_speak* and start prefetching immediately."""
             assert streamer is not None
             try:
                 audio_iter = streamer.stream(text_to_speak)
             except Exception as exc:
                 logger.warning("Streaming TTS synthesis failed: %s", exc)
                 return
-            # Block until a prefetch slot is free — caps concurrent
-            # in-flight synthesis threads so a long reply doesn't
-            # reserve one thread + one queue per sentence up front.
             _prefetch_sem.acquire()
             chunk_queue: "queue.Queue[Optional[bytes]]" = queue.Queue(maxsize=_CHUNK_QUEUE_MAX)
             _audio_queue.put(chunk_queue)
@@ -3655,7 +3619,6 @@ def stream_tts_to_speaker(
             _prefetch_threads.append(t)
             t.start()
 
-        # Start the single playback worker (only when we have a streamer).
         _worker_thread: Optional[threading.Thread] = None
         if streamer is not None:
             _worker_thread = threading.Thread(target=_playback_worker, daemon=True)
@@ -3712,16 +3675,23 @@ def stream_tts_to_speaker(
                     except OSError:
                         pass
 
-        def _play_via_tempfile(audio_iter, stop_evt, sample_rate=24000):
-            """Write PCM chunks to a temp WAV file and play it.
+        def _align_int16_chunks(chunks, stop_evt):
+            """Yield int16-aligned byte chunks from an iterable."""
+            leftover = b""
+            for chunk in chunks:
+                if stop_evt.is_set():
+                    break
+                buf = leftover + chunk
+                aligned_len = len(buf) - (len(buf) % 2)
+                if aligned_len >= 2:
+                    yield buf[:aligned_len]
+                leftover = buf[aligned_len:] if aligned_len < len(buf) else b""
+            if leftover:
+                yield b"\x00"
 
-            Applies int16 (2-byte) frame alignment before writing: streaming
-            providers can yield chunks on arbitrary byte boundaries, and
-            ``wave.writeframes`` fed a half-sample at a chunk boundary would
-            produce a corrupted click.  Leftover bytes are carried into the
-            next chunk so every frame written is whole — same carry logic as
-            the live playback path.
-            """
+        def _play_via_tempfile(audio_iter, stop_evt, sample_rate=24000):
+            """Write PCM chunks to a temp WAV file and play it."""
+            tmp = None
             tmp_path = None
             try:
                 import wave
@@ -3731,21 +3701,8 @@ def stream_tts_to_speaker(
                     wf.setnchannels(1)
                     wf.setsampwidth(2)  # 16-bit
                     wf.setframerate(sample_rate)
-                    pcm_leftover = b""
-                    for chunk in audio_iter:
-                        if stop_evt.is_set():
-                            break
-                        buf = pcm_leftover + chunk
-                        aligned_len = len(buf) - (len(buf) % 2)
-                        if aligned_len >= 2:
-                            wf.writeframes(buf[:aligned_len])
-                        pcm_leftover = (
-                            buf[aligned_len:] if aligned_len < len(buf) else b""
-                        )
-                    # Flush any trailing byte as silence (can't write half a
-                    # sample, but a single leftover byte is inaudible).
-                    if pcm_leftover:
-                        wf.writeframes(b"\x00")
+                    for aligned in _align_int16_chunks(audio_iter, stop_evt):
+                        wf.writeframes(aligned)
                 # wave.open() given a file object flushes but does NOT close it
                 # (it only closes files it opened itself, by name), so the OS
                 # handle to tmp stays open.  On Windows an open write handle
@@ -3796,35 +3753,18 @@ def stream_tts_to_speaker(
             except queue.Empty:
                 break
 
-        # Signal the playback worker that no more audio is coming, then wait
-        # for it to finish playing everything in the queue. This ensures
-        # continuous voice mode doesn't start the next turn while audio is
-        # still playing.
-        #
-        # The timeout must be generous: a 1 000-character response is ~70 s
-        # of audio at 15 chars/s.  The old 30-second timeout was too short
-        # for anything beyond a few sentences — the join would expire
-        # mid-playback, the finally block would close the output stream
-        # out from under the still-running worker, and the worker's next
-        # write would hit PortAudio -9986 on the closed stream.  300 s
-        # gives even the longest responses room to finish; the sentinel
-        # on the audio queue is the real exit signal, the timeout is just
-        # a safety net against a wedged worker.
-        if streamer is not None and _worker_thread is not None:
-            _audio_queue.put(None)
-            _worker_thread.join(timeout=300.0)
-
-        # Join prefetch threads so in-flight HTTP requests complete before
-        # the pipeline exits (prevents orphaned connections on rapid turn
-        # changes).
-        for t in _prefetch_threads:
-            t.join(timeout=10.0)
-
         # output_stream is closed in the finally block below
 
     except Exception as exc:
         logger.warning("Streaming TTS pipeline error: %s", exc)
     finally:
+        # Signal the playback worker that no more audio is coming.  This lives
+        # in finally: so an exception in the text pump still sends the sentinel.
+        if streamer is not None and _worker_thread is not None:
+            _audio_queue.put(None)
+            _worker_thread.join(timeout=300.0)
+        for t in _prefetch_threads:
+            t.join(timeout=10.0)
         # Always close the audio output stream to avoid locking the device
         if output_stream is not None:
             try:


### PR DESCRIPTION
## Summary
Salvage of PR #71084 — per-sentence prefetch pipeline for streaming TTS with PortAudio error resilience, rebased onto current main with 8 follow-up fixes for regressions and bugs found during review.

The original PR fixes three real issues in `stream_tts_to_speaker`: inter-sentence gaps (HTTP request only fired when playback reached the sentence, not when it was enqueued), scattered audio fragments (odd-byte PCM chunks silently dropped by `numpy.frombuffer`), and process hangs on transient PortAudio errors.

## Changes
- **Contributor commit** (@beardedeagle): per-sentence prefetch pipeline — each sentence gets its own `streamer.stream()` call immediately, a background thread fires the HTTP request right away, a single playback worker drains segments in FIFO order. PCM chunk alignment (carry leftover bytes). PortAudio error recovery (reinit up to 3 attempts, then temp-file fallback). Worker join timeout 30s → 300s.
- **fix: carry mark_audio_output_active into playback worker** — main commit df093bf33 added this for the ambient thinking sound; the PR's base predated it. Without this, the thinking sound plays over TTS audio.
- **fix: close temp WAV handle before playback** — main commit 555d4e10a; without it, Windows can't read the file and temp .wav files pile up.
- **fix: move sentinel + join into finally block** — the sentinel and worker join were inside `try:`, so an exception before reaching them left the worker hanging on `_audio_queue.get()` forever with a ref to the closed stream.
- **fix: update _pcm_leftover before continue on reinit+rewrite** — `continue` after a successful reinit+rewrite skipped the leftover update, causing a stale byte to be prepended to the next chunk (1-sample glitch).
- **refactor: remove dead _playback_done event** — set but never waited on; `_worker_thread.join()` is used instead.
- **refactor: extract shared _create_output_stream helper** — dedup the `sd.OutputStream(...)` + `.start()` sequence between initial creation and `_reinit_output_stream`.
- **refactor: extract shared _align_int16_chunks generator** — dedup the int16 frame alignment carry logic for `_play_via_tempfile`.
- **test: reconcile test file with main's current structure** — main renamed/added/removed tests since the PR's base; start from main's 13 tests and append the PR's 12 new regression tests (25 total).

## Validation
| | Before | After |
|---|---|---|
| Tests | 13 on main | 25 passed |
| E2E checks | — | 7/7 passed |

Closes #71084
