### PR TITLE
fix(cli): stop hermes import-agent from destroying an unreadable config.yaml (#76673 salvage)

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -47,7 +47,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from utils import atomic_write_text
+from utils import atomic_write_text, atomic_yaml_write
 
 logger = logging.getLogger(__name__)
 
@@ -107,19 +107,9 @@ class ConfigReadError(RuntimeError):
 def load_yaml_file(path: Path) -> Dict[str, Any]:
     """Load a YAML mapping, distinguishing "absent" from "unreadable".
 
-    Every caller of this function reads ``config.yaml``, merges a section into
-    it, and writes the whole mapping straight back over the original.  So
-    collapsing a present-but-unreadable file to ``{}`` is destructive: a YAML
-    syntax error, a permission problem, or a broken mount would make the
-    importer replace every setting the user had with only the one or two keys
-    it merged — and still report the item as ``imported``.
-
-    This is the same invariant ``hermes_cli.config`` enforces for its own
-    writers via ``require_readable_config_before_write`` / ``atomic_config_write``
-    ("``read_raw_config()`` returns ``{}`` for BOTH an absent file and an
-    unreadable-but-present file"), and that ``set_config_value`` gained for
-    YAML syntax errors.  This module has its own private helper pair and so
-    was never covered by either.
+    Callers read ``config.yaml``, merge a section in, and write the whole
+    mapping back — so collapsing a present-but-unreadable file to ``{}``
+    would replace every existing setting with just the merged keys.
 
     - Absent, or present but empty  -> ``{}``; first-time creation still works.
     - Present but unreadable, unparseable, or not a mapping -> raise
@@ -158,24 +148,17 @@ def load_yaml_file(path: Path) -> Dict[str, Any]:
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
-    """Write ``data`` as YAML via temp file + fsync + atomic rename.
+    """Write ``data`` as YAML atomically (temp file + fsync + rename).
 
     Only ever reached after :func:`load_yaml_file` has successfully read the
     same path, so the mapping being written is the real file's content plus
     the merged section — never a silently-empty stand-in.
 
-    ``atomic_write_text`` (already used by this module for the memory store)
-    means an interrupted import cannot leave a truncated ``config.yaml``
-    behind, and a symlinked config stays a symlink.  It creates the parent
-    directory itself.
+    ``atomic_yaml_write`` keeps a symlinked config a symlink, creates the
+    parent directory, and preserves the previous file's mode/owner (a
+    ``0o600``-secured config stays ``0o600``).
     """
-    import yaml
-
-    atomic_write_text(
-        path,
-        yaml.safe_dump(data, default_flow_style=False, sort_keys=False,
-                       allow_unicode=True),
-    )
+    atomic_yaml_write(path, data)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -95,26 +95,86 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+class ConfigReadError(RuntimeError):
+    """An existing config file is present but cannot be read or parsed.
+
+    Signals that a read-modify-write round trip must be abandoned: the caller
+    has no idea what the file holds, so writing a merged result back would
+    replace real settings with only the keys it merged.
+    """
+
+
 def load_yaml_file(path: Path) -> Dict[str, Any]:
+    """Load a YAML mapping, distinguishing "absent" from "unreadable".
+
+    Every caller of this function reads ``config.yaml``, merges a section into
+    it, and writes the whole mapping straight back over the original.  So
+    collapsing a present-but-unreadable file to ``{}`` is destructive: a YAML
+    syntax error, a permission problem, or a broken mount would make the
+    importer replace every setting the user had with only the one or two keys
+    it merged — and still report the item as ``imported``.
+
+    This is the same invariant ``hermes_cli.config`` enforces for its own
+    writers via ``require_readable_config_before_write`` / ``atomic_config_write``
+    ("``read_raw_config()`` returns ``{}`` for BOTH an absent file and an
+    unreadable-but-present file"), and that ``set_config_value`` gained for
+    YAML syntax errors.  This module has its own private helper pair and so
+    was never covered by either.
+
+    - Absent, or present but empty  -> ``{}``; first-time creation still works.
+    - Present but unreadable, unparseable, or not a mapping -> raise
+      :class:`ConfigReadError` so the caller refuses and leaves the file
+      byte-identical.
+    """
     import yaml
 
     if not path.exists():
         return {}
     try:
-        data = yaml.safe_load(read_text(path))
-    except Exception:
+        raw = read_text(path)
+    except OSError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file is not valid YAML "
+            f"({exc}). Fix it with `hermes config edit` (or move it aside), then "
+            f"re-run the import."
+        ) from exc
+    # An empty file parses to None — a legitimate state with nothing to lose.
+    if data is None:
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: expected the existing file to hold a "
+            f"YAML mapping but found {type(data).__name__}. Fix it with "
+            f"`hermes config edit` (or move it aside), then re-run the import."
+        )
+    return data
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
+    """Write ``data`` as YAML via temp file + fsync + atomic rename.
+
+    Only ever reached after :func:`load_yaml_file` has successfully read the
+    same path, so the mapping being written is the real file's content plus
+    the merged section — never a silently-empty stand-in.
+
+    ``atomic_write_text`` (already used by this module for the memory store)
+    means an interrupted import cannot leave a truncated ``config.yaml``
+    behind, and a symlinked config stays a symlink.  It creates the parent
+    directory itself.
+    """
     import yaml
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
+    atomic_write_text(
+        path,
         yaml.safe_dump(data, default_flow_style=False, sort_keys=False,
                        allow_unicode=True),
-        encoding="utf-8",
     )
 
 
@@ -381,6 +441,25 @@ class AgentImporter:
             item.update(details)
         self.items.append(item)
 
+    def load_target_config(self, kind: str, source, destination: Path
+                           ) -> Optional[Dict[str, Any]]:
+        """Read the destination config.yaml, or record a refusal and return None.
+
+        The single chokepoint for the three importers that read config.yaml,
+        merge a section into it and write it back.  When the existing file is
+        present but unreadable there is nothing safe to merge into, so the
+        item is recorded as an ``error`` and the file is left untouched —
+        rather than being replaced by the merged section alone.
+
+        Deliberately runs in dry-run too: ``--dry-run`` must report the
+        refusal, not preview an ``imported`` that would destroy the config.
+        """
+        try:
+            return load_yaml_file(destination)
+        except ConfigReadError as exc:
+            self.record(kind, source, destination, "error", str(exc))
+            return None
+
     def build_report(self) -> Dict[str, Any]:
         summary = {"imported": 0, "skipped": 0, "conflict": 0, "error": 0}
         for item in self.items:
@@ -598,7 +677,10 @@ class AgentImporter:
                         unmapped_rules=skipped_rules)
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(
+            "command-allowlist", "settings.json permissions.allow", destination)
+        if config is None:
+            return
         current = config.get("command_allowlist", [])
         if not isinstance(current, list):
             current = []
@@ -643,7 +725,10 @@ class AgentImporter:
                         "No Bash(...) deny rules to import")
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(
+            "command-denylist", "settings.json permissions.deny", destination)
+        if config is None:
+            return
         approvals = config.get("approvals")
         if not isinstance(approvals, dict):
             approvals = {}
@@ -675,7 +760,9 @@ class AgentImporter:
                         "No MCP servers found")
             return
 
-        config = load_yaml_file(destination)
+        config = self.load_target_config(kind, None, destination)
+        if config is None:
+            return
         existing = config.get("mcp_servers")
         if not isinstance(existing, dict):
             existing = {}

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -444,12 +444,17 @@ def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
             except OSError:
                 pass
             # fsync the copied target so the durability claim holds on the
-            # cross-device path too (mirrors utils.atomic_replace).
-            target_fd = os.open(target, os.O_RDONLY)
+            # cross-device path too (mirrors utils.atomic_replace, including
+            # its swallow — a failed fsync must not report the already-copied
+            # write as failed).
             try:
-                os.fsync(target_fd)
-            finally:
-                os.close(target_fd)
+                target_fd = os.open(target, os.O_RDONLY)
+                try:
+                    os.fsync(target_fd)
+                finally:
+                    os.close(target_fd)
+            except OSError:
+                pass
             os.unlink(tmp_path)
     except BaseException:
         try:

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -439,6 +439,17 @@ def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
             if exc.errno not in (errno.EXDEV, errno.EBUSY):
                 raise
             shutil.copyfile(tmp_path, target)
+            try:
+                shutil.copystat(tmp_path, target)
+            except OSError:
+                pass
+            # fsync the copied target so the durability claim holds on the
+            # cross-device path too (mirrors utils.atomic_replace).
+            target_fd = os.open(target, os.O_RDONLY)
+            try:
+                os.fsync(target_fd)
+            finally:
+                os.close(target_fd)
             os.unlink(tmp_path)
     except BaseException:
         try:

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -346,26 +347,92 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
     return None
 
 
+class ConfigReadError(RuntimeError):
+    """An existing config file is present but cannot be read or parsed.
+
+    Signals that a read-modify-write round trip must be abandoned: the caller
+    has no idea what the file holds, so writing a merged result back would
+    replace real settings with only the keys it merged.
+    """
+
+
 def load_yaml_file(path: Path) -> Dict[str, Any]:
+    """Load a YAML mapping, distinguishing "absent" from "unreadable".
+
+    Every config.yaml caller here reads the file, merges a section into it and
+    writes the whole mapping straight back.  Collapsing a present-but-unreadable
+    file to ``{}`` therefore destroys it: a YAML syntax error, a permission
+    problem or a broken mount would make the migration replace every setting
+    the user had with only the section it merged, and still report ``migrated``.
+
+    - Absent, or present but empty -> ``{}``; first-time creation still works.
+    - Present but unreadable, unparseable, or not a mapping -> raise
+      :class:`ConfigReadError` so the caller refuses and leaves the file
+      byte-identical.
+
+    ``yaml is None`` (PyYAML not installed) still yields ``{}``: nothing can be
+    written in that state either, since :func:`dump_yaml_file` raises.
+    """
     if yaml is None or not path.exists():
         return {}
     try:
         # errors="replace" means read_text() cannot raise UnicodeDecodeError;
         # OSError covers races like the file disappearing or being unreadable.
-        data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
-    except (yaml.YAMLError, OSError):
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: the existing file is not valid YAML "
+            f"({exc}). Fix it with `hermes config edit` (or move it aside), then "
+            f"re-run the migration."
+        ) from exc
+    # An empty file parses to None — a legitimate state with nothing to lose.
+    if data is None:
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        raise ConfigReadError(
+            f"Refusing to overwrite {path}: expected the existing file to hold a "
+            f"YAML mapping but found {type(data).__name__}. Fix it with "
+            f"`hermes config edit` (or move it aside), then re-run the migration."
+        )
+    return data
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
+    """Write ``data`` as YAML via temp file + fsync + atomic rename.
+
+    Only ever reached after :func:`load_yaml_file` has successfully read the
+    same path, so the mapping being written is the real file's content plus the
+    merged section — never a silently-empty stand-in.  Writing atomically means
+    an interrupted migration cannot leave a truncated config.yaml behind.
+
+    Inlined rather than importing ``utils.atomic_write_text``: this script is
+    standalone and runs with only the stdlib on its path.
+    """
     if yaml is None:
         raise RuntimeError("PyYAML is required to update Hermes config.yaml")
     ensure_parent(path)
-    path.write_text(
-        yaml.safe_dump(data, sort_keys=False, allow_unicode=False),
-        encoding="utf-8",
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".tmp_", suffix=".yaml"
     )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(yaml.safe_dump(data, sort_keys=False, allow_unicode=False))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def parse_env_file(path: Path) -> Dict[str, str]:
@@ -783,7 +850,14 @@ class Migrator:
                     # ws_path is outside source_root — use it as custom workspace
                     self._custom_workspace = ws_path
 
-        config = load_yaml_file(self.target_root / "config.yaml")
+        # Read-only probe for the memory limits, during construction — nothing
+        # is written from here, so an unreadable config just falls back to the
+        # defaults.  Every path that WRITES config.yaml refuses separately (see
+        # run_if_selected), so this cannot become a silent overwrite.
+        try:
+            config = load_yaml_file(self.target_root / "config.yaml")
+        except ConfigReadError:
+            config = {}
         mem_cfg = config.get("memory", {}) if isinstance(config.get("memory"), dict) else {}
         self.memory_limit = int(mem_cfg.get("memory_char_limit", DEFAULT_MEMORY_CHAR_LIMIT))
         self.user_limit = int(mem_cfg.get("user_char_limit", DEFAULT_USER_CHAR_LIMIT))
@@ -1001,7 +1075,24 @@ class Migrator:
                 option_label=meta["label"],
             )
             return
-        func()
+        try:
+            func()
+        except ConfigReadError as exc:
+            # The destination config.yaml is present but unreadable, so this
+            # step cannot merge into it.  Record the refusal against the
+            # config path — record() then flips _config_apply_blocked, and the
+            # remaining config-mutating options short-circuit above instead of
+            # each rediscovering the same unreadable file.  The file itself is
+            # left byte-identical.
+            meta = MIGRATION_OPTION_METADATA[option_id]
+            self.record(
+                option_id,
+                None,
+                self.target_root / "config.yaml",
+                STATUS_ERROR,
+                str(exc),
+                option_label=meta["label"],
+            )
 
     def build_report(self) -> Dict[str, Any]:
         summary: Dict[str, int] = {

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -9,6 +9,7 @@ reports exactly what was skipped and why.
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
@@ -413,20 +414,32 @@ def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
     an interrupted migration cannot leave a truncated config.yaml behind.
 
     Inlined rather than importing ``utils.atomic_write_text``: this script is
-    standalone and runs with only the stdlib on its path.
+    standalone and runs with only the stdlib on its path.  The symlink and
+    cross-device handling mirrors ``utils.atomic_replace``: a plain
+    ``os.replace`` onto a symlinked config.yaml would replace the *link* with a
+    regular file, silently detaching managed deployments that symlink
+    ``~/.hermes/config.yaml`` into a dotfiles repo or profile package.
     """
     if yaml is None:
         raise RuntimeError("PyYAML is required to update Hermes config.yaml")
     ensure_parent(path)
+    target = os.path.realpath(str(path)) if os.path.islink(str(path)) else str(path)
     fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent), prefix=".tmp_", suffix=".yaml"
+        dir=os.path.dirname(target) or ".", prefix=".tmp_", suffix=".yaml"
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(yaml.safe_dump(data, sort_keys=False, allow_unicode=False))
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp_path, path)
+        try:
+            os.replace(tmp_path, target)
+        except OSError as exc:
+            # Cross-device or bind-mount deployments cannot rename into place.
+            if exc.errno not in (errno.EXDEV, errno.EBUSY):
+                raise
+            shutil.copyfile(tmp_path, target)
+            os.unlink(tmp_path)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -548,7 +548,9 @@ class TestExistingConfigPreserved:
         """A permission problem is the other half of the same root cause."""
         import os
 
-        if os.geteuid() == 0:
+        if os.name != "posix":
+            pytest.skip("chmod-based permission denial is POSIX-only")
+        if getattr(os, "geteuid", lambda: 1)() == 0:
             pytest.skip("root bypasses file permissions")
         config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
         before = config_path.read_bytes()

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -464,6 +464,213 @@ class TestExistingMemoryStorePreserved:
         assert backups[0].read_text(encoding="utf-8") == EXISTING_MEMORY
 
 
+# ---------------------------------------------------------------------------
+# config.yaml preservation (sibling of the MEMORY.md case above)
+# ---------------------------------------------------------------------------
+
+EXISTING_CONFIG = """\
+model: hermes-4-405b
+api_key_env: OPENROUTER_API_KEY
+command_allowlist:
+  - ls *
+  - cat *
+approvals:
+  deny:
+    - shutdown *
+mcp_servers:
+  local-notes:
+    command: uvx
+    args:
+      - notes-mcp
+telegram:
+  enabled: true
+  chat_id: 12345
+"""
+
+MALFORMED_CONFIG = """\
+model: hermes-4-405b
+command_allowlist:
+  - ls *
+   - cat *
+approvals: [unclosed
+"""
+
+CONFIG_WRITING_KINDS = ("command-allowlist", "command-denylist", "mcp-servers")
+
+
+class TestExistingConfigPreserved:
+    """An import must not destroy the config.yaml it merges into.
+
+    ``load_yaml_file`` returned ``{}`` for an absent file AND for a present
+    file it could not read or parse.  The three importers below read
+    config.yaml, merge one section into it, and write the whole mapping back —
+    so a YAML syntax error or a permission problem meant every existing
+    setting was replaced by just the merged section, reported as ``imported``.
+    """
+
+    @pytest.fixture()
+    def config_path(self, hermes_home):
+        return hermes_home / "config.yaml"
+
+    @staticmethod
+    def items_for(report, kind):
+        return [i for i in report["items"] if i["kind"] == kind]
+
+    # -- present but unreadable: refuse, change nothing --------------------
+
+    def test_malformed_config_is_left_byte_identical(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.read_bytes() == before
+
+    def test_malformed_config_records_an_error_not_an_import(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        for kind in CONFIG_WRITING_KINDS:
+            items = self.items_for(report, kind)
+            assert items, f"no {kind} item recorded"
+            assert [i["status"] for i in items] == ["error"], kind
+            reason = items[0]["reason"]
+            assert str(config_path) in reason
+            assert "not valid YAML" in reason
+            # Points the user at a way out.
+            assert "hermes config edit" in reason
+
+    def test_unreadable_config_is_left_byte_identical(
+            self, claude_tree, hermes_home, config_path):
+        """A permission problem is the other half of the same root cause."""
+        import os
+
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses file permissions")
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+        config_path.chmod(0o000)
+        try:
+            report = run_import("claude-code", claude_tree, hermes_home,
+                                execute=True)
+            statuses = {
+                i["status"]
+                for kind in CONFIG_WRITING_KINDS
+                for i in self.items_for(report, kind)
+            }
+            assert statuses == {"error"}
+        finally:
+            config_path.chmod(0o600)
+        assert config_path.read_bytes() == before
+
+    def test_non_mapping_config_is_refused(
+            self, claude_tree, hermes_home, config_path):
+        """Valid YAML that is not a mapping was also collapsed to {}."""
+        config_path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        before = config_path.read_bytes()
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.read_bytes() == before
+        reasons = [i["reason"] for i in self.items_for(report, "command-allowlist")]
+        assert any("YAML mapping" in r for r in reasons)
+
+    def test_dry_run_reports_the_refusal_rather_than_a_preview(
+            self, claude_tree, hermes_home, config_path):
+        """--dry-run must not promise an import that would destroy the file."""
+        config_path.write_text(MALFORMED_CONFIG, encoding="utf-8")
+
+        report = run_import("claude-code", claude_tree, hermes_home, execute=False)
+
+        for kind in CONFIG_WRITING_KINDS:
+            statuses = [i["status"] for i in self.items_for(report, kind)]
+            assert statuses == ["error"], kind
+            assert "imported" not in statuses
+
+    # -- the regression that actually pins the data loss -------------------
+
+    def test_import_preserves_every_pre_existing_config_key(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        merged = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        # Untouched sections survive verbatim.
+        assert merged["model"] == "hermes-4-405b"
+        assert merged["api_key_env"] == "OPENROUTER_API_KEY"
+        assert merged["telegram"] == {"enabled": True, "chat_id": 12345}
+        # Merged-into sections keep their existing members ...
+        assert "ls *" in merged["command_allowlist"]
+        assert "shutdown *" in merged["approvals"]["deny"]
+        assert "local-notes" in merged["mcp_servers"]
+        # ... alongside the imported ones.
+        assert "npm run build" in merged["command_allowlist"]
+        assert "github" in merged["mcp_servers"]
+
+    def test_absent_config_is_still_created(
+            self, claude_tree, hermes_home, config_path):
+        """The guard must not break first-time creation."""
+        assert not config_path.exists()
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        created = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "npm run build" in created["command_allowlist"]
+
+    def test_empty_config_is_treated_as_absent(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text("", encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        created = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "npm run build" in created["command_allowlist"]
+
+    # -- the write itself --------------------------------------------------
+
+    def test_config_write_is_atomic_and_leaves_no_temp_files(
+            self, claude_tree, hermes_home, config_path):
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        leftovers = [p.name for p in hermes_home.glob(".tmp*")]
+        assert leftovers == []
+
+    def test_symlinked_config_stays_a_symlink(
+            self, claude_tree, hermes_home, tmp_path, config_path):
+        """A non-atomic ``write_text`` would follow it; ``os.replace`` would
+        clobber it.  ``atomic_replace`` keeps the link and writes the target."""
+        real = tmp_path / "real-config.yaml"
+        real.write_text(EXISTING_CONFIG, encoding="utf-8")
+        config_path.symlink_to(real)
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        assert config_path.is_symlink()
+        assert "npm run build" in real.read_text(encoding="utf-8")
+
+    def test_failed_write_does_not_truncate_the_existing_config(
+            self, hermes_home, config_path, monkeypatch):
+        """An interrupted dump leaves the previous file complete."""
+        from hermes_cli import agent_import
+
+        config_path.write_text(EXISTING_CONFIG, encoding="utf-8")
+        before = config_path.read_bytes()
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(agent_import, "atomic_write_text", boom)
+        with pytest.raises(OSError):
+            agent_import.dump_yaml_file(config_path, {"model": "replacement"})
+
+        assert config_path.read_bytes() == before
+
 
 # ---------------------------------------------------------------------------
 # CLI wiring

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -667,7 +667,7 @@ class TestExistingConfigPreserved:
         def boom(*_args, **_kwargs):
             raise OSError("no space left on device")
 
-        monkeypatch.setattr(agent_import, "atomic_write_text", boom)
+        monkeypatch.setattr(agent_import, "atomic_yaml_write", boom)
         with pytest.raises(OSError):
             agent_import.dump_yaml_file(config_path, {"model": "replacement"})
 

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -120,6 +120,156 @@ def test_migrator_copies_skill_and_merges_allowlist(tmp_path: Path):
     assert imported_skill.exists()
     assert "/home/test/**" in (target / "config.yaml").read_text(encoding="utf-8")
     assert report["summary"]["migrated"] >= 2
+    # The merge is written atomically — no temp file survives the run.
+    assert [p.name for p in target.glob(".tmp*")] == []
+
+
+def _allowlist_migrator(mod, tmp_path: Path, existing_config: str):
+    """Migrator wired to merge an exec-approvals allowlist into config.yaml."""
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir(parents=True)
+    (source / "exec-approvals.json").write_text(
+        json.dumps({"agents": {"*": {"allowlist": [{"pattern": "/home/test/**"}]}}}),
+        encoding="utf-8",
+    )
+    (target / "config.yaml").write_text(existing_config, encoding="utf-8")
+    return mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=target / "migration-report",
+    ), target / "config.yaml"
+
+
+MALFORMED_HERMES_CONFIG = """\
+model: hermes-4-405b
+api_key_env: OPENROUTER_API_KEY
+command_allowlist:
+  - /usr/bin/*
+approvals:
+  deny: [shutdown *
+telegram:
+  enabled: true
+"""
+
+
+def test_unreadable_config_is_refused_not_overwritten(tmp_path: Path):
+    """A present-but-unparseable config.yaml must survive the migration.
+
+    ``load_yaml_file`` returned ``{}`` for an absent file AND for one it could
+    not parse; the config-mutating steps read, merge and write the whole
+    mapping back, so a YAML syntax error meant every existing setting was
+    replaced by just the merged section.  Same defect as the ported twin in
+    ``hermes_cli/agent_import.py``.
+    """
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod, tmp_path, MALFORMED_HERMES_CONFIG)
+    before = config_path.read_bytes()
+
+    report = migrator.migrate()
+
+    assert config_path.read_bytes() == before
+    allowlist = [i for i in report["items"] if i["kind"] == "command-allowlist"]
+    assert allowlist and allowlist[0]["status"] == mod.STATUS_ERROR
+    assert "not valid YAML" in allowlist[0]["reason"]
+
+
+def test_unreadable_config_blocks_later_config_steps_instead_of_partial_writes(
+        tmp_path: Path):
+    """One refusal flips the existing _config_apply_blocked short-circuit."""
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod, tmp_path, MALFORMED_HERMES_CONFIG)
+
+    report = migrator.migrate()
+
+    assert migrator._config_apply_blocked is True
+    statuses = {
+        i["status"] for i in report["items"]
+        if i["kind"] in mod.Migrator._CONFIG_MUTATING_OPTIONS
+    }
+    # Nothing claimed a successful config write.
+    assert "migrated" not in statuses
+    assert config_path.read_text(encoding="utf-8") == MALFORMED_HERMES_CONFIG
+
+
+def test_readable_config_keeps_every_pre_existing_key(tmp_path: Path):
+    mod = load_module()
+    migrator, config_path = _allowlist_migrator(
+        mod,
+        tmp_path,
+        "model: hermes-4-405b\n"
+        "api_key_env: OPENROUTER_API_KEY\n"
+        "command_allowlist:\n  - /usr/bin/*\n",
+    )
+
+    migrator.migrate()
+
+    import yaml
+
+    merged = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert merged["model"] == "hermes-4-405b"
+    assert merged["api_key_env"] == "OPENROUTER_API_KEY"
+    assert "/usr/bin/*" in merged["command_allowlist"]
+    assert "/home/test/**" in merged["command_allowlist"]
+
+
+def test_absent_config_is_still_created(tmp_path: Path):
+    """The guard must not break first-time creation.
+
+    Only ``absent`` may read as ``{}``; ``model-config`` creates config.yaml
+    from scratch when the target has none.
+    """
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"model": "anthropic/claude-sonnet-4"}}}),
+        encoding="utf-8",
+    )
+    config_path = target / "config.yaml"
+    assert not config_path.exists()
+
+    mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=True, migrate_secrets=False,
+        output_dir=None, selected_options={"model-config"},
+    ).migrate()
+
+    assert "anthropic/claude-sonnet-4" in config_path.read_text(encoding="utf-8")
+
+
+def test_unreadable_config_refused_by_model_config_too(tmp_path: Path):
+    """The refusal is at the shared helper, so every config step inherits it."""
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"model": "anthropic/claude-sonnet-4"}}}),
+        encoding="utf-8",
+    )
+    config_path = target / "config.yaml"
+    config_path.write_text(MALFORMED_HERMES_CONFIG, encoding="utf-8")
+
+    report = mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=True, migrate_secrets=False,
+        output_dir=None, selected_options={"model-config"},
+    ).migrate()
+
+    assert config_path.read_text(encoding="utf-8") == MALFORMED_HERMES_CONFIG
+    items = [i for i in report["items"] if i["kind"] == "model-config"]
+    assert items and items[0]["status"] == mod.STATUS_ERROR
 
 
 def test_migrator_optionally_imports_supported_secrets_and_messaging_settings(tmp_path: Path):

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -247,6 +247,29 @@ def test_absent_config_is_still_created(tmp_path: Path):
     assert "anthropic/claude-sonnet-4" in config_path.read_text(encoding="utf-8")
 
 
+def test_symlinked_config_stays_a_symlink(tmp_path: Path):
+    """Managed deployments symlink ~/.hermes/config.yaml into a dotfiles repo.
+
+    A plain ``os.replace`` onto the link would detach it into a regular file;
+    ``dump_yaml_file`` resolves the link first, as ``utils.atomic_replace`` does.
+    """
+    mod = load_module()
+    real = tmp_path / "dotfiles" / "config.yaml"
+    real.parent.mkdir(parents=True)
+    real.write_text("model: hermes-4-405b\ncommand_allowlist:\n  - /usr/bin/*\n",
+                    encoding="utf-8")
+    migrator, config_path = _allowlist_migrator(mod, tmp_path, "placeholder: true\n")
+    config_path.unlink()
+    config_path.symlink_to(real)
+
+    migrator.migrate()
+
+    assert config_path.is_symlink()
+    assert config_path.resolve() == real.resolve()
+    assert "/home/test/**" in real.read_text(encoding="utf-8")
+    assert "hermes-4-405b" in real.read_text(encoding="utf-8")
+
+
 def test_unreadable_config_refused_by_model_config_too(tmp_path: Path):
     """The refusal is at the shared helper, so every config step inherits it."""
     mod = load_module()


### PR DESCRIPTION
Closes #76673 (salvage — @briandevans's commits cherry-picked with authorship preserved)

## Summary

`hermes import-agent` (and the openclaw migration script) no longer silently destroys a present-but-unreadable `config.yaml`. A YAML syntax error, permission problem, or non-mapping content now refuses with an error naming the path and leaves the file byte-identical; the config write is atomic. Sibling follow-up to #73598 (MEMORY.md shredding in the same two files).

Root cause: the modules' private `load_yaml_file` collapsed absent, unreadable, and malformed to the same `{}` — and three importers read config.yaml, merge one section, and write the whole mapping back, so a broken config was replaced by only the merged keys and reported "imported".

## Changes

- **@briandevans (#76673, 2 commits, authorship preserved):**
  - `hermes_cli/agent_import.py`: `load_yaml_file` raises typed `ConfigReadError` for present-but-unreadable/unparseable/non-mapping (absent + empty still → `{}`); new `load_target_config` chokepoint records the refusal per importer; `dump_yaml_file` writes atomically; all 3 config-writing importers routed through the guard
  - openclaw script twin: same guard + stdlib-only inline atomic write (symlink-preserving, EXDEV/EBUSY fallback); one `ConfigReadError` flips the pre-existing `_config_apply_blocked` so later config steps short-circuit; `Migrator.__init__`'s read-only probe falls back to defaults
  - 16 new tests: byte-identical on malformed/permission-denied/non-mapping, dry-run reports the refusal, every pre-existing key survives a normal import, first-time creation intact, atomic write leaves no temp files, symlinked config stays a symlink, failed write doesn't truncate
- **Review follow-ups (this salvage):**
  - `dump_yaml_file` → `utils.atomic_yaml_write` (same atomicity + symlink preservation, plus mode/owner preservation for a 0600-secured config; −8 LOC)
  - openclaw EXDEV copy-fallback gains `copystat` + target `fsync` so its "mirrors utils.atomic_replace" durability claim is true on cross-device deployments
  - docstring trimmed to the behavior contract

## Validation

| Check | Result |
|---|---|
| tests/hermes_cli/test_agent_import.py + tests/skills/test_openclaw_migration.py | 68 passed |
| tests/hermes_cli/test_config.py (adjacent) | 74 passed |
| E2E both ways (real imports, temp HERMES_HOME): bug REPRODUCED on main (config destroyed, "imported: 2, error: 0"); PR branch: byte-identical + typed errors; happy path preserves all keys; absent config created; openclaw twin same both ways | all passed |
| Mutation check (final stack): prod reverted to main → 9 guard tests fail; restored → 68 pass | teeth confirmed |
| ruff | clean |

Credit: fix authored by @briandevans — cherry-picked to preserve authorship, continuing their #73598 sibling work.
