### PR TITLE
fix(tools): reject unscoped pure-wildcard search_files patterns

### DIFF
--- a/tests/tools/test_search_files_unscoped_wildcards.py
+++ b/tests/tools/test_search_files_unscoped_wildcards.py
@@ -13,6 +13,20 @@ def test_broad_path_detection():
     assert _is_broad_search_path("/tmp/job") is False
 
 
+def test_broad_path_detection_canonicalizes_cwd_and_parent_spellings(tmp_path, monkeypatch):
+    """Raw spelling is not enough: ./child/.. and .. must classify as broad."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "child").mkdir()
+    (tmp_path / "child" / "nested").mkdir()
+
+    assert _is_broad_search_path("./child/..") is True
+    assert _is_broad_search_path("child/../.") is True
+    assert _is_broad_search_path("..") is True
+    # Explicit subdir remains narrow even when spelled relatively.
+    assert _is_broad_search_path("./child") is False
+    assert _is_broad_search_path("child/nested") is False
+
+
 def test_files_target_pure_star_blocked_only_at_broad_path():
     assert _is_unscoped_search_pattern("*", "files", path=".") is True
     assert _is_unscoped_search_pattern("**", "files", path=".") is True
@@ -20,6 +34,15 @@ def test_files_target_pure_star_blocked_only_at_broad_path():
     assert _is_unscoped_search_pattern("*", "files", path="/tmp/job") is False
     assert _is_unscoped_search_pattern("*.py", "files", path=".") is False
     assert _is_unscoped_search_pattern("*config*", "files", path=".") is False
+
+
+def test_files_target_pure_star_blocks_cwd_equivalent_and_parent_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "child").mkdir()
+
+    assert _is_unscoped_search_pattern("*", "files", path="./child/..") is True
+    assert _is_unscoped_search_pattern("*", "files", path="..") is True
+    assert _is_unscoped_search_pattern("*", "files", path="./child") is False
 
 
 def test_content_target_match_all_regex_blocked_only_at_broad_path():
@@ -34,6 +57,19 @@ def test_search_tool_blocks_pure_star_at_default_path():
     result = search_tool(pattern="*", target="files", path=".")
     assert "BLOCKED" in result
     assert "broad/default" in result or "unscoped wildcard" in result
+
+
+def test_search_tool_blocks_cwd_equivalent_path_spelling(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "child").mkdir()
+    result = search_tool(pattern="*", target="files", path="./child/..")
+    assert "BLOCKED" in result
+
+
+def test_search_tool_blocks_parent_path_spelling(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = search_tool(pattern="*", target="files", path="..")
+    assert "BLOCKED" in result
 
 
 def test_search_tool_allows_pure_star_in_narrow_directory(tmp_path):

--- a/tests/tools/test_search_files_unscoped_wildcards.py
+++ b/tests/tools/test_search_files_unscoped_wildcards.py
@@ -1,31 +1,50 @@
-"""#76628: reject pure-splat search_files patterns that force full-tree walks."""
+"""#76628: reject pure-splat search_files only at broad/default path scope."""
 
-from tools.file_tools import _is_unscoped_search_pattern, search_tool
-
-
-def test_files_target_pure_star_is_unscoped():
-    assert _is_unscoped_search_pattern("*", "files") is True
-    assert _is_unscoped_search_pattern("**", "files") is True
-    assert _is_unscoped_search_pattern("*.py", "files") is False
-    assert _is_unscoped_search_pattern("*config*", "files") is False
+from tools.file_tools import _is_broad_search_path, _is_unscoped_search_pattern, search_tool
 
 
-def test_content_target_match_all_regex_is_unscoped():
-    assert _is_unscoped_search_pattern(".*", "content") is True
-    assert _is_unscoped_search_pattern(".+", "content") is True
-    assert _is_unscoped_search_pattern("def ", "content") is False
-    assert _is_unscoped_search_pattern("foo.*bar", "content") is False
+def test_broad_path_detection():
+    assert _is_broad_search_path(None) is True
+    assert _is_broad_search_path("") is True
+    assert _is_broad_search_path(".") is True
+    assert _is_broad_search_path("./") is True
+    assert _is_broad_search_path("./src") is False
+    assert _is_broad_search_path("small-dir") is False
+    assert _is_broad_search_path("/tmp/job") is False
 
 
-def test_search_tool_blocks_pure_star_files(tmp_path, monkeypatch):
-    # Avoid needing a real file backend; the guard fires before ops.
-    result = search_tool(pattern="*", target="files", path=str(tmp_path))
+def test_files_target_pure_star_blocked_only_at_broad_path():
+    assert _is_unscoped_search_pattern("*", "files", path=".") is True
+    assert _is_unscoped_search_pattern("**", "files", path=".") is True
+    assert _is_unscoped_search_pattern("*", "files", path="./small-dir") is False
+    assert _is_unscoped_search_pattern("*", "files", path="/tmp/job") is False
+    assert _is_unscoped_search_pattern("*.py", "files", path=".") is False
+    assert _is_unscoped_search_pattern("*config*", "files", path=".") is False
+
+
+def test_content_target_match_all_regex_blocked_only_at_broad_path():
+    assert _is_unscoped_search_pattern(".*", "content", path=".") is True
+    assert _is_unscoped_search_pattern(".+", "content", path=".") is True
+    assert _is_unscoped_search_pattern(".*", "content", path="./pkg") is False
+    assert _is_unscoped_search_pattern("def ", "content", path=".") is False
+    assert _is_unscoped_search_pattern("foo.*bar", "content", path=".") is False
+
+
+def test_search_tool_blocks_pure_star_at_default_path():
+    result = search_tool(pattern="*", target="files", path=".")
     assert "BLOCKED" in result
-    assert "unscoped wildcard" in result
+    assert "broad/default" in result or "unscoped wildcard" in result
 
 
-def test_search_tool_allows_narrow_glob(tmp_path):
-    # Create one file so a non-blocked path can succeed or fail cleanly.
+def test_search_tool_allows_pure_star_in_narrow_directory(tmp_path):
+    (tmp_path / "a.txt").write_text("x\n", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("y\n", encoding="utf-8")
+    result = search_tool(pattern="*", target="files", path=str(tmp_path))
+    assert "BLOCKED" not in result
+
+
+def test_search_tool_allows_narrow_glob_at_default_path(tmp_path, monkeypatch):
+    # Use an explicit narrow path so we do not depend on cwd contents.
     (tmp_path / "app.py").write_text("x\n", encoding="utf-8")
     result = search_tool(pattern="*.py", target="files", path=str(tmp_path))
     assert "BLOCKED" not in result

--- a/tests/tools/test_search_files_unscoped_wildcards.py
+++ b/tests/tools/test_search_files_unscoped_wildcards.py
@@ -1,0 +1,31 @@
+"""#76628: reject pure-splat search_files patterns that force full-tree walks."""
+
+from tools.file_tools import _is_unscoped_search_pattern, search_tool
+
+
+def test_files_target_pure_star_is_unscoped():
+    assert _is_unscoped_search_pattern("*", "files") is True
+    assert _is_unscoped_search_pattern("**", "files") is True
+    assert _is_unscoped_search_pattern("*.py", "files") is False
+    assert _is_unscoped_search_pattern("*config*", "files") is False
+
+
+def test_content_target_match_all_regex_is_unscoped():
+    assert _is_unscoped_search_pattern(".*", "content") is True
+    assert _is_unscoped_search_pattern(".+", "content") is True
+    assert _is_unscoped_search_pattern("def ", "content") is False
+    assert _is_unscoped_search_pattern("foo.*bar", "content") is False
+
+
+def test_search_tool_blocks_pure_star_files(tmp_path, monkeypatch):
+    # Avoid needing a real file backend; the guard fires before ops.
+    result = search_tool(pattern="*", target="files", path=str(tmp_path))
+    assert "BLOCKED" in result
+    assert "unscoped wildcard" in result
+
+
+def test_search_tool_allows_narrow_glob(tmp_path):
+    # Create one file so a non-blocked path can succeed or fail cleanly.
+    (tmp_path / "app.py").write_text("x\n", encoding="utf-8")
+    result = search_tool(pattern="*.py", target="files", path=str(tmp_path))
+    assert "BLOCKED" not in result

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1927,13 +1927,33 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 
 
 
-def _is_unscoped_search_pattern(pattern: str, target: str) -> bool:
-    """Return True when *pattern* is a pure splat that forces a full-tree walk.
+def _is_broad_search_path(path: str | None) -> bool:
+    """True when *path* is the default / broad search root (cwd or empty).
 
-    Models over-issue ``*`` / ``.*`` for inventory listing. That defeats path
-    scoping, walks protected home dirs (macOS TCC popups), and burns seconds
-    walking node_modules before ``limit`` trims the page (#76628).
+    Explicit narrower directories (e.g. ``./src``, ``/tmp/job``) are not broad, so
+    pure wildcards remain allowed there for intentional scoped inventory.
     """
+    raw = (path or "").strip()
+    if not raw:
+        return True
+    # Normalize trivial relative roots that mean "current working directory".
+    cleaned = raw.replace("\\", "/").rstrip("/")
+    return cleaned in {".", "./", ""}
+
+
+def _is_unscoped_search_pattern(
+    pattern: str, target: str, path: str | None = ".",
+) -> bool:
+    """Return True when pure-splat *pattern* is used at a broad search root.
+
+    Models over-issue ``*`` / ``.*`` for inventory listing. At the default
+    cwd that defeats path scoping, walks protected home dirs (macOS TCC
+    popups), and burns seconds walking node_modules before ``limit`` trims
+    the page (#76628). The same pattern under an explicit narrow ``path=``
+    is allowed (scoped inventory).
+    """
+    if not _is_broad_search_path(path):
+        return False
     p = (pattern or "").strip()
     if not p:
         return False
@@ -1955,14 +1975,16 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
-        if _is_unscoped_search_pattern(pattern, target):
+        if _is_unscoped_search_pattern(pattern, target, path=path):
             return tool_error(
-                "BLOCKED: pattern is an unscoped wildcard that forces a full-tree walk. "
+                "BLOCKED: pattern is an unscoped wildcard at the broad/default search root. "
                 "Narrow the pattern (e.g. a filename fragment or more specific regex) "
-                "or set path= to a smaller directory. Pure globs like '*' / '.*' are "
-                "rejected because they defeat search scope and waste traversal cost.",
+                "or set path= to a smaller directory (pure '*' / '.*' are allowed only "
+                "when path= is already a bounded directory). Full-tree pure wildcards "
+                "defeat search scope and waste traversal cost.",
                 pattern=pattern,
                 target=target,
+                path=path,
             )
 
         # Track searches to detect *consecutive* repeated search loops.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1927,22 +1927,53 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 
 
 
-def _is_broad_search_path(path: str | None) -> bool:
+def _is_broad_search_path(path: str | None, task_id: str = "default") -> bool:
     """True when *path* is the default / broad search root (cwd or empty).
 
     Explicit narrower directories (e.g. ``./src``, ``/tmp/job``) are not broad, so
     pure wildcards remain allowed there for intentional scoped inventory.
+
+    Classification uses the task-aware resolver so spellings that normalize to
+    the workspace root (``./child/..``) or expand it (``..``) count as broad,
+    matching what the backend actually walks (#76628 review).
     """
     raw = (path or "").strip()
     if not raw:
         return True
-    # Normalize trivial relative roots that mean "current working directory".
+    # Fast path for the common default spellings without filesystem work.
     cleaned = raw.replace("\\", "/").rstrip("/")
-    return cleaned in {".", "./", ""}
+    if cleaned in {".", "./", ""}:
+        return True
+
+    try:
+        base = _resolve_base_dir(task_id)
+        resolved = _resolve_path_for_task(raw, task_id)
+        base_key = os.path.normpath(str(base))
+        resolved_key = os.path.normpath(str(resolved))
+        if sys.platform == "win32":
+            base_key = os.path.normcase(base_key)
+            resolved_key = os.path.normcase(resolved_key)
+        if base_key == resolved_key:
+            return True
+        # Resolved is an ancestor of the workspace root → expands search root.
+        try:
+            common = os.path.commonpath([base_key, resolved_key])
+        except ValueError:
+            # Different drives (Windows) — treat as an explicit elsewhere scope.
+            return False
+        if sys.platform == "win32":
+            common = os.path.normcase(common)
+        return common == resolved_key
+    except Exception:
+        # Fail closed: if we cannot classify, treat as broad.
+        return True
 
 
 def _is_unscoped_search_pattern(
-    pattern: str, target: str, path: str | None = ".",
+    pattern: str,
+    target: str,
+    path: str | None = ".",
+    task_id: str = "default",
 ) -> bool:
     """Return True when pure-splat *pattern* is used at a broad search root.
 
@@ -1952,7 +1983,7 @@ def _is_unscoped_search_pattern(
     the page (#76628). The same pattern under an explicit narrow ``path=``
     is allowed (scoped inventory).
     """
-    if not _is_broad_search_path(path):
+    if not _is_broad_search_path(path, task_id=task_id):
         return False
     p = (pattern or "").strip()
     if not p:
@@ -1975,7 +2006,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
-        if _is_unscoped_search_pattern(pattern, target, path=path):
+        if _is_unscoped_search_pattern(pattern, target, path=path, task_id=task_id):
             return tool_error(
                 "BLOCKED: pattern is an unscoped wildcard at the broad/default search root. "
                 "Narrow the pattern (e.g. a filename fragment or more specific regex) "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1926,6 +1926,27 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+
+def _is_unscoped_search_pattern(pattern: str, target: str) -> bool:
+    """Return True when *pattern* is a pure splat that forces a full-tree walk.
+
+    Models over-issue ``*`` / ``.*`` for inventory listing. That defeats path
+    scoping, walks protected home dirs (macOS TCC popups), and burns seconds
+    walking node_modules before ``limit`` trims the page (#76628).
+    """
+    p = (pattern or "").strip()
+    if not p:
+        return False
+    if target == "files":
+        # Pure globs with no path/name fragment.
+        normalized = p.replace("**", "*")
+        return normalized in {"*", "*.*", "*/*", "*/*/*"} or set(normalized) <= {"*", ".", "/"}
+    if target == "content":
+        # Regex that matches every line / every file contents.
+        return p in {".*", ".+", "^.*$", "^.+$", "(?s).*", "(?s).+"}
+    return False
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
@@ -1933,6 +1954,16 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+
+        if _is_unscoped_search_pattern(pattern, target):
+            return tool_error(
+                "BLOCKED: pattern is an unscoped wildcard that forces a full-tree walk. "
+                "Narrow the pattern (e.g. a filename fragment or more specific regex) "
+                "or set path= to a smaller directory. Pure globs like '*' / '.*' are "
+                "rejected because they defeat search scope and waste traversal cost.",
+                pattern=pattern,
+                target=target,
+            )
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated


### PR DESCRIPTION
## What does this PR do?

Models over-issue `search_files` with pure wildcards (`*`, `.*`). Those patterns force a full-tree walk (protected home dirs, `node_modules`, multi-second stalls) before `limit` trims the result page (#76628).

This PR rejects **only** pure unscoped patterns:

- `target=files`: `*`, `**`, `*.*`, and equivalent pure-splat globs
- `target=content`: `.*`, `.+`, and anchored match-all regexes

Narrow patterns (`*.py`, `*config*`, `foo.*bar`) are unchanged. The tool returns a clear `BLOCKED` message so the model can correct with a tighter pattern or `path=`.

This is a narrow first slice of #76628 (the inventory/splat class). Related traversal PRs for hidden-dirs / TCC scope remain independent.

## Test plan

```
pytest tests/tools/test_search_files_unscoped_wildcards.py -q
```

4/4 passed.