### PR TITLE
fix(telegram): retain seed IPs after DoH discovery

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -235,9 +235,9 @@ async def discover_fallback_ips() -> list[str]:
     unique A records.  IPs that match the local system resolver are kept rather
     than excluded: in many networks the system-DNS IP is the most reliable path
     to api.telegram.org and a transient primary-path failure should be retried
-    against the same address via the IP-rewrite path before the seed list is
-    consulted (#14520).  Falls back to a hardcoded seed list only when DoH
-    yields no usable answers.
+    against the same address via the IP-rewrite path (#14520).  The hardcoded
+    seeds are appended after DoH results so a partial DoH answer cannot turn
+    one endpoint into the fallback path's single point of failure.
     """
     async with httpx.AsyncClient(timeout=httpx.Timeout(_DOH_TIMEOUT)) as client:
         doh_tasks = [_query_doh_provider(client, p) for p in _DOH_PROVIDERS]
@@ -274,8 +274,16 @@ async def discover_fallback_ips() -> list[str]:
     validated = _normalize_fallback_ips(candidates)
 
     if validated:
-        logger.debug("Discovered Telegram fallback IPs via DoH: %s", ", ".join(validated))
-        return validated
+        # DoH commonly returns only one Telegram edge. Keep discovered IPs
+        # first, but retain the known seeds as last-resort alternatives. If
+        # the one discovered edge later becomes unreachable, returning only
+        # that address defeats the purpose of a fallback pool.
+        fallback_ips = list(dict.fromkeys([*validated, *_SEED_FALLBACK_IPS]))
+        logger.debug(
+            "Discovered Telegram fallback IPs via DoH; effective fallback pool: %s",
+            ", ".join(fallback_ips),
+        )
+        return fallback_ips
 
     logger.info(
         "DoH discovery yielded no usable IPs (system DNS: %s); using seed fallback IPs %s",

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -435,24 +435,24 @@ class TestDiscoverFallbackIps:
         assert ips == ["149.154.166.110", "149.154.167.220"]
 
     @pytest.mark.asyncio
-    async def test_doh_results_deduplicated(self, monkeypatch):
+    async def test_doh_results_deduplicated_and_seed_pool_retained(self, monkeypatch):
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.220")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.167.220"]
+        assert ips[0] == "149.154.167.220"
+        assert ips.count("149.154.167.220") == 1
+        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
 
 
     @pytest.mark.asyncio
     async def test_all_doh_ips_same_as_system_dns_kept(self, monkeypatch):
         """DoH agrees with system DNS — keep that IP instead of seed list (#14520).
 
-        Previous behavior fell through to ``_SEED_FALLBACK_IPS`` here, but the
-        seed addresses are not routable on every network.  When DoH confirms
-        the system IP, that IP is the best candidate we have and should be
-        used as the fallback target.
+        The confirmed system IP remains the preferred fallback target while
+        the seed pool supplies additional paths if that edge later fails.
         """
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110")),
@@ -460,7 +460,8 @@ class TestDiscoverFallbackIps:
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.166.110"]
+        assert ips[0] == "149.154.166.110"
+        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
 
 
     @pytest.mark.asyncio
@@ -486,6 +487,6 @@ class TestDiscoverFallbackIps:
         ips = await tnet.discover_fallback_ips()
         elapsed = _time.monotonic() - start
 
-        assert ips == ["149.154.167.220"]
+        assert ips[0] == "149.154.167.220"
+        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
-

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -442,9 +442,7 @@ class TestDiscoverFallbackIps:
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips[0] == "149.154.167.220"
-        assert ips.count("149.154.167.220") == 1
-        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
+        assert ips == ["149.154.167.220", "149.154.166.110"]
 
 
     @pytest.mark.asyncio
@@ -460,8 +458,7 @@ class TestDiscoverFallbackIps:
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips[0] == "149.154.166.110"
-        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
+        assert ips == ["149.154.166.110", "149.154.167.220"]
 
 
     @pytest.mark.asyncio
@@ -487,6 +484,5 @@ class TestDiscoverFallbackIps:
         ips = await tnet.discover_fallback_ips()
         elapsed = _time.monotonic() - start
 
-        assert ips[0] == "149.154.167.220"
-        assert set(tnet._SEED_FALLBACK_IPS).issubset(ips)
+        assert ips == ["149.154.167.220", "149.154.166.110"]
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1135,9 +1135,10 @@ In some restricted networks, `api.telegram.org` may resolve to an IP that is unr
 
 1. If `TELEGRAM_FALLBACK_IPS` is set, those IPs are used directly.
 2. Otherwise, the adapter automatically queries **Google DNS** and **Cloudflare DNS** via DNS-over-HTTPS (DoH) to discover alternative IPs for `api.telegram.org`.
-3. IPs returned by DoH that differ from the system DNS result are used as fallbacks.
-4. If DoH is also blocked, a hardcoded seed IP (`149.154.167.220`) is used as a last resort.
-5. Once a fallback IP succeeds, it becomes "sticky" — subsequent requests use it directly without retrying the primary path first.
+3. Valid IPs returned by DoH are kept first in discovery order, including an IP that matches the system DNS result.
+4. The built-in seed IPs are appended as last-resort alternatives, even when DoH succeeds, so a partial DoH answer does not become a single point of failure.
+5. The combined list is deduplicated while preserving that DoH-first, seed-last order.
+6. Once a fallback IP succeeds, it becomes "sticky" — subsequent requests use it directly without retrying the primary path first.
 
 ### Configuration
 
@@ -1157,7 +1158,7 @@ platforms:
 ```
 
 :::tip
-You usually don't need to configure this manually. The auto-discovery via DoH handles most restricted-network scenarios. The `TELEGRAM_FALLBACK_IPS` env var is only needed if DoH is also blocked on your network.
+You usually don't need to configure this manually. DoH discovery plus the retained seed pool handles most restricted-network scenarios. Set `TELEGRAM_FALLBACK_IPS` only when you need to override the automatically assembled fallback pool.
 :::
 
 ## Proxy Support


### PR DESCRIPTION
## Summary

- keep DNS-over-HTTPS results first in the Telegram fallback order
- append the built-in seed IPs as last-resort alternatives
- deduplicate the combined pool while preserving preference order

## Why

`discover_fallback_ips()` currently returns immediately when DoH yields any usable answer. If Google and Cloudflare both return the same single Telegram edge, that edge becomes the fallback path's single point of failure and the existing seed pool is never consulted.

This was reproduced on a Windows gateway where DoH returned only `149.154.166.110`. During intermittent failures, both the primary hostname path and the sticky fallback to that IP failed even though the second built-in seed remained reachable.

The change preserves the intent of #14520: DoH-confirmed/system-DNS addresses remain first. Seeds are only attempted after those preferred paths fail.

## Tests

- `scripts/run_tests_parallel.py tests/gateway/test_telegram_network.py -q`
- 19 passed
- `ruff check plugins/platforms/telegram/telegram_network.py tests/gateway/test_telegram_network.py`