### PR TITLE
fix(agent): key tool_call dedup off outstanding calls, keep replay protection

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3269,13 +3269,22 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
     #   (b) drop later tool result messages reusing an already-seen id
-    seen_assistant_call_ids: set = set()
-    seen_result_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
         role = msg.get("role")
         if role == "assistant" and msg.get("tool_calls"):
+            # Tool-call IDs are LOCAL per assistant message: Hermes reuses
+            # `toolname:0..N` counters on every turn, so the seen-sets must
+            # be reset at each assistant message. A conversation-wide
+            # seen-set misclassifies later turns' calls as duplicates of the
+            # first turn's, strips them, and (before the #58755 follow-up
+            # below) wrote `tool_calls: []` — which strict providers
+            # (DeepSeek) reject with HTTP 400 "Invalid 'messages[N].
+            # tool_calls': empty array". Mirrors repair_message_sequence
+            # Pass 1, which resets its known_tool_ids per assistant message.
+            seen_assistant_call_ids = set()
+            seen_result_call_ids = set()
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
                 cid = _ra().AIAgent._get_tool_call_id_static(tc)
@@ -3286,7 +3295,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # All tool calls in this message were duplicates — drop
+                    # the key entirely instead of writing an empty array.
+                    # Strict providers (DeepSeek) reject `tool_calls: []`
+                    # with HTTP 400 "Invalid 'messages[N].tool_calls':
+                    # empty array" (#58755 follow-up: the dedup pass runs
+                    # AFTER the empty-array normalization above and
+                    # re-introduced `[]` when every call in a message was
+                    # already seen).
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3268,23 +3268,27 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # tool result. This is the final pre-API chokepoint, so dedup defensively
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
-    #   (b) drop later tool result messages reusing an already-seen id
+    #   (b) drop tool results that answer no OUTSTANDING tool call
+    #
+    # (b) tracks OUTSTANDING calls rather than every id ever seen, because
+    # ``tool_call_id`` is NOT globally unique in practice. Hermes reuses
+    # local counters (`image_generate:0..N` on successive turns) and some
+    # servers (llama.cpp) emit one constant id for every call (#66429,
+    # #70734), so the same id legitimately appears in MULTIPLE assistant
+    # messages. A seen-once-drop-forever rule misreads the second legitimate
+    # call as a duplicate, strips it, and re-writes ``tool_calls: []`` (the
+    # #58755 HTTP 400, since the normalization above already ran). So: an
+    # assistant call ARMS its id, a tool result CONSUMES it, and a result
+    # answering nothing outstanding is still dropped — while a fresh call
+    # reuses the id by re-arming it first. Answering also retires the id
+    # from the seen-set so the re-arm is possible.
+    seen_assistant_call_ids: set = set()
+    outstanding_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
         role = msg.get("role")
         if role == "assistant" and msg.get("tool_calls"):
-            # Tool-call IDs are LOCAL per assistant message: Hermes reuses
-            # `toolname:0..N` counters on every turn, so the seen-sets must
-            # be reset at each assistant message. A conversation-wide
-            # seen-set misclassifies later turns' calls as duplicates of the
-            # first turn's, strips them, and (before the #58755 follow-up
-            # below) wrote `tool_calls: []` — which strict providers
-            # (DeepSeek) reject with HTTP 400 "Invalid 'messages[N].
-            # tool_calls': empty array". Mirrors repair_message_sequence
-            # Pass 1, which resets its known_tool_ids per assistant message.
-            seen_assistant_call_ids = set()
-            seen_result_call_ids = set()
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
                 cid = _ra().AIAgent._get_tool_call_id_static(tc)
@@ -3293,28 +3297,22 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     continue
                 if cid:
                     seen_assistant_call_ids.add(cid)
+                    outstanding_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                if kept_tcs:
-                    msg = {**msg, "tool_calls": kept_tcs}
-                else:
-                    # All tool calls in this message were duplicates — drop
-                    # the key entirely instead of writing an empty array.
-                    # Strict providers (DeepSeek) reject `tool_calls: []`
-                    # with HTTP 400 "Invalid 'messages[N].tool_calls':
-                    # empty array" (#58755 follow-up: the dedup pass runs
-                    # AFTER the empty-array normalization above and
-                    # re-introduced `[]` when every call in a message was
-                    # already seen).
-                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+                msg = {**msg, "tool_calls": kept_tcs}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
-            if cid and cid in seen_result_call_ids:
+            if cid and cid not in outstanding_call_ids:
                 removed_dupes += 1
                 continue
             if cid:
-                seen_result_call_ids.add(cid)
+                # Answered: no longer outstanding, so a replayed result is
+                # still caught above. Retire from the seen-set too so a
+                # later assistant call may legitimately re-arm the id.
+                outstanding_call_ids.discard(cid)
+                seen_assistant_call_ids.discard(cid)
             deduped.append(msg)
         else:
             deduped.append(msg)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -358,15 +358,17 @@ def test_sanitize_drops_empty_tool_calls_array():
 
 
 def test_sanitize_preserves_reused_tool_call_ids_across_turns():
-    """Dedup must be scoped per assistant message, not conversation-wide.
+    """Reused ids survive: dedup keys off OUTSTANDING calls, not seen-forever.
 
     Hermes reuses local tool_call id counters on every turn
     (``image_generate:0..N`` in successive image rounds), so the same ids
-    legitimately appear in MULTIPLE assistant messages. A conversation-wide
-    seen-set misclassifies later turns' calls as duplicates, strips them and
-    re-writes ``tool_calls: []`` — which DeepSeek rejects with HTTP 400
+    legitimately appear in MULTIPLE assistant messages. A seen-once-drop-
+    forever rule misclassifies later turns' calls as duplicates, strips them
+    and re-writes ``tool_calls: []`` — which DeepSeek rejects with HTTP 400
     (the #58755 follow-up: the dedup pass ran after the empty-array drop
-    and re-introduced `[]`). Each assistant message opens a fresh id scope.
+    and re-introduced `[]`). Each assistant call ARMS its id and each tool
+    result CONSUMES it, so a fresh call re-arms the id; only a result that
+    answers nothing outstanding is dropped.
     """
     from agent.agent_runtime_helpers import sanitize_api_messages
 
@@ -397,6 +399,35 @@ def test_sanitize_preserves_reused_tool_call_ids_across_turns():
     tool_ids = sorted(m["tool_call_id"] for m in out if m.get("role") == "tool")
     assert tool_ids == ["image_generate:0", "image_generate:0",
                         "image_generate:1", "image_generate:1"]
+
+
+def test_sanitize_still_drops_replayed_result_for_retired_call():
+    """The #58327 protection holds under outstanding-call semantics: a second
+    result replaying an already-answered call id answers nothing outstanding
+    and is still dropped, even after a later assistant message re-armed it."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        # call id:0 armed by turn 1
+        {"role": "assistant", "content": "one",
+         "tool_calls": [{"id": "local:0", "call_id": "local:0", "type": "function",
+                         "function": {"name": "image_generate", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "local:0", "content": "imgA"},
+        # a replay of the SAME result after the call was answered — must drop
+        {"role": "tool", "tool_call_id": "local:0", "content": "imgA (replayed)"},
+        # turn 2 re-arms local:0 legitimately
+        {"role": "assistant", "content": "two",
+         "tool_calls": [{"id": "local:0", "call_id": "local:0", "type": "function",
+                         "function": {"name": "image_generate", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "local:0", "content": "imgB"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    # replay dropped; both legitimate answers survive
+    assert [m["content"] for m in tool_msgs] == ["imgA", "imgB"]
+    assistants = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(assistants) == 2
 
 
 # ── Self-recovery: heal empty-content non-final messages ──────────────────

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -357,6 +357,48 @@ def test_sanitize_drops_empty_tool_calls_array():
 
 
 
+def test_sanitize_preserves_reused_tool_call_ids_across_turns():
+    """Dedup must be scoped per assistant message, not conversation-wide.
+
+    Hermes reuses local tool_call id counters on every turn
+    (``image_generate:0..N`` in successive image rounds), so the same ids
+    legitimately appear in MULTIPLE assistant messages. A conversation-wide
+    seen-set misclassifies later turns' calls as duplicates, strips them and
+    re-writes ``tool_calls: []`` — which DeepSeek rejects with HTTP 400
+    (the #58755 follow-up: the dedup pass ran after the empty-array drop
+    and re-introduced `[]`). Each assistant message opens a fresh id scope.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    def _tc(cid: str) -> dict:
+        return {"id": cid, "call_id": cid, "type": "function",
+                "function": {"name": "image_generate", "arguments": "{}"}}
+
+    messages = [
+        {"role": "user", "content": "make images"},
+        # turn 1: image_generate:0..1
+        {"role": "assistant", "content": "one",
+         "tool_calls": [_tc("image_generate:0"), _tc("image_generate:1")]},
+        {"role": "tool", "tool_call_id": "image_generate:0", "content": "imgA"},
+        {"role": "tool", "tool_call_id": "image_generate:1", "content": "imgB"},
+        # turn 2: SAME local ids again — legitimate, must survive
+        {"role": "assistant", "content": "two",
+         "tool_calls": [_tc("image_generate:0"), _tc("image_generate:1")]},
+        {"role": "tool", "tool_call_id": "image_generate:0", "content": "imgC"},
+        {"role": "tool", "tool_call_id": "image_generate:1", "content": "imgD"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(assistants) == 2
+    for a in assistants:
+        ids = [tc["id"] for tc in a["tool_calls"]]
+        assert ids == ["image_generate:0", "image_generate:1"]
+    assert all("tool_calls" in a and a["tool_calls"] for a in assistants)
+    tool_ids = sorted(m["tool_call_id"] for m in out if m.get("role") == "tool")
+    assert tool_ids == ["image_generate:0", "image_generate:0",
+                        "image_generate:1", "image_generate:1"]
+
+
 # ── Self-recovery: heal empty-content non-final messages ──────────────────
 # Repro of the production incident: a dead stream persisted an empty-content
 # assistant stub mid-transcript, and every later request 400'd with


### PR DESCRIPTION
## Summary

Fixes a bug in `sanitize_api_messages` (the final pre-API chokepoint in `agent/agent_runtime_helpers.py`) that breaks multi-turn tool-calling sessions against strict providers.

### The bug

The dedup pass keyed off **every id ever seen**, but `tool_call_id` is not globally unique in practice:

- Hermes reuses **local** tool_call id counters on every turn (e.g. `image_generate:0..N` in successive image rounds), so calls from turn 2+ were misclassified as duplicates of turn 1's calls, stripped, and the message rewritten with `tool_calls: []` — DeepSeek rejects that with **HTTP 400 "Invalid 'messages[N].tool_calls': empty array"** (#58755).
- llama.cpp emits **one constant id** for every tool call it returns (#66429), so a seen-once-drop-forever rule deleted every result after the first.

### The fix — outstanding-call semantics (per maintainer review, design shared with #70734)

- An assistant tool call **ARMS** its id (`outstanding_call_ids`).
- A tool result **CONSUMES** it, and also retires the id from `seen_assistant_call_ids` so a later assistant call can legitimately re-arm it.
- A result answering nothing outstanding is still **dropped** (the #58327 payload-wide replay protection is preserved).
- Duplicate tool_calls sharing an id **within one assistant message** are still collapsed.

The earlier draft reset both seen-sets per assistant message; review (teknium1) correctly flagged that this removed main's payload-wide replay protection, and the all-duplicate empty-array fallback it introduced was unreachable. Reworked in `d978a2291` per the suggested pending-call state machine. The post-dedup empty-array path remains owned by #64345/#74906.

### Regression tests

- `test_sanitize_preserves_reused_tool_call_ids_across_turns` — reused local ids across turns must survive (legitimate re-arm); verified **fails on old code** (`assert 1 == 2`), passes with the fix.
- `test_sanitize_still_drops_replayed_result_for_retired_call` — an unmatched replayed result is still dropped even after a later assistant message re-armed the same id.

## Test Plan

- [x] `scripts/run_tests.sh tests/run_agent/test_message_sequence_repair.py -q` — 16/16 pass
- [x] New tests fail/pass as documented above

Follow-up to #58755. Related: #70734 (same outstanding-call design, llama.cpp constant-id focus), #64345/#74906 (post-dedup empty-array path).