### PR TITLE
fix(gateway): reap only the background processes an abandoned turn created

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -43,6 +43,7 @@ import asyncio
 import errno
 import hashlib
 import hmac
+import itertools
 import json
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
@@ -52,6 +53,7 @@ import os
 import re
 import sqlite3
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -617,30 +619,106 @@ def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Respons
     )
 
 
-def _reap_disconnected_agent_processes(agent: Any) -> None:
-    """Reap background processes an SSE-disconnected agent's turn created.
+def _reap_disconnected_agent_processes(
+    agent: Any, *, source: str = "api_server_sse_disconnect"
+) -> None:
+    """Reap background processes an abandoned API-server turn created.
 
     Mirrors the gateway-turn cleanup in ``gateway/run.py`` (#76115) for this
     API-server surface, which runs its own agent lifecycle via ``_run_agent``
     and never passes through ``TurnRunner`` — so it needs its own trigger for
     the same baseline-diff reap. Fire-and-forget on a daemon thread so the
     SSE handler's own cleanup isn't blocked on process-tree teardown.
+
+    Reaping is epoch-gated: client-provided session IDs are conversation
+    scopes, and multiple concurrent runs can intentionally share one (see
+    ``_handle_runs``). Without the gate, run A disconnecting could kill a
+    process a still-live run B (same task_id) spawned after A's baseline
+    snapshot — the same stale-reaper bug class the gateway path gates via
+    ``run_generation``. The epoch closure skips the reap when a newer run
+    has since claimed the task_id; that newer run's own baseline covers its
+    eventual cleanup.
     """
     process_task_id = getattr(agent, "_gateway_turn_process_task_id", "")
     process_baseline = getattr(agent, "_gateway_turn_process_baseline", None)
     if not process_task_id or process_baseline is None:
         return
-    import threading
+    epoch = getattr(agent, "_gateway_turn_process_epoch", None)
+    is_still_current: Optional[Any] = None
+    if epoch is not None:
+        def _epoch_still_current(_task_id=process_task_id, _epoch=epoch):
+            # Skip only when a NEWER run has claimed this task_id. A missing
+            # entry means the abandoned run's own clear pruned it (worker
+            # returned after the interrupt) — no newer claimant exists, so
+            # the reap must still proceed or the leak survives. This matches
+            # the gateway gate's semantics: worker completion does not bump
+            # run_generation either.
+            with _TURN_PROCESS_EPOCH_LOCK:
+                current = _TURN_PROCESS_EPOCHS.get(_task_id)
+            return current is None or current == _epoch
+
+        is_still_current = _epoch_still_current
 
     from gateway.run import _reap_gateway_turn_processes
 
     threading.Thread(
         target=_reap_gateway_turn_processes,
         args=(process_task_id, process_baseline),
-        kwargs={"source": "api_server_sse_disconnect"},
+        kwargs={"source": source, "is_still_current": is_still_current},
         name=f"api-turn-reaper-{process_task_id[:12]}",
         daemon=True,
     ).start()
+
+
+# Per-task-id run epochs for the reap gate above. task_id is a conversation
+# scope shared by concurrent API runs, so each run that claims it bumps the
+# epoch; a reaper holding a stale epoch declines to kill. Epochs come from a
+# single monotonic counter (never reused), so pruning an entry and later
+# re-claiming the task_id can never resurrect a stale reaper's claim.
+# Entries are pruned on clear when still current, bounding the dict to
+# in-flight runs.
+_TURN_PROCESS_EPOCHS: Dict[str, int] = {}
+_TURN_PROCESS_EPOCH_LOCK = threading.Lock()
+_TURN_PROCESS_EPOCH_COUNTER = itertools.count(1)
+
+
+def _publish_turn_process_ownership(agent: Any, task_id: str) -> None:
+    """Snapshot the process baseline and claim the task_id's current epoch.
+
+    Single place all API-server agent lifecycles (chat/responses ``_run_agent``
+    and ``/v1/runs``) record turn ownership, so the marker attribute names and
+    epoch bookkeeping cannot drift between surfaces.
+    """
+    from tools.process_registry import process_registry
+
+    with _TURN_PROCESS_EPOCH_LOCK:
+        epoch = next(_TURN_PROCESS_EPOCH_COUNTER)
+        _TURN_PROCESS_EPOCHS[task_id] = epoch
+    agent._gateway_turn_process_task_id = task_id
+    agent._gateway_turn_process_baseline = process_registry.snapshot_running_ids(
+        task_id
+    )
+    agent._gateway_turn_process_epoch = epoch
+
+
+def _clear_turn_process_ownership(agent: Any) -> None:
+    """Clear turn ownership the moment the turn finishes (success or crash).
+
+    A disconnect/cancel landing after this point must not reap background
+    work the turn deliberately left running — mirrors the same race-window
+    guard in ``gateway/run.py``'s ``_run_sync_with_timeout_lifecycle``.
+    """
+    task_id = getattr(agent, "_gateway_turn_process_task_id", "")
+    epoch = getattr(agent, "_gateway_turn_process_epoch", None)
+    if task_id and epoch is not None:
+        with _TURN_PROCESS_EPOCH_LOCK:
+            # Prune only when this run is still the current claimant; a
+            # newer concurrent run owns the entry otherwise.
+            if _TURN_PROCESS_EPOCHS.get(task_id) == epoch:
+                del _TURN_PROCESS_EPOCHS[task_id]
+    agent._gateway_turn_process_task_id = ""
+    agent._gateway_turn_process_baseline = frozenset()
+    agent._gateway_turn_process_epoch = None
 
 
 def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Optional["web.Response"]]:
@@ -4860,6 +4938,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     agent.interrupt("SSE task cancelled")
                 except Exception:
                     pass
+                # Same abandonment as a client disconnect: the run will never
+                # be resumed, so reap the background processes it created
+                # (#76115). Epoch-gated; no-op when the turn already
+                # finished and cleared its markers.
+                _reap_disconnected_agent_processes(
+                    agent, source="api_server_sse_cancelled"
+                )
             if not agent_task.done():
                 agent_task.cancel()
             logger.info("SSE task cancelled; persisted incomplete snapshot for %s", response_id)
@@ -5868,11 +5953,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     # gateway-turn cleanup (#76115); this API-server surface
                     # runs its own agent lifecycle and doesn't go through
                     # TurnRunner, so it needs its own baseline.
-                    from tools.process_registry import process_registry
-                    agent._gateway_turn_process_task_id = effective_task_id
-                    agent._gateway_turn_process_baseline = (
-                        process_registry.snapshot_running_ids(effective_task_id)
-                    )
+                    _publish_turn_process_ownership(agent, effective_task_id)
                     result = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
@@ -6001,8 +6082,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     # running on purpose. Mirrors the same race-window guard
                     # in gateway/run.py's _run_sync_with_timeout_lifecycle.
                     if agent is not None:
-                        agent._gateway_turn_process_task_id = ""
-                        agent._gateway_turn_process_baseline = frozenset()
+                        _clear_turn_process_ownership(agent)
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()
@@ -6355,12 +6435,23 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_id=session_id or "",
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
+                            # /v1/runs runs its own agent lifecycle (no
+                            # TurnRunner, no _run_agent) — record turn process
+                            # ownership so stop/cancel can reap only the
+                            # background processes this run created (#76115).
+                            _publish_turn_process_ownership(agent, effective_task_id)
                             r = agent.run_conversation(
                                 user_message=user_message,
                                 conversation_history=conversation_history,
                                 task_id=effective_task_id,
                             )
                         finally:
+                            # Worker finished (interrupted or complete) —
+                            # clear turn ownership immediately so a later
+                            # stop/cancel can't reap background work this
+                            # run deliberately left running (same race-window
+                            # guard as gateway/run.py and _run_agent above).
+                            _clear_turn_process_ownership(agent)
                             try:
                                 unregister_gateway_notify(approval_session_key)
                             finally:
@@ -6700,6 +6791,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent.interrupt("Stop requested via API")
             except Exception:
                 pass
+            # The stopped run is abandoned — reap only the background
+            # processes it created (#76115). Epoch-gated inside, so a
+            # concurrent run sharing the same session_id keeps its own
+            # processes; no-op if the run already finished and cleared
+            # its ownership markers.
+            _reap_disconnected_agent_processes(
+                agent, source="api_server_run_stop"
+            )
 
         return web.json_response({"run_id": run_id, "status": "stopping"})
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -617,6 +617,32 @@ def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Respons
     )
 
 
+def _reap_disconnected_agent_processes(agent: Any) -> None:
+    """Reap background processes an SSE-disconnected agent's turn created.
+
+    Mirrors the gateway-turn cleanup in ``gateway/run.py`` (#76115) for this
+    API-server surface, which runs its own agent lifecycle via ``_run_agent``
+    and never passes through ``TurnRunner`` — so it needs its own trigger for
+    the same baseline-diff reap. Fire-and-forget on a daemon thread so the
+    SSE handler's own cleanup isn't blocked on process-tree teardown.
+    """
+    process_task_id = getattr(agent, "_gateway_turn_process_task_id", "")
+    process_baseline = getattr(agent, "_gateway_turn_process_baseline", None)
+    if not process_task_id or process_baseline is None:
+        return
+    import threading
+
+    from gateway.run import _reap_gateway_turn_processes
+
+    threading.Thread(
+        target=_reap_gateway_turn_processes,
+        args=(process_task_id, process_baseline),
+        kwargs={"source": "api_server_sse_disconnect"},
+        name=f"api-turn-reaper-{process_task_id[:12]}",
+        daemon=True,
+    ).start()
+
+
 def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Optional["web.Response"]]:
     """Parse and normalize session chat ``message`` / ``input`` like chat completions."""
     user_message = body.get("message") or body.get("input")
@@ -4234,6 +4260,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     agent.interrupt("SSE client disconnected")
                 except Exception:
                     pass
+                _reap_disconnected_agent_processes(agent)
             if not agent_task.done():
                 agent_task.cancel()
                 try:
@@ -4813,6 +4840,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     agent.interrupt("SSE client disconnected")
                 except Exception:
                     pass
+                _reap_disconnected_agent_processes(agent)
             if not agent_task.done():
                 agent_task.cancel()
                 try:
@@ -5815,6 +5843,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
                 )
+                agent = None
                 try:
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
@@ -5834,6 +5863,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
+                    # Baseline for selective background-process reaping on
+                    # SSE client disconnect — mirrors gateway/run.py's
+                    # gateway-turn cleanup (#76115); this API-server surface
+                    # runs its own agent lifecycle and doesn't go through
+                    # TurnRunner, so it needs its own baseline.
+                    from tools.process_registry import process_registry
+                    agent._gateway_turn_process_task_id = effective_task_id
+                    agent._gateway_turn_process_baseline = (
+                        process_registry.snapshot_running_ids(effective_task_id)
+                    )
                     result = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
@@ -5956,6 +5995,14 @@ class APIServerAdapter(BasePlatformAdapter):
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
                 finally:
+                    # Turn finished (success, auth failure, or crash) — clear
+                    # ownership markers so a disconnect landing after this
+                    # point can't reap background work this turn left
+                    # running on purpose. Mirrors the same race-window guard
+                    # in gateway/run.py's _run_sync_with_timeout_lifecycle.
+                    if agent is not None:
+                        agent._gateway_turn_process_task_id = ""
+                        agent._gateway_turn_process_baseline = frozenset()
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2690,6 +2690,116 @@ _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
+
+def _reap_gateway_turn_processes(
+    task_id: str,
+    process_baseline,
+    *,
+    source: str,
+) -> int:
+    """Reap only background processes created by one abandoned turn."""
+    from tools.process_registry import process_registry
+
+    try:
+        killed = process_registry.kill_started_since(
+            task_id,
+            process_baseline,
+            source=source,
+        )
+    except Exception:
+        # Runs on a detached daemon thread (interrupt and timeout call
+        # sites both fire-and-forget it) — an uncaught exception here
+        # would only surface via threading.excepthook, bypassing the
+        # app's logger. Swallow and log through the normal channel instead.
+        logger.warning(
+            "Failed to reap background processes for turn %s (%s)",
+            task_id,
+            source,
+            exc_info=True,
+        )
+        return 0
+    if killed:
+        logger.warning(
+            "Reaped %d background process(es) created by abandoned turn %s (%s)",
+            killed,
+            task_id,
+            source,
+        )
+    return killed
+
+
+def _abandon_timed_out_gateway_turn(
+    *,
+    agent_holder,
+    task_id: str,
+    process_baseline,
+    worker_done: threading.Event,
+    timeout_fired: threading.Event,
+    cleanup_lock: threading.Lock,
+) -> bool:
+    """Interrupt one timed-out turn and reap only processes it created."""
+    with cleanup_lock:
+        if worker_done.is_set() or timeout_fired.is_set():
+            return False
+        timeout_fired.set()
+
+    agent = agent_holder[0] if agent_holder else None
+    if agent is not None and hasattr(agent, "interrupt"):
+        try:
+            agent.interrupt(_INTERRUPT_REASON_TIMEOUT)
+        except Exception:
+            logger.debug("Timed-out agent interrupt failed", exc_info=True)
+
+    try:
+        _reap_gateway_turn_processes(
+            task_id,
+            process_baseline,
+            source="gateway_turn_timeout",
+        )
+    except Exception:
+        logger.warning(
+            "Failed to reap background processes for timed-out turn %s",
+            task_id,
+            exc_info=True,
+        )
+    return True
+
+
+def _watch_gateway_turn_inactivity(
+    *,
+    agent_holder,
+    task_id: str,
+    process_baseline,
+    timeout: float,
+    worker_done: threading.Event,
+    timeout_fired: threading.Event,
+    cleanup_lock: threading.Lock,
+    poll_interval: float = 5.0,
+) -> None:
+    """Thread watchdog that remains runnable when gateway asyncio is starved."""
+    while not worker_done.wait(max(0.01, poll_interval)):
+        agent = agent_holder[0] if agent_holder else None
+        if agent is None or not hasattr(agent, "get_activity_summary"):
+            continue
+        try:
+            idle_seconds = float(
+                agent.get_activity_summary().get("seconds_since_activity", 0.0)
+            )
+        except Exception:
+            continue
+        if idle_seconds < timeout:
+            continue
+        _abandon_timed_out_gateway_turn(
+            agent_holder=agent_holder,
+            task_id=task_id,
+            process_baseline=process_baseline,
+            worker_done=worker_done,
+            timeout_fired=timeout_fired,
+            cleanup_lock=cleanup_lock,
+        )
+        return
+
+
 _CONTROL_INTERRUPT_MESSAGES = frozenset(
     {
         _INTERRUPT_REASON_STOP.lower(),
@@ -4755,6 +4865,11 @@ class TurnRunner:
         agent.thinking_progress = ctx._thinking_enabled
         # Store agent reference for interrupt support
         ctx.agent_holder[0] = agent
+        # Publish turn ownership for explicit /stop, /new, disconnect, and
+        # shutdown interrupts. Older session processes are outside this
+        # baseline and remain alive.
+        agent._gateway_turn_process_task_id = ctx.process_task_id
+        agent._gateway_turn_process_baseline = ctx.process_baseline
         # Capture the full tool definitions for transcript logging
         ctx.tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
         
@@ -22132,6 +22247,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = _iac_state.turn.agent if _iac_state else None
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
+            _process_task_id = getattr(
+                running_agent, "_gateway_turn_process_task_id", ""
+            )
+            _process_baseline = getattr(
+                running_agent, "_gateway_turn_process_baseline", None
+            )
+            if _process_task_id and _process_baseline is not None:
+                threading.Thread(
+                    target=_reap_gateway_turn_processes,
+                    args=(_process_task_id, _process_baseline),
+                    kwargs={"source": "gateway_turn_interrupt"},
+                    name=f"gateway-turn-reaper-{_process_task_id[:12]}",
+                    daemon=True,
+                ).start()
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self._adapter_for_source(source)
         interrupt_session_activity = getattr(
@@ -24095,8 +24224,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _agent_warning_raw = _float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
+
+            # A background=true process intentionally survives a successful
+            # turn, so capture existing IDs and reap only children created by
+            # THIS turn if it times out. The daemon watchdog is independent of
+            # asyncio: cgroup memory reclaim may starve the event loop that runs
+            # the normal timeout poll, but it need not also postpone cleanup
+            # until the loop recovers (#76115).
+            from tools.process_registry import process_registry
+
+            _turn_task_id = session_id or ""
+            _turn_process_baseline = process_registry.snapshot_running_ids(_turn_task_id)
+            turn_ctx.process_task_id = _turn_task_id
+            turn_ctx.process_baseline = _turn_process_baseline
+            _turn_worker_done = threading.Event()
+            _turn_timeout_fired = threading.Event()
+            _turn_cleanup_lock = threading.Lock()
+
+            def _run_sync_with_timeout_lifecycle():
+                try:
+                    return run_sync()
+                finally:
+                    _turn_worker_done.set()
+                    # `.turn.agent` on the session state is only reset to
+                    # _AGENT_PENDING_SENTINEL when the *next* turn is
+                    # claimed (see _session_state(...).turn.agent = ... at
+                    # claim time), so a stale reference to this exact agent
+                    # instance stays reachable from
+                    # _interrupt_and_clear_session() until then. Clearing
+                    # the ownership markers here — the instant this turn's
+                    # own worker finishes — closes that window: an
+                    # explicit /stop landing on the already-finished turn
+                    # no longer reaps background work the turn deliberately
+                    # left running (#76115).
+                    _finished_agent = agent_holder[0] if agent_holder else None
+                    if _finished_agent is not None:
+                        _finished_agent._gateway_turn_process_task_id = ""
+                        _finished_agent._gateway_turn_process_baseline = frozenset()
+
+            if _agent_timeout is not None:
+                threading.Thread(
+                    target=_watch_gateway_turn_inactivity,
+                    kwargs={
+                        "agent_holder": agent_holder,
+                        "task_id": _turn_task_id,
+                        "process_baseline": _turn_process_baseline,
+                        "timeout": _agent_timeout,
+                        "worker_done": _turn_worker_done,
+                        "timeout_fired": _turn_timeout_fired,
+                        "cleanup_lock": _turn_cleanup_lock,
+                        "poll_interval": 5.0,
+                    },
+                    name=f"gateway-turn-watchdog-{_turn_task_id[:12]}",
+                    daemon=True,
+                ).start()
             _executor_task = asyncio.ensure_future(
-                self._run_in_executor_with_context(run_sync)
+                self._run_in_executor_with_context(_run_sync_with_timeout_lifecycle)
             )
 
             _inactivity_timeout = False
@@ -24158,6 +24341,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     done, _ = await asyncio.wait(
                         {_executor_task}, timeout=_POLL_INTERVAL
                     )
+                    if _turn_timeout_fired.is_set():
+                        _inactivity_timeout = True
+                        break
                     if done:
                         response = _executor_task.result()
                         break
@@ -24191,6 +24377,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 logger.debug("Inactivity warning send error: %s", _warn_err)
                     if _idle_secs >= _agent_timeout:
                         _inactivity_timeout = True
+                        threading.Thread(
+                            target=_abandon_timed_out_gateway_turn,
+                            kwargs={
+                                "agent_holder": agent_holder,
+                                "task_id": _turn_task_id,
+                                "process_baseline": _turn_process_baseline,
+                                "worker_done": _turn_worker_done,
+                                "timeout_fired": _turn_timeout_fired,
+                                "cleanup_lock": _turn_cleanup_lock,
+                            },
+                            name=f"gateway-turn-reaper-{_turn_task_id[:12]}",
+                            daemon=True,
+                        ).start()
                         break
                     # Backup interrupt check (same as unlimited path).
                     if not _interrupt_detected.is_set() and session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2696,8 +2696,37 @@ def _reap_gateway_turn_processes(
     process_baseline,
     *,
     source: str,
+    is_still_current: Optional[Callable[[], bool]] = None,
 ) -> int:
-    """Reap only background processes created by one abandoned turn."""
+    """Reap only background processes created by one abandoned turn.
+
+    ``task_id`` is session-scoped (task_id == session_id), not turn-scoped,
+    so a *replacement* turn on the same session can start and spawn its own
+    legitimate process while this reap is still in flight. ``is_still_current``
+    — a closure over the run_generation captured when the reaping turn began
+    or was interrupted — lets the caller detect that a newer turn has since
+    claimed the session and bail out instead of killing that newer turn's
+    process. The newer turn snapshots its own baseline independently, so
+    skipping here does not leave anything permanently unreaped.
+    """
+    if is_still_current is not None:
+        try:
+            if not is_still_current():
+                logger.debug(
+                    "Skipping reap for turn %s (%s): a newer turn already "
+                    "claimed this session; it owns its own baseline.",
+                    task_id,
+                    source,
+                )
+                return 0
+        except Exception:
+            logger.debug(
+                "is_still_current check failed for turn %s (%s); reaping anyway",
+                task_id,
+                source,
+                exc_info=True,
+            )
+
     from tools.process_registry import process_registry
 
     try:
@@ -2736,6 +2765,7 @@ def _abandon_timed_out_gateway_turn(
     worker_done: threading.Event,
     timeout_fired: threading.Event,
     cleanup_lock: threading.Lock,
+    is_still_current: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Interrupt one timed-out turn and reap only processes it created."""
     with cleanup_lock:
@@ -2755,6 +2785,7 @@ def _abandon_timed_out_gateway_turn(
             task_id,
             process_baseline,
             source="gateway_turn_timeout",
+            is_still_current=is_still_current,
         )
     except Exception:
         logger.warning(
@@ -2775,6 +2806,7 @@ def _watch_gateway_turn_inactivity(
     timeout_fired: threading.Event,
     cleanup_lock: threading.Lock,
     poll_interval: float = 5.0,
+    is_still_current: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Thread watchdog that remains runnable when gateway asyncio is starved."""
     while not worker_done.wait(max(0.01, poll_interval)):
@@ -2796,6 +2828,7 @@ def _watch_gateway_turn_inactivity(
             worker_done=worker_done,
             timeout_fired=timeout_fired,
             cleanup_lock=cleanup_lock,
+            is_still_current=is_still_current,
         )
         return
 
@@ -22245,6 +22278,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         _iac_state = self._peek_session_state(session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
+        _process_task_id = ""
+        _process_baseline = None
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
             _process_task_id = getattr(
@@ -22253,15 +22288,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _process_baseline = getattr(
                 running_agent, "_gateway_turn_process_baseline", None
             )
-            if _process_task_id and _process_baseline is not None:
-                threading.Thread(
-                    target=_reap_gateway_turn_processes,
-                    args=(_process_task_id, _process_baseline),
-                    kwargs={"source": "gateway_turn_interrupt"},
-                    name=f"gateway-turn-reaper-{_process_task_id[:12]}",
-                    daemon=True,
-                ).start()
-        self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
+        # Bump the generation *before* scheduling the reap thread and capture
+        # the post-bump value: task_id is session-scoped (task_id ==
+        # session_id), so if a replacement turn claims this session and
+        # spawns its own process before the reap thread actually runs, that
+        # claim bumps the generation again. The closure below then sees a
+        # stale generation and skips — the replacement turn's own baseline
+        # covers its own cleanup, so nothing is left permanently unreaped.
+        _generation_at_interrupt = self._invalidate_session_run_generation(
+            session_key, reason=invalidation_reason
+        )
+        if _process_task_id and _process_baseline is not None:
+            threading.Thread(
+                target=_reap_gateway_turn_processes,
+                args=(_process_task_id, _process_baseline),
+                kwargs={
+                    "source": "gateway_turn_interrupt",
+                    "is_still_current": lambda: self._is_session_run_current(
+                        session_key, _generation_at_interrupt
+                    ),
+                },
+                name=f"gateway-turn-reaper-{_process_task_id[:12]}",
+                daemon=True,
+            ).start()
         adapter = self._adapter_for_source(source)
         interrupt_session_activity = getattr(
             type(adapter), "interrupt_session_activity", None
@@ -24240,6 +24289,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _turn_worker_done = threading.Event()
             _turn_timeout_fired = threading.Event()
             _turn_cleanup_lock = threading.Lock()
+            # task_id above is session-scoped, not turn-scoped (#76115
+            # review): gate the eventual reap on this exact claim still
+            # being current, so a replacement turn that starts on the same
+            # session before the watchdog fires doesn't get its own fresh
+            # process killed by this turn's stale baseline.
+            _turn_run_generation = run_generation
+            _turn_is_current = (
+                (lambda: self._is_session_run_current(session_key, _turn_run_generation))
+                if _turn_run_generation is not None
+                else (lambda: True)
+            )
 
             def _run_sync_with_timeout_lifecycle():
                 try:
@@ -24274,6 +24334,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "timeout_fired": _turn_timeout_fired,
                         "cleanup_lock": _turn_cleanup_lock,
                         "poll_interval": 5.0,
+                        "is_still_current": _turn_is_current,
                     },
                     name=f"gateway-turn-watchdog-{_turn_task_id[:12]}",
                     daemon=True,
@@ -24386,6 +24447,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "worker_done": _turn_worker_done,
                                 "timeout_fired": _turn_timeout_fired,
                                 "cleanup_lock": _turn_cleanup_lock,
+                                "is_still_current": _turn_is_current,
                             },
                             name=f"gateway-turn-reaper-{_turn_task_id[:12]}",
                             daemon=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2709,6 +2709,11 @@ def _reap_gateway_turn_processes(
     process. The newer turn snapshots its own baseline independently, so
     skipping here does not leave anything permanently unreaped.
     """
+    if not task_id:
+        # ProcessSession.task_id defaults to "" for sessionless callers, so a
+        # blank id would match (and kill) every unrelated empty-task process
+        # instead of this turn's own. Nothing session-scoped to reap.
+        return 0
     if is_still_current is not None:
         try:
             if not is_still_current():
@@ -24402,11 +24407,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     done, _ = await asyncio.wait(
                         {_executor_task}, timeout=_POLL_INTERVAL
                     )
+                    if done:
+                        # Prefer the real result when the worker finished,
+                        # even if the watchdog fired in the same window: the
+                        # completed run already persisted its reply to session
+                        # history, so surfacing the "agent inactive" diagnostic
+                        # here would contradict the stored transcript. This
+                        # mirrors _abandon_timed_out_gateway_turn's own
+                        # worker_done-wins tiebreak (under cleanup_lock).
+                        response = _executor_task.result()
+                        break
                     if _turn_timeout_fired.is_set():
                         _inactivity_timeout = True
-                        break
-                    if done:
-                        response = _executor_task.result()
                         break
                     # Agent still running — check inactivity.
                     _agent_ref = agent_holder[0]

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -84,6 +84,8 @@ class TurnContext:
     session_id: Optional[str] = None
     session_key: Optional[str] = None
     run_generation: Optional[int] = None
+    process_task_id: str = ""
+    process_baseline: frozenset[str] = field(default_factory=frozenset)
     _interrupt_depth: int = 0
     event_message_id: Optional[str] = None
     moa_config: Optional[dict] = None

--- a/tests/gateway/test_abandoned_turn_process_cleanup.py
+++ b/tests/gateway/test_abandoned_turn_process_cleanup.py
@@ -1,0 +1,114 @@
+"""Regression coverage for abandoned gateway-turn subprocess cleanup (#76115)."""
+
+import threading
+
+from gateway.run import (
+    _abandon_timed_out_gateway_turn,
+    _watch_gateway_turn_inactivity,
+)
+from tools.process_registry import process_registry
+
+
+class _IdleAgent:
+    def __init__(self, idle_seconds=60.0):
+        self.idle_seconds = idle_seconds
+        self.interrupts = []
+
+    def get_activity_summary(self):
+        return {"seconds_since_activity": self.idle_seconds}
+
+    def interrupt(self, reason):
+        self.interrupts.append(reason)
+
+
+def _state():
+    return threading.Event(), threading.Event(), threading.Lock()
+
+
+def test_thread_watchdog_reaps_only_processes_created_by_timed_out_turn(monkeypatch):
+    agent = _IdleAgent()
+    worker_done, timeout_fired, cleanup_lock = _state()
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda task_id, baseline, *, source: calls.append(
+            (task_id, baseline, source)
+        )
+        or 1,
+    )
+
+    watchdog = threading.Thread(
+        target=_watch_gateway_turn_inactivity,
+        kwargs={
+            "agent_holder": [agent],
+            "task_id": "session-a",
+            "process_baseline": frozenset({"proc_existing"}),
+            "timeout": 30.0,
+            "worker_done": worker_done,
+            "timeout_fired": timeout_fired,
+            "cleanup_lock": cleanup_lock,
+            "poll_interval": 0.01,
+        },
+    )
+    watchdog.start()
+    watchdog.join(timeout=1)
+
+    assert not watchdog.is_alive()
+    assert timeout_fired.is_set()
+    assert agent.interrupts == ["Execution timed out (inactivity)"]
+    assert calls == [
+        (
+            "session-a",
+            frozenset({"proc_existing"}),
+            "gateway_turn_timeout",
+        )
+    ]
+
+
+def test_completed_worker_wins_race_and_preserves_background_process(monkeypatch):
+    agent = _IdleAgent()
+    worker_done, timeout_fired, cleanup_lock = _state()
+    worker_done.set()
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("completed turn must not reap background work")
+        ),
+    )
+
+    assert not _abandon_timed_out_gateway_turn(
+        agent_holder=[agent],
+        task_id="session-a",
+        process_baseline=frozenset(),
+        worker_done=worker_done,
+        timeout_fired=timeout_fired,
+        cleanup_lock=cleanup_lock,
+    )
+    assert not timeout_fired.is_set()
+    assert agent.interrupts == []
+
+
+def test_timeout_cleanup_is_idempotent(monkeypatch):
+    agent = _IdleAgent()
+    worker_done, timeout_fired, cleanup_lock = _state()
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_args, **_kwargs: calls.append(True) or 0,
+    )
+    kwargs = {
+        "agent_holder": [agent],
+        "task_id": "session-a",
+        "process_baseline": frozenset(),
+        "worker_done": worker_done,
+        "timeout_fired": timeout_fired,
+        "cleanup_lock": cleanup_lock,
+    }
+
+    assert _abandon_timed_out_gateway_turn(**kwargs)
+    assert not _abandon_timed_out_gateway_turn(**kwargs)
+    assert len(calls) == 1
+    assert len(agent.interrupts) == 1

--- a/tests/gateway/test_abandoned_turn_process_cleanup.py
+++ b/tests/gateway/test_abandoned_turn_process_cleanup.py
@@ -4,6 +4,7 @@ import threading
 
 from gateway.run import (
     _abandon_timed_out_gateway_turn,
+    _reap_gateway_turn_processes,
     _watch_gateway_turn_inactivity,
 )
 from tools.process_registry import process_registry
@@ -112,3 +113,102 @@ def test_timeout_cleanup_is_idempotent(monkeypatch):
     assert not _abandon_timed_out_gateway_turn(**kwargs)
     assert len(calls) == 1
     assert len(agent.interrupts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-turn race guard (#76188 review): task_id is session-scoped, not
+# turn-scoped, so a replacement turn on the same session could otherwise
+# have its freshly-spawned process killed by a stale reaper. Gated on
+# run_generation via an injected `is_still_current` check.
+# ---------------------------------------------------------------------------
+
+
+def test_reap_skips_when_a_newer_turn_has_claimed_the_session(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_a, **_k: calls.append(True) or 1,
+    )
+
+    killed = _reap_gateway_turn_processes(
+        "session-a",
+        frozenset({"proc_old"}),
+        source="gateway_turn_timeout",
+        is_still_current=lambda: False,
+    )
+
+    assert killed == 0
+    assert calls == []
+
+
+def test_reap_proceeds_when_this_turn_is_still_current(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda task_id, baseline, *, source: calls.append(
+            (task_id, baseline, source)
+        )
+        or 1,
+    )
+
+    killed = _reap_gateway_turn_processes(
+        "session-a",
+        frozenset({"proc_old"}),
+        source="gateway_turn_timeout",
+        is_still_current=lambda: True,
+    )
+
+    assert killed == 1
+    assert calls == [("session-a", frozenset({"proc_old"}), "gateway_turn_timeout")]
+
+
+def test_reap_fails_open_when_is_still_current_raises(monkeypatch):
+    """A bug in the generation-check closure must not silently disable the
+    underlying leak fix — it should log and fall through to reaping."""
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_a, **_k: calls.append(True) or 1,
+    )
+
+    def _boom():
+        raise RuntimeError("session state lookup failed")
+
+    killed = _reap_gateway_turn_processes(
+        "session-a",
+        frozenset(),
+        source="gateway_turn_timeout",
+        is_still_current=_boom,
+    )
+
+    assert killed == 1
+    assert calls == [True]
+
+
+def test_timeout_abandon_propagates_is_still_current_to_the_reap(monkeypatch):
+    agent = _IdleAgent()
+    worker_done, timeout_fired, cleanup_lock = _state()
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_a, **_k: calls.append(True) or 1,
+    )
+
+    assert _abandon_timed_out_gateway_turn(
+        agent_holder=[agent],
+        task_id="session-a",
+        process_baseline=frozenset(),
+        worker_done=worker_done,
+        timeout_fired=timeout_fired,
+        cleanup_lock=cleanup_lock,
+        is_still_current=lambda: False,
+    )
+
+    # The turn was still marked abandoned (interrupt fired), but the actual
+    # reap was skipped because a newer turn already claimed the session.
+    assert agent.interrupts == ["Execution timed out (inactivity)"]
+    assert calls == []

--- a/tests/gateway/test_abandoned_turn_process_cleanup.py
+++ b/tests/gateway/test_abandoned_turn_process_cleanup.py
@@ -188,6 +188,26 @@ def test_reap_fails_open_when_is_still_current_raises(monkeypatch):
     assert calls == [True]
 
 
+def test_reap_skips_empty_task_id(monkeypatch):
+    """ProcessSession.task_id defaults to "" — a blank turn id must never
+    fan out into killing unrelated sessionless processes (#76188 review)."""
+    calls = []
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_a, **_k: calls.append(True) or 1,
+    )
+
+    killed = _reap_gateway_turn_processes(
+        "",
+        frozenset(),
+        source="gateway_turn_timeout",
+    )
+
+    assert killed == 0
+    assert calls == []
+
+
 def test_timeout_abandon_propagates_is_still_current_to_the_reap(monkeypatch):
     agent = _IdleAgent()
     worker_done, timeout_fired, cleanup_lock = _state()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -481,6 +481,146 @@ class TestDisconnectedAgentReap:
         time.sleep(0.1)
         assert calls == []
 
+    def test_stale_epoch_skips_reap_when_newer_run_claimed_task_id(self, monkeypatch):
+        """#76188 follow-up: concurrent API runs can share a client-provided
+        session_id (same task_id). A disconnecting run whose epoch has been
+        superseded must NOT kill the newer run's processes."""
+        from gateway.platforms.api_server import (
+            _clear_turn_process_ownership,
+            _publish_turn_process_ownership,
+            _reap_disconnected_agent_processes,
+        )
+        from tools.process_registry import process_registry
+
+        calls = []
+        monkeypatch.setattr(
+            process_registry,
+            "kill_started_since",
+            lambda *a, **k: calls.append(True) or 1,
+        )
+        monkeypatch.setattr(
+            process_registry, "snapshot_running_ids", lambda _tid: frozenset()
+        )
+
+        run_a = types.SimpleNamespace()
+        run_b = types.SimpleNamespace()
+        _publish_turn_process_ownership(run_a, "shared-session")
+        # Run B claims the same session_id — supersedes A's epoch.
+        _publish_turn_process_ownership(run_b, "shared-session")
+
+        _reap_disconnected_agent_processes(run_a)
+        time.sleep(0.2)
+        assert calls == [], "stale run A must not reap run B's processes"
+
+        # Run B disconnecting IS current — its reap proceeds.
+        _reap_disconnected_agent_processes(run_b)
+        deadline = time.time() + 1.0
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [True]
+        _clear_turn_process_ownership(run_b)
+
+    def test_reap_proceeds_when_own_clear_pruned_the_epoch_entry(self, monkeypatch):
+        """A missing epoch entry (the abandoned run's own finally already
+        cleared it) means no newer claimant — the reap must proceed using a
+        pre-captured marker snapshot, or the leak survives."""
+        from gateway.platforms.api_server import (
+            _clear_turn_process_ownership,
+            _publish_turn_process_ownership,
+            _reap_disconnected_agent_processes,
+        )
+        from tools.process_registry import process_registry
+
+        calls = []
+        monkeypatch.setattr(
+            process_registry,
+            "kill_started_since",
+            lambda *a, **k: calls.append(True) or 1,
+        )
+        monkeypatch.setattr(
+            process_registry, "snapshot_running_ids", lambda _tid: frozenset()
+        )
+
+        run = types.SimpleNamespace()
+        _publish_turn_process_ownership(run, "solo-session")
+        # Simulate the disconnect handler capturing the agent while the
+        # worker's finally clears ownership: snapshot markers, then clear.
+        stale_view = types.SimpleNamespace(
+            _gateway_turn_process_task_id=run._gateway_turn_process_task_id,
+            _gateway_turn_process_baseline=run._gateway_turn_process_baseline,
+            _gateway_turn_process_epoch=run._gateway_turn_process_epoch,
+        )
+        _clear_turn_process_ownership(run)
+
+        _reap_disconnected_agent_processes(stale_view)
+        deadline = time.time() + 1.0
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [True]
+
+    def test_publish_and_clear_ownership_roundtrip(self, monkeypatch):
+        from gateway.platforms.api_server import (
+            _TURN_PROCESS_EPOCHS,
+            _clear_turn_process_ownership,
+            _publish_turn_process_ownership,
+        )
+        from tools.process_registry import process_registry
+
+        monkeypatch.setattr(
+            process_registry,
+            "snapshot_running_ids",
+            lambda tid: frozenset({f"pre-{tid}"}),
+        )
+
+        agent = types.SimpleNamespace()
+        _publish_turn_process_ownership(agent, "sess-rt")
+        assert agent._gateway_turn_process_task_id == "sess-rt"
+        assert agent._gateway_turn_process_baseline == frozenset({"pre-sess-rt"})
+        assert isinstance(agent._gateway_turn_process_epoch, int)
+        assert "sess-rt" in _TURN_PROCESS_EPOCHS
+
+        _clear_turn_process_ownership(agent)
+        assert agent._gateway_turn_process_task_id == ""
+        assert agent._gateway_turn_process_baseline == frozenset()
+        assert agent._gateway_turn_process_epoch is None
+        # Entry pruned — dict stays bounded to in-flight runs.
+        assert "sess-rt" not in _TURN_PROCESS_EPOCHS
+
+    @pytest.mark.asyncio
+    async def test_stop_run_reaps_owned_processes(self, adapter, monkeypatch):
+        """POST /v1/runs/{id}/stop abandons the run — it must reap the
+        background processes that run created (#76115 sibling surface)."""
+        from gateway.platforms.api_server import _publish_turn_process_ownership
+        from tools.process_registry import process_registry
+
+        calls = []
+        monkeypatch.setattr(
+            process_registry,
+            "kill_started_since",
+            lambda task_id, baseline, *, source: calls.append(
+                (task_id, baseline, source)
+            )
+            or 1,
+        )
+        monkeypatch.setattr(
+            process_registry, "snapshot_running_ids", lambda _tid: frozenset()
+        )
+
+        agent = MagicMock()
+        _publish_turn_process_ownership(agent, "run-stop-sess")
+        adapter._active_run_agents["run_x"] = agent
+
+        request = MagicMock()
+        request.match_info = {"run_id": "run_x"}
+        resp = await adapter._handle_stop_run(request)
+        assert resp.status == 200
+
+        deadline = time.time() + 1.0
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [("run-stop-sess", frozenset(), "api_server_run_stop")]
+        agent.interrupt.assert_called_once()
+
 
 class TestRunEventCallback:
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -392,6 +392,95 @@ class TestAgentExecution:
             task_id="session-123",
         )
 
+    @pytest.mark.asyncio
+    async def test_run_agent_sets_and_clears_process_ownership_markers(self, adapter):
+        """#76188 review: this surface runs its own agent lifecycle outside
+        TurnRunner, so it needs its own baseline snapshot/clear — verify the
+        markers _reap_disconnected_agent_processes() reads are actually
+        populated during the turn and cleared once it finishes."""
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        captured = {}
+
+        def _capture_markers(**_kwargs):
+            captured["task_id"] = mock_agent._gateway_turn_process_task_id
+            captured["baseline"] = mock_agent._gateway_turn_process_baseline
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = _capture_markers
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-456",
+                requested_model="MiniMax-M3",
+                requested_provider="minimax",
+                model_options={"reasoning": {"enabled": False}, "fast": False},
+            )
+
+        assert captured["task_id"] == "session-456"
+        assert isinstance(captured["baseline"], frozenset)
+        # Turn completed normally — markers must be cleared so a disconnect
+        # arriving after this point can't reap work this turn left running.
+        assert mock_agent._gateway_turn_process_task_id == ""
+        assert mock_agent._gateway_turn_process_baseline == frozenset()
+
+
+class TestDisconnectedAgentReap:
+    """#76188 review: SSE disconnect handlers must reap only the background
+    processes the disconnected turn created, and must no-op when no turn
+    ownership was ever recorded on the agent."""
+
+    def test_reaps_baseline_diff_for_owned_turn(self, monkeypatch):
+        from gateway.platforms.api_server import _reap_disconnected_agent_processes
+        from tools.process_registry import process_registry
+
+        calls = []
+        monkeypatch.setattr(
+            process_registry,
+            "kill_started_since",
+            lambda task_id, baseline, *, source: calls.append(
+                (task_id, baseline, source)
+            )
+            or 1,
+        )
+        agent = types.SimpleNamespace(
+            _gateway_turn_process_task_id="session-abc",
+            _gateway_turn_process_baseline=frozenset({"proc-1"}),
+        )
+
+        _reap_disconnected_agent_processes(agent)
+
+        deadline = time.time() + 1.0
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [
+            ("session-abc", frozenset({"proc-1"}), "api_server_sse_disconnect")
+        ]
+
+    def test_noop_when_agent_has_no_ownership_markers(self, monkeypatch):
+        from gateway.platforms.api_server import _reap_disconnected_agent_processes
+        from tools.process_registry import process_registry
+
+        calls = []
+        monkeypatch.setattr(
+            process_registry,
+            "kill_started_since",
+            lambda *a, **k: calls.append(True),
+        )
+        agent = types.SimpleNamespace(
+            _gateway_turn_process_task_id="",
+            _gateway_turn_process_baseline=None,
+        )
+
+        _reap_disconnected_agent_processes(agent)
+
+        time.sleep(0.1)
+        assert calls == []
+
 
 class TestRunEventCallback:
 

--- a/tests/gateway/test_tool_response_drop_recovery.py
+++ b/tests/gateway/test_tool_response_drop_recovery.py
@@ -256,7 +256,9 @@ class TestPostStopInterruptSwallow:
         assert "send it again" in response
 
     @pytest.mark.asyncio
-    async def test_interrupt_and_clear_session_evicts_cached_agent(self):
+    async def test_interrupt_and_clear_session_evicts_cached_agent(
+        self, monkeypatch
+    ):
         """The control-interrupt path must evict the session's cached agent
         so its ``_interrupt_requested`` flag cannot leak into the next turn."""
         import threading
@@ -271,6 +273,8 @@ class TestPostStopInterruptSwallow:
                 self.interrupt_reasons.append(reason)
 
         agent = _RecordingAgent()
+        agent._gateway_turn_process_task_id = "session-123"
+        agent._gateway_turn_process_baseline = frozenset({"proc_existing"})
         session_key = "agent:main:telegram:dm:12345"
         source = SessionSource(
             platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"
@@ -291,6 +295,16 @@ class TestPostStopInterruptSwallow:
         runner._release_running_agent_state = (
             lambda key, **kw: released.append(key)
         )
+        reaped = []
+        reaped_event = threading.Event()
+        from tools.process_registry import process_registry
+
+        def _record_reap(task_id, baseline, *, source):
+            reaped.append((task_id, baseline, source))
+            reaped_event.set()
+            return 1
+
+        monkeypatch.setattr(process_registry, "kill_started_since", _record_reap)
 
         await runner._interrupt_and_clear_session(
             session_key,
@@ -301,6 +315,14 @@ class TestPostStopInterruptSwallow:
 
         assert agent.interrupt_reasons == [_INTERRUPT_REASON_STOP]
         assert released == [session_key]
+        assert reaped_event.wait(1)
+        assert reaped == [
+            (
+                "session-123",
+                frozenset({"proc_existing"}),
+                "gateway_turn_interrupt",
+            )
+        ]
         assert session_key not in runner._agent_cache, (
             "Cached agent with a set interrupt flag must be evicted on /stop "
             "so the flag cannot kill the session's next message (#44212)"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -92,6 +92,33 @@ def test_kill_started_since_preserves_preexisting_and_foreign_processes(registry
     ]
 
 
+def test_kill_all_backward_compat_and_exclude_ids(registry):
+    """kill_all keeps its historical default behavior (kill everything for
+    the task, consume_output=False, source='kill_all') and honors the new
+    exclude_ids kwarg that kill_started_since delegates through (#76188)."""
+    a = _make_session(sid="proc_a", task_id="session-a")
+    b = _make_session(sid="proc_b", task_id="session-a")
+    registry._running[a.id] = a
+    registry._running[b.id] = b
+
+    calls = []
+
+    def fake_kill(session_id, **kwargs):
+        calls.append((session_id, kwargs))
+        return {"status": "killed"}
+
+    registry.kill_process = fake_kill
+
+    assert registry.kill_all("session-a", exclude_ids=frozenset({"proc_a"})) == 1
+    assert calls == [
+        ("proc_b", {"source": "kill_all", "consume_output": False})
+    ]
+
+    calls.clear()
+    assert registry.kill_all("session-a") == 2
+    assert sorted(c[0] for c in calls) == ["proc_a", "proc_b"]
+
+
 def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
     """Poll a predicate until it returns truthy or the timeout elapses."""
     deadline = time.monotonic() + timeout

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -55,6 +55,43 @@ def _spawn_python_sleep(seconds: float) -> subprocess.Popen:
     )
 
 
+def test_kill_started_since_preserves_preexisting_and_foreign_processes(registry):
+    old = _make_session(sid="proc_old", task_id="session-a")
+    finished = _make_session(
+        sid="proc_finished", task_id="session-a", exited=True, exit_code=0
+    )
+    registry._running[old.id] = old
+    registry._finished[finished.id] = finished
+    baseline = registry.snapshot_running_ids("session-a")
+
+    new = _make_session(sid="proc_new", task_id="session-a")
+    foreign = _make_session(sid="proc_foreign", task_id="session-b")
+    registry._running[new.id] = new
+    registry._running[foreign.id] = foreign
+
+    calls = []
+
+    def fake_kill(session_id, **kwargs):
+        calls.append((session_id, kwargs))
+        return {"status": "killed"}
+
+    registry.kill_process = fake_kill
+
+    assert baseline == frozenset({"proc_old"})
+    assert registry.kill_started_since(
+        "session-a", baseline, source="gateway_turn_timeout"
+    ) == 1
+    assert calls == [
+        (
+            "proc_new",
+            {
+                "source": "gateway_turn_timeout",
+                "consume_output": True,
+            },
+        )
+    ]
+
+
 def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
     """Poll a predicate until it returns truthy or the timeout elapses."""
     deadline = time.monotonic() + timeout

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1617,7 +1617,10 @@ class ProcessRegistry:
         ``consume_output`` is true for explicit tool/RPC kills because their
         caller observes the returned output. Bulk cleanup passes false: it
         discards each result and therefore must not suppress an autonomous
-        output-bearing completion notification.
+        output-bearing completion notification. Exception: abandoned-turn
+        reaping (``kill_started_since``) is bulk cleanup that deliberately
+        passes true — a killed abandoned process must not enqueue a synthetic
+        follow-up that revives work the timeout/interrupt stopped.
         """
         from tools.ansi_strip import strip_ansi
 
@@ -1951,13 +1954,34 @@ class ProcessRegistry:
         *,
         source: str,
     ) -> int:
-        """Kill processes created for ``task_id`` after a prior snapshot."""
-        baseline = frozenset(baseline_ids or ())
+        """Kill processes created for ``task_id`` after a prior snapshot.
+
+        ``consume_output`` is forced on: abandoned-turn output must not
+        enqueue a synthetic follow-up that revives work the timeout
+        deliberately stopped.
+        """
+        return self.kill_all(
+            task_id,
+            exclude_ids=frozenset(baseline_ids or ()),
+            source=source,
+            consume_output=True,
+        )
+
+    def kill_all(
+        self,
+        task_id: Optional[str] = None,
+        *,
+        exclude_ids: frozenset = frozenset(),
+        source: str = "kill_all",
+        consume_output: bool = False,
+    ) -> int:
+        """Kill all running processes, optionally filtered by task_id. Returns count killed."""
         with self._lock:
             targets = [
-                s
-                for s in self._running.values()
-                if s.task_id == task_id and s.id not in baseline and not s.exited
+                s for s in self._running.values()
+                if (task_id is None or s.task_id == task_id)
+                and s.id not in exclude_ids
+                and not s.exited
             ]
 
         killed = 0
@@ -1965,28 +1989,7 @@ class ProcessRegistry:
             result = self.kill_process(
                 session.id,
                 source=source,
-                # Abandoned-turn output must not enqueue a synthetic follow-up
-                # that revives work the timeout deliberately stopped.
-                consume_output=True,
-            )
-            if result.get("status") in {"killed", "already_exited"}:
-                killed += 1
-        return killed
-
-    def kill_all(self, task_id: str = None) -> int:
-        """Kill all running processes, optionally filtered by task_id. Returns count killed."""
-        with self._lock:
-            targets = [
-                s for s in self._running.values()
-                if (task_id is None or s.task_id == task_id) and not s.exited
-            ]
-
-        killed = 0
-        for session in targets:
-            result = self.kill_process(
-                session.id,
-                source="kill_all",
-                consume_output=False,
+                consume_output=consume_output,
             )
             if result.get("status") in {"killed", "already_exited"}:
                 killed += 1

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1929,6 +1929,50 @@ class ProcessRegistry:
         with self._lock:
             return any(not s.exited for s in self._running.values())
 
+    def snapshot_running_ids(self, task_id: str) -> frozenset[str]:
+        """Capture running process IDs owned by ``task_id``.
+
+        Gateway turns use this as a boundary marker: if a turn times out, only
+        processes absent from its starting snapshot belong to the abandoned
+        turn. Older session processes must survive because background tasks
+        intentionally span successful turns.
+        """
+        with self._lock:
+            return frozenset(
+                s.id
+                for s in self._running.values()
+                if s.task_id == task_id and not s.exited
+            )
+
+    def kill_started_since(
+        self,
+        task_id: str,
+        baseline_ids,
+        *,
+        source: str,
+    ) -> int:
+        """Kill processes created for ``task_id`` after a prior snapshot."""
+        baseline = frozenset(baseline_ids or ())
+        with self._lock:
+            targets = [
+                s
+                for s in self._running.values()
+                if s.task_id == task_id and s.id not in baseline and not s.exited
+            ]
+
+        killed = 0
+        for session in targets:
+            result = self.kill_process(
+                session.id,
+                source=source,
+                # Abandoned-turn output must not enqueue a synthetic follow-up
+                # that revives work the timeout deliberately stopped.
+                consume_output=True,
+            )
+            if result.get("status") in {"killed", "already_exited"}:
+                killed += 1
+        return killed
+
     def kill_all(self, task_id: str = None) -> int:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""
         with self._lock:


### PR DESCRIPTION
## Summary

Abandoned gateway turns (inactivity timeout, /stop, /new, SSE disconnect) now reap only the background processes they created — pre-existing session processes and work a successful turn deliberately left running survive. Fixes #76115, where a single leaked `next build` pushed the gateway cgroup past MemoryHigh, starved the event loop, and took every platform connection and cron offline.

Salvages #76188 by @JoaoMarcos44 — all three commits cherry-picked with authorship preserved — plus three follow-up commits fixing review findings.

## Changes

Salvaged (@JoaoMarcos44, authorship preserved):
- `tools/process_registry.py`: `snapshot_running_ids(task_id)` + `kill_started_since(task_id, baseline, source=...)` — baseline-diff ownership.
- `gateway/run.py`: per-turn baseline snapshot; daemon watchdog thread (immune to event-loop starvation — the failure mode itself); shared `_reap_gateway_turn_processes` for the timeout and /stop//new//disconnect paths; `run_generation` gating so a stale reaper can't kill a replacement turn's process; ownership markers cleared the instant the worker returns.
- `gateway/platforms/api_server.py`: mirrored baseline + SSE-disconnect reap for the API surface (own agent lifecycle, no TurnRunner).

Follow-ups (review findings):
- `gateway/run.py`: blank `task_id` no longer reaps (would match every sessionless process registered with `task_id=""`); the asyncio poll prefers the finished worker's real result over the watchdog's timeout flag when both race (the reply was already persisted to history — the diagnostic would contradict the transcript).
- `gateway/platforms/api_server.py`: the disconnect reap is now epoch-gated — concurrent API runs can intentionally share a client-provided session_id (= task_id), so a disconnecting run must not kill a still-live concurrent run's processes (same bug class the salvaged fix gates on the gateway path via run_generation). Marker set/clear consolidated into `_publish/_clear_turn_process_ownership` helpers. `/v1/runs` — the third own-lifecycle surface — now records ownership and reaps on `POST /v1/runs/{id}/stop` and server-side SSE cancellation.
- `tools/process_registry.py`: `kill_started_since` folded into `kill_all` via `exclude_ids`/`source`/`consume_output` kwargs (was a line-for-line copy); public signatures unchanged.

## Validation

| Check | Result |
|---|---|
| Targeted suites (api_server, abandoned-turn, turn_context, drop-recovery, process_registry) | 172 passed, 1 pre-existing env-dependent failure (health `degraded`, fails identically on upstream/main) |
| E2E with real subprocesses (fresh registry, `sleep 300` × 3) | pre-existing survives, turn-spawned killed (SIGTERM), foreign session survives; re-run after refactor: pass |
| Mutation checks | removing empty-task_id guard → test fails; breaking epoch gate → test fails; dropping exclude_ids → 2 tests fail; restored → all green |
| ruff on all touched files | clean |

Based on #76188 by @JoaoMarcos44 — commits cherry-picked to preserve authorship. Closes #76115.
