### PR TITLE
fix(cli): bound managed uv python provisioning with subprocess timeouts

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -217,13 +217,22 @@ def _ensure_uv_path(
     # Verify
     result = resolve_uv()
     if result:
-        version = subprocess.run(
-            [result, "--version"],
-            capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
-            check=False,
-        timeout=UV_VERSION_TIMEOUT_SECONDS,
-        ).stdout.strip()
+        try:
+            version = subprocess.run(
+                [result, "--version"],
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                check=False,
+                timeout=UV_VERSION_TIMEOUT_SECONDS,
+            ).stdout.strip()
+        except subprocess.TimeoutExpired:
+            # Non-fatal: the binary is present and usable; only the label probe
+            # hung. Callers (e.g. ``hermes update``) invoke ensure_uv unguarded.
+            logger.debug(
+                "uv --version timed out after %ss after install",
+                UV_VERSION_TIMEOUT_SECONDS,
+            )
+            version = "version unavailable"
         print(f"  ✓ Managed uv installed ({version})")
         # Compatibility boundary: an older, already-imported updater calls the
         # freshly pulled ``ensure_uv()`` after bootstrapping uv.  Repair here so
@@ -360,13 +369,22 @@ def update_managed_uv(
             result = None
         if result is not None and result.returncode == 0:
             _touch_uv_self_update_stamp()
-            version = subprocess.run(
-                [existing, "--version"],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                check=False,
-            timeout=UV_VERSION_TIMEOUT_SECONDS,
-        ).stdout.strip()
+            try:
+                version = subprocess.run(
+                    [existing, "--version"],
+                    capture_output=True,
+                    text=True, encoding='utf-8', errors='replace',
+                    check=False,
+                    timeout=UV_VERSION_TIMEOUT_SECONDS,
+                ).stdout.strip()
+            except subprocess.TimeoutExpired:
+                # Non-fatal: self-update already succeeded; only the label probe
+                # hung. ``hermes update`` calls this unguarded.
+                logger.debug(
+                    "uv --version timed out after %ss after self update",
+                    UV_VERSION_TIMEOUT_SECONDS,
+                )
+                version = "version unavailable"
             print(f"  ✓ Managed uv updated ({version})")
         elif result is not None:
             # Non-fatal — old uv still works fine.
@@ -1019,7 +1037,7 @@ def _uv_version_string(uv_bin: str) -> str:
             encoding="utf-8",
             errors="replace",
             check=False,
-            timeout=UV_PYTHON_LIST_TIMEOUT_SECONDS,
+            timeout=UV_VERSION_TIMEOUT_SECONDS,
         )
     except Exception:
         return ""

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -584,6 +584,12 @@ def _attempt_install_generation(
             request,
             UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
         )
+        # Immediate operator feedback (stdout may be quiet under logging-only).
+        print(
+            f"  ✗ uv python install timed out after {UV_PYTHON_INSTALL_TIMEOUT_SECONDS}s"
+            " — check your network connection.",
+            file=sys.stderr,
+        )
         _remove_tree(generation, boundary=python_root)
         return None
     if install.returncode != 0:
@@ -618,6 +624,11 @@ def _attempt_install_generation(
             "private Python lookup timed out for %s after %ss",
             request,
             UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  ✗ uv python find timed out after {UV_PYTHON_FIND_TIMEOUT_SECONDS}s"
+            " — check your network connection.",
+            file=sys.stderr,
         )
         _remove_tree(generation, boundary=python_root)
         return None
@@ -821,6 +832,11 @@ def _stage_candidate_venv(
             "candidate venv creation timed out after %ss",
             UV_VENV_TIMEOUT_SECONDS,
         )
+        print(
+            f"  ✗ uv venv timed out after {UV_VENV_TIMEOUT_SECONDS}s"
+            " — check your network connection.",
+            file=sys.stderr,
+        )
         _remove_tree(candidate, boundary=runtime_root)
         return None
     if created.returncode != 0:
@@ -860,6 +876,11 @@ def _stage_candidate_venv(
         logger.warning(
             "candidate dependency sync timed out after %ss",
             UV_SYNC_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  ✗ uv sync timed out after {UV_SYNC_TIMEOUT_SECONDS}s"
+            " — check your network connection.",
+            file=sys.stderr,
         )
         _remove_tree(candidate, boundary=runtime_root)
         return None

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -222,6 +222,7 @@ def _ensure_uv_path(
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             check=False,
+        timeout=UV_VERSION_TIMEOUT_SECONDS,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
         # Compatibility boundary: an older, already-imported updater calls the
@@ -310,6 +311,17 @@ UV_SELF_UPDATE_INTERVAL_SECONDS = 7 * 24 * 3600
 # `uv self update` is a network call; unbounded it can hang forever on a
 # blackholed connection (no default timeout in uv's downloader path).
 UV_SELF_UPDATE_TIMEOUT_SECONDS = 60
+# Network-bound uv python provisioning can hang forever on blackholed
+# connectivity (observed on restricted networks during every-update
+# SQLite-runtime repair). Bound every download/install/find/sync step.
+UV_PYTHON_LIST_TIMEOUT_SECONDS = 30
+UV_PYTHON_INSTALL_TIMEOUT_SECONDS = 180
+UV_PYTHON_FIND_TIMEOUT_SECONDS = 30
+UV_VENV_TIMEOUT_SECONDS = 60
+UV_SYNC_TIMEOUT_SECONDS = 300
+UV_VERSION_TIMEOUT_SECONDS = 15
+UV_BOOTSTRAP_DOWNLOAD_TIMEOUT_SECONDS = 120
+UV_BOOTSTRAP_INSTALL_TIMEOUT_SECONDS = 180
 
 
 def update_managed_uv(
@@ -353,7 +365,8 @@ def update_managed_uv(
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 check=False,
-            ).stdout.strip()
+            timeout=UV_VERSION_TIMEOUT_SECONDS,
+        ).stdout.strip()
             print(f"  ✓ Managed uv updated ({version})")
         elif result is not None:
             # Non-fatal — old uv still works fine.
@@ -477,7 +490,7 @@ def _list_available_patches(
             capture_output=True,
             text=True,
             check=False,
-            timeout=15,
+            timeout=UV_PYTHON_LIST_TIMEOUT_SECONDS,
         )
         if result.returncode != 0 or not result.stdout.strip():
             return []
@@ -528,23 +541,33 @@ def _attempt_install_generation(
     _make_world_traversable(generation)
 
     env = managed_python_env(project_root, install_dir=generation)
-    install = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "install",
+    try:
+        install = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "install",
+                request,
+                "--reinstall",
+                "--no-bin",
+                "--no-registry",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python install timed out for %s after %ss",
             request,
-            "--reinstall",
-            "--no-bin",
-            "--no-registry",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+            UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if install.returncode != 0:
         logger.warning(
             "private Python install failed for %s (rc=%d): %s",
@@ -555,21 +578,31 @@ def _attempt_install_generation(
         _remove_tree(generation, boundary=python_root)
         return None
 
-    found = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "find",
+    try:
+        found = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "find",
+                request,
+                "--managed-python",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python lookup timed out for %s after %ss",
             request,
-            "--managed-python",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+            UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if found.returncode != 0 or not found.stdout.strip():
         logger.warning(
             "private Python lookup failed for %s (rc=%d): %s",
@@ -745,24 +778,33 @@ def _stage_candidate_venv(
     })
 
     print("  → Building a relocatable replacement environment...")
-    created = subprocess.run(
-        [
-            uv_bin,
-            "venv",
-            str(candidate),
-            "--python",
-            str(python),
-            "--managed-python",
-            "--no-python-downloads",
-            "--relocatable",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        created = subprocess.run(
+            [
+                uv_bin,
+                "venv",
+                str(candidate),
+                "--python",
+                str(python),
+                "--managed-python",
+                "--no-python-downloads",
+                "--relocatable",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_VENV_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate venv creation timed out after %ss",
+            UV_VENV_TIMEOUT_SECONDS,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
     if created.returncode != 0:
         logger.warning(
             "candidate venv creation failed (rc=%d): %s",
@@ -780,20 +822,29 @@ def _stage_candidate_venv(
     # UV_NO_CONFIG drops it and uv 0.12+ refuses --locked.
     sync_env = dict(env)
     sync_env.pop("UV_NO_CONFIG", None)
-    synced = subprocess.run(
-        [
-            uv_bin,
-            "sync",
-            "--extra",
-            "all",
-            "--locked",
-            "--python",
-            str(_venv_python(candidate)),
-        ],
-        cwd=project_root,
-        env=sync_env,
-        check=False,
-    )
+    try:
+        synced = subprocess.run(
+            [
+                uv_bin,
+                "sync",
+                "--extra",
+                "all",
+                "--locked",
+                "--python",
+                str(_venv_python(candidate)),
+            ],
+            cwd=project_root,
+            env=sync_env,
+            check=False,
+            timeout=UV_SYNC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate dependency sync timed out after %ss",
+            UV_SYNC_TIMEOUT_SECONDS,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
     if synced.returncode != 0:
         logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
         _remove_tree(candidate, boundary=runtime_root)
@@ -968,7 +1019,7 @@ def _uv_version_string(uv_bin: str) -> str:
             encoding="utf-8",
             errors="replace",
             check=False,
-            timeout=15,
+            timeout=UV_PYTHON_LIST_TIMEOUT_SECONDS,
         )
     except Exception:
         return ""
@@ -1275,12 +1326,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=UV_BOOTSTRAP_DOWNLOAD_TIMEOUT_SECONDS,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=UV_BOOTSTRAP_INSTALL_TIMEOUT_SECONDS,
         )
     finally:
         try:
@@ -1297,6 +1350,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=UV_BOOTSTRAP_INSTALL_TIMEOUT_SECONDS,
     )
 
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1100,3 +1100,46 @@ class TestVenvPythonUpdateBoundary:
             "/opt/hermes/venv/bin/python"
         )
 
+
+
+class TestManagedUvSubprocessTimeouts:
+    """#76684: network-bound uv provisioning must not hang forever."""
+
+    def test_timeout_constants_are_positive(self):
+        from hermes_cli import managed_uv as m
+
+        assert m.UV_PYTHON_INSTALL_TIMEOUT_SECONDS > 0
+        assert m.UV_PYTHON_FIND_TIMEOUT_SECONDS > 0
+        assert m.UV_VENV_TIMEOUT_SECONDS > 0
+        assert m.UV_SYNC_TIMEOUT_SECONDS > 0
+        assert m.UV_PYTHON_LIST_TIMEOUT_SECONDS > 0
+
+    def test_attempt_install_generation_treats_timeout_as_failure(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_uv as m
+        import subprocess
+        from types import SimpleNamespace
+
+        python_root = tmp_path / "python"
+        python_root.mkdir()
+        project_root = tmp_path
+        current = SimpleNamespace(
+            python_version=(3, 11, 0),
+            wal_reset_vulnerable=True,
+            sqlite_version_string="3.50.4",
+        )
+
+        def _timeout(*_a, **_k):
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        monkeypatch.setattr(m.subprocess, "run", _timeout)
+        result = m._attempt_install_generation(
+            "uv",
+            "3.11",
+            project_root=project_root,
+            python_root=python_root,
+            current=current,
+        )
+        assert result is None
+        # generation dir cleaned up on timeout
+        gens = list(python_root.glob("generation-*"))
+        assert gens == []

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1116,7 +1116,7 @@ class TestManagedUvSubprocessTimeouts:
         assert m.UV_VERSION_TIMEOUT_SECONDS > 0
         assert m.UV_VERSION_TIMEOUT_SECONDS != m.UV_PYTHON_LIST_TIMEOUT_SECONDS
 
-    def test_attempt_install_generation_treats_timeout_as_failure(self, tmp_path, monkeypatch):
+    def test_attempt_install_generation_treats_timeout_as_failure(self, tmp_path, monkeypatch, capsys):
         from hermes_cli import managed_uv as m
         import subprocess
         from types import SimpleNamespace
@@ -1130,7 +1130,10 @@ class TestManagedUvSubprocessTimeouts:
             sqlite_version_string="3.50.4",
         )
 
-        def _timeout(*_a, **_k):
+        seen = {}
+
+        def _timeout(*_a, **kwargs):
+            seen["timeout"] = kwargs.get("timeout")
             raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
 
         monkeypatch.setattr(m.subprocess, "run", _timeout)
@@ -1145,6 +1148,43 @@ class TestManagedUvSubprocessTimeouts:
         # generation dir cleaned up on timeout
         gens = list(python_root.glob("generation-*"))
         assert gens == []
+        assert seen["timeout"] == m.UV_PYTHON_INSTALL_TIMEOUT_SECONDS
+        err = capsys.readouterr().err
+        assert "uv python install timed out" in err
+        assert str(m.UV_PYTHON_INSTALL_TIMEOUT_SECONDS) in err
+
+    def test_stage_candidate_venv_timeout_prints_stderr_and_uses_timeout(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from hermes_cli import managed_uv as m
+        import subprocess
+
+        project_root = tmp_path
+        generation = tmp_path / "python" / "generation-x"
+        generation.mkdir(parents=True)
+        python = generation / "bin" / "python"
+        python.parent.mkdir(parents=True, exist_ok=True)
+        python.write_text("#!/bin/sh\n")
+        python.chmod(0o755)
+
+        seen = {}
+
+        def _timeout(*_a, **kwargs):
+            seen["timeout"] = kwargs.get("timeout")
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        monkeypatch.setattr(m.subprocess, "run", _timeout)
+        result = m._stage_candidate_venv(
+            "uv",
+            project_root=project_root,
+            generation=generation,
+            python=python,
+        )
+        assert result is None
+        assert seen["timeout"] == m.UV_VENV_TIMEOUT_SECONDS
+        err = capsys.readouterr().err
+        assert "uv venv timed out" in err
+        assert str(m.UV_VENV_TIMEOUT_SECONDS) in err
 
     def test_ensure_uv_version_probe_timeout_still_returns_path(self, tmp_path, capsys):
         """Post-install ``uv --version`` timeout must not abort ensure_uv."""

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1113,6 +1113,8 @@ class TestManagedUvSubprocessTimeouts:
         assert m.UV_VENV_TIMEOUT_SECONDS > 0
         assert m.UV_SYNC_TIMEOUT_SECONDS > 0
         assert m.UV_PYTHON_LIST_TIMEOUT_SECONDS > 0
+        assert m.UV_VERSION_TIMEOUT_SECONDS > 0
+        assert m.UV_VERSION_TIMEOUT_SECONDS != m.UV_PYTHON_LIST_TIMEOUT_SECONDS
 
     def test_attempt_install_generation_treats_timeout_as_failure(self, tmp_path, monkeypatch):
         from hermes_cli import managed_uv as m
@@ -1143,3 +1145,82 @@ class TestManagedUvSubprocessTimeouts:
         # generation dir cleaned up on timeout
         gens = list(python_root.glob("generation-*"))
         assert gens == []
+
+    def test_ensure_uv_version_probe_timeout_still_returns_path(self, tmp_path, capsys):
+        """Post-install ``uv --version`` timeout must not abort ensure_uv."""
+        import subprocess
+        from hermes_cli.managed_uv import ensure_uv
+
+        def fake_install(target):
+            _make_executable(target)
+
+        def fake_run(cmd, *args, **kwargs):
+            if len(cmd) >= 2 and cmd[1] == "--version":
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")), \
+             patch("hermes_cli.managed_uv._install_uv", side_effect=fake_install), \
+             patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.managed_uv.platform.system", return_value="Linux"):
+            path = ensure_uv()
+
+        assert path == str(tmp_path / "bin" / "uv")
+        out = capsys.readouterr().out
+        assert "Managed uv installed" in out
+        assert "version unavailable" in out
+
+    def test_update_managed_uv_version_probe_timeout_is_nonfatal(self, tmp_path, capsys):
+        """Post-self-update ``uv --version`` timeout must not fail update_managed_uv."""
+        import os as _os
+        import subprocess
+        import time as _time
+
+        from hermes_cli.managed_uv import (
+            UV_SELF_UPDATE_INTERVAL_SECONDS,
+            update_managed_uv,
+        )
+
+        uv = tmp_path / "bin" / "uv"
+        _make_executable(uv)
+        import hermes_constants
+        stamp = hermes_constants.get_hermes_home() / "cache" / ".uv_self_update_stamp"
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch()
+        old = _time.time() - UV_SELF_UPDATE_INTERVAL_SECONDS - 60
+        _os.utime(stamp, (old, old))
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[-2:] == ["self", "update"] or (
+                len(cmd) >= 3 and cmd[1] == "self" and cmd[2] == "update"
+            ):
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if len(cmd) >= 2 and cmd[1] == "--version":
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.repair_vulnerable_runtime", return_value=_RRR("not-applicable")), \
+             patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run):
+            result = update_managed_uv()
+
+        assert result == str(uv)
+        out = capsys.readouterr().out
+        assert "Managed uv updated" in out
+        assert "version unavailable" in out
+
+    def test_uv_version_string_uses_version_timeout_and_swallows_timeout(self, monkeypatch):
+        """_uv_version_string must use UV_VERSION_TIMEOUT_SECONDS and return '' on timeout."""
+        import subprocess
+        from hermes_cli import managed_uv as m
+
+        seen = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            seen["timeout"] = kwargs.get("timeout")
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+
+        monkeypatch.setattr(m.subprocess, "run", fake_run)
+        assert m._uv_version_string("/fake/uv") == ""
+        assert seen["timeout"] == m.UV_VERSION_TIMEOUT_SECONDS


### PR DESCRIPTION
## What does this PR do?

`hermes update` can hang forever during managed Python runtime repair when `uv python install` / `find` / `venv` / `sync` stall on a blackholed connection. Those `subprocess.run` calls had no `timeout=`, while `uv self update` already does.

This PR:

- Adds explicit timeout constants for list/install/find/venv/sync/bootstrap steps
- Treats `TimeoutExpired` as a non-fatal failure (clean up partial generation, continue / report)
- Keeps existing `uv self update` timeout behavior

## Related work

Fixes #76684

Older open PRs (#42488, #42769, #42857) attempted partial timeouts but are merge-conflicting with current main and do not cover the `uv python install` path that hangs in the report. Happy for maintainers to close those as superseded once this lands.

## Test plan

```
pytest tests/hermes_cli/test_managed_uv.py::TestManagedUvSubprocessTimeouts -q
```

2/2 passed (constants + install-generation TimeoutExpired cleanup).