### PR TITLE
fix(cron): heartbeat during cronjob(action=run) so the watchdog doesn't kill the parent turn (#76502)

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -66,13 +66,18 @@ class TestCronjobRunExecutesImmediately:
         executes so the gateway inactivity watchdog doesn't kill the parent
         turn (#76502)."""
         touches = []
-        set_activity_callback(lambda desc: touches.append(desc))
-        try:
-            started = threading.Event()
+        heartbeat_seen = threading.Event()
 
+        def record(desc):
+            touches.append(desc)
+            heartbeat_seen.set()
+
+        set_activity_callback(record)
+        try:
             def slow_run(job):
-                started.set()
-                time.sleep(0.15)
+                # Deterministic: block until at least one heartbeat has fired
+                # (bounded so a broken heartbeat can't hang the test).
+                assert heartbeat_seen.wait(timeout=5.0), "no heartbeat within 5s"
                 return True
 
             with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
@@ -96,9 +101,43 @@ class TestCronjobRunExecutesImmediately:
             with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                       return_value={"last_status": "ok", "last_error": None}), \
+                 patch("tools.cronjob_tools.threading.Thread") as m_thread:
                 res = _execute_job_now(dict(_JOB))
             assert res["success"] is True
             m_run.assert_called_once()
+            m_thread.assert_not_called()   # heartbeat thread truly never created
+        finally:
+            set_activity_callback(None)
+
+    def test_heartbeat_survives_callback_exception(self):
+        """One raising callback must not silently kill watchdog protection
+        for the rest of a long job — the loop continues heartbeating."""
+        calls = []
+        second_beat = threading.Event()
+
+        def flaky(desc):
+            calls.append(desc)
+            if len(calls) >= 2:
+                second_beat.set()
+            if len(calls) == 1:
+                raise RuntimeError("transient")
+
+        set_activity_callback(flaky)
+        try:
+            def slow_run(job):
+                # Block until a heartbeat AFTER the raising one has fired.
+                assert second_beat.wait(timeout=5.0), \
+                    "heartbeat stopped after one callback exception"
+                return True
+
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
+                 patch("cron.scheduler.run_one_job", side_effect=slow_run), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _execute_job_now(dict(_JOB))
+            assert res["success"] is True
+            assert len(calls) >= 2, calls
         finally:
             set_activity_callback(None)

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -88,7 +88,7 @@ class TestCronjobRunExecutesImmediately:
                 res = _execute_job_now(dict(_JOB))
 
             m_run.assert_called_once()
-            assert res["success"] is True
+            assert res["success"] is True, res
             assert any("cronjob: running job" in t for t in touches), touches
         finally:
             set_activity_callback(None)
@@ -107,6 +107,37 @@ class TestCronjobRunExecutesImmediately:
             assert res["success"] is True
             m_run.assert_called_once()
             m_thread.assert_not_called()   # heartbeat thread truly never created
+        finally:
+            set_activity_callback(None)
+
+    def test_heartbeat_stops_at_ceiling_but_job_completes(self):
+        """Past _CRON_RUN_HEARTBEAT_CEILING the heartbeat stops (so the
+        gateway watchdog regains authority over a wedged run) while the job
+        itself keeps running to completion."""
+        touches = []
+        first_beat = threading.Event()
+
+        def record(desc):
+            touches.append(desc)
+            first_beat.set()
+
+        set_activity_callback(record)
+        try:
+            def slow_run(job):
+                # Ceiling=0 → the very first wake stops the loop without
+                # touching. Give it a couple of cycles to prove silence.
+                time.sleep(0.2)
+                return True
+
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
+                 patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_CEILING", 0.0), \
+                 patch("cron.scheduler.run_one_job", side_effect=slow_run), \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _execute_job_now(dict(_JOB))
+            assert res["success"] is True, res
+            assert not first_beat.is_set(), touches   # heartbeat never fired
         finally:
             set_activity_callback(None)
 
@@ -137,7 +168,7 @@ class TestCronjobRunExecutesImmediately:
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
                 res = _execute_job_now(dict(_JOB))
-            assert res["success"] is True
+            assert res["success"] is True, res
             assert len(calls) >= 2, calls
         finally:
             set_activity_callback(None)

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -5,11 +5,18 @@ success, relying on the scheduler ticker to actually run the job. With no
 gateway/ticker active (e.g. a CLI-only Windows setup) the job never executed and
 last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
 blocking a concurrent tick) and fires it inline via the shared run_one_job body.
+
+#76502: the inline fire is synchronous, so while it runs it fires a heartbeat
+into the calling agent's activity tracker — otherwise the gateway inactivity
+watchdog kills the parent turn at ~1800s.
 """
 import json
+import threading
+import time
 from unittest.mock import patch
 
 from tools.cronjob_tools import cronjob, _execute_job_now
+from tools.environments.base import set_activity_callback
 
 
 _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
@@ -53,3 +60,45 @@ class TestCronjobRunExecutesImmediately:
         assert res["success"] is False
         assert "boom" in res["error"]
         m_mark.assert_called_once()
+
+    def test_execute_job_now_heartbeats_while_job_runs(self):
+        """A manual run ticks the caller's activity tracker while the job
+        executes so the gateway inactivity watchdog doesn't kill the parent
+        turn (#76502)."""
+        touches = []
+        set_activity_callback(lambda desc: touches.append(desc))
+        try:
+            started = threading.Event()
+
+            def slow_run(job):
+                started.set()
+                time.sleep(0.15)
+                return True
+
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
+                 patch("cron.scheduler.run_one_job", side_effect=slow_run) as m_run, \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _execute_job_now(dict(_JOB))
+
+            m_run.assert_called_once()
+            assert res["success"] is True
+            assert any("cronjob: running job" in t for t in touches), touches
+        finally:
+            set_activity_callback(None)
+
+    def test_execute_job_now_without_callback_does_not_heartbeat(self):
+        """No activity callback registered (direct callers, tests) → the
+        heartbeat thread is never started and behavior is unchanged."""
+        set_activity_callback(None)
+        try:
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                res = _execute_job_now(dict(_JOB))
+            assert res["success"] is True
+            m_run.assert_called_once()
+        finally:
+            set_activity_callback(None)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -660,6 +660,12 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                     if elapsed > _CRON_RUN_HEARTBEAT_CEILING:
                         # Stop masking the gateway watchdog — a run this long
                         # with an unlimited child watchdog is likely wedged.
+                        logger.warning(
+                            "cronjob run heartbeat ceiling reached for job "
+                            "'%s' (%.0fs) — stopping heartbeat; gateway "
+                            "watchdog regains authority",
+                            job_name, elapsed,
+                        )
                         return
                     try:
                         activity_cb(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -9,12 +9,21 @@ import json
 import logging
 import re
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+# Cadence for the heartbeat that keeps the calling agent's inactivity watchdog
+# at bay while a manual `cronjob(action="run")` executes the job synchronously
+# in-process (#76502). Mirrors the 10s cadence used by
+# tools/environments/base.py::touch_activity_if_due and delegate_task's
+# heartbeat — comfortably below the 1800s default HERMES_AGENT_TIMEOUT.
+_CRON_RUN_HEARTBEAT_INTERVAL = 10.0
 
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -608,7 +617,57 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        #
+        # A manual `run` executes the job synchronously on the caller's thread,
+        # and a cron job is itself a full agent run that routinely takes
+        # minutes. The calling turn emits no tool activity for that entire
+        # window, so the gateway inactivity watchdog concludes the agent is
+        # hung and kills the parent turn (#76502). Fire a heartbeat into the
+        # caller's activity tracker (the same signal tool progress uses) while
+        # the job runs, so the watchdog sees a working tool instead of a
+        # silent one — mirrors the delegate_task heartbeat pattern. Best-effort:
+        # if no activity callback is registered (direct Python callers, tests),
+        # behavior is unchanged.
+        try:
+            from tools.environments.base import _get_activity_callback
+
+            # Capture on THIS thread: the callback is thread-local (installed
+            # by the tool executor as the calling agent's _touch_activity), so
+            # a freshly spawned thread cannot read it back.
+            activity_cb = _get_activity_callback()
+        except Exception:
+            activity_cb = None
+
+        _heartbeat_stop = threading.Event()
+        _heartbeat_thread = None
+
+        if activity_cb is not None:
+            job_name = str(job.get("name") or job_id)
+
+            def _heartbeat_loop() -> None:
+                started = time.monotonic()
+                while not _heartbeat_stop.wait(_CRON_RUN_HEARTBEAT_INTERVAL):
+                    try:
+                        elapsed = int(time.monotonic() - started)
+                        activity_cb(
+                            f"cronjob: running job '{job_name}' ({elapsed}s elapsed)"
+                        )
+                    except Exception:
+                        return  # never break the job run
+
+            _heartbeat_thread = threading.Thread(
+                target=_heartbeat_loop,
+                daemon=True,
+                name="cronjob-run-heartbeat",
+            )
+            _heartbeat_thread.start()
+
+        try:
+            processed = run_one_job(job)
+        finally:
+            _heartbeat_stop.set()
+            if _heartbeat_thread is not None:
+                _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -20,10 +20,19 @@ logger = logging.getLogger(__name__)
 
 # Cadence for the heartbeat that keeps the calling agent's inactivity watchdog
 # at bay while a manual `cronjob(action="run")` executes the job synchronously
-# in-process (#76502). Mirrors the 10s cadence used by
-# tools/environments/base.py::touch_activity_if_due and delegate_task's
-# heartbeat — comfortably below the 1800s default HERMES_AGENT_TIMEOUT.
+# in-process (#76502). Mirrors the 10s cadence of
+# tools/environments/base.py::touch_activity_if_due (delegate_task's heartbeat
+# uses 30s) — comfortably below the 1800s default HERMES_AGENT_TIMEOUT.
 _CRON_RUN_HEARTBEAT_INTERVAL = 10.0
+
+# Hard ceiling on how long the heartbeat keeps the parent watchdog at bay.
+# The child cron run has its own inactivity watchdog (HERMES_CRON_TIMEOUT,
+# default 600s) that bounds a wedged job, but with HERMES_CRON_TIMEOUT=0
+# (explicit "unlimited") a truly hung run_one_job would otherwise mask the
+# gateway watchdog forever — pre-#76502 the parent was at least reaped at
+# ~1800s. After this ceiling the heartbeat stops and the gateway watchdog
+# regains authority over the turn.
+_CRON_RUN_HEARTBEAT_CEILING = 6 * 3600.0
 
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -629,12 +638,12 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         # if no activity callback is registered (direct Python callers, tests),
         # behavior is unchanged.
         try:
-            from tools.environments.base import _get_activity_callback
+            from tools.environments.base import get_activity_callback
 
             # Capture on THIS thread: the callback is thread-local (installed
             # by the tool executor as the calling agent's _touch_activity), so
             # a freshly spawned thread cannot read it back.
-            activity_cb = _get_activity_callback()
+            activity_cb = get_activity_callback()
         except Exception:
             activity_cb = None
 
@@ -647,13 +656,20 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
             def _heartbeat_loop() -> None:
                 started = time.monotonic()
                 while not _heartbeat_stop.wait(_CRON_RUN_HEARTBEAT_INTERVAL):
+                    elapsed = time.monotonic() - started
+                    if elapsed > _CRON_RUN_HEARTBEAT_CEILING:
+                        # Stop masking the gateway watchdog — a run this long
+                        # with an unlimited child watchdog is likely wedged.
+                        return
                     try:
-                        elapsed = int(time.monotonic() - started)
                         activity_cb(
-                            f"cronjob: running job '{job_name}' ({elapsed}s elapsed)"
+                            f"cronjob: running job '{job_name}' ({int(elapsed)}s elapsed)"
                         )
                     except Exception:
-                        return  # never break the job run
+                        # Never break the job run; keep heartbeating — one
+                        # transient callback error must not silently drop
+                        # watchdog protection for the rest of a long job.
+                        continue
 
             _heartbeat_thread = threading.Thread(
                 target=_heartbeat_loop,

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -150,7 +150,14 @@ def set_activity_callback(cb: Callable[[str], None] | None) -> None:
     _activity_callback_local.callback = cb
 
 
-def _get_activity_callback() -> Callable[[str], None] | None:
+def get_activity_callback() -> Callable[[str], None] | None:
+    """Return the thread-local activity callback (see ``set_activity_callback``).
+
+    Public accessor for callers outside this module that need to capture the
+    calling thread's callback before handing work to another thread (the
+    callback is thread-local, so a freshly spawned thread cannot read it
+    back) — e.g. the manual cron-run heartbeat (#76502).
+    """
     return getattr(_activity_callback_local, "callback", None)
 
 
@@ -172,7 +179,7 @@ def touch_activity_if_due(
         return
     state["last_touch"] = now
     try:
-        cb = _get_activity_callback()
+        cb = get_activity_callback()
         if cb:
             elapsed = int(now - state["start"])
             cb(f"{label} ({elapsed}s elapsed)")
@@ -997,7 +1004,7 @@ class BaseEnvironment(ABC):
         _iter_count = 0
         _last_heartbeat = _now
         _last_interrupt_state = False
-        _cb_was_none = _get_activity_callback() is None
+        _cb_was_none = get_activity_callback() is None
         if _DEBUG_INTERRUPT:
             logger.info(
                 "[interrupt-debug] _wait_for_process ENTER tid=%s pid=%s "
@@ -1047,7 +1054,7 @@ class BaseEnvironment(ABC):
                 # the activity-callback state (thread-local, can get clobbered
                 # by nested tool calls or executor thread reuse).
                 if _DEBUG_INTERRUPT and time.monotonic() - _last_heartbeat >= 30.0:
-                    _cb_now_none = _get_activity_callback() is None
+                    _cb_now_none = get_activity_callback() is None
                     logger.info(
                         "[interrupt-debug] _wait_for_process HEARTBEAT "
                         "tid=%s pid=%s iter=%d elapsed=%.0fs "


### PR DESCRIPTION
Closes #76502
Supersedes #76524 (salvage — @webtecnica's commit cherry-picked with authorship preserved)

## Summary

`cronjob(action="run")` now heartbeats the calling agent's activity tracker while the job runs synchronously, so the gateway inactivity watchdog no longer kills the parent turn at 1800s.

## Changes

- **tools/cronjob_tools.py** (@webtecnica, #76524): capture the thread-local activity callback on the caller's thread, tick it every 10s from a daemon heartbeat thread while `run_one_job` executes, stop via Event in `finally`. Best-effort — no callback registered (direct callers, tests) means no thread, behavior unchanged.
- **Review follow-ups** (this salvage):
  - heartbeat loop `continue`s past a raising callback instead of silently stopping (matches delegate_task / `touch_activity_if_due` swallow-and-continue semantics)
  - hard 6h elapsed ceiling: with `HERMES_CRON_TIMEOUT=0` (unlimited child watchdog) a wedged job can no longer mask the gateway watchdog forever — pre-fix the parent was at least reaped at 1800s
  - public `get_activity_callback()` accessor in `tools/environments/base.py` (the PR was the first cross-module importer of the private `_get_activity_callback`)
  - tests: deterministic event-gated heartbeat test (no timing sleep), no-callback test now asserts the thread is truly never created, new exception-survival guard
  - comment fix: delegate_task's heartbeat cadence is 30s, not 10s

## Validation

| Check | Result |
|---|---|
| tests/tools/test_cronjob_run_immediate.py + test_cronjob_tools.py | 74 passed |
| tests/cron/ | 373 passed |
| E2E (real imports, temp HERMES_HOME): heartbeat fires, thread exits, no-callback no-thread, raising callback doesn't break the run, ceiling stops the heartbeat | all passed |
| Mutation checks: revert prod → 3 heartbeat tests fail; `continue`→`return` → exception-survival test fails | teeth confirmed |
| ruff | clean |

Credit: fix authored by @webtecnica in #76524 — cherry-picked to preserve authorship. Heartbeat approach also independently proposed by @JonthanaHanh in #76523.

### Post-review hardening (3rd commit)

- `logger.warning` when the 6h heartbeat ceiling stops the loop (matches delegate_task's stale-stop precedent) — the eventual watchdog reap is now explainable from logs
- mutation-checked ceiling test: past the ceiling the heartbeat stops while the job still completes
