### PR TITLE
fix(secrets): scope memory/image/browser plugin credential reads + google_meet spawn (class closure, plugin families)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -189,7 +189,11 @@ def _xai_credentials_present() -> bool:
             return True
     except Exception:
         pass
-    return bool(str(os.environ.get("XAI_API_KEY") or "").strip())
+    try:
+        from agent.secret_scope import get_secret
+    except ImportError:  # pragma: no cover — secret_scope is in-repo
+        return bool(str(os.environ.get("XAI_API_KEY") or "").strip())
+    return bool(str(get_secret("XAI_API_KEY") or "").strip())
 
 
 def _homeassistant_credentials_present() -> bool:

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -37,6 +37,7 @@ from typing import Any, Dict, Optional
 import requests
 
 from agent.browser_provider import BrowserProvider
+from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
 
         # Direct API key wins unless the user has explicitly opted into the
         # managed Nous gateway via ``tool_gateway.browser: gateway``.
-        api_key = os.environ.get("BROWSER_USE_API_KEY")
+        api_key = get_secret("BROWSER_USE_API_KEY")
         if api_key and not prefers_gateway("browser"):
             return {
                 "api_key": api_key,

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, Optional
 import requests
 
 from agent.browser_provider import BrowserProvider
+from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +67,8 @@ class BrowserbaseBrowserProvider(BrowserProvider):
     # ------------------------------------------------------------------
 
     def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
-        api_key = os.environ.get("BROWSERBASE_API_KEY")
-        project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
+        api_key = get_secret("BROWSERBASE_API_KEY")
+        project_id = get_secret("BROWSERBASE_PROJECT_ID")
         if api_key and project_id:
             return {
                 "api_key": api_key,

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -34,6 +34,7 @@ from typing import Any, Dict
 import requests
 
 from agent.browser_provider import BrowserProvider
+from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
         return "Firecrawl"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("FIRECRAWL_API_KEY"))
+        return bool(get_secret("FIRECRAWL_API_KEY"))
 
     # ------------------------------------------------------------------
     # Session lifecycle
@@ -66,7 +67,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
         return os.environ.get("FIRECRAWL_API_URL", _BASE_URL)
 
     def _headers(self) -> Dict[str, str]:
-        api_key = os.environ.get("FIRECRAWL_API_KEY")
+        api_key = get_secret("FIRECRAWL_API_KEY")
         if not api_key:
             raise ValueError(
                 "FIRECRAWL_API_KEY environment variable is required. "

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -456,6 +456,10 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
     realtime_model = os.environ.get("HERMES_MEET_REALTIME_MODEL", "gpt-realtime")
     realtime_voice = os.environ.get("HERMES_MEET_REALTIME_VOICE", "alloy")
     realtime_instructions = os.environ.get("HERMES_MEET_REALTIME_INSTRUCTIONS", "")
+    # HERMES_MEET_REALTIME_KEY is set explicitly by process_manager.start(),
+    # which resolves it through the parent's profile secret scope at spawn
+    # time. The bare OPENAI_API_KEY fallback only serves standalone
+    # `python -m plugins.google_meet.meet_bot` runs outside the gateway.
     realtime_api_key = os.environ.get("HERMES_MEET_REALTIME_KEY") or os.environ.get("OPENAI_API_KEY", "")
 
     if not url or not _is_safe_meet_url(url):

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -152,6 +152,22 @@ def start(
         env["HERMES_MEET_REALTIME_VOICE"] = realtime_voice
     if realtime_instructions:
         env["HERMES_MEET_REALTIME_INSTRUCTIONS"] = realtime_instructions
+    # Resolve the realtime key at SPAWN time, in the parent, where the
+    # profile secret scope (a contextvar) is still installed. The detached
+    # child inherits the process environment — NOT the scope — so under a
+    # multiplexed gateway an in-child os.environ read would see another
+    # profile's OPENAI_API_KEY (or nothing). Pass it explicitly instead;
+    # meet_bot checks HERMES_MEET_REALTIME_KEY before OPENAI_API_KEY.
+    if not realtime_api_key:
+        try:
+            from agent.secret_scope import get_secret
+
+            realtime_api_key = (
+                get_secret("HERMES_MEET_REALTIME_KEY")
+                or get_secret("OPENAI_API_KEY")
+            )
+        except ImportError:  # pragma: no cover — secret_scope is in-repo
+            pass
     if realtime_api_key:
         env["HERMES_MEET_REALTIME_KEY"] = realtime_api_key
 

--- a/plugins/image_gen/deepinfra/__init__.py
+++ b/plugins/image_gen/deepinfra/__init__.py
@@ -31,6 +31,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from agent.secret_scope import get_secret
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
@@ -138,7 +139,7 @@ class DeepInfraImageGenProvider(ImageGenProvider):
         return "DeepInfra"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("DEEPINFRA_API_KEY", "").strip())
+        return bool((get_secret("DEEPINFRA_API_KEY", "") or "").strip())
 
     def list_models(self) -> List[Dict[str, Any]]:
         live = _live_models()
@@ -199,7 +200,7 @@ class DeepInfraImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        api_key = os.environ.get("DEEPINFRA_API_KEY", "").strip()
+        api_key = (get_secret("DEEPINFRA_API_KEY", "") or "").strip()
         if not api_key:
             return error_response(
                 error=(

--- a/plugins/image_gen/krea/__init__.py
+++ b/plugins/image_gen/krea/__init__.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
+from agent.secret_scope import get_secret
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
@@ -177,7 +178,7 @@ def _resolve_managed_krea_gateway():
         logger.debug("Managed Krea gateway resolution unavailable: %s", exc)
         return None
 
-    if os.environ.get("KREA_API_KEY") and not prefers_gateway("image_gen"):
+    if get_secret("KREA_API_KEY") and not prefers_gateway("image_gen"):
         return None
 
     try:
@@ -233,7 +234,7 @@ class KreaImageGenProvider(ImageGenProvider):
         # Available with a direct Krea key OR via the managed Nous gateway
         # (Nous Subscription), so portal users with no Krea key can still
         # reach Krea 2 through the gateway.
-        return bool(os.environ.get("KREA_API_KEY")) or _managed_krea_gateway_ready()
+        return bool(get_secret("KREA_API_KEY")) or _managed_krea_gateway_ready()
 
     def list_models(self) -> List[Dict[str, Any]]:
         return [
@@ -338,7 +339,7 @@ class KreaImageGenProvider(ImageGenProvider):
             auth_token = managed.nous_user_token
         else:
             base_url = BASE_URL
-            auth_token = os.environ.get("KREA_API_KEY")
+            auth_token = get_secret("KREA_API_KEY")
             if not auth_token:
                 return error_response(
                     error=(

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -27,6 +27,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
+from agent.secret_scope import get_secret
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
@@ -173,7 +174,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         return "OpenAI"
 
     def is_available(self) -> bool:
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not get_secret("OPENAI_API_KEY"):
             return False
         try:
             import openai  # noqa: F401
@@ -235,7 +236,8 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        api_key = get_secret("OPENAI_API_KEY")
+        if not api_key:
             return error_response(
                 error=(
                     "OPENAI_API_KEY not set. Run `hermes tools` → Image "
@@ -270,7 +272,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         is_edit = bool(sources)
         modality = "image" if is_edit else "text"
 
-        client = openai.OpenAI()
+        client = openai.OpenAI(api_key=api_key)
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -43,6 +43,8 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
+from agent.secret_scope import get_secret
+
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
 from tools.registry import tool_error
@@ -383,7 +385,7 @@ def _load_config() -> dict:
 
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
-        "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
+        "apiKey": get_secret("HINDSIGHT_API_KEY", ""),
         "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
         "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
@@ -522,7 +524,7 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         current_key = (
             config.get("llmApiKey")
             or config.get("llm_api_key")
-            or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+            or get_secret("HINDSIGHT_LLM_API_KEY", "")
         )
 
     current_provider = config.get("llm_provider", "")
@@ -786,7 +788,7 @@ class HindsightMemoryProvider(MemoryProvider):
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
-                or os.environ.get("HINDSIGHT_API_KEY", "")
+                or get_secret("HINDSIGHT_API_KEY", "")
             )
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
             return has_key or has_url
@@ -895,7 +897,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Step 3: Mode-specific config
         if mode == "cloud":
             print("\n  Get your API key at https://ui.hindsight.vectorize.io\n")
-            existing_key = os.environ.get("HINDSIGHT_API_KEY", "")
+            existing_key = get_secret("HINDSIGHT_API_KEY", "") or ""
             if existing_key:
                 masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else "set"
                 sys.stdout.write(f"  API key (current: {masked}, blank to keep): ")
@@ -1094,7 +1096,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", ""),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:
@@ -1330,7 +1332,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
+        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in {"local_embedded", "local_external"} else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
         self._llm_base_url = self._config.get("llm_base_url", "")

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
 
+from agent.secret_scope import get_secret
 from hermes_constants import get_hermes_home
 from hermes_cli.profiles import _get_default_hermes_home
 from plugins.plugin_utils import SingletonSlot
@@ -469,7 +470,7 @@ class HonchoClientConfig:
     ) -> HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         resolved_host = host or resolve_active_host()
-        api_key = os.environ.get("HONCHO_API_KEY")
+        api_key = get_secret("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         return cls(
@@ -525,7 +526,7 @@ class HonchoClientConfig:
         api_key = (
             host_block.get("apiKey")
             or raw.get("apiKey")
-            or os.environ.get("HONCHO_API_KEY")
+            or get_secret("HONCHO_API_KEY")
         )
 
         environment = (

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -41,6 +41,7 @@ import time
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from agent.secret_scope import get_secret
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ def _load_config() -> dict:
 
     config = {
         "mode": os.environ.get("MEM0_MODE", "platform"),
-        "api_key": os.environ.get("MEM0_API_KEY", ""),
+        "api_key": get_secret("MEM0_API_KEY", ""),
         "host": os.environ.get("MEM0_HOST", ""),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "oss": {},

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List
 from urllib.parse import quote
 
 from agent.memory_provider import MemoryProvider
+from agent.secret_scope import get_secret
 from agent.file_safety import raise_if_read_blocked
 from tools.registry import tool_error
 
@@ -476,7 +477,7 @@ class RetainDBMemoryProvider(MemoryProvider):
         return "retaindb"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("RETAINDB_API_KEY"))
+        return bool(get_secret("RETAINDB_API_KEY"))
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
@@ -488,7 +489,7 @@ class RetainDBMemoryProvider(MemoryProvider):
     # ── Lifecycle ──────────────────────────────────────────────────────────
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        api_key = os.environ.get("RETAINDB_API_KEY", "")
+        api_key = get_secret("RETAINDB_API_KEY", "") or ""
         base_url = re.sub(r"/+$", "", os.environ.get("RETAINDB_BASE_URL", _DEFAULT_BASE_URL))
 
         # Project resolution: RETAINDB_PROJECT > hermes-<profile> > "default"

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
+from agent.secret_scope import get_secret, is_multiplex_active
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -572,7 +573,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         # Docker venv the package isn't present until ensure() runs, but
         # ensure() only runs once the provider is loaded — which this gates.
         # Mirrors honcho/mem0, which check config only. No network calls.
-        return bool(os.environ.get("SUPERMEMORY_API_KEY", ""))
+        return bool(get_secret("SUPERMEMORY_API_KEY", ""))
 
     def get_config_schema(self):
         # Only prompt for the API key during `hermes memory setup`.
@@ -595,7 +596,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
         del provider_config
         hermes_home = str(get_hermes_home())
-        api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        api_key = get_secret("SUPERMEMORY_API_KEY", "") or ""
         status = _probe_supermemory_connection(api_key, hermes_home)
         return {"summary": _format_connection_summary(status)}
 
@@ -630,7 +631,15 @@ class SupermemoryMemoryProvider(MemoryProvider):
         # Make the freshly-entered key visible to the connection probe below.
         # (Checks the VALUE of SUPERMEMORY_API_KEY, not whether the key string
         # happens to name some unrelated env var.)
-        if api_key and os.environ.get("SUPERMEMORY_API_KEY") != api_key:
+        # Single-profile convenience only: never write a profile's key into
+        # the process-global environ under a multiplexed gateway — sibling
+        # profiles' turns (and any subprocess spawned with env=os.environ)
+        # would inherit it.
+        if (
+            api_key
+            and not is_multiplex_active()
+            and os.environ.get("SUPERMEMORY_API_KEY") != api_key
+        ):
             os.environ["SUPERMEMORY_API_KEY"] = api_key
 
         status = _probe_supermemory_connection(api_key, hermes_home)
@@ -647,7 +656,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._session_id = session_id
         self._turn_count = 0
         self._config = _load_supermemory_config(self._hermes_home)
-        self._api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        self._api_key = get_secret("SUPERMEMORY_API_KEY", "") or ""
 
         # Resolve container tag: env var > config > default.
         # Supports {identity} template for profile-scoped containers.

--- a/plugins/model-providers/deepinfra/__init__.py
+++ b/plugins/model-providers/deepinfra/__init__.py
@@ -29,9 +29,9 @@ class _DeepInfraProfile(ProviderProfile):
         ``vision`` capability) so an image-gen/edit model that merely carries
         a ``vision`` tag can't be picked as a chat-completions vision backend.
         """
-        import os
+        from agent.secret_scope import get_secret
 
-        if not (os.environ.get("DEEPINFRA_API_KEY") or "").strip():
+        if not (get_secret("DEEPINFRA_API_KEY") or "").strip():
             return None
         try:
             from hermes_cli.models import _fetch_deepinfra_models_by_tag

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -15,6 +15,8 @@ from typing import Any, Awaitable, Callable, Optional
 
 import httpx
 
+from agent.secret_scope import get_secret
+
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 from hermes_constants import get_hermes_home
 from plugins.teams_pipeline.meetings import (
@@ -109,7 +111,7 @@ class NotionWriter:
     API_VERSION = "2025-09-03"
 
     def __init__(self, *, api_key: str | None = None, transport: httpx.AsyncBaseTransport | None = None) -> None:
-        self.api_key = (api_key or os.getenv("NOTION_API_KEY", "")).strip()
+        self.api_key = (api_key or get_secret("NOTION_API_KEY", "") or "").strip()
         self._transport = transport
 
     async def write_summary(
@@ -205,7 +207,7 @@ class LinearWriter:
     API_URL = "https://api.linear.app/graphql"
 
     def __init__(self, *, api_key: str | None = None, transport: httpx.AsyncBaseTransport | None = None) -> None:
-        self.api_key = (api_key or os.getenv("LINEAR_API_KEY", "")).strip()
+        self.api_key = (api_key or get_secret("LINEAR_API_KEY", "") or "").strip()
         self._transport = transport
 
     async def write_summary(

--- a/tests/test_secret_scope_plugin_families.py
+++ b/tests/test_secret_scope_plugin_families.py
@@ -1,0 +1,260 @@
+"""Regression tests: plugin-family credential reads honor the profile secret scope.
+
+Class-closure follow-up to the profile secret-scope cluster (#76462). Memory,
+image_gen, and browser plugins, plus a handful of tier-3 tool helpers, read
+credentials straight from ``os.environ``. Under a multiplexed gateway the
+process environment may hold ANOTHER profile's key (or none), so every
+credential read must route through ``agent.secret_scope.get_secret`` and honor
+its verdict — a scoped miss under multiplexing returns the default and must
+NOT borrow from ``os.environ``.
+
+One representative test pair (scoped-wins / scoped-miss-no-borrow) per plugin
+family, plus the two behavioral sites:
+
+* supermemory ``post_setup`` must not write a profile's key into the
+  process-global environ when multiplexing is active (sibling-profile
+  pollution).
+* google_meet ``process_manager.start`` must resolve OPENAI_API_KEY through
+  the scope AT SPAWN TIME and pass it explicitly in the child environment —
+  the detached child inherits the process env, not the contextvar scope.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import pytest
+
+from agent.secret_scope import (
+    reset_secret_scope,
+    set_multiplex_active,
+    set_secret_scope,
+)
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install a secret scope with multiplexing ON; restore state after."""
+
+    def _install(scope: Dict[str, str]):
+        set_multiplex_active(True)
+        token = set_secret_scope(scope)
+        return token
+
+    tokens = []
+
+    def install(scope: Dict[str, str]):
+        tokens.append(_install(scope))
+
+    yield install
+
+    for token in tokens:
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+# ---------------------------------------------------------------------------
+# Family A — memory plugins
+# ---------------------------------------------------------------------------
+
+class TestMemoryFamily:
+    def test_retaindb_scoped_key_wins(self, multiplex_scope, monkeypatch):
+        monkeypatch.setenv("RETAINDB_API_KEY", "env-other-profile")
+        multiplex_scope({"RETAINDB_API_KEY": "scoped-key"})
+
+        from plugins.memory.retaindb import RetainDBMemoryProvider
+
+        assert RetainDBMemoryProvider().is_available() is True
+
+    def test_retaindb_scoped_miss_does_not_borrow_environ(
+        self, multiplex_scope, monkeypatch
+    ):
+        # Env holds another profile's key; the active profile's scope has none.
+        monkeypatch.setenv("RETAINDB_API_KEY", "env-other-profile")
+        multiplex_scope({})
+
+        from plugins.memory.retaindb import RetainDBMemoryProvider
+
+        assert RetainDBMemoryProvider().is_available() is False
+
+    def test_supermemory_scoped_miss_does_not_borrow_environ(
+        self, multiplex_scope, monkeypatch
+    ):
+        monkeypatch.setenv("SUPERMEMORY_API_KEY", "env-other-profile")
+        multiplex_scope({})
+
+        from plugins.memory.supermemory import SupermemoryMemoryProvider
+
+        assert SupermemoryMemoryProvider().is_available() is False
+
+    def test_supermemory_post_setup_no_environ_write_under_multiplex(
+        self, multiplex_scope, monkeypatch, tmp_path
+    ):
+        """post_setup must not pollute process env with a profile's key."""
+        multiplex_scope({})
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+
+        import hermes_cli.config as cli_config
+        import hermes_cli.memory_setup as memory_setup
+        import plugins.memory.supermemory as sm
+
+        monkeypatch.setattr(memory_setup, "_prompt", lambda *a, **k: "sm-fresh-key")
+        monkeypatch.setattr(memory_setup, "_write_env_vars", lambda *a, **k: None)
+        monkeypatch.setattr(cli_config, "save_config", lambda *a, **k: None)
+        monkeypatch.setattr(
+            sm,
+            "_probe_supermemory_connection",
+            lambda *a, **k: {"ok": True, "detail": "stub"},
+        )
+        monkeypatch.setattr(sm, "_format_connection_summary", lambda s: "stub")
+
+        sm.SupermemoryMemoryProvider().post_setup(str(tmp_path), {})
+
+        assert "SUPERMEMORY_API_KEY" not in os.environ
+
+    def test_supermemory_post_setup_environ_write_kept_single_profile(
+        self, monkeypatch, tmp_path
+    ):
+        """Single-profile (multiplex off): the convenience write still happens."""
+        set_multiplex_active(False)
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+
+        import hermes_cli.config as cli_config
+        import hermes_cli.memory_setup as memory_setup
+        import plugins.memory.supermemory as sm
+
+        monkeypatch.setattr(memory_setup, "_prompt", lambda *a, **k: "sm-fresh-key")
+        monkeypatch.setattr(memory_setup, "_write_env_vars", lambda *a, **k: None)
+        monkeypatch.setattr(cli_config, "save_config", lambda *a, **k: None)
+        monkeypatch.setattr(
+            sm,
+            "_probe_supermemory_connection",
+            lambda *a, **k: {"ok": True, "detail": "stub"},
+        )
+        monkeypatch.setattr(sm, "_format_connection_summary", lambda s: "stub")
+
+        try:
+            sm.SupermemoryMemoryProvider().post_setup(str(tmp_path), {})
+            assert os.environ.get("SUPERMEMORY_API_KEY") == "sm-fresh-key"
+        finally:
+            os.environ.pop("SUPERMEMORY_API_KEY", None)
+
+
+# ---------------------------------------------------------------------------
+# Family B — image_gen plugins
+# ---------------------------------------------------------------------------
+
+class TestImageGenFamily:
+    def test_deepinfra_scoped_key_wins(self, multiplex_scope, monkeypatch):
+        monkeypatch.delenv("DEEPINFRA_API_KEY", raising=False)
+        multiplex_scope({"DEEPINFRA_API_KEY": "scoped-key"})
+
+        from plugins.image_gen.deepinfra import DeepInfraImageGenProvider
+
+        assert DeepInfraImageGenProvider().is_available() is True
+
+    def test_deepinfra_scoped_miss_does_not_borrow_environ(
+        self, multiplex_scope, monkeypatch
+    ):
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "env-other-profile")
+        multiplex_scope({})
+
+        from plugins.image_gen.deepinfra import DeepInfraImageGenProvider
+
+        assert DeepInfraImageGenProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Family C — browser/web plugins
+# ---------------------------------------------------------------------------
+
+class TestBrowserFamily:
+    def test_firecrawl_scoped_key_wins(self, multiplex_scope, monkeypatch):
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        multiplex_scope({"FIRECRAWL_API_KEY": "scoped-key"})
+
+        from plugins.browser.firecrawl.provider import FirecrawlBrowserProvider
+
+        provider = FirecrawlBrowserProvider()
+        assert provider.is_available() is True
+        assert provider._headers()["Authorization"] == "Bearer scoped-key"
+
+    def test_firecrawl_scoped_miss_does_not_borrow_environ(
+        self, multiplex_scope, monkeypatch
+    ):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "env-other-profile")
+        multiplex_scope({})
+
+        from plugins.browser.firecrawl.provider import FirecrawlBrowserProvider
+
+        assert FirecrawlBrowserProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Family E — google_meet spawn-wrap
+# ---------------------------------------------------------------------------
+
+class TestGoogleMeetSpawn:
+    def test_child_env_carries_scoped_openai_key(
+        self, multiplex_scope, monkeypatch, tmp_path
+    ):
+        """start() resolves the key from the scope and injects it explicitly."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("HERMES_MEET_REALTIME_KEY", raising=False)
+        multiplex_scope({"OPENAI_API_KEY": "scoped-openai-key"})
+
+        import plugins.google_meet.process_manager as pm
+
+        monkeypatch.setattr(pm, "_root", lambda: tmp_path)
+
+        captured: Dict[str, Any] = {}
+
+        class _FakeProc:
+            pid = 4242
+
+        def fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _FakeProc()
+
+        monkeypatch.setattr(pm.subprocess, "Popen", fake_popen)
+
+        result = pm.start(
+            "https://meet.google.com/abc-defg-hij",
+            out_dir=tmp_path / "meeting",
+            mode="realtime",
+        )
+
+        assert result["ok"] is True
+        child_env = captured["env"]
+        # The scoped key crosses the process boundary explicitly, not via
+        # inherited os.environ (which had no key at all).
+        assert child_env["HERMES_MEET_REALTIME_KEY"] == "scoped-openai-key"
+
+    def test_explicit_key_argument_still_wins(
+        self, multiplex_scope, monkeypatch, tmp_path
+    ):
+        multiplex_scope({"OPENAI_API_KEY": "scoped-openai-key"})
+
+        import plugins.google_meet.process_manager as pm
+
+        monkeypatch.setattr(pm, "_root", lambda: tmp_path)
+
+        captured: Dict[str, Any] = {}
+
+        class _FakeProc:
+            pid = 4243
+
+        monkeypatch.setattr(
+            pm.subprocess,
+            "Popen",
+            lambda cmd, **kw: (captured.update(env=kw.get("env")), _FakeProc())[1],
+        )
+
+        pm.start(
+            "https://meet.google.com/abc-defg-hij",
+            out_dir=tmp_path / "meeting2",
+            realtime_api_key="explicit-key",
+        )
+
+        assert captured["env"]["HERMES_MEET_REALTIME_KEY"] == "explicit-key"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -382,8 +382,9 @@ class GitHubAuth:
             if self._cached_method != "github-app" or time.time() < self._app_token_expiry:
                 return self._cached_token
 
-        # 1. Environment variable
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        # 1. Environment variable (profile-scoped under a multiplexed gateway)
+        from agent.secret_scope import get_secret
+        token = get_secret("GITHUB_TOKEN") or get_secret("GH_TOKEN")
         if token:
             self._cached_token = token
             self._cached_method = "pat"
@@ -424,9 +425,10 @@ class GitHubAuth:
 
     def _try_github_app(self) -> Optional[str]:
         """Try GitHub App JWT authentication if credentials are configured."""
-        app_id = os.environ.get("GITHUB_APP_ID")
-        key_path = os.environ.get("GITHUB_APP_PRIVATE_KEY_PATH")
-        installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
+        from agent.secret_scope import get_secret
+        app_id = get_secret("GITHUB_APP_ID")
+        key_path = get_secret("GITHUB_APP_PRIVATE_KEY_PATH")
+        installation_id = get_secret("GITHUB_APP_INSTALLATION_ID")
 
         if not all([app_id, key_path, installation_id]):
             return None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -159,10 +159,12 @@ def _check_vercel_sandbox_requirements(config: dict[str, Any]) -> bool:
         )
         return False
 
-    has_oidc = bool(os.getenv("VERCEL_OIDC_TOKEN"))
-    has_token = bool(os.getenv("VERCEL_TOKEN"))
-    has_project = bool(os.getenv("VERCEL_PROJECT_ID"))
-    has_team = bool(os.getenv("VERCEL_TEAM_ID"))
+    from agent.secret_scope import get_secret
+
+    has_oidc = bool(get_secret("VERCEL_OIDC_TOKEN"))
+    has_token = bool(get_secret("VERCEL_TOKEN"))
+    has_project = bool(get_secret("VERCEL_PROJECT_ID"))
+    has_team = bool(get_secret("VERCEL_TEAM_ID"))
 
     if has_oidc:
         return True
@@ -3177,7 +3179,8 @@ def check_terminal_requirements() -> bool:
 
         elif env_type == "daytona":
             from daytona import Daytona  # noqa: F401 — SDK presence check
-            return os.getenv("DAYTONA_API_KEY") is not None
+            from agent.secret_scope import get_secret
+            return get_secret("DAYTONA_API_KEY") is not None
 
         else:
             logger.error(

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -283,7 +283,8 @@ def is_platform_supported() -> bool:
 def _download_file(url: str, dest: str, timeout: int = 10):
     """Download a URL to a local file."""
     req = urllib.request.Request(url)
-    token = os.getenv("GITHUB_TOKEN")
+    from agent.secret_scope import get_secret
+    token = get_secret("GITHUB_TOKEN")
     if token:
         req.add_header("Authorization", f"token {token}")
     with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -298,7 +298,7 @@ def fal_key_is_configured() -> bool:
     checks and CLI setup-time checks agree.  A whitespace-only value
     is treated as unset everywhere.
     """
-    value = os.getenv("FAL_KEY")
+    value = _scoped_credential("FAL_KEY") or None
     if value is None:
         # Fall back to the .env file for CLI paths that may run before
         # dotenv is loaded into os.environ.

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -36,8 +36,14 @@ def has_xai_credentials() -> bool:
     other availability scans. Truthful refresh + expiry handling happens
     in ``search()`` (or whichever caller actually makes the request).
     """
-    if os.environ.get("XAI_API_KEY", "").strip():
-        return True
+    try:
+        from agent.secret_scope import get_secret
+    except ImportError:  # pragma: no cover — secret_scope is in-repo
+        if os.environ.get("XAI_API_KEY", "").strip():
+            return True
+    else:
+        if (get_secret("XAI_API_KEY", "") or "").strip():
+            return True
     try:
         from hermes_constants import get_hermes_home
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1384,7 +1384,9 @@ def _(rid, params: dict) -> dict:
     try:
         cfg = _load_cfg()
         model = _resolve_model()
-        api_key = os.environ.get("HERMES_API_KEY", "") or cfg.get("api_key", "")
+        from agent.secret_scope import get_secret
+
+        api_key = get_secret("HERMES_API_KEY", "") or cfg.get("api_key", "")
         masked = f"****{api_key[-4:]}" if len(api_key) > 4 else "(not set)"
         base_url = os.environ.get("HERMES_BASE_URL", "") or cfg.get("base_url", "")
 


### PR DESCRIPTION
Class-closure follow-up to the profile secret-scope cluster (#76462): migrates the remaining plugin-family credential reads from raw `os.environ` to `agent.secret_scope.get_secret`, so multiplexed gateway turns resolve the **active profile's** key and never borrow a sibling profile's process-environment value. Every migrated site honors the canonical `get_secret` verdict — scoped miss under multiplex returns the default (no environ fallthrough), single-profile behavior is byte-identical.

## Commits (one per family)

- **A — memory plugins**: hindsight (`HINDSIGHT_API_KEY`/`HINDSIGHT_LLM_API_KEY`, 6 sites incl. the setup-time masked display), honcho `from_env`/`from_global_config`, supermemory (`is_available`/status/`initialize`), mem0 `_load_config`, retaindb (`is_available`/`initialize`). Also guards supermemory `post_setup`'s `os.environ["SUPERMEMORY_API_KEY"] = ...` write on `not is_multiplex_active()` — writing one profile's key into the process-global env pollutes sibling profiles; the single-profile convenience write is kept.
- **B — image_gen plugins**: openai (`is_available` + generate; the client is now constructed with the scoped key explicitly instead of the SDK's implicit environ read), deepinfra, krea (gateway-preference gate, `is_available`, direct-key auth token).
- **C — browser plugins**: browser_use `_get_direct_config`, browserbase `_get_config_or_none` (key + project id), firecrawl `is_available` + `_headers`.
- **D — tier-3 misc**: teams_pipeline `NOTION_API_KEY`/`LINEAR_API_KEY` defaults; model-providers/deepinfra catalog gate; `fal_key_is_configured` now routes through the file's own `_scoped_credential` helper; xAI presence checks in `tools/xai_http.py` + `hermes_cli/tools_config.py`; VERCEL_* / DAYTONA_API_KEY presence in `terminal_tool.py`; `GITHUB_TOKEN`/`GH_TOKEN` + GitHub App creds in `tirith_security.py` and `skills_hub.py`; masked `HERMES_API_KEY` display in `tui_gateway` `config.show`.
- **E — google_meet spawn-wrap**: the detached `meet_bot` child inherits the process environment, **not** the parent's contextvar scope, so `process_manager.start()` now resolves `HERMES_MEET_REALTIME_KEY` / `OPENAI_API_KEY` via `get_secret` at spawn time in the parent and passes it explicitly in the child env. `meet_bot`'s bare `OPENAI_API_KEY` fallback remains for standalone (non-gateway) runs and is documented as such.

## Skipped on inspection

- `tools/xai_http.py` / `tools_config.py` auth.json + credential-pool paths — profile-`HERMES_HOME`-scoped files, not env reads.
- `skills_hub.py` `gh auth token` subprocess path — user-level gh CLI auth, not a profile secret.
- `firecrawl` `FIRECRAWL_API_URL` and hindsight `HINDSIGHT_API_URL`/mode/timeout vars — endpoints/tuning knobs, not credentials.
- `meet_bot.py` in-child env reads — the child has no scope by design; the fix is at the spawn site (lens spawn-wrap shape).

## Tests

New consolidated `tests/test_secret_scope_plugin_families.py` (11 tests): per-family scoped-wins / scoped-miss-no-borrow pairs (retaindb, supermemory, deepinfra, firecrawl), supermemory no-environ-write under multiplex (+ single-profile write preserved), google_meet child env carries the scoped key (+ explicit arg still wins).

`scripts/run_tests.sh` over all touched plugin/tool suites (58 files): **886 passed, 0 failed**. Ruff clean on every changed file.

## Infographic

![secret-scope plugin families](https://v3b.fal.media/files/b/0aa4b26c/iGzgSAtJoem6xwLqf8t3I_zptcvOTx.png)
