### PR TITLE
fix(secrets): route core gateway/tool/aux credential reads through the profile secret scope (class closure, tier 1)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -960,6 +960,29 @@ def _nous_min_key_ttl_seconds() -> int:
         return 1800
 
 
+def _scoped_key_env(name: str) -> str:
+    """Read a provider API key env var through the profile secret scope.
+
+    Auxiliary-client resolution runs both inside agent turns (secret scope
+    installed — its verdict is authoritative under multiplex, so a scoped
+    miss must NOT borrow another profile's process-env key) and on unscoped
+    startup/CLI probe paths, which keep the legacy ``os.environ`` read via
+    the ``UnscopedSecretError`` fallback (Slack pattern, #59739).
+    """
+    if not name:
+        return ""
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            return (get_secret(name) or "").strip()
+        except UnscopedSecretError:
+            pass
+    except Exception:
+        pass
+    return (os.getenv(name) or "").strip()
+
+
 # ── Codex Responses → chat.completions adapter ─────────────────────────────
 # All auxiliary consumers call client.chat.completions.create(**kwargs) and
 # read response.choices[0].message.content. This adapter translates those
@@ -2232,7 +2255,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         # the OPENROUTER_API_KEY env-var path rather than failing outright.
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
+    or_key = explicit_api_key or _scoped_key_env("OPENROUTER_API_KEY")
     if not or_key:
         _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
@@ -2249,7 +2272,7 @@ def _describe_openrouter_unavailable() -> str:
             return "OpenRouter credential pool has no usable entries (credentials may be exhausted)"
         if not _pool_runtime_api_key(entry):
             return "OpenRouter credential pool entry is missing a runtime API key"
-    if not str(os.getenv("OPENROUTER_API_KEY") or "").strip():
+    if not _scoped_key_env("OPENROUTER_API_KEY"):
         return "OPENROUTER_API_KEY not set"
     return "no usable OpenRouter credentials found"
 
@@ -2878,7 +2901,7 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
 
     if not isinstance(runtime, dict):
         openai_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
-        openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+        openai_key = _scoped_key_env("OPENAI_API_KEY")
         if not openai_base:
             return None, None, None
         runtime = {
@@ -5684,7 +5707,7 @@ def resolve_provider_client(
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
-                or os.getenv("OPENAI_API_KEY", "").strip()
+                or _scoped_key_env("OPENAI_API_KEY")
                 or _read_main_api_key_if_same_host(custom_base)
                 or "no-key-required"  # local servers don't need auth
             )
@@ -5780,7 +5803,7 @@ def resolve_provider_client(
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                custom_key = _scoped_key_env(custom_key_env)
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(
@@ -6602,7 +6625,7 @@ def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> di
     misses the case where a custom base URL serves e.g. ``gpt-5.4``.
     """
     custom_base = _current_custom_base_url()
-    or_key = os.getenv("OPENROUTER_API_KEY")
+    or_key = _scoped_key_env("OPENROUTER_API_KEY")
     # Use max_completion_tokens for direct OpenAI-compatible providers that reject
     # max_tokens on newer GPT-4o/o-series/GPT-5-style models.
     _custom_host = base_url_hostname(custom_base) or ""
@@ -7063,7 +7086,7 @@ def _resolve_task_provider_model(
                 task_config.get("key_env") or task_config.get("api_key_env") or ""
             ).strip()
             if cfg_key_env:
-                cfg_api_key = os.getenv(cfg_key_env, "").strip() or None
+                cfg_api_key = _scoped_key_env(cfg_key_env) or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not

--- a/agent/azure_identity_adapter.py
+++ b/agent/azure_identity_adapter.py
@@ -367,11 +367,27 @@ def describe_active_credential(config: Optional[EntraIdentityConfig] = None,
         info["tenant_id_env"] = os.environ["AZURE_TENANT_ID"].strip()
 
     # Surface which env-var sources are present without minting yet.
+    # Credential-bearing vars (AZURE_CLIENT_SECRET, AZURE_FEDERATED_TOKEN_FILE)
+    # are read through the profile secret scope so a multiplexed profile's
+    # diagnostics don't report another profile's env-bridged credentials;
+    # unscoped CLI probes keep the legacy env read (Slack pattern).
+    def _scoped_env(name: str) -> str:
+        try:
+            from agent.secret_scope import UnscopedSecretError, get_secret
+
+            try:
+                return (get_secret(name) or "").strip()
+            except UnscopedSecretError:
+                pass
+        except Exception:
+            pass
+        return os.environ.get(name, "").strip()
+
     env_sources = []
-    if os.environ.get("AZURE_FEDERATED_TOKEN_FILE", "").strip():
+    if _scoped_env("AZURE_FEDERATED_TOKEN_FILE"):
         env_sources.append("WorkloadIdentityCredential (AZURE_FEDERATED_TOKEN_FILE)")
     if (os.environ.get("AZURE_CLIENT_ID", "").strip()
-            and os.environ.get("AZURE_CLIENT_SECRET", "").strip()
+            and _scoped_env("AZURE_CLIENT_SECRET")
             and os.environ.get("AZURE_TENANT_ID", "").strip()):
         env_sources.append("EnvironmentCredential (client secret)")
     if os.environ.get("IDENTITY_ENDPOINT", "").strip() or os.environ.get("MSI_ENDPOINT", "").strip():

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -456,7 +456,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _platform_gate_env(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -498,7 +498,7 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and _platform_gate_env(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True
 
         if not user_id:
@@ -876,13 +876,13 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if _platform_gate_env(platform_env_map.get(platform, "")).strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _platform_gate_env(env_key).strip():
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if _platform_gate_env("GATEWAY_ALLOWED_USERS").strip():
             return "ignore"
 
         return "pair"

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -146,6 +146,32 @@ def _user_ids_match(platform: str, left: str, right: str) -> bool:
     return bool(left_aliases and right_aliases and (left_aliases & right_aliases))
 
 
+def _read_allowlist_env(env_var: str) -> str:
+    """Read a platform allowlist env var through the profile secret scope.
+
+    Under multiplexing the process env may hold ANOTHER profile's allowlist
+    (first-writer-wins YAML→env bridges), so reads must honor the installed
+    scope's verdict — including a scoped miss returning empty rather than
+    borrowing the process value.  Unscoped callers (single-profile CLI /
+    admin endpoints) keep the legacy ``os.getenv`` read.
+
+    TODO(profile-secrets): the grant mirror below still WRITES through
+    ``hermes_cli.config.save_env_value`` / ``remove_env_value``, which target
+    the root ``.env`` — those writes need a profile-aware counterpart before
+    pairing grants can be mirrored correctly under multiplexing.
+    """
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            return (get_secret(env_var) or "").strip()
+        except UnscopedSecretError:
+            pass
+    except Exception:
+        pass
+    return (os.getenv(env_var) or "").strip()
+
+
 def _sync_allowlist_add(platform: str, user_id: str) -> None:
     """Add ``user_id`` to the platform allowlist env var IF one is configured.
 
@@ -158,7 +184,7 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = os.getenv(env_var, "").strip()
+    current = _read_allowlist_env(env_var)
     if not current:
         return  # No allowlist configured — leave the gateway open (option i).
     ids = _split_allowlist(current)
@@ -278,7 +304,7 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = os.getenv(env_var, "").strip()
+    current = _read_allowlist_env(env_var)
     if not current:
         return  # No allowlist configured — do not touch config-only snapshots.
     ids = _split_allowlist(current)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22886,7 +22886,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "tools": [],
             }
 
-        proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+        # Scope-aware read: the proxy key is a per-profile credential; under
+        # multiplex honor the installed scope's verdict (Slack pattern for
+        # the unscoped default-profile loop).
+        try:
+            from agent.secret_scope import UnscopedSecretError, get_secret
+
+            try:
+                proxy_key = (get_secret("GATEWAY_PROXY_KEY") or "").strip()
+            except UnscopedSecretError:
+                proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+        except Exception:
+            proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
 
         def _run_still_current() -> bool:
             if run_generation is None or not session_key:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -387,7 +387,19 @@ def _slack_tools_loaded() -> bool:
     except Exception:
         pass
 
-    if not (os.environ.get("SLACK_BOT_TOKEN") or "").strip():
+    # Presence check through the profile secret scope: under multiplex the
+    # process env may carry another profile's token (Slack pattern for the
+    # unscoped default-profile path).
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            _slack_token = get_secret("SLACK_BOT_TOKEN") or ""
+        except UnscopedSecretError:
+            _slack_token = os.environ.get("SLACK_BOT_TOKEN") or ""
+    except Exception:
+        _slack_token = os.environ.get("SLACK_BOT_TOKEN") or ""
+    if not _slack_token.strip():
         return False
     try:
         from hermes_cli.config import load_config

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4320,7 +4320,20 @@ async def get_elevenlabs_voices(profile: Optional[str] = None):
     # Config-only scope (await-safe): the key lookup reads the requested
     # profile's .env, matching the profile the settings UI writes to.
     with _config_profile_scope(profile):
-        api_key = (load_env().get("ELEVENLABS_API_KEY") or os.environ.get("ELEVENLABS_API_KEY") or "").strip()
+        api_key = (load_env().get("ELEVENLABS_API_KEY") or "").strip()
+    if not api_key:
+        # Fallback for env-only deployments — scope-aware (Slack pattern):
+        # under multiplex os.environ may hold another profile's key, so
+        # honor the installed scope's verdict before touching the env.
+        try:
+            from agent.secret_scope import UnscopedSecretError, get_secret
+
+            try:
+                api_key = (get_secret("ELEVENLABS_API_KEY") or "").strip()
+            except UnscopedSecretError:
+                api_key = (os.environ.get("ELEVENLABS_API_KEY") or "").strip()
+        except Exception:
+            api_key = (os.environ.get("ELEVENLABS_API_KEY") or "").strip()
     if not api_key:
         return {"available": False, "voices": []}
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9467,7 +9467,14 @@ async def _standalone_send(
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
 
-    token = (getattr(pconfig, "token", None) or os.getenv("DISCORD_BOT_TOKEN", "")).strip()
+    token = (getattr(pconfig, "token", None) or "").strip()
+    if not token:
+        # Profile-scoped read: under multiplex the process env may hold a
+        # different profile's bot token, so honor the secret scope's verdict
+        # (scoped miss ⇒ no token; unscoped multiplex ⇒ UnscopedSecretError).
+        from agent.secret_scope import get_secret
+
+        token = (get_secret("DISCORD_BOT_TOKEN", "") or "").strip()
     if not token:
         return {"error": "Discord standalone send: DISCORD_BOT_TOKEN is not set"}
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -874,6 +874,20 @@ def _pre_sanitize_matrix_markdown(text: str) -> str:
     return result
 
 
+def _startup_env_secret(name: str) -> str:
+    """Read a Matrix credential at adapter-startup time, scope-aware.
+
+    Slack pattern (#59739): a scoped read honors the installed profile's
+    secret scope verdict (scoped miss ⇒ empty, no borrowing the process
+    env); only an UNSCOPED read under multiplex (default-profile startup
+    loop) falls back to ``os.environ``, which is that profile's own value.
+    """
+    try:
+        return (get_secret(name) or "").strip()
+    except UnscopedSecretError:
+        return os.getenv(name, "").strip()
+
+
 def check_matrix_requirements() -> bool:
     """Return True if the Matrix adapter can be used.
 
@@ -885,8 +899,8 @@ def check_matrix_requirements() -> bool:
     forever and broke E2EE connect with ``No module named 'asyncpg'``
     (#31116).  Rebinds module-level type globals on success.
     """
-    token = os.getenv("MATRIX_ACCESS_TOKEN", "")
-    password = os.getenv("MATRIX_PASSWORD", "")
+    token = _startup_env_secret("MATRIX_ACCESS_TOKEN")
+    password = _startup_env_secret("MATRIX_PASSWORD")
     homeserver = os.getenv("MATRIX_HOMESERVER", "")
 
     if not token and not password:
@@ -1013,12 +1027,14 @@ class MatrixAdapter(BasePlatformAdapter):
         self._homeserver: str = (
             config.extra.get("homeserver", "") or os.getenv("MATRIX_HOMESERVER", "")
         ).rstrip("/")
-        self._access_token: str = config.token or os.getenv("MATRIX_ACCESS_TOKEN", "")
+        self._access_token: str = config.token or _startup_env_secret(
+            "MATRIX_ACCESS_TOKEN"
+        )
         self._user_id: str = config.extra.get("user_id", "") or os.getenv(
             "MATRIX_USER_ID", ""
         )
-        self._password: str = config.extra.get("password", "") or os.getenv(
-            "MATRIX_PASSWORD", ""
+        self._password: str = config.extra.get("password", "") or _startup_env_secret(
+            "MATRIX_PASSWORD"
         )
         self._e2ee_mode: str = _resolve_e2ee_mode(config.extra)
         self._encryption: bool = self._e2ee_mode != "off"
@@ -4801,7 +4817,10 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         homeserver = (extra.get("homeserver") or os.getenv("MATRIX_HOMESERVER", "")).rstrip("/")
-        token = token or os.getenv("MATRIX_ACCESS_TOKEN", "")
+        # In-turn read: standalone sends run inside an installed secret
+        # scope, so honor get_secret's verdict directly (no env fallback on
+        # a scoped miss).
+        token = token or get_secret("MATRIX_ACCESS_TOKEN", "") or ""
         if not homeserver or not token:
             return {"error": "Matrix not configured (MATRIX_HOMESERVER, MATRIX_ACCESS_TOKEN required)"}
         txn_id = f"hermes_{int(time.time() * 1000)}_{os.urandom(4).hex()}"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -8609,7 +8609,10 @@ async def _standalone_send(
     ``chat.postMessage``.
     """
     del force_document  # signature parity with other standalone senders
-    raw_token = getattr(pconfig, "token", None) or os.getenv("SLACK_BOT_TOKEN", "")
+    # Profile-scoped read: under multiplex os.environ may hold ANOTHER
+    # profile's bot token (first-writer-wins env bridges), so honor the
+    # secret scope's verdict instead of reading the process env directly.
+    raw_token = getattr(pconfig, "token", None) or get_secret("SLACK_BOT_TOKEN", "")
 
     # ``SLACK_BOT_TOKEN`` can be a comma-separated list in multi-workspace
     # gateways, and OAuth installs persist per-workspace tokens in

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4038,7 +4038,20 @@ class TelegramAdapter(BasePlatformAdapter):
                     os.getenv("TELEGRAM_WEBHOOK_HOST", "").strip()
                     or str((self.config.extra or {}).get("webhook_host") or "").strip()
                 )
-                webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+                # Profile-scoped read (adapter startup, Slack pattern
+                # #59739): a scoped read honors the profile's own secret;
+                # only an UNSCOPED read under multiplex (default-profile
+                # startup loop) falls back to the process env, which is that
+                # profile's own value.
+                from agent.secret_scope import (
+                    UnscopedSecretError,
+                    get_secret,
+                )
+
+                try:
+                    webhook_secret = (get_secret("TELEGRAM_WEBHOOK_SECRET") or "").strip()
+                except UnscopedSecretError:
+                    webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
                 if not webhook_secret:
                     raise RuntimeError(
                         "TELEGRAM_WEBHOOK_SECRET is required when "
@@ -9932,7 +9945,13 @@ async def _standalone_send(
     parse-mode fallback). Implements the standalone_sender_fn contract so
     deliver=telegram cron jobs succeed when cron runs separately from the
     gateway."""
-    token = getattr(pconfig, "token", None) or os.getenv("TELEGRAM_BOT_TOKEN", "")
+    token = getattr(pconfig, "token", None)
+    if not token:
+        # Profile-scoped read: honor the secret scope's verdict rather than
+        # borrowing another profile's env-bridged token under multiplex.
+        from agent.secret_scope import get_secret
+
+        token = get_secret("TELEGRAM_BOT_TOKEN", "") or ""
     disable_link_previews = bool(
         getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews")
     )

--- a/tests/agent/test_secret_scope_tier1_migration.py
+++ b/tests/agent/test_secret_scope_tier1_migration.py
@@ -1,0 +1,233 @@
+"""Regression tests for the Tier-1 core-gateway secret-scope migration.
+
+Class-closure follow-up to the profile secret-scope cluster (#76462 /
+#76574): representative call sites from each migrated cluster are exercised
+against the three canonical scope semantics:
+
+- scoped value wins (the installed profile's secret is used),
+- scoped miss does NOT borrow the process env under multiplex (no-borrow),
+- unscoped-under-multiplex behavior per pattern:
+  * in-turn sites (get_secret direct) propagate/honor UnscopedSecretError
+    semantics via get_secret's verdict,
+  * startup sites (Slack pattern) fall back to os.environ on
+    UnscopedSecretError.
+"""
+
+import pytest
+
+from agent import secret_scope as ss
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+class _Scope:
+    """Context manager installing a secret scope."""
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+        self.token = None
+
+    def __enter__(self):
+        self.token = ss.set_secret_scope(self.mapping)
+        return self
+
+    def __exit__(self, *exc):
+        ss.reset_secret_scope(self.token)
+
+
+# ── Cluster A: gateway/pairing.py allowlist reads ─────────────────────────
+
+class TestPairingAllowlistRead:
+    def test_scoped_value_wins(self, monkeypatch):
+        from gateway.pairing import _read_allowlist_env
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+        ss.set_multiplex_active(True)
+        with _Scope({"TELEGRAM_ALLOWED_USERS": "222"}):
+            assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "222"
+
+    def test_scoped_miss_no_borrow(self, monkeypatch):
+        from gateway.pairing import _read_allowlist_env
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "other-profile")
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == ""
+
+    def test_unscoped_multiplex_falls_back_to_env(self, monkeypatch):
+        # Slack pattern: unscoped read under multiplex uses the process env.
+        from gateway.pairing import _read_allowlist_env
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "own-env")
+        ss.set_multiplex_active(True)
+        assert _read_allowlist_env("TELEGRAM_ALLOWED_USERS") == "own-env"
+
+
+# ── Cluster A: gateway/authz_mixin.py gate reads ───────────────────────────
+
+class TestAuthzPlatformGateEnv:
+    def test_scoped_value_wins(self, monkeypatch):
+        from gateway.authz_mixin import _platform_gate_env
+
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+        ss.set_multiplex_active(True)
+        with _Scope({"DISCORD_ALLOW_BOTS": "all"}):
+            assert _platform_gate_env("DISCORD_ALLOW_BOTS", "none") == "all"
+
+    def test_scoped_miss_returns_default_not_env(self, monkeypatch):
+        from gateway.authz_mixin import _platform_gate_env
+
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")  # another profile's bridge
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert _platform_gate_env("DISCORD_ALLOW_BOTS", "none") == "none"
+
+    def test_single_profile_legacy_env(self, monkeypatch):
+        from gateway.authz_mixin import _platform_gate_env
+
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "42")
+        assert _platform_gate_env("GATEWAY_ALLOWED_USERS") == "42"
+
+
+# ── Cluster B: matrix startup reads (Slack pattern) ────────────────────────
+
+class TestMatrixStartupSecret:
+    def _helper(self):
+        mod = pytest.importorskip("plugins.platforms.matrix.adapter")
+        return mod._startup_env_secret
+
+    def test_scoped_value_wins(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "env-token")
+        ss.set_multiplex_active(True)
+        with _Scope({"MATRIX_ACCESS_TOKEN": "scoped-token"}):
+            assert helper("MATRIX_ACCESS_TOKEN") == "scoped-token"
+
+    def test_scoped_miss_no_borrow(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "other-profile")
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert helper("MATRIX_ACCESS_TOKEN") == ""
+
+    def test_unscoped_multiplex_falls_back(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_PASSWORD", "own-env-pass")
+        ss.set_multiplex_active(True)
+        assert helper("MATRIX_PASSWORD") == "own-env-pass"
+
+
+# ── Cluster C: managed tool gateway token override ─────────────────────────
+
+class TestToolGatewayUserToken:
+    def test_scoped_value_wins(self, monkeypatch):
+        from tools.managed_tool_gateway import _read_user_token_override
+
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "env-tok")
+        ss.set_multiplex_active(True)
+        with _Scope({"TOOL_GATEWAY_USER_TOKEN": "scoped-tok"}):
+            assert _read_user_token_override() == "scoped-tok"
+
+    def test_scoped_miss_no_borrow(self, monkeypatch):
+        from tools.managed_tool_gateway import _read_user_token_override
+
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "other-profile-tok")
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert _read_user_token_override() is None
+
+    def test_unscoped_multiplex_falls_back(self, monkeypatch):
+        from tools.managed_tool_gateway import _read_user_token_override
+
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "own-env-tok")
+        ss.set_multiplex_active(True)
+        assert _read_user_token_override() == "own-env-tok"
+
+
+class TestOpenRouterCheckApiKey:
+    def test_scoped_value_wins(self, monkeypatch):
+        from tools.openrouter_client import check_api_key
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        ss.set_multiplex_active(True)
+        with _Scope({"OPENROUTER_API_KEY": "sk-or-scoped"}):
+            assert check_api_key() is True
+
+    def test_scoped_miss_no_borrow(self, monkeypatch):
+        from tools.openrouter_client import check_api_key
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-other-profile")
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert check_api_key() is False
+
+
+# ── Cluster D: auxiliary client key resolution ──────────────────────────────
+
+class TestAuxiliaryScopedKeyEnv:
+    def test_scoped_value_wins(self, monkeypatch):
+        from agent.auxiliary_client import _scoped_key_env
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-env")
+        ss.set_multiplex_active(True)
+        with _Scope({"OPENROUTER_API_KEY": "sk-scoped"}):
+            assert _scoped_key_env("OPENROUTER_API_KEY") == "sk-scoped"
+
+    def test_scoped_miss_no_borrow(self, monkeypatch):
+        from agent.auxiliary_client import _scoped_key_env
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-other-profile")
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert _scoped_key_env("OPENAI_API_KEY") == ""
+
+    def test_unscoped_multiplex_falls_back(self, monkeypatch):
+        from agent.auxiliary_client import _scoped_key_env
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-own-env")
+        ss.set_multiplex_active(True)
+        assert _scoped_key_env("OPENAI_API_KEY") == "sk-own-env"
+
+    def test_empty_name_returns_empty(self):
+        from agent.auxiliary_client import _scoped_key_env
+
+        assert _scoped_key_env("") == ""
+
+
+# ── Cluster E: azure identity presence reads ────────────────────────────────
+
+class TestAzureIdentityPresence:
+    def _describe(self):
+        azure = pytest.importorskip("agent.azure_identity_adapter")
+        if not azure.has_azure_identity_installed():
+            pytest.skip("azure-identity not installed")
+        return azure.describe_active_credential
+
+    def test_scoped_client_secret_detected(self, monkeypatch):
+        describe = self._describe()
+        monkeypatch.setenv("AZURE_CLIENT_ID", "cid")
+        monkeypatch.setenv("AZURE_TENANT_ID", "tid")
+        monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("AZURE_FEDERATED_TOKEN_FILE", raising=False)
+        ss.set_multiplex_active(True)
+        with _Scope({"AZURE_CLIENT_SECRET": "scoped-secret"}):
+            info = describe(timeout_seconds=0.01, allow_install=False)
+        assert any("EnvironmentCredential" in s for s in info.get("env_sources", []))
+
+    def test_scoped_miss_hides_env_secret(self, monkeypatch):
+        describe = self._describe()
+        monkeypatch.setenv("AZURE_CLIENT_ID", "cid")
+        monkeypatch.setenv("AZURE_TENANT_ID", "tid")
+        monkeypatch.setenv("AZURE_CLIENT_SECRET", "other-profile-secret")
+        monkeypatch.delenv("AZURE_FEDERATED_TOKEN_FILE", raising=False)
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            info = describe(timeout_seconds=0.01, allow_install=False)
+        assert not any(
+            "EnvironmentCredential" in s for s in info.get("env_sources", [])
+        )

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -73,6 +73,28 @@ def _access_token_is_expiring(expires_at: object, skew_seconds: int) -> bool:
     return remaining <= max(0, int(skew_seconds))
 
 
+def _read_user_token_override() -> Optional[str]:
+    """Read the TOOL_GATEWAY_USER_TOKEN env override through the secret scope.
+
+    Availability scans run both inside agent turns (scope installed) and in
+    unscoped CLI paths, so this uses the Slack pattern: honor the scope's
+    verdict when installed (a scoped miss does NOT borrow the process env
+    under multiplex), fall back to ``os.environ`` only when unscoped.
+    """
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            explicit = get_secret("TOOL_GATEWAY_USER_TOKEN")
+        except UnscopedSecretError:
+            explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
+    except Exception:
+        explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    return None
+
+
 def peek_nous_access_token() -> Optional[str]:
     """Cheap probe for a Nous gateway token without triggering refresh.
 
@@ -83,9 +105,9 @@ def peek_nous_access_token() -> Optional[str]:
     network calls. Truthful refresh handling stays in request/session paths
     that call :func:`read_nous_access_token`.
     """
-    explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
-    if isinstance(explicit, str) and explicit.strip():
-        return explicit.strip()
+    explicit = _read_user_token_override()
+    if explicit:
+        return explicit
 
     nous_provider = _read_nous_provider_state() or {}
     access_token = nous_provider.get("access_token")
@@ -96,9 +118,9 @@ def peek_nous_access_token() -> Optional[str]:
 
 def read_nous_access_token() -> Optional[str]:
     """Read a Nous Subscriber OAuth access token from auth store or env override."""
-    explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
-    if isinstance(explicit, str) and explicit.strip():
-        return explicit.strip()
+    explicit = _read_user_token_override()
+    if explicit:
+        return explicit
     nous_provider = _read_nous_provider_state() or {}
     cached_token = peek_nous_access_token()
 

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -29,5 +29,19 @@ def get_async_client():
 
 
 def check_api_key() -> bool:
-    """Check whether the OpenRouter API key is present."""
+    """Check whether the OpenRouter API key is present.
+
+    Scope-aware (Slack pattern): tool paths run inside an installed profile
+    secret scope, whose verdict is authoritative under multiplex; unscoped
+    CLI probes keep the legacy env read.
+    """
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            return bool(get_secret("OPENROUTER_API_KEY"))
+        except UnscopedSecretError:
+            pass
+    except Exception:
+        pass
     return bool(os.getenv("OPENROUTER_API_KEY"))

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -977,9 +977,21 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if sudo_count == 0:
         return command, None
 
-    has_configured_password = "SUDO_PASSWORD" in os.environ
+    # Scope-aware read (Slack pattern): under multiplex the process env may
+    # hold another profile's SUDO_PASSWORD, so honor the installed scope's
+    # verdict; unscoped callers keep the legacy os.environ read.
+    try:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+
+        try:
+            _configured_password = get_secret("SUDO_PASSWORD")
+        except UnscopedSecretError:
+            _configured_password = os.environ.get("SUDO_PASSWORD")
+    except Exception:
+        _configured_password = os.environ.get("SUDO_PASSWORD")
+    has_configured_password = _configured_password is not None
     sudo_password = (
-        os.environ.get("SUDO_PASSWORD", "")
+        _configured_password
         if has_configured_password
         else _get_cached_sudo_password()
     )


### PR DESCRIPTION
## Summary

Tier-1 class-closure migration from the raw-credential-read audit: routes the remaining `os.getenv`/`os.environ` credential reads in core gateway, platform-adapter, tool, auxiliary-client, and identity paths through the profile secret scope (`agent.secret_scope.get_secret`). Follow-up to the profile secret-scope cluster (#76462) and the class-closure audit tracked in #76574.

Per the standing boundary rule: **the isolation boundary is the profile, not the process** — no site gains an environ fallback on a *scoped* miss. Two patterns are used, matching the canonical semantics in `agent/secret_scope.py`:

- **In-turn reads** (standalone senders, tool-path key resolution) call `get_secret` directly — they run inside an installed scope (cron scheduler, delegate spawns, and bg-review forks all propagate it).
- **Startup / unscoped-reachable reads** use the Slack pattern (#59739): `get_secret`, falling back to `os.environ` **only** on `UnscopedSecretError` (the unscoped default-profile path, where the process env is that profile's own).

## Clusters (one commit each)

**A — gateway authz + pairing**
- `gateway/authz_mixin.py`: group chat allowlists (`TELEGRAM_GROUP_ALLOWED_CHATS`/`QQ_GROUP_ALLOWED_USERS`), `{PLATFORM}_ALLOW_BOTS`, and the pairing-mode allowlist presence checks now use the file's own `_platform_gate_env` (scope-authoritative under multiplex, same as the surrounding `_auth_env` sites).
- `gateway/pairing.py`: grant-mirror/revoke allowlist **reads** go through `get_secret` via a new `_read_allowlist_env`; writes still use `save_env_value` with a TODO for profile-aware writes.

**B — standalone-send / adapter-startup token reads**
- Discord/Slack/Telegram standalone senders (`DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`) → in-turn `get_secret`.
- Telegram `TELEGRAM_WEBHOOK_SECRET` (webhook startup) → Slack pattern.
- Matrix `MATRIX_ACCESS_TOKEN`/`MATRIX_PASSWORD` startup reads (`check_matrix_requirements`, adapter `__init__`) → new `_startup_env_secret` (Slack pattern, mirrors the existing `_scoped_recovery_key`); the standalone send at ~:4804 → in-turn `get_secret`.

**C — core tool / gateway / web-server paths**
- `tools/managed_tool_gateway.py`: `TOOL_GATEWAY_USER_TOKEN` override reads (both `peek_nous_access_token` and `read_nous_access_token`) → shared `_read_user_token_override` (Slack pattern).
- `tools/openrouter_client.py`: `check_api_key()` → scope-aware.
- `tools/terminal_tool.py`: `SUDO_PASSWORD` resolution → scope-aware (Slack pattern).
- `gateway/run.py`: `GATEWAY_PROXY_KEY` → scope-aware.
- `gateway/session.py`: `SLACK_BOT_TOKEN` presence check → scope-aware.
- `hermes_cli/web_server.py`: ElevenLabs voices endpoint — the profile `.env` read stays primary; the process-env fallback is now scope-aware.

**D — agent/auxiliary_client.py**
All seven raw provider-key reads (`OPENROUTER_API_KEY` ×3, `OPENAI_API_KEY` ×2, named-custom-provider `key_env`, auxiliary task-config `key_env`) → shared `_scoped_key_env` helper.

**E — agent/azure_identity_adapter.py**
`AZURE_CLIENT_SECRET` / `AZURE_FEDERATED_TOKEN_FILE` presence reads in the Entra diagnostics path → scope-aware.

## Skipped claimed sites

- `tools/openrouter_client.py` ~:26 — not a raw read on current main: it's the `ValueError` message inside `get_async_client`, which already delegates key resolution to `resolve_provider_client` (scoped by cluster D). Only `check_api_key` (~:33) carried a raw read.
- `gateway/authz_mixin.py` non-credential vars (e.g. `TELEGRAM_WEBHOOK_HOST`, `MATRIX_HOMESERVER` in adapters) — deployment settings, not profile secrets; left as env reads.

## Tests

New consolidated regression file `tests/agent/test_secret_scope_tier1_migration.py` (18 tests): per-cluster representative sites × {scoped value wins, scoped miss no-borrow under multiplex, unscoped-multiplex behavior per pattern}.

Ran green locally: secret-scope suites, authz/pairing (incl. multiplex profile authz + pairing stores + allowlist bypass), platform bot-auth-bypass suites, matrix/slack/telegram/discord adapter suites, auxiliary client suites, azure identity adapter, managed tool gateway, terminal tool, session, voice wrapper, `tests/plugins/platforms` — 0 failures. Ruff and the Windows-footgun checker pass on all touched files.

## Infographic

![Secret scope tier-1 infographic](https://v3b.fal.media/files/b/0aa4b270/XbgnK1IbmqbqPjmk2VrRi_HMfi23Ib.png)

Refs #76574.
