### PR TITLE
chore(desktop): bump app version to 0.19.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.19.1",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.0",
+      "version": "0.19.1",
       "dependencies": {
         "@assistant-ui/react": "^0.14.23",
         "@assistant-ui/react-streamdown": "^0.3.4",


### PR DESCRIPTION
## Summary

Bumps the Hermes Desktop app version to `0.19.1` to match the current Hermes backend release.

## Changes

- Updated `apps/desktop/package.json`
- Updated the `apps/desktop` workspace version in `package-lock.json`

## Verification

- Lint: passed with 0 errors
- Typecheck: passed
- Tests: 2508 passed, 0 failed
- macOS build: passed
- Generated artifacts:
  - `Hermes-0.19.1-mac-arm64.dmg`
  - `Hermes-0.19.1-mac-arm64.zip`
- Bundle metadata:
  - `CFBundleShortVersionString=0.19.1`
  - `CFBundleVersion=0.19.1`
- Secret scan: passed with 0 matches

No unrelated dependency, API, schema, or architecture changes are included.
