### PR TITLE
fix(cli): stop hermes import-agent from destroying an unreadable config.yaml

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -95,26 +95,86 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+class ConfigReadError(RuntimeError):
+    """An existing config file is present but cannot be read or parsed.
+
+    Signals that a read-modify-write round trip must be abandoned: the caller
+    has no idea what the file holds, so writing a merged result back would
+    replace real settings with only the keys it merged.
+    """
+
+
 def load_yaml_file(path: Path) -> Dict[str, Any]:
+    """Load a YAML mapping, distinguishing "absent" from "unreadable".
+
+    Every caller of this function reads ``config.yaml``, merges a section into
+    it, and writes the whole mapping straight back over the original.  So
+    collapsing a present-but-unreadable file to ``{}`` is destructive: a YAML
+    syntax error, a permission problem, or a broken mount would make the
+    importer replace every setting the user had with only the one or two keys
+    it merged — and still report the item as ``imported``.
+
+    This is the same invariant ``hermes_cli.config`` enforces for its own
+    writers via ``require_readable_config_before_write`` / ``atomic_config_write``
+    ("``read_raw_config()`` returns ``{}`` for BOTH an absent file and an
+    unreadable-but-present file"), and that ``set_config_value`` gained for
+    YAML syntax errors.  This module has its own private helper pair and so
+    was never covered by either.
+
+    - Absent, or present but empty  -> ``{}``; first-time creation still works.
+    - Present but unreadable, unparseable, or not a mapping -> raise
+      :class:`ConfigReadError` so the caller refuses and leaves the file
+      byte-identical.
+    """
     import yaml
 
     if not path.exists():
         return {}
     try:
-        data = yaml.safe_load(read_text(path))
-    except Exception:
+        raw = read_text(path)
+    except OSError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file is not valid YAML "
+            f"({exc}). Fix it with `hermes config edit` (or move it aside), then "
+            f"re-run the import."
+        ) from exc
+    # An empty file parses to None — a legitimate state with nothing to lose.
+    if data is None:
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: expected the existing file to hold a "
+            f"YAML mapping but found {type(data).__name__}. Fix it with "
+            f"`hermes config edit` (or move it aside), then re-run the import."
+        )
+    return data
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
+    """Write ``data`` as YAML via temp file + fsync + atomic rename.
+
+    Only ever reached after :func:`load_yaml_file` has successfully read the
+    same path, so the mapping being written is the real file's content plus
+    the merged section — never a silently-empty stand-in.
+
+    ``atomic_write_text`` (already used by this module for the memory store)
+    means an interrupted import cannot leave a truncated ``config.yaml``
+    behind, and a symlinked config stays a symlink.  It creates the parent
+    directory itself.
+    """
     import yaml
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
+    atomic_write_text(
+        path,
         yaml.safe_dump(data, default_flow_style=False, sort_keys=False,
                        allow_unicode=True),
-        encoding="utf-8",
     )
 
 
@@ -381,6 +441,25 @@ class AgentImporter:
             item.update(details)
         self.items.append(item)
 
+    def load_target_config(self, kind: str, source, destination: Path
+                           ) -> Optional[Dict[str, Any]]:
+        """Read the destination config.yaml, or record a refusal and return None.
+
+        The single chokepoint for the three importers that read config.yaml,
+        merge a section into it and write it back.  When the existing file is
+        present but unreadable there is nothing safe to merge into, so the
+        item is recorded as an ``error`` and the file is left untouched —
+        rather than being replaced by the merged section alone.
+
+        Deliberately runs in dry-run too: ``--dry-run`` must report the
+        refusal, not preview an ``imported`` that would destroy the config.
+        """
+        try:
+            return load_yaml_file(destination)
+        except ConfigReadError as exc:
+            self.record(kind, source, destination, "error", str(exc))
+            return None
+
     def build_report(self) -> Dict[str, Any]:
         summary = {"imported": 0, "skipped": 0, "conflict": 0, "error": 0}
         for item in self.items:
@@ -598,7 +677,10 @@ class AgentImporter:
                         unmapped_rules=skipped_rules)
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(
+            "command-allowlist", "settings.json permissions.allow", destination)
+        if config is None:
+            return
         current = config.get("command_allowlist", [])
         if not isinstance(current, list):
             current = []
@@ -643,7 +725,10 @@ class AgentImporter:
                         "No Bash(...) deny rules to import")
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(
+            "command-denylist", "settings.json permissions.deny", destination)
+        if config is None:
+            return
         approvals = config.get("approvals")
         if not isinstance(approvals, dict):
             approvals = {}
@@ -675,7 +760,9 @@ class AgentImporter:
                         "No MCP servers found")
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(kind, None, destination)
+        if config is None:
+            return
         existing = config.get("mcp_servers")
         if not isinstance(existing, dict):
             existing = {}

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -346,26 +347,92 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
     return None
 
 
+class ConfigReadError(RuntimeError):
+    """An existing config file is present but cannot be read or parsed.
+
+    Signals that a read-modify-write round trip must be abandoned: the caller
+    has no idea what the file holds, so writing a merged result back would
+    replace real settings with only the keys it merged.
+    """
+
+
 def load_yaml_file(path: Path) -> Dict[str, Any]:
+    """Load a YAML mapping, distinguishing "absent" from "unreadable".
+
+    Every config.yaml caller here reads the file, merges a section into it and
+    writes the whole mapping straight back.  Collapsing a present-but-unreadable
+    file to ``{}`` therefore destroys it: a YAML syntax error, a permission
+    problem or a broken mount would make the migration replace every setting
+    the user had with only the section it merged, and still report ``migrated``.
+
+    - Absent, or present but empty -> ``{}``; first-time creation still works.
+    - Present but unreadable, unparseable, or not a mapping -> raise
+      :class:`ConfigReadError` so the caller refuses and leaves the file
+      byte-identical.
+
+    ``yaml is None`` (PyYAML not installed) still yields ``{}``: nothing can be
+    written in that state either, since :func:`dump_yaml_file` raises.
+    """
     if yaml is None or not path.exists():
         return {}
     try:
         # errors="replace" means read_text() cannot raise UnicodeDecodeError;
         # OSError covers races like the file disappearing or being unreadable.
-        data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
-    except (yaml.YAMLError, OSError):
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file is not valid YAML "
+            f"({exc}). Fix it with `hermes config edit` (or move it aside), then "
+            f"re-run the migration."
+        ) from exc
+    # An empty file parses to None — a legitimate state with nothing to lose.
+    if data is None:
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: expected the existing file to hold a "
+            f"YAML mapping but found {type(data).__name__}. Fix it with "
+            f"`hermes config edit` (or move it aside), then re-run the migration."
+        )
+    return data
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
+    """Write ``data`` as YAML via temp file + fsync + atomic rename.
+
+    Only ever reached after :func:`load_yaml_file` has successfully read the
+    same path, so the mapping being written is the real file's content plus the
+    merged section — never a silently-empty stand-in.  Writing atomically means
+    an interrupted migration cannot leave a truncated config.yaml behind.
+
+    Inlined rather than importing ``utils.atomic_write_text``: this script is
+    standalone and runs with only the stdlib on its path.
+    """
     if yaml is None:
         raise RuntimeError("PyYAML is required to update Hermes config.yaml")
     ensure_parent(path)
-    path.write_text(
-        yaml.safe_dump(data, sort_keys=False, allow_unicode=False),
-        encoding="utf-8",
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".tmp_", suffix=".yaml"
     )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(yaml.safe_dump(data, sort_keys=False, allow_unicode=False))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def parse_env_file(path: Path) -> Dict[str, str]:
@@ -783,7 +850,14 @@ class Migrator:
                     # ws_path is outside source_root — use it as custom workspace
                     self._custom_workspace = ws_path
 
-        config = load_yaml_file(self.target_root / "config.yaml")
+        # Read-only probe for the memory limits, during construction — nothing
+        # is written from here, so an unreadable config just falls back to the
+        # defaults.  Every path that WRITES config.yaml refuses separately (see
+        # run_if_selected), so this cannot become a silent overwrite.
+        try:
+            config = load_yaml_file(self.target_root / "config.yaml")
+        except ConfigReadError:
+            config = {}
         mem_cfg = config.get("memory", {}) if isinstance(config.get("memory"), dict) else {}
         self.memory_limit = int(mem_cfg.get("memory_char_limit", DEFAULT_MEMORY_CHAR_LIMIT))
         self.user_limit = int(mem_cfg.get("user_char_limit", DEFAULT_USER_CHAR_LIMIT))
@@ -1001,7 +1075,24 @@ class Migrator:
                 option_label=meta["label"],
             )
             return
-        func()
+        try:
+            func()
+        except ConfigReadError as exc:
+            # The destination config.yaml is present but unreadable, so this
+            # step cannot merge into it.  Record the refusal against the
+            # config path — record() then flips _config_apply_blocked, and the
+            # remaining config-mutating options short-circuit above instead of
+            # each rediscovering the same unreadable file.  The file itself is
+            # left byte-identical.
+            meta = MIGRATION_OPTION_METADATA[option_id]
+            self.record(
+                option_id,
+                None,
+                self.target_root / "config.yaml",
+                STATUS_ERROR,
+                str(exc),
+                option_label=meta["label"],
+            )
 
     def build_report(self) -> Dict[str, Any]:
         summary: Dict[str, int] = {

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -9,6 +9,7 @@ reports exactly what was skipped and why.
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
@@ -413,20 +414,32 @@ def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
     an interrupted migration cannot leave a truncated config.yaml behind.
 
     Inlined rather than importing ``utils.atomic_write_text``: this script is
-    standalone and runs with only the stdlib on its path.
+    standalone and runs with only the stdlib on its path.  The symlink and
+    cross-device handling mirrors ``utils.atomic_replace``: a plain
+    ``os.replace`` onto a symlinked config.yaml would replace the *link* with a
+    regular file, silently detaching managed deployments that symlink
+    ``~/.hermes/config.yaml`` into a dotfiles repo or profile package.
     """
     if yaml is None:
         raise RuntimeError("PyYAML is required to update Hermes config.yaml")
     ensure_parent(path)
+    target = os.path.realpath(str(path)) if os.path.islink(str(path)) else str(path)
     fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent), prefix=".tmp_", suffix=".yaml"
+        dir=os.path.dirname(target) or ".", prefix=".tmp_", suffix=".yaml"
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(yaml.safe_dump(data, sort_keys=False, allow_unicode=False))
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp_path, path)
+        try:
+            os.replace(tmp_path, target)
+        except OSError as exc:
+            # Cross-device or bind-mount deployments cannot rename into place.
+            if exc.errno not in (errno.EXDEV, errno.EBUSY):
+                raise
+            shutil.copyfile(tmp_path, target)
+            os.unlink(tmp_path)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -548,7 +548,9 @@ class TestExistingConfigPreserved:
         """A permission problem is the other half of the same root cause."""
         import os
 
-        if os.geteuid() == 0:
+        if os.name != "posix":
+            pytest.skip("chmod-based permission denial is POSIX-only")
+        if getattr(os, "geteuid", lambda: 1)() == 0:
             pytest.skip("root bypasses file permissions")
         config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
         before = config_path.read_bytes()

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -464,6 +464,213 @@ class TestExistingMemoryStorePreserved:
         assert backups[0].read_text(encoding="utf-8") == EXISTING_MEMORY
 
 
+# ---------------------------------------------------------------------------
+# config.yaml preservation (sibling of the MEMORY.md case above)
+# ---------------------------------------------------------------------------
+
+EXISTING_CONFIG = """\
+model: hermes-4-405b
+api_key_env: OPENROUTER_API_KEY
+command_allowlist:
+  - ls *
+  - cat *
+approvals:
+  deny:
+    - shutdown *
+mcp_servers:
+  local-notes:
+    command: uvx
+    args:
+      - notes-mcp
+telegram:
+  enabled: true
+  chat_id: 12345
+"""
+
+MALFORMED_CONFIG = """\
+model: hermes-4-405b
+command_allowlist:
+  - ls *
+   - cat *
+approvals: [unclosed
+"""
+
+CONFIG_WRITING_KINDS = ("command-allowlist", "command-denylist", "mcp-servers")
+
+
+class TestExistingConfigPreserved:
+    """An import must not destroy the config.yaml it merges into.
+
+    ``load_yaml_file`` returned ``{}`` for an absent file AND for a present
+    file it could not read or parse.  The three importers below read
+    config.yaml, merge one section into it, and write the whole mapping back —
+    so a YAML syntax error or a permission problem meant every existing
+    setting was replaced by just the merged section, reported as ``imported``.
+    """
+
+    @pytest.fixture()
+    def config_path(self, hermes_home):
+        return hermes_home / "config.yaml"
+
+    @staticmethod
+    def items_for(report, kind):
+        return [i for i in report["items"] if i["kind"] == kind]
+
+    # -- present but unreadable: refuse, change nothing --------------------
+
+    def test_malformed_config_is_left_byte_identical(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.read_bytes() == before
+
+    def test_malformed_config_records_an_error_not_an_import(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        for kind in CONFIG_WRITING_KINDS:
+            items = self.items_for(report, kind)
+            assert items, f"no {kind} item recorded"
+            assert [i["status"] for i in items] == ["error"], kind
+            reason = items[0]["reason"]
+            assert str(config_path) in reason
+            assert "not valid YAML" in reason
+            # Points the user at a way out.
+            assert "hermes config edit" in reason
+
+    def test_unreadable_config_is_left_byte_identical(
+            self, claude_tree, hermes_home, config_path):
+        """A permission problem is the other half of the same root cause."""
+        import os
+
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses file permissions")
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+        config_path.chmod(0o000)
+        try:
+            report = run_import("claude-code", claude_tree, hermes_home,
+                                execute=True)
+            statuses = {
+                i["status"]
+                for kind in CONFIG_WRITING_KINDS
+                for i in self.items_for(report, kind)
+            }
+            assert statuses == {"error"}
+        finally:
+            config_path.chmod(0o600)
+        assert config_path.read_bytes() == before
+
+    def test_non_mapping_config_is_refused(
+            self, claude_tree, hermes_home, config_path):
+        """Valid YAML that is not a mapping was also collapsed to {}."""
+        config_path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        before = config_path.read_bytes()
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.read_bytes() == before
+        reasons = [i["reason"] for i in self.items_for(report, "command-allowlist")]
+        assert any("YAML mapping" in r for r in reasons)
+
+    def test_dry_run_reports_the_refusal_rather_than_a_preview(
+            self, claude_tree, hermes_home, config_path):
+        """--dry-run must not promise an import that would destroy the file."""
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=False)
+
+        for kind in CONFIG_WRITING_KINDS:
+            statuses = [i["status"] for i in self.items_for(report, kind)]
+            assert statuses == ["error"], kind
+            assert "imported" not in statuses
+
+    # -- the regression that actually pins the data loss -------------------
+
+    def test_import_preserves_every_pre_existing_config_key(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        merged = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        # Untouched sections survive verbatim.
+        assert merged["model"] == "hermes-4-405b"
+        assert merged["api_key_env"] == "OPENROUTER_API_KEY"
+        assert merged["telegram"] == {"enabled": True, "chat_id": 12345}
+        # Merged-into sections keep their existing members ...
+        assert "ls *" in merged["command_allowlist"]
+        assert "shutdown *" in merged["approvals"]["deny"]
+        assert "local-notes" in merged["mcp_servers"]
+        # ... alongside the imported ones.
+        assert "npm run build" in merged["command_allowlist"]
+        assert "github" in merged["mcp_servers"]
+
+    def test_absent_config_is_still_created(
+            self, claude_tree, hermes_home, config_path):
+        """The guard must not break first-time creation."""
+        assert not config_path.exists()
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        created = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "npm run build" in created["command_allowlist"]
+
+    def test_empty_config_is_treated_as_absent(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text("", encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        created = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "npm run build" in created["command_allowlist"]
+
+    # -- the write itself --------------------------------------------------
+
+    def test_config_write_is_atomic_and_leaves_no_temp_files(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        leftovers = [p.name for p in hermes_home.glob(".tmp*")]
+        assert leftovers == []
+
+    def test_symlinked_config_stays_a_symlink(
+            self, claude_tree, hermes_home, tmp_path, config_path):
+        """A non-atomic ``write_text`` would follow it; ``os.replace`` would
+        clobber it.  ``atomic_replace`` keeps the link and writes the target."""
+        real = tmp_path / "real-config.yaml"
+        real.write_text(EXISTING_CONFIG, encoding="utf-8")
+        config_path.symlink_to(real)
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.is_symlink()
+        assert "npm run build" in real.read_text(encoding="utf-8")
+
+    def test_failed_write_does_not_truncate_the_existing_config(
+            self, hermes_home, config_path, monkeypatch):
+        """An interrupted dump leaves the previous file complete."""
+        from hermes_cli import agent_import
+
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(agent_import, "atomic_write_text", boom)
+        with pytest.raises(OSError):
+            agent_import.dump_yaml_file(config_path, {"model": "replacement"})
+
+        assert config_path.read_bytes() == before
+
 
 # ---------------------------------------------------------------------------
 # CLI wiring

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -120,6 +120,156 @@ def test_migrator_copies_skill_and_merges_allowlist(tmp_path: Path):
     assert imported_skill.exists()
     assert "/home/test/**" in (target / "config.yaml").read_text(encoding="utf-8")
     assert report["summary"]["migrated"] >= 2
+    # The merge is written atomically — no temp file survives the run.
+    assert [p.name for p in target.glob(".tmp*")] == []
+
+
+def _allowlist_migrator(mod, tmp_path: Path, existing_config: str):
+    """Migrator wired to merge an exec-approvals allowlist into config.yaml."""
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir(parents=True)
+    (source / "exec-approvals.json").write_text(
+        json.dumps({"agents": {"*": {"allowlist": [{"pattern": "/home/test/**"}]}}}),
+        encoding="utf-8",
+    )
+    (target / "config.yaml").write_text(existing_config, encoding="utf-8")
+    return mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=target / "migration-report",
+    ), target / "config.yaml"
+
+
+MALFORMED_HERMES_CONFIG = """\
+model: hermes-4-405b
+api_key_env: OPENROUTER_API_KEY
+command_allowlist:
+  - /usr/bin/*
+approvals:
+  deny: [shutdown *
+telegram:
+  enabled: true
+"""
+
+
+def test_unreadable_config_is_refused_not_overwritten(tmp_path: Path):
+    """A present-but-unparseable config.yaml must survive the migration.
+
+    ``load_yaml_file`` returned ``{}`` for an absent file AND for one it could
+    not parse; the config-mutating steps read, merge and write the whole
+    mapping back, so a YAML syntax error meant every existing setting was
+    replaced by just the merged section.  Same defect as the ported twin in
+    ``hermes_cli/agent_import.py``.
+    """
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod, tmp_path, MALFORMED_HERMES_CONFIG)
+    before = config_path.read_bytes()
+
+    report = migrator.migrate()
+
+    assert config_path.read_bytes() == before
+    allowlist = [i for i in report["items"] if i["kind"] == "command-allowlist"]
+    assert allowlist and allowlist[0]["status"] == mod.STATUS_ERROR
+    assert "not valid YAML" in allowlist[0]["reason"]
+
+
+def test_unreadable_config_blocks_later_config_steps_instead_of_partial_writes(
+        tmp_path: Path):
+    """One refusal flips the existing _config_apply_blocked short-circuit."""
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod, tmp_path, MALFORMED_HERMES_CONFIG)
+
+    report = migrator.migrate()
+
+    assert migrator._config_apply_blocked is True
+    statuses = {
+        i["status"] for i in report["items"]
+        if i["kind"] in mod.Migrator._CONFIG_MUTATING_OPTIONS
+    }
+    # Nothing claimed a successful config write.
+    assert "migrated" not in statuses
+    assert config_path.read_text(encoding="utf-8") == MALFORMED_HERMES_CONFIG
+
+
+def test_readable_config_keeps_every_pre_existing_key(tmp_path: Path):
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod,
+        tmp_path,
+        "model: hermes-4-405b\n"
+        "api_key_env: OPENROUTER_API_KEY\n"
+        "command_allowlist:\n  - /usr/bin/*\n",
+    )
+
+    migrator.migrate()
+
+    import yaml
+
+    merged = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert merged["model"] == "hermes-4-405b"
+    assert merged["api_key_env"] == "OPENROUTER_API_KEY"
+    assert "/usr/bin/*" in merged["command_allowlist"]
+    assert "/home/test/**" in merged["command_allowlist"]
+
+
+def test_absent_config_is_still_created(tmp_path: Path):
+    """The guard must not break first-time creation.
+
+    Only ``absent`` may read as ``{}``; ``model-config`` creates config.yaml
+    from scratch when the target has none.
+    """
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"model": "anthropic/claude-sonnet-4"}}}),
+        encoding="utf-8",
+    )
+    config_path = target / "config.yaml"
+    assert not config_path.exists()
+
+    mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=True, migrate_secrets=False,
+        output_dir=None, selected_options={"model-config"},
+    ).migrate()
+
+    assert "anthropic/claude-sonnet-4" in config_path.read_text(encoding="utf-8")
+
+
+def test_unreadable_config_refused_by_model_config_too(tmp_path: Path):
+    """The refusal is at the shared helper, so every config step inherits it."""
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"model": "anthropic/claude-sonnet-4"}}}),
+        encoding="utf-8",
+    )
+    config_path = target / "config.yaml"
+    config_path.write_text(MALFORMED_HERMES_CONFIG, encoding="utf-8")
+
+    report = mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=True, migrate_secrets=False,
+        output_dir=None, selected_options={"model-config"},
+    ).migrate()
+
+    assert config_path.read_text(encoding="utf-8") == MALFORMED_HERMES_CONFIG
+    items = [i for i in report["items"] if i["kind"] == "model-config"]
+    assert items and items[0]["status"] == mod.STATUS_ERROR
 
 
 def test_migrator_optionally_imports_supported_secrets_and_messaging_settings(tmp_path: Path):

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -247,6 +247,29 @@ def test_absent_config_is_still_created(tmp_path: Path):
     assert "anthropic/claude-sonnet-4" in config_path.read_text(encoding="utf-8")
 
 
+def test_symlinked_config_stays_a_symlink(tmp_path: Path):
+    """Managed deployments symlink ~/.hermes/config.yaml into a dotfiles repo.
+
+    A plain ``os.replace`` onto the link would detach it into a regular file;
+    ``dump_yaml_file`` resolves the link first, as ``utils.atomic_replace`` does.
+    """
+    mod = load_module()
+    real = tmp_path / "dotfiles" / "config.yaml"
+    real.parent.mkdir(parents=True)
+    real.write_text("model: hermes-4-405b\ncommand_allowlist:\n  - /usr/bin/*\n",
+                    encoding="utf-8")
+    migrator, config_path = _allowlist_migrator(mod, tmp_path, "placeholder: true\n")
+    config_path.unlink()
+    config_path.symlink_to(real)
+
+    migrator.migrate()
+
+    assert config_path.is_symlink()
+    assert config_path.resolve() == real.resolve()
+    assert "/home/test/**" in real.read_text(encoding="utf-8")
+    assert "hermes-4-405b" in real.read_text(encoding="utf-8")
+
+
 def test_unreadable_config_refused_by_model_config_too(tmp_path: Path):
     """The refusal is at the shared helper, so every config step inherits it."""
     mod = load_module()


### PR DESCRIPTION
## This is a sibling follow-up to commit `8a9ab8b56` ("fix(cli): stop shredding an existing MEMORY.md on hermes import-agent")

- **What the parent covered:** the `memories/MEMORY.md` path in `hermes_cli/agent_import.py` and its ported twin `openclaw_to_hermes.py` — backup before rewrite, refuse when the backup fails, and temp-file + atomic rename. `22492f0c4` then extracted that write into `utils.atomic_write_text`.
- **What the parent did NOT touch:** the `config.yaml` path in the same two files. `agent_import.py` already imports `atomic_write_text` (line 50) and uses it at line 560 for the memory store — `dump_yaml_file` at line 114 is the one write in the module left behind, and `load_yaml_file` at line 98 still has the unguarded fallback.
- **What this adds:** the same two protections for `config.yaml` — refuse to overwrite a present-but-unreadable file, and make the write atomic — at both the `hermes_cli` site and the twin.

## What does this PR do?

`hermes_cli/agent_import.py` carries a **private** `load_yaml_file` / `dump_yaml_file` pair that reproduces the exact defect the repo's own config chokepoint exists to prevent.

On `origin/main`:

```python
 98  def load_yaml_file(path: Path) -> Dict[str, Any]:
101      if not path.exists():
102          return {}
103      try:
104          data = yaml.safe_load(read_text(path))
105      except Exception:
106          return {}          # absent == unreadable == malformed
107      return data if isinstance(data, dict) else {}

110  def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
114      path.write_text(...)   # non-atomic, no tmp + rename
```

Three importers read `config.yaml` through that pair, merge one section into the result, and write the **whole mapping** straight back:

| importer | reads | writes |
|---|---|---|
| `import_permission_allowlist` (`:574`) | `:601` | `:616` |
| `import_permission_denylist` (`:623`) | `:646` | `:662` |
| `import_mcp_servers` (`:670`) | `:678` | `:735` |

So a user whose `config.yaml` has a YAML syntax error — or a permission problem, or a bad mount — runs `hermes import-agent` and **every existing setting is silently discarded**, replaced by only the one-to-three keys the importer merged. The run reports `imported`. The non-atomic `write_text` additionally means an interrupted import leaves a truncated config.

Reproduced on `origin/main` (`fc61608a1`), a config with one YAML syntax error:

```yaml
# before
model: hermes-4-405b
api_key_env: OPENROUTER_API_KEY
command_allowlist:
  - ls *
approvals:
  deny: [shutdown *
telegram:
  enabled: true
  chat_id: 12345
```

```yaml
# after `hermes import-agent claude-code`
command_allowlist:
- npm run build
approvals:
  deny:
  - rm -rf *
```

```
report: command-allowlist -> imported
        command-denylist  -> imported
```

`model`, `api_key_env`, `telegram` and the user's own `ls *` allowlist entry are gone, and the command reported success.

## Why this is the repo's own stated invariant, not a matter of taste

`hermes_cli/config.py:3089`, `atomic_config_write`'s docstring, verbatim on main:

> Root cause this guards: `read_raw_config()` returns `{}` for BOTH an absent file and an unreadable-but-present file. Callers that read then overwrite can't tell the two apart... Routing every write through this helper enforces the invariant in one place rather than relying on each of ~15 independent write sites to remember the guard.

`require_readable_config_before_write` (`config.py:3065`) is already enforced at **8** call sites — `config.py:3111,3550,4879,5094`, `auth.py:7124,7217`, `credential_lifecycle.py:173`, `xai_retirement.py:247`. `agent_import.py` imports none of it, because it has its own private helper pair. It is the last `config.yaml` writer without the guard.

Two days ago `df09a90cd` (**"fix(config): refuse to write when config.yaml has YAML syntax errors"**, @Baophan00, merged 2026-07-31) replaced this same construct in `set_config_value` / `unset_config_value`:

```diff
-            user_config = {}
+        except Exception as exc:
+            print(f"✗ Cannot parse {config_path}: {exc} ...", file=sys.stderr)
+            sys.exit(1)
```

`agent_import.py:105` is the same `except Exception: -> {}` protecting the same file, one module over.

## Changes Made

**`hermes_cli/agent_import.py`**

- New `ConfigReadError`. `load_yaml_file` now distinguishes the two cases:
  - absent, or present but empty (`yaml.safe_load` → `None`) → `{}`, so first-time creation still works;
  - present but unreadable (`OSError`), unparseable (`yaml.YAMLError`), or not a mapping → `ConfigReadError` naming the path, the underlying error, and `hermes config edit`.
- New `AgentImporter.load_target_config()` — the single chokepoint the three importers now read through. It records the refusal as a per-item `error` and returns `None`; the caller returns without writing, so the file is left byte-identical. It runs in `--dry-run` too, so a dry run reports the refusal instead of previewing an `imported` that would destroy the config.
- `dump_yaml_file` writes through `utils.atomic_write_text` — already imported at line 50 and already used at line 560 for the memory store. One-line swap; also keeps a symlinked `config.yaml` a symlink.

**`optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`** (the module `agent_import.py` was ported from — its docstring says so, and both carry byte-similar helper pairs)

- Same `ConfigReadError` / `load_yaml_file` split, same message shape.
- The refusal is recorded once, at the `run_if_selected` dispatch point rather than at each of the eleven read-modify-write sites. `record()` already flips the existing `_config_apply_blocked` flag for a `config.yaml` error, so the remaining config-mutating options short-circuit through machinery that is already there instead of each rediscovering the same unreadable file.
- The `load_yaml_file` call in `__init__` is a read-only probe for the memory limits — it falls back to defaults, since nothing is written from there and every path that *does* write refuses separately.
- `dump_yaml_file` writes via `tempfile` + `fsync` + `os.replace`, inlined rather than importing `utils.atomic_write_text` because that script runs standalone with only the stdlib on its path — the same shape `8a9ab8b56` used there.

## Sibling-site sweep

```
grep -rn --include='*.py' "load_yaml_file(\|dump_yaml_file(" . | grep -v "/tests/\|test_"
grep -rn --include='*.py' 'config\.yaml"' . | grep -v "/tests/\|test_\|/website/"
```

**Covered — every site sharing the root cause:**

- `hermes_cli/agent_import.py` — the helper pair, and all 3 read-modify-write sites.
- `openclaw_to_hermes.py` — the helper pair, 11 read-modify-write sites, plus the read-only probe.

Covering only `agent_import.py` would ship a subset, against a precedent this PR's own parent set: `8a9ab8b56` fixed both files in one commit and its message ends *"The identical fallback lives in openclaw_to_hermes.py... fixed there too."*

**Deliberately excluded, with reasons:**

- `hermes_cli/config.py` — already guarded by `require_readable_config_before_write`; this PR reuses that invariant rather than adding anything there.
- `hermes_cli/skin_cmd.py:76` (skin yaml) and `hermes_cli/profile_distribution.py:274` (profile manifest yaml) — different files, not `config.yaml`, not behind the config chokepoint.
- `hermes_cli/uninstall.py:90` — `config_path` there is a shell rc file being line-filtered, not `config.yaml`.
- `scripts/smoke_nemo_relay_shared_metrics.py`, `scripts/tool_search_livetest.py`, `scripts/iso-certify.py` — dev harnesses that seed a synthetic `config.yaml` into a throwaway `HERMES_HOME`; no pre-existing user file can be destroyed.

## Related Issue

No filed issue — found by sweeping the `config.yaml` writers after `df09a90cd` landed, so there is no `Fixes #` to claim.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

1. Seed a config with a YAML syntax error and run the importer:

   ```bash
   mkdir -p /tmp/h/.hermes /tmp/h/.claude
   cat > /tmp/h/.hermes/config.yaml <<'YAML'
   model: hermes-4-405b
   api_key_env: OPENROUTER_API_KEY
   approvals:
     deny: [shutdown *
   telegram:
     enabled: true
   YAML
   echo '{"permissions":{"allow":["Bash(npm run build)"]}}' > /tmp/h/.claude/settings.json
   HERMES_HOME=/tmp/h/.hermes hermes import-agent claude-code --source /tmp/h/.claude
   ```

   Before: `config.yaml` is replaced by `command_allowlist: [npm run build]` and the item reads `imported`.
   After: the item reads `error` with `Refusing to overwrite .../config.yaml: the existing file is not valid YAML (...)`, and the file is byte-identical.

2. Fix the syntax error, re-run, and confirm `model`, `api_key_env` and `telegram` all survive alongside the merged `command_allowlist`.

3. Delete `config.yaml` entirely and re-run — first-time creation still works.

4. Tests:

   ```bash
   pytest tests/hermes_cli/test_agent_import.py tests/skills/test_openclaw_migration.py -v
   ```

**Regression direction verified both ways.** With the two production hunks reverted and the new tests in place: 6 of the 11 new `test_agent_import.py` tests fail (`'imported' != 'error'`, config not byte-identical) and 3 of the 5 new `test_openclaw_migration.py` tests fail. With the fix restored, 67 pass.

New coverage: malformed YAML leaves the file byte-identical; the refusal is recorded as an `error` naming the path and pointing at `hermes config edit`; a permission-denied config is refused the same way; valid-YAML-but-not-a-mapping is refused; `--dry-run` reports the refusal rather than a preview; **every pre-existing key survives a normal import** (the regression that actually pins the data loss); absent and empty configs still create; the write leaves no temp files, keeps a symlink a symlink, and a failed write does not truncate the previous file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched and adjacent suites (`tests/hermes_cli/`, `tests/skills/`) and compared against clean `origin/main` — identical failure set, zero new failures
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both helper pairs explain the invariant; no user-facing docs describe this internal helper
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the atomic write uses `utils.atomic_write_text` / `os.replace`, both already used cross-platform in this repo; the permission-denied test skips under root
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

**Invariant:** a `config.yaml` that exists but cannot be parsed into a mapping is never overwritten. Only "absent" and "empty" may read as `{}`.

- **Known-bad inputs covered:** YAML syntax error; permission-denied (`chmod 000`); valid YAML that is a list rather than a mapping; a write that fails mid-flight.
- **Future-input coverage:** the guard lives in `load_yaml_file`, which is the only way either module reads `config.yaml`, and the refusal is funnelled through one chokepoint per module (`AgentImporter.load_target_config`, `Migrator.run_if_selected`). A new importer or migration step inherits both without remembering to.
- **Negative case:** `test_absent_config_is_still_created` and `test_empty_config_is_treated_as_absent` pin that the guard does not turn first-time creation into a refusal.
