### PR TITLE
test(update): make EOL-churn dirtiness deterministic under racy-git stat caching

### DIFF
--- a/tests/hermes_cli/test_update_eol_churn.py
+++ b/tests/hermes_cli/test_update_eol_churn.py
@@ -59,6 +59,19 @@ def _managed_repo(tmp_path: Path, files: dict[str, bytes]) -> Path:
     for name in files:
         (repo / name).unlink()
     _git(repo, "checkout", "--", ".")
+    # Deterministic dirtiness: whether `git diff` content-checks an entry (and
+    # so sees the CRLF churn) or trusts the stat cache depends on racy-git
+    # detection — entries whose mtime equals the index timestamp get content-
+    # compared, later ones read clean. On a fast runner a large checkout
+    # straddles that boundary nondeterministically (CI flake: 92/661 of 1200
+    # dirty). Bump every worktree mtime past the index write so ALL entries
+    # are stat-stale and git must content-compare each one.
+    import os as _os
+    import time as _time
+
+    bumped = _time.time() + 5
+    for name in files:
+        _os.utime(repo / name, (bumped, bumped))
     return repo
 
 


### PR DESCRIPTION
## Summary
Makes `test_churn_across_more_files_than_fit_in_one_argv` deterministic — it flaked on two unrelated PRs within minutes (`assert 92 == 1200`, `assert 661 == 1200`) because git's racy-git stat-cache detection decides per-entry whether the CRLF churn is even visible.

Root cause: after the fixture's `git checkout`, entries whose recorded stat is non-racy (mtime older than the index write) are trusted clean by `git diff`; racy entries get content-compared and read dirty. A 1200-file checkout on a CI runner straddles that timestamp boundary nondeterministically. Empirically reproduced both directions: a frozen non-racy stat cache yields 0/N dirty; bumping worktree mtimes past the index write yields N/N, deterministically.

## Changes
- `tests/hermes_cli/test_update_eol_churn.py` (`_managed_repo` fixture): bump every worktree mtime +5s after checkout so all entries are stat-stale and git must content-compare each one. Production `_normalize_managed_eol` untouched.

## Validation
| Scenario | Dirty count |
|---|---|
| CI flake shape (non-racy stat cache, no fix) | 0–661 of N, nondeterministic |
| With mtime bump | N/N, deterministic |
| Full test file locally | 9/9 pass |

Flaked runs: [30738759530](https://github.com/NousResearch/hermes-agent/actions/runs/30738759530) (92/1200, PR #76664), [30738842393](https://github.com/NousResearch/hermes-agent/actions/runs/30738842393) (661/1200, PR #76666) — both PRs touch zero update/EOL code.

## Infographic

![racy git tamed](https://v3b.fal.media/files/b/0aa4b2ab/9A7zWWs14HSoGIDbZ-MX__WLnz56q4.png)
