### PR TITLE
feat(plugins): add additive profileScope SDK surface (read + subscribe to the profile switcher)

### DIFF
--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -8,6 +8,7 @@ import {
 import { useLocation, useSearchParams } from "react-router";
 import { api, setManagementProfile } from "@/lib/api";
 import { ProfileContext } from "@/contexts/profile-context";
+import { profileBridge } from "@/plugins/profile-bridge";
 
 /**
  * Machine-level management-profile scope.
@@ -130,6 +131,19 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     () => ({ profile, currentProfile, profiles, setProfile }),
     [profile, currentProfile, profiles, setProfile],
   );
+
+  // Mirror the live profile scope into the host-internal plugin bridge so the
+  // plugin SDK's profileScope surface (and non-React consumers like a plain-JS
+  // plugin bundle) can read it and react to switcher flips. Read fields only;
+  // setProfile is never mirrored (the SDK surface is read + subscribe, not
+  // write). Keyed on the three primitives, not the memo value: the memo's deps
+  // include setProfile, whose identity can churn across renders and would
+  // re-fire this effect needlessly. No teardown reset: a flip-to-empty on
+  // unmount would be worse than a brief stale snapshot (which the host's
+  // single-provider runtime never actually hits).
+  useEffect(() => {
+    profileBridge.set({ profile, currentProfile, profiles });
+  }, [profile, currentProfile, profiles]);
 
   return (
     <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>

--- a/web/src/plugins/profile-bridge.test.ts
+++ b/web/src/plugins/profile-bridge.test.ts
@@ -26,15 +26,56 @@ describe("profileBridge", () => {
       // A zero-arg callback that re-reads get() must observe the NEW value.
       seen.push(bridge.get());
     });
+    // seen[0] is the bootstrap delivery of the seed; the change lands after it.
     bridge.set({
       profile: "alice",
       currentProfile: "default",
       profiles: ["default", "alice"],
     });
+    expect(seen).toHaveLength(2);
+    expect(seen[0].profile).toBe("");
+    expect(seen[1].profile).toBe("alice");
+    expect(seen[1].currentProfile).toBe("default");
+    expect([...seen[1].profiles]).toEqual(["default", "alice"]);
+  });
+
+  it("subscribe() after set() immediately delivers the current state (bootstrap)", async () => {
+    // Plugin bundles load asynchronously, so subscribing AFTER the provider's
+    // first set() is the normal case for a plain-JS consumer. The bootstrap
+    // call must hand it the live value; nothing waits for the next flip.
+    const bridge = await freshBridge();
+    bridge.set({
+      profile: "alice",
+      currentProfile: "default",
+      profiles: ["default", "alice"],
+    });
+
+    const seen: ProfileScopeSnapshot[] = [];
+    bridge.subscribe(() => {
+      seen.push(bridge.get());
+    });
+
     expect(seen).toHaveLength(1);
     expect(seen[0].profile).toBe("alice");
     expect(seen[0].currentProfile).toBe("default");
     expect([...seen[0].profiles]).toEqual(["default", "alice"]);
+  });
+
+  it("a throwing bootstrap callback neither escapes subscribe() nor loses registration", async () => {
+    const bridge = await freshBridge();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cb = vi.fn(() => {
+      throw new Error("boom at bootstrap");
+    });
+
+    expect(() => bridge.subscribe(cb)).not.toThrow();
+    expect(cb).toHaveBeenCalledTimes(1); // bootstrap attempt happened
+    expect(errSpy).toHaveBeenCalledTimes(1);
+
+    // Still registered: the next real change reaches it.
+    bridge.set({ profile: "alice", currentProfile: "d", profiles: [] });
+    expect(cb).toHaveBeenCalledTimes(2);
+    errSpy.mockRestore();
   });
 
   it("notifies on a currentProfile-only change (fields are equal-weight)", async () => {
@@ -42,6 +83,7 @@ describe("profileBridge", () => {
     bridge.set({ profile: "", currentProfile: "default", profiles: [] });
     const cb = vi.fn();
     bridge.subscribe(cb);
+    cb.mockClear(); // drop the bootstrap call; this test counts change dispatches
     bridge.set({ profile: "", currentProfile: "gibson", profiles: [] });
     expect(cb).toHaveBeenCalledTimes(1);
   });
@@ -51,6 +93,7 @@ describe("profileBridge", () => {
     bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b"] });
     const cb = vi.fn();
     bridge.subscribe(cb);
+    cb.mockClear(); // drop the bootstrap call; this test counts change dispatches
     bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b", "c"] }); // add
     bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b"] }); // remove
     bridge.set({ profile: "", currentProfile: "d", profiles: ["b", "a"] }); // reorder
@@ -62,6 +105,7 @@ describe("profileBridge", () => {
     bridge.set({ profile: "x", currentProfile: "d", profiles: ["a"] });
     const cb = vi.fn();
     bridge.subscribe(cb);
+    cb.mockClear(); // drop the bootstrap call; this test counts change dispatches
     bridge.set({ profile: "x", currentProfile: "d", profiles: ["a"] }); // identical
     expect(cb).not.toHaveBeenCalled();
   });
@@ -79,6 +123,7 @@ describe("profileBridge", () => {
     unsubB = bridge.subscribe(() => {
       order.push("b");
     });
+    order.length = 0; // drop the two bootstrap calls; this test tracks dispatches
 
     bridge.set({ profile: "1", currentProfile: "d", profiles: [] });
     expect(order).toEqual(["a", "b"]);
@@ -106,6 +151,8 @@ describe("profileBridge", () => {
     bridge.subscribe(() => {
       calls.push("second");
     });
+    calls.length = 0; // drop bootstrap calls; this test tracks the dispatch
+    errSpy.mockClear(); // (the first subscriber already threw once at bootstrap)
 
     expect(() =>
       bridge.set({ profile: "z", currentProfile: "d", profiles: [] }),

--- a/web/src/plugins/profile-bridge.test.ts
+++ b/web/src/plugins/profile-bridge.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ProfileScopeSnapshot } from "./profile-bridge";
+
+// Each test gets a fresh module instance so module-level store state (the
+// snapshot and the subscriber set) never leaks across cases. The seed-default
+// case in particular needs a pristine store.
+async function freshBridge() {
+  vi.resetModules();
+  return (await import("./profile-bridge")).profileBridge;
+}
+
+describe("profileBridge", () => {
+  it("get() returns the seeded empty default before any set()", async () => {
+    const bridge = await freshBridge();
+    expect(bridge.get()).toEqual({
+      profile: "",
+      currentProfile: "",
+      profiles: [],
+    });
+  });
+
+  it("set() replaces the snapshot BEFORE notifying (ordering invariant)", async () => {
+    const bridge = await freshBridge();
+    const seen: ProfileScopeSnapshot[] = [];
+    bridge.subscribe(() => {
+      // A zero-arg callback that re-reads get() must observe the NEW value.
+      seen.push(bridge.get());
+    });
+    bridge.set({
+      profile: "alice",
+      currentProfile: "default",
+      profiles: ["default", "alice"],
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].profile).toBe("alice");
+    expect(seen[0].currentProfile).toBe("default");
+    expect([...seen[0].profiles]).toEqual(["default", "alice"]);
+  });
+
+  it("notifies on a currentProfile-only change (fields are equal-weight)", async () => {
+    const bridge = await freshBridge();
+    bridge.set({ profile: "", currentProfile: "default", profiles: [] });
+    const cb = vi.fn();
+    bridge.subscribe(cb);
+    bridge.set({ profile: "", currentProfile: "gibson", profiles: [] });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies on profiles add / remove / reorder (element-wise compare)", async () => {
+    const bridge = await freshBridge();
+    bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b"] });
+    const cb = vi.fn();
+    bridge.subscribe(cb);
+    bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b", "c"] }); // add
+    bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b"] }); // remove
+    bridge.set({ profile: "", currentProfile: "d", profiles: ["b", "a"] }); // reorder
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT notify when all three fields are unchanged", async () => {
+    const bridge = await freshBridge();
+    bridge.set({ profile: "x", currentProfile: "d", profiles: ["a"] });
+    const cb = vi.fn();
+    bridge.subscribe(cb);
+    bridge.set({ profile: "x", currentProfile: "d", profiles: ["a"] }); // identical
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("keeps subscribe/unsubscribe idempotent and isolates the in-flight dispatch", async () => {
+    const bridge = await freshBridge();
+    const order: string[] = [];
+    let unsubB: () => void = () => {};
+    // `a` unsubscribes `b` mid-notification; because notify iterates a
+    // [...subs] copy captured before dispatch, `b` still runs THIS flip.
+    bridge.subscribe(() => {
+      order.push("a");
+      unsubB();
+    });
+    unsubB = bridge.subscribe(() => {
+      order.push("b");
+    });
+
+    bridge.set({ profile: "1", currentProfile: "d", profiles: [] });
+    expect(order).toEqual(["a", "b"]);
+
+    // Next flip: b is gone.
+    order.length = 0;
+    bridge.set({ profile: "2", currentProfile: "d", profiles: [] });
+    expect(order).toEqual(["a"]);
+
+    // Double-unsubscribe is a no-op (Set delete is idempotent).
+    expect(() => {
+      unsubB();
+      unsubB();
+    }).not.toThrow();
+  });
+
+  it("isolates a throwing subscriber so siblings still run", async () => {
+    const bridge = await freshBridge();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const calls: string[] = [];
+    bridge.subscribe(() => {
+      calls.push("first");
+      throw new Error("boom");
+    });
+    bridge.subscribe(() => {
+      calls.push("second");
+    });
+
+    expect(() =>
+      bridge.set({ profile: "z", currentProfile: "d", profiles: [] }),
+    ).not.toThrow();
+    expect(calls).toEqual(["first", "second"]);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
+  it("returns a frozen profiles copy that cannot mutate the store", async () => {
+    const bridge = await freshBridge();
+    bridge.set({ profile: "", currentProfile: "d", profiles: ["a", "b"] });
+
+    const got = bridge.get().profiles;
+    expect(Object.isFrozen(got)).toBe(true);
+    expect(() => {
+      (got as string[]).push("c");
+    }).toThrow();
+    // The internal snapshot is untouched by the attempted mutation.
+    expect([...bridge.get().profiles]).toEqual(["a", "b"]);
+
+    // Copy-in: mutating the caller's array after set() must not affect the store.
+    const input = ["a", "b"];
+    bridge.set({ profile: "p", currentProfile: "d", profiles: input });
+    input.push("MUTATED");
+    expect([...bridge.get().profiles]).toEqual(["a", "b"]);
+  });
+});

--- a/web/src/plugins/profile-bridge.ts
+++ b/web/src/plugins/profile-bridge.ts
@@ -1,0 +1,113 @@
+/**
+ * Host-internal profile bridge store.
+ *
+ * Mirrors the live management-profile scope (`profile`, `currentProfile`,
+ * `profiles`) out of React's `ProfileProvider` into a plain module-level store
+ * so the plugin SDK's `profileScope` surface (see `plugins/registry.ts`) can
+ * expose it to NON-React consumers (plain-JS plugin bundles that cannot use a
+ * hook) as well as React plugins.
+ *
+ * Why a store and not a snapshot captured in `exposePluginSDK()`:
+ * `exposePluginSDK()` runs once at boot, outside any React render, so a value
+ * read there would freeze and never reflect a switcher flip. `ProfileProvider`
+ * writes into this store via an effect; the SDK getters read from it on access
+ * and `subscribe(cb)` notifies on change.
+ *
+ * This module is host-internal: it is imported only by `registry.ts` and
+ * `ProfileProvider.tsx` and is never named in the public `sdk.d.ts` contract.
+ *
+ * Write-surface fence: only the three READ fields are mirrored here; the
+ * provider's `setProfile` is never stored, so the public surface stays
+ * read + subscribe, one getter away from a write path.
+ *
+ * Array immutability: the store owns its own `profiles` array. `set()` copies
+ * the caller's array in (never aliasing the provider's React-state array) and
+ * the getter returns a frozen copy out, so a plugin cannot mutate host state
+ * through the read-only surface (`sdk.profileScope.profiles.push(...)` is a
+ * no-op-or-throw, and never reaches the stored snapshot).
+ */
+
+/** Immutable view of the host's management-profile scope. */
+export interface ProfileScopeSnapshot {
+  readonly profile: string;
+  readonly currentProfile: string;
+  readonly profiles: readonly string[];
+}
+
+type Subscriber = () => void;
+
+// Internal mutable snapshot. Seeded with a safe empty default so a read before
+// `ProfileProvider` mounts never throws or returns undefined. The empty default
+// is indistinguishable from a genuine "no profiles / own-profile" state, so a
+// consumer that needs the live value must subscribe (or re-read after first
+// paint) rather than latch this seed.
+let _snapshot: { profile: string; currentProfile: string; profiles: string[] } = {
+  profile: "",
+  currentProfile: "",
+  profiles: [],
+};
+
+const _subscribers: Set<Subscriber> = new Set();
+
+/** Element-wise array compare (length + each index): add / remove / reorder all differ. */
+function _profilesEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+export const profileBridge = {
+  /** Current snapshot. `profiles` is a fresh frozen copy (caller cannot mutate the store). */
+  get(): ProfileScopeSnapshot {
+    return {
+      profile: _snapshot.profile,
+      currentProfile: _snapshot.currentProfile,
+      profiles: Object.freeze([..._snapshot.profiles]),
+    };
+  },
+
+  /**
+   * Replace the snapshot and notify, but only when a field actually changed
+   * (no spurious callback storms). All three fields are equal-weight: a
+   * `currentProfile`-only delta notifies. `profile` / `currentProfile` compare
+   * by string equality; `profiles` compares element-wise.
+   */
+  set(value: ProfileScopeSnapshot): void {
+    const changed =
+      value.profile !== _snapshot.profile ||
+      value.currentProfile !== _snapshot.currentProfile ||
+      !_profilesEqual(value.profiles, _snapshot.profiles);
+    if (!changed) return;
+
+    // Ordering invariant: replace the snapshot BEFORE notifying, so a callback
+    // that re-reads `get()` observes the new value. Copy the array in so the
+    // provider's React-state array is never aliased or mutable via the SDK.
+    _snapshot = {
+      profile: value.profile,
+      currentProfile: value.currentProfile,
+      profiles: [...value.profiles],
+    };
+
+    // Iterate a snapshot copy of the subscriber set so a callback that
+    // subscribes / unsubscribes mid-notification affects only later flips,
+    // never the in-flight one. Isolate each callback so one thrower cannot
+    // starve siblings or escape into the provider's effect.
+    for (const cb of [..._subscribers]) {
+      try {
+        cb();
+      } catch (err) {
+        console.error("[hermes] profileScope subscriber threw:", err);
+      }
+    }
+  },
+
+  /** Register a zero-arg callback; returns an idempotent unsubscribe thunk. */
+  subscribe(cb: Subscriber): () => void {
+    _subscribers.add(cb);
+    return () => {
+      _subscribers.delete(cb);
+    };
+  },
+};

--- a/web/src/plugins/profile-bridge.ts
+++ b/web/src/plugins/profile-bridge.ts
@@ -11,7 +11,7 @@
  * `exposePluginSDK()` runs once at boot, outside any React render, so a value
  * read there would freeze and never reflect a switcher flip. `ProfileProvider`
  * writes into this store via an effect; the SDK getters read from it on access
- * and `subscribe(cb)` notifies on change.
+ * and `subscribe(cb)` fires once immediately (bootstrap) and then on change.
  *
  * This module is host-internal: it is imported only by `registry.ts` and
  * `ProfileProvider.tsx` and is never named in the public `sdk.d.ts` contract.
@@ -39,8 +39,9 @@ type Subscriber = () => void;
 // Internal mutable snapshot. Seeded with a safe empty default so a read before
 // `ProfileProvider` mounts never throws or returns undefined. The empty default
 // is indistinguishable from a genuine "no profiles / own-profile" state, so a
-// consumer that needs the live value must subscribe (or re-read after first
-// paint) rather than latch this seed.
+// consumer that needs the live value must subscribe; the bootstrap call plus
+// change notifications make subscribing alone sufficient (no polling, no
+// re-read-after-paint choreography).
 let _snapshot: { profile: string; currentProfile: string; profiles: string[] } = {
   profile: "",
   currentProfile: "",
@@ -103,9 +104,25 @@ export const profileBridge = {
     }
   },
 
-  /** Register a zero-arg callback; returns an idempotent unsubscribe thunk. */
+  /**
+   * Register a zero-arg callback; returns an idempotent unsubscribe thunk.
+   *
+   * Bootstrap delivery: the callback fires once, synchronously, at subscribe
+   * time. Plugin bundles load asynchronously (see `usePlugins.ts`), so a
+   * consumer can subscribe AFTER the provider's first `set()`; without the
+   * bootstrap call it would read nothing until the next switcher flip. Firing
+   * immediately makes "subscribe and read the getters in the callback" a
+   * complete consumption pattern with no missable window between a `get()`
+   * and a `subscribe()`. Same isolation as a change dispatch: a throwing
+   * callback is logged, never escapes, and stays registered.
+   */
   subscribe(cb: Subscriber): () => void {
     _subscribers.add(cb);
+    try {
+      cb();
+    } catch (err) {
+      console.error("[hermes] profileScope subscriber threw:", err);
+    }
     return () => {
       _subscribers.delete(cb);
     };

--- a/web/src/plugins/profile-scope.test-d.ts
+++ b/web/src/plugins/profile-scope.test-d.ts
@@ -1,0 +1,46 @@
+/**
+ * Type-level contract guard for the plugin SDK `profileScope` surface.
+ *
+ * Regression for the exact bug this surface exists to prevent: shipping a
+ * shape a plain-JS plugin cannot consume. The motivating non-React consumer
+ * probes `typeof sdk.profileScope === "object"` and calls `.subscribe(cb)`, so
+ * the field MUST be an OBJECT with `profile` / `currentProfile` / `profiles`
+ * plus a `subscribe(cb: () => void): () => void` method, never a bare hook.
+ *
+ * This file has no runtime (it is not picked up by the Vitest `*.test.ts`
+ * glob). It fails `npm run typecheck` (tsc) if someone "simplifies"
+ * `profileScope` back to a function, softens `subscribe`, or widens a field.
+ */
+import type { HermesPluginSDK, ProfileScopeValue } from "./sdk";
+
+// Compile-time exact-equality assertion helpers.
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+// The field is optional (`profileScope?:`); assert against the non-optional shape.
+type Scope = NonNullable<HermesPluginSDK["profileScope"]>;
+
+/**
+ * Each element is `Expect<true>`; any failing assertion collapses to
+ * `Expect<false>`, which is a type error. Exported so it is never flagged as
+ * an unused declaration.
+ */
+export type ProfileScopeContractAssertions = [
+  // 1. The exposed shape is exactly ProfileScopeValue (object + subscribe).
+  Expect<Equal<Scope, ProfileScopeValue>>,
+  // 2. It is an object, NOT callable: a bare hook `() => ProfileScopeValue`
+  //    would have a call signature; assert Scope has none.
+  Expect<Equal<Scope extends (...args: never[]) => unknown ? true : false, false>>,
+  // 3. Full subscribe signature: zero-arg `() => void` callback in, unsubscribe
+  //    `() => void` out. Blocks softening to a snapshot-arg callback or a
+  //    `void` return.
+  Expect<Equal<Scope["subscribe"], (cb: () => void) => () => void>>,
+  // 4. Fields are correctly typed; `profiles` is `readonly string[]` (contents
+  //    immutable), not `string[]`.
+  Expect<Equal<Scope["profile"], string>>,
+  Expect<Equal<Scope["currentProfile"], string>>,
+  Expect<Equal<Scope["profiles"], readonly string[]>>,
+];

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -168,7 +168,8 @@ export function exposePluginSDK() {
     useI18n,
 
     // Live, read-only view of the host's management-profile switcher, plus a
-    // subscribe(cb) to react when an operator flips it. An object with live
+    // subscribe(cb) that fires once immediately (bootstrap) and then on every
+    // operator flip. An object with live
     // getters (not a bare hook) so non-React consumers (plain-JS plugin
     // bundles that probe `typeof sdk.profileScope === "object"` and call
     // `.subscribe`) work too. Getters re-read the host-internal store at

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -30,6 +30,7 @@ import { Separator } from "@nous-research/ui/ui/components/separator";
 import { Tabs, TabsList, TabsTrigger } from "@nous-research/ui/ui/components/tabs";
 import { useI18n } from "@/i18n";
 import { registerSlot, PluginSlot } from "./slots";
+import { profileBridge } from "./profile-bridge";
 
 // ---------------------------------------------------------------------------
 // Plugin registry — plugins call register() to add their component.
@@ -90,12 +91,13 @@ export function getRegisteredCount(): number {
 
 /**
  * Version of the plugin SDK contract (see ``plugins/sdk.d.ts``). Bump the
- * major on any backwards-incompatible change to the exposed surface;
- * additive changes (new optional fields / helpers) don't require a bump.
+ * major on any backwards-incompatible change to the exposed surface; additive
+ * changes (new optional fields / helpers) take a minor bump so a runtime compat
+ * gate can advertise the new capability, never a major bump.
  * Exposed at runtime as ``window.__HERMES_PLUGIN_SDK__.sdkVersion`` so a
  * plugin (or a future host-side compatibility gate) can read it.
  */
-export const SDK_CONTRACT_VERSION = "1.1.0";
+export const SDK_CONTRACT_VERSION = "1.2.0";
 
 // Window globals for the plugin SDK are declared in ``plugins/sdk.d.ts`` —
 // the single source of truth for the public contract. Don't redeclare them
@@ -109,7 +111,7 @@ export function exposePluginSDK() {
 
   window.__HERMES_PLUGIN_SDK__ = {
     // Contract version of the plugin SDK surface (see plugins/sdk.d.ts).
-    // Bump on backwards-incompatible changes; additive changes don't need it.
+    // Bump major on backwards-incompatible changes; additive changes take a minor bump.
     sdkVersion: SDK_CONTRACT_VERSION,
     // React core — plugins use these instead of importing react
     React,
@@ -164,5 +166,26 @@ export function exposePluginSDK() {
 
     // Hooks
     useI18n,
+
+    // Live, read-only view of the host's management-profile switcher, plus a
+    // subscribe(cb) to react when an operator flips it. An object with live
+    // getters (not a bare hook) so non-React consumers (plain-JS plugin
+    // bundles that probe `typeof sdk.profileScope === "object"` and call
+    // `.subscribe`) work too. Getters re-read the host-internal store at
+    // access time; read + subscribe only (setProfile is not re-exported).
+    profileScope: {
+      get profile() {
+        return profileBridge.get().profile;
+      },
+      get currentProfile() {
+        return profileBridge.get().currentProfile;
+      },
+      get profiles() {
+        return profileBridge.get().profiles;
+      },
+      subscribe(cb: () => void) {
+        return profileBridge.subscribe(cb);
+      },
+    },
   };
 }

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -105,13 +105,16 @@ export interface PluginRegistry {
  * well as React plugins (read the fields, ``subscribe`` inside a ``useEffect``).
  *
  * Freshness: the getters re-read the host's live store on each access, so a
- * consumer that RE-READS after a change sees the new value. Before
- * ``ProfileProvider`` mounts, the fields read a safe empty default
- * (``profile: ""``, ``currentProfile: ""``, ``profiles: []``) which is
- * indistinguishable from a genuine "no profiles / own-profile" state, so a
- * consumer that needs the live value MUST ``subscribe`` (or re-read after
- * first paint) rather than latch the initial read. ``profiles`` is returned
- * frozen; treat it as read-only (mutating it does not affect host state).
+ * consumer that RE-READS after a change sees the new value. Before the host
+ * provider mounts, the fields read a safe empty default (``profile: ""``,
+ * ``currentProfile: ""``, ``profiles: []``) which is indistinguishable from
+ * a genuine "no profiles / own-profile" state. Subscribing alone is
+ * sufficient to never latch that seed: ``subscribe`` fires the callback once
+ * immediately with whatever is current at subscribe time, and again on every
+ * later change, so there is no missable window for a consumer that loads
+ * after the host booted (plugin bundles load asynchronously). ``profiles``
+ * is returned frozen; treat it as read-only (mutating it does not affect
+ * host state).
  */
 export interface ProfileScopeValue {
   /** Profile every management surface reads/writes ("" = the dashboard's own). */
@@ -121,8 +124,10 @@ export interface ProfileScopeValue {
   /** Known profile names (frozen; treat as read-only). */
   readonly profiles: readonly string[];
   /**
-   * Register a zero-arg callback fired on any change to the fields above
-   * (the callback re-reads the getters); returns an unsubscribe thunk.
+   * Register a zero-arg callback; returns an unsubscribe thunk. The callback
+   * fires once immediately at subscribe time (bootstrap: read the getters
+   * inside it for the current state) and again on any change to the fields
+   * above. Call the returned thunk on plugin teardown.
    */
   subscribe(cb: () => void): () => void;
 }

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -22,7 +22,8 @@
  * Versioning: bump ``HermesPluginSDK["sdkVersion"]`` (and the
  * ``SDK_CONTRACT_VERSION`` const the host exposes) on any
  * backwards-incompatible change to this surface. Additive changes
- * (new optional fields, new helpers) don't require a major bump.
+ * (new optional fields / helpers) take a minor bump so a runtime compat
+ * gate can advertise the new capability; never a major bump.
  *
  * OPEN QUESTIONS for productionising this spike (do not block the auth fix):
  *   - Ship as a published ``@hermes/dashboard-plugin-sdk`` types package, or
@@ -88,6 +89,45 @@ export interface PluginRegistry {
 }
 
 // ---------------------------------------------------------------------------
+// Profile scope surface (read + subscribe)
+// ---------------------------------------------------------------------------
+
+/**
+ * Live, read-only view of the host's management-profile switcher, plus a
+ * ``subscribe`` to react when an operator flips it.
+ *
+ * Hand-authored inline (NOT imported from ``@/contexts/...``) so no
+ * host-internal module path leaks into this versioned contract.
+ *
+ * Shape is an OBJECT with live getters + ``subscribe``, deliberately not a
+ * bare hook: it must serve non-React consumers (plain-JS plugin bundles that
+ * probe ``typeof sdk.profileScope === "object"`` and call ``.subscribe``) as
+ * well as React plugins (read the fields, ``subscribe`` inside a ``useEffect``).
+ *
+ * Freshness: the getters re-read the host's live store on each access, so a
+ * consumer that RE-READS after a change sees the new value. Before
+ * ``ProfileProvider`` mounts, the fields read a safe empty default
+ * (``profile: ""``, ``currentProfile: ""``, ``profiles: []``) which is
+ * indistinguishable from a genuine "no profiles / own-profile" state, so a
+ * consumer that needs the live value MUST ``subscribe`` (or re-read after
+ * first paint) rather than latch the initial read. ``profiles`` is returned
+ * frozen; treat it as read-only (mutating it does not affect host state).
+ */
+export interface ProfileScopeValue {
+  /** Profile every management surface reads/writes ("" = the dashboard's own). */
+  readonly profile: string;
+  /** The profile the dashboard process itself runs under. */
+  readonly currentProfile: string;
+  /** Known profile names (frozen; treat as read-only). */
+  readonly profiles: readonly string[];
+  /**
+   * Register a zero-arg callback fired on any change to the fields above
+   * (the callback re-reads the getters); returns an unsubscribe thunk.
+   */
+  subscribe(cb: () => void): () => void;
+}
+
+// ---------------------------------------------------------------------------
 // SDK surface (window.__HERMES_PLUGIN_SDK__)
 // ---------------------------------------------------------------------------
 
@@ -148,6 +188,14 @@ export interface HermesPluginSDK {
    * ``I18nContextValue`` shape. Plugins typically call ``useI18n().t(...)``.
    */
   useI18n: () => unknown;
+
+  /**
+   * Live view of the host's management-profile switcher (read + subscribe).
+   * OPTIONAL: a plugin compiled against this type may run on an older host that
+   * predates the field, so probe ``sdk.profileScope`` (or gate on
+   * ``sdkVersion``) before use. Added in SDK contract 1.2.0.
+   */
+  profileScope?: ProfileScopeValue;
 }
 
 declare global {

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -537,6 +537,9 @@ SDK.utils.isoTimeAgo         // "5m ago" from ISO string
 
 // Hooks
 SDK.useI18n                  // i18n hook for multi-language plugins
+
+// Profile scope (SDK 1.2.0+, read-only)
+SDK.profileScope             // management-profile switcher: profile, currentProfile, profiles, subscribe(cb)
 ```
 
 #### Calling your plugin's backend
@@ -560,6 +563,30 @@ SDK.api.getSessions(10).then((resp) => console.log(resp.sessions.length));
 ```
 
 See [Web Dashboard → REST API](./web-dashboard#rest-api) for the full list.
+
+#### Reading the management-profile scope
+
+`SDK.profileScope` (SDK 1.2.0+) is a live, read-only view of the sidebar profile switcher: which profile the management pages are scoped to (`profile`, where `""` means the dashboard's own profile), which profile the dashboard process itself runs under (`currentProfile`), and the known profile names (`profiles`, a frozen array).
+
+`subscribe(cb)` fires the callback once immediately with the current state and again on every change, so subscribing is all a plugin needs to do; there is no gap to poll around even though plugin bundles load after the host boots. It returns an unsubscribe function. Always call it when your plugin tears down.
+
+```javascript
+const scope = SDK.profileScope;
+
+// The field is optional in the contract: absent on hosts older than SDK 1.2.0.
+if (typeof scope === "object") {
+  const unsubscribe = scope.subscribe(() => {
+    // Re-read the live getters inside the callback.
+    console.log("managing profile:", scope.profile || "(dashboard's own)");
+    console.log("known profiles:", [...scope.profiles]);
+  });
+
+  // Later, on plugin teardown:
+  unsubscribe();
+}
+```
+
+The surface is read + subscribe only. There is no setter, and mutating `profiles` throws or is ignored; changing the scope stays an operator action in the host UI.
 
 ### Shell slots
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `profileScope` field to the dashboard plugin SDK: a live, read-only view of the management-profile switcher (`profile`, `currentProfile`, `profiles`) plus `subscribe(cb)` for change notification.

Plugins render inside the host's profile scope, but the SDK says nothing about it. A React plugin can only get it by reaching into host-internal context (exactly the coupling `sdk.d.ts` warns against), and a plain-JS plugin bundle has no supported way at all to know which profile the operator is driving or when they flip the switcher. This adds that one missing surface, additively: no change to `register`, any existing SDK field, or switcher semantics, and `setProfile` is deliberately not exposed.

Implements the proposal in #51816 as scoped there.

## Related Issue

Closes #51816

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `web/src/plugins/profile-bridge.ts` (new): host-internal store mirroring the live scope. Replaces the snapshot before notifying, notifies only on a real change with all three fields equal weight (element-wise compare on `profiles`), copies the array in on set and hands a frozen copy out on read, and isolates subscribers (one throwing callback cannot starve the rest).
- `web/src/contexts/ProfileProvider.tsx`: mirrors its scope into the bridge via an effect keyed on the three primitives.
- `web/src/plugins/registry.ts`: `exposePluginSDK()` exposes `profileScope` as live getters plus `subscribe` over the bridge; `SDK_CONTRACT_VERSION` bumped `1.1.0` to `1.2.0`.
- `web/src/plugins/sdk.d.ts`: hand-authored inline `ProfileScopeValue` (no host-internal module path leaks into the contract) and the optional `profileScope?` field.
- `web/src/plugins/profile-bridge.test.ts` (new): Node Vitest unit tests for the bridge semantics above.
- `web/src/plugins/profile-scope.test-d.ts` (new): type-level guard riding `npm run typecheck`, pinning the object + subscribe shape (not a bare hook) and the field's optionality.

## How to Test

1. `cd web && npm run check` (typecheck + vitest + eslint). On this branch: tsc clean, 22 test files / 152 tests passed, eslint 0 errors.
2. Manual: run the dashboard, open the devtools console, run `window.__HERMES_PLUGIN_SDK__.profileScope.subscribe(() => console.log(window.__HERMES_PLUGIN_SDK__.profileScope.profile))`, then flip the sidebar profile switcher and watch the callback fire with the new scope.

## Design notes

- **Object + subscribe, not a bare hook.** A hook serves only React-tree plugins. The object shape serves both worlds: React plugins read the fields and re-subscribe inside `useEffect`; a plain-JS bundle probes `typeof sdk.profileScope === "object"` and calls `.subscribe(cb)`. A `useProfileScope` hook sibling is easy to add later if wanted; it is not pre-bundled here (issue question 2).
- **Optional field, minor version bump.** The field is optional in the contract so a plugin compiled against 1.2 still runs on a 1.1 host, where the field is simply absent. The two in-repo notes on additive versioning disagreed (`sdk.d.ts` said no major bump needed, `registry.ts` said no bump at all); both now read the same way: additive changes take a minor bump so a runtime compatibility gate can advertise the new capability, never a major bump. Hence `1.2.0` (issue question 3).
- **Seed-value caveat.** Before `ProfileProvider` mounts, reads return a safe empty default that is indistinguishable from a genuine own-profile state, so the contract doc tells consumers to subscribe (or re-read after first paint) rather than latch the first read.
- **Render-reactivity test split out.** A test that mounts a consumer under `ProfileProvider` and flips via the real `setProfile` needs jsdom plus React Testing Library, which `web/` does not have yet. Per the issue (question 4), that lands as a small follow-up unless you would rather wire the DOM test env here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Web-only change: ran the full `web` gate (`npm run check`: typecheck, vitest, eslint) in place of `pytest tests/ -q`; no Python is touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`sdk.d.ts` is the versioned contract doc; its doc comments cover the new surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): N/A, dashboard TypeScript only
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
