### PR TITLE
test: harden update validation across platforms

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -44,6 +44,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, Future
@@ -298,6 +299,21 @@ _FLAKY_RESULTS: List[Tuple[Path, str]] = []
 _flaky_lock = threading.Lock()
 
 
+def _isolated_basetemp_arg(pytest_args: List[str], temp_root: str) -> List[str]:
+    """Give each pytest subprocess a private temp root unless explicitly set.
+
+    Without this, parallel pytest processes race while maintaining the shared
+    ``pytest-current`` symlink and can fail during session cleanup even when
+    every test passed.
+    """
+    if any(
+        arg == "--basetemp" or arg.startswith("--basetemp=")
+        for arg in pytest_args
+    ):
+        return []
+    return [f"--basetemp={Path(temp_root) / 'run'}"]
+
+
 def _run_one_file_once(
     file: Path,
     pytest_args: List[str],
@@ -305,7 +321,15 @@ def _run_one_file_once(
     file_timeout: float,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
-    cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
+    pytest_temp = tempfile.TemporaryDirectory(prefix="hermes-pytest-")
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(file),
+        *_isolated_basetemp_arg(pytest_args, pytest_temp.name),
+        *pytest_args,
+    ]
     
     subproc_start = time.monotonic()
     # launch the pytest process
@@ -352,6 +376,7 @@ def _run_one_file_once(
         # KeyboardInterrupt / runner crash — make sure no zombie
         # grandchildren outlive us.
         _kill_tree(proc, pgid=pgid)
+        pytest_temp.cleanup()
         raise
     else:
         # Happy path: pytest exited on its own. Kill the group anyway in
@@ -370,6 +395,7 @@ def _run_one_file_once(
         rc = 0
     summary = _parse_pytest_summary(output)
     subproc_wall = time.monotonic() - subproc_start
+    pytest_temp.cleanup()
     return file, rc, output, summary, subproc_wall
 
 

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -371,6 +371,14 @@ class TestFailureAttribution:
 
     def _make_pool(self, tmp_path, monkeypatch, entries):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        # This fixture is exercising only the explicit entries below. Keep a
+        # developer's real Claude Code credentials from being auto-seeded into
+        # the temporary pool, which would turn a singleton into a multi-entry
+        # pool and make the rotation assertions depend on host state.
+        monkeypatch.setattr(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            lambda _provider: False,
+        )
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(
@@ -491,4 +499,3 @@ class TestFailureAttribution:
         assert recovered is False
         assert self._statuses(pool)["cred-0"] != "exhausted"
         agent._swap_credential.assert_not_called()
-

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    not hasattr(socket, "AF_UNIX") or sys.platform != "linux",
+    reason="Linux abstract Unix datagram sockets are unavailable",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"
@@ -77,5 +79,4 @@ async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     assert "WATCHDOG=1" in calls
     assert calls[-1] == "STOPPING=1"
     assert watchdog.unhealthy is False
-
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -494,6 +494,9 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        # This test exercises the systemd restart sequence, not host D-Bus
+        # discovery. Keep it runnable on non-Linux development hosts.
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
@@ -1755,4 +1758,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -192,22 +192,37 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 # tests/docker/test_s6_profile_gateway_integration.py.
 
 
-def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
+def test_seed_supervise_skeleton_creates_expected_layout(tmp_path, monkeypatch) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
     import stat
+    from pathlib import Path
 
     from hermes_cli.service_manager import _seed_supervise_skeleton
 
     svc_dir = tmp_path / "gateway-foo"
     svc_dir.mkdir()
 
+    chmod_calls: list[tuple[Path, int]] = []
+    original_chmod = Path.chmod
+
+    def recording_chmod(path: Path, mode: int, *args, **kwargs) -> None:
+        chmod_calls.append((path, mode))
+        original_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "chmod", recording_chmod)
+
     _seed_supervise_skeleton(svc_dir)
 
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
+    # Some non-container hosts clear setgid when the caller cannot chown the
+    # directory to the target group. The chmod spy below fixes the requested
+    # 03730 invariant, while the Docker integration test validates live s6
+    # behavior; this portable stat assertion requires every functional bit.
+    event_mode = stat.S_IMODE(event.stat().st_mode)
+    assert event_mode in {0o1730, 0o3730}, (
+        f"event/ mode = {oct(event.stat().st_mode)}, want 01730 or 03730"
     )
 
     # supervise/ dir.
@@ -218,7 +233,9 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(supervise_event.stat().st_mode) in {0o1730, 0o3730}
+    assert (event, 0o3730) in chmod_calls
+    assert (supervise_event, 0o3730) in chmod_calls
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -487,5 +504,3 @@ def test_s6_log_run_never_invokes_chown_with_symlinked_log_dir(tmp_path) -> None
     assert after.st_gid == before.st_gid
     assert (victim / "marker").read_text(encoding="utf-8") == "keep"
     assert (victim / "lock").read_text(encoding="utf-8") == "keep-lock"
-
-

--- a/tests/test_run_tests_parallel_stdio.py
+++ b/tests/test_run_tests_parallel_stdio.py
@@ -67,3 +67,17 @@ def test_glyph_safe_stdio_noop_without_reconfigure(monkeypatch) -> None:
     print("✓ still fine")
 
     assert "✓ still fine" in plain.getvalue()
+
+
+def test_parallel_runner_uses_private_pytest_basetemp_by_default(tmp_path) -> None:
+    mod = _load_runner()
+
+    assert mod._isolated_basetemp_arg([], str(tmp_path)) == [
+        f"--basetemp={tmp_path / 'run'}"
+    ]
+    assert mod._isolated_basetemp_arg(
+        ["--basetemp=/explicit/root"], str(tmp_path)
+    ) == []
+    assert mod._isolated_basetemp_arg(
+        ["--basetemp", "/explicit/root"], str(tmp_path)
+    ) == []

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -101,8 +101,10 @@ class TestDetectDangerousRm:
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            canonical_tmp = os.path.realpath("/tmp")
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                command = f"rm -f {canonical_tmp}/{prefix}example.py"
+                assert detect_dangerous_command(command) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1221,7 +1221,8 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -49,6 +50,8 @@ def test_real_binaries_execute_leading_dash_program_payload(
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
+    if sys.platform == "darwin" and tool in {"sort", "man"}:
+        pytest.skip(f"{tool} payload execution semantics require GNU/Linux")
 
     marker = tmp_path / "executed"
     payload = tmp_path / "-payload-marker"

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -52,7 +53,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -143,7 +146,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -397,6 +397,7 @@ class TestTranscribeLocalExtended:
              patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None), \
+             patch("tools.transcription_tools._should_force_faster_whisper_cpu", return_value=False), \
              patch("tools.transcription_tools._load_stt_config", return_value=fake_config):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "base")

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -2,6 +2,7 @@
 
 import os
 import struct
+import tempfile
 import time
 import wave
 from pathlib import Path
@@ -20,6 +21,20 @@ def _non_wsl_proc_version(real_open):
         return real_open(file, *args, **kwargs)
 
     return _fake_open
+
+
+class _TimeWithFixedStrftime:
+    """Module-local time proxy that does not patch stdlib logging globally."""
+
+    def __init__(self, real_time, value: str) -> None:
+        self._real = real_time
+        self._value = value
+
+    def strftime(self, _format: str) -> str:
+        return self._value
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
 
 
 # ============================================================================
@@ -49,6 +64,13 @@ def temp_voice_dir(tmp_path, monkeypatch):
     voice_dir.mkdir()
     monkeypatch.setattr("tools.voice_mode._TEMP_DIR", str(voice_dir))
     return voice_dir
+
+
+@pytest.fixture
+def short_socket_runtime_dir():
+    """Keep AF_UNIX paths below macOS's short sockaddr_un limit."""
+    with tempfile.TemporaryDirectory(prefix="hm-pulse-", dir="/tmp") as path:
+        yield Path(path)
 
 
 @pytest.fixture
@@ -121,10 +143,10 @@ def fake_clock(monkeypatch):
 # ============================================================================
 
 class TestPulseSocketReachable:
-    def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
+    def test_stale_socket_file_not_reachable(self, monkeypatch, short_socket_runtime_dir):
         """A socket file with no listener should not count as reachable."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = short_socket_runtime_dir / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         # Create + bind, then close so the path is a stale socket file.
         s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -132,14 +154,16 @@ class TestPulseSocketReachable:
         s.close()
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(short_socket_runtime_dir))
         from tools.voice_mode import _pulse_socket_reachable
         assert _pulse_socket_reachable() is False
 
-    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, tmp_path):
+    def test_listening_socket_reachable_via_xdg_runtime(
+        self, monkeypatch, short_socket_runtime_dir
+    ):
         """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = short_socket_runtime_dir / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         server.bind(str(sock_path))
@@ -147,7 +171,7 @@ class TestPulseSocketReachable:
         try:
             monkeypatch.delenv("PULSE_SERVER", raising=False)
             monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-            monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(short_socket_runtime_dir))
             from tools.voice_mode import _pulse_socket_reachable
             assert _pulse_socket_reachable() is True
         finally:
@@ -343,7 +367,10 @@ class TestTermuxAudioRecorder:
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
         monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
-        monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
+        monkeypatch.setattr(
+            "tools.voice_mode.time",
+            _TimeWithFixedStrftime(time, "20260409_120000"),
+        )
         monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
 
         from tools.voice_mode import TermuxAudioRecorder
@@ -368,7 +395,10 @@ class TestTermuxAudioRecorder:
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record")
         monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: True)
-        monkeypatch.setattr("tools.voice_mode.time.strftime", lambda fmt: "20260409_120000")
+        monkeypatch.setattr(
+            "tools.voice_mode.time",
+            _TimeWithFixedStrftime(time, "20260409_120000"),
+        )
         monkeypatch.setattr("tools.voice_mode.subprocess.run", fake_run)
 
         from tools.voice_mode import TermuxAudioRecorder
@@ -689,7 +719,7 @@ class TestCleanupTempRecordings:
 # ============================================================================
 
 class TestPlayBeep:
-    def test_beep_calls_sounddevice_play(self, mock_sd):
+    def test_beep_calls_sounddevice_play(self, mock_sd, monkeypatch):
         np = pytest.importorskip("numpy")
 
         from tools.voice_mode import play_beep
@@ -698,6 +728,7 @@ class TestPlayBeep:
         mock_stream = MagicMock()
         mock_stream.active = False
         mock_sd.get_stream.return_value = mock_stream
+        monkeypatch.setattr("tools.voice_mode._sounddevice_output_allowed", lambda: True)
 
         play_beep(frequency=880, duration=0.1, count=1)
 
@@ -1408,6 +1439,7 @@ class TestWSL2PowerShellFallback:
             return m
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
@@ -1460,6 +1492,7 @@ class TestWSL2PowerShellFallback:
             return open(path, *args, **kwargs)
 
         with patch("builtins.open", side_effect=_fake_open), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
              patch("subprocess.check_output", side_effect=_capture_check_output), \
              patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -472,7 +472,7 @@ class TestDelegationCleanup:
         parent._active_children.append(child)
         relay_host = MagicMock()
         monkeypatch.setattr(relay_runtime, "get_runtime", lambda **_kwargs: relay_host)
-        monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 0.1)
+        monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 1.0)
 
         def run_conversation(**kwargs):
             lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(


### PR DESCRIPTION
## Summary

- isolate every parallel pytest subprocess with a private basetemp to eliminate pytest-current cleanup races
- prevent developer credentials and live host configuration from leaking into unit tests
- make Linux, macOS, WSL, systemd, s6, file-path, audio, and tool-execution tests assert their intended platform contracts
- retain the exact s6 chmod 03730 invariant while tolerating host filesystem behavior

## Root cause

The post-update suite exposed test assumptions tied to Linux paths, GNU command semantics, host credentials, Apple Silicon audio safeguards, and a shared pytest temporary symlink. Production behavior was correct; the tests and parallel runner did not fully isolate those host-specific conditions.

## Validation

- 514 passed, 5 skipped across all changed test modules after syncing with upstream main
- 62 passed for voice-mode tests after removing the global time-module mock
- 11 passed for parallel-runner regression tests
- 9 passed in a two-file parallel smoke run with no cleanup flake
- Ruff passed for all changed Python files
- git diff --check passed
- dependency and npm audits reported zero vulnerabilities during the update verification