### PR TITLE
fix(gateway): strip media directives before auto-TTS

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18329,9 +18329,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         audio_path = None
         actual_path = None
         try:
+            from gateway.platforms.base import BasePlatformAdapter
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            # Auto-TTS runs before the normal outbound media extraction path.
+            # Clean a copy with the same canonical display rules so attachment
+            # directives and local paths are never spoken aloud; keep ``text``
+            # unchanged for the later attachment-delivery pass (#76620).
+            display_text = BasePlatformAdapter.strip_media_directives_for_display(text)
+            tts_text = _strip_markdown_for_tts(display_text[:4000])
             if not tts_text:
                 return
 

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -52,6 +52,40 @@ class TestAutoVoiceReplyFormat:
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".ogg")
 
+    @pytest.mark.asyncio
+    async def test_auto_voice_reply_strips_media_directives_before_tts(self):
+        """Auto-TTS speaks visible text, not native attachment paths (#76620)."""
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.TELEGRAM)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM)
+        synthesized_text = []
+
+        response = (
+            "Capture ready.\n\n"
+            "[[as_document]]\n"
+            "MEDIA:/private/tmp/hermes-capture.png"
+        )
+
+        def fake_tts(*, text, output_path):
+            synthesized_text.append(text)
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_bytes(b"fake ogg opus")
+            return json.dumps({
+                "success": True,
+                "file_path": output_path,
+                "provider": "edge",
+                "voice_compatible": True,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+            await runner._send_voice_reply(event, response)
+
+        assert synthesized_text == ["Capture ready."]
+        assert "MEDIA:" in response
+        assert "/private/tmp/hermes-capture.png" in response
+        adapter.send_voice.assert_awaited_once()
+
     def test_should_send_voice_reply_streamed_global_auto_tts_fires(self):
         """Streamed reply + global voice.auto_tts (no /voice opt-in) sends voice.
 


### PR DESCRIPTION
## What does this PR do?

Cleans a copy of the final response with the canonical media-directive display sanitizer before passing it to automatic TTS.

The original response remains unchanged for the later attachment-delivery pass, so native files are still delivered while TTS receives only user-visible text.

## Root cause

Automatic TTS runs before the normal outbound media extraction path. Responses containing `MEDIA:<path>` or internal attachment markers could therefore send those directives and local paths to the speech synthesizer.

## Validation

- `venv/bin/pytest tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_platform_base.py -q` — 84 passed, 1 skipped
- `venv/bin/ruff check gateway/run.py tests/gateway/test_auto_voice_reply_format.py` — passed

Adds a regression test that verifies the visible caption is synthesized while the `MEDIA:` path remains available in the original response for attachment handling.

Fixes #76620