### PR TITLE
fix(auth): actionable CAPTCHA-aware guidance on Nous device-auth timeout

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5123,7 +5123,10 @@ def _poll_for_token(
         description = error_payload.get("error_description") or "Unknown authentication error"
         raise RuntimeError(f"{error_code}: {description}")
 
-    raise TimeoutError("Timed out waiting for device authorization")
+    # Enriched at the SOURCE so every caller inherits the guidance:
+    # the CLI login (_nous_device_code_login) and the dashboard/desktop
+    # poller (web_server._nous_poller, which surfaces str(e) to the UI).
+    raise TimeoutError(_nous_device_auth_timeout_message(portal_base_url))
 
 
 # =============================================================================
@@ -8631,19 +8634,14 @@ def _nous_device_code_login(
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
-        try:
-            token_data = _poll_for_token(
-                client=client,
-                portal_base_url=portal_base_url,
-                client_id=client_id,
-                device_code=str(device_data["device_code"]),
-                expires_in=expires_in,
-                poll_interval=interval,
-            )
-        except TimeoutError as exc:
-            raise TimeoutError(
-                _nous_device_auth_timeout_message(portal_base_url)
-            ) from exc
+        token_data = _poll_for_token(
+            client=client,
+            portal_base_url=portal_base_url,
+            client_id=client_id,
+            device_code=str(device_data["device_code"]),
+            expires_in=expires_in,
+            poll_interval=interval,
+        )
 
     now = datetime.now(timezone.utc)
     token_expires_in = _coerce_ttl_seconds(token_data.get("expires_in", 0))

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5058,6 +5058,25 @@ def _request_device_code(
     return data
 
 
+def _nous_device_auth_timeout_message(portal_base_url: str) -> str:
+    """Actionable timeout text for Nous device-code login failures.
+
+    A bare "Timed out waiting for device authorization" gives the user
+    nothing to act on. The most common cause is Portal sign-in failing in
+    the opened browser tab (including the server-side CAPTCHA loop from
+    #20605), so point at the Portal login page and the retry command.
+    """
+    portal = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    return (
+        "Timed out waiting for device authorization.\n"
+        "  Portal sign-in is required before the device code can be approved.\n"
+        "  If the browser showed a CAPTCHA / 'You did not pass CAPTCHA' error,\n"
+        "  finish signing in at the Portal in a normal browser tab, then retry:\n"
+        "    hermes portal\n"
+        f"  Portal login: {portal}/login"
+    )
+
+
 def _poll_for_token(
     client: httpx.Client,
     portal_base_url: str,
@@ -8612,14 +8631,19 @@ def _nous_device_code_login(
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
-        token_data = _poll_for_token(
-            client=client,
-            portal_base_url=portal_base_url,
-            client_id=client_id,
-            device_code=str(device_data["device_code"]),
-            expires_in=expires_in,
-            poll_interval=interval,
-        )
+        try:
+            token_data = _poll_for_token(
+                client=client,
+                portal_base_url=portal_base_url,
+                client_id=client_id,
+                device_code=str(device_data["device_code"]),
+                expires_in=expires_in,
+                poll_interval=interval,
+            )
+        except TimeoutError as exc:
+            raise TimeoutError(
+                _nous_device_auth_timeout_message(portal_base_url)
+            ) from exc
 
     now = datetime.now(timezone.utc)
     token_expires_in = _coerce_ttl_seconds(token_data.get("expires_in", 0))

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1092,8 +1092,45 @@ class TestNousDeviceAuthTimeoutMessage:
         assert f"{DEFAULT_NOUS_PORTAL_URL.rstrip('/')}/login" in msg
 
 
+def test_poll_for_token_timeout_raises_actionable_message():
+    """The poll deadline must raise the CAPTCHA-aware guidance at the SOURCE,
+    so both the CLI login and the dashboard poller (web_server._nous_poller,
+    which surfaces str(e) to the UI) inherit it."""
+    import httpx
+    import pytest
+
+    import hermes_cli.auth as auth_mod
+
+    class _PendingClient:
+        def post(self, url, data=None):
+            request = httpx.Request("POST", url)
+            return httpx.Response(
+                400,
+                json={"error": "authorization_pending"},
+                request=request,
+            )
+
+    from typing import cast
+
+    with pytest.raises(TimeoutError) as excinfo:
+        auth_mod._poll_for_token(
+            client=cast(httpx.Client, _PendingClient()),
+            portal_base_url="https://portal.nousresearch.com",
+            client_id="hermes-cli",
+            device_code="device",
+            expires_in=1,
+            poll_interval=1,
+        )
+
+    msg = str(excinfo.value)
+    assert "CAPTCHA" in msg
+    assert "hermes portal" in msg
+    assert "https://portal.nousresearch.com/login" in msg
+
+
 def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):
-    """Poll timeout must surface the CAPTCHA-aware guidance, not a bare line."""
+    """Poll timeout must surface the CAPTCHA-aware guidance through the CLI
+    login flow (propagates unchanged from _poll_for_token)."""
     import pytest
 
     import hermes_cli.auth as auth_mod
@@ -1115,7 +1152,11 @@ def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):
     )
 
     def _timeout(**kwargs):
-        raise TimeoutError("Timed out waiting for device authorization")
+        raise TimeoutError(
+            auth_mod._nous_device_auth_timeout_message(
+                kwargs.get("portal_base_url", "")
+            )
+        )
 
     monkeypatch.setattr(auth_mod, "_poll_for_token", _timeout)
     monkeypatch.setattr(auth_mod.webbrowser, "open", lambda url: True)

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1064,3 +1064,72 @@ class TestStalePortalBaseUrlMigration:
 
         auth_mod.resolve_nous_runtime_credentials()
         assert refresh_calls == [auth_mod.DEFAULT_NOUS_PORTAL_URL]
+
+
+# =============================================================================
+# Device-auth timeout guidance (#20605 kernel from PR #75290)
+# =============================================================================
+
+
+class TestNousDeviceAuthTimeoutMessage:
+    def test_timeout_message_mentions_captcha_login_and_retry(self):
+        from hermes_cli.auth import _nous_device_auth_timeout_message
+
+        msg = _nous_device_auth_timeout_message("https://portal.nousresearch.com")
+        assert "CAPTCHA" in msg
+        assert "hermes portal" in msg
+        assert "https://portal.nousresearch.com/login" in msg
+        # Must NOT point at the nonexistent /device page (live Portal 404s it).
+        assert "/device" not in msg
+
+    def test_timeout_message_falls_back_to_default_portal(self):
+        from hermes_cli.auth import (
+            DEFAULT_NOUS_PORTAL_URL,
+            _nous_device_auth_timeout_message,
+        )
+
+        msg = _nous_device_auth_timeout_message("")
+        assert f"{DEFAULT_NOUS_PORTAL_URL.rstrip('/')}/login" in msg
+
+
+def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):
+    """Poll timeout must surface the CAPTCHA-aware guidance, not a bare line."""
+    import pytest
+
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_request_device_code",
+        lambda **kwargs: {
+            "device_code": "device",
+            "user_code": "SMCL-97YT",
+            "verification_uri": "https://portal.nousresearch.com/manage-subscription",
+            "verification_uri_complete": (
+                "https://portal.nousresearch.com/manage-subscription"
+                "?user_code=SMCL-97YT"
+            ),
+            "expires_in": 600,
+            "interval": 1,
+        },
+    )
+
+    def _timeout(**kwargs):
+        raise TimeoutError("Timed out waiting for device authorization")
+
+    monkeypatch.setattr(auth_mod, "_poll_for_token", _timeout)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda url: True)
+    monkeypatch.setattr("builtins.print", lambda *a, **k: None)
+
+    with pytest.raises(TimeoutError) as excinfo:
+        auth_mod._nous_device_code_login(
+            portal_base_url="https://portal.nousresearch.com",
+            inference_base_url="https://inference.example.com/v1",
+            open_browser=False,
+            timeout_seconds=1,
+        )
+
+    msg = str(excinfo.value)
+    assert "CAPTCHA" in msg
+    assert "hermes portal" in msg
+    assert "https://portal.nousresearch.com/login" in msg


### PR DESCRIPTION
## Summary
When a Nous Portal device-code login times out, the CLI now tells the user what actually went wrong and how to recover — instead of a bare "Timed out waiting for device authorization".

## Context

First-time users sign in via `hermes portal` / quick setup: Hermes opens a browser page and polls up to 10 minutes for the user to approve the sign-in. When approval never comes — most commonly because the Portal website hit them with the "You did not pass CAPTCHA" loop so they could never sign in at all — the CLI gave up with:

```
Login failed: Timed out waiting for device authorization
Login cancelled or failed.
```

That's a dead end: the user can't tell whether Hermes is broken, whether to retry, or what to fix. Issue #20605 is exactly this — a user filed "i can not sign in" because the message gave them nothing to act on. (The CAPTCHA loop itself is server-side on portal.nousresearch.com; the client can't fix it, but it CAN tell the user how to get around it.)

After this PR, the same failure prints:

```
Timed out waiting for device authorization.
  Portal sign-in is required before the device code can be approved.
  If the browser showed a CAPTCHA / 'You did not pass CAPTCHA' error,
  finish signing in at the Portal in a normal browser tab, then retry:
    hermes portal
  Portal login: https://portal.nousresearch.com/login
```

The user learns: the problem was in the browser tab (not Hermes), the concrete recovery (sign in at the Portal normally, then rerun `hermes portal`), and the exact URL. Successful logins are untouched — this only changes the timeout path.

## Provenance — salvaged from #75290 by @HexLab98

#75290 contained two changes; only this one survived review:

1. **Kept (this PR):** the CAPTCHA-aware timeout message. Authorship preserved (commit authored by @HexLab98).
2. **Dropped:** rewriting the Portal's `manage-subscription?user_code=…` verification URL to `/device?user_code=…`. Live verification killed it: the Portal's device-code API intentionally returns manage-subscription URLs, and the `/device` route **does not exist** (404 with a real user_code — full probe in the close comment on #75290). The rewrite would have sent every Portal login to a dead page. The guidance text here is accordingly reworded to reference only real URLs (`/login`), and a regression test pins that the message never mentions `/device`.

## Changes
- `hermes_cli/auth.py`: new `_nous_device_auth_timeout_message()` helper; `_poll_for_token`'s deadline raise is enriched at the SOURCE so both callers inherit it — the CLI login (`_nous_device_code_login`) AND the dashboard/desktop poller (`web_server._nous_poller`, which surfaces `str(e)` to the UI). (The first commit wrapped only the CLI call site; the follow-up commit from the /simplify-code pass moved the enrichment to the source after the reviewers caught the uncovered dashboard sibling.)
- `tests/hermes_cli/test_auth_nous_provider.py`: 4 tests — message content, default-portal fallback, a source-level test driving the real `_poll_for_token` loop to its deadline (covers the dashboard path), the CLI-flow propagation test, plus the "never points at /device" guard

## Validation
| | Result |
|---|---|
| tests/hermes_cli/test_auth_nous_provider.py | 29 passed |
| tests/hermes_cli/test_web_oauth_dispatch.py | 15 passed |
| Mutation check (revert source enrichment) | guard test fails → restore → green |
| ruff | clean |

Related: #20605 (closed — root cause is the server-side CAPTCHA loop).
Based on #75290 by @HexLab98.

## Sibling sites (noted, out of scope)
The xAI device flow (`hermes_cli/auth.py` ~L7849) and Copilot (`hermes_cli/copilot_auth.py` ~L284) also print bare timeout messages. The CAPTCHA/portal-login guidance here is Nous-Portal-specific and doesn't generalize as-is, so those are left for a follow-up if their providers develop comparable recurring sign-in failure modes.
