### PR TITLE
fix(secrets): Weixin Slack-pattern scoping, API_SERVER_* global allowlist, xai_http fail-closed (corrects #66073/#68854/#69524; salvages #56982)

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -105,6 +105,14 @@ _GLOBAL_ENV_EXACT = frozenset({
     "VIRTUAL_ENV", "PYTHONPATH", "SSL_CERT_FILE",
     # Kanban paths (per-board, not per-profile-secret)
     "HERMES_KANBAN_DB", "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_BOARD",
+    # API-server LISTENER settings — deployment config (Docker compose
+    # ``environment:`` block, systemd ``Environment=``), not profile secrets.
+    # The scoped runner reload (#64674) must keep seeing them or container
+    # deployments silently lose the api_server platform (#69379). NOTE:
+    # API_SERVER_KEY is deliberately NOT here — it IS a credential and stays
+    # profile-scoped.
+    "API_SERVER_ENABLED", "API_SERVER_HOST", "API_SERVER_PORT",
+    "API_SERVER_CORS_ORIGINS",
 })
 _GLOBAL_ENV_PREFIXES = (
     "HERMES_KANBAN_",

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -68,7 +68,25 @@ from gateway.platforms.base import (
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
-from agent.secret_scope import get_secret
+from agent.secret_scope import UnscopedSecretError, get_secret
+
+
+def _wx_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Scope-aware WEIXIN_* read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under
+    ``_profile_runtime_scope`` — the scope is authoritative and a scoped miss
+    returns ``default`` (no cross-profile borrow from ``os.environ``). The
+    DEFAULT profile's adapter constructs and sends *unscoped* under
+    multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash its Weixin path; there ``os.environ`` is
+    that profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and WhatsApp's ``_get_wsecret``.
+    """
+    try:
+        return get_secret(name, default)
+    except UnscopedSecretError:
+        return os.getenv(name, default)
 
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WEIXIN_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
@@ -1175,11 +1193,11 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
-        self._account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-        self._token = str(config.token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
-        self._base_url = str(extra.get("base_url") or get_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+        self._account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
+        self._token = str(config.token or extra.get("token") or _wx_secret("WEIXIN_TOKEN", "")).strip()
+        self._base_url = str(extra.get("base_url") or _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
         self._cdn_base_url = str(
-            extra.get("cdn_base_url") or get_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
+            extra.get("cdn_base_url") or _wx_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
         self._send_chunk_delay_seconds = float(
             extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")
@@ -2313,10 +2331,10 @@ async def send_weixin_direct(
 
     This bypasses the long-poll adapter lifecycle and uses the raw API directly.
     """
-    account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-    base_url = str(extra.get("base_url") or get_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
-    cdn_base_url = str(extra.get("cdn_base_url") or get_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
-    resolved_token = str(token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
+    account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
+    base_url = str(extra.get("base_url") or _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+    cdn_base_url = str(extra.get("cdn_base_url") or _wx_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
+    resolved_token = str(token or extra.get("token") or _wx_secret("WEIXIN_TOKEN", "")).strip()
     if not resolved_token:
         return {"error": "Weixin token missing. Configure WEIXIN_TOKEN or platforms.weixin.token."}
     if not account_id:

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -155,3 +155,40 @@ class TestEnvFileParsing:
         )
 
         assert ss.build_profile_secret_scope(profile) == {}
+
+
+class TestApiServerListenerGlobals:
+    """API_SERVER listener settings are deployment config (#69379), not
+    profile secrets: the scoped runner reload must keep seeing container env
+    (Docker compose ``environment:`` block). API_SERVER_KEY IS a credential
+    and stays profile-scoped."""
+
+    LISTENER_VARS = (
+        "API_SERVER_ENABLED",
+        "API_SERVER_HOST",
+        "API_SERVER_PORT",
+        "API_SERVER_CORS_ORIGINS",
+    )
+
+    def test_listener_vars_read_environ_even_when_scoped_multiplex(self, monkeypatch):
+        for name in self.LISTENER_VARS:
+            monkeypatch.setenv(name, f"container-{name.lower()}")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"TELEGRAM_BOT_TOKEN": "scoped"})
+        try:
+            for name in self.LISTENER_VARS:
+                assert ss.get_secret(name) == f"container-{name.lower()}"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_api_server_key_stays_profile_scoped(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_KEY", "default-profile-key-0123456789abcdef")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"OTHER": "x"})
+        try:
+            # A scoped miss must NOT borrow the (potentially cross-profile)
+            # environ value: API_SERVER_KEY is a credential.
+            assert ss.get_secret("API_SERVER_KEY") is None
+        finally:
+            ss.reset_secret_scope(token)
+        assert not ss._is_global_env("API_SERVER_KEY")

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -49,6 +49,64 @@ class TestLoadGatewayConfigForRunner:
         cfg = run_mod.load_gateway_config_for_runner()
         assert cfg.multiplex_profiles is False
 
+    def test_scoped_reload_still_sees_container_api_server_env(self, tmp_path, monkeypatch):
+        """#69379 — container-env API_SERVER_* visible during the scoped reload.
+
+        Docker/systemd deployments enable the api_server platform via the
+        process environment (compose ``environment:`` block), not the profile
+        ``.env``. The multiplex runner reload happens inside the default
+        profile's secret scope; the listener settings are on the global
+        allowlist (deployment config, not profile secrets) so they must stay
+        visible there — while API_SERVER_KEY (a credential) still resolves
+        through the profile scope.
+        """
+        from agent import secret_scope as ss
+        from gateway import run as run_mod
+
+        home = tmp_path / "home"
+        home.mkdir()
+        # Credentials belong in the profile .env; listener settings do not.
+        (home / ".env").write_text(
+            "TELEGRAM_BOT_TOKEN=default-profile-token-123\n"
+            "API_SERVER_KEY=profile-scoped-key-0123456789abcdef\n",
+            encoding="utf-8",
+        )
+        (home / "config.yaml").write_text(
+            "gateway:\n  multiplex_profiles: true\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Listener settings live ONLY in os.environ — the Docker compose case.
+        monkeypatch.setenv("API_SERVER_ENABLED", "true")
+        monkeypatch.setenv("API_SERVER_HOST", "0.0.0.0")
+        monkeypatch.setenv("API_SERVER_PORT", "8642")
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(run_mod, "_hermes_home", home)
+        # Model the real multiplexed gateway: run.py flips the runtime flag
+        # before the runner reload, making any installed scope authoritative.
+        ss.set_multiplex_active(True)
+
+        cfg = run_mod.load_gateway_config_for_runner()
+
+        assert cfg.multiplex_profiles is True
+        # Telegram token from the profile scope (.env)
+        tg = cfg.platforms.get(Platform.TELEGRAM)
+        assert tg is not None
+        assert tg.token == "default-profile-token-123"
+        # api_server present: key from the profile scope, listener settings
+        # from the container environment via the global allowlist.
+        api = cfg.platforms.get(Platform.API_SERVER)
+        assert api is not None, (
+            "api_server should be enabled from container env even inside "
+            "the scoped runner reload (#69379)"
+        )
+        assert api.enabled is True
+        assert api.extra.get("key") == "profile-scoped-key-0123456789abcdef"
+        assert api.extra.get("host") == "0.0.0.0"
+        assert api.extra.get("port") == 8642
+
+
 
 class TestPlatformHasBotCredential:
     def test_telegram_empty_token_false(self):

--- a/tests/gateway/test_weixin_secret_scope.py
+++ b/tests/gateway/test_weixin_secret_scope.py
@@ -1,0 +1,103 @@
+"""Weixin adapter secret-scope regression tests.
+
+The adapter's WEIXIN_* credential reads must follow the Slack pattern
+(#59739): under multiplexing a SCOPED miss is authoritative (no borrow from
+``os.environ`` — that would be a cross-profile leak), while an UNSCOPED read
+(default-profile startup/send path) falls back to ``os.environ``, which is
+that profile's own value, instead of raising ``UnscopedSecretError``.
+"""
+
+import pytest
+
+from agent import secret_scope
+from gateway.config import PlatformConfig
+from gateway.platforms.weixin import WeixinAdapter, _wx_secret
+
+
+@pytest.fixture()
+def multiplex_on():
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+
+class TestWxSecretHelper:
+    def test_scoped_read_uses_scope_value(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-profile-token")
+        token = secret_scope.set_secret_scope({"WEIXIN_TOKEN": "scoped-token"})
+        try:
+            assert _wx_secret("WEIXIN_TOKEN") == "scoped-token"
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_scoped_miss_does_not_borrow_environ(self, multiplex_on, monkeypatch):
+        """A secondary profile without WEIXIN_TOKEN must NOT inherit the
+        default profile's process-env token."""
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-profile-token")
+        token = secret_scope.set_secret_scope({"OTHER_KEY": "x"})
+        try:
+            assert _wx_secret("WEIXIN_TOKEN", "") == ""
+            assert _wx_secret("WEIXIN_TOKEN") is None
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_unscoped_read_falls_back_to_environ(self, multiplex_on, monkeypatch):
+        """The default profile's adapter runs unscoped under multiplexing;
+        os.environ is its own value — fall back instead of raising."""
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-profile-token")
+        token = secret_scope.set_secret_scope(None)
+        try:
+            assert _wx_secret("WEIXIN_TOKEN") == "default-profile-token"
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+
+class TestWeixinAdapterConstructionScope:
+    def test_multiplex_scoped_construction_reads_scope_not_environ(
+        self, multiplex_on, monkeypatch
+    ):
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "env-account")
+        monkeypatch.setenv("WEIXIN_TOKEN", "env-token")
+        token = secret_scope.set_secret_scope(
+            {
+                "WEIXIN_ACCOUNT_ID": "scoped-account",
+                "WEIXIN_TOKEN": "scoped-token",
+            }
+        )
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._account_id == "scoped-account"
+        assert adapter._token == "scoped-token"
+
+    def test_multiplex_scoped_miss_yields_empty_not_environ_borrow(
+        self, multiplex_on, monkeypatch
+    ):
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "env-account")
+        monkeypatch.setenv("WEIXIN_TOKEN", "env-token")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._account_id == ""
+        assert adapter._token == ""
+
+    def test_multiplex_unscoped_construction_falls_back_to_environ(
+        self, multiplex_on, monkeypatch
+    ):
+        """Regression for the bare get_secret reads: default-profile adapter
+        construction under multiplexing must not raise UnscopedSecretError."""
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "env-account")
+        monkeypatch.setenv("WEIXIN_TOKEN", "env-token")
+        token = secret_scope.set_secret_scope(None)
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._account_id == "env-account"
+        assert adapter._token == "env-token"

--- a/tests/tools/test_xai_http_credentials.py
+++ b/tests/tools/test_xai_http_credentials.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+def _set_xai_oauth_unavailable(monkeypatch):
+    from hermes_cli import auth
+
+    monkeypatch.setattr(auth, "resolve_xai_oauth_runtime_credentials", lambda **_: {})
+
+
+def test_xai_credentials_fail_closed_without_profile_scope(tmp_path, monkeypatch):
+    from agent import secret_scope
+    from hermes_cli.config import invalidate_env_cache
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    monkeypatch.setenv("XAI_BASE_URL", "https://foreign.example/v1")
+    _set_xai_oauth_unavailable(monkeypatch)
+    invalidate_env_cache()
+    previous_multiplex = secret_scope.is_multiplex_active()
+    token = secret_scope.set_secret_scope(None)
+    secret_scope.set_multiplex_active(True)
+    try:
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            resolve_xai_http_credentials(force_refresh=True)
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+        invalidate_env_cache()
+
+
+def test_xai_credentials_do_not_fall_back_to_environ_when_scope_has_no_key(
+    tmp_path, monkeypatch
+):
+    from agent import secret_scope
+    from hermes_cli.config import invalidate_env_cache
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    monkeypatch.setenv("XAI_BASE_URL", "https://foreign.example/v1")
+    _set_xai_oauth_unavailable(monkeypatch)
+    invalidate_env_cache()
+    previous_multiplex = secret_scope.is_multiplex_active()
+    token = secret_scope.set_secret_scope({})
+    secret_scope.set_multiplex_active(True)
+    try:
+        credentials = resolve_xai_http_credentials(force_refresh=True)
+        assert credentials == {
+            "provider": "xai",
+            "api_key": "",
+            "base_url": "https://api.x.ai/v1",
+        }
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+        invalidate_env_cache()

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -79,13 +79,11 @@ def get_env_value(name: str, default=None):
     """
     try:
         from hermes_cli.config import get_env_value as _hermes_get_env_value
+    except ImportError:
+        return os.environ.get(name, default)
 
-        value = _hermes_get_env_value(name)
-        if value is not None:
-            return value
-    except Exception:
-        pass
-    return os.environ.get(name, default)
+    value = _hermes_get_env_value(name)
+    return value if value is not None else default
 
 
 def hermes_xai_user_agent() -> str:


### PR DESCRIPTION
Corrections for three wrong-direction secret-scope PRs, plus a salvage of the live piece of #56982. Each fix follows the canonical `get_secret` semantics in `agent/secret_scope.py` rather than adding per-caller environ fallthroughs.

## 1. Weixin: Slack-pattern scoping (corrects #66073 / #68854)

`WeixinAdapter.__init__` and `send_weixin_direct` read `WEIXIN_ACCOUNT_ID` / `WEIXIN_TOKEN` / `WEIXIN_BASE_URL` / `WEIXIN_CDN_BASE_URL` via bare `get_secret`, which raises `UnscopedSecretError` when the **default profile's** adapter constructs or sends unscoped under multiplexing. #66073/#68854 tried to fix this by borrowing `os.environ` on every read — but **a scoped miss must never borrow the process env**: that re-opens the cross-profile leak (a secondary profile missing `WEIXIN_TOKEN` would silently inherit the default profile's account).

Fix: module-level `_wx_secret(name, default)` following the established Slack `SLACK_APP_TOKEN` pattern (#59739) and WhatsApp's `_get_wsecret`:

- **scope installed + miss** → return `default` (scope is authoritative, no environ borrow)
- **unscoped under multiplex** → fall back to `os.getenv` (that's the default profile's own value)

Regression tests cover both directions: scoped construction reads the scope's value / scoped miss yields empty, and unscoped construction falls back to `os.environ` instead of raising.

## 2. API_SERVER listener settings → global allowlist (fixes #69379, corrects #69524)

#69379: the v2026.7.20 multiplex runner reload (`load_gateway_config_for_runner`, #64674) runs inside the default profile's secret scope, which dropped `API_SERVER_*` set via the container environment (Docker compose `environment:` block) — the api_server platform silently vanished.

#69524 patched `gateway/config._getenv` to fall through to `os.environ` on **every** scoped miss. That silences the symptom but defeats scope authority for all credentials read through `_getenv` — the exact fallthrough the scope design forbids.

The right mechanism already exists: `_GLOBAL_ENV_EXACT`. **Deployment settings ≠ profile secrets.** `API_SERVER_ENABLED` / `API_SERVER_HOST` / `API_SERVER_PORT` / `API_SERVER_CORS_ORIGINS` are process-level listener config and join the allowlist, so `get_secret` reads them from `os.environ` regardless of scope. `gateway/config._getenv` is untouched.

**`API_SERVER_KEY` deliberately stays scoped** — it IS a credential. The #69379 scenario only needs the listener vars global: the key belongs in the profile `.env`, which the scoped reload already resolves (verified by the ported regression test, where the key comes from the scope and host/port/enabled come from container env). `tests/gateway/test_config.py`'s secondary-profile isolation tests stay green, and a new unit test locks `API_SERVER_KEY` out of the allowlist.

## 3. xai_http fail-closed (salvages the live piece of #56982, by @rayjun)

Most of #56982 (`hermes_cli/config.py::get_env_value` honoring the scope + its cache tests) already merged via ed1170cd8b (#76462). The still-live piece: `tools/xai_http.py::get_env_value` wrapped the scope-aware read in `except Exception` + a raw `os.environ` fallback — swallowing `UnscopedSecretError` and borrowing the process env, so a multiplexed xAI credential read could pick up another profile's `XAI_API_KEY`.

Fix (cherry-picked with @rayjun's authorship, `hermes_cli`/cache-test hunks dropped as redundant): narrow the except to `ImportError` only, remove the raw environ fallback. **Migrating a credential read means honoring `get_secret`'s verdict** — including letting `UnscopedSecretError` propagate. Includes rayjun's fail-closed and no-borrow-on-scoped-miss tests.

## Tests

```
tests/gateway/test_weixin.py
tests/gateway/test_weixin_typing.py
tests/gateway/test_weixin_secret_scope.py        (new)
tests/gateway/test_config.py
tests/gateway/test_64674_multiplex_primary_token_scope.py
tests/agent/test_secret_scope.py
tests/tools/test_xai_http_credentials.py         (new, from #56982)
tests/tools/test_xai_http_storage.py
tests/hermes_cli/test_env_load_cache.py
tests/hermes_cli/test_env_loader.py

10 files, 133 tests passed, 0 failed
```

## Infographic

![Secret scope corrections](https://v3b.fal.media/files/b/0aa4b259/5B6_54euL0E6xTGJy00_n_lomtuDw3.png)

Corrects #66073, #68854, #69524. Fixes #69379. Salvages #56982 (thanks @rayjun).
