### PR TITLE
fix(tts): prevent stalled streaming prefetch from wedging voice barge-in

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -602,6 +602,61 @@ def test_hybrid_done_event_waits_for_prefetch(monkeypatch):
     )
 
 
+def test_hybrid_interrupt_unblocks_stalled_prefetch_pipeline(monkeypatch):
+    """Barge-in must release capacity and playback waits on stalled streams."""
+    from tools import tts_tool
+
+    three_prefetches_started = threading.Event()
+    release_prefetches = threading.Event()
+    started = 0
+    started_lock = threading.Lock()
+
+    class _Stalled(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            nonlocal started
+            with started_lock:
+                started += 1
+                if started == 3:
+                    three_prefetches_started.set()
+            release_prefetches.wait(timeout=30.0)
+            yield b""
+
+    sd, out = _sd_mock()
+    q = _drain_queue([
+        "First sentence stalls here. ",
+        "Second sentence stalls here. ",
+        "Third sentence stalls here. ",
+        "Fourth sentence waits for capacity. ",
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Stalled({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        consumer = threading.Thread(
+            target=tts_tool.stream_tts_to_speaker,
+            args=(q, stop, done),
+            daemon=True,
+        )
+        consumer.start()
+        assert three_prefetches_started.wait(timeout=2.0)
+        try:
+            stop.set()
+            assert done.wait(timeout=1.0), (
+                "TTS interruption remained blocked on stalled prefetch requests"
+            )
+        finally:
+            release_prefetches.set()
+            consumer.join(timeout=2.0)
+
+
 def test_hybrid_single_sentence_still_works(monkeypatch):
     """A single-sentence reply should stream immediately with no batch."""
     from tools import tts_tool

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3459,7 +3459,14 @@ def stream_tts_to_speaker(
                             "mid-sentence) — partial audio only"
                         )
                         break
-                    chunk_queue.put(chunk, timeout=30.0)
+                    while not stop_event.is_set():
+                        try:
+                            chunk_queue.put(chunk, timeout=0.1)
+                            break
+                        except queue.Full:
+                            continue
+                    if stop_event.is_set():
+                        break
             except Exception as exc:
                 logger.warning(
                     "TTS CUT: streaming TTS prefetch failed mid-sentence "
@@ -3467,8 +3474,31 @@ def stream_tts_to_speaker(
                     exc,
                 )
             finally:
-                chunk_queue.put(None)  # sentinel: no more chunks
+                # On barge-in the playback worker abandons queued audio.  Make
+                # room for the sentinel instead of stranding this producer on
+                # a full bounded queue forever.
+                while True:
+                    try:
+                        chunk_queue.put(None, timeout=0.1)
+                        break
+                    except queue.Full:
+                        if stop_event.is_set():
+                            try:
+                                chunk_queue.get_nowait()
+                            except queue.Empty:
+                                pass
                 _prefetch_sem.release()  # free a prefetch slot
+
+        def _next_chunk_or_stop(
+            chunk_queue: "queue.Queue[Optional[bytes]]",
+        ) -> Optional[bytes]:
+            """Wait for one chunk while keeping barge-in responsive."""
+            while not stop_event.is_set():
+                try:
+                    return chunk_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+            return None
 
         def _reinit_output_stream():
             """Close the broken PortAudio stream and try to create a fresh one."""
@@ -3519,7 +3549,7 @@ def stream_tts_to_speaker(
                         if _current_stream is None:
                             _chunks = []
                             while True:
-                                chunk = chunk_queue.get()
+                                chunk = _next_chunk_or_stop(chunk_queue)
                                 if chunk is None:
                                     break
                                 _chunks.append(chunk)
@@ -3529,7 +3559,7 @@ def stream_tts_to_speaker(
                             continue
                         _pcm_leftover = b""
                         while True:
-                            chunk = chunk_queue.get()
+                            chunk = _next_chunk_or_stop(chunk_queue)
                             if chunk is None:
                                 break
                             if stop_event.is_set():
@@ -3592,7 +3622,7 @@ def stream_tts_to_speaker(
                         continue
                     _chunks = []
                     while True:
-                        chunk = chunk_queue.get()
+                        chunk = _next_chunk_or_stop(chunk_queue)
                         if chunk is None:
                             break
                         _chunks.append(chunk)
@@ -3608,7 +3638,14 @@ def stream_tts_to_speaker(
             except Exception as exc:
                 logger.warning("Streaming TTS synthesis failed: %s", exc)
                 return
-            _prefetch_sem.acquire()
+            while not stop_event.is_set():
+                if _prefetch_sem.acquire(timeout=0.1):
+                    break
+            else:
+                return
+            if stop_event.is_set():
+                _prefetch_sem.release()
+                return
             chunk_queue: "queue.Queue[Optional[bytes]]" = queue.Queue(maxsize=_CHUNK_QUEUE_MAX)
             _audio_queue.put(chunk_queue)
             t = threading.Thread(
@@ -3763,8 +3800,13 @@ def stream_tts_to_speaker(
         if streamer is not None and _worker_thread is not None:
             _audio_queue.put(None)
             _worker_thread.join(timeout=300.0)
-        for t in _prefetch_threads:
-            t.join(timeout=10.0)
+        # A provider iterator may be blocked inside network I/O and Python
+        # cannot cancel that thread.  Normal completion still drains every
+        # prefetch before signalling done; barge-in must not wedge the next
+        # voice turn waiting for an upstream request that stopped yielding.
+        if not stop_event.is_set():
+            for t in _prefetch_threads:
+                t.join(timeout=10.0)
         # Always close the audio output stream to avoid locking the device
         if output_stream is not None:
             try:


### PR DESCRIPTION
## What does this PR do?

The per-sentence streaming TTS prefetch pipeline from #71084, salvaged onto current main by #76623, caps in-flight requests with a semaphore and plays each bounded chunk queue in order. If three provider iterators stop yielding, the fourth sentence blocks forever in `Semaphore.acquire()`. Barge-in only sets `stop_event`, so it cannot release that wait; the playback worker can also remain blocked in `chunk_queue.get()`, and cleanup waits up to 300 seconds while the old pipeline keeps the audio device.

This makes every prefetch-capacity and playback-queue wait interruption-aware. Normal completion still drains and joins all prefetches. On barge-in, Hermes abandons stalled upstream iterators, closes playback promptly, sets the done event, and allows the next voice turn to start. Full bounded queues are drained just enough to let producer threads terminate instead of leaking.

## Related Issue

No issue filed. Follow-up to #71084 / #76623; open and closed PRs/issues were searched for this behavior.

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py`: make prefetch semaphore, chunk-queue writes, playback reads, and interrupted cleanup responsive to `stop_event`.
- `tests/tools/test_tts_streaming.py`: reproduce three stalled prefetches plus the blocked fourth sentence and prove barge-in completes promptly.

## How to Test

1. Start four streaming TTS sentences with the first three provider iterators stalled.
2. Set the real pipeline `stop_event` while sentence four is waiting for prefetch capacity.
3. On current main, `tts_done_event` remains unset; on this branch it is set within one second and the consumer exits.

Regression proof:

```text
main:   FAILED test_hybrid_interrupt_unblocks_stalled_prefetch_pipeline
        AssertionError: TTS interruption remained blocked on stalled prefetch requests
branch: 1 passed in 0.37s
```

Focused validation:

```text
123 passed, 1 deselected in 5.63s
ruff: passed
compileall: passed
Windows footgun scan: passed
git diff --check: passed
```

The deselected test is an existing Windows-only clock-resolution assertion in `test_hybrid_prefetch_fires_http_immediately`; the focused test and all other voice/TTS tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs/issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass - focused voice/TTS suites were run instead
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] Documentation update - N/A; no user-facing contract changed
- [x] `cli-config.yaml.example` update - N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update - N/A
- [x] Cross-platform impact considered; synchronization uses stdlib queues/events/semaphores
- [x] Tool descriptions/schemas update - N/A

## Screenshots / Logs

See the main-vs-branch regression proof and validation output above.