### PR TITLE
fix(dashboard): authenticate /health/detailed probe with API_SERVER_KEY (#76051)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1564,6 +1564,7 @@ def _apply_main_model_assignment(
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
+_GATEWAY_HEALTH_API_KEY = os.getenv("API_SERVER_KEY", "").strip()
 _GATEWAY_HEALTH_TIMEOUT_MAX = 1.0
 _GATEWAY_HEALTH_ROUTE_TIMEOUT = 1.0
 try:
@@ -1610,6 +1611,9 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     Uses ``/health/detailed`` first (returns full state), falling back to
     the simpler ``/health`` endpoint.  Returns ``(is_alive, body_dict)``.
 
+    When ``API_SERVER_KEY`` is set, the detailed probe authenticates with a
+    Bearer token; the public ``/health`` fallback is never sent credentials.
+
     Accepts any of these as ``GATEWAY_HEALTH_URL``:
     - ``http://gateway:8642``                (base URL — recommended)
     - ``http://gateway:8642/health``         (explicit health path)
@@ -1631,6 +1635,12 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     for path in (f"{base}/health/detailed", f"{base}/health"):
         try:
             req = urllib.request.Request(path, method="GET")
+            # /health/detailed requires the gateway's API key when one is
+            # configured (a missing key 401s and spams the gateway log on
+            # every poll — #76051).  The public /health fallback stays
+            # credential-free so the key is never sent where it isn't needed.
+            if _GATEWAY_HEALTH_API_KEY and path.endswith("/health/detailed"):
+                req.add_header("Authorization", f"Bearer {_GATEWAY_HEALTH_API_KEY}")
             with urllib.request.urlopen(req, timeout=_GATEWAY_HEALTH_TIMEOUT) as resp:
                 if resp.status == 200:
                     body = json.loads(resp.read())

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2210,6 +2210,63 @@ class TestProbeGatewayHealth:
         assert call_count[0] == 2
 
 
+    def test_detailed_probe_sends_bearer_only_to_detailed(self, monkeypatch):
+        """API_SERVER_KEY authenticates /health/detailed but is never sent to
+        the public /health fallback (#76051)."""
+        import hermes_cli.web_server as ws
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_TIMEOUT", 1)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_API_KEY", "test-key")
+
+        seen = []  # (url, Authorization header or None)
+
+        def mock_urlopen(req, **kwargs):
+            seen.append((req.full_url, req.headers.get("Authorization")))
+            if req.full_url.endswith("/health/detailed"):
+                raise ConnectionError("detailed failed")
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.read.return_value = json.dumps({"status": "ok"}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", mock_urlopen)
+        alive, body = ws._probe_gateway_health()
+
+        assert alive is True
+        assert body["status"] == "ok"
+        assert seen == [
+            ("http://gw:8642/health/detailed", "Bearer test-key"),
+            ("http://gw:8642/health", None),
+        ]
+
+
+    def test_probe_sends_no_auth_when_api_key_unset(self, monkeypatch):
+        """Without API_SERVER_KEY, neither probe carries credentials."""
+        import hermes_cli.web_server as ws
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_TIMEOUT", 1)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_API_KEY", "")
+
+        seen = []
+
+        def mock_urlopen(req, **kwargs):
+            seen.append(req.headers.get("Authorization"))
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.read.return_value = json.dumps({"status": "ok"}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", mock_urlopen)
+        alive, _ = ws._probe_gateway_health()
+
+        assert alive is True
+        assert seen == [None]
+
+
 class TestStatusRemoteGateway:
     """Tests for /api/status with remote gateway health fallback."""
 


### PR DESCRIPTION
## Summary

Fixes #76051.

When the gateway API server has `API_SERVER_KEY` configured, the dashboard's cross-container `_probe_gateway_health()` (in `hermes_cli/web_server.py`) probed `/health/detailed` without credentials. The endpoint 401s and the gateway logs `API server rejected invalid API key` on every dashboard status poll, flooding `gateway.log`:

```
WARNING gateway.platforms.api_server: API server rejected invalid API key: remote='127.0.0.1' method='GET' path='/health/detailed'
```

## Fix

- Read `API_SERVER_KEY` alongside `GATEWAY_HEALTH_URL` and send `Authorization: Bearer <key>` on the `/health/detailed` probe when the key is available.
- The public `/health` fallback stays **credential-free** — the key is never sent to an endpoint that doesn't require it.

Builds on the direction of #76070, applying the triage feedback from @GottZ on the issue (restrict the Bearer header to `/health/detailed`, add regression coverage).

## Tests

Added to `TestProbeGatewayHealth` in `tests/hermes_cli/test_web_server.py`:

- `test_detailed_probe_sends_bearer_only_to_detailed` — detailed probe carries `Bearer <key>`; the `/health` fallback carries no credentials; fallback still succeeds after the detailed probe fails.
- `test_probe_sends_no_auth_when_api_key_unset` — without `API_SERVER_KEY`, no probe sends credentials.

`scripts/run_tests.sh tests/hermes_cli/test_web_server.py` → 116 passed.