### PR TITLE
fix(desktop): restore persisted backend skin after gateway registers it

### DIFF
--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -67,4 +67,29 @@ describe('ThemeProvider ← backend skin sync', () => {
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
   })
+
+  it('restores a persisted BACKEND skin after the gateway.ready seed (no apply)', () => {
+    // A backend skin (e.g. `catppuccin` from $HERMES_HOME/skins) cannot
+    // resolve at boot — the gateway hasn't announced it yet — so the user's
+    // persisted choice would previously fall back to the default and stay
+    // there. The gateway.ready seed (apply:false) must re-resolve it.
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'bloomberg')
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    // Before the backend announces anything, the persisted skin is unresolvable:
+    // paint is on the default.
+    expect(cssVar('--theme-foreground')).not.toBe('#ff9f0a')
+
+    // gateway.ready: seed the backend skin into the registry WITHOUT applying.
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    // The persisted pref now resolves — the user's choice must repaint even
+    // though the seed itself never applies.
+    expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+  })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -351,6 +351,20 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
 
+  // A backend skin (from $HERMES_HOME/skins, announced via gateway.ready /
+  // skin.changed) registers AFTER boot, so the persisted pick that the boot
+  // paint and the initial state fell back from may only resolve now. Re-read
+  // the persisted skin whenever the backend theme registry grows; if it now
+  // resolves to something we're not already showing, adopt it. This is what
+  // lets a backend skin the user already chose survive a restart instead of
+  // snapping back to the default. The functional update preserves reference
+  // identity on the common no-op path so unrelated registry churn never
+  // re-renders the (expensive) themed tree.
+  useEffect(() => {
+    const persisted = skinPref.resolve(profileKey)
+    setThemeNameState(prev => (persisted === prev ? prev : persisted))
+  }, [backendThemes, profileKey])
+
   const systemDark = useMediaQuery('(prefers-color-scheme: dark)')
   const resolvedMode = resolveMode(mode, systemDark)
 


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app snapping back to the default theme on every restart when the chosen theme is a backend skin (a YAML skin under `$HERMES_HOME/skins`, announced by the gateway, e.g. `skin: catppuccin` in `config.yaml`).

Root cause: backend skins are announced on `gateway.ready`, which fires after the ThemeProvider has already resolved the persisted theme choice. At that point `normalizeSkin` can't resolve the stored name yet, so it falls back to the default. Nothing re-reads the persisted choice once the skin registers, so the user's pick is stored but never painted again.

The fix re-reads the persisted skin whenever the backend theme registry grows and adopts it when it resolves to something we're not already showing. A functional `setState` keeps reference identity on the no-op path, so unrelated registry churn doesn't re-render the themed tree.

Related: #75374 fixes the same class of bug for plugin-contributed themes (contrib registry). This PR covers the backend-skin store; the two registries don't overlap.

## Related Issue

No issue filed — found while debugging on Fedora. Searched open PRs before opening; #75374 is the closest existing one and covers the contributed-theme path, not backend skins.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/themes/context.tsx`: new effect keyed on `backendThemes` + `profileKey` that re-resolves the persisted skin name whenever the backend registry grows
- `apps/desktop/src/themes/context.test.tsx`: regression test reproducing the race (persisted backend skin → boot falls back to default → gateway seed registers the skin → assert repaint)

## How to Test

Reproduction: set `skin: catppuccin` (or any skin in `$HERMES_HOME/skins`) in `config.yaml`, pick it in Appearance, restart the app. Without the fix the app paints the default on every launch; with it the choice sticks.

Verification done:

1. New regression test fails on `main` without the fix, passes with it (red-green confirmed)
2. Full themes suite green: 8 files / 67 tests
3. Rebuilt the packaged desktop app and confirmed the fix is in the shipped bundle

Platform tested: Fedora 44 x86_64, packaged Electron build.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: change is in the desktop app (TypeScript); ran the vitest themes suite instead (8 files / 67 tests green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44 x86_64

### Documentation & Housekeeping

- [x] N/A for all: no new config keys, no architecture changes, no tool behavior changes, no new skills

## Notes

Authored with AI assistance (Hermes Agent); the diff, reproduction, and test were verified manually before submitting.
