### PR TITLE
fix(skills): guard install rmtree against wiping category directories (#75983)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -23,7 +23,6 @@ from rich.table import Table
 # Lazy imports to avoid circular dependencies and slow startup.
 # tools.skills_hub and tools.skills_guard are imported inside functions.
 from hermes_constants import display_hermes_home
-from agent.skill_utils import is_excluded_skill_path
 
 _console = Console()
 
@@ -184,29 +183,18 @@ def _existing_categories() -> List[str]:
     Used to suggest reusable categories when interactively installing from a
     URL. Hidden dirs (``.hub``, ``.trash``) are skipped.
     """
-    from tools.skills_hub import SKILLS_DIR
-    out: List[str] = []
+    from tools.skills_hub import SKILLS_DIR, _category_skill_dirs
     try:
-        for entry in SKILLS_DIR.iterdir():
-            if not entry.is_dir() or entry.name.startswith("."):
-                continue
-            # Only count as a category if it contains skills, not if it IS a skill.
-            # Heuristic: if ``<entry>/SKILL.md`` exists, it's a skill at the
-            # top level (no category); otherwise treat as a category bucket.
-            if (entry / "SKILL.md").exists():
-                continue
-            # Has at least one nested SKILL.md (excluding dependency/cache dirs)?
-            try:
-                if any(
-                    not is_excluded_skill_path(p)
-                    for p in entry.rglob("SKILL.md")
-                ):
-                    out.append(entry.name)
-            except OSError:
-                continue
+        # _category_skill_dirs returns children containing any active
+        # SKILL.md — including top-level skills themselves. Only children
+        # WITHOUT their own SKILL.md are category buckets.
+        return sorted(
+            name
+            for name in set(_category_skill_dirs(SKILLS_DIR))
+            if not (SKILLS_DIR / name / "SKILL.md").exists()
+        )
     except (FileNotFoundError, OSError):
         return []
-    return sorted(set(out))
 
 
 def _prompt_for_skill_name(c: Console, url: str, default: str = "") -> Optional[str]:

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1157,6 +1157,153 @@ class TestInstallPathSafety:
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
 
+    def test_install_from_quarantine_rejects_category_bucket_overwrite(self, tmp_path):
+        """Installing a skill whose name matches an existing category directory
+        that contains other skills must NOT silently wipe that entire directory.
+
+        Regression test for GitHub issue #75983: ``hermes skills install … --name
+        research`` deleted the whole ``skills/research/`` category bucket,
+        destroying 16 unrelated skills.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Simulate a user-created category bucket with multiple skills.
+        category = skills_dir / "research"
+        category.mkdir()
+        for skill in ("alpha", "bravo", "charlie"):
+            (category / skill).mkdir()
+            (category / skill / "SKILL.md").write_text(f"name: {skill}")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: research\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="research",
+            files={"SKILL.md": "---\nname: research\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="research",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="Refusing to overwrite category directory"):
+                hub.install_from_quarantine(
+                    q_dir, "research", "", bundle, scan_result,
+                )
+
+        # Verify the category bucket and its skills are intact.
+        assert (category / "alpha" / "SKILL.md").exists()
+        assert (category / "bravo" / "SKILL.md").exists()
+        assert (category / "charlie" / "SKILL.md").exists()
+
+    def test_install_from_quarantine_allows_existing_skill_overwrite(self, tmp_path):
+        """Installing over an existing skill directory (containing SKILL.md) is
+        still allowed — that scenario is already guarded by the lock-file check
+        in do_install()."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Existing skill directory with SKILL.md.
+        existing = skills_dir / "my-skill"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("old content")
+        (existing / "refs").mkdir()
+        (existing / "refs" / "guide.md").write_text("old guide")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: my-skill\n---\nnew")
+        (q_dir / "refs").mkdir()
+        (q_dir / "refs" / "guide.md").write_text("new guide")
+
+        bundle = hub.SkillBundle(
+            name="my-skill",
+            files={"SKILL.md": "---\nname: my-skill\n---\nnew"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="my-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            installed = hub.install_from_quarantine(
+                q_dir, "my-skill", "", bundle, scan_result,
+            )
+
+        # The old directory was replaced by the new one.
+        assert installed.exists()
+        assert (installed / "SKILL.md").read_text().strip() == "---\nname: my-skill\n---\nnew"
+
+    def test_install_from_quarantine_allows_empty_category_dir(self, tmp_path):
+        """Installing into an existing but empty category directory is allowed
+        (no sibling skills to destroy)."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Empty category directory (no skills inside).
+        category = skills_dir / "research"
+        category.mkdir()
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: research\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="research",
+            files={"SKILL.md": "---\nname: research\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="research",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            installed = hub.install_from_quarantine(
+                q_dir, "research", "", bundle, scan_result,
+            )
+
+        assert installed.exists()
+        assert (installed / "SKILL.md").exists()
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1304,6 +1304,136 @@ class TestInstallPathSafety:
         assert installed.exists()
         assert (installed / "SKILL.md").exists()
 
+    def test_install_from_quarantine_rejects_nested_only_category(self, tmp_path):
+        """A category whose skills live only in sub-categories (depth >= 2,
+        e.g. ``mlops/training/<skill>``) must also be protected — the guard
+        must not be fooled by the absence of direct-child skills (#75983)."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        # Nested-only category: no skill directly under mlops/, skills at depth 2.
+        for sub, name in (("training", "trl"), ("inference", "vllm")):
+            skill = skills_dir / "mlops" / sub / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: mlops\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="mlops",
+            files={"SKILL.md": "---\nname: mlops\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="mlops",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="category directory"):
+                hub.install_from_quarantine(
+                    q_dir, "mlops", "", bundle, scan_result,
+                )
+
+        # Every nested skill must survive.
+        assert (skills_dir / "mlops" / "training" / "trl" / "SKILL.md").is_file()
+        assert (skills_dir / "mlops" / "inference" / "vllm" / "SKILL.md").is_file()
+
+    def test_install_from_quarantine_rejects_category_inside_skill(self, tmp_path):
+        """Installing with --category naming an existing *skill* directory must
+        be refused: it would create a hybrid skill-plus-category dir whose later
+        update/uninstall rmtree would destroy the nested skill (#75983 sibling)."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        # Existing normal skill directory.
+        outer = skills_dir / "devops"
+        outer.mkdir(parents=True)
+        (outer / "SKILL.md").write_text("---\nname: devops\n---\n")
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: docker\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="docker",
+            files={"SKILL.md": "---\nname: docker\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="docker",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="existing skill directory"):
+                hub.install_from_quarantine(
+                    q_dir, "docker", "devops", bundle, scan_result,
+                )
+
+        # The outer skill is untouched and no hybrid child was created.
+        assert (outer / "SKILL.md").is_file()
+        assert not (outer / "docker").exists()
+
+    def test_install_from_quarantine_rejects_regular_file_collision(self, tmp_path):
+        """A stray regular file at the install path must produce the caller's
+        ValueError contract, not an uncaught NotADirectoryError from iterdir/rmtree."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        (skills_dir / "notes").write_text("not a directory")
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: notes\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="notes",
+            files={"SKILL.md": "---\nname: notes\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="notes",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="not a directory"):
+                hub.install_from_quarantine(
+                    q_dir, "notes", "", bundle, scan_result,
+                )
+
+        assert (skills_dir / "notes").read_text() == "not a directory"
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3680,6 +3680,32 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     return dest
 
 
+def _category_skill_dirs(directory: Path) -> List[str]:
+    """Names of direct children of *directory* that contain skills.
+
+    A child counts when it is a non-hidden directory holding at least one
+    active ``SKILL.md`` anywhere below it (recursive, so nested category
+    layouts like ``mlops/training/<skill>`` are detected). Vendored,
+    cache, and progressive-disclosure support paths are pruned via
+    :func:`is_excluded_skill_path` so a lone ``node_modules`` or
+    ``references/pkg/SKILL.md`` hit does not misclassify the directory as
+    a category. Shared by the install-time category guard here and
+    ``hermes_cli.skills_hub._existing_categories``.
+    """
+    skill_dirs: List[str] = []
+    for entry in directory.iterdir():
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        for skill_md in entry.rglob("SKILL.md"):
+            if is_excluded_skill_path(
+                skill_md.relative_to(directory), root=directory
+            ):
+                continue
+            skill_dirs.append(entry.name)
+            break
+    return skill_dirs
+
+
 def install_from_quarantine(
     quarantine_path: Path,
     skill_name: str,
@@ -3711,49 +3737,43 @@ def install_from_quarantine(
     # skill-plus-category directory; a later update or uninstall of the outer
     # skill would then rmtree the inner one — the sibling case of the
     # category-bucket wipe reported in issue #75983.
-    _skills_root = _skills_dir().resolve()
-    _ancestor = install_dir.parent
-    while _ancestor != _skills_root and _ancestor.is_relative_to(_skills_root):
-        if (_ancestor / "SKILL.md").is_file():
+    skills_root = _skills_dir().resolve()
+    ancestor = install_dir.parent
+    while ancestor != skills_root and ancestor.is_relative_to(skills_root):
+        if (ancestor / "SKILL.md").is_file():
             raise ValueError(
-                f"Refusing to install into '{_ancestor.name}': it is an "
+                f"Refusing to install into '{ancestor.name}': it is an "
                 f"existing skill directory, not a category. Choose a "
                 f"different category."
             )
-        _ancestor = _ancestor.parent
-
-    if install_dir.exists() and not install_dir.is_dir():
-        # A stray regular file at the install path. rmtree() on a file raises
-        # NotADirectoryError (an uncaught traceback at the CLI); refuse with
-        # the same actionable ValueError contract the guards below use.
-        raise ValueError(
-            f"Refusing to install: '{install_dir.name}' already exists and "
-            f"is not a directory. Remove it or choose a different skill name."
-        )
+        ancestor = ancestor.parent
 
     if install_dir.exists():
+        if not install_dir.is_dir():
+            # A stray regular file at the install path. rmtree() on a file
+            # raises NotADirectoryError (an uncaught traceback at the CLI);
+            # refuse with the same actionable ValueError contract instead.
+            raise ValueError(
+                f"Refusing to install: '{install_dir.name}' already exists "
+                f"and is not a directory. Remove it or choose a different "
+                f"skill name."
+            )
         # Guard against silent data loss when the install target collides with
         # an existing category bucket (a directory that holds other skills).
         # This was reported as GitHub issue #75983: installing a skill with
         # --name matching an existing category directory caused rmtree to wipe
-        # all sibling skills.  An existing skill installation (a directory that
-        # directly contains SKILL.md) is safe to overwrite — that path is
-        # already guarded by the lock-file check in do_install().  But a
-        # directory that contains *other* skill directories is a category bucket
-        # and must NOT be silently deleted.
-        if install_dir.is_dir() and not (install_dir / "SKILL.md").exists():
-            _skill_dirs_in = [
-                entry.name
-                for entry in install_dir.iterdir()
-                if entry.is_dir()
-                and not entry.name.startswith(".")
-                and any(entry.rglob("SKILL.md"))
-            ]
-            if _skill_dirs_in:
+        # all sibling skills.  A directory that directly contains SKILL.md is
+        # an existing skill installation and stays overwritable (hub-installed
+        # skills are additionally guarded by the lock-file check in
+        # do_install()).  But a directory that contains *other* skill
+        # directories is a category bucket and must NOT be silently deleted.
+        if not (install_dir / "SKILL.md").exists():
+            skill_dirs_in = _category_skill_dirs(install_dir)
+            if skill_dirs_in:
                 raise ValueError(
                     f"Refusing to overwrite category directory '{install_dir}' "
-                    f"which contains {len(_skill_dirs_in)} skill(s): "
-                    f"{', '.join(sorted(_skill_dirs_in))}. "
+                    f"which contains {len(skill_dirs_in)} skill(s): "
+                    f"{', '.join(sorted(skill_dirs_in))}. "
                     f"Use a different --name or install into a subcategory."
                 )
         shutil.rmtree(install_dir)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3707,6 +3707,30 @@ def install_from_quarantine(
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
     if install_dir.exists():
+        # Guard against silent data loss when the install target collides with
+        # an existing category bucket (a directory that holds other skills).
+        # This was reported as GitHub issue #75983: installing a skill with
+        # --name matching an existing category directory caused rmtree to wipe
+        # all sibling skills.  An existing skill installation (a directory that
+        # directly contains SKILL.md) is safe to overwrite — that path is
+        # already guarded by the lock-file check in do_install().  But a
+        # directory that contains *other* skill directories is a category bucket
+        # and must NOT be silently deleted.
+        if install_dir.is_dir() and not (install_dir / "SKILL.md").exists():
+            _skill_dirs_in = [
+                entry.name
+                for entry in install_dir.iterdir()
+                if entry.is_dir()
+                and not entry.name.startswith(".")
+                and any(entry.rglob("SKILL.md"))
+            ]
+            if _skill_dirs_in:
+                raise ValueError(
+                    f"Refusing to overwrite category directory '{install_dir}' "
+                    f"which contains {len(_skill_dirs_in)} skill(s): "
+                    f"{', '.join(sorted(_skill_dirs_in))}. "
+                    f"Use a different --name or install into a subcategory."
+                )
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3706,6 +3706,31 @@ def install_from_quarantine(
     # path can never refer to a redirected target.
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
+    # Refuse to nest a skill inside an existing skill directory. Installing
+    # with ``--category <name-of-an-existing-skill>`` would create a hybrid
+    # skill-plus-category directory; a later update or uninstall of the outer
+    # skill would then rmtree the inner one — the sibling case of the
+    # category-bucket wipe reported in issue #75983.
+    _skills_root = _skills_dir().resolve()
+    _ancestor = install_dir.parent
+    while _ancestor != _skills_root and _ancestor.is_relative_to(_skills_root):
+        if (_ancestor / "SKILL.md").is_file():
+            raise ValueError(
+                f"Refusing to install into '{_ancestor.name}': it is an "
+                f"existing skill directory, not a category. Choose a "
+                f"different category."
+            )
+        _ancestor = _ancestor.parent
+
+    if install_dir.exists() and not install_dir.is_dir():
+        # A stray regular file at the install path. rmtree() on a file raises
+        # NotADirectoryError (an uncaught traceback at the CLI); refuse with
+        # the same actionable ValueError contract the guards below use.
+        raise ValueError(
+            f"Refusing to install: '{install_dir.name}' already exists and "
+            f"is not a directory. Remove it or choose a different skill name."
+        )
+
     if install_dir.exists():
         # Guard against silent data loss when the install target collides with
         # an existing category bucket (a directory that holds other skills).


### PR DESCRIPTION
## Summary

`hermes skills install <name>` can no longer silently delete an entire category directory (or a skill nested inside another skill) — the unconditional `shutil.rmtree(install_dir)` in `install_from_quarantine()` is now guarded. Fixes the P1 data-loss incident in #75983 (16 skills wiped by one install).

Salvages #76000 by @x7peeps (cherry-picked, authorship preserved) — the earlier and more robust of the competing fixes: its recursive category detection also protects nested-only categories (skills at depth ≥ 2, e.g. `mlops/training/<skill>`), which the direct-children heuristic in #76066 misses (empirically reproduced: nested skills were still wiped with that patch applied).

## Changes

- `tools/skills_hub.py` (from #76000): before `rmtree`, refuse when the existing target has no `SKILL.md` of its own but contains skill directories — raises `ValueError` listing the affected skills; `do_install` already surfaces it as "Installation blocked".
- `tools/skills_hub.py` (follow-up): refuse installing INTO an existing skill directory (`--category <existing-skill>` would create a hybrid skill-plus-category dir whose later update/uninstall `rmtree` destroys the nested skill — sibling case of the same bug class); refuse a stray regular file at the install path with the same `ValueError` contract instead of an uncaught `NotADirectoryError`.
- `tools/skills_hub.py` + `hermes_cli/skills_hub.py` (cleanup): extract `_category_skill_dirs()` as the single shared category detector — the install guard and `_existing_categories()` now use it, and rglob hits are pruned via `is_excluded_skill_path` so vendored `SKILL.md` files (`node_modules/…`, `references/pkg/…`) can't misclassify a plain directory as a category and block a legitimate install.
- `tests/tools/test_skills_hub.py`: 6 regression tests — category-bucket refusal, nested-only category, category-inside-skill, file collision, plus non-regression coverage (normal skill overwrite and empty-category install still succeed).

## Validation

| Check | Result |
|---|---|
| skills_hub test files (tools + hermes_cli + browse + clawhub) | 86/86 pass |
| Mutation check on final stack (production reverted to main) | 4 guard tests fail as expected, 7 non-regression pass |
| E2E case matrix (flat / nested / normal-skill / empty / loose-files / vendored-only-SKILL.md) | refuse ×2, install ×4 — zero skills lost, zero false positives |
| ruff | clean |

## Credit

Based on #76000 by @x7peeps — cherry-picked to preserve authorship. Closes #75983. Supersedes #76066 (@RelaxJonh, same guard but direct-children-only detection).
