### PR TITLE
feat(gateway): expose detailed session usage on request

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3090,6 +3090,7 @@ class APIServerAdapter(BasePlatformAdapter):
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
+        include_usage = _coerce_request_bool(request.query.get("include_usage"), default=False)
         sessions = await asyncio.to_thread(db.list_sessions_rich,
             source=source,
             limit=limit,
@@ -3097,9 +3098,19 @@ class APIServerAdapter(BasePlatformAdapter):
             include_children=include_children,
             order_by_last_active=True,
         )
+        payloads = [self._session_response(session) for session in sessions]
+        if include_usage:
+            usage_by_session = await asyncio.to_thread(
+                db.get_session_model_usage,
+                [str(session.get("id") or "") for session in sessions],
+            )
+            for payload in payloads:
+                payload["usage_by_model"] = usage_by_session.get(
+                    str(payload.get("id") or ""), []
+                )
         return web.json_response({
             "object": "list",
-            "data": [self._session_response(s) for s in sessions],
+            "data": payloads,
             "limit": limit,
             "offset": offset,
             "has_more": len(sessions) == limit,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3100,10 +3100,69 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         payloads = [self._session_response(session) for session in sessions]
         if include_usage:
-            usage_by_session = await asyncio.to_thread(
-                db.get_session_model_usage,
-                [str(session.get("id") or "") for session in sessions],
-            )
+            def _load_usage():
+                lineages = {}
+                for session in sessions:
+                    session_id = str(session.get("id") or "")
+                    lineages[session_id] = (
+                        [session_id]
+                        if include_children
+                        else db.get_compression_lineage(session_id)
+                    )
+                usage_by_raw_session = db.get_session_model_usage(
+                    list(dict.fromkeys(
+                        lineage_id
+                        for lineage in lineages.values()
+                        for lineage_id in lineage
+                    ))
+                )
+                merged = {}
+                counter_fields = (
+                    "api_call_count",
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cache_write_tokens",
+                    "reasoning_tokens",
+                )
+                cost_fields = ("estimated_cost_usd", "actual_cost_usd")
+                for session_id, lineage in lineages.items():
+                    rows = {}
+                    for lineage_id in lineage:
+                        for source in usage_by_raw_session.get(lineage_id, []):
+                            key = tuple(
+                                str(source.get(field) or "")
+                                for field in (
+                                    "task",
+                                    "model",
+                                    "billing_provider",
+                                    "billing_mode",
+                                )
+                            )
+                            if key not in rows:
+                                rows[key] = dict(source)
+                                continue
+                            target = rows[key]
+                            for field in counter_fields:
+                                target[field] = int(target.get(field) or 0) + int(
+                                    source.get(field) or 0
+                                )
+                            for field in cost_fields:
+                                target[field] = float(target.get(field) or 0.0) + float(
+                                    source.get(field) or 0.0
+                                )
+                            target["first_seen"] = min(
+                                float(target.get("first_seen") or 0.0),
+                                float(source.get("first_seen") or 0.0),
+                            )
+                            target["last_seen"] = max(
+                                float(target.get("last_seen") or 0.0),
+                                float(source.get("last_seen") or 0.0),
+                            )
+                    merged[session_id] = [rows[key] for key in sorted(rows)]
+                return merged
+
+            usage_by_session = await asyncio.to_thread(_load_usage)
             for payload in payloads:
                 payload["usage_by_model"] = usage_by_session.get(
                     str(payload.get("id") or ""), []

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4642,11 +4642,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             rows = conn.execute(
                 f"""
                 SELECT session_id, model, billing_provider, billing_mode, task,
-                       api_call_count, input_tokens, output_tokens,
-                       cache_read_tokens, cache_write_tokens, reasoning_tokens,
-                       estimated_cost_usd, actual_cost_usd, first_seen, last_seen
+                       SUM(api_call_count) AS api_call_count,
+                       SUM(input_tokens) AS input_tokens,
+                       SUM(output_tokens) AS output_tokens,
+                       SUM(cache_read_tokens) AS cache_read_tokens,
+                       SUM(cache_write_tokens) AS cache_write_tokens,
+                       SUM(reasoning_tokens) AS reasoning_tokens,
+                       SUM(estimated_cost_usd) AS estimated_cost_usd,
+                       SUM(actual_cost_usd) AS actual_cost_usd,
+                       MIN(first_seen) AS first_seen,
+                       MAX(last_seen) AS last_seen
                 FROM session_model_usage
                 WHERE session_id IN ({placeholders})
+                GROUP BY session_id, model, billing_provider, billing_mode, task
                 ORDER BY session_id, task, model, billing_provider, billing_mode
                 """,
                 ids,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4617,6 +4617,47 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
         self._execute_write(_do)
 
+    def get_session_model_usage(
+        self, session_ids: List[str]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Return client-safe detailed usage rows grouped by session ID.
+
+        ``sessions`` contains only the main agent loop's summary counters.
+        Auxiliary calls are intentionally recorded solely in
+        ``session_model_usage`` so they cannot be clobbered by the gateway's
+        absolute summary updates. Consumers that need complete accounting
+        therefore have to read this ledger rather than summing session rows.
+
+        The billing base URL and internal cost provenance are deliberately not
+        exported: callers need provider/model/task and counters, not endpoint
+        details that may contain tenant-specific routing information.
+        """
+        ids = [str(session_id) for session_id in session_ids if session_id]
+        if not ids:
+            return {}
+        self.flush_token_counts()
+        placeholders = ",".join("?" for _ in ids)
+        with self._read_ctx() as conn:
+            assert conn is not None
+            rows = conn.execute(
+                f"""
+                SELECT session_id, model, billing_provider, billing_mode, task,
+                       api_call_count, input_tokens, output_tokens,
+                       cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                       estimated_cost_usd, actual_cost_usd, first_seen, last_seen
+                FROM session_model_usage
+                WHERE session_id IN ({placeholders})
+                ORDER BY session_id, task, model, billing_provider, billing_mode
+                """,
+                ids,
+            ).fetchall()
+        grouped: Dict[str, List[Dict[str, Any]]] = {session_id: [] for session_id in ids}
+        for row in rows:
+            payload = dict(row)
+            session_id = payload.pop("session_id")
+            grouped.setdefault(session_id, []).append(payload)
+        return grouped
+
     def prune_empty_ghost_sessions(self, sessions_dir: "Optional[Path]" = None) -> int:
         """Remove empty TUI ghost sessions (no messages, no title, >24hr old)."""
         cutoff = time.time() - 86400  # Only sessions older than 24 hours

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -146,8 +146,18 @@ async def test_list_sessions_can_include_detailed_model_and_aux_usage(adapter, s
         "compression",
         model="gpt-5.6-luna",
         billing_provider="openai-codex",
+        billing_base_url="https://route-a.invalid/v1",
         input_tokens=30,
         output_tokens=10,
+    )
+    session_db.record_auxiliary_usage(
+        session_id,
+        "compression",
+        model="gpt-5.6-luna",
+        billing_provider="openai-codex",
+        billing_base_url="https://route-b.invalid/v1",
+        input_tokens=7,
+        output_tokens=3,
     )
 
     app = _create_session_app(adapter)
@@ -181,8 +191,57 @@ async def test_list_sessions_can_include_detailed_model_and_aux_usage(adapter, s
     assert usage[0]["first_seen"] > 0
     assert usage[0]["last_seen"] >= usage[0]["first_seen"]
     assert usage[1]["model"] == "gpt-5.6-luna"
-    assert usage[1]["input_tokens"] == 30
-    assert usage[1]["output_tokens"] == 10
+    assert usage[1]["api_call_count"] == 2
+    assert usage[1]["input_tokens"] == 37
+    assert usage[1]["output_tokens"] == 13
+    assert "billing_base_url" not in usage[1]
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_merges_usage_across_compression_lineage(
+    adapter, session_db
+):
+    root_id = session_db.create_session(
+        "usage-compression-root", "discord", model="gpt-5.6-sol"
+    )
+    session_db.update_token_counts(
+        root_id,
+        input_tokens=100,
+        output_tokens=20,
+        model="gpt-5.6-sol",
+        billing_provider="openai-codex",
+        billing_mode="subscription_included",
+        api_call_count=1,
+    )
+    session_db.end_session(root_id, "compression")
+    tip_id = session_db.create_session(
+        "usage-compression-tip",
+        "discord",
+        model="gpt-5.6-sol",
+        parent_session_id=root_id,
+    )
+    session_db.update_token_counts(
+        tip_id,
+        input_tokens=50,
+        output_tokens=10,
+        model="gpt-5.6-sol",
+        billing_provider="openai-codex",
+        billing_mode="subscription_included",
+        api_call_count=1,
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get("/api/sessions?include_usage=true&limit=20")
+        assert response.status == 200
+        body = await response.json()
+
+    logical = next(row for row in body["data"] if row["id"] == tip_id)
+    assert len(logical["usage_by_model"]) == 1
+    usage = logical["usage_by_model"][0]
+    assert usage["api_call_count"] == 2
+    assert usage["input_tokens"] == 150
+    assert usage["output_tokens"] == 30
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -127,6 +127,65 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_list_sessions_can_include_detailed_model_and_aux_usage(adapter, session_db):
+    session_id = session_db.create_session(
+        "usage-session", "discord", model="gpt-5.6-sol"
+    )
+    session_db.update_token_counts(
+        session_id,
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_tokens=80,
+        model="gpt-5.6-sol",
+        billing_provider="openai-codex",
+        billing_mode="subscription_included",
+        api_call_count=1,
+    )
+    session_db.record_auxiliary_usage(
+        session_id,
+        "compression",
+        model="gpt-5.6-luna",
+        billing_provider="openai-codex",
+        input_tokens=30,
+        output_tokens=10,
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        ordinary = await (await cli.get("/api/sessions?include_children=true")).json()
+        detailed = await (
+            await cli.get(
+                "/api/sessions?include_children=true&include_usage=true"
+            )
+        ).json()
+
+    assert "usage_by_model" not in ordinary["data"][0]
+    usage = detailed["data"][0]["usage_by_model"]
+    assert [row["task"] for row in usage] == ["", "compression"]
+    assert usage[0] == {
+        "model": "gpt-5.6-sol",
+        "billing_provider": "openai-codex",
+        "billing_mode": "subscription_included",
+        "task": "",
+        "api_call_count": 1,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cache_read_tokens": 80,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "actual_cost_usd": 0.0,
+        "first_seen": usage[0]["first_seen"],
+        "last_seen": usage[0]["last_seen"],
+    }
+    assert usage[0]["first_seen"] > 0
+    assert usage[0]["last_seen"] >= usage[0]["first_seen"]
+    assert usage[1]["model"] == "gpt-5.6-luna"
+    assert usage[1]["input_tokens"] == 30
+    assert usage[1]["output_tokens"] == 10
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -445,7 +445,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`) |
+| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`, `include_usage`) |
 | `POST` | `/api/sessions` | Create an empty session |
 | `GET` | `/api/sessions/{id}` | Read session metadata |
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
@@ -454,6 +454,53 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+
+### Session list query parameters
+
+`GET /api/sessions` accepts these query parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `50` | Number of sessions to return, from `0` to `200` |
+| `offset` | integer | `0` | Number of sessions to skip for pagination |
+| `source` | string | — | Return only sessions from this source |
+| `include_children` | boolean | `false` | Include raw child sessions instead of only logical, user-facing sessions |
+| `include_usage` | boolean | `false` | Add a `usage_by_model` array to each returned session |
+
+When `include_usage=true`, each `usage_by_model` row identifies the model,
+billing provider and mode, and task, followed by its cumulative API-call, token,
+cost, and first/last-seen counters:
+
+```json
+{
+  "id": "session-id",
+  "usage_by_model": [
+    {
+      "model": "gpt-5.6-sol",
+      "billing_provider": "openai-codex",
+      "billing_mode": "subscription_included",
+      "task": "",
+      "api_call_count": 3,
+      "input_tokens": 1200,
+      "output_tokens": 240,
+      "cache_read_tokens": 800,
+      "cache_write_tokens": 0,
+      "reasoning_tokens": 100,
+      "estimated_cost_usd": 0.0,
+      "actual_cost_usd": 0.0,
+      "first_seen": 1785632400.0,
+      "last_seen": 1785632460.0
+    }
+  ]
+}
+```
+
+The field is omitted unless requested so ordinary session listings remain
+lightweight. For the default logical listing, usage from every session in a
+compression lineage is merged into the projected session. With
+`include_children=true`, each raw session carries only its own usage. Rows that
+differ only by internal billing endpoint are combined; billing base URLs and
+internal pricing provenance are never returned.
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in detailed usage export to the existing Sessions REST API. `GET /api/sessions?include_usage=true` includes cumulative per-model and auxiliary-task usage without changing the default lightweight response.

This uses Hermes' existing `session_model_usage` ledger rather than the main-loop summary counters, so API consumers can account for compression, delegation, TTS, and other auxiliary model calls. Usage is merged across compression lineages for logical session listings. Internal billing base URLs and pricing provenance remain private.

## Related Issue

Related to #23270 and its implementation in #65537, which added auxiliary usage accounting. This PR exposes that existing ledger through the authenticated Sessions API; it does not duplicate another open API-export PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: read and aggregate detailed main-model and auxiliary-task usage while preserving public accounting dimensions.
- `gateway/platforms/api_server.py`: add `include_usage=true`, merge compression-lineage usage, and keep the default response unchanged.
- `tests/gateway/test_session_api.py`: cover default compatibility, opt-in usage, hidden billing-route aggregation, and compression lineages.
- `website/docs/user-guide/features/api-server.md`: document the query parameter and conditional response schema.

## How to Test

1. Run `scripts/run_tests.sh` from the repository root.
2. Start the API server and request `GET /api/sessions` without `include_usage`; confirm the response has no `usage_by_model` field.
3. Request `GET /api/sessions?include_usage=true`; confirm every returned session has a `usage_by_model` array and no billing base URL or pricing-provenance field is exposed.

Verification:

```text
scripts/run_tests.sh tests/gateway/test_session_api.py
14 passed

scripts/run_tests.sh tests/test_hermes_state.py
140 passed

uv run ruff check hermes_state.py gateway/platforms/api_server.py tests/gateway/test_session_api.py
All checks passed!

npm run build  # website/
Production build completed for en and zh-Hans; only pre-existing repository link warnings were reported.
```

The full `scripts/run_tests.sh` suite was also attempted under both the active and a clean HOME. The clean run reported 65 failures in 26 unrelated files plus 12 collection/no-run files (primarily absent optional SDKs and ACP timeouts); none of the four files changed by this PR failed. The full-suite checklist remains deliberately unchecked rather than claiming a green run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent SQLite reads and JSON response shaping only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tools changed

## Screenshots / Logs

The opt-in response shape and test output are included above. The default response remains backward-compatible and lightweight.