### PR TITLE
fix(agent): suppress file-mutation footer for args-missing calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3305,11 +3305,13 @@ class AIAgent:
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
-        success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
+        On failure, store ``{path: {error_preview, tool, kind}}`` entries.
+        ``kind`` is ``args_missing`` when the tool never reached disk (bad
+        call shape) or ``apply_failed`` after a real attempt.  On success,
+        remove any prior failure entries for the same paths (the model
+        recovered within the turn).  Silently no-ops if the per-turn state
+        dict hasn't been initialised yet (e.g. a tool dispatched outside
+        ``run_conversation``).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -3326,6 +3328,21 @@ class AIAgent:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
         if is_error and not landed:
             preview = _extract_error_preview(result)
+            # Formation errors never touched disk. Keep them in per-turn
+            # state so a later success can clear them, but do not treat them
+            # as overclaim-worthy attempted edits (#70719).
+            preview_l = preview.strip().lower()
+            args_missing_markers = (
+                "path required",
+                "old_string and new_string required",
+                "patch content required",
+                "content required",
+            )
+            kind = (
+                "args_missing"
+                if any(m in preview_l for m in args_missing_markers)
+                else "apply_failed"
+            )
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
@@ -3334,6 +3351,7 @@ class AIAgent:
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,
+                        "kind": kind,
                     }
         else:
             for path in targets:
@@ -3409,6 +3427,14 @@ class AIAgent:
         bare-path media extractor can never auto-attach a protected file
         (e.g. ``~/.hermes/config.yaml``) to a messaging channel (#35584).
         """
+        # Formation errors never attempted a write. Keep the tool error for
+        # the model; reserve the overclaim footer for real apply failures
+        # (#70719). Missing ``kind`` keeps pre-classification behavior.
+        failed = {
+            path: info
+            for path, info in failed.items()
+            if info.get("kind", "apply_failed") != "args_missing"
+        }
         if not failed:
             return ""
         lines = [

--- a/run_agent.py
+++ b/run_agent.py
@@ -3345,9 +3345,14 @@ class AIAgent:
             )
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
-                # later see success.  A repeated failure with a different
-                # message shouldn't silently overwrite the original.
-                if path not in state:
+                # later see success.  Exception: promote args_missing to
+                # apply_failed so a real failed edit is not hidden by the
+                # formation-error footer filter.
+                existing = state.get(path)
+                if existing is None or (
+                    existing.get("kind") == "args_missing"
+                    and kind == "apply_failed"
+                ):
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -147,6 +147,32 @@ class TestRecordFileMutationResult:
         assert state["/tmp/a.md"]["kind"] == "args_missing"
         assert AIAgent._format_file_mutation_failure_footer(state) == ""
 
+    def test_args_missing_promoted_by_later_apply_failed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": "/tmp/a.md"},
+            json.dumps({"success": False, "error": "old_string and new_string required"}),
+            is_error=True,
+        )
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "/tmp/a.md",
+                "old_string": "x",
+                "new_string": "y",
+            },
+            json.dumps({"success": False, "error": "Could not find old_string"}),
+            is_error=True,
+        )
+
+        state = agent._turn_failed_file_mutations
+        assert state["/tmp/a.md"]["kind"] == "apply_failed"
+        assert "Could not find old_string" in state["/tmp/a.md"]["error_preview"]
+        footer = AIAgent._format_file_mutation_failure_footer(state)
+        assert footer
+        assert "/tmp/a.md" in footer
+
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()
         # First attempt fails

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -133,6 +133,19 @@ class TestRecordFileMutationResult:
         assert "/tmp/a.md" in state
         assert state["/tmp/a.md"]["tool"] == "patch"
         assert "Could not find old_string" in state["/tmp/a.md"]["error_preview"]
+        assert state["/tmp/a.md"]["kind"] == "apply_failed"
+
+    def test_missing_patch_arguments_do_not_render_overclaim_footer(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": "/tmp/a.md"},
+            json.dumps({"success": False, "error": "old_string and new_string required"}),
+            is_error=True,
+        )
+
+        state = agent._turn_failed_file_mutations
+        assert state["/tmp/a.md"]["kind"] == "args_missing"
+        assert AIAgent._format_file_mutation_failure_footer(state) == ""
 
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()


### PR DESCRIPTION
## Summary

The file-mutation verifier footer was firing on tool-call formation errors such as `old_string and new_string required`. Those calls never touch disk, so the overclaim banner is noise.

This change tags failures as `args_missing` vs `apply_failed`, keeps them in per-turn state so a later success can still clear them, and only renders the user footer for real apply failures.

## Test plan

- [x] `pytest tests/run_agent/test_file_mutation_verifier.py` (26 passed)
- [ ] Smoke: intentionally call `patch` with only `mode`+`path` and confirm no verifier footer; failed fuzzy match still shows footer

Closes #70719
