### PR TITLE
fix(classifier): classify region opt-in 403 as provider_policy_blocked, not auth

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -404,6 +404,33 @@ _PROVIDER_POLICY_BLOCKED_PATTERNS = [
     "no endpoints found matching your data policy",
 ]
 
+# Region-restricted model opt-in patterns.
+#
+# Some providers host the latest model versions only inside their home
+# region and gate access from elsewhere behind an explicit account-level
+# opt-in. OpenCode Go does this for China-hosted DeepSeek models:
+#
+#   "The latest version of this model is only available hosted in China
+#    and requires explicit opt in:
+#    https://opencode.ai/workspace/<workspace_id>/go"
+#
+# The credentials are valid — this is a geo/entitlement gate, not an auth
+# failure. Classified as ``provider_policy_blocked`` so the provider's own
+# fix URL in the error body is surfaced instead of generic (and
+# misleading) API-key guidance. Unlike the OpenRouter privacy-guardrail
+# case, provider fallback IS useful here: the same model stays reachable
+# via DeepSeek direct, OpenRouter, etc., so callers keep
+# ``should_fallback=True``.
+#
+# Matching is deliberately narrow: BOTH phrase fragments are required
+# (the real OpenCode message contains both), or the structured error
+# ``type`` is exactly ``RegionError``. A 403 mentioning only a
+# region-hosted model — without the opt-in wording — stays ``auth``.
+_REGION_OPT_IN_PATTERNS = [
+    "requires explicit opt in",
+    "only available hosted in",
+]
+
 # Provider content-policy / safety-filter blocks. Distinct from
 # ``provider_policy_blocked`` above (which is an OpenRouter *account*-level
 # data/privacy guardrail) — these are *per-prompt* safety decisions made by
@@ -1021,6 +1048,23 @@ def _classify_by_status(
                 FailoverReason.billing,
                 retryable=False,
                 should_rotate_credential=True,
+                should_fallback=True,
+            )
+        # Region-restricted model requiring account-level opt-in (e.g.
+        # OpenCode Go RegionError for China-hosted DeepSeek). The error
+        # body already contains the fix URL, so surface it as
+        # ``provider_policy_blocked`` instead of ``auth`` — the generic
+        # auth guidance ("is your API key valid?") is misleading here.
+        # Fallback stays enabled: the model is reachable via other
+        # providers without any opt-in.
+        # Narrow match: both phrase fragments (the real OpenCode message
+        # has both) OR the structured error type "RegionError".
+        if error_code.lower() == "regionerror" or all(
+            p in error_msg for p in _REGION_OPT_IN_PATTERNS
+        ):
+            return result_fn(
+                FailoverReason.provider_policy_blocked,
+                retryable=False,
                 should_fallback=True,
             )
         return result_fn(

--- a/contributors/emails/nguyenquang2796@gmail.com
+++ b/contributors/emails/nguyenquang2796@gmail.com
@@ -1,0 +1,2 @@
+Ngquang
+# PR #76637: region opt-in 403 classification fix

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -199,6 +199,75 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
 
+    # ── Region-restricted opt-in (OpenCode Go RegionError) ──
+
+    def test_403_region_opt_in_classified_as_provider_policy_blocked(self):
+        """OpenCode Go returns 403 RegionError when a China-hosted model
+        (e.g. deepseek-v4-flash) requires an account-level opt-in. The
+        credentials are valid, so this must NOT classify as ``auth``
+        (which would surface misleading API-key guidance) — the error
+        body already carries the fix URL. Fallback must stay enabled:
+        the same model is reachable via other providers without opt-in."""
+        e = MockAPIError(
+            "Forbidden",
+            status_code=403,
+            body={
+                "error": {
+                    "type": "RegionError",
+                    "message": (
+                        "The latest version of this model is only available "
+                        "hosted in China and requires explicit opt in: "
+                        "https://opencode.ai/workspace/wrk_test/go"
+                    ),
+                }
+            },
+        )
+        result = classify_api_error(e, provider="opencode-go", model="deepseek-v4-flash")
+        assert result.reason == FailoverReason.provider_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.is_auth is False
+
+    def test_403_region_opt_in_matches_message_only(self):
+        """Match on the message pattern even when the structured body is
+        absent (SDKs sometimes surface the provider message only through
+        str(error)). Both phrase fragments must be present."""
+        e = MockAPIError(
+            "The latest version of this model is only available hosted in China "
+            "and requires explicit opt in: https://opencode.ai/workspace/wrk_test/go",
+            status_code=403,
+        )
+        result = classify_api_error(e, provider="opencode-go")
+        assert result.reason == FailoverReason.provider_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_403_region_error_code_alone_classifies(self):
+        """The structured ``error.type: RegionError`` is a definitive
+        signal even when the message wording is trimmed by the relay."""
+        e = MockAPIError(
+            "Forbidden",
+            status_code=403,
+            body={"error": {"type": "RegionError", "message": "region restriction"}},
+        )
+        result = classify_api_error(e, provider="opencode-go")
+        assert result.reason == FailoverReason.provider_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("fragment", ["only available hosted in", "requires explicit opt in"])
+    def test_403_single_opt_in_fragment_stays_auth(self, fragment):
+        """A 403 mentioning only one fragment (e.g. any model that happens
+        to be region-hosted) must remain ``auth`` — the opt-in exception
+        requires both phrase signals or the structured RegionError code."""
+        e = MockAPIError(
+            f"model {fragment} for region ap-east-1",
+            status_code=403,
+        )
+        result = classify_api_error(e, provider="opencode-go")
+        assert result.reason == FailoverReason.auth
+        assert result.should_fallback is True
+
 
 
 


### PR DESCRIPTION
## Summary
OpenCode Go returns **HTTP 403 RegionError** when a China-hosted model (e.g. `deepseek-v4-flash`) requires an explicit account-level opt-in:
```
The latest version of this model is only available hosted in China and requires explicit opt in:
https://opencode.ai/workspace/<workspace_id>/go
```
The 403 branch in `error_classifier.py` previously fell through to `FailoverReason.auth`, which surfaced generic **"Your API key was rejected... Is the key valid?"** guidance — contradicting the provider's own message. The credentials are valid; the model is geo-gated behind an opt-in the user must perform on their OpenCode workspace.
## Change
- Add `_REGION_OPT_IN_PATTERNS` matching the provider's opt-in wording.
- In the 403 branch, match those patterns and classify as `FailoverReason.provider_policy_blocked` instead of `auth`:
  - The error body's own fix URL is surfaced as-is (same stance as the existing OpenRouter privacy-guardrail 404 path).
  - The misleading API-key hint is suppressed (`is_auth` is False).
  - `should_fallback=True` is preserved — unlike the OpenRouter case, the same model is reachable via DeepSeek direct / OpenRouter without any opt-in, so provider fallback genuinely helps here.
## Tests
- `test_403_region_opt_in_classified_as_provider_policy_blocked` — full RegionError body shape (OpenCode Go → deepseek-v4-flash).
- `test_403_region_opt_in_matches_message_only` — pattern match works when the SDK only surfaces the message via `str(error)`.
`tests/agent/test_error_classifier.py`: 71 passed. No new failures (3 pre-existing failures on `main` are unrelated: LSP e2e + temperature-retry env issues).

