### PR TITLE
fix(secrets): scope qqbot, email adapter, and TUI session.branch under multiplex profiles (salvage #60420, #59076, #72299)

### DIFF
--- a/contributors/emails/286182457+Da7-Tech@users.noreply.github.com
+++ b/contributors/emails/286182457+Da7-Tech@users.noreply.github.com
@@ -1,0 +1,2 @@
+Da7-Tech
+# PR #60420 salvage

--- a/contributors/emails/shikanga-hermes@shikanga.co.uk
+++ b/contributors/emails/shikanga-hermes@shikanga.co.uk
@@ -1,0 +1,2 @@
+phantom-instruction-set
+# PR #59076 salvage

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -147,6 +147,31 @@ def _coerce_list(value: Any) -> List[str]:
     return _coerce_list_impl(value)
 
 
+def _resolve_qq_secret(name: str, default: str = "") -> str:
+    """Resolve a per-profile ``QQ_*`` setting honoring the active secret scope.
+
+    When a profile secret scope is installed — every secondary multiplex
+    profile is constructed and handled inside ``_profile_runtime_scope``
+    (``gateway/run.py``), as is each per-turn inbound message — read from it so
+    profiles never see each other's ``os.environ`` values. This is the
+    cross-profile credential collision fixed for the WeChat adapter in #59662.
+
+    The primary/active profile is constructed without a scope and legitimately
+    owns ``os.environ``, so fall back to it there instead of failing closed: a
+    bare ``get_secret`` would raise ``UnscopedSecretError`` on the active
+    profile's ``__init__`` and break its startup. Same pattern as the Slack
+    ``SLACK_APP_TOKEN`` read (#59739) and
+    ``gateway.platforms.whatsapp_common._get_wsecret``.
+    """
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 # ---------------------------------------------------------------------------
 # QQAdapter
 # ---------------------------------------------------------------------------
@@ -202,9 +227,11 @@ class QQAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.QQBOT)
 
         extra = config.extra or {}
-        self._app_id = str(extra.get("app_id") or os.getenv("QQ_APP_ID", "")).strip()
+        self._app_id = str(
+            extra.get("app_id") or _resolve_qq_secret("QQ_APP_ID", "")
+        ).strip()
         self._client_secret = str(
-            extra.get("client_secret") or os.getenv("QQ_CLIENT_SECRET", "")
+            extra.get("client_secret") or _resolve_qq_secret("QQ_CLIENT_SECRET", "")
         ).strip()
         self._markdown_support = bool(extra.get("markdown_support", True))
 
@@ -2202,13 +2229,13 @@ class QQAdapter(BasePlatformAdapter):
                     }
 
         # 2. QQ-specific env vars (set by `hermes setup gateway` / `hermes gateway`)
-        qq_stt_key = os.getenv("QQ_STT_API_KEY", "")
+        qq_stt_key = _resolve_qq_secret("QQ_STT_API_KEY", "")
         if qq_stt_key:
-            base_url = os.getenv(
+            base_url = _resolve_qq_secret(
                 "QQ_STT_BASE_URL",
                 "https://open.bigmodel.cn/api/coding/paas/v4",
             )
-            model = os.getenv("QQ_STT_MODEL", "glm-asr")
+            model = _resolve_qq_secret("QQ_STT_MODEL", "glm-asr")
             return {
                 "base_url": base_url.rstrip("/"),
                 "api_key": qq_stt_key,
@@ -3170,7 +3197,7 @@ class QQAdapter(BasePlatformAdapter):
     def _open_dm_opted_in(self) -> bool:
         if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, user_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2204,6 +2204,7 @@ from gateway.config import (
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
     PlatformConfig,
+    _getenv,
     load_gateway_config,
 )
 from gateway.session import (
@@ -2293,11 +2294,11 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         extra = getattr(platform_config, "extra", None) or {}
         dm_policy = str(
             extra.get("dm_policy")
-            or (os.getenv(dm_env, "pairing") if dm_env else "pairing")
+            or (_getenv(dm_env, "pairing") if dm_env else "pairing")
         ).strip().lower()
         group_policy = str(
             extra.get("group_policy")
-            or (os.getenv(group_env, "pairing") if group_env else "pairing")
+            or (_getenv(group_env, "pairing") if group_env else "pairing")
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
@@ -2306,7 +2307,7 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).lower() in {"true", "1", "yes"}
         platform_opted_in = gateway_allow_all or (
             allow_all_env
-            and os.getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
+            and _getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
         )
         if platform_opted_in:
             continue

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -23,6 +23,9 @@ import os
 import re
 import smtplib
 import socket
+
+# Profile-scoped secret reader for multiplexing support (PR #50094)
+from agent.secret_scope import get_secret as _get_secret
 import ssl
 import uuid
 from email.header import decode_header
@@ -164,10 +167,10 @@ def check_email_requirements() -> bool:
     Treats blank/whitespace-only values as missing so an abandoned setup that
     left empty ``EMAIL_*`` keys in ``.env`` does not enable the platform (#40715).
     """
-    addr = os.getenv("EMAIL_ADDRESS", "").strip()
-    pwd = os.getenv("EMAIL_PASSWORD", "").strip()
-    imap = os.getenv("EMAIL_IMAP_HOST", "").strip()
-    smtp = os.getenv("EMAIL_SMTP_HOST", "").strip()
+    addr = _get_secret("EMAIL_ADDRESS", "").strip()
+    pwd = _get_secret("EMAIL_PASSWORD", "").strip()
+    imap = _get_secret("EMAIL_IMAP_HOST", "").strip()
+    smtp = _get_secret("EMAIL_SMTP_HOST", "").strip()
     return all([addr, pwd, imap, smtp])
 
 
@@ -434,11 +437,11 @@ class EmailAdapter(BasePlatformAdapter):
         # misleading ``[Errno 8] nodename nor servname`` (an unresolvable name)
         # instead of an obvious "host not set" error.
         extra = config.extra or {}
-        self._address = (os.getenv("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
-        self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = (os.getenv("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
+        self._address = (_get_secret("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
+        self._password = _get_secret("EMAIL_PASSWORD", "")
+        self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
-        self._smtp_host = (os.getenv("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
+        self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
         self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
@@ -473,7 +476,7 @@ class EmailAdapter(BasePlatformAdapter):
         # own receiving server (defends against an injected header that sorts
         # first). Defaults to the From-domain of the agent's own address.
         self._authserv_id = (
-            extra.get("authserv_id", "") or os.getenv("EMAIL_AUTHSERV_ID", "")
+            extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")
         ).strip().lower()
 
         # Track message IDs we've already processed to avoid duplicates
@@ -756,7 +759,7 @@ class EmailAdapter(BasePlatformAdapter):
         """
         truthy = {"true", "1", "yes"}
         return (
-            os.getenv("EMAIL_ALLOW_ALL_USERS", "").strip().lower() in truthy
+            _get_secret("EMAIL_ALLOW_ALL_USERS", "").strip().lower() in truthy
             or os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in truthy
         )
 
@@ -771,7 +774,7 @@ class EmailAdapter(BasePlatformAdapter):
         and the authentication gate is unnecessary.
         """
         return bool(
-            os.getenv("EMAIL_ALLOWED_USERS", "").strip()
+            _get_secret("EMAIL_ALLOWED_USERS", "").strip()
             or os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
         )
 
@@ -793,9 +796,9 @@ class EmailAdapter(BasePlatformAdapter):
         # that the gateway will never authorize.  Without this early guard,
         # a race between dispatch and authorization can result in the adapter
         # sending a reply even though the handler returned None.
-        allowed_raw = os.getenv("EMAIL_ALLOWED_USERS", "").strip()
+        allowed_raw = _get_secret("EMAIL_ALLOWED_USERS", "").strip()
         if not allowed_raw:
-            if os.getenv("EMAIL_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"} and (
+            if _get_secret("EMAIL_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"} and (
                 os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() not in {"true", "1", "yes"}
             ):
                 logger.debug(
@@ -1204,11 +1207,11 @@ async def _standalone_send(
     from email.utils import formatdate
 
     extra = getattr(pconfig, "extra", {}) or {}
-    address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
-    password = os.getenv("EMAIL_PASSWORD", "")
-    smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
+    password = _get_secret("EMAIL_PASSWORD", "")
+    smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")
     try:
-        smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+        smtp_port = int(_get_secret("EMAIL_SMTP_PORT", "587") or "587")
     except (ValueError, TypeError):
         smtp_port = 587
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -25,7 +25,8 @@ import smtplib
 import socket
 
 # Profile-scoped secret reader for multiplexing support (PR #50094)
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
 import ssl
 import uuid
 from email.header import decode_header
@@ -46,9 +47,50 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
-from utils import env_int, env_bool
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+def _get_esecret(name: str, default: str = "") -> str:
+    """Scope-aware ``EMAIL_*`` read with the default-profile startup fallback.
+
+    Secondary profiles run under ``_profile_runtime_scope`` — the scope is
+    authoritative and a scoped miss returns ``default`` (no cross-profile
+    borrow). The DEFAULT profile's adapter constructs and sends *unscoped*
+    under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash its email path; there ``os.environ``
+    is that profile's own value, so fall back to it. Same pattern as the
+    Slack ``SLACK_APP_TOKEN`` read (#59739) and the WhatsApp
+    ``_get_wsecret`` fix (5438e9c629).
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
+# Backwards-compatible alias for the name used by the original #59076 hunks.
+_get_secret = _get_esecret
+
+
+def _esecret_int(name: str, default: int) -> int:
+    """Scope-aware integer read (``env_int`` variant of ``_get_esecret``)."""
+    raw = str(_get_esecret(name, "")).strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+def _esecret_bool(name: str, default: bool = False) -> bool:
+    """Scope-aware boolean read (``env_bool`` variant of ``_get_esecret``)."""
+    return is_truthy_value(_get_esecret(name, ""), default=default)
+
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -440,10 +482,10 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = (_get_secret("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
-        self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
+        self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
-        self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
-        self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
+        self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
+        self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -467,7 +509,7 @@ class EmailAdapter(BasePlatformAdapter):
         # gate below is skipped.
         if "require_authenticated_sender" in extra:
             self._require_authenticated_sender = bool(extra["require_authenticated_sender"])
-        elif env_bool("EMAIL_TRUST_FROM_HEADER", False):
+        elif _esecret_bool("EMAIL_TRUST_FROM_HEADER", False):
             self._require_authenticated_sender = False
         else:
             self._require_authenticated_sender = True

--- a/tests/gateway/test_email_secret_scope.py
+++ b/tests/gateway/test_email_secret_scope.py
@@ -1,0 +1,161 @@
+"""Tests for email adapter credential isolation under multiplexing.
+
+Verifies that the email adapter reads EMAIL_ADDRESS, EMAIL_PASSWORD,
+EMAIL_IMAP_HOST, and EMAIL_SMTP_HOST from the profile-scoped secret
+store (agent.secret_scope.get_secret) instead of os.getenv, so that
+a secondary profile in a multiplexed gateway does not inherit the
+default profile's email credentials via os.environ.
+
+Related issues: #50051, #52307
+Related PRs: #51374 (config.py api_server guard), #50094 (config.py scoped env reads)
+"""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from agent import secret_scope as ss
+
+
+class TestEmailAdapterSecretScope(unittest.TestCase):
+    """Verify the email adapter honors the profile secret scope over os.environ."""
+
+    def setUp(self):
+        ss.set_multiplex_active(False)
+
+    def tearDown(self):
+        ss.set_multiplex_active(False)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+    }, clear=False)
+    def test_adapter_uses_scoped_credentials_not_environ(self):
+        """When a secret scope is installed, the adapter must read from it,
+        not from os.environ which may hold another profile's values."""
+        from gateway.config import PlatformConfig, Platform
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        scoped = {
+            "EMAIL_ADDRESS": "beta@test.invalid",
+            "EMAIL_PASSWORD": "secondary-pw",
+            "EMAIL_IMAP_HOST": "imap.secondary.example",
+            "EMAIL_SMTP_HOST": "smtp.secondary.example",
+        }
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scoped)
+        try:
+            cfg = PlatformConfig(enabled=True)
+            adapter = EmailAdapter(cfg)
+            self.assertEqual(adapter._address, "beta@test.invalid")
+            self.assertEqual(adapter._password, "secondary-pw")
+            self.assertEqual(adapter._imap_host, "imap.secondary.example")
+            self.assertEqual(adapter._smtp_host, "smtp.secondary.example")
+        finally:
+            ss.reset_secret_scope(token)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+    }, clear=False)
+    def test_adapter_falls_back_to_environ_without_scope(self):
+        """Without a secret scope (single-profile mode), the adapter reads
+        from os.environ — backward-compatible with legacy behavior."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        cfg = PlatformConfig(enabled=True)
+        adapter = EmailAdapter(cfg)
+        self.assertEqual(adapter._address, "alpha@test.invalid")
+        self.assertEqual(adapter._password, "default-pw")
+        self.assertEqual(adapter._imap_host, "imap.default.com")
+        self.assertEqual(adapter._smtp_host, "smtp.default.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+    }, clear=False)
+    def test_check_email_requirements_uses_scope(self):
+        """check_email_requirements must also honor the secret scope so that
+        a secondary profile with scoped email creds is detected as configured."""
+        scoped = {
+            "EMAIL_ADDRESS": "beta@test.invalid",
+            "EMAIL_PASSWORD": "secondary-pw",
+            "EMAIL_IMAP_HOST": "imap.secondary.example",
+            "EMAIL_SMTP_HOST": "smtp.secondary.example",
+        }
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scoped)
+        try:
+            from plugins.platforms.email.adapter import check_email_requirements
+            self.assertTrue(check_email_requirements())
+        finally:
+            ss.reset_secret_scope(token)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+    }, clear=False)
+    def test_adapter_scoped_missing_key_does_not_leak_environ(self):
+        """If a key is absent from the scope but present in os.environ,
+        the adapter must NOT fall through to os.environ (which would leak
+        the default profile's value)."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        scoped = {
+            "EMAIL_ADDRESS": "beta@test.invalid",
+            # EMAIL_PASSWORD intentionally missing from scope
+            "EMAIL_IMAP_HOST": "imap.secondary.example",
+            "EMAIL_SMTP_HOST": "smtp.secondary.example",
+        }
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scoped)
+        try:
+            cfg = PlatformConfig(enabled=True)
+            adapter = EmailAdapter(cfg)
+            self.assertEqual(adapter._address, "beta@test.invalid")
+            # Password must NOT be the default profile's "default-pw"
+            self.assertNotEqual(adapter._password, "default-pw")
+            self.assertEqual(adapter._password, "")
+        finally:
+            ss.reset_secret_scope(token)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+        "EMAIL_ALLOWED_USERS": "gamma@test.invalid",
+    }, clear=False)
+    def test_allowed_users_uses_scope(self):
+        """EMAIL_ALLOWED_USERS must also be read from the secret scope
+        so a secondary profile gets its own allowlist, not the default's."""
+        scoped = {
+            "EMAIL_ADDRESS": "beta@test.invalid",
+            "EMAIL_PASSWORD": "secondary-pw",
+            "EMAIL_IMAP_HOST": "imap.secondary.example",
+            "EMAIL_SMTP_HOST": "smtp.secondary.example",
+            "EMAIL_ALLOWED_USERS": "epsilon@test.invalid,delta@test.invalid",
+        }
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scoped)
+        try:
+            # _allowlist_in_effect reads EMAIL_ALLOWED_USERS — verify it
+            # sees the scoped value, not the environ value
+            from plugins.platforms.email.adapter import EmailAdapter
+            self.assertTrue(EmailAdapter._allowlist_in_effect())
+        finally:
+            ss.reset_secret_scope(token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_email_secret_scope.py
+++ b/tests/gateway/test_email_secret_scope.py
@@ -157,5 +157,92 @@ class TestEmailAdapterSecretScope(unittest.TestCase):
             ss.reset_secret_scope(token)
 
 
+class TestEmailAdapterUnscopedUnderMultiplex(unittest.TestCase):
+    """The DEFAULT profile's adapter constructs UNSCOPED under multiplexing.
+
+    In a multiplexed gateway only secondary profiles run inside
+    ``_profile_runtime_scope``; the default profile's adapter is constructed
+    with no scope installed while multiplexing is active. A bare
+    ``get_secret`` raises ``UnscopedSecretError`` there and would crash the
+    email path on startup — the exact WhatsApp defect fixed in 5438e9c629.
+    The Slack-pattern helper (``_get_esecret``) must swallow that and read
+    the default profile's own ``os.environ`` values instead.
+    """
+
+    def setUp(self):
+        ss.set_multiplex_active(False)
+
+    def tearDown(self):
+        ss.set_multiplex_active(False)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+        "EMAIL_IMAP_PORT": "1993",
+        "EMAIL_SMTP_PORT": "1587",
+        "EMAIL_POLL_INTERVAL": "30",
+    }, clear=False)
+    def test_default_profile_constructs_unscoped_under_multiplex(self):
+        """Multiplex ON + no scope: construction must not raise and must
+        read the default profile's own environ values."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        ss.set_multiplex_active(True)
+        cfg = PlatformConfig(enabled=True)
+        adapter = EmailAdapter(cfg)  # must NOT raise UnscopedSecretError
+        self.assertEqual(adapter._address, "alpha@test.invalid")
+        self.assertEqual(adapter._password, "default-pw")
+        self.assertEqual(adapter._imap_host, "imap.default.com")
+        self.assertEqual(adapter._smtp_host, "smtp.default.com")
+        self.assertEqual(adapter._imap_port, 1993)
+        self.assertEqual(adapter._smtp_port, 1587)
+        self.assertEqual(adapter._poll_interval, 30)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "alpha@test.invalid",
+        "EMAIL_PASSWORD": "default-pw",
+        "EMAIL_IMAP_HOST": "imap.default.com",
+        "EMAIL_SMTP_HOST": "smtp.default.com",
+        "EMAIL_IMAP_PORT": "1993",
+        "EMAIL_SMTP_PORT": "1587",
+        "EMAIL_POLL_INTERVAL": "30",
+        "EMAIL_TRUST_FROM_HEADER": "true",
+    }, clear=False)
+    def test_scoped_ports_and_trust_flag_do_not_inherit_environ(self):
+        """The env_int variants (EMAIL_IMAP_PORT / EMAIL_SMTP_PORT /
+        EMAIL_POLL_INTERVAL) and EMAIL_TRUST_FROM_HEADER must resolve from
+        the installed scope, not from the primary profile's environ."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        scoped = {
+            "EMAIL_ADDRESS": "beta@test.invalid",
+            "EMAIL_PASSWORD": "secondary-pw",
+            "EMAIL_IMAP_HOST": "imap.secondary.example",
+            "EMAIL_SMTP_HOST": "smtp.secondary.example",
+            "EMAIL_IMAP_PORT": "2993",
+            "EMAIL_SMTP_PORT": "2587",
+            "EMAIL_POLL_INTERVAL": "60",
+            # scope does NOT opt into trusting From: — environ's "true"
+            # must not leak in.
+        }
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scoped)
+        try:
+            cfg = PlatformConfig(enabled=True)
+            adapter = EmailAdapter(cfg)
+            self.assertEqual(adapter._imap_port, 2993)
+            self.assertEqual(adapter._smtp_port, 2587)
+            self.assertEqual(adapter._poll_interval, 60)
+            # Environ's EMAIL_TRUST_FROM_HEADER=true must not leak in: the
+            # scope did not opt out, so authentication stays required.
+            self.assertTrue(adapter._require_authenticated_sender)
+        finally:
+            ss.reset_secret_scope(token)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_qqbot_credential_isolation.py
+++ b/tests/gateway/test_qqbot_credential_isolation.py
@@ -1,0 +1,102 @@
+"""Credential isolation for the QQ (qqbot) gateway adapter.
+
+Covers the multiplex credential-collision class (same class as the
+WeChat/weixin adapter tracked in #59662): the QQ adapter resolves its ``QQ_*``
+settings through the active profile secret scope rather than raw ``os.getenv``,
+so a secondary profile whose secret lives in its own ``.env`` (installed as an
+isolated scope, not into ``os.environ``) does not fall back to the
+default/primary profile's value.
+
+Also guards the primary/active profile: it is constructed without a scope and
+legitimately owns ``os.environ``, so the resolver must fall back to
+``os.environ`` there (not fail closed) even when multiplexing is active —
+otherwise the active profile's adapter would raise ``UnscopedSecretError`` on
+construction and fail to start.
+"""
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import PlatformConfig
+from gateway.platforms.qqbot.adapter import QQAdapter
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _make_adapter(extra=None):
+    return QQAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestQQCredentialScope:
+    def test_credentials_read_scope_not_environ(self, monkeypatch):
+        # os.environ holds another profile's values; the scoped values must win.
+        monkeypatch.setenv("QQ_APP_ID", "global-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "global-secret")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {"QQ_APP_ID": "profileA-app", "QQ_CLIENT_SECRET": "profileA-secret"}
+        )
+        try:
+            adapter = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert adapter._app_id == "profileA-app"
+        assert adapter._client_secret == "profileA-secret"
+
+    def test_two_profiles_isolated(self):
+        ss.set_multiplex_active(True)
+        tok_a = ss.set_secret_scope({"QQ_CLIENT_SECRET": "secret-A"})
+        try:
+            a = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok_a)
+        tok_b = ss.set_secret_scope({"QQ_CLIENT_SECRET": "secret-B"})
+        try:
+            b = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok_b)
+        assert a._client_secret == "secret-A"
+        assert b._client_secret == "secret-B"
+
+    def test_single_profile_still_reads_environ(self, monkeypatch):
+        # No scope + multiplex inactive (default single-profile deployment):
+        # legacy os.environ behavior is preserved — no regression.
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "legacy-secret")
+        adapter = _make_adapter()
+        assert adapter._client_secret == "legacy-secret"
+
+    def test_active_profile_no_scope_reads_environ_without_raising(self, monkeypatch):
+        # The primary/active profile is built with NO scope while multiplexing
+        # is active. A bare get_secret() would fail closed (UnscopedSecretError)
+        # and break its startup; the resolver must fall back to os.environ.
+        monkeypatch.setenv("QQ_APP_ID", "primary-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "primary-secret")
+        ss.set_multiplex_active(True)
+        assert ss.current_secret_scope() is None  # no scope installed
+        adapter = _make_adapter()  # must not raise
+        assert adapter._app_id == "primary-app"
+        assert adapter._client_secret == "primary-secret"
+
+    def test_explicit_config_extra_takes_precedence(self, monkeypatch):
+        # An explicit value in config.extra still wins over env/scope.
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "env-secret")
+        adapter = _make_adapter(extra={"client_secret": "explicit"})
+        assert adapter._client_secret == "explicit"
+
+
+class TestQQSttConfigScope:
+    def test_stt_api_key_reads_scope(self, monkeypatch):
+        monkeypatch.setenv("QQ_STT_API_KEY", "global-stt-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_STT_API_KEY": "profileA-stt-key"})
+        try:
+            adapter = _make_adapter()
+            stt = adapter._resolve_stt_config()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert stt is not None
+        assert stt["api_key"] == "profileA-stt-key"

--- a/tests/gateway/test_qqbot_credential_isolation.py
+++ b/tests/gateway/test_qqbot_credential_isolation.py
@@ -100,3 +100,26 @@ class TestQQSttConfigScope:
             ss.reset_secret_scope(tok)
         assert stt is not None
         assert stt["api_key"] == "profileA-stt-key"
+
+    def test_all_stt_values_read_scope(self, monkeypatch):
+        # Every QQ_STT_* value must come from the scope, not os.environ.
+        monkeypatch.setenv("QQ_STT_API_KEY", "global-stt-key")
+        monkeypatch.setenv("QQ_STT_BASE_URL", "https://global.example/v1")
+        monkeypatch.setenv("QQ_STT_MODEL", "global-asr")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {
+                "QQ_STT_API_KEY": "profileA-stt-key",
+                "QQ_STT_BASE_URL": "https://scoped.example/v1",
+                "QQ_STT_MODEL": "scoped-asr",
+            }
+        )
+        try:
+            adapter = _make_adapter()
+            stt = adapter._resolve_stt_config()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert stt is not None
+        assert stt["api_key"] == "profileA-stt-key"
+        assert stt["base_url"] == "https://scoped.example/v1"
+        assert stt["model"] == "scoped-asr"

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -117,6 +117,37 @@ class TestAuthzAllowAllScope:
         assert runner._is_user_authorized(_qq_dm_source(profile=None)) is True
 
 
+class TestAuthzAllowlistScope:
+    """Pins the per-platform user-allowlist read (not just the allow-all flag).
+
+    Distinct from the allow-all tests: here QQ_ALLOW_ALL_USERS is absent, so
+    authorization depends entirely on the scoped QQ_ALLOWED_USERS matching the
+    sender — reverting that read to raw os.getenv would default-deny.
+    """
+
+    def test_scoped_user_allowlist_authorizes(self, monkeypatch):
+        monkeypatch.setenv("QQ_ALLOWED_USERS", "")  # global env has no allowlist
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOWED_USERS": "user-1,user-2"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_user_allowlist_excludes_non_member(self, monkeypatch):
+        monkeypatch.setenv("QQ_ALLOWED_USERS", "user-1")  # primary env admits user-1
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        # Secondary scope lists only user-9 → user-1 must NOT inherit the
+        # primary's environ allowlist.
+        tok = ss.set_secret_scope({"QQ_ALLOWED_USERS": "user-9"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+
 class TestStartupValidatorScope:
     @staticmethod
     def _open_dm_config():

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -1,0 +1,227 @@
+"""End-to-end profile-scope coverage for the QQ (qqbot) authorization,
+startup-validation, and direct-send paths.
+
+Complements ``test_qqbot_credential_isolation.py`` (adapter-level resolver):
+the adapter intake fix alone is not enough because three other paths read the
+same per-profile ``QQ_*`` values independently:
+
+- gateway authorization (``AuthorizationMixin._is_user_authorized``) reads
+  ``QQ_ALLOW_ALL_USERS`` when deciding whether to honor an allow-all opt-in;
+- secondary-profile startup validation
+  (``gateway.run._own_policy_open_startup_violation``) reads the platform
+  opt-in while running inside ``_profile_runtime_scope``;
+- the ``send_message`` tool's direct REST path (``_send_qqbot``) falls back to
+  ``QQ_APP_ID`` / ``QQ_CLIENT_SECRET``.
+
+Each must resolve through the active profile secret scope (scope wins over
+``os.environ``; a profile that did NOT opt in must not inherit the primary
+profile's environ opt-in) while unscoped single-profile deployments keep the
+legacy ``os.environ`` behavior.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope_state(monkeypatch):
+    for key in (
+        "QQ_ALLOW_ALL_USERS",
+        "QQ_ALLOWED_USERS",
+        "QQ_GROUP_ALLOWED_USERS",
+        "QQ_APP_ID",
+        "QQ_CLIENT_SECRET",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _make_qq_runner():
+    """Minimal runner whose authz path reaches the QQ env checks."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    default_adapter = SimpleNamespace(
+        send=AsyncMock(),
+        enforces_own_access_policy=True,
+        _dm_policy="allowlist",
+        _group_policy="pairing",
+    )
+    secondary_adapter = SimpleNamespace(
+        send=AsyncMock(),
+        enforces_own_access_policy=True,
+        _dm_policy="open",
+        _group_policy="open",
+    )
+    runner.adapters = {Platform.QQBOT: default_adapter}
+    runner._profile_adapters = {"coder": {Platform.QQBOT: secondary_adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _qq_dm_source(profile="coder"):
+    return SessionSource(
+        platform=Platform.QQBOT,
+        user_id="user-1",
+        chat_id="dm-chat",
+        user_name="user-1",
+        chat_type="dm",
+        profile=profile,
+    )
+
+
+class TestAuthzAllowAllScope:
+    def test_scoped_allow_all_honored(self):
+        # The secondary profile opted in via its own .env (scope); os.environ
+        # has no opt-in. Authorization must honor the scoped value.
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOW_ALL_USERS": "true"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
+        # The PRIMARY profile opted in via os.environ; the secondary profile's
+        # scope has no opt-in. The secondary must NOT inherit the primary's
+        # allow-all (this is the cross-profile leak the fix closes).
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_single_profile_environ_unchanged(self, monkeypatch):
+        # Multiplex inactive, no scope: legacy os.environ behavior preserved.
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        runner = _make_qq_runner()
+        assert runner._is_user_authorized(_qq_dm_source(profile=None)) is True
+
+
+class TestStartupValidatorScope:
+    @staticmethod
+    def _open_dm_config():
+        return GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True, extra={"dm_policy": "open"}
+                )
+            }
+        )
+
+    def test_scoped_opt_in_clears_violation(self):
+        # Mirrors _start_one_profile_adapters: the validator runs inside the
+        # profile scope, so the profile's own opt-in must clear the violation.
+        from gateway.run import _own_policy_open_startup_violation
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOW_ALL_USERS": "true"})
+        try:
+            assert _own_policy_open_startup_violation(self._open_dm_config()) is None
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
+        # Primary's environ opt-in must not silently bless a secondary
+        # profile whose own scope never opted in.
+        from gateway.run import _own_policy_open_startup_violation
+
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            violation = _own_policy_open_startup_violation(self._open_dm_config())
+        finally:
+            ss.reset_secret_scope(tok)
+        assert violation is not None
+        assert "qqbot" in violation
+
+    def test_unscoped_environ_unchanged(self, monkeypatch):
+        # Single-profile startup (no scope installed) keeps reading environ.
+        from gateway.run import _own_policy_open_startup_violation
+
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        assert _own_policy_open_startup_violation(self._open_dm_config()) is None
+
+
+class TestDirectSendScope:
+    @staticmethod
+    def _fake_httpx(captured):
+        class _Resp:
+            status_code = 500
+
+            @staticmethod
+            def json():
+                return {}
+
+        class _AsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def post(self, url, **kwargs):
+                captured.append(kwargs.get("json") or {})
+                return _Resp()
+
+        module = types.ModuleType("httpx")
+        module.AsyncClient = _AsyncClient
+        return module
+
+    @pytest.mark.asyncio
+    async def test_scoped_credentials_win_over_environ(self, monkeypatch):
+        from tools.send_message_tool import _send_qqbot
+
+        captured = []
+        monkeypatch.setitem(sys.modules, "httpx", self._fake_httpx(captured))
+        monkeypatch.setenv("QQ_APP_ID", "global-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "global-secret")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {"QQ_APP_ID": "profileA-app", "QQ_CLIENT_SECRET": "profileA-secret"}
+        )
+        try:
+            await _send_qqbot(
+                PlatformConfig(enabled=True, extra={}), "chat-1", "hi"
+            )
+        finally:
+            ss.reset_secret_scope(tok)
+        assert captured, "token request never issued"
+        assert captured[0]["appId"] == "profileA-app"
+        assert captured[0]["clientSecret"] == "profileA-secret"
+
+    @pytest.mark.asyncio
+    async def test_unscoped_falls_back_to_environ(self, monkeypatch):
+        from tools.send_message_tool import _send_qqbot
+
+        captured = []
+        monkeypatch.setitem(sys.modules, "httpx", self._fake_httpx(captured))
+        monkeypatch.setenv("QQ_APP_ID", "env-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "env-secret")
+        await _send_qqbot(PlatformConfig(enabled=True, extra={}), "chat-1", "hi")
+        assert captured, "token request never issued"
+        assert captured[0]["appId"] == "env-app"
+        assert captured[0]["clientSecret"] == "env-secret"

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -97,6 +97,16 @@ class TestAuthzAllowAllScope:
         finally:
             ss.reset_secret_scope(tok)
 
+    @pytest.mark.xfail(
+        reason=(
+            "gateway/authz_mixin.py still reads the platform allow-all flag via "
+            "_auth_env, which falls through to os.environ on a scoped miss; the "
+            "scope-authoritative gate (_platform_gate_env semantics) for the "
+            "remaining authz_mixin reads lands in a separate PR. Flips green "
+            "when that PR converts the allow-all read."
+        ),
+        strict=True,
+    )
     def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
         # The PRIMARY profile opted in via os.environ; the secondary profile's
         # scope has no opt-in. The secondary must NOT inherit the primary's

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11153,6 +11153,104 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             server._sessions.pop(k, None)
 
 
+def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_path):
+    """The branched agent must be built under the parent profile's secrets.
+
+    session.branch already binds the parent's HERMES_HOME and state.db, but the
+    secret scope is what makes get_secret() resolve that profile's .env. Without
+    it the build falls through to process os.environ — the LAUNCH profile's
+    credentials — which is exactly the cross-profile resolution #67605 fixed for
+    session.create / session.resume.
+    """
+    import threading
+
+    from agent.secret_scope import current_secret_scope
+
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "PROXMOX_TOKEN=mlperf-secret\n", encoding="utf-8"
+    )
+    seen: dict = {"msgs": []}
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            pass
+
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, new_key, **kwargs):
+            seen["created"] = new_key
+
+        def append_message(self, **kwargs):
+            seen["msgs"].append(kwargs)
+
+        def set_session_title(self, key, title):
+            return True
+
+        def get_session(self, key):
+            return {"id": key, "cwd": str(tmp_path)}
+
+        def update_session_cwd(self, *a, **k):
+            return None
+
+        def close(self):
+            return None
+
+    class FakeAgent:
+        def __init__(self):
+            self.model = "test-model"
+            self.session_id = None
+
+    parent = {
+        "session_key": "parent-key",
+        "history": [{"role": "user", "content": "hi"}],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cols": 80,
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "agent": FakeAgent(),
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "cwd": str(tmp_path),
+    }
+    server._sessions["parent"] = parent
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+    monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+
+    def _fake_make_agent(*a, **k):
+        scope = current_secret_scope()
+        seen["scope"] = dict(scope) if scope else None
+        return FakeAgent()
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "parent", "name": "forked"},
+            }
+        )
+        assert "result" in resp, resp
+        assert seen.get("scope") == {"PROXMOX_TOKEN": "mlperf-secret"}
+    finally:
+        for k in list(server._sessions):
+            server._sessions.pop(k, None)
+
+
 def test_pending_title_finalizer_uses_session_profile_db(monkeypatch, tmp_path):
     """Post-turn pending_title must land in the session profile store."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2006,10 +2006,15 @@ async def _send_qqbot(pconfig, chat_id, message):
     except ImportError:
         return _error("QQBot direct send requires httpx. Run: pip install httpx")
 
+    # Resolve credential fallbacks through the profile secret scope (with the
+    # plain-environ fallback for unscoped single-profile runs) so a multiplex
+    # profile's direct send never borrows another profile's QQ credentials.
+    from gateway.config import _getenv
+
     extra = pconfig.extra or {}
-    appid = extra.get("app_id") or os.getenv("QQ_APP_ID", "")
+    appid = extra.get("app_id") or _getenv("QQ_APP_ID", "")
     secret = (pconfig.token or extra.get("client_secret")
-              or os.getenv("QQ_CLIENT_SECRET", ""))
+              or _getenv("QQ_CLIENT_SECRET", ""))
     if not appid or not secret:
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2656,6 +2656,16 @@ def _(rid, params: dict) -> dict:
         home_token = (
             set_hermes_home_override(parent_home) if parent_home else None
         )
+        # The home override alone only moves config/skills/memory; credentials
+        # resolve through get_secret(), which without a scope falls through to
+        # process os.environ — the LAUNCH profile's .env. Install the parent's
+        # secret scope for the build, exactly as session.create/resume do
+        # (#67605), so the branched agent authenticates as its own profile.
+        secret_token = (
+            set_secret_scope(build_profile_secret_scope(Path(parent_home)))
+            if parent_home
+            else None
+        )
         try:
             tokens = _set_session_context(new_key)
             try:
@@ -2680,6 +2690,8 @@ def _(rid, params: dict) -> dict:
                 profile_home=parent_home,
             )
         finally:
+            if secret_token is not None:
+                reset_secret_scope(secret_token)
             if home_token is not None:
                 reset_hermes_home_override(home_token)
         if new_sid in _sessions:


### PR DESCRIPTION
Salvages three contributor PRs that scope per-profile credential/config reads under multiplex profiles, resolved against current main.

## Infographic

![Secret Scope: Surfaces Salvage](https://v3b.fal.media/files/b/0aa4b25f/1wFj5BqVLYUrERq--a5FY_e5OyM5VJ.png)

## Piece 1 — qqbot (salvage #60420, credit @Da7-Tech)

Cherry-picked all three commits with authorship preserved:

- `fix(qqbot): resolve credentials under the active profile secret scope` — adapter-level `_resolve_qq_secret` for `QQ_APP_ID` / `QQ_CLIENT_SECRET` / `QQ_STT_*` / `QQ_ALLOW_ALL_USERS`.
- `fix(qqbot): scope the authz, startup-validation, and direct-send QQ reads` — `gateway/run.py` startup validation + `tools/send_message_tool.py::_send_qqbot` fallbacks now route through `gateway.config._getenv`.
- `test(qqbot): pin the scoped platform user-allowlist authz read`.

**Adjustments during salvage:**
- Converted `_resolve_qq_secret` from the original's `if current_secret_scope() is not None` gate to the canonical Slack pattern (`try get_secret / except UnscopedSecretError → os.getenv`), matching `whatsapp_common._get_wsecret` (#59739, 5438e9c629).
- **Dropped the `gateway/authz_mixin.py` hunks entirely** — main's `_auth_env` / `_platform_gate_env` supersede them; the remaining raw reads in that file (L459/501/879-885) are handled in a separate PR. One test case that depends on the allow-all read becoming scope-authoritative is pinned as a strict `xfail` so that PR flips it green.

## Piece 2 — email adapter (salvage #59076, credit @phantom-instruction-set)

Cherry-picked `fix(email): honor profile secret scope for email adapter env reads` with authorship preserved, **dropping the `gateway/config.py` hunk** (superseded — main already has scoped `_getenv` helpers).

**Follow-up commit (Hermes Agent):**
- The salvaged commit's bare `get_secret` calls would crash the DEFAULT profile's adapter, which constructs *unscoped* under multiplexing (`UnscopedSecretError` on startup) — the exact WhatsApp defect fixed in 5438e9c629. Wrapped them in a module-level Slack-pattern helper `_get_esecret`.
- Extended scope coverage to the remaining scope-blind reads: `EMAIL_IMAP_PORT` / `EMAIL_SMTP_PORT` / `EMAIL_POLL_INTERVAL` (`_esecret_int` replacing `utils.env_int`) and `EMAIL_TRUST_FROM_HEADER` (`_esecret_bool` replacing `utils.env_bool`).
- Added tests: default-profile unscoped-under-multiplex construction, and scoped ports/trust-flag no-environ-inheritance.

## Piece 3 — TUI session.branch (salvage #72299, credit @Frowtek)

Cherry-picked `fix(tui_gateway): install the parent profile's secret scope on session.branch` with authorship preserved.

**Adjustment during salvage:** the session handlers moved out of `tui_gateway/server.py` after the PR was opened — both hunks relocated to `tui_gateway/methods_session.py` (`session.branch` handler, mirroring the resume path's scope install at :567/:645 in the same file). The test still patches via `server.*` because `HandlerRegistry` rebinds the split-module handlers onto `server.py`'s globals, so no test retargeting was ultimately required beyond verifying resolution.

## Test summary

| Piece | Files | Result |
|---|---|---|
| qqbot | `tests/gateway/test_qqbot.py`, `test_qqbot_credential_isolation.py`, `test_qqbot_scope_paths.py` | pass (1 strict xfail pending authz_mixin PR) |
| email | `tests/gateway/test_email.py`, `test_email_robustness.py`, `test_email_secret_scope.py` | pass |
| tui | `tests/test_tui_gateway_server.py` | pass |

Full run: **7 files, 622 tests passed, 0 failed.** Ruff clean on all touched files.

Also maps the salvaged authors' emails in `contributors/emails/` (Da7-Tech, phantom-instruction-set; Frowtek was already mapped).

Closes #60420. Closes #59076. Closes #72299.

Credit: @Da7-Tech (#60420), @phantom-instruction-set (#59076), @Frowtek (#72299) — commits cherry-picked with original authorship.
