### PR TITLE
ci: temporarily disable Desktop E2E — red on every PR since Aug 1 engines churn (#76627)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,15 @@ jobs:
     # + `hermes serve` backend, which never import anything under tests/.
     # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
     # single job in the workflow — while still running the full pytest lanes.
-    if: needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true'
+    #
+    # ⛔ TEMPORARILY DISABLED (Aug 2, 2026, Teknium) — the suite is red on
+    # every PR and on main itself since the Aug 1 night engines/npm churn
+    # (#76499 → #76562 → #76575): the mock-backend Electron window never
+    # gets a title, so boot/chat/setup/interim specs all fail identically
+    # regardless of the PR's diff (verified on #76573 and the docs-only
+    # #76582). Tracking issue: #76627 (assigned: Ari). To re-enable,
+    # delete the `false &&` below — nothing else changed.
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## Summary
Temporarily disables the Desktop E2E CI job — it is red on every PR regardless of diff since the Aug 1 night engines/npm churn, blocking the entire merge queue. Root fix + re-enable tracked in #76627 (Ari).

## Changes
- `.github/workflows/ci.yml`: `e2e-desktop.if` gated with `false &&` (one-line re-enable: delete it). Comment block in the workflow carries the evidence and the tracking issue.

## Validation
| | Evidence |
|---|---|
| Not diff-dependent | identical spec failures on #76573 (Python-only, twice — before and after rebase) and #76582 (docs-only) |
| Harness-level | mock-backend Electron window never gets a title (fails in ~200ms); dead-backend boot-failure spec still passes |
| Window | matches #76499 → #76562 → #76575 engines/lockfile churn; main has no completed successful CI run since `c7b4b4e1` |
| Not a required check | branch protection: none — skipped job cannot wedge merges |

## Infographic

![e2e lane parked](https://v3b.fal.media/files/b/0aa4afe7/ZIoX_P9iZAcdR7zHDpENu_kF50L6kR.png)
