### PR TITLE
fix(computer-use): attest driver selection and bound MCP startup

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2926,7 +2926,11 @@ DEFAULT_CONFIG = {
 
     # Computer Use (cua-driver) toolset settings.
     "computer_use": {
-        # cua-driver ships with anonymous usage telemetry (PostHog) ENABLED
+        # Exact cua-driver executable selected for this Hermes profile.
+        # Prefer this over the legacy HERMES_CUA_DRIVER_CMD environment
+        # override; empty means resolve from PATH/canonical install locations.
+        "driver_path": "",
+        # cua-driver ships with anonymous usage telemetry (PostHog) enabled
         # by default upstream. Hermes disables it for our users unless they
         # explicitly opt in here. When false (default), Hermes sets
         # CUA_DRIVER_RS_TELEMETRY_ENABLED=0 in the cua-driver child env for

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -694,9 +694,9 @@ TOOL_CATEGORIES = {
                 ),
                 "env_vars": [
                     # cua-driver reads HOME/TMPDIR from the process env, no
-                    # extra keys required. Set HERMES_CUA_DRIVER_CMD to use a
-                    # specific binary (e.g. a local build); there is no
-                    # version-pin env var.
+                    # extra keys required. Use computer_use.driver_path for a
+                    # profile-safe binary pin; HERMES_CUA_DRIVER_CMD remains a
+                    # legacy override when no profile path is configured.
                 ],
                 "post_setup": "cua_driver",
             },

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1012,9 +1012,8 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # the MCP tab) — fold it into the agent tab rather than spawning a
     # one-field orphan category.
     "mcp": "agent",
-    # `computer_use.cua_telemetry` is the only schema-surfaced computer_use
-    # field — fold it into the agent tab rather than spawning a one-field
-    # orphan category.
+    # Keep the computer_use settings grouped into the agent tab rather than
+    # spawning a small single-purpose category.
     "computer_use": "agent",
     # `telemetry.shared_metrics.enabled` is the only schema-surfaced telemetry
     # field — fold it into security alongside the other privacy-posture toggles.

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -144,6 +144,103 @@ class TestDoctorExitCodes:
             code = doctor.run_doctor()
         assert code == 1
 
+    def test_missing_configured_driver_json_reports_fail_closed_provenance(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.computer_use import doctor
+
+        configured = tmp_path / "missing-profile-driver"
+        legacy = tmp_path / "working-legacy-driver"
+        legacy.write_text("#!/bin/sh\nexit 0\n")
+        legacy.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {configured}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(legacy))
+
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            assert doctor.run_doctor(json_output=True) == 2
+
+        payload = json.loads(out.getvalue())
+        assert payload["error"]["code"] == "driver_not_found"
+        identity = payload["hermes_identity"]
+        assert identity["selection_source"] == "config"
+        assert identity["configured_driver_path"] == str(configured)
+        assert identity["legacy_env_driver_cmd"] == str(legacy)
+        assert identity["resolved_binary"] is None
+
+    def test_missing_configured_driver_text_names_config_and_repair(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.computer_use import doctor
+
+        configured = tmp_path / "missing-profile-driver"
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {configured}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_CUA_DRIVER_CMD", raising=False)
+
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            assert doctor.run_doctor() == 2
+
+        text = out.getvalue()
+        assert "selection: config" in text
+        assert f"configured: {configured}" in text
+        assert "PATH and canonical install paths" not in text
+        assert "computer_use.driver_path" in text
+
+
+    def test_health_report_failure_json_keeps_selection_provenance(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.computer_use import doctor
+
+        driver = tmp_path / "profile-cua-driver"
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {driver}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch(
+            "tools.computer_use.doctor._drive_health_report_or_fallback",
+            side_effect=RuntimeError("handshake exploded"),
+        ), patch("sys.stdout", new_callable=StringIO) as out:
+            assert doctor.run_doctor(json_output=True) == 2
+
+        payload = json.loads(out.getvalue())
+        assert payload["error"]["code"] == "health_report_failed"
+        identity = payload["hermes_identity"]
+        assert identity["selection_source"] == "config"
+        assert identity["configured_driver_path"] == str(driver)
+        assert identity["resolved_binary"] == str(driver.resolve())
+
+    def test_health_report_failure_text_keeps_selection_provenance(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from tools.computer_use import doctor
+
+        driver = tmp_path / "profile-cua-driver"
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {driver}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch(
+            "tools.computer_use.doctor._drive_health_report_or_fallback",
+            side_effect=RuntimeError("handshake exploded"),
+        ):
+            assert doctor.run_doctor() == 2
+
+        text = capsys.readouterr().err
+        assert "selection: config" in text
+        assert f"configured: {driver}" in text
+        assert f"binary: {driver.resolve()}" in text
 
     def test_protocol_error_exits_2(self, capsys):
         """An empty stdout response (driver crashed during handshake) is a
@@ -267,6 +364,23 @@ class TestJsonOutput:
         assert "hermes_identity" in parsed
         assert parsed["hermes_identity"]["resolved_binary"]
 
+    def test_text_output_includes_driver_selection_provenance(self, capsys):
+        from tools.computer_use import doctor
+
+        doctor._print_text_report(
+            _ok_report(),
+            color=False,
+            identity={
+                "resolved_binary": "/real/cua-driver",
+                "selection_source": "config",
+                "configured_driver_path": "/selected/cua-driver",
+            },
+        )
+
+        rendered = capsys.readouterr().out
+        assert "selection: config" in rendered
+        assert "configured: /selected/cua-driver" in rendered
+
 
 # ── HERMES_CUA_DRIVER_CMD resolution ───────────────────────────────────────
 
@@ -322,6 +436,31 @@ class TestDriverCmdResolution:
             assert doctor.run_doctor() == 0
 
         health.assert_called_once_with(str(driver), include=(), skip=(), timeout=12.0)
+
+    def test_json_identity_reports_profile_driver_provenance(self, tmp_path, monkeypatch):
+        from tools.computer_use import doctor
+
+        driver = tmp_path / "profile-cua-driver"
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {driver}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", "/missing/legacy-driver")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        with patch(
+            "tools.computer_use.doctor._drive_health_report_or_fallback",
+            return_value=_ok_report(),
+        ), patch("sys.stdout", new_callable=StringIO) as out:
+            assert doctor.run_doctor(json_output=True) == 0
+
+        identity = json.loads(out.getvalue())["hermes_identity"]
+        assert identity["selection_source"] == "config"
+        assert identity["configured_driver_path"] == str(driver)
+        assert identity["legacy_env_driver_cmd"] == "/missing/legacy-driver"
+        assert identity["resolved_binary"] == str(driver.resolve())
 
 
 # ── cua-driver 0.10 unclassified health_report fallback ────────────────────

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1449,6 +1449,176 @@ class TestCaptureAfterExactTarget:
             "mode": "som", "app": None, "pid": 7675, "window_id": 42,
         }]
 
+class TestCuaMcpStartupCleanup:
+    def test_lifecycle_timeout_unwinds_stdio_before_outer_guard(self, monkeypatch):
+        """A wedged initialize must time out inside the lifecycle owner.
+
+        The synchronous 30s ready guard cannot safely reap an SDK-owned child:
+        setting the shutdown event is ineffective while initialize is blocked.
+        The owning asyncio task must time itself out so stdio_client.__aexit__
+        completes before setup failure is reported.
+        """
+        import asyncio
+        import time
+        from contextlib import asynccontextmanager
+        from unittest.mock import MagicMock
+
+        from tools.computer_use import cua_backend
+
+        session = cua_backend._CuaDriverSession(cua_backend._AsyncBridge())
+        stdio_exited = asyncio.Event()
+
+        @asynccontextmanager
+        async def fake_stdio_client(_params):
+            try:
+                yield MagicMock(), MagicMock()
+            finally:
+                stdio_exited.set()
+
+        class HangingSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return False
+
+            async def initialize(self):
+                await asyncio.sleep(3600)
+
+        monkeypatch.setattr(
+            cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.05, raising=False
+        )
+        monkeypatch.setattr(cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver")
+        monkeypatch.setattr(
+            cua_backend,
+            "_resolve_mcp_invocation",
+            lambda _cmd: ("cua-driver", ["mcp"]),
+        )
+        monkeypatch.setattr("mcp.client.stdio.stdio_client", fake_stdio_client)
+        monkeypatch.setattr("mcp.ClientSession", lambda *_args, **_kwargs: HangingSession())
+
+        async def drive():
+            started = time.monotonic()
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(session._lifecycle_coro(), timeout=0.5)
+            return time.monotonic() - started
+
+        elapsed = asyncio.run(drive())
+        assert elapsed < 0.25
+        assert stdio_exited.is_set(), "stdio context must unwind before failure returns"
+        assert isinstance(session._setup_error, asyncio.TimeoutError)
+        assert "mcp-initialize" in str(session._setup_error)
+        assert "0.05s" in str(session._setup_error)
+
+    def test_startup_deadline_includes_blocking_manifest_discovery(self, monkeypatch):
+        """Manifest probing must not consume the cleanup headroom outside the deadline."""
+        import asyncio
+        import time
+        from contextlib import asynccontextmanager
+        from unittest.mock import MagicMock
+
+        from tools.computer_use import cua_backend
+
+        session = cua_backend._CuaDriverSession(cua_backend._AsyncBridge())
+        stdio_entered = False
+
+        def slow_manifest(_cmd):
+            time.sleep(0.2)
+            return "cua-driver", ["mcp"]
+
+        @asynccontextmanager
+        async def fake_stdio_client(_params):
+            nonlocal stdio_entered
+            stdio_entered = True
+            yield MagicMock(), MagicMock()
+
+        class HangingSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return False
+
+            async def initialize(self):
+                await asyncio.sleep(3600)
+
+        monkeypatch.setattr(
+            cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.05
+        )
+        monkeypatch.setattr(cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver")
+        monkeypatch.setattr(cua_backend, "_resolve_mcp_invocation", slow_manifest)
+        monkeypatch.setattr("mcp.client.stdio.stdio_client", fake_stdio_client)
+        monkeypatch.setattr("mcp.ClientSession", lambda *_args, **_kwargs: HangingSession())
+
+        async def drive():
+            started = time.monotonic()
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(session._lifecycle_coro(), timeout=0.5)
+            return time.monotonic() - started
+
+        elapsed = asyncio.run(drive())
+        assert elapsed < 0.15
+        assert not stdio_entered
+        assert "manifest-discovery" in str(session._setup_error)
+
+    @pytest.mark.skipif(os.name != "posix", reason="process watchdog is POSIX-only")
+    def test_real_wedged_mcp_child_is_reaped_before_timeout_returns(
+        self, tmp_path, monkeypatch
+    ):
+        """Exercise the real MCP SDK + watchdog against a child that never speaks."""
+        import asyncio
+        import signal
+        import sys
+        import time
+
+        from tools.computer_use import cua_backend
+
+        pid_file = tmp_path / "wedged-child.pid"
+        server = tmp_path / "wedged_mcp.py"
+        server.write_text(
+            "import os, pathlib, sys, time\n"
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()))\n"
+            "time.sleep(3600)\n",
+            encoding="utf-8",
+        )
+
+        session = cua_backend._CuaDriverSession(cua_backend._AsyncBridge())
+        monkeypatch.setattr(cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.5)
+        monkeypatch.setattr(cua_backend, "resolve_cua_driver_cmd", lambda: sys.executable)
+        monkeypatch.setattr(
+            cua_backend,
+            "_resolve_mcp_invocation",
+            lambda _cmd: (sys.executable, [str(server), str(pid_file)]),
+        )
+
+        def pid_alive(pid: int) -> bool:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+            return True
+
+        child_pid = None
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                asyncio.run(
+                    asyncio.wait_for(session._lifecycle_coro(), timeout=5.0)
+                )
+            assert pid_file.exists(), "real child never reached its entry point"
+            child_pid = int(pid_file.read_text(encoding="utf-8"))
+            deadline = time.monotonic() + 5.0
+            while pid_alive(child_pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert not pid_alive(child_pid), (
+                f"wedged MCP child {child_pid} survived lifecycle timeout cleanup"
+            )
+        finally:
+            if child_pid is not None and pid_alive(child_pid):
+                os.kill(child_pid, signal.SIGKILL)
+
+
 class TestCuaEnvironmentScrubbing:
     """Verify that cua-driver subprocess environment is sanitized (issue #37878)."""
 
@@ -1472,6 +1642,7 @@ class TestCuaEnvironmentScrubbing:
         session = _CuaDriverSession(bridge)
 
         captured_env: Dict[str, str] = {}
+        captured_invocation: Dict[str, Any] = {}
 
         async def drive_lifecycle():
             test_env = {
@@ -1484,6 +1655,10 @@ class TestCuaEnvironmentScrubbing:
 
             def capture_env(**kwargs):
                 captured_env.update(kwargs.get("env", {}))
+                captured_invocation.update({
+                    "command": kwargs.get("command"),
+                    "args": kwargs.get("args"),
+                })
                 # Return any sentinel — never actually used by the
                 # patched stdio_client path below.
                 return MagicMock()
@@ -1546,6 +1721,18 @@ class TestCuaEnvironmentScrubbing:
         # At least one safe var must survive the scrub.
         assert "PATH" in captured_env or "SAFE_VAR" in captured_env, \
             "At least one safe environment variable should be preserved"
+        if os.name == "posix":
+            from tools import mcp_stdio_watchdog
+
+            assert captured_invocation["command"] == sys.executable
+            assert captured_invocation["args"] == [
+                os.path.abspath(mcp_stdio_watchdog.__file__),
+                "--ppid",
+                str(os.getpid()),
+                "--",
+                "cua-driver",
+                "mcp",
+            ]
 
 
 class TestCuaCliFallbackResolution:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1561,6 +1561,242 @@ class TestCuaMcpStartupCleanup:
         assert not stdio_entered
         assert "manifest-discovery" in str(session._setup_error)
 
+    def test_unrestricted_embedded_daemon_is_inside_startup_deadline(self, monkeypatch):
+        """A wedged private daemon must be stopped before timeout reaches the caller."""
+        import asyncio
+        import threading
+        import time
+
+        from tools.computer_use import cua_backend
+
+        class HangingEmbeddedDaemon:
+            def __init__(self):
+                self.started = threading.Event()
+                self.stop_requested = threading.Event()
+                self.worker_finished = threading.Event()
+
+            def start(self, _driver_cmd=None, cancel_event=None):
+                self.started.set()
+                while not self.stop_requested.wait(timeout=0.01):
+                    if cancel_event is not None and cancel_event.is_set():
+                        break
+                self.worker_finished.set()
+
+            def stop(self):
+                self.stop_requested.set()
+
+            def proxy_invocation(self):
+                raise AssertionError("MCP proxy must not start before daemon readiness")
+
+            def child_env(self):
+                return {}
+
+        daemon = HangingEmbeddedDaemon()
+        session = cua_backend._CuaDriverSession(
+            cua_backend._AsyncBridge(), cast(Any, daemon)
+        )
+        # _lifecycle_coro imports the optional MCP SDK before entering its
+        # startup timeout. Warm that import so elapsed time below measures the
+        # bounded daemon phase rather than one-time module import cost.
+        __import__("mcp.client.stdio")
+        monkeypatch.setattr(
+            cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.05
+        )
+        monkeypatch.setattr(
+            cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver"
+        )
+
+        async def drive():
+            started = time.monotonic()
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(session._lifecycle_coro(), timeout=0.5)
+            return time.monotonic() - started
+
+        elapsed = asyncio.run(drive())
+        assert elapsed < 0.25
+        assert daemon.started.is_set()
+        assert daemon.stop_requested.is_set()
+        assert daemon.worker_finished.is_set(), (
+            "embedded daemon startup worker must finish before failure returns"
+        )
+        assert "embedded-daemon" in str(session._setup_error)
+
+    def test_unrestricted_timeout_cannot_spawn_after_cleanup_begins(
+        self, monkeypatch
+    ):
+        """Cancellation during manifest probing must prevent a later daemon spawn."""
+        import asyncio
+        import time
+
+        from tools.computer_use import cua_backend
+
+        daemon = cua_backend._EmbeddedCuaDaemon("", "unrestricted")
+        session = cua_backend._CuaDriverSession(
+            cua_backend._AsyncBridge(), daemon
+        )
+        spawned = False
+
+        def slow_manifest(_driver_cmd):
+            time.sleep(0.12)
+            return "cua-driver", ["mcp"]
+
+        def forbidden_spawn(*_args, **_kwargs):
+            nonlocal spawned
+            spawned = True
+            raise AssertionError("daemon spawned after startup timeout")
+
+        monkeypatch.setattr(
+            cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.05
+        )
+        monkeypatch.setattr(
+            cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver"
+        )
+        monkeypatch.setattr(cua_backend, "_resolve_mcp_invocation", slow_manifest)
+        __import__("mcp.client.stdio")
+        monkeypatch.setattr(cua_backend.subprocess, "Popen", forbidden_spawn)
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(
+                asyncio.wait_for(session._lifecycle_coro(), timeout=0.5)
+            )
+
+        assert not spawned
+        assert "embedded-daemon" in str(session._setup_error)
+
+    def test_external_cancellation_joins_embedded_startup_worker(self, monkeypatch):
+        """Lifecycle cancellation must not detach an unrestricted startup thread."""
+        import asyncio
+        import threading
+
+        from tools.computer_use import cua_backend
+
+        class HangingEmbeddedDaemon:
+            def __init__(self):
+                self.started = threading.Event()
+                self.stop_requested = threading.Event()
+                self.worker_finished = threading.Event()
+
+            def start(self, _driver_cmd=None, cancel_event=None):
+                import time
+
+                self.started.set()
+                rescue_deadline = time.monotonic() + 0.3
+                while (
+                    not self.stop_requested.wait(timeout=0.01)
+                    and time.monotonic() < rescue_deadline
+                ):
+                    if cancel_event is not None and cancel_event.is_set():
+                        break
+                self.worker_finished.set()
+
+            def stop(self):
+                self.stop_requested.set()
+
+            def proxy_invocation(self):
+                raise AssertionError("MCP proxy must not start before daemon readiness")
+
+            def child_env(self):
+                return {}
+
+        daemon = HangingEmbeddedDaemon()
+        session = cua_backend._CuaDriverSession(
+            cua_backend._AsyncBridge(), cast(Any, daemon)
+        )
+        monkeypatch.setattr(
+            cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver"
+        )
+        __import__("mcp.client.stdio")
+
+        async def drive():
+            task = asyncio.create_task(session._lifecycle_coro())
+            started = await asyncio.to_thread(daemon.started.wait, 0.2)
+            assert started
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(drive())
+        assert daemon.stop_requested.is_set()
+        assert daemon.worker_finished.is_set(), (
+            "embedded daemon startup worker must finish before cancellation returns"
+        )
+
+    def test_synchronous_start_guard_waits_for_timeout_cleanup(self, monkeypatch):
+        """The outer ready guard must leave the lifecycle enough cleanup headroom."""
+        import asyncio
+        import threading
+        import time
+
+        from tools.computer_use import cua_backend
+
+        native_event = threading.Event
+
+        class SlowCleanupDaemon:
+            def __init__(self):
+                self.stop_finished = native_event()
+
+            def start(self, _driver_cmd=None, cancel_event=None):
+                while cancel_event is None or not cancel_event.wait(timeout=0.01):
+                    pass
+
+            def stop(self):
+                time.sleep(0.12)
+                self.stop_finished.set()
+
+            def proxy_invocation(self):
+                raise AssertionError("MCP proxy must not start before daemon readiness")
+
+            def child_env(self):
+                return {}
+
+        class ScaledReadyEvent:
+            """Compress the old fixed 30s guard so this regression stays fast."""
+
+            def __init__(self):
+                self._event = native_event()
+
+            def set(self):
+                self._event.set()
+
+            def is_set(self):
+                return self._event.is_set()
+
+            def wait(self, timeout=None):
+                # Old code asks for 30s and is simulated as 0.10s. Revised
+                # code asks for startup + cleanup grace and gets that budget.
+                if timeout == 30.0:
+                    timeout = 0.10
+                return self._event.wait(timeout)
+
+        daemon = SlowCleanupDaemon()
+        session = cua_backend._CuaDriverSession(
+            cua_backend._AsyncBridge(), cast(Any, daemon)
+        )
+        monkeypatch.setattr(
+            cua_backend, "_CUA_MCP_STARTUP_TIMEOUT_SECONDS", 0.05
+        )
+        monkeypatch.setattr(
+            cua_backend,
+            "_CUA_MCP_STARTUP_CLEANUP_GRACE_SECONDS",
+            0.20,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver"
+        )
+        __import__("mcp.client.stdio")
+        monkeypatch.setattr(cua_backend.threading, "Event", ScaledReadyEvent)
+
+        try:
+            with pytest.raises(RuntimeError):
+                session.start()
+            assert daemon.stop_finished.is_set(), (
+                "synchronous startup failure returned before daemon cleanup finished"
+            )
+        finally:
+            daemon.stop_finished.wait(timeout=0.5)
+            session._bridge.stop()
+
     @pytest.mark.skipif(os.name != "posix", reason="process watchdog is POSIX-only")
     def test_real_wedged_mcp_child_is_reaped_before_timeout_returns(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -82,11 +82,127 @@ class TestRegistration:
         driver.write_text("#!/bin/sh\nexit 0\n")
         driver.chmod(0o755)
 
+        monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
         monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(driver))
         monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
         assert cua_backend.resolve_cua_driver_cmd() == str(driver)
         assert cua_backend.cua_driver_binary_available() is True
+
+    def test_profile_driver_path_wins_over_legacy_env(self, tmp_path, monkeypatch):
+        """A profile setting must select the runtime binary ahead of legacy env."""
+        from tools.computer_use import cua_backend
+
+        driver = tmp_path / "profile-cua-driver"
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {driver}\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", "/missing/legacy-driver")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        assert cua_backend.resolve_cua_driver_cmd() == str(driver.resolve())
+
+    def test_invalid_profile_driver_path_is_authoritative(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        fallback = tmp_path / "fallback-cua-driver"
+        fallback.write_text("#!/bin/sh\nexit 0\n")
+        fallback.chmod(0o755)
+        missing = tmp_path / "missing-profile-driver"
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {missing}\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(fallback))
+        monkeypatch.setenv("PATH", str(tmp_path))
+
+        assert cua_backend.resolve_cua_driver_cmd() is None
+        assert cua_backend.cua_driver_binary_available() is False
+
+    def test_profile_driver_path_is_returned_canonically(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        driver = tmp_path / "real-cua-driver"
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        link = tmp_path / "selected-cua-driver"
+        link.symlink_to(driver)
+        (tmp_path / "config.yaml").write_text(
+            f"computer_use:\n  driver_path: {link}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_CUA_DRIVER_CMD", raising=False)
+
+        assert cua_backend.resolve_cua_driver_cmd() == str(driver.resolve())
+
+    def test_malformed_profile_driver_config_falls_back_safely(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        fallback = tmp_path / "fallback-cua-driver"
+        fallback.write_text("#!/bin/sh\nexit 0\n")
+        fallback.chmod(0o755)
+        (tmp_path / "config.yaml").write_text("computer_use:\n  - malformed\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(fallback))
+
+        assert cua_backend.resolve_cua_driver_cmd() == str(fallback.resolve())
+
+    def test_nonscalar_profile_driver_path_fails_closed(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        fallback = tmp_path / "fallback-cua-driver"
+        fallback.write_text("#!/bin/sh\nexit 0\n")
+        fallback.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            "computer_use:\n  driver_path:\n    - not-a-path\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", str(fallback))
+
+        assert cua_backend.resolve_cua_driver_cmd() is None
+
+    def test_bare_profile_driver_name_is_anchored_to_profile(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        profile_driver = tmp_path / "cua-driver"
+        profile_driver.write_text("#!/bin/sh\nexit 0\n")
+        profile_driver.chmod(0o755)
+        path_dir = tmp_path / "path-bin"
+        path_dir.mkdir()
+        path_driver = path_dir / "cua-driver"
+        path_driver.write_text("#!/bin/sh\nexit 0\n")
+        path_driver.chmod(0o755)
+        (tmp_path / "config.yaml").write_text(
+            "computer_use:\n  driver_path: cua-driver\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("PATH", str(path_dir))
+
+        assert cua_backend.resolve_cua_driver_cmd() == str(profile_driver.resolve())
+
+    def test_relative_profile_driver_path_is_anchored_to_profile(self, tmp_path, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        profile = tmp_path / "profile"
+        workspace = tmp_path / "workspace"
+        driver = profile / "bin" / "cua-driver"
+        driver.parent.mkdir(parents=True)
+        driver.write_text("#!/bin/sh\nexit 0\n")
+        driver.chmod(0o755)
+        workspace.mkdir()
+        (profile / "config.yaml").write_text(
+            "computer_use:\n  driver_path: bin/cua-driver\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.delenv("HERMES_CUA_DRIVER_CMD", raising=False)
+        monkeypatch.chdir(workspace)
+
+        assert cua_backend.resolve_cua_driver_cmd() == str(driver.resolve())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -187,7 +189,19 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
         proxy_command, proxy_args = daemon.proxy_invocation()
         daemon.stop()
 
-    assert command[:2] == ["/opt/cua-driver", "serve"]
+    if os.name == "posix":
+        from tools import mcp_stdio_watchdog
+
+        assert command[:5] == [
+            sys.executable,
+            os.path.abspath(mcp_stdio_watchdog.__file__),
+            "--ppid",
+            str(os.getpid()),
+            "--",
+        ]
+        assert command[5:7] == ["/opt/cua-driver", "serve"]
+    else:
+        assert command[:2] == ["/opt/cua-driver", "serve"]
     assert "--embedded" in command
     assert command[command.index("--permission-mode") + 1] == "unrestricted"
     assert "--dangerously-bypass-approvals" in command

--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,7 +1,10 @@
 """Contract tests for the direct POSIX stdio MCP child watchdog."""
 
 import os
+import signal
+import subprocess
 import sys
+import time
 
 import pytest
 
@@ -15,6 +18,27 @@ def test_is_orphaned_is_false_while_direct_parent_is_unchanged():
         original_ppid,
         getppid=lambda: original_ppid,
     ) is False
+
+
+@pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
+def test_watchdog_module_wrap_command_uses_calling_parent_pid():
+    parent_pid = os.getpid()
+
+    wrapped_command, wrapped_args = mcp_stdio_watchdog.wrap_command(
+        "/opt/hermes/bin/cua-driver",
+        ["mcp", "--no-overlay"],
+    )
+
+    assert wrapped_command == sys.executable
+    assert wrapped_args == [
+        os.path.abspath(mcp_stdio_watchdog.__file__),
+        "--ppid",
+        str(parent_pid),
+        "--",
+        "/opt/hermes/bin/cua-driver",
+        "mcp",
+        "--no-overlay",
+    ]
 
 
 @pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
@@ -38,3 +62,56 @@ def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
         *command_args,
     ]
     assert "--create-time" not in wrapped_args
+
+
+@pytest.mark.skipif(os.name != "posix", reason="watchdog wrapping is POSIX-only")
+@pytest.mark.live_system_guard_bypass
+def test_sigterm_resistant_child_is_killed_before_sdk_cleanup_deadline(tmp_path):
+    """The supervisor must finish escalation before MCP SDK kills the wrapper."""
+    pid_file = tmp_path / "child.pid"
+    child_script = tmp_path / "ignore_term.py"
+    child_script.write_text(
+        "import os, pathlib, signal, sys, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()))\n"
+        "while True: time.sleep(1)\n",
+        encoding="utf-8",
+    )
+    watchdog = subprocess.Popen(
+        [
+            sys.executable,
+            os.path.abspath(mcp_stdio_watchdog.__file__),
+            "--ppid",
+            str(os.getpid()),
+            "--",
+            sys.executable,
+            str(child_script),
+            str(pid_file),
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    child_pid = None
+    try:
+        deadline = time.monotonic() + 2.0
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert pid_file.exists(), "watchdog child never reached its entry point"
+        child_pid = int(pid_file.read_text(encoding="utf-8"))
+
+        started = time.monotonic()
+        watchdog.send_signal(signal.SIGTERM)
+        watchdog.wait(timeout=1.8)
+        assert time.monotonic() - started < 1.8
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
+    finally:
+        if watchdog.poll() is None:
+            watchdog.kill()
+            watchdog.wait(timeout=2.0)
+        if child_pid is not None:
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -151,8 +151,12 @@ _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # `_resolve_mcp_invocation` below)
 # The lifecycle owner times out its own MCP startup so the same asyncio task
 # that entered stdio_client/ClientSession also unwinds them and reaps the child.
-# Keep this below the synchronous 30s ready guard to leave cleanup headroom.
 _CUA_MCP_STARTUP_TIMEOUT_SECONDS = 25.0
+# The synchronous caller must wait beyond the startup deadline while the
+# lifecycle owner joins a blocking daemon-start worker and reaps owned children.
+# Embedded status probes can consume 2s and stop escalation roughly 10s, so 15s
+# preserves a bounded outer guard without exposing failure before cleanup ends.
+_CUA_MCP_STARTUP_CLEANUP_GRACE_SECONDS = 15.0
 
 # Whole-screen / desktop capture. cua-driver is a window-oriented driver —
 # its `get_window_state` / `screenshot` tools capture a single window (by
@@ -436,16 +440,30 @@ class _EmbeddedCuaDaemon:
         except Exception:
             pass
 
-    def start(self) -> None:
+    def start(
+        self,
+        driver_cmd: Optional[str] = None,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> None:
         if self._process is not None and self._process.poll() is None:
             return
         from tools.environments.local import _sanitize_subprocess_env
 
+        def _raise_if_cancelled() -> None:
+            if cancel_event is not None and cancel_event.is_set():
+                raise RuntimeError("embedded cua-driver startup cancelled")
+
+        _raise_if_cancelled()
+        if driver_cmd:
+            self._driver_cmd = driver_cmd
         if not self._driver_cmd:
             self._driver_cmd = resolve_cua_driver_cmd() or ""
         if not self._driver_cmd:
             raise RuntimeError(cua_driver_install_hint())
         self._command, self._mcp_args = _resolve_mcp_invocation(self._driver_cmd)
+        # Manifest discovery is blocking. A lifecycle timeout may arrive while
+        # it runs, so re-check before crossing the process-spawn boundary.
+        _raise_if_cancelled()
         env = _sanitize_subprocess_env(self.child_env())
         command = [
             self._command,
@@ -469,6 +487,11 @@ class _EmbeddedCuaDaemon:
             text=True,
             env=env,
         )
+        # Close the narrow check→Popen race: if cancellation landed between
+        # those operations, reap the process before the worker can return.
+        if cancel_event is not None and cancel_event.is_set():
+            self.stop()
+            raise RuntimeError("embedded cua-driver startup cancelled")
         self._stderr_thread = threading.Thread(
             target=self._drain_stderr,
             args=(self._process,),
@@ -479,6 +502,9 @@ class _EmbeddedCuaDaemon:
 
         deadline = time.monotonic() + self._START_TIMEOUT_SECONDS
         while time.monotonic() < deadline:
+            if cancel_event is not None and cancel_event.is_set():
+                self.stop()
+                raise RuntimeError("embedded cua-driver startup cancelled")
             if self._process.poll() is not None:
                 detail = "; ".join(self._stderr_tail) or "no diagnostic output"
                 raise RuntimeError(
@@ -1187,6 +1213,25 @@ class _CuaDriverSession:
         # when startup wedges, the caller reports HOW FAR it got instead of
         # an opaque "never reached ready".
         self._startup_phase = "binary-check"
+        embedded_start_task: Optional[asyncio.Task[Any]] = None
+        embedded_cancel_event = (
+            threading.Event() if self._embedded_daemon is not None else None
+        )
+
+        async def _cleanup_embedded_startup() -> None:
+            """Cancel, join, then reap the exact private-daemon startup."""
+            if self._embedded_daemon is None:
+                return
+            if embedded_cancel_event is not None:
+                embedded_cancel_event.set()
+            # Join before the final stop so a worker blocked before Popen cannot
+            # spawn after stop() has already observed an empty process slot.
+            if embedded_start_task is not None:
+                try:
+                    await asyncio.shield(embedded_start_task)
+                except BaseException:
+                    pass
+            await asyncio.to_thread(self._embedded_daemon.stop)
 
         try:
             # Own the complete startup budget here, including synchronous
@@ -1197,6 +1242,21 @@ class _CuaDriverSession:
                 driver_cmd = await asyncio.to_thread(resolve_cua_driver_cmd)
                 if not driver_cmd:
                     raise RuntimeError(cua_driver_install_hint())
+
+                if self._embedded_daemon is not None:
+                    self._startup_phase = "embedded-daemon"
+                    embedded_start_task = asyncio.create_task(
+                        asyncio.to_thread(
+                            self._embedded_daemon.start,
+                            driver_cmd,
+                            embedded_cancel_event,
+                        )
+                    )
+                    # Keep ownership of the worker when the absolute startup
+                    # timeout cancels this lifecycle task. The timeout handler
+                    # stops the daemon and joins this exact worker before
+                    # exposing failure to the synchronous caller.
+                    await asyncio.shield(embedded_start_task)
 
                 # Surface 8: ask cua-driver itself which subcommand spawns
                 # the MCP server, instead of hardcoding ["mcp"]. Falls back
@@ -1257,6 +1317,7 @@ class _CuaDriverSession:
                         await self._shutdown_event.wait()
         except asyncio.TimeoutError as e:
             phase = getattr(self, "_startup_phase", "unknown")
+            await _cleanup_embedded_startup()
             timeout_error = asyncio.TimeoutError(
                 "cua-driver MCP startup timed out after "
                 f"{_CUA_MCP_STARTUP_TIMEOUT_SECONDS:g}s "
@@ -1269,6 +1330,7 @@ class _CuaDriverSession:
             # Capture ordinary errors and anyio CancelledError.
             # The caller (start()) inspects this to surface setup
             # failures to the synchronous world.
+            await _cleanup_embedded_startup()
             self._setup_error = e
             self._ready_event.set()
             raise
@@ -1359,7 +1421,11 @@ class _CuaDriverSession:
         self._lifecycle_future = asyncio.run_coroutine_threadsafe(
             self._lifecycle_coro(), loop
         )
-        if not self._ready_event.wait(timeout=30.0):
+        ready_guard_seconds = (
+            _CUA_MCP_STARTUP_TIMEOUT_SECONDS
+            + _CUA_MCP_STARTUP_CLEANUP_GRACE_SECONDS
+        )
+        if not self._ready_event.wait(timeout=ready_guard_seconds):
             # Best-effort: signal shutdown if the future is still alive.
             self._signal_shutdown_locked()
             # Surface which startup phase wedged (issue #57025) — "doctor
@@ -1368,7 +1434,8 @@ class _CuaDriverSession:
             phase = getattr(self, "_startup_phase", "unknown")
             from hermes_constants import display_hermes_home
             raise RuntimeError(
-                "cua-driver session never reached ready (timeout 30s; "
+                "cua-driver session never reached ready "
+                f"(timeout {ready_guard_seconds:g}s including cleanup; "
                 f"stuck in phase: {phase}). "
                 "Run `hermes computer-use doctor` and check "
                 f"{display_hermes_home()}/logs/agent.log for the phase timings."
@@ -1986,7 +2053,7 @@ class CuaDriverBackend(ComputerUseBackend):
             raise ValueError(f"unsupported cua-driver permission mode: {permission_mode}")
         self.permission_mode = permission_mode
         self._embedded_daemon = (
-            _EmbeddedCuaDaemon(resolve_cua_driver_cmd() or "", permission_mode)
+            _EmbeddedCuaDaemon("", permission_mode)
             if permission_mode == "unrestricted"
             else None
         )
@@ -2061,8 +2128,6 @@ class CuaDriverBackend(ComputerUseBackend):
         import importlib
         importlib.invalidate_caches()
         try:
-            if self._embedded_daemon is not None:
-                self._embedded_daemon.start()
             self._session.start()
         except Exception:
             if self._embedded_daemon is not None:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -191,11 +191,15 @@ _CUA_TELEMETRY_ENV_VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
 
 
 def _computer_use_cfg() -> Dict[str, Any]:
-    """The ``computer_use`` config block, or ``{}`` when config is unreadable."""
+    """The ``computer_use`` config block, or ``{}`` when invalid/unreadable."""
     try:
         from hermes_cli.config import load_config
 
-        return (load_config() or {}).get("computer_use") or {}
+        cfg = load_config() or {}
+        if not isinstance(cfg, dict):
+            return {}
+        section = cfg.get("computer_use", {}) or {}
+        return section if isinstance(section, dict) else {}
     except Exception:
         return {}
 
@@ -689,12 +693,27 @@ def _has_path_separator(value: str) -> bool:
     return os.sep in value or (os.altsep is not None and os.altsep in value)
 
 
+def configured_cua_driver_path() -> str:
+    """Return the profile-configured cua-driver path when it is a string."""
+    value = _computer_use_cfg().get("driver_path", "")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def configured_cua_driver_path_error() -> Optional[str]:
+    """Describe an explicitly invalid profile driver_path value, if present."""
+    value = _computer_use_cfg().get("driver_path", "")
+    if isinstance(value, str):
+        return None
+    return f"expected a string, got {type(value).__name__}"
+
+
 def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
     """Return candidate cua-driver commands in resolution order.
 
-    ``override`` is authoritative when supplied. Otherwise a non-empty
-    ``HERMES_CUA_DRIVER_CMD`` is authoritative; only when neither is set do we
-    use PATH and canonical install locations.
+    ``override`` is authoritative when supplied. Otherwise the profile-safe
+    ``computer_use.driver_path`` setting wins, followed by the legacy
+    ``HERMES_CUA_DRIVER_CMD`` environment override. Only when none is set do
+    we use PATH and canonical install locations.
 
     Desktop apps launched from Finder/Dock often inherit a narrow PATH that
     omits user-local install directories. The upstream cua-driver installer
@@ -702,7 +721,24 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
     Hermes Desktop/TUI session can otherwise filter out the `computer_use`
     tool even though `hermes computer-use doctor` succeeds from a login shell.
     """
-    configured = (override if override is not None else os.environ.get(_CUA_DRIVER_CMD_ENV, "")).strip()
+    if override is not None:
+        configured = override.strip()
+    else:
+        config_error = configured_cua_driver_path_error()
+        if config_error:
+            # The profile explicitly contains driver_path but its value cannot
+            # name an executable. Do not silently weaken the pin to env/PATH.
+            return []
+        configured = configured_cua_driver_path()
+        if configured:
+            expanded = os.path.expanduser(configured)
+            if not os.path.isabs(expanded):
+                from hermes_cli.config import get_config_path
+
+                expanded = str(get_config_path().parent / expanded)
+            configured = expanded
+        if not configured:
+            configured = os.environ.get(_CUA_DRIVER_CMD_ENV, "").strip()
     if configured:
         # An explicit override is authoritative: if it is wrong, report the
         # driver missing instead of silently picking a different binary.
@@ -728,19 +764,21 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
 def resolve_cua_driver_cmd(override: Optional[str] = None) -> Optional[str]:
     """Resolve the cua-driver executable for every runtime/status surface.
 
-    A supplied override (or ``HERMES_CUA_DRIVER_CMD``) is never silently
-    replaced by another binary. Otherwise resolve PATH first, then canonical
-    user-local installation locations used by the official installer.
+    An explicit CLI override, profile path, or legacy environment override is
+    never silently replaced by another binary. Resolved executables are
+    returned as absolute canonical paths. Otherwise resolve PATH first, then
+    canonical user-local installation locations used by the installer.
     """
     for candidate in _candidate_cua_driver_commands(override):
         expanded = os.path.expanduser(candidate)
         if _has_path_separator(expanded):
-            if shutil.which(expanded):
-                return expanded
+            resolved = shutil.which(expanded)
+            if resolved:
+                return os.path.realpath(os.path.abspath(resolved))
         else:
             resolved = shutil.which(expanded)
             if resolved:
-                return resolved
+                return os.path.realpath(os.path.abspath(resolved))
     return None
 
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -149,6 +149,10 @@ _CUA_DRIVER_DEFAULT_CMD = "cua-driver"
 _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # driver doesn't expose `manifest` — see
                             # `_resolve_mcp_invocation` below)
+# The lifecycle owner times out its own MCP startup so the same asyncio task
+# that entered stdio_client/ClientSession also unwinds them and reaps the child.
+# Keep this below the synchronous 30s ready guard to leave cleanup headroom.
+_CUA_MCP_STARTUP_TIMEOUT_SECONDS = 25.0
 
 # Whole-screen / desktop capture. cua-driver is a window-oriented driver —
 # its `get_window_state` / `screenshot` tools capture a single window (by
@@ -454,8 +458,11 @@ class _EmbeddedCuaDaemon:
             "unrestricted",
             "--dangerously-bypass-approvals",
         ]
+        from tools.mcp_stdio_watchdog import wrap_command
+
+        supervised_command, supervised_args = wrap_command(command[0], command[1:])
         self._process = subprocess.Popen(
-            command,
+            [supervised_command, *supervised_args],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -1182,55 +1189,84 @@ class _CuaDriverSession:
         self._startup_phase = "binary-check"
 
         try:
-            driver_cmd = resolve_cua_driver_cmd()
-            if not driver_cmd:
-                raise RuntimeError(cua_driver_install_hint())
+            # Own the complete startup budget here, including synchronous
+            # driver/manifest discovery.  Run blocking probes in a worker so
+            # this lifecycle task can enforce its deadline; the MCP SDK async
+            # contexts themselves still enter and exit in this same task.
+            async with asyncio.timeout(_CUA_MCP_STARTUP_TIMEOUT_SECONDS) as startup_timeout:
+                driver_cmd = await asyncio.to_thread(resolve_cua_driver_cmd)
+                if not driver_cmd:
+                    raise RuntimeError(cua_driver_install_hint())
 
-            # Surface 8: ask cua-driver itself which subcommand spawns
-            # the MCP server, instead of hardcoding ["mcp"]. Falls back
-            # transparently for older drivers / any discovery failure.
-            self._startup_phase = "manifest-discovery"
-            if self._embedded_daemon is not None:
-                command, args = self._embedded_daemon.proxy_invocation()
-                child_env = self._embedded_daemon.child_env()
-            else:
-                command, args = _resolve_mcp_invocation(driver_cmd)
-                child_env = cua_driver_child_env()
-            _t_manifest = _time.monotonic()
-            params = StdioServerParameters(
-                command=command,
-                args=args,
-                # Apply the telemetry policy first (default: disabled), then
-                # sanitize Hermes-managed secrets out of the child env.
-                env=_sanitize_subprocess_env(child_env),
-            )
-
-            async with stdio_client(params) as (read, write):
-                self._startup_phase = "mcp-initialize"
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    _t_init = _time.monotonic()
-                    # Populate capabilities + capability_version BEFORE
-                    # exposing the session to callers, so the first
-                    # tool call already sees them.
-                    self._startup_phase = "capability-discovery"
-                    await self._populate_capabilities(session)
-                    self._session = session
-                    self._startup_phase = "ready"
-                    self._ready_event.set()
-                    logger.info(
-                        "cua-driver session ready in %.1fs "
-                        "(manifest=%.1fs, mcp_init=%.1fs)",
-                        _time.monotonic() - _t0,
-                        _t_manifest - _t0,
-                        _t_init - _t_manifest,
+                # Surface 8: ask cua-driver itself which subcommand spawns
+                # the MCP server, instead of hardcoding ["mcp"]. Falls back
+                # transparently for older drivers / any discovery failure.
+                self._startup_phase = "manifest-discovery"
+                if self._embedded_daemon is not None:
+                    command, args = await asyncio.to_thread(
+                        self._embedded_daemon.proxy_invocation
                     )
-                    # Hold the contexts open until stop() / restart asks
-                    # us to wind down. Tool calls run as their own tasks
-                    # on the same loop and touch self._session directly.
-                    await self._shutdown_event.wait()
+                    child_env = self._embedded_daemon.child_env()
+                else:
+                    command, args = await asyncio.to_thread(
+                        _resolve_mcp_invocation, driver_cmd
+                    )
+                    child_env = cua_driver_child_env()
+                # Reuse Hermes's stdio MCP parent-death supervisor on POSIX. It
+                # owns only this invocation's process group, so a hard gateway
+                # death reaps the exact cua-driver tree without name-based kills.
+                from tools.mcp_stdio_watchdog import wrap_command
+
+                command, args = wrap_command(command, args)
+                _t_manifest = _time.monotonic()
+                params = StdioServerParameters(
+                    command=command,
+                    args=args,
+                    # Apply the telemetry policy first (default: disabled), then
+                    # sanitize Hermes-managed secrets out of the child env.
+                    env=_sanitize_subprocess_env(child_env),
+                )
+
+                self._startup_phase = "mcp-spawn"
+                async with stdio_client(params) as (read, write):
+                    self._startup_phase = "mcp-initialize"
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        _t_init = _time.monotonic()
+                        # Populate capabilities + capability_version BEFORE
+                        # exposing the session to callers, so the first
+                        # tool call already sees them.
+                        self._startup_phase = "capability-discovery"
+                        await self._populate_capabilities(session)
+                        self._session = session
+                        self._startup_phase = "ready"
+                        self._ready_event.set()
+                        logger.info(
+                            "cua-driver session ready in %.1fs "
+                            "(manifest=%.1fs, mcp_init=%.1fs)",
+                            _time.monotonic() - _t0,
+                            _t_manifest - _t0,
+                            _t_init - _t_manifest,
+                        )
+                        # Startup is complete: disarm the setup deadline while
+                        # preserving this task as owner of both async contexts.
+                        startup_timeout.reschedule(None)
+                        # Hold the contexts open until stop() / restart asks
+                        # us to wind down. Tool calls run as their own tasks
+                        # on the same loop and touch self._session directly.
+                        await self._shutdown_event.wait()
+        except asyncio.TimeoutError as e:
+            phase = getattr(self, "_startup_phase", "unknown")
+            timeout_error = asyncio.TimeoutError(
+                "cua-driver MCP startup timed out after "
+                f"{_CUA_MCP_STARTUP_TIMEOUT_SECONDS:g}s "
+                f"(stuck in phase: {phase})"
+            )
+            self._setup_error = timeout_error
+            self._ready_event.set()
+            raise timeout_error from e
         except BaseException as e:
-            # Capture both ordinary errors and anyio CancelledError.
+            # Capture ordinary errors and anyio CancelledError.
             # The caller (start()) inspects this to surface setup
             # failures to the synchronous world.
             self._setup_error = e

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -135,14 +135,41 @@ def _normalize_version_token(text: str) -> str:
     return m.group(1) if m else text.strip().lower()
 
 
-def _build_identity(binary: str, report: Dict[str, Any]) -> Dict[str, Any]:
-    """Hermes-side identity block comparing resolved binary vs health_report."""
-    cli = _read_cli_version(binary) or ""
+def _build_identity(
+    binary: Optional[str],
+    report: Optional[Dict[str, Any]] = None,
+    *,
+    driver_cmd: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Hermes identity and provenance for selected or failed resolution."""
+    from tools.computer_use.cua_backend import (
+        configured_cua_driver_path,
+        configured_cua_driver_path_error,
+    )
+
+    report = report or {}
+    configured_path = configured_cua_driver_path()
+    configured_error = configured_cua_driver_path_error()
+    legacy_env = os.getenv("HERMES_CUA_DRIVER_CMD", "").strip()
+    if driver_cmd is not None and driver_cmd.strip():
+        selection_source = "cli"
+    elif configured_path or configured_error:
+        selection_source = "config"
+    elif legacy_env:
+        selection_source = "environment"
+    else:
+        selection_source = "auto"
+
+    cli = (_read_cli_version(binary) or "") if binary else ""
     report_v = str(report.get("driver_version") or "")
     cli_tok = _normalize_version_token(cli)
     report_tok = _normalize_version_token(report_v)
     mismatch = bool(cli_tok and report_tok and cli_tok != report_tok)
     return {
+        "selection_source": selection_source,
+        "configured_driver_path": configured_path or None,
+        "configured_driver_error": configured_error,
+        "legacy_env_driver_cmd": legacy_env or None,
         "resolved_binary": binary,
         "cli_version": cli or None,
         "health_report_driver_version": report_v or None,
@@ -746,6 +773,10 @@ def _print_text_report(
     )
     if identity.get("resolved_binary"):
         print(f"  {col_dim}binary: {identity['resolved_binary']}{col_reset}")
+    if identity.get("selection_source"):
+        print(f"  {col_dim}selection: {identity['selection_source']}{col_reset}")
+    if identity.get("configured_driver_path"):
+        print(f"  {col_dim}configured: {identity['configured_driver_path']}{col_reset}")
     if cli_v and report_v and str(report_v) not in str(cli_v) and str(cli_v) not in str(report_v):
         # Only annotate when the free-form strings clearly differ.
         print(
@@ -827,9 +858,41 @@ def run_doctor(
 
     binary = resolve_cua_driver_cmd(driver_cmd)
     if not binary:
-        looked_for = driver_cmd or "cua-driver (PATH and canonical install paths)"
-        print(f"cua-driver: not installed (looked for {looked_for!r}).")
-        print("  Run: hermes computer-use install")
+        identity = _build_identity(None, driver_cmd=driver_cmd)
+        source = identity["selection_source"]
+        attempted = {
+            "cli": driver_cmd,
+            "config": identity["configured_driver_path"]
+            or f"<invalid: {identity['configured_driver_error']}>",
+            "environment": identity["legacy_env_driver_cmd"],
+            "auto": "cua-driver (PATH and canonical install paths)",
+        }[source]
+        message = f"cua-driver not found for {source} selection: {attempted!r}"
+        if json_output:
+            payload = {
+                "schema_version": "1",
+                "overall": "failed",
+                "checks": [],
+                "error": {"code": "driver_not_found", "message": message},
+                "hermes_identity": identity,
+            }
+            json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            print(f"cua-driver: not installed ({message}).")
+            print(f"  selection: {source}")
+            if identity["configured_driver_path"]:
+                print(f"  configured: {identity['configured_driver_path']}")
+            if identity["configured_driver_error"]:
+                print(f"  config error: {identity['configured_driver_error']}")
+            if source == "config":
+                print("  Fix or remove computer_use.driver_path in this profile's config.")
+            elif source == "environment":
+                print("  Fix or unset HERMES_CUA_DRIVER_CMD.")
+            elif source == "cli":
+                print("  Fix the explicit cua-driver command/path.")
+            else:
+                print("  Run: hermes computer-use install")
         return 2
 
     try:
@@ -837,10 +900,30 @@ def run_doctor(
             binary, include=include, skip=skip,
         )
     except RuntimeError as e:
-        print(f"cua-driver health_report failed: {e}", file=sys.stderr)
+        identity = _build_identity(binary, driver_cmd=driver_cmd)
+        message = f"cua-driver health_report failed: {e}"
+        if json_output:
+            payload = {
+                "schema_version": "1",
+                "overall": "failed",
+                "checks": [],
+                "error": {"code": "health_report_failed", "message": message},
+                "hermes_identity": identity,
+            }
+            json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            print(message, file=sys.stderr)
+            print(f"  binary: {identity['resolved_binary']}", file=sys.stderr)
+            print(f"  selection: {identity['selection_source']}", file=sys.stderr)
+            if identity["configured_driver_path"]:
+                print(
+                    f"  configured: {identity['configured_driver_path']}",
+                    file=sys.stderr,
+                )
         return 2
 
-    identity = _build_identity(binary, report)
+    identity = _build_identity(binary, report, driver_cmd=driver_cmd)
 
     if json_output:
         # Additive envelope: preserve the upstream health_report keys and

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -51,7 +51,33 @@ import threading
 import time
 
 _POLL_INTERVAL_S = 2.0
-_TERM_GRACE_S = 3.0
+# The MCP Python SDK gives its direct child (this watchdog) 2 seconds to
+# terminate before SIGKILL.  Complete both TERM and KILL phases comfortably
+# inside that window so the SDK cannot kill us while the real server's process
+# group is still alive.
+_TERM_GRACE_S = 0.5
+
+
+def wrap_command(command: str, args: list[str]) -> tuple[str, list[str]]:
+    """Wrap a stdio MCP command with this parent-death supervisor on POSIX.
+
+    Non-POSIX callers receive the invocation unchanged. Bookkeeping failure is
+    fail-open so watchdog support can never prevent an MCP server from starting.
+    """
+    if os.name != "posix":
+        return command, args
+    try:
+        parent_pid = os.getpid()
+    except Exception:
+        return command, args
+    return sys.executable, [
+        os.path.abspath(__file__),
+        "--ppid",
+        str(parent_pid),
+        "--",
+        command,
+        *args,
+    ]
 
 
 def _is_orphaned(original_ppid: int, getppid=os.getppid) -> bool:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -700,31 +700,10 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
 
 
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
-    """Wrap a stdio MCP server command in the parent-death watchdog supervisor.
+    """Wrap a stdio MCP command in the shared parent-death supervisor."""
+    from tools.mcp_stdio_watchdog import wrap_command
 
-    On POSIX, the watchdog records this process's PID and later detects parent
-    death directly through ``getppid()``. Returns the (command, args) unchanged
-    on non-POSIX platforms or if the PID cannot be read.
-    """
-    if os.name != "posix":
-        # Relies on process groups (os.getpgid/os.killpg); no POSIX
-        # equivalent wired up here yet, matching the existing killpg-based
-        # orphan cleanup's platform scope (Windows falls back to plain
-        # os.kill there too).
-        return command, args
-    try:
-        my_pid = os.getpid()
-    except Exception:
-        # Never let watchdog bookkeeping failure block a real MCP connection.
-        return command, args
-    watchdog_args = [
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_stdio_watchdog.py"),
-        "--ppid", str(my_pid),
-        "--",
-        command,
-        *args,
-    ]
-    return sys.executable, watchdog_args
+    return wrap_command(command, args)
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -317,11 +317,19 @@ real headless Chromium and is the right answer for web-only tasks.
 
 ## Configuration
 
-Override the driver binary path (tests / CI / local builds):
+Pin an exact driver binary for this Hermes profile (tests / CI / local builds)
+in `config.yaml`:
 
+```yaml
+computer_use:
+  driver_path: /path/to/your/cua-driver
 ```
-HERMES_CUA_DRIVER_CMD=/path/to/your/cua-driver
-```
+
+`~` is expanded, and relative paths are resolved from the profile directory
+containing `config.yaml`. An explicit path is authoritative: if it is invalid,
+Hermes reports that error instead of silently selecting another installed
+driver. `HERMES_CUA_DRIVER_CMD` remains a legacy fallback only when
+`computer_use.driver_path` is empty.
 
 Swap the backend entirely (for testing):
 
@@ -352,8 +360,9 @@ CUA_DRIVER_RS_TELEMETRY_ENABLED`.
 
 When you're developing cua-driver itself — or want to test an
 unreleased fix — point Hermes at a binary you built from source instead
-of the published release. Hermes resolves the driver with
-`shutil.which("cua-driver")` and **does not enforce
+of the published release. Hermes honors the profile's
+`computer_use.driver_path` before checking the legacy environment override,
+PATH, and canonical install locations. It **does not enforce
 `HERMES_CUA_DRIVER_VERSION`**, so a local build (reported as
 `0.0.0-local-*`) is accepted as-is. Two approaches:
 
@@ -393,18 +402,21 @@ cua-driver --version                 # local builds report 0.0.0-local-release
 ### Option B — point Hermes straight at the built binary (fastest loop)
 
 Skip the install ceremony entirely: `cargo build` and set
-`HERMES_CUA_DRIVER_CMD` to the resulting binary. Best for rapid
+`computer_use.driver_path` to the resulting binary. Best for rapid
 edit/build/test.
 
 ```bash
 cargo build -p cua-driver            # add --release for a release build; run from libs/cua-driver/rust
 ```
 
-```
-# Windows (.env)
-HERMES_CUA_DRIVER_CMD=C:\path\to\cua\libs\cua-driver\rust\target\debug\cua-driver.exe
-# macOS / Linux (.env)
-HERMES_CUA_DRIVER_CMD=/path/to/cua/libs/cua-driver/rust/target/debug/cua-driver
+```yaml
+# config.yaml — Windows
+computer_use:
+  driver_path: 'C:\path\to\cua\libs\cua-driver\rust\target\debug\cua-driver.exe'
+
+# config.yaml — macOS / Linux
+computer_use:
+  driver_path: /path/to/cua/libs/cua-driver/rust/target/debug/cua-driver
 ```
 
 ### Confirm Hermes is using your build


### PR DESCRIPTION
## Summary

- add profile-safe `computer_use.cua_driver_path` selection, including profile-relative resolution, malformed-config handling, and doctor provenance/attestation
- make the computer-use MCP startup deadline cover driver resolution, manifest discovery, process spawn, and MCP initialization while keeping timeout ownership inside the lifecycle contexts
- move blocking driver/manifest probes off the event loop so deadline cancellation remains responsive
- reuse the shared POSIX MCP parent-death watchdog for generic MCP, computer-use MCP, and the unrestricted embedded daemon
- ensure timeout/cancellation teardown reaps the exact owned process group before startup failure is returned, without process-name killing
- report truthful startup timeout diagnostics with the stuck phase and configured deadline

## Why

Computer-use could select a driver from an unrelated legacy environment override, doctor output did not attest which executable was actually selected, and the previous outer startup timeout could return while stdio/session contexts and `cua-driver` children were still alive. Synchronous manifest discovery could also consume unbounded time before MCP initialization began.

## Verification

Rebased onto current `origin/main` before publication.

- `pytest -q tests/tools/test_computer_use.py tests/computer_use` — **133 passed**
- `pytest -q tests/tools/test_mcp_stdio_watchdog.py tests/tools/test_mcp_stdio_init_timeout.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool.py` — **115 passed**
- `git diff --check origin/main...HEAD` — passed
- `python3 -m compileall -q` over changed runtime/test modules — passed
- independent pre-commit review — approved with no remaining blockers

Live-certified on Fedora 44 KDE/Wayland using the exact configured KDE-native `cua-driver` 0.13.1:

- standard mode: startup/list-apps succeeded (**515 apps**); MCP child was watchdog-owned; `DRAIN_OK`
- unrestricted mode: startup/list-apps succeeded (**510 apps**); embedded daemon and MCP proxy were watchdog-owned; `DRAIN_OK`

Regression coverage includes malformed/profile-relative driver configuration, doctor selection provenance, manifest-discovery deadline enforcement, wedged MCP initialization, orderly context cleanup, real child-process reaping (including SIGTERM resistance), watchdog invocation, and environment sanitization.
