### PR TITLE
fix(agent): auxiliary auto-chain free-only fallback (#75803)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -14,6 +14,16 @@ Resolution order for text tasks (auto mode):
   6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
   7. None
 
+OpenRouter fallback cost guard (issue #75803):
+  The step-2 OpenRouter fallback model is ``auxiliary.openrouter_model`` in
+  config.yaml (default: google/gemini-3.6-flash — a PAID model).  Because
+  auxiliary traffic is background-shaped (compression, title generation,
+  session search, vision, web extract), a paid fallback must never be
+  silent: set ``auxiliary.free_only: true`` to restrict the fallback to
+  ``:free`` SKUs (skipping OpenRouter entirely when the model is not a
+  ``:free`` id), and a one-time WARNING is logged whenever a non-``:free``
+  model is engaged so no cash lane is reachable without the user knowing.
+
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
@@ -2159,8 +2169,104 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 # ── Provider resolution helpers ─────────────────────────────────────────────
 
 
+# ── Issue #75803: paid-lane guard for the OpenRouter auxiliary fallback ─────
+# The auto-chain's step-2 OpenRouter fallback historically used a hardcoded
+# PAID model (_OPENROUTER_MODEL) with no config surface and no free marker.
+# A user whose fallback ladder is deliberately :free/local could still have
+# background auxiliary traffic (compression, title generation, session
+# search, vision, web extract) land on a real-money OpenRouter lane.
+#
+# Guards (all best-effort, config-driven):
+#   * auxiliary.free_only: true  — the OpenRouter fallback is skipped unless
+#     the resolved model is a :free SKU. This is the opt-out.
+#   * auxiliary.openrouter_model — replaces the hardcoded fallback model
+#     (e.g. "nvidia/nemotron-3-ultra-550b-a55b:free"). This is the config
+#     surface.
+#   * A one-time WARNING is logged whenever the fallback would serve a
+#     non-:free model, so the paid lane is never silent.
+_paid_lane_warned: set = set()
+
+
+def _is_free_model(model: Optional[str]) -> bool:
+    """True when ``model`` is an OpenRouter free SKU (``:free`` suffix)."""
+    return bool(model) and str(model).strip().endswith(":free")
+
+
+def _aux_free_only() -> bool:
+    """Read ``auxiliary.free_only`` from config.yaml (default False).
+
+    When enabled, the auxiliary auto-chain's OpenRouter fallback refuses to
+    engage a PAID model: if the resolved fallback model is not a ``:free``
+    SKU, the OpenRouter step is skipped entirely with an explicit WARNING.
+    Best-effort — any config-read failure falls back to the default.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        val = cfg_get(load_config(), "auxiliary", "free_only", default=False)
+        return bool(val)
+    except Exception:
+        return False
+
+
+def _aux_openrouter_model() -> str:
+    """Resolve the auxiliary OpenRouter fallback model.
+
+    ``auxiliary.openrouter_model`` in config.yaml wins; otherwise the module
+    default ``_OPENROUTER_MODEL`` is used. Best-effort — a config-read
+    failure falls back to the default.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        val = cfg_get(load_config(), "auxiliary", "openrouter_model")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    except Exception:
+        pass
+    return _OPENROUTER_MODEL
+
+
+def _warn_paid_lane_once(model: str) -> None:
+    """Log a WARNING the first time a non-:free OpenRouter model is engaged.
+
+    Auxiliary traffic is background-shaped (compression and title generation
+    fire inside cron and idle sessions), so a paid lane must never be silent.
+    Deduplicated per model id to avoid log spam on every aux call.
+    """
+    if model in _paid_lane_warned:
+        return
+    _paid_lane_warned.add(model)
+    logger.warning(
+        "Auxiliary client: PAID lane engaged for auxiliary task — OpenRouter "
+        "fallback model %r is not a :free SKU and may incur real spend. Set "
+        "auxiliary.free_only: true to restrict auxiliary fallbacks to free "
+        "models, or auxiliary.openrouter_model to a :free model.",
+        model,
+    )
+
 
 def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+    # Issue #75803: never let the OpenRouter fallback silently engage a PAID
+    # lane. The fallback model is configurable (auxiliary.openrouter_model)
+    # and auxiliary.free_only: true skips OpenRouter unless the model is a
+    # :free SKU. Explicit caller models (auxiliary.<task>.model) go through
+    # the same guard so the opt-out covers every OpenRouter aux path.
+    or_model = model or _aux_openrouter_model()
+    if _aux_free_only() and not _is_free_model(or_model):
+        logger.warning(
+            "Auxiliary client: auxiliary.free_only is enabled but the "
+            "OpenRouter fallback model %r is not a :free SKU — skipping the "
+            "OpenRouter fallback. Set auxiliary.openrouter_model to a :free "
+            "model (e.g. nvidia/nemotron-3-ultra-550b-a55b:free) or disable "
+            "auxiliary.free_only.",
+            or_model,
+        )
+        _mark_provider_unhealthy("openrouter", ttl=60)
+        return None, None
+    if not _is_free_model(or_model):
+        _warn_paid_lane_once(or_model)
+
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
@@ -2168,7 +2274,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
             base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
             logger.debug("Auxiliary client: OpenRouter via pool")
             return _create_openai_client(api_key=or_key, base_url=base_url,
-                           default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+                           default_headers=build_or_headers()), or_model
         # Pool exists but is exhausted (no usable runtime key) — fall through to
         # the OPENROUTER_API_KEY env-var path rather than failing outright.
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
@@ -2179,7 +2285,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+                   default_headers=build_or_headers()), or_model
 
 
 def _describe_openrouter_unavailable() -> str:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -14,15 +14,9 @@ Resolution order for text tasks (auto mode):
   6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
   7. None
 
-OpenRouter fallback cost guard (issue #75803):
-  The step-2 OpenRouter fallback model is ``auxiliary.openrouter_model`` in
-  config.yaml (default: google/gemini-3.6-flash — a PAID model).  Because
-  auxiliary traffic is background-shaped (compression, title generation,
-  session search, vision, web extract), a paid fallback must never be
-  silent: set ``auxiliary.free_only: true`` to restrict the fallback to
-  ``:free`` SKUs (skipping OpenRouter entirely when the model is not a
-  ``:free`` id), and a one-time WARNING is logged whenever a non-``:free``
-  model is engaged so no cash lane is reachable without the user knowing.
+OpenRouter fallback cost guard: ``auxiliary.free_only: true`` restricts the
+step-2 fallback to ``:free`` SKUs; ``auxiliary.openrouter_model`` overrides
+the default. A one-time WARNING is logged for non-``:free`` models.
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
@@ -2169,21 +2163,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 # ── Provider resolution helpers ─────────────────────────────────────────────
 
 
-# ── Issue #75803: paid-lane guard for the OpenRouter auxiliary fallback ─────
-# The auto-chain's step-2 OpenRouter fallback historically used a hardcoded
-# PAID model (_OPENROUTER_MODEL) with no config surface and no free marker.
-# A user whose fallback ladder is deliberately :free/local could still have
-# background auxiliary traffic (compression, title generation, session
-# search, vision, web extract) land on a real-money OpenRouter lane.
-#
-# Guards (all best-effort, config-driven):
-#   * auxiliary.free_only: true  — the OpenRouter fallback is skipped unless
-#     the resolved model is a :free SKU. This is the opt-out.
-#   * auxiliary.openrouter_model — replaces the hardcoded fallback model
-#     (e.g. "nvidia/nemotron-3-ultra-550b-a55b:free"). This is the config
-#     surface.
-#   * A one-time WARNING is logged whenever the fallback would serve a
-#     non-:free model, so the paid lane is never silent.
 _paid_lane_warned: set = set()
 
 
@@ -2192,48 +2171,26 @@ def _is_free_model(model: Optional[str]) -> bool:
     return bool(model) and str(model).strip().endswith(":free")
 
 
-def _aux_free_only() -> bool:
-    """Read ``auxiliary.free_only`` from config.yaml (default False).
+def _aux_openrouter_settings() -> Tuple[bool, str]:
+    """Read free_only and openrouter_model from config in one pass.
 
-    When enabled, the auxiliary auto-chain's OpenRouter fallback refuses to
-    engage a PAID model: if the resolved fallback model is not a ``:free``
-    SKU, the OpenRouter step is skipped entirely with an explicit WARNING.
-    Best-effort — any config-read failure falls back to the default.
+    Returns (free_only, model) — defaults (False, _OPENROUTER_MODEL) on any
+    config-read failure.
     """
     try:
-        from hermes_cli.config import cfg_get, load_config
+        from hermes_cli.config import cfg_get, load_config_readonly
 
-        val = cfg_get(load_config(), "auxiliary", "free_only", default=False)
-        return bool(val)
+        cfg = load_config_readonly()
+        free_only = bool(cfg_get(cfg, "auxiliary", "free_only", default=False))
+        val = cfg_get(cfg, "auxiliary", "openrouter_model")
+        model = val.strip() if isinstance(val, str) and val.strip() else _OPENROUTER_MODEL
+        return free_only, model
     except Exception:
-        return False
-
-
-def _aux_openrouter_model() -> str:
-    """Resolve the auxiliary OpenRouter fallback model.
-
-    ``auxiliary.openrouter_model`` in config.yaml wins; otherwise the module
-    default ``_OPENROUTER_MODEL`` is used. Best-effort — a config-read
-    failure falls back to the default.
-    """
-    try:
-        from hermes_cli.config import cfg_get, load_config
-
-        val = cfg_get(load_config(), "auxiliary", "openrouter_model")
-        if isinstance(val, str) and val.strip():
-            return val.strip()
-    except Exception:
-        pass
-    return _OPENROUTER_MODEL
+        return False, _OPENROUTER_MODEL
 
 
 def _warn_paid_lane_once(model: str) -> None:
-    """Log a WARNING the first time a non-:free OpenRouter model is engaged.
-
-    Auxiliary traffic is background-shaped (compression and title generation
-    fire inside cron and idle sessions), so a paid lane must never be silent.
-    Deduplicated per model id to avoid log spam on every aux call.
-    """
+    """Log a WARNING the first time a non-:free OpenRouter model is engaged."""
     if model in _paid_lane_warned:
         return
     _paid_lane_warned.add(model)
@@ -2247,13 +2204,9 @@ def _warn_paid_lane_once(model: str) -> None:
 
 
 def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
-    # Issue #75803: never let the OpenRouter fallback silently engage a PAID
-    # lane. The fallback model is configurable (auxiliary.openrouter_model)
-    # and auxiliary.free_only: true skips OpenRouter unless the model is a
-    # :free SKU. Explicit caller models (auxiliary.<task>.model) go through
-    # the same guard so the opt-out covers every OpenRouter aux path.
-    or_model = model or _aux_openrouter_model()
-    if _aux_free_only() and not _is_free_model(or_model):
+    free_only, cfg_model = _aux_openrouter_settings()
+    or_model = model or cfg_model
+    if free_only and not _is_free_model(or_model):
         logger.warning(
             "Auxiliary client: auxiliary.free_only is enabled but the "
             "OpenRouter fallback model %r is not a :free SKU — skipping the "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -802,6 +802,20 @@ DEFAULT_CONFIG = {
         # not a meaningful recovery, so an unretried blip silently loses the
         # call.
         "transient_retries": 2,
+        # Restrict the auxiliary auto-chain's OpenRouter fallback to free
+        # (:free) SKUs. When true, the OpenRouter step is skipped entirely
+        # unless the resolved fallback model ends in ":free" — a PAID lane
+        # is never engaged for background auxiliary traffic (compression,
+        # title generation, session search, vision, web extract) even when
+        # OPENROUTER_API_KEY is present. Default false keeps the historical
+        # paid fallback for users who want it.
+        "free_only": False,
+        # Override the auxiliary auto-chain's OpenRouter fallback model
+        # (default: google/gemini-3.6-flash, a PAID model). Set e.g.
+        # "nvidia/nemotron-3-ultra-550b-a55b:free" together with
+        # free_only: true to keep auxiliary traffic free-only. A one-time
+        # WARNING is logged whenever a non-":free" model is engaged.
+        "openrouter_model": "",
         # Endpoints that reject NON-streaming chat requests outright (e.g.
         # Tencent Copilot returns HTTP 400 "Non-stream chat request is
         # currently not supported"). Auxiliary calls to a matching endpoint

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -78,6 +78,7 @@ LEGACY_AUTHOR_MAP = {
     "BB-light@users.noreply.github.com": "BB-light",  # PR #76015 salvage (caching: honor cache_ttl disable; #33555)
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "contato@webtecnica.com.br": "webtecnica",  # PR #70888 salvage
+    "webtecnica@gmail.com": "webtecnica",  # PR #75838 salvage (aux: free-only fallback guard; #75803)
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)
     "jdjiayou@163.com": "JiaDe-Wu",  # PR #34742 salvage (bedrock: bearer routing + streaming fallback + image decode; #28156)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -989,6 +989,93 @@ class TestExplicitProviderRouting:
         assert mock_openai.call_args.kwargs["base_url"] == OPENROUTER_BASE_URL
 
 
+class TestOpenRouterPaidLaneGuard:
+    """Issue #75803: auxiliary auto-chain OpenRouter fallback must be
+    configurable and never silently engage a PAID model."""
+
+    def test_free_only_skips_paid_default_model(self, monkeypatch):
+        """free_only=true + default (paid) model → OpenRouter skipped."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = _try_openrouter()
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+    def test_free_only_allows_free_model(self, monkeypatch):
+        """free_only=true + :free model → OpenRouter used with that model."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"auxiliary": {"free_only": True,
+                                              "openrouter_model": "nvidia/nemotron-3-ultra-550b-a55b:free"}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = _try_openrouter()
+        assert client is mock_client
+        assert model == "nvidia/nemotron-3-ultra-550b-a55b:free"
+
+    def test_configured_model_overrides_hardcoded_default(self, monkeypatch):
+        """auxiliary.openrouter_model replaces _OPENROUTER_MODEL."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"auxiliary": {"openrouter_model": "some/vendor-model"}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = _try_openrouter()
+        assert client is mock_client
+        assert model == "some/vendor-model"
+
+    def test_explicit_caller_model_respects_free_only(self, monkeypatch):
+        """Auxiliary.<task>.model (explicit) is also gated by free_only."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = _try_openrouter(model="google/gemini-3.6-flash")
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+    def test_paid_lane_warns_once(self, monkeypatch, caplog):
+        """Engaging the default paid model logs a WARNING (once per model)."""
+        import logging
+        from agent.auxiliary_client import _paid_lane_warned
+        _paid_lane_warned.discard(_OPENROUTER_MODEL)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config", return_value={"auxiliary": {}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = _try_openrouter()
+        assert client is mock_client
+        assert model == _OPENROUTER_MODEL
+        assert any("PAID lane engaged" in r.getMessage() for r in caplog.records)
+        # Second call logs nothing new.
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config", return_value={"auxiliary": {}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                _try_openrouter()
+        assert not any("PAID lane engaged" in r.getMessage() for r in caplog.records)
+        _paid_lane_warned.discard(_OPENROUTER_MODEL)
+
+    def test_is_free_model(self):
+        from agent.auxiliary_client import _is_free_model
+        assert _is_free_model("nvidia/nemotron-3-ultra-550b-a55b:free")
+        assert not _is_free_model("google/gemini-3.6-flash")
+        assert not _is_free_model("")
+        assert not _is_free_model(None)
+
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -997,7 +997,7 @@ class TestOpenRouterPaidLaneGuard:
         """free_only=true + default (paid) model → OpenRouter skipped."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"free_only": True}}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {"free_only": True}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = _try_openrouter()
         assert client is None
@@ -1008,7 +1008,7 @@ class TestOpenRouterPaidLaneGuard:
         """free_only=true + :free model → OpenRouter used with that model."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config",
+             patch("hermes_cli.config.load_config_readonly",
                    return_value={"auxiliary": {"free_only": True,
                                               "openrouter_model": "nvidia/nemotron-3-ultra-550b-a55b:free"}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
@@ -1022,7 +1022,7 @@ class TestOpenRouterPaidLaneGuard:
         """auxiliary.openrouter_model replaces _OPENROUTER_MODEL."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config",
+             patch("hermes_cli.config.load_config_readonly",
                    return_value={"auxiliary": {"openrouter_model": "some/vendor-model"}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_client = MagicMock(name="openrouter_client")
@@ -1035,7 +1035,7 @@ class TestOpenRouterPaidLaneGuard:
         """Auxiliary.<task>.model (explicit) is also gated by free_only."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"free_only": True}}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {"free_only": True}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = _try_openrouter(model="google/gemini-3.6-flash")
         assert client is None
@@ -1049,7 +1049,7 @@ class TestOpenRouterPaidLaneGuard:
         _paid_lane_warned.discard(_OPENROUTER_MODEL)
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config", return_value={"auxiliary": {}}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_client = MagicMock(name="openrouter_client")
             mock_openai.return_value = mock_client
@@ -1060,7 +1060,7 @@ class TestOpenRouterPaidLaneGuard:
         assert any("PAID lane engaged" in r.getMessage() for r in caplog.records)
         # Second call logs nothing new.
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
-             patch("hermes_cli.config.load_config", return_value={"auxiliary": {}}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {}}), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             caplog.clear()
             with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):


### PR DESCRIPTION
## Summary
Auxiliary OpenRouter fallback is now configurable and never silently engages a paid model — `auxiliary.free_only: true` skips the fallback unless the model is a `:free` SKU, `auxiliary.openrouter_model` overrides the hardcoded default, and a one-time WARNING is logged for non-`:free` models.

Closes #75803. Salvage of #75838 (@webtecnica's work cherry-picked with authorship preserved).

## Changes
- `agent/auxiliary_client.py`: `_is_free_model`, `_aux_openrouter_settings` (single config read via `load_config_readonly`), `_warn_paid_lane_once` + guard in `_try_openrouter`
- `hermes_cli/config_defaults.py`: `auxiliary.free_only` (default `false`) + `auxiliary.openrouter_model` (default `""`)
- `tests/agent/test_auxiliary_client.py`: 6 tests covering skip-with-free-only, :free allowed, config override, explicit model gated, warning dedup, `_is_free_model`
- `scripts/release.py`: AUTHOR_MAP entry for webtecnica@gmail.com

## Simplifications applied on top of contributor's work
- Collapsed `_aux_free_only()` + `_aux_openrouter_model()` into single `_aux_openrouter_settings()` — one config read instead of two, using `load_config_readonly` to avoid deepcopy
- Trimmed 15-line block comment + 5-line inline comment + 10-line module docstring to essentials
- Net: -47 lines vs contributor's original

## Validation
| | Before | After |
|---|---|---|
| Unit tests | — | 169 passed |
| E2E (real imports, temp HERMES_HOME) | — | 7/7 scenarios pass |
| Ruff | — | clean |
