### PR TITLE
fix(cron): pass delivery target to no-agent scripts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2190,6 +2190,15 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+_CRON_SCRIPT_ENV_OVERRIDE_KEYS = frozenset(
+    {
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    }
+)
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
@@ -2226,9 +2235,11 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
-        env_overrides: Non-secret, job-scoped environment values applied after
-            the sanitized subprocess environment is built. This avoids
-            process-global environment mutation for concurrent cron jobs.
+        env_overrides: Job-scoped cron delivery-routing values applied after
+            the sanitized subprocess environment is built. Keys outside the
+            three ``HERMES_CRON_AUTO_DELIVER_*`` variables are ignored so this
+            parameter cannot reintroduce sanitized credentials or internal
+            environment state.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2300,7 +2311,13 @@ def _run_job_script(
         env = build_subprocess_env()
         env.update(env_overlay)
         if env_overrides:
-            env.update(env_overrides)
+            env.update(
+                {
+                    key: value
+                    for key, value in env_overrides.items()
+                    if key in _CRON_SCRIPT_ENV_OVERRIDE_KEYS
+                }
+            )
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2193,6 +2193,7 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
+    env_overrides: Optional[dict[str, str]] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2225,6 +2226,9 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
+        env_overrides: Non-secret, job-scoped environment values applied after
+            the sanitized subprocess environment is built. This avoids
+            process-global environment mutation for concurrent cron jobs.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2295,6 +2299,8 @@ def _run_job_script(
             }
         env = build_subprocess_env()
         env.update(env_overlay)
+        if env_overrides:
+            env.update(env_overrides)
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into
@@ -2339,7 +2345,10 @@ def _run_job_script(
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str, workdir: Optional[str] = None,
+    job: dict,
+    script_path: str,
+    workdir: Optional[str] = None,
+    env_overrides: Optional[dict[str, str]] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2361,7 +2370,9 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, env_overrides=env_overrides
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2392,10 +2403,14 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, env_overrides=env_overrides
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, env_overrides=env_overrides
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2809,9 +2824,38 @@ def run_job(
             )
             _job_workdir = None
 
+        # no_agent returns before the LLM path initializes the cron delivery
+        # ContextVars below. Pass routing metadata directly to this script's
+        # sanitized subprocess environment instead. Empty defaults are
+        # intentional: they prevent an ambient gateway/cron context from
+        # leaking another job's destination into local or concurrent jobs.
+        _delivery_target = _resolve_delivery_target(job)
+        _script_env = {
+            "HERMES_CRON_AUTO_DELIVER_PLATFORM": "",
+            "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "",
+            "HERMES_CRON_AUTO_DELIVER_THREAD_ID": "",
+        }
+        if _delivery_target:
+            _script_env.update(
+                {
+                    "HERMES_CRON_AUTO_DELIVER_PLATFORM": str(
+                        _delivery_target["platform"]
+                    ),
+                    "HERMES_CRON_AUTO_DELIVER_CHAT_ID": str(
+                        _delivery_target["chat_id"]
+                    ),
+                    "HERMES_CRON_AUTO_DELIVER_THREAD_ID": ""
+                    if _delivery_target.get("thread_id") is None
+                    else str(_delivery_target["thread_id"]),
+                }
+            )
+
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
-                job, script_path, workdir=_job_workdir,
+                job,
+                script_path,
+                workdir=_job_workdir,
+                env_overrides=_script_env,
             )
         except Exception as exc:
             logger.exception(

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -105,6 +105,80 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_exposes_resolved_delivery_target(hermes_env):
+    """Script-only jobs receive routing metadata without entering the LLM path."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "route.py"
+    script_path.write_text(
+        "import json, os\n"
+        "print(json.dumps({k: os.environ.get(k) for k in (\n"
+        "    'HERMES_CRON_AUTO_DELIVER_PLATFORM',\n"
+        "    'HERMES_CRON_AUTO_DELIVER_CHAT_ID',\n"
+        "    'HERMES_CRON_AUTO_DELIVER_THREAD_ID',\n"
+        ")}))\n"
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="route.py",
+        no_agent=True,
+        deliver="discord:123456789012345678:987654321098765432",
+    )
+    success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert json.loads(final_response) == {
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM": "discord",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "123456789012345678",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID": "987654321098765432",
+    }
+
+
+def test_run_job_no_agent_clears_ambient_route_for_local_delivery(
+    hermes_env, monkeypatch
+):
+    """A local script must not inherit another session or job's destination."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    for key, value in {
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM": "discord",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "ambient-chat",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID": "ambient-thread",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    script_path = hermes_env / "scripts" / "local-route.py"
+    script_path.write_text(
+        "import json, os\n"
+        "print(json.dumps({k: os.environ.get(k) for k in (\n"
+        "    'HERMES_CRON_AUTO_DELIVER_PLATFORM',\n"
+        "    'HERMES_CRON_AUTO_DELIVER_CHAT_ID',\n"
+        "    'HERMES_CRON_AUTO_DELIVER_THREAD_ID',\n"
+        ")}))\n"
+    )
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="local-route.py",
+        no_agent=True,
+        deliver="local",
+    )
+    success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert json.loads(final_response) == {
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM": "",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID": "",
+    }
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -180,8 +180,27 @@ def test_run_job_no_agent_clears_ambient_route_for_local_delivery(
 
 
 # ---------------------------------------------------------------------------
-# _run_job_script: shell-script support
+# _run_job_script: shell-script support and environment boundaries
 # ---------------------------------------------------------------------------
+
+
+def test_run_job_script_rejects_non_routing_env_overrides(hermes_env):
+    """Post-sanitization overrides are limited to cron delivery metadata."""
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "inspect-env.py"
+    script_path.write_text(
+        "import os\n"
+        "print(os.environ.get('UNRELATED_TEST_ONLY_ENV', '<absent>'))\n"
+    )
+
+    ok, output = _run_job_script(
+        "inspect-env.py",
+        env_overrides={"UNRELATED_TEST_ONLY_ENV": "must-not-pass"},
+    )
+
+    assert ok is True
+    assert output == "<absent>"
 
 
 def test_run_job_script_path_traversal_still_blocked(hermes_env):


### PR DESCRIPTION
## Summary

- resolve each `no_agent` cron job's concrete delivery target before its early-return execution path
- pass `HERMES_CRON_AUTO_DELIVER_PLATFORM`, `HERMES_CRON_AUTO_DELIVER_CHAT_ID`, and `HERMES_CRON_AUTO_DELIVER_THREAD_ID` through a job-scoped subprocess environment overlay
- explicitly blank those values for local or unresolved delivery so ambient gateway/cron routing cannot leak into script-only jobs
- strictly allowlist those three routing keys so post-sanitization overrides cannot reintroduce credentials or unrelated internal environment state
- preserve subprocess sanitization, the no-LLM fast path, and one-shot claim-heartbeat execution

## Root cause

`no_agent` jobs execute and return before the normal agent path initializes the cron delivery ContextVars. As a result, script subprocesses did not receive the job's resolved target and could inherit unrelated ambient routing values.

A follow-up independent review also found that a generic post-sanitization override map could reintroduce arbitrary variables. The final implementation filters that map to the three cron delivery-routing keys only.

## Tests

- `tests/cron/test_cron_no_agent.py`: 8 passed
- `scripts/run_tests.sh tests/cron -q`: 376 passed across 34 isolated test files
- scoped `ruff check`: passed
- scoped `compileall`: passed
- `git diff --check`: passed

Regression coverage verifies explicit Discord platform/chat/thread routing, fail-closed clearing for `deliver=local` under hostile ambient routing values, and rejection of non-routing environment overrides.
