### PR TITLE
fix(kanban): close the vacuous-emptyset gap in promote_task (t_4f545e24)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4038,6 +4038,45 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+def _is_dependency_wait(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return True when ``task_id`` is currently waiting on a task
+    dependency declared via ``kanban_block(kind="dependency")``.
+
+    A dependency block does not enter the human ``blocked`` bucket — it
+    routes the card back to ``todo`` (see :func:`block_task`), stamps
+    ``tasks.block_kind = 'dependency'``, and emits a ``dependency_wait``
+    event.  The card then relies on :func:`recompute_ready` gating it on
+    its parent links until they reach ``done``.  That contract only holds
+    while the card's parent edge is intact.
+
+    :func:`recompute_ready` uses this to tell a card that is *waiting on a
+    dependency* apart from a genuinely standalone ``todo`` card.  It
+    matters because ``all([])`` is vacuously True: a dependency-waiting
+    card whose parent link is transiently or permanently missing would
+    otherwise be promoted on an EMPTY parent set
+    (``satisfied_parent_ids: []``) and thrash on respawn (t_4f14b90d;
+    live repro t_7cf95f5a).
+
+    We look at the most recent event among the lifecycle-transition kinds
+    a dependency wait competes with.  If ``dependency_wait`` is the most
+    recent of those, the card is still waiting on its dependency and must
+    not be promoted on a vacuous parent set.  Any later
+    ``promoted`` / ``claimed`` / ``unblocked`` / terminal event means the
+    card advanced and this guard no longer applies (so it cannot be
+    fooled by a stale ``block_kind`` column left over from an earlier
+    cycle).
+    """
+    row = conn.execute(
+        "SELECT kind FROM task_events "
+        "WHERE task_id = ? "
+        "AND kind IN ('dependency_wait', 'promoted', 'claimed', "
+        "'unblocked', 'done', 'archived') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return bool(row) and row["kind"] == "dependency_wait"
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
@@ -4092,6 +4131,29 @@ def recompute_ready(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            # Vacuous-satisfaction guard (t_4f14b90d). ``all([])`` is True, so a
+            # card with ZERO parent links always passes the gate below. That is
+            # correct for a genuinely standalone task, but WRONG for a card that
+            # only landed in ``todo`` because a worker declared a dependency
+            # wait (``kanban_block(kind="dependency")`` -> routes to ``todo``,
+            # stamps ``block_kind='dependency'``, emits ``dependency_wait``).
+            # Such a card's dependency edge can be transiently absent while a
+            # re-decompose / unlink->recompute sweep churns the links, or when a
+            # link was dropped without being re-added. Promoting on that empty
+            # set flips the card ``todo -> ready`` with ``satisfied_parent_ids:
+            # []``, it gets claimed, the worker re-declares the SAME
+            # ``dependency_wait``, and the card thrashes on a ~5-10 min respawn
+            # cadence burning a worker every cycle with zero forward progress
+            # (Prime-Directive violation; live repro t_7cf95f5a on t_3365a1dd).
+            #
+            # An empty satisfied-parent set is NEVER a satisfied gate for a
+            # dependency-waiting card: a dependency wait with no live (done)
+            # parent is a broken/racing link, not a met dependency. Hold it in
+            # ``todo`` until a real parent link exists AND reaches ``done``.
+            # Standalone tasks are unaffected — they never emit
+            # ``dependency_wait``.
+            if not parents and _is_dependency_wait(conn, task_id):
+                continue
             if all(p["status"] in ("done", "archived") for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5835,6 +5835,24 @@ def promote_task(
             "WHERE l.child_id = ?",
             (task_id,),
         ).fetchall()
+        # Vacuous-satisfaction guard (t_4f14b90d), sibling to the one in
+        # recompute_ready. ``unsatisfied`` is computed as [] when ``parents``
+        # is empty, which reads as "nothing to refuse" — correct for a
+        # genuinely standalone task, but wrong for a task that only landed
+        # in todo/blocked because it declared a dependency wait
+        # (kanban_block(kind="dependency")) whose parent link is now
+        # transiently or permanently missing (link churn). Silently
+        # promoting that case defeats the exact safety check this
+        # function's docstring promises ("refuses to promote if any parent
+        # dep is not in a terminal state"). Refuse it the same way an
+        # explicit unsatisfied parent would be refused; --force still
+        # overrides, same as any other refusal path here.
+        if not parents and _is_dependency_wait(conn, task_id):
+            return False, (
+                f"task {task_id} is a dependency wait with no live parent "
+                f"link (link missing/dropped, not satisfied) "
+                f"(use --force to override)"
+            )
         unsatisfied = [
             p["id"] for p in parents
             if p["status"] not in ("done", "archived")

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -101,6 +101,100 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Vacuous-satisfaction guard (t_4f14b90d)
+#
+# recompute_ready gates a ``todo`` card on ``all(p in {done,archived} for p in
+# parents)``. Python's ``all([])`` is vacuously True, so a card with ZERO
+# parent links passes the gate. That is correct for a standalone task, but a
+# card that only landed in ``todo`` via ``kanban_block(kind="dependency")``
+# relies on its parent link to re-gate it. If that link is transiently dropped
+# (re-decompose / unlink->recompute churn), the dependency-waiting card was
+# promoted ``todo -> ready`` on an EMPTY parent set (``satisfied_parent_ids:
+# []``), got claimed, re-declared the SAME dependency wait, and thrashed on a
+# ~5-10 min respawn cadence — burning a worker every cycle with zero forward
+# progress (live repro t_7cf95f5a on t_3365a1dd).
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_wait_with_missing_parent_stays_todo(kanban_home: Path) -> None:
+    """A dependency-waiting card whose parent link was dropped must NOT be
+    promoted on an empty parent set. It stays in ``todo`` until a real
+    ``done`` parent link exists. This is the core t_4f14b90d regression:
+    it FAILS (card -> ready) without the guard in recompute_ready."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Simulate link churn dropping the child's parent edge (re-decompose /
+        # unlink sweep) while the parent is NOT done — exactly the live repro
+        # state where satisfied_parent_ids came back empty.
+        with kb.write_txn(conn):
+            conn.execute(
+                "DELETE FROM task_links WHERE child_id=?", (child,)
+            )
+        parents = conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id=?", (child,)
+        ).fetchall()
+        assert parents == [], "precondition: child has no parent link"
+
+        promoted = kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo", (
+            "dependency wait with no live done parent must stay todo, "
+            "never promote on a vacuous empty parent set"
+        )
+        # And it must not have emitted a bogus promotion for this card.
+        kinds = [e.kind for e in kb.list_events(conn, child)]
+        assert "promoted" not in kinds, (
+            "no promoted event for a vacuously-satisfied dependency wait"
+        )
+        assert isinstance(promoted, int)
+
+
+def test_dependency_wait_promotes_only_when_parent_done(kanban_home: Path) -> None:
+    """The guard must not over-correct: a dependency wait with an intact
+    parent link still promotes exactly once, and only once the parent is
+    ``done`` — not while the parent is merely blocked/todo."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Parent not done yet -> child must stay todo (real link, undone parent).
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Parent reaches done -> child promotes.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_standalone_todo_still_promotes_on_empty_parents(kanban_home: Path) -> None:
+    """No over-correction: an ordinary standalone card (never a dependency
+    wait) with zero parents must reach ``ready`` — the guard only fires for
+    dependency-waiting cards, never for standalone ones."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="standalone", assignee="worker")
+        # A standalone card with no parents is not gated. Force it back to
+        # ``todo`` and confirm recompute_ready still promotes it (the guard,
+        # which only fires on a dependency_wait, must leave it alone).
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+        assert kb.get_task(conn, tid).status == "todo"
+        assert not kb._is_dependency_wait(conn, tid)
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+# ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -194,6 +194,42 @@ def test_standalone_todo_still_promotes_on_empty_parents(kanban_home: Path) -> N
         assert kb.get_task(conn, tid).status == "ready"
 
 
+def test_promote_task_refuses_dependency_wait_with_missing_parent(
+    kanban_home: Path,
+) -> None:
+    """``promote_task`` (the manual/CLI promotion path) shares the same
+    vacuous-emptyset shape as ``recompute_ready``: it computes
+    ``unsatisfied`` from the live parent-link query, and an empty parent
+    set produces an empty ``unsatisfied`` list, which reads as "nothing to
+    refuse." For a dependency-waiting card whose parent link was dropped,
+    that must NOT translate into an unforced promotion — its docstring
+    promises to refuse promotion while any parent dep is unsatisfied, and
+    a missing link is not a satisfied dependency. This is the sibling
+    promotion trigger named in the t_4f545e24 audit requirement."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        with kb.write_txn(conn):
+            conn.execute("DELETE FROM task_links WHERE child_id=?", (child,))
+
+        ok, reason = kb.promote_task(conn, child, actor="operator")
+        assert ok is False, (
+            "a dependency wait with a dropped parent link must be refused, "
+            "not silently promoted on an empty (vacuously satisfied) set"
+        )
+        assert reason is not None
+        assert kb.get_task(conn, child).status == "todo"
+
+        # --force still overrides, same as any other refusal on this path.
+        ok, reason = kb.promote_task(conn, child, actor="operator", force=True)
+        assert ok is True
+        assert kb.get_task(conn, child).status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Audit follow-up for kanban card `t_4f545e24` (requirement #3: "Audit for any other promotion trigger code paths with the same terminal-status conflation bug and fix them identically").

**Stacking note for the reviewer:** this PR's single substantive commit is `822a9bade1`. It depends on `_is_dependency_wait` from PR #76160 (commit `c55066b3`), which is **not yet merged to `main`**. Because I branched from `main` and cherry-picked `c55066b3` to get that helper, this diff (`main...fix/t_4f545e24-promote-task-vacuous-gap`) shows **2 commits / 210 lines** — `8184a50a` (the #76160 fix, unmodified) plus `822a9bad` (my actual change, 54 lines). **Merge #76160 first, then rebase this branch onto `main` — commit `822a9bade1` will apply cleanly and the diff will shrink to just the 54-line `promote_task` fix + test.** Do not review `8184a50a` here; it belongs to #76160.

`recompute_ready`'s vacuous-emptyset fix (commit c55066b3, PR #76160) does not cover `promote_task`, the manual/CLI promotion path (`hermes kanban promote`). `promote_task` computes `unsatisfied` from the exact same live parent-link query `recompute_ready` used before its fix; when the parent set is empty (link dropped, or never existed), `unsatisfied` is `[]`, and `if unsatisfied:` reads that as "nothing to refuse" — silently promoting a dependency-waiting card whose parent link is missing. This directly contradicts the function's own docstring: "Refuses to promote if any parent dep is not in a terminal state ... unless `force=True`."

## Fix

Reuse the `_is_dependency_wait` helper introduced by c55066b3: when a task's live parent set is empty **and** its most recent lifecycle event is `dependency_wait`, `promote_task` now refuses (same message shape as an explicit unsatisfied-parent refusal). `--force` still overrides, unchanged. Standalone `todo`/`blocked` tasks with genuinely zero parents are unaffected — the guard only fires when `_is_dependency_wait` is true.

## Relationship to t_4f14b90d / #76160

This PR is a narrow, additive follow-up. It does not modify the `recompute_ready` fix; it depends on `_is_dependency_wait` existing (from c55066b3) and is cut on top of current `main` (which already carries that commit at the time of this branch).

## Acceptance criteria addressed (t_4f545e24)

1. Only `done`/`archived` satisfies a hard link — already true in both `recompute_ready` and `promote_task`; unaffected by this change.
2. Empty/vacuous parent set never promotes a dependency-waiting card — extended here to cover `promote_task`, the sibling trigger this audit was scoped to find.
3. This is the audit-required fix for requirement #3.

## Test evidence

`tests/hermes_cli/test_kanban_block_kinds.py::test_promote_task_refuses_dependency_wait_with_missing_parent` — new. Verified fail-without-fix (asserts `ok is False`, got `True`) / pass-with-fix.

Full `-k kanban` selection on top of current `main` (which includes c55066b3): 301 passed (+1 over the 300 baseline established by #76160), same 7 pre-existing failures reproduced identically on a clean `origin/main` baseline with zero changes (test-isolation artifacts, confirmed unrelated to this change or to #76160).

## Deployment impact / rollback

Pure refusal-condition addition in `promote_task` (+ 1 test). No schema change, no migration, no external side effects, no behavior change to `recompute_ready` or the dispatcher's automatic promotion path. Rollback = revert this commit.

Filed from kanban card t_4f545e24 (child of t_4f14b90d).
