### PR TITLE
fix(update): self-owned / hand-off markers must not read as foreign locks(更新标记自锁/交接问题修复——桌面端更新按钮在 Windows 上每次必失败)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/Cargo.toml
+++ b/apps/bootstrap-installer/src-tauri/Cargo.toml
@@ -17,9 +17,15 @@ path = "src/main.rs"
 # The library target name MUST match the `withGlobalTauri` binding name that
 # tauri.conf.json's `app.windows[].label` references. We don't ship a separate
 # lib for now; everything is in src/.
+#
+# NOTE (local build fix): `cdylib` removed — the desktop binary is a plain
+# rlib consumer (main.rs calls hermes_bootstrap_lib::run()), and on the GNU
+# toolchain the cdylib's default export-all-symbols overflows the PE export
+# ordinal limit (65535). MSVC's link.exe only exports marked symbols, which
+# is why upstream CI never hit this. Kept staticlib/rlib for testability.
 [lib]
 name = "hermes_bootstrap_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["staticlib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -150,6 +150,17 @@ fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
     let mut lines = raw.lines();
     let pid: u32 = lines.next()?.trim().parse().ok()?;
     let started_at: u64 = lines.next().unwrap_or("").trim().parse().unwrap_or(0);
+
+    // Self-owned marker: the desktop pre-writes the marker with OUR pid before
+    // spawning us (see electron/update-marker.ts writeUpdateMarker) to close
+    // the #73822 window. A marker whose pid is this very process must never
+    // read as a foreign holder, or a desktop-initiated update immediately
+    // refuses itself with "Another Hermes update is already running
+    // (PID <our own pid>, started 2s ago)" and fails on every click.
+    if pid == std::process::id() {
+        return None;
+    }
+
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -383,6 +394,16 @@ async fn run_update(app: AppHandle) -> Result<()> {
     update_args.push("--force".into());
     update_args.push("--branch".into());
     update_args.push(update_branch);
+
+    // Hand the marker over to `hermes update` before spawning it: the CLI's
+    // UpdateLock.acquire() refuses any live marker it does not own, and with
+    // OUR pid still in the file that would make the updater refuse its own
+    // child ("Another Hermes update is already running (PID <our pid>)"),
+    // dead-ending every desktop-initiated update. complete() is idempotent
+    // (Drop tolerates an already-removed marker), and the CLI takes over by
+    // writing its own pid, so mutual exclusion is preserved across the whole
+    // chain: desktop pre-write -> our guard -> `hermes update`'s lock.
+    _update_marker.complete();
 
     emit_stage(&app, "update", StageState::Running, None, None);
     let started = Instant::now();

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -168,6 +168,27 @@ class UpdateHolder:
     age_seconds: float
 
 
+def _pid_is_updater(pid: int) -> bool:
+    """True when the marker holder is the Tauri updater (hermes-setup.exe).
+
+    The desktop hands the update off to that process, and it spawns this
+    ``hermes update`` as its child — so a marker owned by it is the same
+    update chain, not a foreign concurrent update. The marker contract
+    (update.rs UpdateMarkerGuard + update_lock.py UpdateLock) intends the
+    child to take ownership (overwrite the marker with its own pid); this
+    exemption is what lets the hand-off actually proceed.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return False
+    try:
+        name = psutil.Process(pid).name().lower()
+    except Exception:
+        return False
+    return name in ("hermes-setup.exe", "hermes-setup")
+
+
 def read_live_update(*, path: Path | None = None) -> UpdateHolder | None:
     """Return the live update holding the lock, or ``None``.
 
@@ -191,6 +212,23 @@ def read_live_update(*, path: Path | None = None) -> UpdateHolder | None:
         started_at = float(lines[1].strip())
     except (IndexError, ValueError):
         started_at = float("-inf")
+
+    # Self-owned marker: this process (or its hand-off partner — the desktop
+    # pre-writes the marker with the *updater's own pid* before spawning it,
+    # see electron/update-marker.ts writeUpdateMarker) already owns the lock.
+    # A marker whose pid is ours must never read as a foreign holder, or a
+    # desktop-initiated update would immediately refuse itself with
+    # "Another Hermes update is already running (PID <our own pid>)".
+    if pid == os.getpid():
+        return None
+
+    # Hand-off partner marker: the Tauri updater (hermes-setup.exe) wrote the
+    # marker with ITS pid before spawning this `hermes update` (see
+    # apps/bootstrap-installer/src-tauri/src/update.rs UpdateMarkerGuard).
+    # Same update chain — take over the marker instead of refusing ourselves
+    # with "Another Hermes update is already running (PID <updater's pid>)".
+    if _pid_is_updater(pid):
+        return None
 
     age = time.time() - started_at
     if not _pid_alive(pid) or age > UPDATE_MARKER_MAX_AGE_SECONDS:


### PR DESCRIPTION
Problem
Every in-app "Update" click on Windows fails:

Another Hermes update is already running (PID <updater's own pid>, started 2s ago)
followed by Hermes is still running. Close all Hermes windows and try the update again.
Root cause: the desktop pre-writes .hermes-update-in-progress with the spawned updater's OWN pid before hand-off (writeUpdateMarker, the #73822 window). Three layers then misread that marker as a foreign concurrent update and refused:

Rust UpdateMarkerGuard::acquire() saw its own live pid and aborted.
The CLI hermes update (UpdateLock.acquire) refused the marker the updater still held when the updater spawned it.
update_lock.py release() documented the hand-off-partner contract but acquire() never implemented it.
Fix
update.rs live_marker_owner: pid == self => no foreign owner; and complete() the marker BEFORE spawning hermes update so the CLI takes ownership (writes its own pid).
update_lock.py read_live_update: pid == os.getpid() OR holder is hermes-setup.exe (our hand-off partner) => not a foreign lock.
Cargo.toml: drop cdylib crate-type — with withGlobalTauri: false the desktop binary is a plain rlib consumer, and on the GNU toolchain the cdylib's export-all-symbols overflows the PE ordinal limit (65535).
Verification
Desktop-initiated update completes end-to-end (git pull, deps, web UI, desktop rebuild, auto-relaunch).
Marker mutual exclusion still rejects genuine concurrent updates.

________________________________________
问题
Windows 上点击桌面端"更新软件"按钮每次都失败，报错：

Another Hermes update is already running (PID <更新器自己的PID>, started 2s ago)
随后是 Hermes is still running. Close all Hermes windows and try the update again.
根因
桌面端为防止 #73822 漏洞（更新器启动慢导致 renderer 重启后端、锁住 .pyd 文件）， 在交出更新流程前，会用【即将启动的更新器自己的 PID】预写 .hermes-update-in-progress 标记文件（writeUpdateMarker）。结果三个环节都把该标记误判为"另一个并发更新"而拒绝：

Rust 侧 UpdateMarkerGuard::acquire() 读到自己的 PID 还活着，直接中止—— "Another Hermes update is already running (PID <自己>)"
Rust 更新器调用 hermes update（CLI）时标记仍被更新器持有，CLI 的 UpdateLock.acquire() 因不拥有该标记而拒绝——刚修好第 1 个问题又死在第 2 个
update_lock.py 的 release() 注释明确写了 hand-off partner（更新器）会接管标记， 但 acquire() 的实现从未实现该语义
修复内容
update.rs 的 live_marker_owner：pid == 自身 时不视为外部持有者； 并在启动 hermes update 子进程【之前】调用 complete() 释放自己的标记， 让 CLI 写入自己的 PID 完成接管
update_lock.py 的 read_live_update：pid == os.getpid() 或持有者是 hermes-setup.exe（我们的 hand-off 交接方）时，不视为外部锁
Cargo.toml：移除 cdylib crate-type——withGlobalTauri: false 时桌面端 二进制只是普通 rlib 消费者；且 GNU 工具链下 cdylib 的导出所有符号会溢出 PE 导出序号上限（65535）
验证
桌面端发起更新完整跑通：git 拉取 → 依赖安装 → Web UI 构建 → 桌面端重建 → 自动重启
标记互斥仍然有效：真实的并发更新依旧会被正确拒绝