### PR TITLE
fix(tui): complete TUI-local slash commands in Tab menu

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { completionRequestForInput } from '../hooks/useCompletion.js'
+import { completionRequestForInput, mergeLocalSlashItems } from '../hooks/useCompletion.js'
+
+describe('mergeLocalSlashItems', () => {
+  it('adds TUI-local commands from the dispatch registry', () => {
+    expect(mergeLocalSlashItems('/wid', []).map(item => item.text)).toContain('/widgets-reload')
+  })
+
+  it('preserves gateway entries and does not suggest commands after arguments', () => {
+    const gatewayItem = {
+      display: '/widgets-reload',
+      meta: 'gateway metadata',
+      text: '/widgets-reload'
+    }
+
+    const widgetAppItem = {
+      display: '/widget-usage',
+      meta: 'widget app metadata',
+      text: '/widget-usage'
+    }
+
+    expect(mergeLocalSlashItems('/wid', [gatewayItem, widgetAppItem])).toEqual([gatewayItem, widgetAppItem])
+    expect(mergeLocalSlashItems('/wid reload', [])).toEqual([])
+  })
+})
 
 describe('completionRequestForInput', () => {
   it('routes real slash commands to slash completion', () => {

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
+import { SLASH_COMMANDS } from '../app/slash/registry.js'
 import { inlineSlashTrigger, looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
@@ -20,6 +21,41 @@ export function mergeWidgetAppItems(input: string, items: CompletionItem[]): Com
     .filter(app => `/${app.id}`.startsWith(input.toLowerCase()))
     .filter(app => !items.some(item => item.text === `/${app.id}`))
     .map(app => ({ display: `/${app.id}`, meta: app.help, text: `/${app.id}` }))
+
+  return [...items, ...local]
+}
+
+/** TUI-local slash commands dispatch from SLASH_COMMANDS without going through
+ *  the gateway completer. Merge them into `/` Tab results so names like
+ *  `/widgets-reload` are discoverable (#70649). Gateway entries stay first. */
+export function mergeLocalSlashItems(input: string, items: CompletionItem[]): CompletionItem[] {
+  // Only complete the command NAME position (no args typed yet).
+  if (input.includes(' ')) {
+    return items
+  }
+
+  const knownNames = new Set(items.map(item => item.text.toLowerCase()))
+  const prefix = input.toLowerCase()
+
+  const local = SLASH_COMMANDS.flatMap(command =>
+    [command.name, ...(command.aliases ?? [])].map(name => ({
+      display: `/${name}`,
+      meta: command.help,
+      text: `/${name}`
+    }))
+  )
+    .filter(item => item.text.toLowerCase().startsWith(prefix))
+    .filter(item => {
+      const name = item.text.toLowerCase()
+
+      if (knownNames.has(name)) {
+        return false
+      }
+
+      knownNames.add(name)
+
+      return true
+    })
 
   return [...items, ...local]
 }
@@ -122,7 +158,9 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
           const r = asRpcResult<CompletionResponse>(raw)
 
           const fetched =
-            request.method === 'complete.slash' ? mergeWidgetAppItems(input, r?.items ?? []) : (r?.items ?? [])
+            request.method === 'complete.slash'
+              ? mergeLocalSlashItems(input, mergeWidgetAppItems(input, r?.items ?? []))
+              : (r?.items ?? [])
 
           // Mid-message offers SKILLS only. A built-in like `/model` or `/new`
           // acts on the app, so it's meaningless as a reference inside prose —

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
 import { rankSlashItems } from '../app/slash/fuzzyScore.js'
+import { SLASH_COMMANDS } from '../app/slash/registry.js'
 import { inlineSlashTrigger, looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
@@ -22,6 +23,41 @@ export function mergeWidgetAppItems(input: string, items: CompletionItem[]): Com
   const local = rankSlashItems(listWidgetApps(), input, app => ({ description: app.help, id: app.id }))
     .filter(app => !items.some(item => item.text === `/${app.id}`))
     .map(app => ({ display: `/${app.id}`, meta: app.help, text: `/${app.id}` }))
+
+  return [...items, ...local]
+}
+
+/** TUI-local slash commands dispatch from SLASH_COMMANDS without going through
+ *  the gateway completer. Merge them into `/` Tab results so names like
+ *  `/widgets-reload` are discoverable (#70649). Gateway entries stay first. */
+export function mergeLocalSlashItems(input: string, items: CompletionItem[]): CompletionItem[] {
+  // Only complete the command NAME position (no args typed yet).
+  if (input.includes(' ')) {
+    return items
+  }
+
+  const knownNames = new Set(items.map(item => item.text.toLowerCase()))
+  const prefix = input.toLowerCase()
+
+  const local = SLASH_COMMANDS.flatMap(command =>
+    [command.name, ...(command.aliases ?? [])].map(name => ({
+      display: `/${name}`,
+      meta: command.help,
+      text: `/${name}`
+    }))
+  )
+    .filter(item => item.text.toLowerCase().startsWith(prefix))
+    .filter(item => {
+      const name = item.text.toLowerCase()
+
+      if (knownNames.has(name)) {
+        return false
+      }
+
+      knownNames.add(name)
+
+      return true
+    })
 
   return [...items, ...local]
 }
@@ -124,7 +160,9 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
           const r = asRpcResult<CompletionResponse>(raw)
 
           const fetched =
-            request.method === 'complete.slash' ? mergeWidgetAppItems(input, r?.items ?? []) : (r?.items ?? [])
+            request.method === 'complete.slash'
+              ? mergeLocalSlashItems(input, mergeWidgetAppItems(input, r?.items ?? []))
+              : (r?.items ?? [])
 
           // Mid-message offers SKILLS only. A built-in like `/model` or `/new`
           // acts on the app, so it's meaningless as a reference inside prose —


### PR DESCRIPTION
## Summary

`/widgets-reload` (and other TUI-local `debugCommands`) already dispatch via `SLASH_COMMANDS`, but Tab completion only merged gateway `COMMAND_REGISTRY` results plus live widget app ids. That dual catalog left management names undiscoverable.

This merges `SLASH_COMMANDS` into slash completion on the client, keeps gateway entries first, and skips the name position once arguments are typed.

## Test plan

- [x] vitest `src/__tests__/useCompletion.test.ts` (6 passed)
- [ ] Type `/wid` in TUI and confirm `/widgets-reload` appears

Closes #70649
