### PR TITLE
fix(dashboard): scope OAuth provider logins to profile

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
 afterEach(() => {
+  setManagementProfile("");
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -102,5 +103,72 @@ describe("api OAuth helpers", () => {
       expect(init.credentials).toBe("include");
       expect((init.headers as Headers).has(SESSION_HEADER)).toBe(false);
     }
+  });
+
+  it("scopes OAuth provider reads and mutations to the selected management profile", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+    const fetchMock = jsonFetchMock({
+      flow: "device_code",
+      providers: [],
+      session_id: "oauth-session",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getOAuthProviders();
+    await api.startOAuthLogin("openai-codex");
+    await api.submitOAuthCode("anthropic", "oauth-session", "code-123");
+    await api.pollOAuthSession("anthropic", "oauth-session");
+    await api.cancelOAuthSession("oauth-session");
+    await api.disconnectOAuthProvider("anthropic");
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/providers/oauth?profile=coder",
+      "/api/providers/oauth/openai-codex/start?profile=coder",
+      "/api/providers/oauth/anthropic/submit?profile=coder",
+      "/api/providers/oauth/anthropic/poll/oauth-session?profile=coder",
+      "/api/providers/oauth/sessions/oauth-session?profile=coder",
+      "/api/providers/oauth/anthropic?profile=coder",
+    ]);
+  });
+
+  it("leaves OAuth provider helpers unscoped for the launch profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({
+      flow: "device_code",
+      providers: [],
+      session_id: "oauth-session",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getOAuthProviders();
+    await api.startOAuthLogin("openai-codex");
+    await api.submitOAuthCode("anthropic", "oauth-session", "code-123");
+    await api.pollOAuthSession("anthropic", "oauth-session");
+    await api.cancelOAuthSession("oauth-session");
+    await api.disconnectOAuthProvider("anthropic");
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/providers/oauth",
+      "/api/providers/oauth/openai-codex/start",
+      "/api/providers/oauth/anthropic/submit",
+      "/api/providers/oauth/anthropic/poll/oauth-session",
+      "/api/providers/oauth/sessions/oauth-session",
+      "/api/providers/oauth/anthropic",
+    ]);
+  });
+
+  it("does not rewrite an explicit OAuth provider profile", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+    const fetchMock = jsonFetchMock({ providers: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchJSON("/api/providers/oauth?profile=default");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/providers/oauth?profile=default",
+      expect.objectContaining({ credentials: "include" }),
+    );
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  "/api/providers/oauth",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.


### PR DESCRIPTION
Fixes #76674

Provider Logins in the dashboard were still calling /api/providers/oauth without the selected management profile, even though the backend OAuth routes already accept profile-scoped reads and mutations.

When the dashboard was switched to a non-default profile such as coder, provider status, login start, code submit, polling, cancellation, and disconnect could still hit the launch/default profile's auth state.

This adds /api/providers/oauth to the profile-scoped frontend endpoint list so the existing withManagementProfile path covers the whole OAuth provider family.

The regression coverage checks:

- all OAuth helper paths append ?profile=coder when coder is selected
- launch/default profile behavior stays unscoped
- an explicit profile parameter is not overwritten by the global management profile

Validation:

cd web && npm test -- src/lib/api.test.ts --run
cd web && npm run typecheck
uv run --extra dev pytest tests/hermes_cli/test_web_oauth_dispatch.py -q -k 'profile or stores_profile'

Result:

8 web tests passed
typecheck passed
2 backend OAuth profile tests passed, 13 deselected