### PR TITLE
feat(kanban): add one-shot active-PR revision intent

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -49,14 +49,17 @@ def _fmt_ts(ts: Optional[int]) -> str:
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 
-def _fmt_task_line(t: kb.Task) -> str:
+def _fmt_task_line(t: kb.Task, guard: Optional[dict[str, Any]] = None) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    guarded = f" [guarded: {guard['reason']}]" if guard else ""
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}{guarded}"
 
 
-def _task_to_dict(t: kb.Task) -> dict[str, Any]:
+def _task_to_dict(
+    t: kb.Task, guard: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     return {
         "id": t.id,
         "title": t.title,
@@ -81,6 +84,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "respawn_guard": guard,
     }
 
 
@@ -652,6 +656,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--reason",
         default=None,
         help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
+    )
+    p_unblock.add_argument(
+        "--revision",
+        action="store_true",
+        help=(
+            "Request one auditable review-revision continuation after a terminal run; "
+            "bypasses only the active-PR respawn guard."
+        ),
     )
     p_unblock.add_argument("task_ids", nargs="+")
 
@@ -1590,8 +1602,15 @@ def _cmd_list(args: argparse.Namespace) -> int:
             workflow_template_id=args.workflow_template_id,
             current_step_key=args.current_step_key,
         )
+        guards = {
+            task.id: kb.get_respawn_guard_state(conn, task.id)
+            for task in tasks
+            if task.status == "ready"
+        }
     if getattr(args, "json", False):
-        print(json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False))
+        print(json.dumps([
+            _task_to_dict(t, guards.get(t.id)) for t in tasks
+        ], indent=2, ensure_ascii=False))
         return 0
     # Passive discoverability: when the user has multiple boards, surface
     # which one they're looking at in the list header. Single-board users
@@ -1612,7 +1631,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
         print("(no matching tasks)")
         return 0
     for t in tasks:
-        print(_fmt_task_line(t))
+        print(_fmt_task_line(t, guards.get(t.id)))
     return 0
 
 
@@ -1638,10 +1657,11 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        guard = kb.get_respawn_guard_state(conn, args.task_id)
 
     if getattr(args, "json", False):
         payload = {
-            "task": _task_to_dict(task),
+            "task": _task_to_dict(task, guard),
             "latest_summary": latest_summary,
             "parents": parents,
             "children": children,
@@ -1680,6 +1700,11 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
     print(f"Task {task.id}: {task.title}")
     print(f"  status:    {task.status}")
+    if guard:
+        print(
+            f"  Respawn guard: {guard['reason']} "
+            f"(since {_fmt_ts(int(guard['guarded_at']))})"
+        )
     print(f"  assignee:  {task.assignee or '-'}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
@@ -2328,11 +2353,17 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            if not kb.unblock_task(
+                conn,
+                tid,
+                revision=bool(getattr(args, "revision", False)),
+                actor=_profile_author(),
+            ):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
-                print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
+                prefix = "Revision requested; unblocked" if args.revision else "Unblocked"
+                print(f"{prefix} {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4264,6 +4264,22 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        # ``claim_task`` is also a public/manual path. Keep a recent PR from
+        # being bypassed by callers that do not enter through dispatch_once.
+        # Check the active-PR predicate independently from the guard's priority
+        # ordering so blocker_auth/recent_success cannot mask it. An explicit
+        # revision intent may bypass only active_pr; if any other guard still
+        # applies, the revision claim remains blocked. Ordinary manual claims
+        # without revision intent retain their historical semantics for the
+        # non-PR guards.
+        revision_event = _active_revision_event(conn, task_id)
+        if _active_pr_is_guarded(conn, task_id):
+            return None
+        if (
+            revision_event is not None
+            and check_respawn_guard(conn, task_id) is not None
+        ):
+            return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4334,6 +4350,14 @@ def claim_task(
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
         )
+        if revision_event is not None:
+            _append_event(
+                conn,
+                task_id,
+                "revision_consumed",
+                {"revision_event_id": int(revision_event["id"]), "run_id": run_id},
+                run_id=run_id,
+            )
         claimed = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_claimed",
@@ -5898,7 +5922,13 @@ def promote_task(
     return True, None
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    revision: bool = False,
+    actor: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -5914,6 +5944,23 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
         ).fetchone()
+        prior_run = None
+        if revision:
+            if stale is None:
+                return False
+            prior_run = conn.execute(
+                "SELECT id, ended_at FROM task_runs WHERE task_id = ? "
+                "ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            if (
+                prior_run is None
+                or prior_run["ended_at"] is None
+                or stale["current_run_id"] is not None
+            ):
+                raise ValueError(
+                    "revision unblock requires a terminal prior run and no active writer"
+                )
         if stale and stale["current_run_id"]:
             conn.execute(
                 """
@@ -5947,20 +5994,51 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # triage at ``BLOCK_RECURRENCE_LIMIT``. It is reset to 0 only on a
         # successful completion (see ``complete_task``). ``consecutive_failures``
         # (the *dispatcher* spawn/crash/timeout counter — a different signal) is
-        # still reset here, which is correct: a deliberate unblock is a fresh
-        # start for the dispatcher's retry budget.
+        # still reset for a generic unblock, which is correct: a deliberate
+        # generic restart is a fresh start for the dispatcher's retry budget.
+        # A revision intent is narrower: it bypasses only active_pr, so it
+        # must retain the failure evidence used by the other respawn guards.
+        reset_failures = "" if revision else (
+            ", consecutive_failures = 0, last_failure_error = NULL"
+        )
         cur = conn.execute(
-            "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "consecutive_failures = 0, last_failure_error = NULL "
+            "UPDATE tasks SET status = ?, current_run_id = NULL"
+            f"{reset_failures} "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
         )
         if cur.rowcount != 1:
             return False
+        unblocked_payload: dict[str, Any] = (
+            {"status": new_status} if new_status != "ready" else {}
+        )
+        if revision:
+            unblocked_payload["revision"] = True
         _append_event(
             conn, task_id, "unblocked",
-            {"status": new_status} if new_status != "ready" else None,
+            unblocked_payload or None,
         )
+        if revision:
+            assert prior_run is not None
+            # Timestamps are only second-resolution. Record the newest PR
+            # comment identity seen at the operator action instead of making
+            # up a future timestamp. A same-second PR added later has a larger
+            # comment id and cannot be authorized by this revision intent.
+            latest_pr = _latest_pr_comment(
+                conn, task_id, now - _RESPAWN_GUARD_PR_WINDOW,
+            )
+            _append_event(
+                conn,
+                task_id,
+                "revision_requested",
+                {
+                    "prior_run_id": int(prior_run["id"]),
+                    "actor": actor,
+                    "after_pr_comment_id": (
+                        int(latest_pr["id"]) if latest_pr is not None else None
+                    ),
+                },
+            )
         return True
 
 
@@ -8009,6 +8087,82 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _latest_pr_comment(conn: sqlite3.Connection, task_id: str, cutoff: int):
+    for comment in conn.execute(
+        "SELECT id, body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? ORDER BY created_at DESC, id DESC",
+        (task_id, cutoff),
+    ).fetchall():
+        if comment["body"] and _RESPAWN_GUARD_PR_URL_RE.search(comment["body"]):
+            return comment
+    return None
+
+
+def _active_revision_event(conn: sqlite3.Connection, task_id: str):
+    revision = conn.execute(
+        "SELECT id, payload, created_at FROM task_events "
+        "WHERE task_id = ? AND kind = 'revision_requested' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if revision is None:
+        return None
+    consumed_rows = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'revision_consumed' AND id > ?",
+        (task_id, int(revision["id"])),
+    ).fetchall()
+    for event in consumed_rows:
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if payload.get("revision_event_id") == int(revision["id"]):
+            return None
+    later_attempt = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND id > ? "
+        "AND kind IN ('claimed', 'spawned') LIMIT 1",
+        (task_id, int(revision["id"])),
+    ).fetchone()
+    return None if later_attempt else revision
+
+
+def _revision_authorizes_pr_comment(
+    revision: sqlite3.Row, pr_comment: sqlite3.Row,
+) -> bool:
+    """Return whether ``revision`` explicitly followed this PR comment.
+
+    Comment and event timestamps both have only second precision, so ordering
+    by time alone cannot distinguish a reviewer click from another PR comment
+    in the same second. The revision event records the newest PR comment id it
+    observed; a subsequent comment necessarily has a larger id.
+    """
+    try:
+        payload = json.loads(revision["payload"] or "{}")
+        return int(payload["after_pr_comment_id"]) == int(pr_comment["id"])
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def _active_pr_is_guarded(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return whether a recent PR still lacks valid revision authorization.
+
+    This predicate is intentionally independent of ``check_respawn_guard``'s
+    priority order so public/manual claims cannot hide an active PR behind a
+    higher-priority auth or recent-success reason.
+    """
+    latest_pr = _latest_pr_comment(
+        conn, task_id, int(time.time()) - _RESPAWN_GUARD_PR_WINDOW,
+    )
+    if latest_pr is None:
+        return False
+    revision = _active_revision_event(conn, task_id)
+    return (
+        revision is None
+        or not _revision_authorizes_pr_comment(revision, latest_pr)
+    )
+
+
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -8122,26 +8276,99 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ).fetchone()
     if recent_completed:
         completed_at = int(recent_completed["ended_at"] or 0)
-        requeued_after = conn.execute(
-            "SELECT 1 FROM task_events "
+        requeue_events = conn.execute(
+            "SELECT kind, payload FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
             "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
-            "LIMIT 1",
+            "ORDER BY id ASC",
             (task_id, completed_at),
-        ).fetchone()
+        ).fetchall()
+        requeued_after = any(
+            event["kind"] != "unblocked"
+            or not _event_is_revision_unblock(event["payload"])
+            for event in requeue_events
+        )
         if not requeued_after:
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    if _active_pr_is_guarded(conn, task_id):
+        return "active_pr"
 
     return None
+
+
+def get_respawn_guard_state(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[dict[str, Any]]:
+    """Return the current guard reason and the time its source appeared."""
+    reason = check_respawn_guard(conn, task_id)
+    if reason is None:
+        return None
+    guarded_at: Optional[int] = None
+    if reason == "active_pr":
+        comment = _latest_pr_comment(
+            conn, task_id, int(time.time()) - _RESPAWN_GUARD_PR_WINDOW,
+        )
+        if comment is not None:
+            guarded_at = int(comment["created_at"])
+    elif reason == "recent_success":
+        row = conn.execute(
+            "SELECT MAX(ended_at) AS at FROM task_runs "
+            "WHERE task_id = ? AND outcome = 'completed'",
+            (task_id,),
+        ).fetchone()
+        if row and row["at"] is not None:
+            guarded_at = int(row["at"])
+    if guarded_at is None:
+        guarded_at = _guard_episode_started_at(conn, task_id)
+    return {"reason": reason, "guarded_at": guarded_at}
+
+
+_RESPAWN_GUARD_EPISODE_BOUNDARIES = (
+    "status", "promoted", "promoted_manual", "unblocked", "reclaimed",
+    "revision_requested", "revision_consumed", "claimed", "spawned",
+    "completed", "blocked", "crashed", "timed_out", "spawn_failed",
+    "gave_up", "rate_limited",
+)
+
+
+def _event_is_revision_unblock(payload: Optional[str]) -> bool:
+    try:
+        return bool(json.loads(payload or "{}").get("revision"))
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _guard_episode_started_at(conn: sqlite3.Connection, task_id: str) -> int:
+    """Find the current fallback guard episode start without ticking it."""
+    placeholders = ", ".join("?" for _ in _RESPAWN_GUARD_EPISODE_BOUNDARIES)
+    row = conn.execute(
+        "SELECT kind, created_at FROM task_events WHERE task_id = ? "
+        f"AND kind IN ('respawn_guarded', {placeholders}) "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, *_RESPAWN_GUARD_EPISODE_BOUNDARIES),
+    ).fetchone()
+    return int(row["created_at"]) if row is not None else int(time.time())
+
+
+def _should_emit_respawn_guard_event(
+    conn: sqlite3.Connection, task_id: str, reason: str,
+) -> bool:
+    placeholders = ", ".join("?" for _ in _RESPAWN_GUARD_EPISODE_BOUNDARIES)
+    latest = conn.execute(
+        "SELECT id, kind, payload FROM task_events WHERE task_id = ? "
+        f"AND kind IN ('respawn_guarded', {placeholders}) "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, *_RESPAWN_GUARD_EPISODE_BOUNDARIES),
+    ).fetchone()
+    if latest is None or latest["kind"] != "respawn_guarded":
+        return True
+    try:
+        payload = json.loads(latest["payload"] or "{}")
+    except (TypeError, ValueError):
+        return True
+    return payload.get("reason") != reason
 
 
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
@@ -8159,7 +8386,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     the warning still fires in degraded environments.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
@@ -8171,7 +8398,10 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
         # Can't introspect — assume spawnable, preserve legacy behavior.
         return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if (
+            profile_exists(row["assignee"])
+            and check_respawn_guard(conn, row["id"]) is None
+        ):
             return True
     return False
 
@@ -8510,11 +8740,14 @@ def _dispatch_once_locked(
             # Emit an event so operators can see why the task was
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
-            if not dry_run:
+            if not dry_run and _should_emit_respawn_guard_event(
+                conn, row["id"], guard_reason,
+            ):
                 with write_txn(conn):
                     _append_event(
                         conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
+                        get_respawn_guard_state(conn, row["id"])
+                        or {"reason": guard_reason},
                     )
             continue
         if dry_run:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2866,6 +2866,13 @@
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
               : null,
+            t.respawn_guard
+              ? h(Badge, {
+                  variant: "outline",
+                  className: "hermes-kanban-respawn-guard",
+                  title: `Ready but guarded since ${new Date(t.respawn_guard.guarded_at * 1000).toLocaleString()}`,
+                }, `Guarded: ${t.respawn_guard.reason}`)
+              : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
@@ -4401,6 +4408,11 @@
           task.status === "running" || task.status === "ready",
           getDestructiveConfirm(t, "blocked")),
         b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
+        b("Request revision", {
+          status: "ready",
+          revision: true,
+          actor: "dashboard",
+        }, task.status === "blocked" && task.respawn_guard?.reason === "active_pr"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
           task.status === "running" || task.status === "ready" || task.status === "blocked",
           getDestructiveConfirm(t, "done")),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -159,6 +159,7 @@ def _task_dict(
     task: kanban_db.Task,
     *,
     latest_summary: Optional[str] = None,
+    respawn_guard: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
     # Add derived age metrics so the UI can colour stale cards without
@@ -172,6 +173,7 @@ def _task_dict(
     # ``task_runs.summary`` (the kanban-worker pattern) instead of
     # ``tasks.result``. ``None`` when no run has produced a summary yet.
     d["latest_summary"] = latest_summary
+    d["respawn_guard"] = respawn_guard
     # Keep body short on list endpoints; full body comes from /tasks/:id.
     return d
 
@@ -464,7 +466,14 @@ def get_board(
             preview = (
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
-            d = _task_dict(t, latest_summary=preview)
+            d = _task_dict(
+                t,
+                latest_summary=preview,
+                respawn_guard=(
+                    kanban_db.get_respawn_guard_state(conn, t.id)
+                    if t.status == "ready" else None
+                ),
+            )
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -545,7 +554,11 @@ def get_task(
         # operators can read the complete worker handoff without making
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
-        task_d = _task_dict(task, latest_summary=full_summary)
+        task_d = _task_dict(
+            task,
+            latest_summary=full_summary,
+            respawn_guard=kanban_db.get_respawn_guard_state(conn, task_id),
+        )
         links = _links_for(conn, task_id)
         child_ids = links["children"]
         child_summaries = kanban_db.latest_summaries(conn, child_ids)
@@ -849,6 +862,8 @@ class UpdateTaskBody(BaseModel):
     # override doesn't silently reset the depth the operator chose.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    revision: bool = False
+    actor: Optional[str] = None
 
 
 @router.patch("/tasks/{task_id}")
@@ -890,7 +905,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
                 if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
+                    ok = kanban_db.unblock_task(
+                        conn,
+                        task_id,
+                        revision=payload.revision,
+                        actor=payload.actor or "dashboard",
+                    )
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
                     ok = _set_status_direct(conn, task_id, "ready")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -166,3 +166,24 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_run_slash_revision_unblock_and_guarded_list_show(kanban_home):
+    with kb.connect() as conn:
+        revision_id = kb.create_task(conn, title="revision", assignee="alice")
+        assert kb.claim_task(conn, revision_id, claimer="test:writer") is not None
+        assert kb.block_task(conn, revision_id, reason="review-required")
+        guarded_id = kb.create_task(conn, title="guarded", assignee="alice")
+        kb.add_comment(
+            conn,
+            guarded_id,
+            "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/9",
+        )
+
+    assert "Revision requested" in kc.run_slash(
+        f"unblock --revision {revision_id} --reason 'review fixes'"
+    )
+    listed = kc.run_slash("list --status ready")
+    shown = kc.run_slash(f"show {guarded_id}")
+    assert "guarded: active_pr" in listed
+    assert "Respawn guard: active_pr" in shown
+    assert "since" in shown

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1583,3 +1583,183 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# One-shot active-PR revision intent
+# ---------------------------------------------------------------------------
+
+
+def _blocked_task_with_terminal_run(conn, *, title="review-fix"):
+    task_id = kb.create_task(conn, title=title, assignee="alice")
+    claimed = kb.claim_task(conn, task_id, claimer="test:writer")
+    assert claimed is not None
+    assert kb.block_task(conn, task_id, reason="review-required")
+    return task_id
+
+
+def test_generic_unblock_does_not_bypass_active_pr_guard(kanban_home):
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_terminal_run(conn)
+        kb.add_comment(conn, task_id, "worker", "https://github.com/nousresearch/hermes-agent/pull/1")
+        assert kb.unblock_task(conn, task_id)
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_direct_claim_cannot_bypass_active_pr_guard(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="manual-claim", assignee="alice")
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/10",
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+        assert kb.claim_task(conn, task_id, claimer="manual:operator") is None
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_revision_intent_bypasses_only_active_pr(kanban_home):
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_terminal_run(conn)
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 2, last_failure_error = ? WHERE id = ?",
+            ("authentication failed: invalid credentials", task_id),
+        )
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/11",
+        )
+        assert kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+        task = kb.get_task(conn, task_id)
+        assert task.consecutive_failures == 2
+        assert task.last_failure_error == "authentication failed: invalid credentials"
+        assert kb.check_respawn_guard(conn, task_id) == "blocker_auth"
+        assert kb.claim_task(conn, task_id, claimer="manual:operator") is None
+        assert not [
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "revision_consumed"
+        ]
+
+
+def test_direct_claim_cannot_hide_active_pr_behind_higher_priority_guard(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="masked-active-pr", assignee="alice")
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/12",
+        )
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("authentication failed: invalid credentials", task_id),
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "blocker_auth"
+        assert kb.claim_task(conn, task_id, claimer="manual:operator") is None
+
+
+def test_revision_unblock_does_not_bypass_recent_success(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="recent-success", assignee="alice")
+        now = int(time.time())
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (task_id, now - 60, now - 1),
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (task_id,))
+        assert kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+        assert kb.check_respawn_guard(conn, task_id) == "recent_success"
+        assert kb.claim_task(conn, task_id, claimer="manual:operator") is None
+
+
+def test_revision_unblock_allows_exactly_one_claim(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_terminal_run(conn)
+        now = int(time.time())
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/2",
+        )
+        assert kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+        assert kb.check_respawn_guard(conn, task_id) is None
+        first = kb.claim_task(conn, task_id, claimer="test:revision")
+        assert first is not None
+        assert kb.claim_task(conn, task_id, claimer="test:duplicate") is None
+        events = kb.list_events(conn, task_id)
+        requested = [e for e in events if e.kind == "revision_requested"]
+        consumed = [e for e in events if e.kind == "revision_consumed"]
+        assert len(requested) == len(consumed) == 1
+        assert consumed[0].payload["revision_event_id"] == requested[0].id
+        assert consumed[0].run_id == first.current_run_id
+
+
+def test_revision_same_second_uses_pr_comment_identity(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_terminal_run(conn)
+        now = int(time.time())
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/20",
+        )
+        assert kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+        assert kb.check_respawn_guard(conn, task_id) is None
+        kb.add_comment(
+            conn, task_id, "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/21",
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_revision_unblock_rejects_live_prior_run(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="live-writer", assignee="alice")
+        assert kb.claim_task(conn, task_id, claimer="test:live") is not None
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (task_id,))
+        with pytest.raises(ValueError, match="terminal prior run"):
+            kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+
+
+def test_revision_with_unfinished_parent_cannot_claim(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", assignee="alice")
+        task_id = _blocked_task_with_terminal_run(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent_id, child_id=task_id)
+        assert kb.unblock_task(conn, task_id, revision=True, actor="reviewer")
+        assert kb.get_task(conn, task_id).status == "todo"
+        assert kb.claim_task(conn, task_id, claimer="test:duplicate") is None
+
+
+def test_respawn_guard_event_deduplicates_per_lifecycle_episode(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="guard-event", assignee="alice")
+        now = int(time.time())
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("authentication failed", task_id),
+        )
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        events = [e for e in kb.list_events(conn, task_id) if e.kind == "respawn_guarded"]
+        assert len(events) == 1
+
+        kb._append_event(conn, task_id, "claimed", {"run_id": 99}, run_id=99)
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        events = [e for e in kb.list_events(conn, task_id) if e.kind == "respawn_guarded"]
+        assert len(events) == 2
+
+
+def test_guarded_only_ready_queue_is_not_spawnable(kanban_home, all_assignees_spawnable):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="guarded-health", assignee="alice")
+        kb.add_comment(conn, task_id, "worker", "https://github.com/nousresearch/hermes-agent/pull/6")
+        assert kb.has_spawnable_ready(conn) is False
+        state = kb.get_respawn_guard_state(conn, task_id)
+        assert state["reason"] == "active_pr"
+        assert isinstance(state["guarded_at"], int)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -708,3 +708,36 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_dashboard_revision_unblock_and_guard_visibility(client, monkeypatch):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="dashboard-revision", assignee="alice")
+        assert kb.claim_task(conn, task_id, claimer="test:writer") is not None
+        assert kb.block_task(conn, task_id, reason="review-required")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, 'worker', ?, ?)",
+            (task_id, "https://github.com/nousresearch/hermes-agent/pull/7", now - 2),
+        )
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "ready", "revision": True, "actor": "dashboard-reviewer"},
+    )
+    assert response.status_code == 200, response.text
+    detail = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()
+    assert detail["task"]["respawn_guard"] is None
+
+    with kb.connect() as conn:
+        guarded_id = kb.create_task(conn, title="dashboard-guarded", assignee="alice")
+        kb.add_comment(
+            conn,
+            guarded_id,
+            "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/8",
+        )
+    board = client.get("/api/plugins/kanban/board").json()
+    ready = next(col for col in board["columns"] if col["name"] == "ready")["tasks"]
+    guarded = next(task for task in ready if task["id"] == guarded_id)
+    assert guarded["respawn_guard"]["reason"] == "active_pr"
+    assert isinstance(guarded["respawn_guard"]["guarded_at"], int)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1023,3 +1023,48 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_unblock_revision_intent_is_forwarded(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="revision", assignee="worker")
+        claimed = kb.claim_task(conn, tid, claimer="test:writer")
+        assert claimed is not None
+        assert kb.block_task(conn, tid, reason="review-required")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_unblock({"task_id": tid, "revision": True, "actor": "reviewer"})
+    assert json.loads(out)["ok"] is True
+    conn = kb.connect()
+    try:
+        assert any(e.kind == "revision_requested" for e in kb.list_events(conn, tid))
+    finally:
+        conn.close()
+
+
+def test_list_and_show_surface_ready_guard_reason(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="guarded", assignee="worker")
+        kb.add_comment(
+            conn,
+            tid,
+            "worker",
+            "https://github.com/nousresearch/hermes-agent/pull/21",
+        )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    listed = json.loads(kt._handle_list({"status": "ready"}))
+    task = next(item for item in listed["tasks"] if item["id"] == tid)
+    shown = json.loads(kt._handle_show({"task_id": tid}))
+    assert task["respawn_guard"]["reason"] == "active_pr"
+    assert shown["task"]["respawn_guard"]["reason"] == "active_pr"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -466,6 +466,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
+        "respawn_guard": kb.get_respawn_guard_state(conn, task.id),
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -512,6 +513,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "respawn_guard": kb.get_respawn_guard_state(conn, t.id),
                 }
 
             def _run_dict(r):
@@ -1477,7 +1479,12 @@ def _handle_unblock(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            ok = kb.unblock_task(conn, str(tid))
+            ok = kb.unblock_task(
+                conn,
+                str(tid),
+                revision=bool(args.get("revision", False)),
+                actor=args.get("actor") or os.getenv("HERMES_PROFILE"),
+            )
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
             task = kb.get_task(conn, str(tid))
@@ -2096,6 +2103,17 @@ KANBAN_UNBLOCK_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": "Blocked task id to move to ready or parent-gated todo.",
+            },
+            "revision": {
+                "type": "boolean",
+                "description": (
+                    "Request one auditable review-revision continuation. Requires "
+                    "a terminal prior run and bypasses only the active-PR respawn guard."
+                ),
+            },
+            "actor": {
+                "type": "string",
+                "description": "Optional operator identity recorded with revision intent.",
             },
             "board": _board_schema_prop(),
         },

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -774,7 +774,9 @@ hermes kanban create "nightly backup audit" \
 
 ### Respawn guard
 
-The dispatcher refuses to re-spawn a ready task when it hit a quota/auth/429 error on the previous run (`blocker_auth`), or completed a run successfully within the guard window (`recent_success`), or a recent task comment links to a GitHub PR (`active_pr`). This prevents repeat worker storms on the same bug or task while a human catches up. See the `respawn_guarded` row in the [event reference](#event-reference).
+The dispatcher refuses to re-spawn a ready task when it hit a quota/auth/429 error on the previous run (`blocker_auth`), or completed a run successfully within the guard window (`recent_success`), or a recent task comment links to a GitHub PR (`active_pr`). This prevents repeat worker storms on the same bug or task while a human catches up. Ready-but-guarded tasks show the reason and time in list, show, tool, and dashboard surfaces. See the `respawn_guarded` row in the [event reference](#event-reference).
+
+When a reviewer deliberately requests another pass on the same PR, use `hermes kanban unblock --revision <task-id>` (or `revision: true` in `kanban_unblock` / the dashboard's **Request revision** action). Revision intent is durable, requires a terminal prior run, bypasses only `active_pr`, and is consumed by exactly one successful claim. Plain `unblock` remains guarded, so generic recovery and automated reclaim cannot accidentally create a duplicate writer or PR.
 
 ### Drag-to-delete and bulk delete (dashboard)
 


### PR DESCRIPTION
## Summary
- add an explicit, auditable `--revision`/`revision: true` unblock intent for review fixes on an existing PR
- consume the intent transactionally after exactly one successful claim while bypassing only `active_pr`
- keep direct/manual claims behind active-PR duplicate-writer protection, including when another guard has higher priority
- deduplicate respawn-guard events per lifecycle episode and report ready-but-guarded state in CLI, tools, and dashboard

## Safety properties
- requires a terminal prior run and no active writer
- preserves parent, auth/quota, recent-success, ownership, and concurrency gates
- restart-safe durable events (`revision_requested`, `revision_consumed`)
- same-second PR/revision ordering uses comment identity rather than synthetic timestamps

## Verification
- `uv run --extra dev pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py` — 95 passed
- Ruff on all changed Python/tests — passed
- Python compile checks — passed
- `git diff origin/main...HEAD --check` — passed

No merge or deployment performed.