### PR TITLE
fix(responses): emit type=message on assistant input items (#76657)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -595,16 +595,18 @@ def _chat_messages_to_responses_input(
                 if replayed_message_items > 0:
                     pass
                 elif content_parts:
-                    items.append({"role": "assistant", "content": content_parts})
+                    items.append({"type": "message", "role": "assistant", "content": content_parts})
                 elif content_text.strip():
-                    items.append({"role": "assistant", "content": content_text})
+                    items.append({"type": "message", "role": "assistant",
+                                  "content": [{"type": "output_text", "text": content_text}]})
                 elif has_codex_reasoning:
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
                     # content, emit an empty assistant message as the required
                     # following item.
-                    items.append({"role": "assistant", "content": ""})
+                    items.append({"type": "message", "role": "assistant",
+                                  "content": [{"type": "output_text", "text": ""}]})
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -686,7 +686,11 @@ class TestChatMessagesToResponsesInputMessageItems:
                             base_url="https://chatgpt.com/backend-api/codex")
         messages = [{"role": "assistant", "content": "Hello world"}]
         items = _chat_messages_to_responses_input(messages)
-        assert items == [{"role": "assistant", "content": "Hello world"}]
+        # Assistant message items must carry the Responses API ``type`` field
+        # ("message"); strict Responses servers (llama.cpp) reject role-only
+        # items with HTTP 400 "Cannot determine type of 'item'" (#76657).
+        assert items == [{"type": "message", "role": "assistant",
+                          "content": [{"type": "output_text", "text": "Hello world"}]}]
 
 
 


### PR DESCRIPTION
## Summary

Fixes #76657 — Hermes Desktop (Windows 11) talking to a local llama.cpp server via the OpenAI-compatible Responses API got HTTP 400 `Cannot determine type of 'item'` on every message after the last update.

## Root cause

llama.cpp's `/v1/responses` endpoint converts Responses-API input into chat-completions format (`server-chat.cpp`). That converter **requires every assistant message item to carry an explicit `"type": "message"` field**; an item that is only `{"role": "assistant", "content": ...}` falls through every branch and is rejected with `Cannot determine type of 'item'` (400 invalid_request_error).

Hermes's `_chat_messages_to_responses_input` (in `agent/codex_responses_adapter.py`) emitted the live-path assistant message items **without** the `type` field:

```python
items.append({"role": "assistant", "content": content_parts})          # before
items.append({"role": "assistant", "content": content_text})           # before
items.append({"role": "assistant", "content": ""})                     # before
```

Real OpenAI / Codex / xAI tolerate the role-only shorthand; llama.cpp's strict converter does not, so any conversation with an assistant turn in history 400'd on every subsequent message.

## Fix

Emit assistant message items in the canonical Responses-API shape (`{"type": "message", "role": "assistant", "content": [...]}`), matching what the `codex_message_items` replay path already produces:

- `content_parts` → `{"type": "message", "role": "assistant", "content": content_parts}`
- string content → `{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": content_text}]}`
- empty following-item (reasoning-only turn) → `{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": ""}]}`

User messages keep the role-only shorthand (llama.cpp accepts those; only the assistant branch requires `type`).

## Tests

- Updated `test_fallback_to_plain_when_no_message_items` to assert the typed assistant shape.
- Ran the targeted suites: `tests/agent/test_codex_responses_adapter.py`, `tests/run_agent/test_provider_parity.py`, `tests/run_agent/test_run_agent_codex_responses.py`, `tests/run_agent/test_codex_multimodal_tool_result.py`, `tests/run_agent/test_codex_xai_oauth_recovery.py` — 139 passed.
