### PR TITLE
fix(gateway): strip MEDIA directives from auto-TTS input (#76620)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18505,7 +18505,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            # Strip MEDIA:<path> delivery directives before TTS — these are
+            # internal markers for platform attachment delivery and must not
+            # be spoken aloud (#76620).
+            clean_text = _TOOL_MEDIA_RE.sub('', text[:4000])
+            tts_text = _strip_markdown_for_tts(clean_text)
             if not tts_text:
                 return
 


### PR DESCRIPTION
## Summary

Fixes #76620 — auto-TTS voice replies read `MEDIA:<path>` delivery directives aloud instead of only the visible caption text.

## Root Cause

`_send_voice_reply()` passes the raw response text to `_strip_markdown_for_tts()` without first removing `MEDIA:<path>` markers. The text normalizer handles markdown, think blocks, and emoji — but has no knowledge of MEDIA: directives, so the internal local file path ends up in the spoken audio.

## Fix

Apply `_TOOL_MEDIA_RE.sub('', ...)` to strip MEDIA:<path> patterns from the text before handing it to the TTS normalizer. The original `text` variable is untouched — attachment delivery continues to use the unmodified response.

## Changes

- `gateway/run.py`: Strip MEDIA: directives from auto-TTS input text before `_strip_markdown_for_tts()` call.

## Testing

- MEDIA: paths with supported extensions (png, jpg, mp4, ogg, etc.) are stripped before TTS synthesis.
- The original response text is not mutated — media attachment delivery is unaffected.
- Responses without MEDIA: directives are passed through unchanged.
