### PR TITLE
fix(gateway): restore notices after external restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1662,7 +1662,7 @@ def _planned_restart_notification_path() -> Path:
 
 
 def _planned_restart_notification_pending() -> bool:
-    """Return True when a non-chat planned restart should notify home channels."""
+    """Return True when a non-chat restart should emit startup notifications."""
     return _planned_restart_notification_path().exists()
 
 
@@ -9046,12 +9046,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
-    async def _notify_active_sessions_of_shutdown(self) -> None:
+    async def _notify_active_sessions_of_shutdown(self) -> list[Dict[str, Any]]:
         """Send shutdown/restart notifications to active chats and home channels.
 
         Called at the very start of stop() — adapters are still connected so
         messages can be delivered. Best-effort: individual send failures are
-        logged and swallowed so they never block the shutdown sequence.
+        logged and swallowed so they never block the shutdown sequence. Returns
+        the exact routing targets that successfully received the notice, so a
+        signal-triggered restart can notify those same destinations on startup.
         """
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
@@ -9066,6 +9068,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
+        notified_targets: list[Dict[str, Any]] = []
         for session_key in active:
             source = None
             try:
@@ -9149,6 +9152,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                target: Dict[str, Any] = {
+                    "platform": platform_str,
+                    "chat_id": chat_id,
+                }
+                if source is not None:
+                    chat_type = getattr(source, "chat_type", None)
+                    if chat_type:
+                        target["chat_type"] = str(chat_type)
+                    message_id = getattr(source, "message_id", None)
+                    if message_id:
+                        target["message_id"] = str(message_id)
+                if thread_id:
+                    target["thread_id"] = str(thread_id)
+                notified_targets.append(target)
                 logger.info(
                     "Sent shutdown notification to active chat %s:%s",
                     platform_str, chat_id,
@@ -9161,7 +9178,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if self._restart_requested and restart_source is not None:
             logger.debug("Skipping home-channel shutdown notifications for in-chat restart")
-            return
+            return notified_targets
 
         # Suppress ONLY the home-channel broadcast when the drain that is ending
         # in this shutdown asked us to be quiet (e.g. a NAS auto-update image
@@ -9183,7 +9200,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Home-channel shutdown broadcast suppressed by drain marker "
                     "(suppress_notification=true)"
                 )
-                return
+                return notified_targets
         except Exception as e:
             # Never let the suppression check block the shutdown broadcast —
             # fail toward the louder, more-visible behaviour.
@@ -9232,6 +9249,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                target = {
+                    "platform": platform.value,
+                    "chat_id": str(home.chat_id),
+                }
+                if home.thread_id:
+                    target["thread_id"] = str(home.thread_id)
+                notified_targets.append(target)
                 logger.info(
                     "Sent shutdown notification to home channel %s:%s",
                     platform.value,
@@ -9244,6 +9268,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.chat_id,
                     e,
                 )
+
+        return notified_targets
 
     async def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
@@ -11120,6 +11146,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Notify the chat that initiated /restart that the gateway is back.
         chat_restart_notification_pending = _restart_notification_pending()
         planned_restart_notification_pending = _planned_restart_notification_pending()
+        planned_restart_notification_data: Dict[str, Any] = {}
+        if planned_restart_notification_pending:
+            try:
+                loaded = json.loads(
+                    _planned_restart_notification_path().read_text(encoding="utf-8")
+                )
+                if isinstance(loaded, dict):
+                    planned_restart_notification_data = loaded
+            except Exception as exc:
+                logger.warning("Failed to read planned restart notification marker: %s", exc)
         # Capture, before _send_restart_notification() unlinks the marker,
         # whether this process booted from a chat-originated /restart. Used as
         # a one-shot signal by the /restart redelivery guard so a missing
@@ -11129,15 +11165,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._booted_from_restart = True
         await self._send_restart_notification()
 
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
+        # Send a lightweight "gateway is back" message after non-chat restart
+        # paths. Prefer the exact destinations that successfully received the
+        # shutdown notice, then fall back to configured home channels. A
+        # chat-originated /restart already has its precise reply target in
+        # .restart_notify.json, so keep that lifecycle in the originating
+        # chat/topic instead of also leaking it to the home channel.
         if planned_restart_notification_pending:
             try:
+                delivered_targets = await self._send_planned_restart_target_notifications(
+                    planned_restart_notification_data.get("targets", [])
+                )
                 await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
+                    skip_targets=delivered_targets,
                 )
             finally:
                 _clear_planned_restart_notification()
@@ -12246,7 +12286,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
-            await self._notify_active_sessions_of_shutdown()
+            shutdown_notification_targets = await self._notify_active_sessions_of_shutdown()
             logger.info(
                 "Shutdown phase: notify_active_sessions done at +%.2fs",
                 _phase_elapsed(),
@@ -12536,7 +12576,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            should_notify_after_restart = (
+                getattr(self, "_restart_command_source", None) is None
+                and (
+                    self._restart_requested
+                    or getattr(self, "_signal_initiated_shutdown", False)
+                )
+            )
+            if should_notify_after_restart:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
@@ -12544,6 +12591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "requested_at": time.time(),
                             "via_service": bool(self._restart_via_service),
                             "detached": bool(self._restart_detached),
+                            "targets": shutdown_notification_targets or [],
                         },
                         indent=None,
                     )
@@ -20538,6 +20586,103 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Home-channel startup notification failed for %s:%s: %s",
                     platform.value,
                     home.chat_id,
+                    exc,
+                )
+
+        return delivered
+
+    async def _send_planned_restart_target_notifications(
+        self,
+        targets: Any,
+    ) -> set[tuple[str, str, Optional[str]]]:
+        """Notify exact destinations that received a pre-restart shutdown notice.
+
+        Targets are persisted only after their shutdown notice was delivered.
+        Startup delivery is best-effort and uses the same platform notification
+        opt-out as chat- and home-target restart messages.
+        """
+        delivered: set[tuple[str, str, Optional[str]]] = set()
+        if not isinstance(targets, list):
+            return delivered
+
+        message = "♻️ Gateway online — Hermes is back and ready."
+        for raw_target in targets:
+            if not isinstance(raw_target, dict):
+                continue
+            platform_str = raw_target.get("platform")
+            chat_id = raw_target.get("chat_id")
+            if not platform_str or not chat_id:
+                continue
+
+            try:
+                platform = Platform(str(platform_str))
+            except ValueError:
+                logger.warning(
+                    "Planned restart notification skipped: unknown platform %s",
+                    platform_str,
+                )
+                continue
+
+            thread_id = raw_target.get("thread_id")
+            target = (
+                platform.value,
+                str(chat_id),
+                str(thread_id) if thread_id else None,
+            )
+            if target in delivered:
+                continue
+
+            transport = resolve_delivery_transport(platform, self.config, self.adapters)
+            if transport is None:
+                logger.debug(
+                    "Planned restart notification skipped: no live transport for %s",
+                    platform.value,
+                )
+                continue
+
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Planned restart notification suppressed: %s has gateway_restart_notification=false",
+                    platform.value,
+                )
+                continue
+
+            try:
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    str(chat_id),
+                    str(thread_id) if thread_id else None,
+                    chat_type=raw_target.get("chat_type"),
+                    reply_to_message_id=raw_target.get("message_id"),
+                    adapter=transport.adapter,
+                )
+                result = await transport.send(
+                    platform,
+                    str(chat_id),
+                    message,
+                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                )
+                if result is not None and getattr(result, "success", True) is False:
+                    logger.warning(
+                        "Planned restart notification to %s:%s was not delivered: %s",
+                        platform.value,
+                        chat_id,
+                        getattr(result, "error", "send returned success=False"),
+                    )
+                    continue
+
+                delivered.add(target)
+                logger.info(
+                    "Sent planned restart notification to %s:%s",
+                    platform.value,
+                    chat_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Planned restart notification failed for %s:%s: %s",
+                    platform.value,
+                    chat_id,
                     exc,
                 )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12581,6 +12581,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and (
                     self._restart_requested
                     or getattr(self, "_signal_initiated_shutdown", False)
+                    or getattr(self, "_restart_after_stop_requested", False)
                 )
             )
             if should_notify_after_restart:
@@ -25902,6 +25903,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             except Exception as e:
                 logger.debug("Planned stop marker check failed: %s", e)
 
+        restart_after_stop = False
+        if not planned_takeover:
+            try:
+                from gateway.status import consume_restart_after_stop_marker_for_self
+
+                restart_after_stop = consume_restart_after_stop_marker_for_self()
+            except Exception as e:
+                logger.debug("Restart-after-stop marker check failed: %s", e)
+        runner._restart_after_stop_requested = restart_after_stop
+
         # Fast (<10ms) snapshot of who's asking us to shut down — runs
         # synchronously inside the asyncio signal handler, so we keep it
         # purely stdlib + /proc reads, no subprocesses.  See PR #15826
@@ -25923,6 +25934,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM",
+            )
+        elif planned_stop and restart_after_stop:
+            logger.info(
+                "Received %s as a planned gateway stop for external restart — exiting cleanly",
+                _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",
             )
         elif planned_stop:
             logger.info(

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1579,6 +1579,8 @@ _TAKEOVER_MARKER_FILENAME = ".gateway-takeover.json"
 _TAKEOVER_MARKER_TTL_S = 60  # Marker older than this is treated as stale
 _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
+_RESTART_AFTER_STOP_MARKER_FILENAME = ".gateway-restart-after-stop.json"
+_RESTART_AFTER_STOP_MARKER_TTL_S = 60
 
 
 def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
@@ -1595,6 +1597,12 @@ def _get_planned_stop_marker_path() -> Path:
     """Return the path to the intentional gateway stop marker file."""
     home = _get_process_hermes_home()
     return home / _PLANNED_STOP_MARKER_FILENAME
+
+
+def _get_restart_after_stop_marker_path() -> Path:
+    """Return the path to the explicit stop-now/start-later restart intent."""
+    home = _get_process_hermes_home()
+    return home / _RESTART_AFTER_STOP_MARKER_FILENAME
 
 
 def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
@@ -2073,6 +2081,36 @@ def write_planned_stop_marker(target_pid: int) -> bool:
         return True
     except (OSError, PermissionError):
         return False
+
+
+def write_restart_after_stop_marker(target_pid: int) -> bool:
+    """Request a one-shot recovery notice after an explicit stop and start.
+
+    The PID and process start time bind the short-lived request to the current
+    gateway, so a stale marker cannot turn an unrelated later start into a
+    misleading recovery announcement.
+    """
+    try:
+        record = {
+            "target_pid": target_pid,
+            "target_start_time": _get_process_start_time(target_pid),
+            "requester_pid": os.getpid(),
+            "written_at": _utc_now_iso(),
+        }
+        _write_json_file(_get_restart_after_stop_marker_path(), record)
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
+def consume_restart_after_stop_marker_for_self() -> bool:
+    """Return True when this gateway was explicitly stopped for a restart."""
+    return _consume_pid_marker_for_self(
+        _get_restart_after_stop_marker_path(),
+        pid_field="target_pid",
+        start_time_field="target_start_time",
+        ttl_s=_RESTART_AFTER_STOP_MARKER_TTL_S,
+    )
 
 
 def consume_planned_stop_marker_for_self() -> bool:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -2113,6 +2113,14 @@ def consume_restart_after_stop_marker_for_self() -> bool:
     )
 
 
+def clear_restart_after_stop_marker() -> None:
+    """Remove an explicit restart intent when the requested stop did not occur."""
+    try:
+        _get_restart_after_stop_marker_path().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def consume_planned_stop_marker_for_self() -> bool:
     """Return True when the current process is being intentionally stopped."""
     return _consume_pid_marker_for_self(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7065,6 +7065,24 @@ def _gateway_command_inner(args):
 
         stop_all = getattr(args, "all", False)
         system = getattr(args, "system", False)
+        stop_for_restart = getattr(args, "for_restart", False)
+
+        if stop_for_restart:
+            if stop_all:
+                print_error("--for-restart cannot be combined with --all")
+                sys.exit(2)
+            from gateway.status import (
+                get_running_pid,
+                write_restart_after_stop_marker,
+            )
+
+            running_pid = get_running_pid()
+            if running_pid is None:
+                print_error("No running gateway found to prepare for restart")
+                sys.exit(1)
+            if not write_restart_after_stop_marker(running_pid):
+                print_error("Could not persist the gateway restart intent; stop aborted")
+                sys.exit(1)
 
         # Phase 4: inside a container with s6, dispatch via the service
         # manager. ``--all`` iterates every registered profile gateway

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7066,11 +7066,21 @@ def _gateway_command_inner(args):
         stop_all = getattr(args, "all", False)
         system = getattr(args, "system", False)
         stop_for_restart = getattr(args, "for_restart", False)
+        restart_intent_written = False
+
+        def rollback_restart_intent() -> None:
+            if not restart_intent_written:
+                return
+            from gateway.status import clear_restart_after_stop_marker
+
+            clear_restart_after_stop_marker()
 
         if stop_for_restart:
             if stop_all:
                 print_error("--for-restart cannot be combined with --all")
                 sys.exit(2)
+            if system:
+                _sync_hermes_home_from_systemd_unit(system=True)
             from gateway.status import (
                 get_running_pid,
                 write_restart_after_stop_marker,
@@ -7083,6 +7093,7 @@ def _gateway_command_inner(args):
             if not write_restart_after_stop_marker(running_pid):
                 print_error("Could not persist the gateway restart intent; stop aborted")
                 sys.exit(1)
+            restart_intent_written = True
 
         # Phase 4: inside a container with s6, dispatch via the service
         # manager. ``--all`` iterates every registered profile gateway
@@ -7090,8 +7101,13 @@ def _gateway_command_inner(args):
         # which s6-supervise observes as a crash and immediately restarts).
         if stop_all and _dispatch_all_via_service_manager_if_s6("stop"):
             return
-        if not stop_all and _dispatch_via_service_manager_if_s6("stop"):
-            return
+        if not stop_all:
+            try:
+                if _dispatch_via_service_manager_if_s6("stop"):
+                    return
+            except BaseException:
+                rollback_restart_intent()
+                raise
 
         if stop_all:
             # --all: kill every gateway process on the machine
@@ -7157,11 +7173,15 @@ def _gateway_command_inner(args):
             if not service_available:
                 # No systemd/launchd/schtasks service — use profile-scoped PID file
                 if stop_profile_gateway():
+                    service_available = True
                     print("✓ Stopped gateway for this profile")
                 else:
                     print("✗ No gateway running for this profile")
             else:
                 print(f"✓ Stopped {get_service_name()} service")
+
+            if not service_available:
+                rollback_restart_intent()
 
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -126,6 +126,14 @@ def build_gateway_parser(
         action="store_true",
         help="Stop ALL gateway processes across all profiles",
     )
+    gateway_stop.add_argument(
+        "--for-restart",
+        action="store_true",
+        help=(
+            "Stop the current gateway but notify interrupted chats when it is "
+            "started again (for externally coordinated runtime replacement)"
+        ),
+    )
 
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser(

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -103,6 +103,9 @@ def make_restart_runner(
     runner._send_home_channel_startup_notifications = (
         GatewayRunner._send_home_channel_startup_notifications.__get__(runner, GatewayRunner)
     )
+    runner._send_planned_restart_target_notifications = (
+        GatewayRunner._send_planned_restart_target_notifications.__get__(runner, GatewayRunner)
+    )
     runner._status_action_label = GatewayRunner._status_action_label.__get__(
         runner, GatewayRunner
     )

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -272,6 +272,35 @@ async def test_explicit_stop_does_not_queue_recovery_notification(tmp_path, monk
     assert not (tmp_path / ".restart_pending.json").exists()
 
 
+@pytest.mark.asyncio
+async def test_explicit_stop_for_restart_queues_delivered_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+    runner._restart_after_stop_requested = True
+
+    source = make_restart_source(
+        chat_id="parent-42", chat_type="group", thread_id="topic-7"
+    )
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    running_agent.interrupt.side_effect = lambda *a, **k: runner._running_agents.clear()
+    runner._running_agents[session_key] = running_agent
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = json.loads((tmp_path / ".restart_pending.json").read_text())
+    assert marker["targets"] == [
+        {
+            "platform": "telegram",
+            "chat_id": "parent-42",
+            "chat_type": "group",
+            "thread_id": "topic-7",
+        }
+    ]
+
+
 # ── #42126: zombie PID must be treated as dead in _pid_exists ────────────────
 # Under systemd Restart=always, the old gateway becomes a zombie (still in the
 # process table, not yet reaped) when the replacement starts. _pid_exists must

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -227,6 +228,50 @@ async def test_signal_initiated_shutdown_persists_running_not_stopped(tmp_path, 
     )
 
 
+@pytest.mark.asyncio
+async def test_signal_shutdown_records_delivered_thread_for_recovery(tmp_path, monkeypatch):
+    """A container/S6 restart must remember the exact active destination that
+    received the shutdown notice, even when no home channel is configured."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+    runner._signal_initiated_shutdown = True
+
+    source = make_restart_source(
+        chat_id="parent-42", chat_type="group", thread_id="topic-7"
+    )
+    source.message_id = "active-message"
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    running_agent.interrupt.side_effect = lambda *a, **k: runner._running_agents.clear()
+    runner._running_agents[session_key] = running_agent
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = json.loads((tmp_path / ".restart_pending.json").read_text())
+    assert marker["targets"] == [
+        {
+            "platform": "telegram",
+            "chat_id": "parent-42",
+            "chat_type": "group",
+            "thread_id": "topic-7",
+            "message_id": "active-message",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_stop_does_not_queue_recovery_notification(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert not (tmp_path / ".restart_pending.json").exists()
+
+
 # ── #42126: zombie PID must be treated as dead in _pid_exists ────────────────
 # Under systemd Restart=always, the old gateway becomes a zombie (still in the
 # process table, not yet reaped) when the replacement starts. _pid_exists must
@@ -269,5 +314,3 @@ def test_pid_exists_zombie_via_psutil_returns_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert status._pid_exists(4242) is False
-
-

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -32,6 +32,45 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     assert gateway_run._planned_restart_notification_pending() is False
 
 
+@pytest.mark.asyncio
+async def test_planned_restart_notifies_exact_thread_without_home_channel():
+    runner, adapter = make_restart_runner()
+
+    delivered = await runner._send_planned_restart_target_notifications(
+        [
+            {
+                "platform": "telegram",
+                "chat_id": "parent-42",
+                "chat_type": "group",
+                "thread_id": "topic-7",
+                "message_id": "shutdown-anchor",
+            }
+        ]
+    )
+
+    assert delivered == {("telegram", "parent-42", "topic-7")}
+    assert getattr(adapter, "sent_calls") == [
+        (
+            "parent-42",
+            "♻️ Gateway online — Hermes is back and ready.",
+            {"thread_id": "topic-7"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_planned_restart_target_respects_notification_opt_out():
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+
+    delivered = await runner._send_planned_restart_target_notifications(
+        [{"platform": "telegram", "chat_id": "42"}]
+    )
+
+    assert delivered == set()
+    assert getattr(adapter, "sent_calls") == []
+
+
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
 
 
@@ -411,5 +450,3 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     await runner._notify_active_sessions_of_shutdown()
 
     adapter.send.assert_not_awaited()
-
-

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -773,6 +773,23 @@ class TestPlannedStopMarker:
         assert result is False
 
 
+class TestRestartAfterStopMarker:
+    """Tests for the public stop-now/start-later restart intent."""
+
+    def test_marker_roundtrip_targets_only_the_same_gateway(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+
+        assert status.write_restart_after_stop_marker(os.getpid()) is True
+        marker = tmp_path / ".gateway-restart-after-stop.json"
+        payload = json.loads(marker.read_text())
+        assert payload["target_pid"] == os.getpid()
+        assert payload["target_start_time"] == 42
+
+        assert status.consume_restart_after_stop_marker_for_self() is True
+        assert not marker.exists()
+
+
 class TestReadProcessCmdlinePsFallback:
     """Tests for _read_process_cmdline falling back to ps on non-Linux."""
 
@@ -1127,4 +1144,3 @@ class TestResolveGatewayLiveness:
         # expected_home is what stops a recycled PID belonging to another
         # profile's live gateway from being reported as this profile's.
         assert seen["expected_home"] == profile_dir
-

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -235,6 +235,31 @@ class TestGeneratedSystemdUnits:
 
 
 class TestGatewayStopCleanup:
+    def test_stop_for_restart_persists_public_restart_intent(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(status, "get_running_pid", lambda: 4242)
+        monkeypatch.setattr(
+            status,
+            "write_restart_after_stop_marker",
+            lambda pid: calls.append(pid) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda action: action == "stop",
+        )
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="stop",
+                all=False,
+                system=False,
+                for_restart=True,
+            )
+        )
+
+        assert calls == [4242]
+
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
         """Without --all, stop uses systemd (if available) and does NOT call
         the global kill_gateway_processes()."""
@@ -1755,4 +1780,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -260,6 +260,102 @@ class TestGatewayStopCleanup:
 
         assert calls == [4242]
 
+    def test_stop_for_restart_system_syncs_home_before_pid_lookup(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_sync_hermes_home_from_systemd_unit",
+            lambda system: calls.append(("sync", system)),
+        )
+        monkeypatch.setattr(
+            status,
+            "get_running_pid",
+            lambda: calls.append(("pid", os.environ.get("HERMES_HOME"))) or 4242,
+        )
+        monkeypatch.setattr(
+            status,
+            "write_restart_after_stop_marker",
+            lambda pid: calls.append(("marker", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda action: True,
+        )
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="stop",
+                all=False,
+                system=True,
+                for_restart=True,
+            )
+        )
+
+        assert calls == [("sync", True), ("pid", os.environ.get("HERMES_HOME")), ("marker", 4242)]
+
+    def test_stop_for_restart_clears_intent_when_no_stop_occurs(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(status, "get_running_pid", lambda: 4242)
+        monkeypatch.setattr(status, "write_restart_after_stop_marker", lambda pid: True)
+        monkeypatch.setattr(
+            status,
+            "clear_restart_after_stop_marker",
+            lambda: calls.append("clear"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda action: False,
+        )
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "stop_profile_gateway", lambda: False)
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="stop",
+                all=False,
+                system=False,
+                for_restart=True,
+            )
+        )
+
+        assert calls == ["clear"]
+
+    def test_stop_for_restart_clears_intent_when_dispatch_fails(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(status, "get_running_pid", lambda: 4242)
+        monkeypatch.setattr(status, "write_restart_after_stop_marker", lambda pid: True)
+        monkeypatch.setattr(
+            status,
+            "clear_restart_after_stop_marker",
+            lambda: calls.append("clear"),
+        )
+
+        def fail_dispatch(action):
+            raise RuntimeError("s6 stop failed")
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            fail_dispatch,
+        )
+
+        with pytest.raises(RuntimeError, match="s6 stop failed"):
+            gateway_cli.gateway_command(
+                SimpleNamespace(
+                    gateway_command="stop",
+                    all=False,
+                    system=False,
+                    for_restart=True,
+                )
+            )
+
+        assert calls == ["clear"]
+
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
         """Without --all, stop uses systemd (if available) and does NOT call
         the global kill_gateway_processes()."""

--- a/tests/hermes_cli/test_subcommands_profile_gateway.py
+++ b/tests/hermes_cli/test_subcommands_profile_gateway.py
@@ -61,6 +61,13 @@ def test_gateway_and_proxy_dispatch():
     assert px.func is _h_proxy
 
 
+def test_gateway_stop_for_restart_flag_is_public():
+    args = _gateway_parser().parse_args(["gateway", "stop", "--for-restart"])
+
+    assert args.gateway_command == "stop"
+    assert args.for_restart is True
+
+
 
 
 def test_gateway_enroll_dispatch():

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -158,9 +158,17 @@ hermes gateway install      # Install as a user service (Linux) / launchd servic
 sudo hermes gateway install --system   # Linux only: install a boot-time system service
 hermes gateway start        # Start the default service
 hermes gateway stop         # Stop the default service
+hermes gateway stop --for-restart  # Stop for an externally coordinated restart
 hermes gateway status       # Check default service status
 hermes gateway status --system         # Linux only: inspect the system service explicitly
 ```
+
+Use `gateway stop --for-restart` when an external deploy or runtime manager
+must keep the gateway down while it replaces or validates the runtime, then
+starts it separately. Hermes records a short-lived, process-bound restart
+intent and sends the one-shot online notice to chats that received the shutdown
+warning. A normal `gateway stop` remains a final stop and queues no recovery
+notice.
 
 ### Optional Linux event-loop watchdog
 


### PR DESCRIPTION
## What does this PR do?

Restores the missing recovery half of the Gateway lifecycle for Docker/S6/service restarts and externally coordinated runtime replacement, without requiring a configured home channel.

When a shutdown successfully sends the existing warning to an active chat or thread, the Gateway can now persist that exact routing target in the existing `.restart_pending.json` lifecycle marker. On the next startup it sends `Gateway online` back to those destinations first, then falls back to configured home channels while avoiding duplicates.

Two restart boundaries are covered:

- Docker/S6/service SIGTERM while the recorded Gateway intent remains running.
- A public `hermes gateway stop --for-restart` seam for deploy/runtime managers that must keep the Gateway down during replacement or validation and start it separately later.

Explicit `gateway stop`, cold starts, chat-originated `/restart`, failed shutdown-notice deliveries, and per-platform `gateway_restart_notification: false` keep their existing behavior.

This is intentionally narrower than #66089: it does not classify every graceful stop as a restart. It also closes a gap left by home-channel-only recovery approaches such as #74662: a user who received the shutdown warning in a Lark/Feishu topic can receive the matching recovery notice in that same topic even when no home channel is configured.

## Related Issue

Fixes #66087

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Return the exact destinations that successfully received shutdown notices.
- Persist those destinations only for non-chat planned restarts, signal-initiated shutdowns that preserve the running intent, or the explicit public stop-for-restart path.
- Deliver one-shot startup notices to those exact destinations before the existing home-channel fallback.
- Add `hermes gateway stop --for-restart`, backed by a short-lived PID/start-time-bound intent marker; abort the stop if the intent cannot be persisted.
- Keep ordinary explicit stops silent and retain the existing notification opt-out.
- Document the external runtime-manager workflow.

## How to Test

```bash
scripts/run_tests.sh \
  tests/gateway/test_restart_drain.py \
  tests/gateway/test_restart_resume_pending.py \
  tests/gateway/test_shutdown_cache_cleanup.py \
  tests/gateway/test_gateway_shutdown.py \
  tests/gateway/test_restart_notification.py \
  tests/gateway/test_status.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_subcommands_profile_gateway.py \
  tests/hermes_cli/test_gateway_restart_loop.py -q
```

Result: 270 passed.

Manual scenarios represented by the regression tests:

1. Run a Gateway with an active threaded chat and no home channel.
2. Restart the Docker/S6-managed process so it receives SIGTERM; confirm shutdown and online notices use the same thread.
3. Run `hermes gateway stop --for-restart`, perform external validation/replacement, then `hermes gateway start`; confirm the same one-shot recovery behavior.
4. Run ordinary `hermes gateway stop`; confirm it does not queue a recovery notification.
