### PR TITLE
fix(update): skip gateway cold-start when desktop backend is running (#76129)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3238,6 +3238,38 @@ def _cold_start_windows_gateway_after_update() -> None:
         logger.debug("Could not re-check gateway liveness before cold-start: %s", exc)
         return
 
+    # The Desktop app's backend (``hermes serve``) hosts the gateway runtime
+    # but uses a different subcommand than ``gateway run``, so
+    # ``find_gateway_pids`` does not see it.  Spawning a standalone gateway
+    # alongside the desktop backend creates duplicate daemons that race on
+    # ports and state files (#76129).  Scan for a running ``serve`` process
+    # before spawning.
+    try:
+        import psutil  # type: ignore
+
+        for proc in psutil.process_iter(["cmdline"]):
+            try:
+                cmdline = " ".join(proc.info.get("cmdline") or [])
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            cmdline_lc = cmdline.lower()
+            _tokens = cmdline_lc.split()
+            # Match ``hermes serve`` / ``hermes.exe serve`` and the module
+            # form ``python -m hermes_cli.main serve``.
+            _is_hermes = any(
+                t.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] in ("hermes", "hermes.exe")
+                for t in _tokens
+            ) or "hermes_cli" in cmdline_lc
+            if _is_hermes and "serve" in _tokens:
+                logger.debug(
+                    "Desktop backend (hermes serve) already running (PID %d); "
+                    "skipping gateway cold-start",
+                    proc.pid,
+                )
+                return
+    except Exception:
+        pass
+
     try:
         pid = gateway_windows._spawn_detached()
     except Exception as exc:


### PR DESCRIPTION
## Summary

Fixes #76129 — `hermes update` spawns a duplicate standalone gateway on every update when the Desktop app's backend (`hermes serve`) is already running.

## Root Cause

`_cold_start_windows_gateway_after_update()` uses `find_gateway_pids()` to check if a gateway is already running before spawning. `find_gateway_pids()` delegates to `looks_like_gateway_command_line()` which only matches `gateway run` / `gateway restart` subcommands. The Desktop app's backend uses `hermes serve`, which is invisible to this matcher. Result: the cold-start check always returns empty, and a new gateway is spawned alongside the existing desktop backend.

## Fix

Add a `psutil` process scan in `_cold_start_windows_gateway_after_update()` that detects running `hermes serve` processes before spawning. If the Desktop backend is already hosting the gateway runtime, skip the cold start.

The matcher recognizes:
- `hermes serve --host ... --port ...`
- `hermes.exe serve ...`
- `python -m hermes_cli.main serve ...`

## Changes

- `hermes_cli/update_cmd.py`: Add serve-process detection before gateway cold-start spawn.

## Testing

- On Windows with Desktop app running (`hermes serve`), `hermes update` no longer spawns a duplicate gateway.
- Standalone gateway installations (no Desktop) still cold-start correctly.
- The psutil scan is best-effort — any failure falls through to the existing spawn logic.
