### PR TITLE
fix(tui): honor approvals.destructive_slash_confirm for /new /clear /reset

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2036,8 +2036,9 @@ DEFAULT_CONFIG = {
         # through tools.slash_confirm — native yes/no buttons on Telegram,
         # Discord, and Slack; text fallback elsewhere.  Users click "Always
         # Approve" to silence the prompt permanently; that flips this key to
-        # false.  TUI has its own modal overlay (HERMES_TUI_NO_CONFIRM=1 to
-        # opt out there).
+        # false.  TUI also honors this setting for its /clear, /new, and /reset
+        # modal; HERMES_TUI_NO_CONFIRM=1 force-skips that modal regardless of
+        # the configured value.
         "destructive_slash_confirm": True,
     },
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -482,6 +482,19 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['/new sprint planning', 'new session started', 'sprint planning'],
+    ['/clear', undefined, undefined]
+  ])('skips the confirmation for %s when config disables it', (command, message, title) => {
+    patchUiState({ destructiveSlashConfirm: false })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)(command)).toBe(true)
+
+    expect(getOverlayState().confirm).toBeNull()
+    expect(ctx.session.newSession).toHaveBeenCalledWith(message, title)
+  })
+
   it('routes the /reset catalog alias through the local fresh-session lifecycle', () => {
     const ctx = buildCtx({
       local: {
@@ -499,6 +512,26 @@ describe('createSlashHandler', () => {
 
     expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('skips the confirmation for the /reset alias when config disables it', () => {
+    patchUiState({ destructiveSlashConfirm: false })
+
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/new': '/new',
+            '/reset': '/new'
+          }
+        }
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/reset')).toBe(true)
+
+    expect(getOverlayState().confirm).toBeNull()
+    expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
   })
 
   it('keeps visible scrollback when branching a TUI session', async () => {

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -47,6 +47,54 @@ describe('applyDisplay', () => {
     expect(s.streaming).toBe(false)
   })
 
+  it('hydrates the destructive slash confirmation policy from approvals', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: false },
+          display: {}
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(false)
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: true },
+          display: {}
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(true)
+  })
+
+  it('defaults destructive slash confirmation on and preserves it across config RPC failure', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().destructiveSlashConfirm).toBe(true)
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: false },
+          display: {}
+        }
+      },
+      setBell
+    )
+    applyDisplay(null, setBell)
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(false)
+  })
+
   it('coerces legacy true + "on" alias to top', () => {
     const setBell = vi.fn()
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  destructiveSlashConfirm: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -199,7 +199,7 @@ export const coreCommands: SlashCommand[] = [
         ctx.session.newSession(isNew ? 'new session started' : undefined, requestedTitle || undefined)
       }
 
-      if (NO_CONFIRM_DESTRUCTIVE) {
+      if (NO_CONFIRM_DESTRUCTIVE || !ctx.ui.destructiveSlashConfirm) {
         return commit()
       }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  destructiveSlashConfirm: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -253,6 +253,7 @@ export const applyDisplay = (
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
 ) => {
   const d = cfg?.config?.display ?? {}
+  const approvals = cfg?.config?.approvals
 
   setBell(!!d.bell_on_complete)
 
@@ -273,6 +274,10 @@ export const applyDisplay = (
     battery: !!d.battery,
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    // Fail safe: only YAML boolean false disables the prompt. A transient
+    // config RPC failure (cfg=null) preserves the last known policy instead
+    // of silently changing approval behavior until the next successful poll.
+    ...(cfg ? { destructiveSlashConfirm: approvals?.destructive_slash_confirm !== false } : {}),
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -118,12 +118,19 @@ export interface ConfigVoiceConfig {
   record_key?: unknown
 }
 
+export interface ConfigApprovalsConfig {
+  // Raw config value: only the explicit boolean false disables the safety gate.
+  destructive_slash_confirm?: unknown
+}
+
+
 export interface ConfigFullResponse {
   config?: {
+    approvals?: ConfigApprovalsConfig
     display?: ConfigDisplayConfig
-    voice?: ConfigVoiceConfig
-    paste_collapse_threshold?: number
     paste_collapse_char_threshold?: number
+    paste_collapse_threshold?: number
+    voice?: ConfigVoiceConfig
   }
 }
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -305,4 +305,4 @@ For each of these the CLI opens a three-choice modal: **Approve Once** (proceed 
 
 **Inline skip:** append `now`, `--yes`, or `-y` to bypass the modal for a single invocation — e.g. `/reset now`, `/new --yes my-session`, `/clear -y`, `/undo -y`. Useful when the modal doesn't render correctly on your terminal (see [issue #30768](https://github.com/NousResearch/hermes-agent/issues/30768) for native Windows PowerShell) or when scripting against the CLI.
 
-Set `approvals.destructive_slash_confirm: false` in `~/.hermes/config.yaml` to disable the prompts globally; set it back to `true` to re-enable. See [Security — Destructive slash command confirmation](../user-guide/security.md#dangerous-command-approval) for context.
+Set `approvals.destructive_slash_confirm: false` in `~/.hermes/config.yaml` to disable the prompts globally (CLI, messaging, and the TUI `/clear` / `/new` / `/reset` modal); set it back to `true` to re-enable. In the TUI, `HERMES_TUI_NO_CONFIRM=1` still force-skips that modal regardless of the config value. See [Security — Destructive slash command confirmation](../user-guide/security.md#dangerous-command-approval) for context.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -46,7 +46,7 @@ The full set of keys:
 | `timeout` | `300` | Seconds Hermes waits for an approval reply before timing out. |
 | `cron_mode` | `deny` | How [cron jobs](./features/cron.md) behave headlessly when they trigger a dangerous-command prompt. `deny` blocks the command (the agent must find another path); `approve` auto-approves everything in cron context. |
 | `mcp_reload_confirm` | `true` | When true, `/reload-mcp` asks before rebuilding the MCP tool set. Rebuilding invalidates the provider prompt cache (tool schemas live in the system prompt), so the next message re-sends full input tokens. Users who click **Always Approve** flip this key to `false`. |
-| `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. TUI uses its own modal overlay (set `HERMES_TUI_NO_CONFIRM=1` to opt out there). |
+| `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. The TUI also honors this setting for its `/clear`, `/new`, and `/reset` modal; `HERMES_TUI_NO_CONFIRM=1` force-skips that modal regardless of the configured value. |
 
 | Mode | Behavior |
 |------|----------|


### PR DESCRIPTION
## Summary

TUI always showed a local confirm modal for `/new`, `/clear`, and `/reset`, even when users set:

```yaml
approvals:
  destructive_slash_confirm: false
```

CLI/gateway already honor that key. This hydrates it into TUI UI state via `config.get full`, skips the overlay when the policy is off, and keeps `HERMES_TUI_NO_CONFIRM=1` as a force-skip.

## Test plan

- [x] vitest `createSlashHandler.test.ts` + `useConfigSync.test.ts` (123 passed)
- [ ] Set `approvals.destructive_slash_confirm: false`, run `/new` in TUI, confirm no modal

Closes #70675
