### PR TITLE
fix(kanban): resume tasks after PR review requeue

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8049,8 +8049,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds). A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        A later explicit requeue bypasses this guard because dependency
+        promotion or operator action deliberately resumed the existing task.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8133,12 +8135,28 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A later explicit requeue is deliberate continuation after review or
+    #    operator action, so it must resume the existing task instead of being
+    #    trapped by the stale PR comment for the full guard window.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    latest_pr_comment_at: Optional[int] = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? ORDER BY created_at DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            latest_pr_comment_at = int(c["created_at"] or 0)
+            break
+    if latest_pr_comment_at is not None:
+        requeued_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND created_at > ? "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "LIMIT 1",
+            (task_id, latest_pr_comment_at),
+        ).fetchone()
+        if not requeued_after:
             return "active_pr"
 
     return None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8127,7 +8127,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "AND kind IN ('status', 'promoted', 'promoted_manual', "
+            "'unblocked', 'reclaimed') "
             "LIMIT 1",
             (task_id, completed_at),
         ).fetchone()
@@ -8152,7 +8153,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at > ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "AND kind IN ('status', 'promoted', 'promoted_manual', "
+            "'unblocked', 'reclaimed') "
             "LIMIT 1",
             (task_id, latest_pr_comment_at),
         ).fetchone()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -871,22 +871,60 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
         assert kb.check_respawn_guard(conn, task_id) == "active_pr"
 
 
-def test_respawn_guard_active_pr_bypassed_by_later_requeue(kanban_home):
-    """A dependency promotion after PR review deliberately resumes the task."""
+def test_recent_success_bypassed_by_later_manual_promotion(kanban_home):
+    """Manual promotion is an explicit rerun for recent-success guards too."""
     with kb.connect() as conn:
-        task_id = kb.create_task(conn, title="fix-review", assignee="alice")
+        task_id = kb.create_task(
+            conn, title="rerun", assignee="alice", initial_status="blocked"
+        )
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (task_id, now - 120, now - 60),
+        )
+        promoted, reason = kb.promote_task(
+            conn, task_id, actor="test", reason="operator requested rerun"
+        )
+        assert promoted, reason
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_respawn_guard_active_pr_bypassed_by_later_manual_promotion(kanban_home):
+    """The real promote API resumes a task after PR review."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="fix-review", assignee="alice", initial_status="blocked"
+        )
         now = int(time.time())
         conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, 'worker', ?, ?)",
             (task_id, "Opened https://github.com/example/repo/pull/42", now - 60),
         )
+        promoted, reason = kb.promote_task(
+            conn, task_id, actor="test", reason="review complete"
+        )
+        assert promoted, reason
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_respawn_guard_equal_timestamp_requeue_does_not_bypass(kanban_home):
+    """Second-resolution timestamp equality is not proof of later intent."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ambiguous-order", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (task_id, "Opened https://github.com/example/repo/pull/42", now),
+        )
         conn.execute(
             "INSERT INTO task_events (task_id, kind, created_at) "
             "VALUES (?, 'promoted', ?)",
-            (task_id, now - 10),
+            (task_id, now),
         )
-        assert kb.check_respawn_guard(conn, task_id) is None
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
 
 
 def test_respawn_guard_requeue_before_pr_does_not_bypass(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -854,6 +854,60 @@ class TestSharedBoardPaths:
 
 
 # ---------------------------------------------------------------------------
+# Respawn guard
+# ---------------------------------------------------------------------------
+
+
+def test_respawn_guard_active_pr_in_comment(kanban_home):
+    """A recent PR comment guards against an accidental duplicate worker."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="has-pr", assignee="alice")
+        kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Opened https://github.com/example/repo/pull/42",
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_respawn_guard_active_pr_bypassed_by_later_requeue(kanban_home):
+    """A dependency promotion after PR review deliberately resumes the task."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fix-review", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (task_id, "Opened https://github.com/example/repo/pull/42", now - 60),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, now - 10),
+        )
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_respawn_guard_requeue_before_pr_does_not_bypass(kanban_home):
+    """Only a requeue after the latest PR comment bypasses the guard."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="still-has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, now - 60),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (task_id, "Opened https://github.com/example/repo/pull/43", now - 10),
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+# ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem\nA recent PR URL guards a Ready task for the full PR window even after an explicit later promotion, unblock, reclaim, or status requeue. This strands implementation tasks after an independent review completes, including REQUEST CHANGES flows that need the original worker to continue.\n\n## Fix\nTreat a requeue event after the latest recent PR comment as deliberate continuation, matching the existing recent-success bypass. Requeues before the PR comment do not bypass the guard.\n\n## Tests\n- `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -o addopts= -q` → 33 passed\n- `git diff --check`\n\nLinear: POL-66