### PR TITLE
fix(secrets): Slack-pattern scoped reads for 13 platform adapters + api_server init (class closure, adapter tier)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -92,6 +92,30 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from gateway.readiness import collect_runtime_readiness
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -1196,7 +1220,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if raw_port is None:
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
-        self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        self._api_key: str = extra.get("key", _get_scoped_secret("API_SERVER_KEY", ""))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -56,6 +56,30 @@ _BLUEBUBBLES_AUDIO_EXT_OVERRIDES = {
     "audio/aac": ".m4a",  # preserves historical bluebubbles mapping (shared table says .aac)
 }
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -148,7 +172,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self.server_url = _normalize_server_url(
             extra.get("server_url") or os.getenv("BLUEBUBBLES_SERVER_URL", "")
         )
-        self.password = extra.get("password") or os.getenv("BLUEBUBBLES_PASSWORD", "")
+        self.password = extra.get("password") or _get_scoped_secret("BLUEBUBBLES_PASSWORD", "")
         self.webhook_host = (
             extra.get("webhook_host")
             or os.getenv("BLUEBUBBLES_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -49,6 +49,30 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 from gateway.platforms.base import (
@@ -226,7 +250,7 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
 
     NEVER log the return value.
     """
-    key = os.getenv("BUZZ_PRIVATE_KEY", "").strip()
+    key = _get_scoped_secret("BUZZ_PRIVATE_KEY", "").strip()
     if key:
         return key
     configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -103,6 +103,30 @@ from gateway.platforms.base import (
     SendResult,
 )
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 20000
@@ -166,7 +190,7 @@ def check_dingtalk_requirements() -> bool:
         httpx = _httpx
         DINGTALK_STREAM_AVAILABLE = True
         HTTPX_AVAILABLE = True
-    if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
+    if not os.getenv("DINGTALK_CLIENT_ID") or not _get_scoped_secret("DINGTALK_CLIENT_SECRET"):
         return False
     return True
 
@@ -213,7 +237,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._client_id: str = extra.get("client_id") or os.getenv(
             "DINGTALK_CLIENT_ID", ""
         )
-        self._client_secret: str = extra.get("client_secret") or os.getenv(
+        self._client_secret: str = extra.get("client_secret") or _get_scoped_secret(
             "DINGTALK_CLIENT_SECRET", ""
         )
 
@@ -1842,7 +1866,7 @@ def _is_connected(config) -> bool:
     extra = getattr(config, "extra", {}) or {}
     return bool(
         (extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
-        and (extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
+        and (extra.get("client_secret") or _get_scoped_secret("DINGTALK_CLIENT_SECRET"))
     )
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -145,6 +145,30 @@ from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write, env_float, env_int
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1553,14 +1577,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
-            app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
+            app_secret=str(extra.get("app_secret") or _get_scoped_secret("FEISHU_APP_SECRET", "")).strip(),
             domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
             connection_mode=str(
                 extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
-            encrypt_key=str(extra.get("encrypt_key") or os.getenv("FEISHU_ENCRYPT_KEY", "")).strip(),
+            encrypt_key=str(extra.get("encrypt_key") or _get_scoped_secret("FEISHU_ENCRYPT_KEY", "")).strip(),
             verification_token=str(
-                extra.get("verification_token") or os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+                extra.get("verification_token") or _get_scoped_secret("FEISHU_VERIFICATION_TOKEN", "")
             ).strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -36,6 +36,30 @@ from gateway.platforms.base import (
     SendResult,
 )
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -46,7 +70,7 @@ def check_ha_requirements() -> bool:
 
 def validate_ha_config(config: PlatformConfig) -> bool:
     """Return True when Home Assistant has enough credential config to connect."""
-    token = (getattr(config, "token", None) or os.getenv("HASS_TOKEN", "")).strip()
+    token = (getattr(config, "token", None) or _get_scoped_secret("HASS_TOKEN", "")).strip()
     return bool(token)
 
 
@@ -76,7 +100,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
         # Configuration from extra
         extra = config.extra or {}
-        token = config.token or os.getenv("HASS_TOKEN", "")
+        token = config.token or _get_scoped_secret("HASS_TOKEN", "")
         url = extra.get("url") or os.getenv("HASS_URL", "http://homeassistant.local:8123")
         self._hass_url: str = url.rstrip("/")
         self._hass_token: str = token
@@ -488,7 +512,7 @@ async def _standalone_send(
 
     extra = getattr(pconfig, "extra", {}) or {}
     hass_url = (extra.get("url") or os.getenv("HASS_URL", "")).rstrip("/")
-    token = (getattr(pconfig, "token", None) or os.getenv("HASS_TOKEN", "")).strip()
+    token = (getattr(pconfig, "token", None) or _get_scoped_secret("HASS_TOKEN", "")).strip()
     if not hass_url or not token:
         return {
             "error": (

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -35,6 +35,30 @@ import ssl
 import time
 from typing import Any, Dict, List, Optional
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -118,8 +142,8 @@ class IRCAdapter(BasePlatformAdapter):
             if os.getenv("IRC_USE_TLS")
             else extra.get("use_tls", True)
         )
-        self.server_password = os.getenv("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
-        self.nickserv_password = os.getenv("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
+        self.server_password = _get_scoped_secret("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
+        self.nickserv_password = _get_scoped_secret("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
 
         # Auth
         self.allowed_users: list = extra.get("allowed_users", [])
@@ -685,10 +709,10 @@ def _env_enablement() -> dict | None:
         seed["use_tls"] = use_tls in {"1", "true", "yes"}
     # Passwords live in PlatformConfig.extra as well for back-compat with
     # existing config.yaml users; env-reads at construct time still win.
-    if os.getenv("IRC_SERVER_PASSWORD"):
-        seed["server_password"] = os.getenv("IRC_SERVER_PASSWORD")
-    if os.getenv("IRC_NICKSERV_PASSWORD"):
-        seed["nickserv_password"] = os.getenv("IRC_NICKSERV_PASSWORD")
+    if _get_scoped_secret("IRC_SERVER_PASSWORD"):
+        seed["server_password"] = _get_scoped_secret("IRC_SERVER_PASSWORD")
+    if _get_scoped_secret("IRC_NICKSERV_PASSWORD"):
+        seed["nickserv_password"] = _get_scoped_secret("IRC_NICKSERV_PASSWORD")
     # Optional home-channel (usually the same as IRC_CHANNEL, but can be a
     # dedicated reports channel).  Defaults to IRC_CHANNEL so cron jobs
     # with ``deliver=irc`` have a sensible target without extra config.
@@ -762,8 +786,8 @@ async def _standalone_send(
     else:
         use_tls = bool(extra.get("use_tls", True))
 
-    server_password = os.getenv("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
-    nickserv_password = os.getenv("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
+    server_password = _get_scoped_secret("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
+    nickserv_password = _get_scoped_secret("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
 
     # Reject control characters in chat_id to block IRC command injection.
     raw_target = chat_id or channel

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -80,6 +80,30 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import quote as _urlquote
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -678,11 +702,11 @@ class LineAdapter(BasePlatformAdapter):
 
         # Credentials
         self.channel_access_token = (
-            os.getenv("LINE_CHANNEL_ACCESS_TOKEN")
+            _get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN")
             or extra.get("channel_access_token", "")
         )
         self.channel_secret = (
-            os.getenv("LINE_CHANNEL_SECRET")
+            _get_scoped_secret("LINE_CHANNEL_SECRET")
             or extra.get("channel_secret", "")
         )
 
@@ -1561,9 +1585,9 @@ def _is_relative_to(child: Path, parent: Path) -> bool:
 
 def check_requirements() -> bool:
     """Plugin gate: require credentials AND aiohttp at runtime."""
-    if not os.getenv("LINE_CHANNEL_ACCESS_TOKEN"):
+    if not _get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN"):
         return False
-    if not os.getenv("LINE_CHANNEL_SECRET"):
+    if not _get_scoped_secret("LINE_CHANNEL_SECRET"):
         return False
     try:
         import aiohttp  # noqa: F401
@@ -1575,10 +1599,10 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     extra = getattr(config, "extra", {}) or {}
     has_token = bool(
-        os.getenv("LINE_CHANNEL_ACCESS_TOKEN") or extra.get("channel_access_token")
+        _get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN") or extra.get("channel_access_token")
     )
     has_secret = bool(
-        os.getenv("LINE_CHANNEL_SECRET") or extra.get("channel_secret")
+        _get_scoped_secret("LINE_CHANNEL_SECRET") or extra.get("channel_secret")
     )
     return has_token and has_secret
 
@@ -1595,7 +1619,7 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     in ``.env`` without a ``platforms.line`` block in ``config.yaml``.
     Mirrors the IRC plugin's pattern.
     """
-    if not (os.getenv("LINE_CHANNEL_ACCESS_TOKEN") and os.getenv("LINE_CHANNEL_SECRET")):
+    if not (_get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN") and _get_scoped_secret("LINE_CHANNEL_SECRET")):
         return None
     seeded: Dict[str, Any] = {}
     if os.getenv("LINE_PORT"):
@@ -1635,7 +1659,7 @@ async def _standalone_send(
     """
     extra = getattr(pconfig, "extra", {}) or {}
     token = (
-        os.getenv("LINE_CHANNEL_ACCESS_TOKEN")
+        _get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN")
         or extra.get("channel_access_token", "")
     )
     if not token or not chat_id:

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -30,6 +30,30 @@ from gateway.platforms.base import (
     SendResult,
 )
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # Mattermost post size limit (server default is 16383, but 4000 is the
@@ -75,7 +99,7 @@ def check_mattermost_requirements() -> bool:
 def validate_mattermost_config(config: PlatformConfig) -> bool:
     """Return True when Mattermost has enough config to connect."""
     extra = getattr(config, "extra", {}) or {}
-    token = (getattr(config, "token", None) or os.getenv("MATTERMOST_TOKEN", "")).strip()
+    token = (getattr(config, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
     url = (extra.get("url", "") or os.getenv("MATTERMOST_URL", "")).strip()
     if not token:
         logger.debug("Mattermost: MATTERMOST_TOKEN not set")
@@ -98,7 +122,7 @@ class MattermostAdapter(BasePlatformAdapter):
             config.extra.get("url", "")
             or os.getenv("MATTERMOST_URL", "")
         ).rstrip("/")
-        self._token: str = config.token or os.getenv("MATTERMOST_TOKEN", "")
+        self._token: str = config.token or _get_scoped_secret("MATTERMOST_TOKEN", "")
 
         self._bot_user_id: str = ""
         self._bot_username: str = ""
@@ -1022,7 +1046,7 @@ async def _standalone_send(
         (getattr(pconfig, "extra", {}) or {}).get("url")
         or os.getenv("MATTERMOST_URL", "")
     ).rstrip("/")
-    token = (getattr(pconfig, "token", None) or os.getenv("MATTERMOST_TOKEN", "")).strip()
+    token = (getattr(pconfig, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
     if not base_url or not token:
         return {
             "error": (

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -68,6 +68,30 @@ from gateway.platforms.base import (
     SendResult,
 )
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,7 +197,7 @@ class NtfyAdapter(BasePlatformAdapter):
             or os.getenv("NTFY_PUBLISH_TOPIC", "")
             or self._topic
         )
-        self._token: str = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+        self._token: str = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
 
         self._stream_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -472,7 +496,7 @@ def _env_enablement() -> dict | None:
     publish_topic = os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
     if publish_topic:
         seed["publish_topic"] = publish_topic
-    token = os.getenv("NTFY_TOKEN", "").strip()
+    token = _get_scoped_secret("NTFY_TOKEN", "").strip()
     if token:
         seed["token"] = token
     markdown = os.getenv("NTFY_MARKDOWN", "").strip().lower()
@@ -526,7 +550,7 @@ async def _standalone_send(
     if not publish_topic:
         return {"error": "ntfy standalone send: NTFY_TOPIC not configured"}
 
-    token = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+    token = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
     markdown_env = os.getenv("NTFY_MARKDOWN", "").strip().lower()
     markdown_enabled = bool(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -67,6 +67,30 @@ from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
 
 from .auth import load_project_credentials
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -511,7 +535,7 @@ def _reinstall_sidecar_deps() -> None:
 def validate_config(cfg: PlatformConfig) -> bool:
     extra = cfg.extra or {}
     project_id = extra.get("project_id") or os.getenv("PHOTON_PROJECT_ID")
-    project_secret = extra.get("project_secret") or os.getenv("PHOTON_PROJECT_SECRET")
+    project_secret = extra.get("project_secret") or _get_scoped_secret("PHOTON_PROJECT_SECRET")
     if not project_id or not project_secret:
         # Fall back to auth.json
         stored_id, stored_sec = load_project_credentials()
@@ -694,7 +718,7 @@ class PhotonAdapter(BasePlatformAdapter):
             or ""
         )
         self._project_secret: str = (
-            os.getenv("PHOTON_PROJECT_SECRET")
+            _get_scoped_secret("PHOTON_PROJECT_SECRET")
             or extra.get("project_secret")
             or stored_sec
             or ""
@@ -707,7 +731,7 @@ class PhotonAdapter(BasePlatformAdapter):
         )
         self._sidecar_bind = _DEFAULT_SIDECAR_BIND
         self._sidecar_token = (
-            os.getenv("PHOTON_SIDECAR_TOKEN") or secrets.token_hex(16)
+            _get_scoped_secret("PHOTON_SIDECAR_TOKEN") or secrets.token_hex(16)
         )
         self._autostart_sidecar = str(
             os.getenv("PHOTON_SIDECAR_AUTOSTART", "true")
@@ -2730,7 +2754,7 @@ async def _standalone_send(
         (pconfig.extra or {}).get("sidecar_port") or os.getenv("PHOTON_SIDECAR_PORT"),
         _DEFAULT_SIDECAR_PORT,
     )
-    token = os.getenv("PHOTON_SIDECAR_TOKEN")
+    token = _get_scoped_secret("PHOTON_SIDECAR_TOKEN")
     if not token:
         # Fall back to the runtime record the gateway persists once its
         # sidecar passes /healthz (issue #69960) — the token only exists in

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -53,6 +53,30 @@ try:
 except ImportError:  # pragma: no cover - httpx is a hermes dependency
     httpx = None  # type: ignore[assignment]
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -231,7 +255,7 @@ def load_project_credentials() -> Tuple[Optional[str], Optional[str]]:
     is the unified project id (dashboard id == spectrumProjectId).
     """
     env_id = os.getenv("PHOTON_PROJECT_ID")
-    env_sec = os.getenv("PHOTON_PROJECT_SECRET")
+    env_sec = _get_scoped_secret("PHOTON_PROJECT_SECRET")
     if env_id and env_sec:
         return env_id, env_sec
     auth = _load_auth()

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -36,6 +36,30 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.helpers import redact_phone, strip_markdown
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
@@ -51,7 +75,7 @@ def check_sms_requirements() -> bool:
         import aiohttp  # noqa: F401
     except ImportError:
         return False
-    return bool(os.getenv("TWILIO_ACCOUNT_SID") and os.getenv("TWILIO_AUTH_TOKEN"))
+    return bool(_get_scoped_secret("TWILIO_ACCOUNT_SID") and _get_scoped_secret("TWILIO_AUTH_TOKEN"))
 
 
 class SmsAdapter(BasePlatformAdapter):
@@ -66,8 +90,8 @@ class SmsAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)
-        self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
-        self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
+        self._account_sid: str = _get_scoped_secret("TWILIO_ACCOUNT_SID", "")
+        self._auth_token: str = _get_scoped_secret("TWILIO_AUTH_TOKEN", "")
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
@@ -435,14 +459,14 @@ async def _standalone_send(
 ):
     """Out-of-process SMS delivery via the Twilio REST API. Implements the
     standalone_sender_fn contract; replaces the legacy _send_sms helper."""
-    auth_token = getattr(pconfig, "api_key", None) or os.getenv("TWILIO_AUTH_TOKEN", "")
+    auth_token = getattr(pconfig, "api_key", None) or _get_scoped_secret("TWILIO_AUTH_TOKEN", "")
     try:
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     import base64
 
-    account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+    account_sid = _get_scoped_secret("TWILIO_ACCOUNT_SID", "")
     from_number = os.getenv("TWILIO_PHONE_NUMBER", "")
     if not account_sid or not auth_token or not from_number:
         return {"error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"}

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -91,6 +91,30 @@ from gateway.platforms.base import (
     cache_media_bytes,
 )
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 3978
@@ -200,7 +224,7 @@ class TeamsSummaryWriter:
         env_defaults = {
             "delivery_mode": os.getenv("TEAMS_DELIVERY_MODE", ""),
             "incoming_webhook_url": os.getenv("TEAMS_INCOMING_WEBHOOK_URL", ""),
-            "access_token": os.getenv("TEAMS_GRAPH_ACCESS_TOKEN", ""),
+            "access_token": _get_scoped_secret("TEAMS_GRAPH_ACCESS_TOKEN", ""),
             "team_id": os.getenv("TEAMS_TEAM_ID", ""),
             "channel_id": os.getenv("TEAMS_CHANNEL_ID", ""),
             "chat_id": os.getenv("TEAMS_CHAT_ID", ""),
@@ -401,7 +425,7 @@ def validate_config(config) -> bool:
     """Return True when the config has the minimum required credentials."""
     extra = getattr(config, "extra", {}) or {}
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
-    client_secret = os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
+    client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
     tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
     return bool(client_id and client_secret and tenant_id)
 
@@ -423,7 +447,7 @@ def _env_enablement() -> dict | None:
     ``HomeChannel`` dataclass on the ``PlatformConfig`` via the core hook.
     """
     client_id = os.getenv("TEAMS_CLIENT_ID", "").strip()
-    client_secret = os.getenv("TEAMS_CLIENT_SECRET", "").strip()
+    client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET", "").strip()
     tenant_id = os.getenv("TEAMS_TENANT_ID", "").strip()
     if not (client_id and client_secret and tenant_id):
         return None
@@ -528,7 +552,7 @@ async def _standalone_send(
     """
     extra = getattr(pconfig, "extra", {}) or {}
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
-    client_secret = os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
+    client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
     tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
     if not (client_id and client_secret and tenant_id):
         return {"error": "Teams standalone send: TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID are all required"}
@@ -728,7 +752,7 @@ class TeamsAdapter(BasePlatformAdapter):
         super().__init__(config, Platform("teams"))
         extra = config.extra or {}
         self._client_id = extra.get("client_id") or os.getenv("TEAMS_CLIENT_ID", "")
-        self._client_secret = extra.get("client_secret") or os.getenv("TEAMS_CLIENT_SECRET", "")
+        self._client_secret = extra.get("client_secret") or _get_scoped_secret("TEAMS_CLIENT_SECRET", "")
         self._tenant_id = extra.get("tenant_id") or os.getenv("TEAMS_TENANT_ID", "")
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -70,6 +70,30 @@ from gateway.platforms.base import (
 )
 from utils import env_float
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware credential read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and sends
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash this path; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_WS_URL = "wss://openws.work.weixin.qq.com"
@@ -154,7 +178,7 @@ class WeComAdapter(BasePlatformAdapter):
 
         extra = config.extra or {}
         self._bot_id = str(extra.get("bot_id") or os.getenv("WECOM_BOT_ID", "")).strip()
-        self._secret = str(extra.get("secret") or os.getenv("WECOM_SECRET", "")).strip()
+        self._secret = str(extra.get("secret") or _get_scoped_secret("WECOM_SECRET", "")).strip()
         self._ws_url = str(
             extra.get("websocket_url")
             or extra.get("websocketUrl")

--- a/tests/gateway/test_adapter_startup_secret_scope.py
+++ b/tests/gateway/test_adapter_startup_secret_scope.py
@@ -1,0 +1,125 @@
+"""Regression tests — Slack-pattern scoped credential reads at adapter startup.
+
+Class-closure follow-up to the profile secret-scope cluster (#76462, Slack
+pattern #59739, WhatsApp ``_get_wsecret``): the 13 platform adapters below
+read credentials at ``__init__`` / availability-check / standalone-send time
+with bare ``os.getenv`` (SMS even used ``os.environ[...]``, which KeyErrors).
+Under ``gateway.multiplex_profiles`` those reads leak the default profile's
+credential into secondary profiles' adapters.
+
+Each migrated module now carries a module-level ``_get_scoped_secret`` helper
+mirroring ``gateway/platforms/whatsapp_common.py::_get_wsecret``:
+
+- scope installed → scope is authoritative; scoped miss returns the default
+  (NO borrow from ``os.environ``)
+- unscoped under multiplex (the default profile's own startup loop) →
+  fall back to ``os.getenv`` without raising ``UnscopedSecretError``
+
+The helpers are imported and exercised directly rather than constructing every
+adapter — construction pulls heavy platform dependencies (slack-bolt-style SDK
+imports, webhook servers, sidecars) that the test environment doesn't need.
+"""
+
+import importlib
+
+import pytest
+
+from agent import secret_scope as ss
+
+# (module path, representative credential env var owned by that adapter)
+MIGRATED_ADAPTER_MODULES = [
+    ("plugins.platforms.irc.adapter", "IRC_SERVER_PASSWORD"),
+    ("plugins.platforms.line.adapter", "LINE_CHANNEL_ACCESS_TOKEN"),
+    ("plugins.platforms.teams.adapter", "TEAMS_CLIENT_SECRET"),
+    ("plugins.platforms.mattermost.adapter", "MATTERMOST_TOKEN"),
+    ("plugins.platforms.ntfy.adapter", "NTFY_TOKEN"),
+    ("plugins.platforms.homeassistant.adapter", "HASS_TOKEN"),
+    ("plugins.platforms.sms.adapter", "TWILIO_AUTH_TOKEN"),
+    ("plugins.platforms.dingtalk.adapter", "DINGTALK_CLIENT_SECRET"),
+    ("plugins.platforms.feishu.adapter", "FEISHU_APP_SECRET"),
+    ("plugins.platforms.wecom.adapter", "WECOM_SECRET"),
+    ("plugins.platforms.photon.adapter", "PHOTON_PROJECT_SECRET"),
+    ("plugins.platforms.photon.auth", "PHOTON_PROJECT_SECRET"),
+    ("plugins.platforms.buzz.adapter", "BUZZ_PRIVATE_KEY"),
+    ("gateway.platforms.bluebubbles", "BLUEBUBBLES_PASSWORD"),
+    ("gateway.platforms.api_server", "API_SERVER_KEY"),
+]
+
+MODULE_IDS = [m for m, _ in MIGRATED_ADAPTER_MODULES]
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    """Multiplex mode off before and after every test."""
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _helper(module_name):
+    mod = importlib.import_module(module_name)
+    helper = getattr(mod, "_get_scoped_secret", None)
+    assert helper is not None, (
+        f"{module_name} must define the module-level _get_scoped_secret helper "
+        "(Slack pattern #59739 / whatsapp_common._get_wsecret)"
+    )
+    return helper
+
+
+@pytest.mark.parametrize(("module_name", "var"), MIGRATED_ADAPTER_MODULES, ids=MODULE_IDS)
+def test_helper_exists(module_name, var):
+    _helper(module_name)
+
+
+@pytest.mark.parametrize(("module_name", "var"), MIGRATED_ADAPTER_MODULES, ids=MODULE_IDS)
+def test_scoped_read_wins_over_environ(module_name, var, monkeypatch):
+    """Scope installed under multiplex: the profile's value wins, not environ's."""
+    helper = _helper(module_name)
+    monkeypatch.setenv(var, "default-profile-value")
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope({var: "secondary-profile-value"})
+    try:
+        assert helper(var) == "secondary-profile-value"
+    finally:
+        ss.reset_secret_scope(tok)
+
+
+@pytest.mark.parametrize(("module_name", "var"), MIGRATED_ADAPTER_MODULES, ids=MODULE_IDS)
+def test_scoped_miss_returns_default_no_environ_borrow(module_name, var, monkeypatch):
+    """Scope installed but key absent: return the default — never borrow the
+    default profile's os.environ value into a secondary profile."""
+    helper = _helper(module_name)
+    monkeypatch.setenv(var, "default-profile-value")
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope({"SOME_OTHER_KEY": "x"})
+    try:
+        assert helper(var) is None
+        assert helper(var, "") == ""
+        assert helper(var, "sentinel") == "sentinel"
+    finally:
+        ss.reset_secret_scope(tok)
+
+
+@pytest.mark.parametrize(("module_name", "var"), MIGRATED_ADAPTER_MODULES, ids=MODULE_IDS)
+def test_unscoped_under_multiplex_falls_back_to_environ(module_name, var, monkeypatch):
+    """The DEFAULT profile constructs its adapters unscoped under multiplexing.
+    A bare get_secret would raise UnscopedSecretError and crash startup; the
+    helper must fall back to os.environ (that profile's own value) instead."""
+    helper = _helper(module_name)
+    monkeypatch.setenv(var, "default-profile-own-value")
+    ss.set_multiplex_active(True)
+    assert ss.current_secret_scope() is None
+    assert helper(var) == "default-profile-own-value"
+
+    monkeypatch.delenv(var, raising=False)
+    assert helper(var, "fallback-default") == "fallback-default"
+
+
+@pytest.mark.parametrize(("module_name", "var"), MIGRATED_ADAPTER_MODULES, ids=MODULE_IDS)
+def test_single_profile_legacy_environ_read(module_name, var, monkeypatch):
+    """Multiplex off, no scope: legacy os.environ read keeps working."""
+    helper = _helper(module_name)
+    monkeypatch.setenv(var, "legacy-env-value")
+    assert helper(var) == "legacy-env-value"
+    monkeypatch.delenv(var, raising=False)
+    assert helper(var, "d") == "d"


### PR DESCRIPTION
## Summary

Class-closure follow-up (adapter tier) to the profile secret-scope cluster (#76462, Slack pattern #59739, WhatsApp `_get_wsecret`, Matrix `MATRIX_RECOVERY_KEY`): 13 platform adapters still read credentials at `__init__` / availability-check / standalone-send time with bare `os.getenv` (SMS even used `os.environ[...]`, which raises `KeyError` when unset). Under `gateway.multiplex_profiles` those reads bypass the profile secret scope and leak the **default profile's** credential into secondary profiles' adapters.

Each migrated module now carries a module-level `_get_scoped_secret` helper that mirrors `gateway/platforms/whatsapp_common.py::_get_wsecret` exactly:

- **Scope installed** (secondary-profile connect/send): the scope is authoritative — a scoped miss returns the default, **no fallthrough to `os.environ`** (which may hold another profile's value).
- **Unscoped under multiplex** (the default profile's own startup loop): a bare `get_secret` would raise `UnscopedSecretError` and crash the adapter; the helper falls back to `os.getenv`, which in that context is the profile's own value.
- **Multiplex off**: legacy `os.environ` semantics, unchanged.

## Migrated credential reads

| Adapter | Vars | Sites |
|---|---|---|
| `plugins/platforms/irc/adapter.py` | `IRC_SERVER_PASSWORD`, `IRC_NICKSERV_PASSWORD` | `__init__`, `_env_enablement` seed, standalone send |
| `plugins/platforms/line/adapter.py` | `LINE_CHANNEL_ACCESS_TOKEN`, `LINE_CHANNEL_SECRET` | `__init__`, `check_requirements`, `validate_config`, `_env_enablement`, standalone send |
| `plugins/platforms/teams/adapter.py` | `TEAMS_GRAPH_ACCESS_TOKEN`, `TEAMS_CLIENT_SECRET` | merged-config env defaults, requirements/validate, standalone send, `__init__` |
| `plugins/platforms/mattermost/adapter.py` | `MATTERMOST_TOKEN` | availability check, `__init__`, standalone send |
| `plugins/platforms/ntfy/adapter.py` | `NTFY_TOKEN` | `__init__`, connectivity check, standalone send |
| `plugins/platforms/homeassistant/adapter.py` | `HASS_TOKEN` | availability check, `__init__`, standalone send |
| `plugins/platforms/sms/adapter.py` | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` | requirements, `__init__` (**was bare `os.environ[...]` → `KeyError`; now defaults to `""` like sibling adapters**), standalone send |
| `plugins/platforms/dingtalk/adapter.py` | `DINGTALK_CLIENT_SECRET` | requirements, `__init__`, `is_connected` |
| `plugins/platforms/feishu/adapter.py` | `FEISHU_APP_SECRET`, `FEISHU_ENCRYPT_KEY`, `FEISHU_VERIFICATION_TOKEN` | `__init__` config resolution |
| `plugins/platforms/wecom/adapter.py` | `WECOM_SECRET` | `__init__` |
| `plugins/platforms/photon/adapter.py` + `photon/auth.py` | `PHOTON_PROJECT_SECRET`, `PHOTON_SIDECAR_TOKEN` | validate, `__init__`, sidecar auth resolve, `load_project_credentials` |
| `plugins/platforms/buzz/adapter.py` | `BUZZ_PRIVATE_KEY` | `_load_private_key` |
| `gateway/platforms/bluebubbles.py` | `BLUEBUBBLES_PASSWORD` | `__init__` |
| `gateway/platforms/api_server.py` | `API_SERVER_KEY` | `__init__` — now consistent with the already-scoped `_expected_api_key` path |

`TWILIO_ACCOUNT_SID` was migrated alongside `TWILIO_AUTH_TOKEN`: it is half of the Basic-auth credential pair and was read on the same `os.environ[...]` lines being fixed.

## Deliberately skipped (non-secret config, per scope rules)

- Host/port/URL/flag reads (`IRC_SERVER`, `IRC_PORT`, `LINE_HOST`, `SMS_WEBHOOK_*`, `API_SERVER_HOST/PORT/CORS`, `PHOTON_SIDECAR_PORT`, `MATTERMOST_URL`, `HASS_URL`, `BLUEBUBBLES_SERVER_URL`, `NTFY_SERVER`, etc.) — not credential-shaped.
- Setup/onboarding flows (`save_env_value` writers, `hermes gateway setup` prompts) — interactive single-profile paths, writes not reads.
- Non-secret ids paired with the migrated secrets (`DINGTALK_CLIENT_ID`, `FEISHU_APP_ID`, `WECOM_BOT_ID`, `TEAMS_CLIENT_ID`/`TEAMS_TENANT_ID`, `PHOTON_PROJECT_ID`, `TWILIO_PHONE_NUMBER`) — identifiers, not credentials; kept minimal per "when in doubt, skip".
- `photon/adapter.py:1576-1579` — writes the secrets into the sidecar child's env (spawn-site propagation, correct per the boundary doc).

## Tests

New `tests/gateway/test_adapter_startup_secret_scope.py` — parametrized over all 15 migrated modules (75 tests), importing each module's helper directly (adapter construction needs heavy platform deps). Per module it asserts: helper exists · scoped read wins over environ · scoped miss returns default (no environ borrow) · unscoped-under-multiplex falls back to environ without raising · legacy single-profile read unchanged.

Also ran the touched adapters' existing suites green: IRC, LINE, Teams (×4 files), Mattermost (×2), ntfy, Home Assistant, SMS, DingTalk, Feishu (×3), WeCom (×3), `tests/plugins/platforms/photon/` (whole dir), Buzz (×2), BlueBubbles, `test_api_server.py`, `test_api_server_multiplex_secret_scope.py`, `test_multiplex_api_server_routing.py`, plus the WhatsApp reference regression `test_75349_whatsapp_multiplex_secret_scope.py`. `ruff check` and the Windows-footgun checker pass.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa4b25d/SGV2lChe0rWEdTxqWPN7P_e3iESgoZ.png)
