### PR TITLE
fix(agent): honor OmniRoute chat_admission_busy with a cumulative wait budget

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -76,8 +76,12 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    admission_retry_wait,
+    is_omniroute_admission_error,
     is_zai_coding_overload_error,
     jittered_backoff,
+    omniroute_admission_cumulative_budget,
+    omniroute_admission_retry_ceiling,
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
@@ -3730,6 +3734,7 @@ def run_conversation(
 
                 status_code = getattr(api_error, "status_code", None)
                 error_context = agent._extract_api_error_context(api_error)
+                _is_omniroute_admission = is_omniroute_admission_error(api_error)
 
                 # ── Classify the error for structured recovery decisions ──
                 _compressor = getattr(agent, "context_compressor", None)
@@ -3781,12 +3786,16 @@ def run_conversation(
                         )
                         continue
 
-                recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
-                    status_code=status_code,
-                    has_retried_429=_retry.has_retried_429,
-                    classified_reason=classified.reason,
-                    error_context=error_context,
-                )
+                # Local OmniRoute admission saturation is process-local
+                # backpressure — rotating credentials cannot free the lease.
+                recovered_with_pool = False
+                if not _is_omniroute_admission:
+                    recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
+                        status_code=status_code,
+                        has_retried_429=_retry.has_retried_429,
+                        classified_reason=classified.reason,
+                        error_context=error_context,
+                    )
                 if recovered_with_pool:
                     continue
 
@@ -4343,9 +4352,15 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                if _is_omniroute_admission:
+                    # High attempt ceiling; cumulative wait budget is binding.
+                    max_retries = max(max_retries, omniroute_admission_retry_ceiling())
                 _should_fallback = (
-                    is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                    not _is_omniroute_admission
+                    and (
+                        is_rate_limited
+                        or (_is_transport_failure and retry_count >= 2)
+                    )
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -5185,9 +5200,15 @@ def run_conversation(
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once
-                    # per API call block.
-                    if not _retry.primary_recovery_attempted and agent._try_recover_primary_transport(
-                        api_error, retry_count=retry_count, max_retries=max_retries,
+                    # per API call block. Admission saturation is not a
+                    # transport fault — rebuilding the client cannot free
+                    # OmniRoute's process-local lease.
+                    if (
+                        not _is_omniroute_admission
+                        and not _retry.primary_recovery_attempted
+                        and agent._try_recover_primary_transport(
+                            api_error, retry_count=retry_count, max_retries=max_retries,
+                        )
                     ):
                         _retry.primary_recovery_attempted = True
                         retry_count = 0
@@ -5200,9 +5221,9 @@ def run_conversation(
                         agent._fallback_activated = False
                         continue
                     # Try fallback before giving up entirely
-                    if agent._has_pending_fallback():
+                    if not _is_omniroute_admission and agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if not _is_omniroute_admission and agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -5386,56 +5407,112 @@ def run_conversation(
 
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
-                if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                    if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
-                            except (TypeError, ValueError):
-                                pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
-                    wait_time, _backoff_policy = adaptive_rate_limit_backoff(
+                if _is_omniroute_admission:
+                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                    _admission_budget = omniroute_admission_cumulative_budget()
+                    _remaining_admission = _admission_budget - _retry.admission_wait_spent
+                    wait_time = admission_retry_wait(
                         retry_count,
-                        base_url=str(_base),
-                        model=_model,
-                        error=api_error,
-                        default_wait=wait_time,
+                        _resp_headers,
+                        remaining_budget=_remaining_admission,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
-                    _policy_note = ""
-                    if _backoff_policy == "zai_coding_overload_long":
-                        _policy_note = " (Z.AI Coding overload adaptive long backoff)"
-                    elif _backoff_policy == "zai_coding_overload_short":
-                        _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
-                    _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
-                    # Normal retries are buffered to avoid noisy transient chatter. Long
-                    # Z.AI Coding waits are different: they can last minutes, so surface
-                    # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
-                        agent._emit_status(_rate_limit_status)
-                    else:
-                        agent._buffer_status(_rate_limit_status)
+                    if wait_time is None:
+                        # Cumulative admission wait budget exhausted — fail
+                        # the turn without credential rotation or fallback.
+                        agent._flush_status_buffer()
+                        _spent = _retry.admission_wait_spent
+                        _final_summary = (
+                            f"Local gateway admission busy (chat_admission_busy) "
+                            f"for {_spent:.0f}s (budget {_admission_budget:.0f}s exhausted)"
+                        )
+                        agent._emit_status(f"❌ {_final_summary}")
+                        logger.error(
+                            "%s admission wait budget exhausted after %.1fs (budget=%.1fs) %s error=%s",
+                            agent.log_prefix,
+                            _spent,
+                            _admission_budget,
+                            agent._client_log_context(),
+                            api_error,
+                        )
+                        return {
+                            "final_response": f"API call failed: {_final_summary}",
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _final_summary,
+                            "failure_reason": "chat_admission_busy",
+                        }
+                    agent._emit_status(
+                        f"⏱️ Local gateway busy; waiting for capacity "
+                        f"{wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}, "
+                        f"waited {_retry.admission_wait_spent:.0f}s/"
+                        f"{_admission_budget:.0f}s)..."
+                    )
+                    logger.warning(
+                        "OmniRoute admission busy: waiting %.1fs (attempt %s/%s, "
+                        "spent=%.1fs budget=%.1fs remaining=%.1fs) %s error=%s",
+                        wait_time,
+                        retry_count,
+                        max_retries,
+                        _retry.admission_wait_spent,
+                        _admission_budget,
+                        _remaining_admission,
+                        agent._client_log_context(),
+                        api_error,
+                    )
+                    _retry.admission_wait_spent += wait_time
                 else:
-                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
-                logger.warning(
-                    "Retrying API call in %ss (attempt %s/%s) %s policy=%s error=%s",
-                    wait_time,
-                    retry_count,
-                    max_retries,
-                    agent._client_log_context(),
-                    _backoff_policy or "default",
-                    api_error,
-                )
+                    if is_rate_limited:
+                        _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                        if _resp_headers and hasattr(_resp_headers, "get"):
+                            _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                            if _ra_raw:
+                                try:
+                                    # Cap at 10 minutes. Anthropic Tier 1 input-token
+                                    # buckets reset in ~171s, so a 120s cap caused us to
+                                    # retry before the actual reset window and re-trip the
+                                    # limit. 600s covers all realistic provider reset
+                                    # windows while still rejecting pathological values. (#26293)
+                                    _retry_after = min(float(_ra_raw), 600)
+                                except (TypeError, ValueError):
+                                    pass
+                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                    if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
+                        wait_time, _backoff_policy = adaptive_rate_limit_backoff(
+                            retry_count,
+                            base_url=str(_base),
+                            model=_model,
+                            error=api_error,
+                            default_wait=wait_time,
+                        )
+                    if is_rate_limited or _is_zai_coding_overload:
+                        _policy_note = ""
+                        if _backoff_policy == "zai_coding_overload_long":
+                            _policy_note = " (Z.AI Coding overload adaptive long backoff)"
+                        elif _backoff_policy == "zai_coding_overload_short":
+                            _policy_note = " (Z.AI Coding overload short retry)"
+                        _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                        _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                        # Normal retries are buffered to avoid noisy transient chatter. Long
+                        # Z.AI Coding waits are different: they can last minutes, so surface
+                        # progress immediately instead of making the TUI look frozen.
+                        if _backoff_policy == "zai_coding_overload_long":
+                            agent._emit_status(_rate_limit_status)
+                        else:
+                            agent._buffer_status(_rate_limit_status)
+                    else:
+                        agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    logger.warning(
+                        "Retrying API call in %ss (attempt %s/%s) %s policy=%s error=%s",
+                        wait_time,
+                        retry_count,
+                        max_retries,
+                        agent._client_log_context(),
+                        _backoff_policy or "default",
+                        api_error,
+                    )
                 # Sleep in small increments so we can respond to interrupts quickly
                 # instead of blocking the entire wait_time in one sleep() call
                 sleep_end = time.time() + wait_time

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5408,10 +5408,17 @@ def run_conversation(
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
                 _backoff_policy = None
+                _admission_hard_deadline = None  # monotonic; admission path only
                 if _is_omniroute_admission:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
                     _admission_budget = omniroute_admission_cumulative_budget()
-                    _remaining_admission = _admission_budget - _retry.admission_wait_spent
+                    # Pin a single monotonic deadline for the whole admission
+                    # wait sequence so fixed-interval sleeps cannot overshoot
+                    # the advertised hard budget (#76682 review).
+                    if _retry.admission_deadline_mono is None:
+                        _retry.admission_deadline_mono = time.monotonic() + _admission_budget
+                    _remaining_admission = _retry.admission_deadline_mono - time.monotonic()
+                    _spent_admission = max(0.0, _admission_budget - max(0.0, _remaining_admission))
                     wait_time = admission_retry_wait(
                         retry_count,
                         _resp_headers,
@@ -5421,16 +5428,15 @@ def run_conversation(
                         # Cumulative admission wait budget exhausted — fail
                         # the turn without credential rotation or fallback.
                         agent._flush_status_buffer()
-                        _spent = _retry.admission_wait_spent
                         _final_summary = (
                             f"Local gateway admission busy (chat_admission_busy) "
-                            f"for {_spent:.0f}s (budget {_admission_budget:.0f}s exhausted)"
+                            f"for {_spent_admission:.0f}s (budget {_admission_budget:.0f}s exhausted)"
                         )
                         agent._emit_status(f"❌ {_final_summary}")
                         logger.error(
                             "%s admission wait budget exhausted after %.1fs (budget=%.1fs) %s error=%s",
                             agent.log_prefix,
-                            _spent,
+                            _spent_admission,
                             _admission_budget,
                             agent._client_log_context(),
                             api_error,
@@ -5447,7 +5453,7 @@ def run_conversation(
                     agent._emit_status(
                         f"⏱️ Local gateway busy; waiting for capacity "
                         f"{wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}, "
-                        f"waited {_retry.admission_wait_spent:.0f}s/"
+                        f"waited {_spent_admission:.0f}s/"
                         f"{_admission_budget:.0f}s)..."
                     )
                     logger.warning(
@@ -5456,13 +5462,13 @@ def run_conversation(
                         wait_time,
                         retry_count,
                         max_retries,
-                        _retry.admission_wait_spent,
+                        _spent_admission,
                         _admission_budget,
                         _remaining_admission,
                         agent._client_log_context(),
                         api_error,
                     )
-                    _retry.admission_wait_spent += wait_time
+                    _admission_hard_deadline = _retry.admission_deadline_mono
                 else:
                     if is_rate_limited:
                         _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
@@ -5514,38 +5520,73 @@ def run_conversation(
                         api_error,
                     )
                 # Sleep in small increments so we can respond to interrupts quickly
-                # instead of blocking the entire wait_time in one sleep() call
-                sleep_end = time.time() + wait_time
-                _backoff_touch_counter = 0
-                while time.time() < sleep_end:
-                    if agent._interrupt_requested:
-                        # Same preserve-redirect rule as the retry-wait above:
-                        # a steering correction must survive backoff, not die
-                        # as "Operation interrupted".
-                        if agent.clear_interrupt(preserve_redirect=True):
-                            _retry.restart_with_redirected_messages = True
+                # instead of blocking the entire wait_time in one sleep() call.
+                # Admission path uses a monotonic hard deadline and clamps each
+                # tick so the final 0.2s sleep cannot cross the 120s budget.
+                if _admission_hard_deadline is not None:
+                    _mono_now = time.monotonic()
+                    sleep_end_mono = min(_mono_now + wait_time, _admission_hard_deadline)
+                    _backoff_touch_counter = 0
+                    while True:
+                        _remaining_sleep = sleep_end_mono - time.monotonic()
+                        _remaining_hard = _admission_hard_deadline - time.monotonic()
+                        if _remaining_sleep <= 0 or _remaining_hard <= 0:
                             break
-                        agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
-                        _interrupt_text = f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries})."
-                        close_interrupted_tool_sequence(messages, _interrupt_text)
-                        agent._persist_session(messages, conversation_history)
-                        agent.clear_interrupt()
-                        return {
-                            "final_response": _interrupt_text,
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "interrupted": True,
-                        }
-                    time.sleep(0.2)  # Check interrupt every 200ms
-                    # Touch activity every ~30s so the gateway's inactivity
-                    # monitor knows we're alive during backoff waits.
-                    _backoff_touch_counter += 1
-                    if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
-                        agent._touch_activity(
-                            f"error retry backoff ({retry_count}/{max_retries}), "
-                            f"{int(sleep_end - time.time())}s remaining"
-                        )
+                        if agent._interrupt_requested:
+                            if agent.clear_interrupt(preserve_redirect=True):
+                                _retry.restart_with_redirected_messages = True
+                                break
+                            agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                            _interrupt_text = f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries})."
+                            close_interrupted_tool_sequence(messages, _interrupt_text)
+                            agent._persist_session(messages, conversation_history)
+                            agent.clear_interrupt()
+                            return {
+                                "final_response": _interrupt_text,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "interrupted": True,
+                            }
+                        time.sleep(min(0.2, _remaining_sleep, _remaining_hard))
+                        _backoff_touch_counter += 1
+                        if _backoff_touch_counter % 150 == 0:
+                            agent._touch_activity(
+                                f"error retry backoff ({retry_count}/{max_retries}), "
+                                f"{int(max(0.0, sleep_end_mono - time.monotonic()))}s remaining"
+                            )
+                else:
+                    sleep_end = time.time() + wait_time
+                    _backoff_touch_counter = 0
+                    while time.time() < sleep_end:
+                        if agent._interrupt_requested:
+                            # Same preserve-redirect rule as the retry-wait above:
+                            # a steering correction must survive backoff, not die
+                            # as "Operation interrupted".
+                            if agent.clear_interrupt(preserve_redirect=True):
+                                _retry.restart_with_redirected_messages = True
+                                break
+                            agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
+                            _interrupt_text = f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries})."
+                            close_interrupted_tool_sequence(messages, _interrupt_text)
+                            agent._persist_session(messages, conversation_history)
+                            agent.clear_interrupt()
+                            return {
+                                "final_response": _interrupt_text,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "interrupted": True,
+                            }
+                        time.sleep(0.2)  # Check interrupt every 200ms
+                        # Touch activity every ~30s so the gateway's inactivity
+                        # monitor knows we're alive during backoff waits.
+                        _backoff_touch_counter += 1
+                        if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
+                            agent._touch_activity(
+                                f"error retry backoff ({retry_count}/{max_retries}), "
+                                f"{int(sleep_end - time.time())}s remaining"
+                            )
                 if _retry.restart_with_redirected_messages:
                     # Leave the retry loop — the check right below rebuilds this
                     # iteration from the correction instead of re-firing the

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -34,6 +34,19 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# OmniRoute holds admission leases for the lifetime of a heavy streaming
+# response. Local ``chat_admission_busy`` 503s are temporary process-local
+# backpressure — not credential failure, not an upstream model outage.
+# Policy: honor a capped Retry-After floor with light jittered backoff, and
+# enforce a hard cumulative wait budget so repeated Retry-After: 30 cannot
+# stretch far past the advertised window (#76468 / #75223 review).
+_OMNIROUTE_ADMISSION_CUMULATIVE_BUDGET_S = 120.0
+_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP = 30.0
+# High attempt ceiling so the cumulative budget is the binding constraint
+# when Retry-After is short (e.g. 1s). The loop still stops early when the
+# budget is exhausted.
+_OMNIROUTE_ADMISSION_RETRY_ATTEMPTS = 64
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value into non-negative seconds.
@@ -137,6 +150,89 @@ def _error_text(error: Any) -> str:
         getattr(error, "response", None),
     ]
     return " ".join(str(part) for part in parts if part is not None).lower()
+
+
+def _structured_error_code(error: Any) -> str | None:
+    """Extract an error code from SDK response data without free-text matching."""
+    candidates = [getattr(error, "body", None)]
+    response = getattr(error, "response", None)
+    if response is not None:
+        json_method = getattr(response, "json", None)
+        if callable(json_method):
+            try:
+                candidates.append(json_method())
+            except Exception:
+                pass
+    for payload in candidates:
+        if not isinstance(payload, dict):
+            continue
+        detail = payload.get("error", payload)
+        if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+            return detail["code"]
+    return None
+
+
+def is_omniroute_admission_error(error: Any) -> bool:
+    """Return True only for structured OmniRoute admission-busy HTTP 503s.
+
+    Requires both HTTP 503 and structured ``error.code == chat_admission_busy``.
+    Generic provider 503/529 overload and free-text 503 bodies must not match.
+    """
+    return (
+        getattr(error, "status_code", None) == 503
+        and _structured_error_code(error) == "chat_admission_busy"
+    )
+
+
+def omniroute_admission_retry_ceiling() -> int:
+    """Retry-loop ceiling for local admission saturation (budget still binds)."""
+    return _OMNIROUTE_ADMISSION_RETRY_ATTEMPTS
+
+
+def omniroute_admission_cumulative_budget() -> float:
+    """Hard cumulative wait budget (seconds) for admission-busy retries."""
+    return _OMNIROUTE_ADMISSION_CUMULATIVE_BUDGET_S
+
+
+def admission_retry_wait(
+    attempt: int,
+    headers: Any,
+    *,
+    remaining_budget: float,
+) -> Optional[float]:
+    """Compute the next admission wait, or ``None`` when the budget is exhausted.
+
+    * ``Retry-After`` (when present) is a floor, capped at
+      ``_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP``.
+    * Missing/unparseable headers fall back to light jittered exponential
+      backoff with the same per-wait cap.
+    * The returned wait never exceeds ``remaining_budget``. A non-positive
+      remaining budget returns ``None`` so the caller can fail the turn with
+      a clear admission-budget error instead of rotating credentials.
+    """
+    if remaining_budget <= 0:
+        return None
+
+    retry_after = parse_retry_after_seconds(headers)
+    if retry_after is not None:
+        retry_after = min(float(retry_after), _OMNIROUTE_ADMISSION_RETRY_AFTER_CAP)
+
+    # Bound the exponential base by both the per-wait cap and the remaining
+    # budget so jitter cannot invent a delay past the cumulative window.
+    max_delay = min(_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP, remaining_budget)
+    if max_delay <= 0:
+        return None
+    backoff = jittered_backoff(
+        attempt,
+        base_delay=2.0,
+        max_delay=max_delay,
+        jitter_ratio=0.2,
+    )
+    wait = max(retry_after or 0.0, backoff)
+    wait = min(wait, remaining_budget)
+    if wait <= 0:
+        return None
+    return wait
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -66,11 +66,13 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
-    # Cumulative seconds already spent waiting on OmniRoute
-    # ``chat_admission_busy`` 503s within this API-call block. Bound by
-    # ``omniroute_admission_cumulative_budget()`` so repeated Retry-After
-    # floors cannot exceed the advertised wait window.
-    admission_wait_spent: float = 0.0
+    # Monotonic deadline for OmniRoute ``chat_admission_busy`` waits within
+    # this API-call block. Set on the first admission 503 to
+    # ``time.monotonic() + omniroute_admission_cumulative_budget()``; every
+    # subsequent sleep is clamped to the remaining time so the hard budget
+    # cannot be exceeded by fixed 0.2s sleep ticks or scheduler oversleep.
+    # ``None`` means no admission wait has started yet.
+    admission_deadline_mono: float | None = None
 
     # ── Auth-failure provider failover ───────────────────────────────────
     # Set once we've escalated a persistent 401/403 (after the per-provider

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -66,6 +66,11 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
+    # Cumulative seconds already spent waiting on OmniRoute
+    # ``chat_admission_busy`` 503s within this API-call block. Bound by
+    # ``omniroute_admission_cumulative_budget()`` so repeated Retry-After
+    # floors cannot exceed the advertised wait window.
+    admission_wait_spent: float = 0.0
 
     # ── Auth-failure provider failover ───────────────────────────────────
     # Set once we've escalated a persistent 401/403 (after the per-provider

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -29,6 +29,8 @@ EXPECTED_FIELDS = {
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
     "has_retried_429",
+    # OmniRoute chat_admission_busy cumulative wait deadline (#76468 / #76682).
+    "admission_deadline_mono",
     "auth_failover_attempted",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -17,7 +17,7 @@ import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from agent.codex_responses_adapter import _normalize_codex_response
@@ -1715,6 +1715,122 @@ class TestRetryAfterCap:
         status = self._drive_once(agent, 300)
         assert "Waiting 300.0s" in status
 
+
+class TestOmniRouteAdmissionRetry:
+    """#76468: structured OmniRoute chat_admission_busy 503s wait for capacity
+    without credential rotation / fallback / transport rebuild, under a hard
+    cumulative wait budget (#75223 review: per-wait caps alone were not enough).
+    """
+
+    def _admission_error(self, retry_after="1"):
+        class _AdmissionError(Exception):
+            status_code = 503
+            body = {
+                "error": {
+                    "code": "chat_admission_busy",
+                    "message": "Structurally heavy chat request capacity is busy",
+                }
+            }
+            response = SimpleNamespace(headers={"Retry-After": str(retry_after)})
+
+            def __str__(self):
+                return "Error code: 503 - admission busy"
+
+        return _AdmissionError()
+
+    def test_structured_admission_503_survives_without_rotation(self, agent):
+        calls = 0
+        default_ceiling = agent._api_max_retries
+
+        def _fake_api_call(api_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls <= default_ceiling:
+                raise self._admission_error(retry_after="1")
+            return _mock_response(content="Recovered after admission wait")
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._recover_with_credential_pool = Mock(
+            side_effect=AssertionError("rotated credentials")
+        )
+        agent._try_activate_fallback = Mock(
+            side_effect=AssertionError("activated fallback")
+        )
+        agent._try_recover_primary_transport = Mock(
+            side_effect=AssertionError("rebuilt transport")
+        )
+
+        with patch("agent.conversation_loop.time.sleep", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after admission wait"
+        assert calls == default_ceiling + 1
+        agent._recover_with_credential_pool.assert_not_called()
+        agent._try_activate_fallback.assert_not_called()
+        agent._try_recover_primary_transport.assert_not_called()
+
+    def test_cumulative_budget_caps_repeated_retry_after_30(self, agent):
+        """Repeated Retry-After: 30 must not exceed the 120s cumulative budget.
+
+        Pre-fix of the cumulative deadline (#75223 review), eight attempts
+        with a 30s floor could wait ~210s. With a 120s budget the total
+        simulated wait is clamped at 120s and the turn fails cleanly with
+        the structured admission cause.
+        """
+        sleeps = []
+
+        def _fake_api_call(api_kwargs):
+            raise self._admission_error(retry_after="30")
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._recover_with_credential_pool = Mock(
+            side_effect=AssertionError("rotated credentials")
+        )
+        agent._try_activate_fallback = Mock(
+            side_effect=AssertionError("activated fallback")
+        )
+        agent._try_recover_primary_transport = Mock(
+            side_effect=AssertionError("rebuilt transport")
+        )
+
+        # Advance the incremental sleep loop without wall-clock delay.
+        # sleep_end = time.time() + wait_time; each time.sleep(0.2) tick
+        # advances the fake clock so the loop exits after wait_time seconds.
+        clock = {"t": 1_000_000.0}
+
+        def _fake_time():
+            return clock["t"]
+
+        def _sleep_and_advance(seconds):
+            sleeps.append(float(seconds))
+            clock["t"] += float(seconds)
+
+        with patch("agent.conversation_loop.time.time", side_effect=_fake_time):
+            with patch(
+                "agent.conversation_loop.time.sleep",
+                side_effect=_sleep_and_advance,
+            ):
+                result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result.get("failed") is True
+        assert result.get("failure_reason") == "chat_admission_busy"
+        assert "chat_admission_busy" in (result.get("error") or "")
+        # Policy spends at most the 120s cumulative budget (logged as
+        # admission_wait_spent). The incremental sleep loop ticks 0.2s so
+        # the sum of sleep() calls can be a single tick over the budget;
+        # that is far below the pre-fix ~210s path under repeated
+        # Retry-After: 30.
+        assert sum(sleeps) <= 121.0
+        assert sum(sleeps) >= 90.0  # at least three full 30s floors
+        agent._recover_with_credential_pool.assert_not_called()
+        agent._try_activate_fallback.assert_not_called()
+        agent._try_recover_primary_transport.assert_not_called()
 
 
 class TestConcurrentToolExecution:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1773,12 +1773,11 @@ class TestOmniRouteAdmissionRetry:
         agent._try_recover_primary_transport.assert_not_called()
 
     def test_cumulative_budget_caps_repeated_retry_after_30(self, agent):
-        """Repeated Retry-After: 30 must not exceed the 120s cumulative budget.
+        """Repeated Retry-After: 30 must not exceed the hard 120s budget.
 
-        Pre-fix of the cumulative deadline (#75223 review), eight attempts
-        with a 30s floor could wait ~210s. With a 120s budget the total
-        simulated wait is clamped at 120s and the turn fails cleanly with
-        the structured admission cause.
+        The admission path pins a monotonic deadline and clamps every sleep
+        tick to the remaining duration, so simulated elapsed time is strictly
+        ``<=120s`` (review on #76682: planned-delay budgets overshoot).
         """
         sleeps = []
 
@@ -1798,36 +1797,36 @@ class TestOmniRouteAdmissionRetry:
             side_effect=AssertionError("rebuilt transport")
         )
 
-        # Advance the incremental sleep loop without wall-clock delay.
-        # sleep_end = time.time() + wait_time; each time.sleep(0.2) tick
-        # advances the fake clock so the loop exits after wait_time seconds.
+        # Shared fake clock for time.time / time.monotonic; each sleep advances
+        # it by the clamped duration so the hard deadline is enforceable.
         clock = {"t": 1_000_000.0}
 
-        def _fake_time():
+        def _fake_clock():
             return clock["t"]
 
         def _sleep_and_advance(seconds):
             sleeps.append(float(seconds))
             clock["t"] += float(seconds)
 
-        with patch("agent.conversation_loop.time.time", side_effect=_fake_time):
+        with patch("agent.conversation_loop.time.time", side_effect=_fake_clock):
             with patch(
-                "agent.conversation_loop.time.sleep",
-                side_effect=_sleep_and_advance,
+                "agent.conversation_loop.time.monotonic", side_effect=_fake_clock
             ):
-                result = agent.run_conversation("hello")
+                with patch(
+                    "agent.conversation_loop.time.sleep",
+                    side_effect=_sleep_and_advance,
+                ):
+                    result = agent.run_conversation("hello")
 
         assert result["completed"] is False
         assert result.get("failed") is True
         assert result.get("failure_reason") == "chat_admission_busy"
         assert "chat_admission_busy" in (result.get("error") or "")
-        # Policy spends at most the 120s cumulative budget (logged as
-        # admission_wait_spent). The incremental sleep loop ticks 0.2s so
-        # the sum of sleep() calls can be a single tick over the budget;
-        # that is far below the pre-fix ~210s path under repeated
-        # Retry-After: 30.
-        assert sum(sleeps) <= 121.0
+        # Hard cumulative budget: sum of clamped sleeps must not exceed 120s
+        # (float noise from 0.2s ticks is far below a real overshoot).
+        assert sum(sleeps) <= 120.0 + 1e-6
         assert sum(sleeps) >= 90.0  # at least three full 30s floors
+
         agent._recover_with_credential_pool.assert_not_called()
         agent._try_activate_fallback.assert_not_called()
         agent._try_recover_primary_transport.assert_not_called()

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,15 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    admission_retry_wait,
+    is_omniroute_admission_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    omniroute_admission_cumulative_budget,
+    omniroute_admission_retry_ceiling,
+)
 
 
 def test_backoff_is_exponential():
@@ -208,3 +216,53 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+def _omniroute_admission_error(*, code="chat_admission_busy", status=503, headers=None):
+    return SimpleNamespace(
+        status_code=status,
+        body={"error": {"code": code, "message": "capacity busy"}},
+        response=SimpleNamespace(headers=headers or {}),
+    )
+
+
+class TestOmniRouteAdmissionRetry:
+    def test_detects_only_exact_structured_code_on_503(self):
+        assert is_omniroute_admission_error(_omniroute_admission_error())
+        assert not is_omniroute_admission_error(
+            _omniroute_admission_error(code="gateway_draining")
+        )
+        assert not is_omniroute_admission_error(
+            _omniroute_admission_error(status=429)
+        )
+        assert not is_omniroute_admission_error(
+            SimpleNamespace(status_code=503, body="chat_admission_busy")
+        )
+
+    def test_extended_ceiling_and_budget(self):
+        assert omniroute_admission_retry_ceiling() > 3
+        assert omniroute_admission_cumulative_budget() == 120.0
+
+    def test_retry_after_is_a_floor_but_hostile_values_are_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            retry_utils,
+            "jittered_backoff",
+            lambda attempt, **kwargs: min(
+                kwargs["base_delay"] * (2 ** max(0, attempt - 1)),
+                kwargs["max_delay"],
+            ),
+        )
+        assert admission_retry_wait(1, {"Retry-After": "5"}, remaining_budget=120.0) == 5.0
+        assert admission_retry_wait(1, {"Retry-After": "999999999"}, remaining_budget=120.0) == 30.0
+        assert admission_retry_wait(4, {"Retry-After": "malformed"}, remaining_budget=120.0) == 16.0
+
+    def test_wait_respects_remaining_budget(self, monkeypatch):
+        monkeypatch.setattr(
+            retry_utils,
+            "jittered_backoff",
+            lambda attempt, **kwargs: kwargs["max_delay"],
+        )
+        # Retry-After floor 30, but only 12s of budget left → clamp to 12.
+        assert admission_retry_wait(1, {"Retry-After": "30"}, remaining_budget=12.0) == 12.0
+        assert admission_retry_wait(1, {"Retry-After": "30"}, remaining_budget=0.0) is None
+        assert admission_retry_wait(1, {"Retry-After": "30"}, remaining_budget=-1.0) is None


### PR DESCRIPTION
## What does this PR do?

When OmniRoute returns a structured local admission response:

```http
HTTP/1.1 503 Service Unavailable
Retry-After: 1

{"error":{"code":"chat_admission_busy","message":"..."}}
```

Hermes previously treated it as a generic provider overload. That path can rotate credentials, activate fallback, rebuild transport, and exhaust retries inside the same saturation window — none of which frees OmniRoute's process-local heavy-request lease.

This PR:

1. Detects **only** HTTP 503 + structured `error.code == chat_admission_busy`.
2. Retries with a capped `Retry-After` floor (max 30s) and light jittered backoff.
3. Enforces a **hard cumulative wait budget of 120s** for the API-call block (the binding constraint).
4. Skips credential pool rotation, provider/model fallback, and primary transport rebuild for this condition.
5. Surfaces `Local gateway busy; waiting for capacity` while waiting, and a clear `chat_admission_busy` failure when the budget is exhausted.

Generic provider 503/529 overload behavior is unchanged.

## Related work

- Fixes #76468
- Completes the remaining review item on #75223 (cumulative budget / loop-level regression for repeated `Retry-After: 30`). Approach and detection shape are from that PR; this branch is rebased on current `main` with the cumulative-budget fix applied. Happy for maintainers to close #75223 as superseded once this lands — credit preserved via Co-authored-by.

## Test plan

Docker (`hermes-agent-local` image, `HERMES_HOME` temp):

```
pytest tests/test_retry_utils.py::TestOmniRouteAdmissionRetry \
       tests/run_agent/test_run_agent.py::TestOmniRouteAdmissionRetry -q
```

**6/6 passed**, including:

- structured admission survives past the default retry ceiling without rotation/fallback/transport rebuild
- repeated `Retry-After: 30` total simulated wait stays within the 120s cumulative budget and fails with `failure_reason=chat_admission_busy`
- detection is exact (other 503 codes / free-text bodies / non-503 status do not match)
- hostile `Retry-After` values are capped; remaining-budget clamping works