### PR TITLE
fix(secret-scope): .env parser parity — BOM, quoted-value unescaping, dotenv-compatible comments (salvage #70053, #75090; supersedes #57718)

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -184,10 +184,14 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     ``set_secret_scope``. Mirrors python-dotenv's basic parsing (KEY=VALUE,
     ``export`` prefix, ``#`` comments, optional matching quotes) but never
     mutates the process environment — that isolation is the whole point.
+
+    Encoding is ``utf-8-sig`` so a leading UTF-8 BOM (Windows Notepad /
+    PowerShell ``Set-Content -Encoding UTF8``) does not prefix the first
+    key as ``\\ufeffNAME`` and make ``get_secret('NAME')`` miss under scope.
     """
     secrets: Dict[str, str] = {}
     try:
-        text = env_path.read_text(encoding="utf-8")
+        text = env_path.read_text(encoding="utf-8-sig")
     except (FileNotFoundError, OSError, UnicodeDecodeError):
         return secrets
 

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -23,6 +23,7 @@ Design rationale lives in ``docs/design/multiplexing-gateway.md`` (Workstream A)
 from __future__ import annotations
 
 import os
+import re
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
@@ -177,12 +178,50 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     return val if val is not None else default
 
 
+def _strip_inline_comment(value: str) -> str:
+    """Strip a dotenv-style inline comment from a raw ``.env`` value.
+
+    Mirrors python-dotenv (1.2.2) semantics, verified empirically:
+
+    - Quoted values: scan for the matching close quote
+      (backslash-escape-aware for double quotes, since ``save_env_value``
+      writes ``\\"``/``\\\\`` escapes). Everything through the close quote is
+      kept; a trailing ``# ...`` remainder after it is discarded, so
+      ``KEY="has # inside" # trailing`` yields ``has # inside``. Non-comment
+      trailing junk leaves the value untouched (lenient, unlike dotenv's
+      hard parse error).
+    - Unquoted values: truncate only at a ``#`` PRECEDED BY WHITESPACE, so
+      ``KEY=foo#bar`` keeps ``foo#bar`` while ``KEY=value # comment`` keeps
+      ``value``. A value that *starts* with ``#`` (``KEY=#leading``) is kept.
+    """
+    value = value.strip()
+    if not value:
+        return value
+    quote = value[0]
+    if quote in ("'", '"'):
+        i = 1
+        while i < len(value):
+            ch = value[i]
+            if quote == '"' and ch == "\\":
+                i += 2  # skip the escaped character
+                continue
+            if ch == quote:
+                remainder = value[i + 1:].lstrip()
+                if remainder.startswith("#"):
+                    return value[: i + 1]
+                return value
+            i += 1
+        return value  # unterminated quote: leave as-is
+    return re.split(r"\s+#", value, maxsplit=1)[0].strip()
+
+
 def load_env_file(env_path: Path) -> Dict[str, str]:
     """Parse a ``.env`` file into a plain dict WITHOUT touching ``os.environ``.
 
     Used to load a profile's secrets into an isolated mapping for
     ``set_secret_scope``. Parses the small KEY=VALUE subset Hermes writes
-    itself (``export`` prefix, ``#`` comments, matching quotes with the
+    itself (``export`` prefix, ``#`` comments — full-line and
+    dotenv-compatible inline, matching quotes with the
     writer's ``\\"``/``\\\\`` escapes reversed — the same semantics as
     ``hermes_cli.config._parse_env_value``) but never mutates the process
     environment — that isolation is the whole point.
@@ -217,7 +256,7 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         key = key.strip()
         if not key:
             continue
-        secrets[key] = _parse_env_value(value)
+        secrets[key] = _parse_env_value(_strip_inline_comment(value))
 
     return secrets
 

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -181,9 +181,11 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     """Parse a ``.env`` file into a plain dict WITHOUT touching ``os.environ``.
 
     Used to load a profile's secrets into an isolated mapping for
-    ``set_secret_scope``. Mirrors python-dotenv's basic parsing (KEY=VALUE,
-    ``export`` prefix, ``#`` comments, optional matching quotes) but never
-    mutates the process environment — that isolation is the whole point.
+    ``set_secret_scope``. Parses the small KEY=VALUE subset Hermes writes
+    itself (``export`` prefix, ``#`` comments, matching quotes with the
+    writer's ``\\"``/``\\\\`` escapes reversed — the same semantics as
+    ``hermes_cli.config._parse_env_value``) but never mutates the process
+    environment — that isolation is the whole point.
 
     Encoding is ``utf-8-sig`` so a leading UTF-8 BOM (Windows Notepad /
     PowerShell ``Set-Content -Encoding UTF8``) does not prefix the first
@@ -194,6 +196,14 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         text = env_path.read_text(encoding="utf-8-sig")
     except (FileNotFoundError, OSError, UnicodeDecodeError):
         return secrets
+
+    # Parse values with the canonical Hermes parser: save_env_value
+    # escapes " and \ inside double quotes, and every other reader
+    # (load_env, python-dotenv) reverses those escapes. Stripping only
+    # the outer quotes here would corrupt credentials containing "
+    # or \ — they work interactively but fail in scoped (cron /
+    # multiplex) resolution.
+    from hermes_cli.config import _parse_env_value
 
     for raw in text.splitlines():
         line = raw.strip()
@@ -207,10 +217,7 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         key = key.strip()
         if not key:
             continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
-        secrets[key] = value
+        secrets[key] = _parse_env_value(value)
 
     return secrets
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -137,6 +137,50 @@ class TestEnvFileParsing:
             "EMPTY": "",
         }
 
+    def test_inline_comment_stripped_from_unquoted_value(self, tmp_path):
+        """`KEY=value # comment` → `value` (python-dotenv semantics)."""
+        (tmp_path / ".env").write_text("KEY=value # comment\nTABBED=foo\t#tabbed\n")
+        assert ss.load_env_file(tmp_path / ".env") == {
+            "KEY": "value",
+            "TABBED": "foo",
+        }
+
+    def test_hash_without_preceding_whitespace_is_not_a_comment(self, tmp_path):
+        """`KEY=foo#bar` stays intact — dotenv only strips `#` after whitespace."""
+        (tmp_path / ".env").write_text("KEY=foo#bar\nLEAD=#leading\n")
+        assert ss.load_env_file(tmp_path / ".env") == {
+            "KEY": "foo#bar",
+            "LEAD": "#leading",
+        }
+
+    def test_inline_comment_after_quoted_value(self, tmp_path):
+        """Quotes strip AND the trailing comment drops; inner `#` survives."""
+        (tmp_path / ".env").write_text(
+            "DQ=\"has # inside\" # trailing\n"
+            "SQ='single # inside' # trailing\n"
+        )
+        assert ss.load_env_file(tmp_path / ".env") == {
+            "DQ": "has # inside",
+            "SQ": "single # inside",
+        }
+
+    def test_inline_comment_with_escaped_quote_inside_value(self, tmp_path):
+        r"""Escape-aware close-quote scan: `\"` must not terminate the value."""
+        (tmp_path / ".env").write_text(
+            'KEY="a \\" quote # x" # trail\n'
+        )
+        assert ss.load_env_file(tmp_path / ".env") == {"KEY": 'a " quote # x'}
+
+    def test_round_trip_writer_value_with_trailing_comment(self, tmp_path):
+        """A value quoted by the save_env_value writer survives an appended
+        inline comment byte-exactly."""
+        from hermes_cli.config import _quote_env_value
+
+        original = 'we#ird "tok\\en" # not a comment'
+        quoted = _quote_env_value(original)
+        (tmp_path / ".env").write_text(f"MY_TOKEN={quoted} # rotated 2026-08\n")
+        assert ss.load_env_file(tmp_path / ".env") == {"MY_TOKEN": original}
+
 
 
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -113,6 +113,30 @@ class TestScopeIsolation:
 class TestEnvFileParsing:
     """load_env_file parses without mutating os.environ."""
 
+    def test_load_env_file_unescapes_quoted_values(self, tmp_path):
+        """Values written by save_env_value must round-trip byte-exactly.
+
+        Regression: load_env_file stripped only the outer quotes, leaving
+        the writer's \\" and \\\\ escapes literal — credentials containing
+        '\"' or '\\' worked interactively but were corrupted under scoped
+        (cron / multiplex) resolution.
+        """
+        from hermes_cli.config import _quote_env_value
+
+        original = 'tok"en\\with spaces'
+        (tmp_path / ".env").write_text(f"MY_TOKEN={_quote_env_value(original)}\n")
+        assert ss.load_env_file(tmp_path / ".env") == {"MY_TOKEN": original}
+
+    def test_load_env_file_single_quotes_and_plain_values(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "PLAIN=abc123\nQUOTED='single quoted'\nEMPTY=\n"
+        )
+        assert ss.load_env_file(tmp_path / ".env") == {
+            "PLAIN": "abc123",
+            "QUOTED": "single quoted",
+            "EMPTY": "",
+        }
+
 
 
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -116,6 +116,33 @@ class TestEnvFileParsing:
 
 
 
+    def test_strips_utf8_bom_from_first_key(self, tmp_path):
+        """Windows editors often save .env as UTF-8 with BOM (EF BB BF).
+
+        Plain utf-8 keeps U+FEFF on the first key name, so get_secret('NAME')
+        misses under an installed scope. utf-8-sig strips the leading BOM.
+        """
+        env = tmp_path / ".env"
+        env.write_bytes(
+            b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-x\nOPENAI_API_KEY=sk-y\n"
+        )
+        out = ss.load_env_file(env)
+        assert out == {
+            "ANTHROPIC_API_KEY": "sk-x",
+            "OPENAI_API_KEY": "sk-y",
+        }
+        assert "\ufeffANTHROPIC_API_KEY" not in out
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scope)
+        try:
+            assert ss.get_secret("ANTHROPIC_API_KEY") == "sk-x"
+            assert ss.get_secret("OPENAI_API_KEY") == "sk-y"
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
     def test_build_profile_secret_scope(self, tmp_path):
         (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-profile\n")
         assert ss.build_profile_secret_scope(tmp_path) == {


### PR DESCRIPTION
# .env parser parity in `agent/secret_scope.load_env_file`

`load_env_file` is the parser behind `build_profile_secret_scope`, which wraps every cron job and every multiplexed gateway turn. It had drifted from every other `.env` reader in the repo (`load_env`/`_parse_env_value`, python-dotenv) in three ways, each of which silently corrupts credentials under scoped resolution while interactive use keeps working:

1. **UTF-8 BOM** — Windows editors (Notepad, PowerShell `Set-Content -Encoding UTF8`) prefix the file with EF BB BF; plain `utf-8` decoding left `\ufeff` glued to the first key, so `get_secret('NAME')` missed that credential under scope. Fixed by reading with `utf-8-sig`. *(salvaged from #70053, authorship preserved — thanks @fangliquanflq)*
2. **Quoted-value unescaping** — `save_env_value` writes values containing `"` or `\` as escaped double-quoted strings; `load_env_file` stripped only the outer quotes and left the escapes literal, corrupting JSON service-account blobs and generated secrets. Fixed by parsing through the canonical `hermes_cli.config._parse_env_value`. *(salvaged from #75090, authorship preserved — thanks @spfcraze; the import is hoisted above the loop rather than per-line)*
3. **Inline comments** — `KEY=value # comment` kept the ` # comment` text in the secret. New commit implements dotenv-compatible stripping: unquoted values truncate only at a `#` **preceded by whitespace** (so `KEY=foo#bar` stays intact), quoted values get an escape-aware close-quote scan that keeps everything through the close quote and drops a trailing `# ...` remainder.

### Relation to #57718

#57718's premise (inline comments should be stripped) was valid, but its scanner treated **every** unescaped `#` in an unquoted value as a comment start, corrupting `foo#bar`-style values (passwords, URLs with fragments) — per its review. This PR supersedes it with the actual python-dotenv rule, verified empirically against the installed python-dotenv **1.2.2**.

## Empirical parity: `load_env_file` vs python-dotenv 1.2.2

| # | Line | python-dotenv 1.2.2 | load_env_file | Parity |
|---|------|---------------------|---------------|--------|
| 1 | `KEY=value # comment` | `value` | `value` | ✅ |
| 2 | `KEY="has # inside" # trailing` | `has # inside` | `has # inside` | ✅ |
| 3 | `KEY=foo#bar` | `foo#bar` | `foo#bar` | ✅ |
| 4 | `KEY="a \" quote # x" # trail` | `a " quote # x` | `a " quote # x` | ✅ |
| 5 | `KEY='single # inside' # trail` | `single # inside` | `single # inside` | ✅ |
| 6 | `KEY=plain` | `plain` | `plain` | ✅ |
| 7 | `KEY=value    # spaced comment` | `value` | `value` | ✅ |
| 8 | `KEY=#leading` | `#leading` | `#leading` | ✅ |
| 9 | `KEY=va lue # c` | `va lue` | `va lue` | ✅ |
| 10 | `KEY="esc\\aped \" quote"` | `esc\aped " quote` | `esc\aped " quote` | ✅ |

(One deliberate leniency: dotenv hard-errors on trailing junk after a close quote, e.g. `KEY="v" extra` → parse error; `load_env_file` keeps the raw value instead of dropping the credential.)

## Tests

- `tests/agent/test_secret_scope.py` — new: unquoted inline comment (space + tab), `foo#bar`/`#leading` preserved, quoted value with inner `#` + trailing comment (both quote styles), escaped-quote + comment combined, writer round-trip (`_quote_env_value` → append comment → byte-exact read-back); plus the salvaged BOM fixture and unescaping regression tests.
- Ran: `tests/agent/test_secret_scope.py` (20✓), `tests/test_env_loader_secret_sources.py` (18✓), `tests/test_env_loader_applied_homes.py`, `tests/test_env_loader_op_bootstrap.py`, `tests/hermes_cli/test_env_loader.py` (12✓), `tests/hermes_cli/test_config_env_expansion.py` (7✓), `tests/hermes_cli/test_config_env_refs.py`, `tests/hermes_cli/test_config_env_ref_parity.py` — **all green, 0 failures**.
- `ruff check` clean; Windows-footgun checker clean (897 files).

## Credits

- @fangliquanflq — #70053 (BOM fix, cherry-picked with authorship preserved)
- @spfcraze — #75090 (quoted-value unescaping, cherry-picked with authorship preserved)

Closes #70053. Closes #75090. Supersedes #57718.

## Infographic

![.env parser parity cracktro](https://v3b.fal.media/files/b/0aa4b24c/_O8Ahmg7lAnWfgMcs-zD5_ZMsiaZen.png)
