### PR TITLE
fix(agent): three fixes for compression deadlock, output cap, and total_tokens

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2401,7 +2401,9 @@ class ContextCompressor(ContextEngine):
         # consistency — otherwise the inflated total still exceeds
         # ``threshold_tokens`` and re-triggers compression after a successful
         # compaction (the \"compression deadlock\" bug, issue #40803).
-        self.last_total_tokens = max(0, usage.get("total_tokens", 0) - cache_read)
+        if "total_tokens" in usage:
+            self.last_total_tokens = max(0, usage["total_tokens"] - cache_read)
+        # else: preserve existing last_total_tokens (provider may omit total_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
             if self.last_prompt_tokens < self.threshold_tokens:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2375,10 +2375,33 @@ class ContextCompressor(ContextEngine):
         self._compression_telemetry_seed: Optional[Dict[str, Any]] = None
 
     def update_from_response(self, usage: Dict[str, Any]):
-        """Update tracked token usage from API response."""
-        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        """Update tracked token usage from API response.
+
+        IMPORTANT: ``last_prompt_tokens`` and ``last_real_prompt_tokens`` must
+        exclude ``cache_read_tokens``.  The API reports ``prompt_tokens`` as
+        ``input_tokens + cache_read_tokens + cache_write_tokens``.  Cache-hit
+        tokens are constant for a given system prompt — they do NOT shrink when
+        conversation messages are compressed.  If we include them in
+        ``last_prompt_tokens``, the compressor sees the same high value after
+        every compaction, thinks compression failed to reduce the context, and
+        fires again, forever (the "compression deadlock" bug).
+        """
+        raw_prompt = usage.get("prompt_tokens", 0)
+        cache_read = usage.get("cache_read_tokens", 0)
+        # Non-cached prompt tokens = the variable portion that actually changes
+        # when messages are compressed.  Clamp to 0 to avoid negatives from
+        # rounding or unexpected usage shapes.
+        self.last_prompt_tokens = max(0, raw_prompt - cache_read)
         self.last_completion_tokens = usage.get("completion_tokens", 0)
-        self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
+        # Exclude ``cache_read_tokens`` from ``total_tokens`` too.
+        # ``total_tokens`` = ``prompt_tokens + completion_tokens``, and
+        # ``prompt_tokens`` = ``input_tokens + cache_read_tokens +
+        # cache_write_tokens``.  Since ``last_prompt_tokens`` already excludes
+        # ``cache_read_tokens``, ``last_total_tokens`` must do the same for
+        # consistency — otherwise the inflated total still exceeds
+        # ``threshold_tokens`` and re-triggers compression after a successful
+        # compaction (the \"compression deadlock\" bug, issue #40803).
+        self.last_total_tokens = max(0, usage.get("total_tokens", 0) - cache_read)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
             if self.last_prompt_tokens < self.threshold_tokens:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4655,13 +4655,21 @@ def run_conversation(
                         )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
-                            safe_out = max(1, min(available_out, local_available_out) - 64)
+                            _total_budget = min(available_out, local_available_out)
+                            # Safety margin: 512 tokens covers estimation
+                            # error (±1-2%), vLLM "at least" semantics,
+                            # meta-token overhead from tools/schemas, and
+                            # retry overhead (additional continuation
+                            # messages in context).  Also enforce a 1% floor
+                            # so extremely small budgets don't round to
+                            # negative after margin subtraction.
+                            safe_out = max(1, min(int(_total_budget * 0.99), _total_budget - 512))
                         else:
                             # The rough local estimate can overshoot the real
                             # request size.  Fall back to the provider-reported
                             # budget, which is authoritative for the failed
-                            # request.
-                            safe_out = max(1, available_out - 64)
+                            # request.  Apply the same safety margin.
+                            safe_out = max(1, min(int(available_out * 0.99), available_out - 512))
                         agent._ephemeral_max_output_tokens = safe_out
                         agent._buffer_vprint(
                             f"⚠️  Output cap too large for current prompt — "

--- a/tests/agent/test_compression_deadlock_cache_read.py
+++ b/tests/agent/test_compression_deadlock_cache_read.py
@@ -1,0 +1,54 @@
+"""Regression: last_total_tokens must exclude cache_read_tokens.
+
+When an API response includes cache_read_tokens, total_tokens =
+prompt_tokens + completion_tokens includes the cache-read portion.
+If last_total_tokens keeps cache_read, it stays above threshold after
+compression and re-triggers compaction — the \"compression deadlock\"
+(issue #40803).
+
+Both last_prompt_tokens and last_total_tokens must exclude cache_read
+so the compressor correctly sees that compression reduced the context.
+"""
+
+from agent.context_compressor import ContextCompressor
+
+
+def test_total_tokens_excludes_cache_read():
+    """last_total_tokens must subtract cache_read_tokens, matching last_prompt_tokens."""
+    c = ContextCompressor(model="test", quiet_mode=True, config_context_length=200000)
+
+    # Scenario: 200k model, cache_read=80k, input=40k, output=10k
+    # prompt_tokens = 40 + 80 + 10(cache_write, assume 0) = 120
+    # total_tokens  = 120 + 10 = 130
+    # last_prompt_tokens = 120 - 80 = 40  (excludes cache_read)
+    # last_total_tokens  must also be ~50 = 40(input) + 10(output)  (excludes cache_read)
+    c.update_from_response({
+        "prompt_tokens": 120,
+        "completion_tokens": 10,
+        "total_tokens": 130,
+        "cache_read_tokens": 80,
+    })
+    assert c.last_prompt_tokens == 40
+    assert c.last_total_tokens == 50, (
+        f"Expected last_total_tokens=50 (excludes cache_read), got {c.last_total_tokens}"
+    )
+
+
+def test_total_tokens_no_cache_unchanged():
+    """When cache_read_tokens is 0 or absent, total should equal API total."""
+    c = ContextCompressor(model="test", quiet_mode=True, config_context_length=200000)
+
+    c.update_from_response({
+        "prompt_tokens": 100,
+        "completion_tokens": 30,
+        "total_tokens": 130,
+    })
+    assert c.last_total_tokens == 130
+
+    c.update_from_response({
+        "prompt_tokens": 100,
+        "completion_tokens": 30,
+        "total_tokens": 130,
+        "cache_read_tokens": 0,
+    })
+    assert c.last_total_tokens == 130


### PR DESCRIPTION
## Summary

Three bug fixes for context compression and output token cap.

### 1. Fix compression deadlock (cache_read_tokens)
Subtract `cache_read_tokens` from `last_total_tokens` in `update_from_response()`. Previously included cache hits caused infinite compression loops.

### 2. Output cap safety margin 64→512 + 1% ratio guard
Increased safety margin and added proportional floor to prevent false positives.

### 3. Preserve last_total_tokens when provider omits total_tokens
Only update when present; preserves previous value instead of corrupting with 0.