### PR TITLE
fix(cli): bound all subprocess.run calls with timeouts + stderr feedback (#76684)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1,4 +1,4 @@
-"""Managed uv — one path, no guessing.
+"""Hermes-managed uv and Python runtime repair.
 
 Hermes owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
 Windows).  Every code path that needs uv resolves it from that single location.
@@ -6,26 +6,49 @@ If the binary is missing, ``ensure_uv()`` bootstraps it via the official
 standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR`` pointed
 at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
 probing, no conda guards, no multi-location resolution chains.
+
+The Python backing the install is different: it is shared by every Hermes
+profile because the checkout's ``venv`` is shared.  Runtime repair therefore
+uses an install-scoped store under ``<checkout>/.hermes-runtime/python``. A
+vulnerable interpreter is never reinstalled in place. We provision a new
+immutable Python generation, build and smoke-test a relocatable sibling venv,
+then cut over with same-filesystem renames. The old venv remains available for
+synchronous rollback and is parked for cleanup after the updating process
+releases it.
 """
 
 from __future__ import annotations
 
+import importlib
+import json
 import logging
 import os
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
+import time
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo, probe_sqlite_runtime
 
 logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_RUNTIME_DIR_NAME = ".hermes-runtime"
+_VENV_NAME = "venv"
+_ALT_VENV_NAME = ".venv"
+_REPAIR_LOCK_NAME = "runtime-repair.lock"
 
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
+
 
 def managed_uv_path() -> Path:
     """Return the path where Hermes keeps *its* uv binary.
@@ -49,6 +72,85 @@ def resolve_uv() -> Optional[str]:
     if p.is_file() and os.access(p, os.X_OK):
         return str(p)
     return None
+
+
+def managed_python_install_dir(project_root: Path | None = None) -> Path:
+    """Return the checkout-scoped Python store shared by all profiles."""
+    root = Path(project_root) if project_root is not None else _PROJECT_ROOT
+    return root / _RUNTIME_DIR_NAME / "python"
+
+
+def managed_python_env(
+    project_root: Path | None = None,
+    *,
+    install_dir: Path | None = None,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a sanitized environment for Hermes-private uv Python commands."""
+    target = (
+        Path(install_dir)
+        if install_dir is not None
+        else managed_python_install_dir(project_root)
+    )
+    env = dict(os.environ if base_env is None else base_env)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_NO_MANAGED_PYTHON",
+        "UV_PYTHON",
+        "UV_PYTHON_DOWNLOADS",
+        "UV_SYSTEM_PYTHON",
+        "VIRTUAL_ENV",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    ):
+        env.pop(key, None)
+    env.update({
+        "UV_MANAGED_PYTHON": "1",
+        "UV_NO_CONFIG": "1",
+        "UV_PYTHON_INSTALL_BIN": "0",
+        "UV_PYTHON_INSTALL_DIR": str(target),
+        "UV_PYTHON_INSTALL_REGISTRY": "0",
+    })
+    return env
+
+
+@dataclass(frozen=True)
+class RuntimeRepairResult:
+    """Outcome of a managed-runtime repair attempt."""
+
+    status: str
+    detail: str = ""
+    sqlite_before: str = ""
+    sqlite_after: str = ""
+    backup_venv: Path | None = None
+
+    @property
+    def repaired(self) -> bool:
+        return self.status == "repaired"
+
+
+@dataclass(frozen=True)
+class _RepairLock:
+    path: Path
+    fd: int
+
+
+def _report_runtime_repair_failure(repair: RuntimeRepairResult) -> None:
+    if repair.backup_venv is None:
+        print(
+            "  ℹ Managed Python runtime was not replaced; "
+            f"the existing venv is unchanged ({repair.detail})."
+        )
+        print(
+            "    Sessions stay protected meanwhile: Hermes keeps databases "
+            "out of WAL mode on this SQLite build. The next `hermes update` "
+            "will retry."
+        )
+        return
+    print(f"  ✗ Managed Python runtime cutover needs manual recovery: {repair.detail}")
+    print(f"    Previous venv: {repair.backup_venv}")
 
 
 class _UvResult(str):
@@ -91,7 +193,10 @@ class _UvResult(str):
         return iter(((str(self) or None), self.fresh_bootstrap))
 
 
-def _ensure_uv_path() -> Optional[str]:
+def _ensure_uv_path(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+) -> Optional[str]:
     """Resolve the managed uv path, installing it if necessary (plain ``str``/``None``)."""
     existing = resolve_uv()
     if existing:
@@ -115,16 +220,31 @@ def _ensure_uv_path() -> Optional[str]:
         version = subprocess.run(
             [result, "--version"],
             capture_output=True,
-            text=True,
+            text=True, encoding='utf-8', errors='replace',
             check=False,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
+        # Compatibility boundary: an older, already-imported updater calls the
+        # freshly pulled ``ensure_uv()`` after bootstrapping uv.  Repair here so
+        # that first update can migrate a vulnerable runtime without requiring
+        # a second ``hermes update``.
+        try:
+            repair = repair_vulnerable_runtime(result)
+            if repair_observer is not None:
+                repair_observer(repair)
+            if repair.status == "failed":
+                _report_runtime_repair_failure(repair)
+        except Exception as exc:
+            logger.warning("Managed Python runtime repair failed: %s", exc)
     else:
         print("  ✗ Managed uv install appeared to succeed but binary not found")
     return result
 
 
-def ensure_uv():
+def ensure_uv(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+):
     """Return the managed uv path, installing it first if necessary.
 
     On **POSIX** the result is a :class:`_UvResult` (a ``str`` subclass) that is
@@ -145,9 +265,10 @@ def ensure_uv():
     results.)
 
     On failure the result is falsy — never raises — so callers can fall back to
-    pip gracefully.
+    pip gracefully. ``repair_observer``, when provided, receives the runtime
+    repair result produced after a fresh uv bootstrap.
     """
-    result = _ensure_uv_path()
+    result = _ensure_uv_path(repair_observer=repair_observer)
     if platform.system() == "Windows":
         # See docstring: a str subclass with an overridden __iter__ is unsafe as
         # a Windows subprocess argument. Hand back the plain path (or None).
@@ -155,41 +276,1034 @@ def ensure_uv():
     return _UvResult(result)
 
 
-def update_managed_uv() -> Optional[str]:
+def _uv_self_update_is_fresh(now: float | None = None) -> bool:
+    """Return True when ``uv self update`` ran recently enough to skip.
+
+    uv releases roughly weekly while many users run ``hermes update`` daily;
+    re-running a blocking network self-update on every invocation is waste
+    and, offline, an unbounded hang risk. A stamp file under HERMES_HOME
+    caches the last successful self-update time.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        stamp = get_hermes_home() / "cache" / ".uv_self_update_stamp"
+        age = (now if now is not None else time.time()) - stamp.stat().st_mtime
+        return 0 <= age < UV_SELF_UPDATE_INTERVAL_SECONDS
+    except Exception:
+        return False
+
+
+def _touch_uv_self_update_stamp() -> None:
+    try:
+        from hermes_constants import get_hermes_home
+
+        stamp = get_hermes_home() / "cache" / ".uv_self_update_stamp"
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch()
+    except OSError:
+        pass
+
+
+# uv ships releases ~weekly; refresh the managed binary at most this often.
+UV_SELF_UPDATE_INTERVAL_SECONDS = 7 * 24 * 3600
+# `uv self update` is a network call; unbounded it can hang forever on a
+# blackholed connection (no default timeout in uv's downloader path).
+UV_SELF_UPDATE_TIMEOUT_SECONDS = 60
+# Network-bound uv python provisioning can hang forever on blackholed
+# connectivity (observed during every-update SQLite-runtime repair on
+# restricted networks, e.g. mainland China).  Bound every step.
+UV_PYTHON_INSTALL_TIMEOUT_SECONDS = 180
+UV_PYTHON_FIND_TIMEOUT_SECONDS = 30
+UV_VENV_TIMEOUT_SECONDS = 60
+UV_SYNC_TIMEOUT_SECONDS = 300
+
+
+def update_managed_uv(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+    force: bool = False,
+) -> Optional[str]:
     """Run ``uv self update`` on the managed uv binary.
 
     Call this during ``hermes update`` so the managed copy stays current.
-    Returns the managed path on success, ``None`` if uv isn't available or
-    the self-update fails (non-fatal — the old version still works).
+    Returns the managed path when uv is available and ``None`` otherwise.
+    A self-update failure is non-fatal because the old version still works.
+    ``repair_observer``, when provided, receives the runtime repair result.
+
+    The network self-update is skipped when it succeeded within the last
+    ``UV_SELF_UPDATE_INTERVAL_SECONDS`` (7 days) unless ``force=True``; the
+    vulnerable-runtime repair probe below ALWAYS runs — CVE-driven runtime
+    repair must never be gated behind the freshness stamp.
     """
     existing = resolve_uv()
     if not existing:
         # Not installed yet — ensure_uv() will handle that elsewhere.
         return None
 
-    result = subprocess.run(
-        [existing, "self", "update"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        version = subprocess.run(
-            [existing, "--version"],
+    if force or not _uv_self_update_is_fresh():
+        try:
+            result = subprocess.run(
+                [existing, "self", "update"],
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                check=False,
+                timeout=UV_SELF_UPDATE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            logger.debug("uv self update timed out after %ss", UV_SELF_UPDATE_TIMEOUT_SECONDS)
+            result = None
+        if result is not None and result.returncode == 0:
+            _touch_uv_self_update_stamp()
+            version = subprocess.run(
+                [existing, "--version"],
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                check=False,
+            ).stdout.strip()
+            print(f"  ✓ Managed uv updated ({version})")
+        elif result is not None:
+            # Non-fatal — old uv still works fine.
+            logger.debug(
+                "uv self update failed (rc=%d): %s", result.returncode, result.stderr
+            )
+
+    # Keep this hook inside the long-standing API. During an update, main.py is
+    # already imported from the old checkout, then ``git pull`` replaces this
+    # module on disk before the updater imports it. Calling the repair here is
+    # what makes the migration happen on that first update.
+    try:
+        repair = repair_vulnerable_runtime(existing)
+        if repair_observer is not None:
+            repair_observer(repair)
+        if repair.status == "failed":
+            _report_runtime_repair_failure(repair)
+    except Exception as exc:
+        # Runtime refresh is deliberately non-fatal. The live venv was not
+        # touched unless a fully prepared candidate reached cutover.
+        logger.warning("Managed Python runtime repair failed: %s", exc)
+        print(f"  ⚠ Managed Python runtime repair skipped: {exc}")
+    return existing
+
+
+# ---------------------------------------------------------------------------
+# Managed Python runtime repair
+# ---------------------------------------------------------------------------
+
+
+def _reload_hermes_constants():
+    """Re-execute ``hermes_constants`` from disk and return the fresh module.
+
+    ``hermes update`` imports ``hermes_constants`` from the OLD checkout,
+    ``git pull`` then replaces that file, and this freshly-pulled module runs
+    its lazy imports against the module object Python already cached in
+    ``sys.modules`` — the pre-upgrade one. A symbol added by the update is
+    absent there while the file named in the resulting ``ImportError`` plainly
+    contains it, which is what made this read as a contradiction:
+
+        cannot import name 'venv_python_path' from 'hermes_constants'
+        (~/.hermes/hermes-agent/hermes_constants.py)
+
+    Reloading picks up the definitions actually on disk, so callers keep using
+    the shared helper instead of hand-rolling a second copy of its logic. Same
+    update-boundary class as the ``ensure_uv()`` arity skew on :class:`_UvResult`.
+    """
+    import hermes_constants
+
+    return importlib.reload(hermes_constants)
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    windows = platform.system() == "Windows"
+    try:
+        from hermes_constants import venv_python_path
+    except ImportError:
+        venv_python_path = _reload_hermes_constants().venv_python_path
+    return venv_python_path(venv_dir, windows=windows)
+
+
+def _remove_tree(path: Path, *, boundary: Path) -> None:
+    """Best-effort removal constrained to a known runtime boundary."""
+    try:
+        path.resolve().relative_to(boundary.resolve())
+    except (OSError, ValueError):
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _make_world_traversable(path: Path) -> None:
+    """Keep root/FHS-managed runtimes executable by non-root callers."""
+    try:
+        path.chmod(path.stat().st_mode | 0o755)
+    except OSError:
+        pass
+
+
+def _runtime_request(info: SQLiteRuntimeInfo) -> str:
+    """Pin the candidate to the current CPython minor line (e.g. ``3.11``).
+
+    Requesting the exact patch can never repair some installs: for a given
+    patch, python-build-standalone may have no artifact with fixed SQLite at
+    all (e.g. every published 3.11.14 build links SQLite 3.50.4; the fix
+    only exists from 3.11.15).  A newer patch on the same minor is what
+    ``uv python install`` would resolve for a fresh install, stays inside
+    ``requires-python``, and the locked ``uv sync`` + import smoke tests gate
+    compatibility before any cutover.
+    """
+    return ".".join(str(part) for part in info.python_version[:2])
+
+
+# Cap on how many newer patches we'll try, newest-first, before giving up.
+# Bounded because each attempt is a real download+install+probe+delete cycle;
+# in practice the fix is almost always in the very next patch or two.
+_MAX_PATCH_RETRIES = 5
+
+
+def _list_available_patches(
+    uv_bin: str, minor: str, *, cwd: Path, env: dict
+) -> list[tuple[int, int, int]]:
+    """Return known patch versions for ``minor`` (e.g. "3.11"), newest first.
+
+    Queries ``uv python list --all-versions`` rather than trusting the bare
+    minor-line request to resolve to the newest patch (issue #71250: on some
+    hosts/uv versions, the resolved candidate for a bare "3.11" request can
+    be an older cached/indexed patch that still links a vulnerable SQLite,
+    even when a newer non-vulnerable patch is available). Returns [] on any
+    failure (network, parse) -- callers fall back to the original bare-minor
+    request in that case, preserving prior behavior.
+    """
+    try:
+        result = subprocess.run(
+            [
+                uv_bin, "python", "list", minor,
+                "--all-versions", "--only-downloads",
+                "--output-format", "json", "--no-config",
+            ],
+            cwd=cwd,
+            env=env,
             capture_output=True,
             text=True,
             check=False,
-        ).stdout.strip()
-        print(f"  ✓ Managed uv updated ({version})")
-    else:
-        # Non-fatal — old uv still works fine.
-        logger.debug("uv self update failed (rc=%d): %s", result.returncode, result.stderr)
-    return existing
+            timeout=15,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        entries = json.loads(result.stdout)
+        versions: list[tuple[int, int, int]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            # Only default/cpython builds -- skip pypy/graalpy/freethreaded
+            # variants, which aren't what this repair path wants.
+            if entry.get("implementation") not in (None, "cpython"):
+                continue
+            if entry.get("variant") not in (None, "default"):
+                continue
+            parts = entry.get("version_parts") or {}
+            try:
+                versions.append(
+                    (int(parts["major"]), int(parts["minor"]), int(parts["patch"]))
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        # Deduplicate (list --all-versions can repeat a version across
+        # platforms/arches if filtering above didn't fully narrow it) and
+        # sort newest-first.
+        return sorted(set(versions), reverse=True)
+    except Exception:
+        return []
+
+
+def _attempt_install_generation(
+    uv_bin: str,
+    request: str,
+    *,
+    project_root: Path,
+    python_root: Path,
+    current: SQLiteRuntimeInfo,
+) -> tuple[Path, Path, SQLiteRuntimeInfo] | None:
+    """One install+probe attempt for a specific version request (bare minor
+    like "3.11", or an explicit patch like "3.11.15"). Each attempt gets its
+    own generation directory so a rejected candidate's files are fully
+    cleaned up before the next attempt, matching --reinstall semantics.
+    Returns None (and cleans up) on any failure, including a vulnerable
+    or off-line candidate.
+    """
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    generation = python_root / f"generation-{token}"
+    generation.mkdir(parents=True, exist_ok=False)
+    _make_world_traversable(generation)
+
+    env = managed_python_env(project_root, install_dir=generation)
+    try:
+        install = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "install",
+                request,
+                "--reinstall",
+                "--no-bin",
+                "--no-registry",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python install timed out for %s after %ss",
+            request, UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv python install timed out after {UV_PYTHON_INSTALL_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if install.returncode != 0:
+        logger.warning(
+            "private Python install failed for %s (rc=%d): %s",
+            request,
+            install.returncode,
+            (install.stderr or install.stdout or "").strip(),
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    try:
+        found = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "find",
+                request,
+                "--managed-python",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python lookup timed out for %s after %ss",
+            request, UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv python find timed out after {UV_PYTHON_FIND_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if found.returncode != 0 or not found.stdout.strip():
+        logger.warning(
+            "private Python lookup failed for %s (rc=%d): %s",
+            request,
+            found.returncode,
+            (found.stderr or "").strip(),
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    python = Path(found.stdout.strip().splitlines()[-1])
+    try:
+        python.resolve().relative_to(generation.resolve())
+    except (OSError, ValueError):
+        logger.warning("uv resolved Python outside the Hermes generation: %s", python)
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    candidate = probe_sqlite_runtime(python)
+    if candidate is None:
+        logger.warning("could not probe candidate Python runtime: %s", python)
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if candidate.python_version[:2] != current.python_version[:2] or (
+        candidate.python_version < current.python_version
+    ):
+        logger.warning(
+            "candidate Python drifted off the %s minor line or downgraded: %s",
+            ".".join(str(p) for p in current.python_version[:2]),
+            candidate.python_version,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if candidate.wal_reset_vulnerable:
+        logger.warning(
+            "candidate Python still links vulnerable SQLite %s (%s)",
+            candidate.sqlite_version_string,
+            candidate.sqlite_source_id,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    return generation, python, candidate
+
+
+def _install_safe_python_generation(
+    uv_bin: str,
+    *,
+    project_root: Path,
+    current: SQLiteRuntimeInfo,
+) -> tuple[Path, Path, SQLiteRuntimeInfo] | None:
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    python_root = managed_python_install_dir(project_root)
+    _make_world_traversable(runtime_root)
+    _make_world_traversable(python_root)
+
+    request = _runtime_request(current)
+    print(f"  → Provisioning a private Python {request} runtime with fixed SQLite...")
+    result = _attempt_install_generation(
+        uv_bin, request, project_root=project_root,
+        python_root=python_root, current=current,
+    )
+    if result is not None:
+        return result
+
+    # The bare minor-line request resolved to a still-vulnerable (or
+    # otherwise rejected) candidate. Rather than giving up immediately,
+    # query which patches on this minor line uv actually knows about and
+    # retry with explicit newer versions, newest-first -- this handles the
+    # case where the default resolution for a bare request picks an older
+    # cached/indexed patch even though a newer, non-vulnerable one is
+    # available (issue #71250).
+    env_for_list = managed_python_env(project_root, install_dir=python_root)
+    patches = _list_available_patches(
+        uv_bin, request, cwd=project_root, env=env_for_list
+    )
+    tried_versions = {current.python_version[:3]}
+    attempts = 0
+    for version_tuple in patches:
+        if attempts >= _MAX_PATCH_RETRIES:
+            break
+        if version_tuple in tried_versions:
+            continue
+        # Only NEWER patches can carry the SQLite fix. A patch at or below the
+        # installed one is either the version we already know is vulnerable or
+        # an older build that cannot contain a later fix, and the downgrade
+        # guard in _attempt_install_generation rejects it anyway -- so trying
+        # it spends a full download+install+probe+delete cycle to reach a
+        # certain rejection. This matters on a uv whose download catalog is
+        # stale: in #71250 the newest indexed 3.11 was 3.11.14, exactly the
+        # installed version, so without this skip the loop burned all five
+        # retries walking backwards (3.11.13 -> 3.11.9) before failing.
+        if version_tuple <= current.python_version[:3]:
+            continue
+        tried_versions.add(version_tuple)
+        explicit_request = ".".join(str(p) for p in version_tuple)
+        print(f"  → Retrying with explicit patch {explicit_request}...")
+        attempts += 1
+        result = _attempt_install_generation(
+            uv_bin, explicit_request, project_root=project_root,
+            python_root=python_root, current=current,
+        )
+        if result is not None:
+            return result
+    return None
+
+
+def _smoke_candidate_venv(venv_dir: Path) -> tuple[bool, str, SQLiteRuntimeInfo | None]:
+    """Exercise the candidate interpreter and imports through its real path."""
+    python = _venv_python(venv_dir)
+    info = probe_sqlite_runtime(python)
+    if info is None:
+        return False, f"could not execute {python}", None
+    if info.wal_reset_vulnerable:
+        return (
+            False,
+            f"candidate still links vulnerable SQLite {info.sqlite_version_string}",
+            info,
+        )
+
+    check = (
+        "import dotenv, fastapi, openai, prompt_toolkit, pydantic, rich, uvicorn, yaml\n"
+        "import hermes_state\n"
+    )
+    env = dict(os.environ)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_PYTHON",
+        "VIRTUAL_ENV",
+    ):
+        env.pop(key, None)
+    try:
+        result = subprocess.run(
+            [str(python), "-I", "-c", check],
+            cwd=venv_dir.parent,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc), info
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "core import smoke failed").strip()
+        last_line = detail.splitlines()[-1] if detail else "core import smoke failed"
+        return False, last_line, info
+    return True, "", info
+
+
+def _stage_candidate_venv(
+    uv_bin: str,
+    *,
+    project_root: Path,
+    generation: Path,
+    python: Path,
+) -> Path | None:
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    candidate = runtime_root / f"venv-candidate-{token}"
+    env = managed_python_env(
+        project_root,
+        install_dir=generation,
+    )
+    env.update({
+        "UV_PROJECT_ENVIRONMENT": str(candidate),
+        "UV_PYTHON": str(python),
+        "UV_PYTHON_DOWNLOADS": "never",
+        "VIRTUAL_ENV": str(candidate),
+    })
+
+    print("  → Building a relocatable replacement environment...")
+    try:
+        created = subprocess.run(
+            [
+                uv_bin,
+                "venv",
+                str(candidate),
+                "--python",
+                str(python),
+                "--managed-python",
+                "--no-python-downloads",
+                "--relocatable",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_VENV_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate venv creation timed out after %ss",
+            UV_VENV_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv venv timed out after {UV_VENV_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    if created.returncode != 0:
+        logger.warning(
+            "candidate venv creation failed (rc=%d): %s",
+            created.returncode,
+            (created.stderr or created.stdout or "").strip(),
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+
+    if not (project_root / "uv.lock").is_file():
+        logger.warning("candidate dependency sync refused: uv.lock is missing")
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    # Locked sync must see project [tool.uv] exclude-newer; --no-config /
+    # UV_NO_CONFIG drops it and uv 0.12+ refuses --locked.
+    sync_env = dict(env)
+    sync_env.pop("UV_NO_CONFIG", None)
+    try:
+        synced = subprocess.run(
+            [
+                uv_bin,
+                "sync",
+                "--extra",
+                "all",
+                "--locked",
+                "--python",
+                str(_venv_python(candidate)),
+            ],
+            cwd=project_root,
+            env=sync_env,
+            check=False,
+            timeout=UV_SYNC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate dependency sync timed out after %ss",
+            UV_SYNC_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv sync timed out after {UV_SYNC_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    if synced.returncode != 0:
+        logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+
+    healthy, detail, _ = _smoke_candidate_venv(candidate)
+    if not healthy:
+        logger.warning("candidate venv smoke failed: %s", detail)
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    return candidate
+
+
+def _rename_with_retry(source: Path, destination: Path) -> None:
+    last_error: OSError | None = None
+    for delay in (0.0, 0.1, 0.25, 0.5, 1.0):
+        if delay:
+            time.sleep(delay)
+        try:
+            source.rename(destination)
+            return
+        except OSError as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+
+
+def _cut_over_candidate(
+    candidate: Path,
+    *,
+    project_root: Path,
+    live: Path | None = None,
+) -> tuple[bool, Path | None, SQLiteRuntimeInfo | None, str]:
+    live = live if live is not None else project_root / _VENV_NAME
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    backup = live.with_name(f"{live.name}.stale.runtime-{token}")
+    rejected = runtime_root / f"venv-rejected-{token}"
+
+    try:
+        try:
+            _rename_with_retry(live, backup)
+        except OSError as exc:
+            return False, None, None, f"could not park the existing venv: {exc}"
+
+        try:
+            _rename_with_retry(candidate, live)
+        except OSError as promote_error:
+            try:
+                _rename_with_retry(backup, live)
+            except OSError as rollback_error:
+                return (
+                    False,
+                    backup,
+                    None,
+                    "could not promote the replacement venv "
+                    f"({promote_error}); rollback failed ({rollback_error})",
+                )
+            return (
+                False,
+                None,
+                None,
+                f"could not promote the replacement venv: {promote_error}",
+            )
+
+        try:
+            healthy, detail, info = _smoke_candidate_venv(live)
+        except Exception as exc:
+            healthy, detail, info = False, f"candidate smoke raised: {exc}", None
+        if healthy:
+            return True, backup, info, ""
+
+        try:
+            _rename_with_retry(live, rejected)
+            _rename_with_retry(backup, live)
+        except OSError as exc:
+            return (
+                False,
+                backup,
+                info,
+                "post-cutover smoke failed "
+                f"({detail}); rollback failed ({exc}); rejected venv: {rejected}",
+            )
+        _remove_tree(rejected, boundary=runtime_root)
+        return False, None, info, f"post-cutover smoke failed: {detail}"
+    except BaseException:
+        if not live.exists() and backup.exists():
+            try:
+                _rename_with_retry(backup, live)
+            except OSError as exc:
+                logger.error(
+                    "interrupted runtime cutover could not restore %s from %s: %s",
+                    live,
+                    backup,
+                    exc,
+                )
+        raise
+
+
+def _acquire_repair_lock(runtime_root: Path) -> _RepairLock | None:
+    """Acquire an OS-held install lock that is released on process exit."""
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    _make_world_traversable(runtime_root)
+    path = runtime_root / _REPAIR_LOCK_NAME
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        return None
+
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (ImportError, OSError):
+        os.close(fd)
+        return None
+    return _RepairLock(path=path, fd=fd)
+
+
+def _release_repair_lock(lock: _RepairLock) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(lock.fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock.fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock.fd, fcntl.LOCK_UN)
+    except (ImportError, OSError):
+        pass
+    finally:
+        try:
+            os.close(lock.fd)
+        except OSError:
+            pass
+
+
+def _windows_runtime_holders() -> tuple[bool, str]:
+    if platform.system() != "Windows":
+        return False, ""
+    main_module = sys.modules.get("hermes_cli.main")
+    detector = getattr(main_module, "_detect_venv_python_processes", None)
+    if detector is None:
+        return True, "cannot verify Windows venv holders from this update context"
+    try:
+        holders = detector()
+    except Exception as exc:
+        return True, f"could not verify Windows venv holders: {exc}"
+    if holders:
+        pids = ", ".join(str(item[0]) for item in holders[:6])
+        return True, f"other Hermes processes still hold the venv (PID {pids})"
+    return False, ""
+
+
+def _uv_version_string(uv_bin: str) -> str:
+    """Return ``uv --version`` output, or ``""`` when it cannot be read."""
+    try:
+        result = subprocess.run(
+            [uv_bin, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=15,
+        )
+    except Exception:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _refresh_managed_uv_catalog(uv_bin: str) -> bool:
+    """Re-bootstrap the managed uv binary to refresh its Python catalog.
+
+    The managed uv is installed with ``UV_UNMANAGED_INSTALL``, which disables
+    ``uv self update`` by design — so its embedded python-build-standalone
+    download catalog stays frozen at bootstrap age.  python-build-standalone
+    re-releases existing CPython patch versions with newer SQLite (e.g. the
+    3.11.15 build was re-cut with SQLite 3.53.x), so a stale catalog can make
+    every provisioning attempt resolve to a vulnerable build even though a
+    fixed build of the SAME patch version exists (issue #72093).  The
+    patch-retry loop cannot recover from that: the fixed build carries no
+    newer version number to retry with.
+
+    Re-running the official installer is the only supported refresh path for
+    unmanaged installs.  Only the Hermes-managed binary is ever refreshed;
+    a caller-supplied foreign uv path is left alone.
+
+    Returns ``True`` when the binary's version actually changed — i.e. a
+    provisioning retry can now see a different catalog.  ``False`` means a
+    retry would resolve identically and is not worth the download cycle.
+    """
+    managed = managed_uv_path()
+    try:
+        if Path(uv_bin).resolve() != managed.resolve():
+            return False
+    except OSError:
+        return False
+    before = _uv_version_string(uv_bin)
+    try:
+        _install_uv(managed)
+    except Exception as exc:
+        logger.warning("managed uv refresh failed: %s", exc)
+        return False
+    after = _uv_version_string(uv_bin)
+    if not after:
+        return False
+    return after != before
+
+
+def _default_live_venv(root: Path) -> Path:
+    """Return the venv that runtime repair should target for *root*.
+
+    Managed installs create ``<checkout>/venv``, but uv-default and dev
+    checkouts use ``<checkout>/.venv``.  Historically only ``venv`` was
+    probed, so a ``.venv`` install linking a vulnerable SQLite returned
+    ``not-applicable`` on every ``hermes update`` and stayed on
+    journal_mode=DELETE forever — even though the WAL fallback warning
+    promises that ``hermes update`` repairs the runtime (issue class:
+    2,600x slower ``state.db`` appends under DELETE).
+
+    ``venv`` wins when it holds an interpreter (managed layout takes
+    precedence); otherwise fall back to ``.venv`` when that one does.
+    When neither has an interpreter, return the ``venv`` path so the
+    caller's existing ``not-applicable`` handling fires unchanged.
+    """
+    primary = root / _VENV_NAME
+    if _venv_python(primary).is_file():
+        return primary
+    fallback = root / _ALT_VENV_NAME
+    if _venv_python(fallback).is_file():
+        return fallback
+    return primary
+
+
+def _sweep_stale_runtime_backups(
+    live: Path,
+    *,
+    root: Path,
+    keep: Path | None = None,
+    min_age_seconds: float = 3600.0,
+) -> None:
+    """Remove leftover ``venv.stale.runtime-*`` backups next to *live*.
+
+    A successful runtime repair parks the previous venv as
+    ``<live>.stale.runtime-<token>``; historically nothing ever reclaimed
+    those, so each repair leaked a full venv (~1 GB) at the project root
+    forever (issue #73109).  On POSIX, deleting the tree is safe even while
+    an older process still maps files from it — open FDs and mmaps keep
+    their inodes alive; the directory entry is what goes away.
+
+    ``min_age_seconds`` guards against racing a concurrent repair in
+    another process: a backup parked seconds ago may still be that
+    repair's rollback path, so only clearly-old markers are swept.
+    ``keep`` exempts the backup the current repair just created.
+    Best-effort: never raises.
+    """
+    try:
+        candidates = list(live.parent.glob(f"{live.name}.stale.runtime-*"))
+    except OSError:
+        return
+    now = time.time()
+    for candidate in candidates:
+        if keep is not None and candidate == keep:
+            continue
+        try:
+            age = now - candidate.stat().st_mtime
+        except OSError:
+            continue
+        if age < min_age_seconds:
+            continue
+        _remove_tree(candidate, boundary=root)
+
+
+def repair_vulnerable_runtime(
+    uv_bin: str,
+    *,
+    project_root: Path | None = None,
+    venv_dir: Path | None = None,
+) -> RuntimeRepairResult:
+    """Replace a vulnerable install venv without mutating it in place.
+
+    Every failure before cutover leaves the live venv untouched. Rename or
+    post-cutover smoke failures restore the parked venv synchronously.
+    """
+    root = Path(project_root) if project_root is not None else _PROJECT_ROOT
+    live = Path(venv_dir) if venv_dir is not None else _default_live_venv(root)
+    live_python = _venv_python(live)
+    if not (root / "pyproject.toml").is_file() or not live_python.is_file():
+        return RuntimeRepairResult("not-applicable")
+
+    current = probe_sqlite_runtime(live_python)
+    if current is None:
+        return RuntimeRepairResult(
+            "skipped",
+            f"could not probe live interpreter {live_python}",
+        )
+    if not current.wal_reset_vulnerable:
+        # The runtime is already fixed — any venv.stale.runtime-* markers
+        # next to the live venv are leftovers from a past repair (or from
+        # a build predating the post-repair cleanup) and will never be
+        # rolled back to. Sweep them so they don't leak ~1 GB each
+        # forever (issue #73109). Age-gated to avoid racing an in-flight
+        # repair in a sibling process.
+        _sweep_stale_runtime_backups(live, root=root)
+        return RuntimeRepairResult(
+            "safe",
+            sqlite_before=current.sqlite_version_string,
+            sqlite_after=current.sqlite_version_string,
+        )
+
+    blocked, detail = _windows_runtime_holders()
+    if blocked:
+        print(f"  ⚠ SQLite runtime repair deferred: {detail}")
+        return RuntimeRepairResult(
+            "skipped",
+            detail,
+            sqlite_before=current.sqlite_version_string,
+        )
+
+    runtime_root = root / _RUNTIME_DIR_NAME
+    lock = _acquire_repair_lock(runtime_root)
+    if lock is None:
+        detail = "another runtime repair is already in progress"
+        print(f"  ⚠ SQLite runtime repair deferred: {detail}")
+        return RuntimeRepairResult(
+            "skipped",
+            detail,
+            sqlite_before=current.sqlite_version_string,
+        )
+
+    generation: Path | None = None
+    candidate: Path | None = None
+    try:
+        # Re-probe under the install-scoped lock: another updater may have
+        # completed the repair while this process was entering the path.
+        current = probe_sqlite_runtime(live_python)
+        if current is None:
+            return RuntimeRepairResult("skipped", "live interpreter probe failed")
+        if not current.wal_reset_vulnerable:
+            return RuntimeRepairResult(
+                "safe",
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=current.sqlite_version_string,
+            )
+
+        print(
+            "  ⚠ Hermes venv links SQLite "
+            f"{current.sqlite_version_string}, which has the WAL-reset bug."
+        )
+        provisioned = _install_safe_python_generation(
+            uv_bin,
+            project_root=root,
+            current=current,
+        )
+        if provisioned is None:
+            # Likely a stale managed-uv catalog: python-build-standalone
+            # re-releases the same patch versions with fixed SQLite, but a
+            # frozen catalog keeps resolving the old vulnerable build and the
+            # patch-retry loop has no newer number to try (issue #72093).
+            # Refresh the managed binary and retry once.
+            if _refresh_managed_uv_catalog(uv_bin):
+                print("  → Managed uv refreshed; retrying provisioning...")
+                provisioned = _install_safe_python_generation(
+                    uv_bin,
+                    project_root=root,
+                    current=current,
+                )
+        if provisioned is None:
+            return RuntimeRepairResult(
+                "failed",
+                "could not provision a fixed private Python runtime",
+                sqlite_before=current.sqlite_version_string,
+            )
+        generation, python, candidate_info = provisioned
+
+        candidate = _stage_candidate_venv(
+            uv_bin,
+            project_root=root,
+            generation=generation,
+            python=python,
+        )
+        if candidate is None:
+            _remove_tree(generation, boundary=managed_python_install_dir(root))
+            return RuntimeRepairResult(
+                "failed",
+                "replacement environment did not pass dependency and import smoke tests",
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=candidate_info.sqlite_version_string,
+            )
+
+        cut_over, backup, final_info, cutover_detail = _cut_over_candidate(
+            candidate,
+            project_root=root,
+            live=live,
+        )
+        if not cut_over:
+            if backup is None:
+                _remove_tree(candidate, boundary=runtime_root)
+                _remove_tree(generation, boundary=managed_python_install_dir(root))
+            return RuntimeRepairResult(
+                "failed",
+                cutover_detail,
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=(
+                    final_info.sqlite_version_string if final_info is not None else ""
+                ),
+                backup_venv=backup,
+            )
+
+        final_version = (
+            final_info.sqlite_version_string
+            if final_info is not None
+            else candidate_info.sqlite_version_string
+        )
+        print(
+            "  ✓ Managed Python runtime repaired "
+            f"(SQLite {current.sqlite_version_string} → {final_version})"
+        )
+        if backup is not None and backup.exists():
+            _remove_tree(backup, boundary=root)
+        return RuntimeRepairResult(
+            "repaired",
+            sqlite_before=current.sqlite_version_string,
+            sqlite_after=final_version,
+            backup_venv=backup,
+        )
+    finally:
+        _release_repair_lock(lock)
 
 
 # ---------------------------------------------------------------------------
 # Installer internals
 # ---------------------------------------------------------------------------
+
 
 def _install_uv(target: Path) -> None:
     """Bootstrap uv into *target* using the official standalone installer.
@@ -240,9 +1354,7 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 def _install_uv_windows(env: dict[str, str]) -> None:
     """Invoke the PowerShell installer."""
-    cmd = (
-        'irm https://astral.sh/uv/install.ps1 | iex'
-    )
+    cmd = "irm https://astral.sh/uv/install.ps1 | iex"
     subprocess.run(
         ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
         env=env,
@@ -250,5 +1362,6 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         capture_output=True,
     )
 
+
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
-    True # dont remove me. ask ethernet
+    True  # dont remove me. ask ethernet

--- a/hermes_cli/sqlite_runtime.py
+++ b/hermes_cli/sqlite_runtime.py
@@ -1,0 +1,124 @@
+"""Import-safe helpers for inspecting a Python interpreter's linked SQLite.
+
+This module intentionally depends only on the standard library.  Installer and
+update code must be able to use it before Hermes' third-party dependencies are
+healthy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+def _version_tuple(parts: Iterable[object]) -> tuple[int, int, int]:
+    values = [int(part) for part in parts]
+    values.extend([0] * (3 - len(values)))
+    return tuple(values[:3])
+
+
+def is_sqlite_wal_reset_vulnerable(
+    version_info: tuple[int, ...],
+) -> bool:
+    """Return whether *version_info* contains SQLite's WAL-reset bug."""
+    info = _version_tuple(version_info)
+    if info < (3, 7, 0):
+        return False
+    if info >= (3, 51, 3):
+        return False
+    if (3, 50, 7) <= info < (3, 51, 0):
+        return False
+    if (3, 44, 6) <= info < (3, 45, 0):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class SQLiteRuntimeInfo:
+    """SQLite details reported by one exact Python executable."""
+
+    executable: Path
+    base_prefix: Path
+    python_version: tuple[int, int, int]
+    sqlite_version: tuple[int, int, int]
+    sqlite_version_string: str
+    sqlite_source_id: str
+
+    @property
+    def wal_reset_vulnerable(self) -> bool:
+        return is_sqlite_wal_reset_vulnerable(self.sqlite_version)
+
+
+_PROBE_SCRIPT = """
+import json
+import sqlite3
+import sys
+
+conn = sqlite3.connect(":memory:")
+try:
+    row = conn.execute("SELECT sqlite_source_id()").fetchone()
+finally:
+    conn.close()
+
+print(json.dumps({
+    "base_prefix": sys.base_prefix,
+    "executable": sys.executable,
+    "python_version": list(sys.version_info[:3]),
+    "sqlite_version": list(sqlite3.sqlite_version_info),
+    "sqlite_version_string": sqlite3.sqlite_version,
+    "sqlite_source_id": str(row[0]) if row and row[0] is not None else "",
+}))
+"""
+
+
+def probe_sqlite_runtime(
+    python: str | Path,
+    *,
+    timeout: float = 30.0,
+) -> SQLiteRuntimeInfo | None:
+    """Probe SQLite in *python*, never the caller's linked SQLite.
+
+    ``None`` means the interpreter could not be executed or returned malformed
+    data.  The child runs isolated from inherited Python path overrides.
+    """
+    executable = Path(python)
+    env = dict(os.environ)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_PYTHON",
+        "VIRTUAL_ENV",
+    ):
+        env.pop(key, None)
+    try:
+        result = subprocess.run(
+            [str(executable), "-I", "-c", _PROBE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+        return SQLiteRuntimeInfo(
+            executable=Path(str(payload["executable"])),
+            base_prefix=Path(str(payload["base_prefix"])),
+            python_version=_version_tuple(payload["python_version"]),
+            sqlite_version=_version_tuple(payload["sqlite_version"]),
+            sqlite_version_string=str(payload["sqlite_version_string"]),
+            sqlite_source_id=str(payload.get("sqlite_source_id", "")),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -253,3 +253,118 @@ class TestInstallUvInternals:
             mock_windows.assert_called_once()
             call_env = mock_windows.call_args[0][0]
             assert call_env["UV_INSTALL_DIR"] == str(tmp_path / "bin")
+
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Provisioning timeout regression tests (#76684)
+# ---------------------------------------------------------------------------
+class TestProvisioningTimeouts:
+    """#76684: provisioning subprocesses must time out and surface to stderr."""
+
+    def test_python_install_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _attempt_install_generation
+        python_root = tmp_path / "python"
+        python_root.mkdir()
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=1)
+            result = _attempt_install_generation(
+                "uv", "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        assert "network" in err.lower()
+        assert list(python_root.glob("generation-*")) == []
+
+    def test_python_find_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _attempt_install_generation
+        python_root = tmp_path / "python"
+        python_root.mkdir()
+
+        call_count = {"n": 0}
+        def _side_effect(*a, **k):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=_side_effect):
+            result = _attempt_install_generation(
+                "uv", "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        assert list(python_root.glob("generation-*")) == []
+
+    def test_venv_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+        generation = tmp_path / "generation-test"
+        generation.mkdir()
+        python_exe = generation / "python"
+        python_exe.touch()
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=1)
+            result = _stage_candidate_venv(
+                "uv",
+                project_root=tmp_path,
+                generation=generation,
+                python=python_exe,
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        runtime_root = tmp_path / ".hermes-runtime"
+        assert list(runtime_root.glob("venv-candidate-*")) == []
+
+    def test_sync_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+        generation = tmp_path / "generation-test"
+        generation.mkdir()
+        python_exe = generation / "python"
+        python_exe.touch()
+        (tmp_path / "uv.lock").touch()
+
+        call_count = {"n": 0}
+        def _side_effect(*a, **k):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=_side_effect), \
+             patch("hermes_cli.managed_uv._venv_python", return_value=python_exe):
+            result = _stage_candidate_venv(
+                "uv",
+                project_root=tmp_path,
+                generation=generation,
+                python=python_exe,
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+
+    def test_timeout_constants_positive(self):
+        from hermes_cli.managed_uv import (
+            UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+            UV_PYTHON_FIND_TIMEOUT_SECONDS,
+            UV_VENV_TIMEOUT_SECONDS,
+            UV_SYNC_TIMEOUT_SECONDS,
+        )
+        assert UV_PYTHON_INSTALL_TIMEOUT_SECONDS > 0
+        assert UV_PYTHON_FIND_TIMEOUT_SECONDS > 0
+        assert UV_VENV_TIMEOUT_SECONDS > 0
+        assert UV_SYNC_TIMEOUT_SECONDS > 0


### PR DESCRIPTION
## Summary

Add explicit `timeout=` to all 4 network-bound provisioning `subprocess.run()` calls in `managed_uv.py` that were identified in #76684, and print a user-visible message to `stderr` on `TimeoutExpired`.

## Gap addressed vs #76690 and #76693

Both existing PRs only call `logger.warning()` in their `TimeoutExpired` handlers — output goes to the log file only. This PR also prints to `stderr` so the terminal user sees the failure immediately.

## Changes

| Call | Timeout | On timeout |
|------|---------|------------|
| `uv python install` | 180s | logger.warning + print to stderr + cleanup + return None |
| `uv python find` | 30s | logger.warning + print to stderr + cleanup + return None |
| `uv venv` | 60s | logger.warning + print to stderr + cleanup + return None |
| `uv sync` | 300s | logger.warning + print to stderr + cleanup + return None |

The existing `uv self update` freshness gate (lines 337–350) is preserved untouched.

## Test plan

- 5 new regression tests in `TestProvisioningTimeouts` covering all 4 timeout handlers + constant assertions
- All 24 tests pass (`pytest tests/hermes_cli/test_managed_uv.py`)

Fixes #76684