### PR TITLE
fix(dashboard): scope Provider Logins OAuth to the active management profile (#76674)

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -119,6 +119,31 @@ describe("api.getModelOptions", () => {
 });
 
 describe("api OAuth helpers", () => {
+  it("scopes Provider Logins to the active management profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ providers: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    setManagementProfile("coder");
+    try {
+      await api.getOAuthProviders();
+      await api.startOAuthLogin("openai-codex");
+      await api.disconnectOAuthProvider("anthropic");
+      await api.cancelOAuthSession("oauth-session");
+    } finally {
+      // Module-level state; reset so later tests see the default scope.
+      setManagementProfile("");
+    }
+
+    const urls = fetchMock.mock.calls.map((call) => call[0] as string);
+    expect(urls).toEqual([
+      "/api/providers/oauth?profile=coder",
+      "/api/providers/oauth/openai-codex/start?profile=coder",
+      "/api/providers/oauth/anthropic?profile=coder",
+      "/api/providers/oauth/sessions/oauth-session?profile=coder",
+    ]);
+  });
+
   it("starts OAuth login in gated mode without requiring an injected session token", async () => {
     vi.stubGlobal("window", { __HERMES_AUTH_REQUIRED__: true });
     const fetchMock = jsonFetchMock({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -79,6 +79,12 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
   "/api/messaging/whatsapp/onboarding",
+  // Provider Logins OAuth. The backend handlers all accept ?profile= and open
+  // per-profile auth state (list/start/submit/poll/cancel/disconnect via
+  // _profile_scope); without scoping, the dashboard reads and mutates the
+  // launch/default profile's credentials even after the management profile is
+  // switched.
+  "/api/providers/oauth",
   "/api/model/info",
   "/api/model/set",
   "/api/model/auxiliary",


### PR DESCRIPTION
## What does this PR do?

Scopes the dashboard **Provider Logins** OAuth card to the currently selected management profile. Fixes #76674.

The OAuth helpers hit `/api/providers/oauth` and its `start`/`submit`/`poll`/`cancel`/`disconnect` sub-paths, but those paths were not in `PROFILE_SCOPED_PREFIXES`, so `withManagementProfile()` left the URLs unscoped. After switching the dashboard to a non-default management profile (e.g. `coder`), OAuth status reads and mutations still targeted the launch/default profile's credentials.

## Root cause

`web/src/lib/api.ts` only appends `?profile=<selected>` for paths listed in `PROFILE_SCOPED_PREFIXES`; `/api/providers/oauth` was missing. The backend was already profile-aware — every handler accepts `profile: Optional[str]` and opens per-profile auth state:

- `GET  /api/providers/oauth` — `list_oauth_providers(profile=...)`
- `POST /api/providers/oauth/{id}/start` — `start_oauth_login(..., profile=...)` (`_validate_oauth_profile`)
- `POST /api/providers/oauth/{id}/submit` — `submit_oauth_code(..., profile=...)`
- `GET  /api/providers/oauth/{id}/poll/{session}` — `poll_oauth_session(..., profile=...)`
- `DELETE /api/providers/oauth/sessions/{session}` — `cancel_oauth_session(..., profile=...)`
- `DELETE /api/providers/oauth/{id}` — `disconnect_oauth_provider(..., profile=...)` via `_profile_scope`

So the only missing piece was front-end request scoping.

## Fix

Add `/api/providers/oauth` to `PROFILE_SCOPED_PREFIXES`. Every OAuth helper routes through `fetchJSON` → `withManagementProfile`, so all six calls now carry `?profile=<selected>` when a non-default profile is active (and stay unscoped in the default/launch profile, where `_managementProfile` is empty). An explicit `profile=` in a caller URL still wins, unchanged.

## Tests

Adds a regression test in `web/src/lib/api.test.ts` asserting the Provider Logins helpers (`getOAuthProviders`, `startOAuthLogin`, `disconnectOAuthProvider`, `cancelOAuthSession`) emit `?profile=coder` when the active management profile is `coder`. The test resets the module-level profile afterward so it doesn't leak into later tests.

Local: `vitest run src/lib/api.test.ts` → 6 passed; `tsc -p . --noEmit` clean.
