### PR TITLE
fix(discord): make thread creation context- and retry-safe

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1465,6 +1465,11 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # READY can run again after a non-resumable reconnect. Any
+                # REST-resolved permission/name/parent context from the prior
+                # Gateway lifecycle must not survive into the new snapshot.
+                adapter_self._authoritative_message_channels.clear()
+
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()
@@ -1480,6 +1485,65 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_message(message: DiscordMessage):
                 await adapter_self._dispatch_discord_message(message)
+
+            @self._client.event
+            async def on_guild_channel_update(before, after):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(after, "id", None) or getattr(before, "id", None),
+                    include_children=True,
+                )
+
+            @self._client.event
+            async def on_guild_channel_delete(channel):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(channel, "id", None),
+                    include_children=True,
+                )
+
+            @self._client.event
+            async def on_thread_update(before, after):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(after, "id", None) or getattr(before, "id", None)
+                )
+
+            @self._client.event
+            async def on_thread_delete(thread):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(thread, "id", None)
+                )
+
+            @self._client.event
+            async def on_thread_join(thread):
+                # discord.py dispatches THREAD_UPDATE as thread_join when the
+                # thread was absent from its Gateway cache. That is the exact
+                # partial-cache state this resolver repairs.
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(thread, "id", None)
+                )
+
+            @self._client.event
+            async def on_thread_remove(thread):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(thread, "id", None)
+                )
+
+            @self._client.event
+            async def on_raw_thread_update(payload):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(payload, "thread_id", None)
+                )
+
+            @self._client.event
+            async def on_raw_thread_delete(payload):
+                adapter_self._invalidate_authoritative_channel(
+                    getattr(payload, "thread_id", None)
+                )
+
+            @self._client.event
+            async def on_guild_remove(guild):
+                adapter_self._invalidate_authoritative_guild(
+                    getattr(guild, "id", None)
+                )
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
@@ -1554,48 +1618,66 @@ class DiscordAdapter(BasePlatformAdapter):
             self._release_platform_lock()
             return False
 
-    def _discord_message_admission(
+    def _discord_message_preflight(
         self,
         message: Any,
         *,
         claim: bool,
-    ) -> tuple[bool, bool]:
-        """Return ``(admitted, role_authorized)`` for one Discord event."""
+    ) -> bool:
+        """Reject context-free provider events before authoritative REST I/O."""
         message_id = str(getattr(message, "id", ""))
         if claim:
             if self._dedup.is_duplicate(message_id):
-                return False, False
+                return False
         elif self._dedup.contains(message_id):
-            return False, False
-        if message.author == self._client.user:
-            return False, False
-        if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
-            return False, False
+            return False
 
-        role_authorized = False
-        if getattr(message.author, "bot", False):
+        author = getattr(message, "author", None)
+        client_user = getattr(self._client, "user", None) if self._client else None
+        if author is None or author == client_user:
+            return False
+        if getattr(message, "type", None) not in {
+            discord.MessageType.default,
+            discord.MessageType.reply,
+        }:
+            return False
+
+        if getattr(author, "bot", False):
             allow_bots = self._get_allow_bots()
             if allow_bots == "none":
-                return False, False
+                return False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
-                return False, False
+                return False
             if (
                 self._discord_bots_require_inline_mention()
                 and not self._self_is_raw_mentioned(message)
             ):
-                return False, False
-        else:
+                return False
+        return True
+
+    def _discord_message_context_admission(
+        self,
+        message: Any,
+    ) -> tuple[bool, bool]:
+        """Authorize one preflighted event using its resolved channel context."""
+        channel = getattr(message, "channel", None)
+        author = getattr(message, "author", None)
+        if channel is None or author is None:
+            return False, False
+
+        role_authorized = False
+        if not getattr(author, "bot", False):
             msg_guild = getattr(message, "guild", None)
-            is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
+            is_dm = isinstance(channel, discord.DMChannel)
             msg_channel_ids = None
             if not is_dm:
-                msg_channel_ids = {str(message.channel.id)}
-                parent_id = self._get_parent_channel_id(message.channel)
+                msg_channel_ids = {str(channel.id)}
+                parent_id = self._get_parent_channel_id(channel)
                 if parent_id:
                     msg_channel_ids.add(parent_id)
             if not self._is_allowed_user(
-                str(message.author.id),
-                message.author,
+                str(author.id),
+                author,
                 guild=msg_guild,
                 is_dm=is_dm,
                 channel_ids=msg_channel_ids,
@@ -1605,7 +1687,7 @@ class DiscordAdapter(BasePlatformAdapter):
             role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
 
         raw_self_mention = self._self_is_explicitly_mentioned(message)
-        if not isinstance(message.channel, discord.DMChannel) and (
+        if not isinstance(channel, discord.DMChannel) and (
             message.mentions or raw_self_mention
         ):
             other_bots_mentioned = any(
@@ -1619,8 +1701,8 @@ class DiscordAdapter(BasePlatformAdapter):
             ).lower() in {"true", "1", "yes"}
             if ignore_no_mention and not raw_self_mention and not other_bots_mentioned:
                 parent_id = None
-                if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                    parent_id = str(message.channel.parent_id)
+                if hasattr(channel, "parent_id") and channel.parent_id:
+                    parent_id = str(channel.parent_id)
                 free_channels = self._discord_free_response_channels()
                 channel_keys = self._discord_channel_keys(message, parent_id)
                 if "*" not in free_channels and not (channel_keys & free_channels):
@@ -1690,13 +1772,137 @@ class DiscordAdapter(BasePlatformAdapter):
             self._authoritative_message_channels.pop(oldest_channel_id, None)
         self._authoritative_message_channels[channel_id] = channel
 
+    def _invalidate_authoritative_channel(
+        self,
+        channel_id: Any,
+        *,
+        include_children: bool = False,
+    ) -> None:
+        """Invalidate REST context changed by a Discord channel event."""
+        try:
+            channel_id_int = int(channel_id)
+        except (TypeError, ValueError):
+            return
+        self._authoritative_message_channels.pop(channel_id_int, None)
+        if not include_children:
+            return
+        channel_id_str = str(channel_id_int)
+        for cached_id, cached_channel in list(
+            self._authoritative_message_channels.items()
+        ):
+            if self._get_parent_channel_id(cached_channel) == channel_id_str:
+                self._authoritative_message_channels.pop(cached_id, None)
+
+    def _invalidate_authoritative_guild(self, guild_id: Any) -> None:
+        """Invalidate every REST channel associated with a removed guild."""
+        try:
+            guild_id_int = int(guild_id)
+        except (TypeError, ValueError):
+            return
+        for cached_id, cached_channel in list(
+            self._authoritative_message_channels.items()
+        ):
+            guild = getattr(cached_channel, "guild", None) or getattr(
+                getattr(cached_channel, "parent", None),
+                "guild",
+                None,
+            )
+            if getattr(guild, "id", None) == guild_id_int:
+                self._authoritative_message_channels.pop(cached_id, None)
+
     @staticmethod
     def _attach_authoritative_message_channel(message: Any, channel: Any) -> None:
         """Attach a REST-resolved channel and guild to a discord.py message."""
         message.channel = channel
-        guild = getattr(channel, "guild", None)
-        if guild is not None:
-            message.guild = guild
+        message.guild = getattr(channel, "guild", None)
+
+    async def _resolve_authoritative_channel(
+        self,
+        channel_id: Any,
+        fallback_channel: Any = None,
+        *,
+        operation_name: str,
+    ) -> tuple[Any, bool]:
+        """Resolve one type-sensitive channel through the per-client authority.
+
+        Gateway cache objects with an unambiguous provider type (DM, thread,
+        forum, or media) are already safe for type routing. A text/partial
+        object is not: hosted Gateway projection can materialize a real
+        forum/media/thread ID as a synthetic ``TextChannel``. Resolve those
+        ambiguous objects through REST and cache the result for this client.
+        """
+        if self._client is None:
+            return fallback_channel, False
+        try:
+            channel_id_int = int(channel_id)
+        except (TypeError, ValueError):
+            return fallback_channel, False
+
+        cached = self._authoritative_message_channels.get(channel_id_int)
+        if cached is not None:
+            return cached, True
+
+        if fallback_channel is None:
+            get_channel = getattr(self._client, "get_channel", None)
+            if callable(get_channel):
+                try:
+                    fallback_channel = get_channel(channel_id_int)
+                except Exception:
+                    fallback_channel = None
+
+        definitive_channel_classes = tuple(
+            cls
+            for cls in (
+                getattr(discord, "DMChannel", None),
+                getattr(discord, "Thread", None),
+                getattr(discord, "ForumChannel", None),
+                getattr(discord, "MediaChannel", None),
+            )
+            if isinstance(cls, type)
+        )
+        fallback_id_matches = str(getattr(fallback_channel, "id", "")) == str(
+            channel_id_int
+        )
+        if (
+            definitive_channel_classes
+            and fallback_id_matches
+            and isinstance(fallback_channel, definitive_channel_classes)
+        ):
+            return fallback_channel, True
+
+        fetch_channel = getattr(self._client, "fetch_channel", None)
+        if not callable(fetch_channel):
+            return fallback_channel, False
+        try:
+            resolved = await self._call_discord_read_with_retry(
+                lambda: fetch_channel(channel_id_int),
+                operation_name=operation_name,
+            )
+        except Exception as error:
+            logger.warning(
+                "[%s] Could not resolve authoritative Discord channel %s "
+                "during %s: %s",
+                self.name,
+                channel_id_int,
+                operation_name,
+                error,
+            )
+            return fallback_channel, False
+        if resolved is None:
+            return fallback_channel, False
+        if str(getattr(resolved, "id", "")) != str(channel_id_int):
+            logger.warning(
+                "[%s] Authoritative Discord channel resolution for %s during %s "
+                "returned mismatched id %s; failing closed",
+                self.name,
+                channel_id_int,
+                operation_name,
+                getattr(resolved, "id", None),
+            )
+            return fallback_channel, False
+
+        self._cache_authoritative_message_channel(resolved)
+        return resolved, True
 
     async def _resolve_authoritative_message_channel(
         self,
@@ -1708,48 +1914,24 @@ class DiscordAdapter(BasePlatformAdapter):
         does not use ``MESSAGE_CREATE.channel_type`` to repair a partial cache.
         A projected or incomplete ``GUILD_CREATE`` can therefore materialize a
         real thread as ``TextChannel`` and can leave ``Message.guild`` unset.
-        Resolve the delivered channel ID through REST before deciding whether
-        auto-threading is legal. This runs only after admission authorization.
+        Resolve the delivered channel ID through REST before context-dependent
+        authorization or auto-thread routing. Context-free provider preflight
+        has already run, so rejected provider events do not cause REST I/O.
         """
         channel = getattr(message, "channel", None)
         if channel is None:
             return None, False
-        if isinstance(channel, (discord.DMChannel, discord.Thread)):
-            return channel, True
-        if self._client is None:
-            return channel, False
-
         try:
             channel_id = int(channel.id)
         except (AttributeError, TypeError, ValueError):
             return channel, False
-
-        cached = self._authoritative_message_channels.get(channel_id)
-        if cached is not None:
-            self._attach_authoritative_message_channel(message, cached)
-            return cached, True
-
-        fetch_channel = getattr(self._client, "fetch_channel", None)
-        if not callable(fetch_channel):
-            return channel, False
-
-        try:
-            resolved = await self._call_discord_read_with_retry(
-                lambda: fetch_channel(channel_id),
-                operation_name=f"channel {channel_id} resolution",
-            )
-        except Exception as error:
-            logger.warning(
-                "[%s] Could not resolve authoritative Discord channel %s: %s",
-                self.name,
-                channel_id,
-                error,
-            )
-            return channel, False
-        if resolved is None:
-            return channel, False
-
-        self._cache_authoritative_message_channel(resolved)
+        resolved, authoritative = await self._resolve_authoritative_channel(
+            channel_id,
+            channel,
+            operation_name=f"message channel {channel_id} resolution",
+        )
+        if not authoritative:
+            return resolved, False
         self._attach_authoritative_message_channel(message, resolved)
         return resolved, True
 
@@ -1760,14 +1942,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
             except asyncio.TimeoutError:
                 pass
-        admitted, role_authorized = self._discord_message_admission(
-            message, claim=True,
-        )
-        if not admitted:
+        if not self._discord_message_preflight(message, claim=True):
             return False
         _channel, channel_context_authoritative = (
             await self._resolve_authoritative_message_channel(message)
         )
+        if not channel_context_authoritative:
+            logger.warning(
+                "[%s] Refusing Discord message %s because authoritative "
+                "channel context could not be resolved",
+                self.name,
+                getattr(message, "id", "unknown"),
+            )
+            return False
+        admitted, role_authorized = self._discord_message_context_admission(message)
+        if not admitted:
+            return False
         return await self._handle_message(
             message,
             role_authorized=role_authorized,
@@ -2556,31 +2746,25 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
-        admitted, role_authorized = self._discord_message_admission(
-            message, claim=False,
-        )
-        if not admitted:
+        # The backfill scan performs only a non-claiming ``contains`` check.
+        # Claim exactly once here so a racing live Gateway event cannot dispatch
+        # the same message while this REST-recovered event is being authorized.
+        if not self._discord_message_preflight(message, claim=True):
             return False
         _channel, channel_context_authoritative = (
             await self._resolve_authoritative_message_channel(message)
         )
-        if not isinstance(message.channel, discord.DMChannel):
-            parent_id = self._get_parent_channel_id(message.channel)
-            channel_keys = self._discord_channel_keys(message, parent_id)
-            free_channels = self._discord_free_response_channels()
-            in_bot_thread = (
-                isinstance(message.channel, discord.Thread)
-                and str(message.channel.id) in self._threads
-                and not self._discord_thread_require_mention()
+        if not channel_context_authoritative:
+            logger.warning(
+                "[%s] Refusing recovered Discord message %s because authoritative "
+                "channel context could not be resolved",
+                self.name,
+                getattr(message, "id", "unknown"),
             )
-            if (
-                self._discord_require_mention()
-                and "*" not in free_channels
-                and not (channel_keys & free_channels)
-                and not in_bot_thread
-                and not self._self_is_explicitly_mentioned(message)
-            ):
-                return False
+            return False
+        admitted, role_authorized = self._discord_message_context_admission(message)
+        if not admitted:
+            return False
         return await self._handle_message(
             message,
             role_authorized=role_authorized,
@@ -3291,15 +3475,21 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Thread {thread_id} not found")
             else:
-                # Get the parent channel
-                channel = self._client.get_channel(int(chat_id))
-                if not channel:
-                    channel = await self._client.fetch_channel(int(chat_id))
-                if not channel:
-                    return SendResult(success=False, error=f"Channel {chat_id} not found")
+                # Parent IDs are type-sensitive: forum/media parents require a
+                # create-thread endpoint, while threads/text channels accept a
+                # normal message. Do not trust a projected TextChannel here.
+                channel, authoritative = await self._resolve_authoritative_channel(
+                    chat_id,
+                    operation_name=f"message target channel {chat_id} resolution",
+                )
+                if not authoritative or channel is None:
+                    return SendResult(
+                        success=False,
+                        error="Could not verify the Discord channel type. Please retry.",
+                    )
 
-            # Forum channels reject channel.send() — create a thread post instead.
-            if self._is_forum_parent(channel):
+            # Forum/media channels reject channel.send() — create a post instead.
+            if not thread_id and self._is_forum_or_media_channel(channel):
                 result = await self._send_to_forum(channel, content)
                 await asyncio.to_thread(
                     self._record_discord_response,
@@ -3815,11 +4005,15 @@ class DiscordAdapter(BasePlatformAdapter):
         if not os.path.isfile(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
-        channel = self._client.get_channel(int(chat_id))
-        if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
-        if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+        channel, authoritative = await self._resolve_authoritative_channel(
+            chat_id,
+            operation_name=f"file target channel {chat_id} resolution",
+        )
+        if not authoritative or channel is None:
+            return SendResult(
+                success=False,
+                error="Could not verify the Discord channel type. Please retry.",
+            )
 
         filename = file_name or os.path.basename(file_path)
         logger.info(
@@ -3833,7 +4027,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # the working image-batch path. Prefer ``files=[...]`` over deprecated
         # singular ``file=`` for the same reason.
         discord_file = discord.File(file_path, filename=filename)
-        if self._is_forum_parent(channel):
+        if self._is_forum_or_media_channel(channel):
             result = await self._forum_post_file(
                 channel,
                 content=(caption or "").strip(),
@@ -3892,16 +4086,16 @@ class DiscordAdapter(BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
 
-        try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
-        except Exception as e:
-            logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+        channel, authoritative = await self._resolve_authoritative_channel(
+            chat_id,
+            operation_name=f"multi-image target channel {chat_id} resolution",
+        )
+        if not authoritative or channel is None:
+            logger.warning(
+                "[%s] Could not verify Discord channel %s for multi-image send",
+                self.name,
+                chat_id,
+            )
             return
 
         CHUNK = 10
@@ -3971,7 +4165,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     self.name, len(files), chunk_idx + 1, len(chunks),
                 )
 
-                if self._is_forum_parent(channel):
+                if self._is_forum_or_media_channel(channel):
                     await self._forum_post_file(
                         channel,
                         content=(content or "").strip(),
@@ -4024,11 +4218,15 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, authoritative = await self._resolve_authoritative_channel(
+                chat_id,
+                operation_name=f"voice target channel {chat_id} resolution",
+            )
+            if not authoritative or channel is None:
+                return SendResult(
+                    success=False,
+                    error="Could not verify the Discord channel type. Please retry.",
+                )
 
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
@@ -4053,7 +4251,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # native voice flag path also targets /messages so it would fail
             # too.  Create a thread post with the audio as the starter
             # attachment instead.
-            if self._is_forum_parent(channel):
+            if self._is_forum_or_media_channel(channel):
                 forum_file = discord.File(io.BytesIO(file_data), filename=filename)
                 return await self._forum_post_file(
                     channel,
@@ -5242,11 +5440,15 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, authoritative = await self._resolve_authoritative_channel(
+                chat_id,
+                operation_name=f"image target channel {chat_id} resolution",
+            )
+            if not authoritative or channel is None:
+                return SendResult(
+                    success=False,
+                    error="Could not verify the Discord channel type. Please retry.",
+                )
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
@@ -5276,7 +5478,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 import io
                 file = discord.File(io.BytesIO(image_data), filename=f"image.{ext}")
 
-                if self._is_forum_parent(channel):
+                if self._is_forum_or_media_channel(channel):
                     return await self._forum_post_file(
                         channel,
                         content=(caption or "").strip(),
@@ -5324,11 +5526,15 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, authoritative = await self._resolve_authoritative_channel(
+                chat_id,
+                operation_name=f"animation target channel {chat_id} resolution",
+            )
+            if not authoritative or channel is None:
+                return SendResult(
+                    success=False,
+                    error="Could not verify the Discord channel type. Please retry.",
+                )
 
             # Download the GIF and send as a Discord file attachment
             # (Discord renders .gif attachments as auto-playing animations inline)
@@ -5348,7 +5554,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 import io
                 file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
 
-                if self._is_forum_parent(channel):
+                if self._is_forum_or_media_channel(channel):
                     return await self._forum_post_file(
                         channel,
                         content=(caption or "").strip(),
@@ -5482,12 +5688,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return {"name": "Unknown", "type": "dm"}
 
         try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-
-            if not channel:
-                return {"name": str(chat_id), "type": "dm"}
+            channel, authoritative = await self._resolve_authoritative_channel(
+                chat_id,
+                operation_name=f"chat info channel {chat_id} resolution",
+            )
+            if not authoritative or channel is None:
+                return {"name": str(chat_id), "type": "unknown"}
 
             # Determine channel type
             if isinstance(channel, discord.DMChannel):
@@ -6938,22 +7144,31 @@ class DiscordAdapter(BasePlatformAdapter):
         return getattr(channel, "parent", None) or channel
 
     async def _resolve_interaction_channel(self, interaction: discord.Interaction) -> Optional[Any]:
-        """Return the interaction channel, fetching it if the payload is partial."""
+        """Return a type-safe interaction channel after slash authorization.
+
+        Guild interaction payload/cache objects can carry the same synthetic
+        ``TextChannel`` projection as message events. Resolve ambiguous channel
+        types through the shared per-client authority before choosing the
+        text-vs-forum/media creation protocol.
+        """
         channel = getattr(interaction, "channel", None)
-        if channel is not None:
+        if isinstance(channel, (discord.DMChannel, discord.Thread)):
             return channel
         if not self._client:
             return None
-        channel_id = getattr(interaction, "channel_id", None)
+        channel_id = getattr(interaction, "channel_id", None) or getattr(
+            channel,
+            "id",
+            None,
+        )
         if channel_id is None:
             return None
-        channel = self._client.get_channel(int(channel_id))
-        if channel is not None:
-            return channel
-        try:
-            return await self._client.fetch_channel(int(channel_id))
-        except Exception:
-            return None
+        resolved, authoritative = await self._resolve_authoritative_channel(
+            channel_id,
+            channel,
+            operation_name=f"interaction channel {channel_id} resolution",
+        )
+        return resolved if authoritative else None
 
     @staticmethod
     def _thread_from_create_result(result: Any) -> Optional[Any]:
@@ -7255,6 +7470,13 @@ class DiscordAdapter(BasePlatformAdapter):
             return {"error": "Could not resolve the current Discord channel."}
         if isinstance(channel, discord.DMChannel):
             return {"error": "Discord threads can only be created inside server text channels, not DMs."}
+        if isinstance(channel, discord.Thread):
+            return {
+                "error": (
+                    "Discord does not support creating a nested thread inside an "
+                    "existing thread. Run /thread in a server text, forum, or media channel."
+                )
+            }
 
         parent_channel = self._thread_parent_channel(channel)
         if parent_channel is None:
@@ -7436,12 +7658,16 @@ class DiscordAdapter(BasePlatformAdapter):
         if utf16_len(cleaned) > 80:
             cleaned = _prefix_within_utf16_limit(cleaned, 77).rstrip() + "..."
 
-        try:
-            thread = self._client.get_channel(thread_id_int)
-            if thread is None:
-                thread = await self._client.fetch_channel(thread_id_int)
-        except Exception:
-            logger.debug("[%s] Failed to resolve Discord thread %s for rename", self.name, thread_id, exc_info=True)
+        thread, authoritative = await self._resolve_authoritative_channel(
+            thread_id_int,
+            operation_name=f"thread {thread_id_int} rename resolution",
+        )
+        if not authoritative or not isinstance(thread, discord.Thread):
+            logger.debug(
+                "[%s] Failed to resolve authoritative Discord thread %s for rename",
+                self.name,
+                thread_id,
+            )
             return False
 
         current_name = getattr(thread, "name", None)
@@ -7488,14 +7714,15 @@ class DiscordAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return None
 
-        try:
-            parent = self._client.get_channel(parent_id)
-            if parent is None:
-                parent = await self._client.fetch_channel(parent_id)
-        except Exception as exc:
+        parent, authoritative = await self._resolve_authoritative_channel(
+            parent_id,
+            operation_name=f"handoff parent channel {parent_id} resolution",
+        )
+        if not authoritative or parent is None:
             logger.warning(
-                "[%s] Handoff thread: cannot resolve parent %s: %s",
-                self.name, parent_chat_id, exc,
+                "[%s] Handoff thread: cannot resolve authoritative parent %s",
+                self.name,
+                parent_chat_id,
             )
             return None
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -70,6 +70,9 @@ _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
 })
 _DISCORD_IMAGE_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 _DISCORD_IMAGE_MAX_REDIRECTS = 10
+_DISCORD_REST_MAX_ATTEMPTS = 2
+_DISCORD_REST_RETRY_DELAY_SECONDS = 0.75
+_DISCORD_AUTHORITATIVE_CHANNEL_CACHE_SIZE = 1024
 # Upgrade-bridge fallback only. The primary mechanism is the persisted
 # non-conversational message-ID set populated from explicitly marked sends
 # (metadata["non_conversational"]). These regexes exist solely to recognize
@@ -183,6 +186,58 @@ async def _read_url_image_with_redirect_guard(
 def _truncate_discord_component_text(text: str, limit: int) -> str:
     """Return text within Discord's UTF-16 component field budget."""
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
+
+
+def _is_transient_discord_rest_error(error: Exception) -> bool:
+    """Return whether a Discord REST failure is safe to retry.
+
+    Discord permission, validation, and other 4xx responses are durable for
+    the request as constructed. Retrying them can duplicate any side effects
+    that happened before the failure. Rate limits, server errors, and network
+    transport failures are the retryable cases.
+    """
+    http_exception = getattr(discord, "HTTPException", ()) if discord is not None else ()
+    if isinstance(http_exception, type) and isinstance(error, http_exception):
+        status = getattr(error, "status", None)
+        return status == 429 or (
+            isinstance(status, int) and 500 <= status < 600
+        )
+
+    rate_limited = getattr(discord, "RateLimited", ()) if discord is not None else ()
+    if isinstance(rate_limited, type) and isinstance(error, rate_limited):
+        return True
+
+    if isinstance(error, (ConnectionError, TimeoutError)):
+        return True
+
+    try:
+        import aiohttp
+    except ImportError:  # pragma: no cover - installed with discord.py
+        return False
+    return isinstance(error, aiohttp.ClientError)
+
+
+def _discord_rest_retry_delay(error: Exception) -> float:
+    """Return Discord's requested retry delay, or the short default backoff."""
+    candidates = [getattr(error, "retry_after", None)]
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers:
+        candidates.extend((
+            headers.get("Retry-After"),
+            headers.get("X-RateLimit-Reset-After"),
+        ))
+
+    for raw_delay in candidates:
+        if raw_delay is None:
+            continue
+        try:
+            delay = float(raw_delay)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(delay) and delay >= 0:
+            return delay
+    return _DISCORD_REST_RETRY_DELAY_SECONDS
 
 
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
@@ -1061,6 +1116,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
+        # ``fetch_channel`` is the authoritative type source when a partial or
+        # synthetic Gateway cache projects a thread as a text channel. Cache
+        # successful REST resolutions for this client connection so ordinary
+        # channel traffic does not add one GET per message.
+        self._authoritative_message_channels: Dict[int, Any] = {}
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -1287,6 +1347,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_mentions=_build_allowed_mentions(),
                 **proxy_kwargs_for_bot(proxy_url),
             )
+            self._authoritative_message_channels.clear()
             adapter_self = self  # capture for closure
 
             # Register event handlers
@@ -1457,6 +1518,101 @@ class DiscordAdapter(BasePlatformAdapter):
 
         return True, role_authorized
 
+    async def _call_discord_rest_with_retry(
+        self,
+        operation: Callable[[], Any],
+        *,
+        operation_name: str,
+    ) -> Any:
+        """Run one Discord REST operation, retrying transient failures once."""
+        for attempt in range(_DISCORD_REST_MAX_ATTEMPTS):
+            try:
+                return await operation()
+            except Exception as error:
+                is_last_attempt = attempt + 1 >= _DISCORD_REST_MAX_ATTEMPTS
+                if is_last_attempt or not _is_transient_discord_rest_error(error):
+                    raise
+                delay = _discord_rest_retry_delay(error)
+                logger.info(
+                    "[%s] Transient Discord REST failure during %s; retrying in %.3fs: %s",
+                    self.name,
+                    operation_name,
+                    delay,
+                    error,
+                )
+                await asyncio.sleep(delay)
+
+        raise RuntimeError("unreachable Discord REST retry state")  # pragma: no cover
+
+    @staticmethod
+    def _attach_authoritative_message_channel(message: Any, channel: Any) -> None:
+        """Attach a REST-resolved channel and guild to a discord.py message."""
+        message.channel = channel
+        guild = getattr(channel, "guild", None)
+        if guild is not None:
+            message.guild = guild
+
+    async def _resolve_authoritative_message_channel(
+        self,
+        message: Any,
+    ) -> tuple[Any, bool]:
+        """Resolve reliable guild/channel context for an admitted message.
+
+        discord.py builds ``Message.channel`` from its Gateway guild cache and
+        does not use ``MESSAGE_CREATE.channel_type`` to repair a partial cache.
+        A projected or incomplete ``GUILD_CREATE`` can therefore materialize a
+        real thread as ``TextChannel`` and can leave ``Message.guild`` unset.
+        Resolve the delivered channel ID through REST before deciding whether
+        auto-threading is legal. This runs only after admission authorization.
+        """
+        channel = getattr(message, "channel", None)
+        if channel is None:
+            return None, False
+        if isinstance(channel, (discord.DMChannel, discord.Thread)):
+            return channel, True
+        if self._client is None:
+            return channel, False
+
+        try:
+            channel_id = int(channel.id)
+        except (AttributeError, TypeError, ValueError):
+            return channel, False
+
+        cached = self._authoritative_message_channels.get(channel_id)
+        if cached is not None:
+            self._attach_authoritative_message_channel(message, cached)
+            return cached, True
+
+        fetch_channel = getattr(self._client, "fetch_channel", None)
+        if not callable(fetch_channel):
+            return channel, False
+
+        try:
+            resolved = await self._call_discord_rest_with_retry(
+                lambda: fetch_channel(channel_id),
+                operation_name=f"channel {channel_id} resolution",
+            )
+        except Exception as error:
+            logger.warning(
+                "[%s] Could not resolve authoritative Discord channel %s: %s",
+                self.name,
+                channel_id,
+                error,
+            )
+            return channel, False
+        if resolved is None:
+            return channel, False
+
+        if (
+            len(self._authoritative_message_channels)
+            >= _DISCORD_AUTHORITATIVE_CHANNEL_CACHE_SIZE
+        ):
+            oldest_channel_id = next(iter(self._authoritative_message_channels))
+            self._authoritative_message_channels.pop(oldest_channel_id, None)
+        self._authoritative_message_channels[channel_id] = resolved
+        self._attach_authoritative_message_channel(message, resolved)
+        return resolved, True
+
     async def _dispatch_discord_message(self, message: Any) -> bool:
         """Apply Discord ingress policy and dispatch one live event."""
         if not self._ready_event.is_set():
@@ -1469,8 +1625,13 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         if not admitted:
             return False
+        _channel, channel_context_authoritative = (
+            await self._resolve_authoritative_message_channel(message)
+        )
         return await self._handle_message(
-            message, role_authorized=role_authorized,
+            message,
+            role_authorized=role_authorized,
+            channel_context_authoritative=channel_context_authoritative,
         )
 
     async def _cancel_bot_task(self) -> None:
@@ -2255,6 +2416,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
+        admitted, role_authorized = self._discord_message_admission(
+            message, claim=False,
+        )
+        if not admitted:
+            return False
+        _channel, channel_context_authoritative = (
+            await self._resolve_authoritative_message_channel(message)
+        )
         if not isinstance(message.channel, discord.DMChannel):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
@@ -2272,15 +2441,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not self._self_is_explicitly_mentioned(message)
             ):
                 return False
-        admitted, role_authorized = self._discord_message_admission(
-            message, claim=False,
-        )
-        if not admitted:
-            return False
         return await self._handle_message(
             message,
             role_authorized=role_authorized,
             recovered=True,
+            channel_context_authoritative=channel_context_authoritative,
         )
 
     async def _iter_missed_message_backfill_candidates(self, channel_ids: set[str]):
@@ -6628,7 +6793,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Tries ``parent_channel.create_thread()`` first.  If Discord rejects
         that (e.g. permission issues), falls back to sending a seed message
-        and creating the thread from it.
+        and creating the thread from it. The seed describes the request rather
+        than claiming success before Discord has accepted the thread.
         """
         name = (name or "").strip()
         if not name:
@@ -6666,8 +6832,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 "thread_name": getattr(thread, "name", None) or name,
             }
         except Exception as direct_error:
+            seed_msg = None
             try:
-                seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
+                seed_content = starter_message or f"\U0001f9f5 Thread requested via Hermes: **{name}**"
                 seed_msg = await parent_channel.send(seed_content)
                 thread = await seed_msg.create_thread(
                     name=name,
@@ -6680,6 +6847,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     "thread_name": getattr(thread, "name", None) or name,
                 }
             except Exception as fallback_error:
+                if seed_msg is not None:
+                    delete_seed = getattr(seed_msg, "delete", None)
+                    if callable(delete_seed):
+                        try:
+                            await delete_seed()
+                        except Exception:
+                            logger.debug(
+                                "[%s] Failed to remove orphan Discord thread seed %s",
+                                self.name,
+                                getattr(seed_msg, "id", "unknown"),
+                                exc_info=True,
+                            )
                 return {
                     "error": (
                         "Discord rejected direct thread creation and the fallback also failed. "
@@ -6714,59 +6893,47 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
         """Create a thread from a user message for auto-threading.
 
-        Returns the created thread object, or ``None`` on failure. Both the
-        primary ``message.create_thread`` and the seed-message fallback are
-        retried once after a short backoff so transient connect errors
-        (e.g. ``Cannot connect to host discord.com:443``) don't immediately
-        burn through to the caller's failure path (#20243).
+        Returns the created thread object, or ``None`` on failure. The original
+        user message is the only thread starter: no bot-authored seed is sent,
+        so a failed request cannot leave a misleading or duplicate orphan.
+        Transient REST failures are retried once; validation and permission
+        failures are not retried.
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
         reason = f"Auto-threaded from mention by {display_name}"
 
-        last_direct_error: Exception | None = None
-        last_fallback_error: Exception | None = None
+        try:
+            thread = await self._call_discord_rest_with_retry(
+                lambda: message.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=1440,
+                    reason=reason,
+                ),
+                operation_name=(
+                    "auto-thread creation from message "
+                    f"{getattr(message, 'id', 'unknown')}"
+                ),
+            )
+        except Exception as error:
+            classification = (
+                "transient retries exhausted"
+                if _is_transient_discord_rest_error(error)
+                else "permanent failure"
+            )
+            logger.warning(
+                "[%s] Auto-thread creation failed (%s): %s",
+                self.name,
+                classification,
+                error,
+            )
+            return None
 
-        for attempt in range(2):
-            try:
-                thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
-                try:
-                    setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
-                except Exception:
-                    pass
-                return thread
-            except Exception as direct_error:
-                last_direct_error = direct_error
-                try:
-                    seed_msg = await message.channel.send(
-                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
-                    )
-                    thread = await seed_msg.create_thread(
-                        name=thread_name,
-                        auto_archive_duration=1440,
-                        reason=reason,
-                    )
-                    try:
-                        setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
-                    except Exception:
-                        pass
-                    return thread
-                except Exception as fallback_error:
-                    last_fallback_error = fallback_error
-                    if attempt == 0:
-                        # Brief backoff before the second attempt — most failures
-                        # in this path are transient connect errors that recover
-                        # within a second or two.
-                        await asyncio.sleep(0.75)
-                        continue
-
-        logger.warning(
-            "[%s] Auto-thread creation failed after retry. Direct error: %s. Fallback error: %s",
-            self.name,
-            last_direct_error,
-            last_fallback_error,
-        )
-        return None
+        try:
+            setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
+        except Exception:
+            pass
+        return thread
 
     async def rename_thread(
         self,
@@ -7557,6 +7724,7 @@ class DiscordAdapter(BasePlatformAdapter):
         role_authorized: bool = False,
         *,
         recovered: bool = False,
+        channel_context_authoritative: bool = True,
     ) -> bool:
         """Handle one Discord message and report whether it reached dispatch."""
         # In server channels (not DMs), require the bot to be @mentioned
@@ -7660,7 +7828,11 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
-                thread = await self._auto_create_thread(message)
+                thread = (
+                    await self._auto_create_thread(message)
+                    if channel_context_authoritative
+                    else None
+                )
                 if thread:
                     parent_channel_id = str(message.channel.id)
                     is_thread = True

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -188,33 +188,63 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
-def _is_transient_discord_rest_error(error: Exception) -> bool:
-    """Return whether a Discord REST failure is safe to retry.
+def _discord_http_status(error: Exception) -> Optional[int]:
+    """Return an HTTP-like status carried by a discord.py exception."""
+    status = getattr(error, "status", None)
+    if status is None:
+        status = getattr(getattr(error, "response", None), "status", None)
+    return status if isinstance(status, int) and not isinstance(status, bool) else None
 
-    Discord permission, validation, and other 4xx responses are durable for
-    the request as constructed. Retrying them can duplicate any side effects
-    that happened before the failure. Rate limits, server errors, and network
-    transport failures are the retryable cases.
-    """
-    http_exception = getattr(discord, "HTTPException", ()) if discord is not None else ()
-    if isinstance(http_exception, type) and isinstance(error, http_exception):
-        status = getattr(error, "status", None)
-        return status == 429 or (
-            isinstance(status, int) and 500 <= status < 600
-        )
 
+def _is_discord_rate_limit_error(error: Exception) -> bool:
+    """Return whether discord.py rejected a request as rate limited."""
     rate_limited = getattr(discord, "RateLimited", ()) if discord is not None else ()
-    if isinstance(rate_limited, type) and isinstance(error, rate_limited):
-        return True
+    return (
+        isinstance(rate_limited, type)
+        and isinstance(error, rate_limited)
+    ) or _discord_http_status(error) == 429
 
+
+def _is_discord_transport_error(error: Exception) -> bool:
+    """Return whether an error represents an ambiguous transport outcome."""
     if isinstance(error, (ConnectionError, TimeoutError)):
         return True
-
     try:
         import aiohttp
     except ImportError:  # pragma: no cover - installed with discord.py
         return False
     return isinstance(error, aiohttp.ClientError)
+
+
+def _is_ambiguous_discord_write_error(error: Exception) -> bool:
+    """Return whether a Discord write may have committed without a response."""
+    status = _discord_http_status(error)
+    return (
+        isinstance(status, int) and 500 <= status < 600
+    ) or _is_discord_transport_error(error)
+
+
+def _is_permanent_discord_write_error(error: Exception) -> bool:
+    """Return whether Discord definitively rejected a write as constructed."""
+    status = _discord_http_status(error)
+    return isinstance(error, (TypeError, ValueError)) or (
+        isinstance(status, int) and 400 <= status < 500 and status != 429
+    )
+
+
+def _is_retryable_discord_read_error(error: Exception) -> bool:
+    """Return whether a read-only Discord REST request is safe to retry.
+
+    Discord permission, validation, and other 4xx responses are durable for
+    the request as constructed. Read-only requests may safely retry rate
+    limits, server errors, and network transport failures.
+    """
+    status = _discord_http_status(error)
+    return (
+        _is_discord_rate_limit_error(error)
+        or (isinstance(status, int) and 500 <= status < 600)
+        or _is_discord_transport_error(error)
+    )
 
 
 def _discord_rest_retry_delay(error: Exception) -> float:
@@ -238,6 +268,86 @@ def _discord_rest_retry_delay(error: Exception) -> float:
         if math.isfinite(delay) and delay >= 0:
             return delay
     return _DISCORD_REST_RETRY_DELAY_SECONDS
+
+
+def _discord_retry_delay_from_headers(headers: Any) -> float:
+    """Return a standalone response's retry delay, or the short default."""
+    if headers:
+        for key in ("Retry-After", "X-RateLimit-Reset-After"):
+            try:
+                raw_delay = headers.get(key)
+                delay = float(raw_delay)
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if math.isfinite(delay) and delay >= 0:
+                return delay
+    return _DISCORD_REST_RETRY_DELAY_SECONDS
+
+
+def _non_idempotent_discord_write_failure(
+    operation_name: str,
+    error: Exception,
+) -> str:
+    """Return a user-safe category for a write that cannot be reconciled."""
+    if _is_discord_rate_limit_error(error):
+        delay = _discord_rest_retry_delay(error)
+        return (
+            f"{operation_name} remained rate limited after one retry. "
+            f"Retry after {delay:g} seconds."
+        )
+    if _is_ambiguous_discord_write_error(error):
+        return (
+            f"{operation_name} may have succeeded, but Discord did not confirm it. "
+            "It was not retried to avoid creating a duplicate."
+        )
+    status = _discord_http_status(error)
+    if status in {401, 403}:
+        return (
+            f"{operation_name} was rejected. Check the bot's channel and thread "
+            "permissions."
+        )
+    if _is_permanent_discord_write_error(error):
+        return (
+            f"{operation_name} was rejected. Check the channel type, thread "
+            "settings, and bot permissions."
+        )
+    return (
+        f"{operation_name} could not be confirmed and was not retried to avoid "
+        "creating a duplicate."
+    )
+
+
+def _non_idempotent_discord_http_failure(
+    operation_name: str,
+    status: int,
+    headers: Any,
+) -> str:
+    """Return a user-safe category for a standalone non-idempotent POST."""
+    if status == 429:
+        retry_after = _discord_retry_delay_from_headers(headers)
+        return (
+            f"{operation_name} remained rate limited after one retry. "
+            f"Retry after {retry_after:g} seconds."
+        )
+    if status in {401, 403}:
+        return (
+            f"{operation_name} was rejected. Check the bot's channel and thread "
+            "permissions."
+        )
+    if 400 <= status < 500:
+        return (
+            f"{operation_name} was rejected. Check the channel type, thread "
+            "settings, and bot permissions."
+        )
+    if 500 <= status < 600:
+        return (
+            f"{operation_name} may have succeeded, but Discord did not confirm it. "
+            "It was not retried to avoid creating a duplicate."
+        )
+    return (
+        f"{operation_name} could not be confirmed and was not retried to avoid "
+        "creating a duplicate."
+    )
 
 
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
@@ -1518,19 +1628,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
         return True, role_authorized
 
-    async def _call_discord_rest_with_retry(
+    async def _call_discord_read_with_retry(
         self,
         operation: Callable[[], Any],
         *,
         operation_name: str,
     ) -> Any:
-        """Run one Discord REST operation, retrying transient failures once."""
+        """Run one read-only Discord REST operation with safe retries."""
         for attempt in range(_DISCORD_REST_MAX_ATTEMPTS):
             try:
                 return await operation()
             except Exception as error:
                 is_last_attempt = attempt + 1 >= _DISCORD_REST_MAX_ATTEMPTS
-                if is_last_attempt or not _is_transient_discord_rest_error(error):
+                if is_last_attempt or not _is_retryable_discord_read_error(error):
                     raise
                 delay = _discord_rest_retry_delay(error)
                 logger.info(
@@ -1543,6 +1653,42 @@ class DiscordAdapter(BasePlatformAdapter):
                 await asyncio.sleep(delay)
 
         raise RuntimeError("unreachable Discord REST retry state")  # pragma: no cover
+
+    async def _call_discord_write_with_rate_limit_retry(
+        self,
+        operation: Callable[[], Any],
+        *,
+        operation_name: str,
+    ) -> Any:
+        """Run a write once, replaying only a definite 429 rejection."""
+        try:
+            return await operation()
+        except Exception as error:
+            if not _is_discord_rate_limit_error(error):
+                raise
+            delay = _discord_rest_retry_delay(error)
+            logger.info(
+                "[%s] %s was rate limited; replaying once in %.3fs",
+                self.name,
+                operation_name,
+                delay,
+            )
+            await asyncio.sleep(delay)
+        return await operation()
+
+    def _cache_authoritative_message_channel(self, channel: Any) -> None:
+        """Cache one successfully resolved channel for the current client."""
+        try:
+            channel_id = int(channel.id)
+        except (AttributeError, TypeError, ValueError):
+            return
+        if channel_id not in self._authoritative_message_channels and (
+            len(self._authoritative_message_channels)
+            >= _DISCORD_AUTHORITATIVE_CHANNEL_CACHE_SIZE
+        ):
+            oldest_channel_id = next(iter(self._authoritative_message_channels))
+            self._authoritative_message_channels.pop(oldest_channel_id, None)
+        self._authoritative_message_channels[channel_id] = channel
 
     @staticmethod
     def _attach_authoritative_message_channel(message: Any, channel: Any) -> None:
@@ -1588,7 +1734,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return channel, False
 
         try:
-            resolved = await self._call_discord_rest_with_retry(
+            resolved = await self._call_discord_read_with_retry(
                 lambda: fetch_channel(channel_id),
                 operation_name=f"channel {channel_id} resolution",
             )
@@ -1603,13 +1749,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if resolved is None:
             return channel, False
 
-        if (
-            len(self._authoritative_message_channels)
-            >= _DISCORD_AUTHORITATIVE_CHANNEL_CACHE_SIZE
-        ):
-            oldest_channel_id = next(iter(self._authoritative_message_channels))
-            self._authoritative_message_channels.pop(oldest_channel_id, None)
-        self._authoritative_message_channels[channel_id] = resolved
+        self._cache_authoritative_message_channel(resolved)
         self._attach_authoritative_message_channel(message, resolved)
         return resolved, True
 
@@ -3278,15 +3418,34 @@ class DiscordAdapter(BasePlatformAdapter):
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
+            thread = await self._call_discord_write_with_rate_limit_retry(
+                lambda: forum_channel.create_thread(
+                    name=thread_name,
+                    content=starter_content,
+                ),
+                operation_name="Discord forum thread creation",
             )
-        except Exception as e:
-            logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
-            return SendResult(success=False, error=f"Forum thread creation failed: {e}")
+        except Exception as error:
+            logger.error(
+                "[%s] Forum thread create failed in %s (status=%s type=%s): %s",
+                self.name,
+                forum_channel.id,
+                _discord_http_status(error),
+                type(error).__name__,
+                error,
+                exc_info=True,
+            )
+            return SendResult(
+                success=False,
+                error=_non_idempotent_discord_write_failure(
+                    "Discord forum thread creation",
+                    error,
+                ),
+            )
 
         thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        if isinstance(thread_channel, discord.Thread):
+            self._cache_authoritative_message_channel(thread_channel)
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
         starter_msg = getattr(thread, "message", None)
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
@@ -3353,17 +3512,32 @@ class DiscordAdapter(BasePlatformAdapter):
             kwargs["files"] = files
 
         try:
-            thread = await forum_channel.create_thread(**kwargs)
-        except Exception as e:
+            thread = await self._call_discord_write_with_rate_limit_retry(
+                lambda: forum_channel.create_thread(**kwargs),
+                operation_name="Discord forum file thread creation",
+            )
+        except Exception as error:
             logger.error(
-                "[%s] Failed to create forum thread with file in %s: %s",
+                "[%s] Forum file thread create failed in %s "
+                "(status=%s type=%s): %s",
                 self.name,
                 getattr(forum_channel, "id", "?"),
-                e,
+                _discord_http_status(error),
+                type(error).__name__,
+                error,
+                exc_info=True,
             )
-            return SendResult(success=False, error=f"Forum thread creation failed: {e}")
+            return SendResult(
+                success=False,
+                error=_non_idempotent_discord_write_failure(
+                    "Discord forum file thread creation",
+                    error,
+                ),
+            )
 
         thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        if isinstance(thread_channel, discord.Thread):
+            self._cache_authoritative_message_channel(thread_channel)
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
         starter_msg = getattr(thread, "message", None)
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
@@ -6781,6 +6955,279 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             return None
 
+    @staticmethod
+    def _thread_from_create_result(result: Any) -> Optional[Any]:
+        """Return the Thread carried by discord.py's create result shapes."""
+        if isinstance(result, discord.Thread):
+            return result
+        thread = getattr(result, "thread", None)
+        return thread if isinstance(thread, discord.Thread) else None
+
+    @staticmethod
+    def _is_forum_or_media_channel(channel: Any) -> bool:
+        """Return whether a channel uses Discord's atomic forum/media create."""
+        channel_classes = tuple(
+            cls
+            for cls in (
+                getattr(discord, "ForumChannel", None),
+                getattr(discord, "MediaChannel", None),
+            )
+            if isinstance(cls, type)
+        )
+        if channel_classes and isinstance(channel, channel_classes):
+            return True
+        channel_type = getattr(channel, "type", None)
+        type_value = getattr(channel_type, "value", channel_type)
+        return type_value in {15, 16}
+
+    def _message_thread_matches_source(self, message: Any, thread: Any) -> bool:
+        """Validate Discord's one-thread-per-message identity relationship."""
+        if not isinstance(thread, discord.Thread):
+            return False
+        source_id = getattr(message, "id", None)
+        parent_id = getattr(getattr(message, "channel", None), "id", None)
+        expected_guild = getattr(message, "guild", None) or getattr(
+            getattr(message, "channel", None), "guild", None
+        )
+        guild_id = getattr(expected_guild, "id", None)
+        actual_guild_id = getattr(getattr(thread, "guild", None), "id", None)
+        actual_parent_id = self._get_parent_channel_id(thread)
+        return (
+            source_id is not None
+            and parent_id is not None
+            and guild_id is not None
+            and str(getattr(thread, "id", "")) == str(source_id)
+            and actual_parent_id == str(parent_id)
+            and str(actual_guild_id) == str(guild_id)
+        )
+
+    async def _read_back_message_thread(
+        self,
+        message: Any,
+        *,
+        operation_name: str,
+    ) -> tuple[Optional[Any], bool]:
+        """Return ``(thread, definitely_absent)`` for a message-backed create."""
+        if self._client is None:
+            return None, False
+        fetch_channel = getattr(self._client, "fetch_channel", None)
+        if not callable(fetch_channel):
+            return None, False
+        try:
+            source_id = int(message.id)
+        except (AttributeError, TypeError, ValueError):
+            return None, False
+
+        try:
+            candidate = await self._call_discord_read_with_retry(
+                lambda: fetch_channel(source_id),
+                operation_name=f"{operation_name} read-back",
+            )
+        except Exception as error:
+            if _discord_http_status(error) == 404:
+                return None, True
+            logger.warning(
+                "[%s] %s read-back failed; write outcome remains unknown: %s",
+                self.name,
+                operation_name,
+                error,
+            )
+            return None, False
+
+        if not self._message_thread_matches_source(message, candidate):
+            logger.warning(
+                "[%s] %s read-back returned an unexpected channel "
+                "(type=%s id=%s parent=%s guild=%s); failing closed",
+                self.name,
+                operation_name,
+                type(candidate).__name__,
+                getattr(candidate, "id", None),
+                self._get_parent_channel_id(candidate),
+                getattr(getattr(candidate, "guild", None), "id", None),
+            )
+            return None, False
+
+        self._cache_authoritative_message_channel(candidate)
+        return candidate, False
+
+    async def _create_message_thread_with_reconciliation(
+        self,
+        message: Any,
+        *,
+        name: str,
+        auto_archive_duration: int,
+        reason: str,
+        operation_name: str,
+    ) -> tuple[Optional[Any], bool, Optional[str]]:
+        """Create one message-backed thread without blindly replaying writes.
+
+        Discord assigns the thread the source message ID and allows only one
+        thread per message. Network/timeouts/5xx are therefore reconciled with
+        ``GET /channels/{message.id}`` before a single replay. A 404 proves the
+        resource is absent; any unexpected read-back fails closed.
+        """
+
+        async def _issue_create() -> Any:
+            return await message.create_thread(
+                name=name,
+                auto_archive_duration=auto_archive_duration,
+                reason=reason,
+            )
+
+        async def _accept_or_read_back(result: Any) -> tuple[Optional[Any], bool]:
+            thread = self._thread_from_create_result(result)
+            if thread is not None and self._message_thread_matches_source(message, thread):
+                self._cache_authoritative_message_channel(thread)
+                return thread, False
+            return await self._read_back_message_thread(
+                message,
+                operation_name=operation_name,
+            )
+
+        had_ambiguous_write = False
+        try:
+            created = await _issue_create()
+        except Exception as first_error:
+            logger.warning(
+                "[%s] %s initial write failed (status=%s type=%s): %s",
+                self.name,
+                operation_name,
+                _discord_http_status(first_error),
+                type(first_error).__name__,
+                first_error,
+                exc_info=True,
+            )
+            if _is_discord_rate_limit_error(first_error):
+                delay = _discord_rest_retry_delay(first_error)
+                logger.info(
+                    "[%s] %s was rate limited; replaying once in %.3fs",
+                    self.name,
+                    operation_name,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            elif _is_ambiguous_discord_write_error(first_error):
+                had_ambiguous_write = True
+                reconciled, definitely_absent = await self._read_back_message_thread(
+                    message,
+                    operation_name=operation_name,
+                )
+                if reconciled is not None:
+                    return reconciled, False, None
+                if not definitely_absent:
+                    return (
+                        None,
+                        False,
+                        f"{operation_name} may have succeeded, but authoritative "
+                        "read-back could not confirm it. It was not retried to "
+                        "avoid creating a duplicate.",
+                    )
+                delay = _discord_rest_retry_delay(first_error)
+                logger.info(
+                    "[%s] %s was absent after an ambiguous failure; "
+                    "replaying once in %.3fs",
+                    self.name,
+                    operation_name,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            elif _is_permanent_discord_write_error(first_error):
+                return (
+                    None,
+                    True,
+                    _non_idempotent_discord_write_failure(
+                        operation_name,
+                        first_error,
+                    ),
+                )
+            else:
+                return (
+                    None,
+                    False,
+                    _non_idempotent_discord_write_failure(
+                        operation_name,
+                        first_error,
+                    ),
+                )
+        else:
+            accepted, _definitely_absent = await _accept_or_read_back(created)
+            if accepted is not None:
+                return accepted, False, None
+            return (
+                None,
+                False,
+                f"{operation_name} returned an unexpected result and authoritative "
+                "read-back could not confirm the thread.",
+            )
+
+        try:
+            replayed = await _issue_create()
+        except Exception as replay_error:
+            logger.warning(
+                "[%s] %s replay failed (status=%s type=%s): %s",
+                self.name,
+                operation_name,
+                _discord_http_status(replay_error),
+                type(replay_error).__name__,
+                replay_error,
+                exc_info=True,
+            )
+            if not had_ambiguous_write and (
+                _is_discord_rate_limit_error(replay_error)
+                or _is_permanent_discord_write_error(replay_error)
+            ):
+                return (
+                    None,
+                    True,
+                    _non_idempotent_discord_write_failure(
+                        operation_name,
+                        replay_error,
+                    ),
+                )
+            reconciled, definitely_absent = await self._read_back_message_thread(
+                message,
+                operation_name=operation_name,
+            )
+            if reconciled is not None:
+                return reconciled, False, None
+            return (
+                None,
+                definitely_absent,
+                (
+                    f"{operation_name} was not created after one safe retry. Check "
+                    "the channel type, thread settings, and bot permissions."
+                    if definitely_absent
+                    else f"{operation_name} may have succeeded, but authoritative "
+                    "read-back could not confirm it. It was not retried again to "
+                    "avoid creating a duplicate."
+                ),
+            )
+
+        accepted, _definitely_absent = await _accept_or_read_back(replayed)
+        if accepted is not None:
+            return accepted, False, None
+        return (
+            None,
+            False,
+            f"{operation_name} replay returned an unexpected result and "
+            "authoritative read-back could not confirm the thread.",
+        )
+
+    async def _delete_owned_thread_seed(self, seed_message: Any) -> None:
+        """Best-effort cleanup for a seed returned by this attempt's send."""
+        delete_seed = getattr(seed_message, "delete", None)
+        if not callable(delete_seed):
+            return
+        try:
+            await delete_seed()
+        except Exception:
+            logger.debug(
+                "[%s] Failed to remove owned Discord thread seed %s",
+                self.name,
+                getattr(seed_message, "id", "unknown"),
+                exc_info=True,
+            )
+
     async def _create_thread(
         self,
         interaction: discord.Interaction,
@@ -6791,10 +7238,9 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> Dict[str, Any]:
         """Create a thread in the current Discord channel.
 
-        Tries ``parent_channel.create_thread()`` first.  If Discord rejects
-        that (e.g. permission issues), falls back to sending a seed message
-        and creating the thread from it. The seed describes the request rather
-        than claiming success before Discord has accepted the thread.
+        Text channels use one owned seed plus Discord's deterministic
+        message-backed thread identity. Forum/media parents require their
+        atomic create endpoint; only a definite 429 rejection is replayed.
         """
         name = (name or "").strip()
         if not name:
@@ -6817,54 +7263,86 @@ class DiscordAdapter(BasePlatformAdapter):
         display_name = getattr(getattr(interaction, "user", None), "display_name", None) or "unknown user"
         reason = f"Requested by {display_name} via /thread"
         starter_message = (message or "").strip()
+        seed_content = starter_message or f"\U0001f9f5 Thread requested via Hermes: **{name}**"
 
-        try:
-            thread = await parent_channel.create_thread(
-                name=name,
-                auto_archive_duration=auto_archive_duration,
-                reason=reason,
-            )
-            if starter_message:
-                await thread.send(starter_message)
+        if self._is_forum_or_media_channel(parent_channel):
+            try:
+                result = await self._call_discord_write_with_rate_limit_retry(
+                    lambda: parent_channel.create_thread(
+                        name=name,
+                        content=seed_content,
+                        auto_archive_duration=auto_archive_duration,
+                        reason=reason,
+                    ),
+                    operation_name="Discord forum/media thread creation",
+                )
+            except Exception as error:
+                logger.warning(
+                    "[%s] /thread forum/media create failed (status=%s type=%s): %s",
+                    self.name,
+                    _discord_http_status(error),
+                    type(error).__name__,
+                    error,
+                    exc_info=True,
+                )
+                return {
+                    "error": _non_idempotent_discord_write_failure(
+                        "Discord forum/media thread creation",
+                        error,
+                    )
+                }
+            thread = self._thread_from_create_result(result)
+            if thread is None:
+                return {"error": "Discord forum/media create returned no thread."}
+            self._cache_authoritative_message_channel(thread)
             return {
                 "success": True,
                 "thread_id": str(thread.id),
                 "thread_name": getattr(thread, "name", None) or name,
             }
-        except Exception as direct_error:
-            seed_msg = None
-            try:
-                seed_content = starter_message or f"\U0001f9f5 Thread requested via Hermes: **{name}**"
-                seed_msg = await parent_channel.send(seed_content)
-                thread = await seed_msg.create_thread(
-                    name=name,
-                    auto_archive_duration=auto_archive_duration,
-                    reason=reason,
+
+        send_seed = getattr(parent_channel, "send", None)
+        if not callable(send_seed):
+            return {"error": "Discord channel cannot send a thread starter message."}
+        try:
+            seed_message = await self._call_discord_write_with_rate_limit_retry(
+                lambda: send_seed(seed_content),
+                operation_name="Discord thread starter message send",
+            )
+        except Exception as error:
+            logger.warning(
+                "[%s] /thread starter send failed (status=%s type=%s): %s",
+                self.name,
+                _discord_http_status(error),
+                type(error).__name__,
+                error,
+                exc_info=True,
+            )
+            return {
+                "error": _non_idempotent_discord_write_failure(
+                    "Discord thread starter message send",
+                    error,
                 )
-                return {
-                    "success": True,
-                    "thread_id": str(thread.id),
-                    "thread_name": getattr(thread, "name", None) or name,
-                }
-            except Exception as fallback_error:
-                if seed_msg is not None:
-                    delete_seed = getattr(seed_msg, "delete", None)
-                    if callable(delete_seed):
-                        try:
-                            await delete_seed()
-                        except Exception:
-                            logger.debug(
-                                "[%s] Failed to remove orphan Discord thread seed %s",
-                                self.name,
-                                getattr(seed_msg, "id", "unknown"),
-                                exc_info=True,
-                            )
-                return {
-                    "error": (
-                        "Discord rejected direct thread creation and the fallback also failed. "
-                        f"Direct error: {direct_error}. Fallback error: {fallback_error}"
-                    )
-                }
+            }
+
+        thread, definitely_absent, failure = (
+            await self._create_message_thread_with_reconciliation(
+                seed_message,
+                name=name,
+                auto_archive_duration=auto_archive_duration,
+                reason=reason,
+                operation_name="Discord /thread message-backed creation",
+            )
+        )
+        if thread is not None:
+            return {
+                "success": True,
+                "thread_id": str(thread.id),
+                "thread_name": getattr(thread, "name", None) or name,
+            }
+        if definitely_absent:
+            await self._delete_owned_thread_seed(seed_message)
+        return {"error": failure or "Discord thread creation failed."}
 
     # ------------------------------------------------------------------
     # Auto-thread helpers
@@ -6895,37 +7373,31 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Returns the created thread object, or ``None`` on failure. The original
         user message is the only thread starter: no bot-authored seed is sent,
-        so a failed request cannot leave a misleading or duplicate orphan.
-        Transient REST failures are retried once; validation and permission
-        failures are not retried.
+        so a failed request cannot leave a misleading or duplicate orphan. An
+        ambiguous write is reconciled by the source message's deterministic
+        thread ID before any single replay.
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
         reason = f"Auto-threaded from mention by {display_name}"
 
-        try:
-            thread = await self._call_discord_rest_with_retry(
-                lambda: message.create_thread(
-                    name=thread_name,
-                    auto_archive_duration=1440,
-                    reason=reason,
-                ),
+        thread, _definitely_absent, failure = (
+            await self._create_message_thread_with_reconciliation(
+                message,
+                name=thread_name,
+                auto_archive_duration=1440,
+                reason=reason,
                 operation_name=(
-                    "auto-thread creation from message "
+                    "Discord auto-thread creation from message "
                     f"{getattr(message, 'id', 'unknown')}"
                 ),
             )
-        except Exception as error:
-            classification = (
-                "transient retries exhausted"
-                if _is_transient_discord_rest_error(error)
-                else "permanent failure"
-            )
+        )
+        if thread is None:
             logger.warning(
-                "[%s] Auto-thread creation failed (%s): %s",
+                "[%s] Auto-thread creation failed: %s",
                 self.name,
-                classification,
-                error,
+                failure or "Discord did not confirm the thread",
             )
             return None
 
@@ -7003,11 +7475,10 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> Optional[str]:
         """Create a Discord thread under a text channel for a handoff.
 
-        Falls back to a seed-message + ``message.create_thread`` path if
-        ``parent.create_thread`` is rejected (some channel types or
-        permission setups). Returns the new thread id as a string, or
-        ``None`` on failure or when the parent isn't a text channel
-        (DMs, voice channels, threads themselves can't host threads).
+        Text channels use one owned seed and deterministic message-backed
+        creation. Forum/media parents use one atomic create whose result is
+        replayed only after a definite 429 rejection because no resource ID is
+        known before other failures.
         """
         if not self._client or not DISCORD_AVAILABLE:
             return None
@@ -7035,44 +7506,94 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, parent_chat_id,
             )
             return None
+        if isinstance(parent, getattr(discord, "Thread", ())):
+            logger.info(
+                "[%s] Handoff thread: parent %s is already a thread; nested "
+                "threads are not supported",
+                self.name,
+                parent_chat_id,
+            )
+            return None
 
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
+        seed_content = f"\U0001f9f5 Hermes handoff: **{thread_name}**"
 
-        # First try: create a thread directly on the channel.
-        try:
-            create = getattr(parent, "create_thread", None)
-            if create is not None:
-                thread = await create(
-                    name=thread_name,
-                    auto_archive_duration=1440,
-                    reason=reason,
+        if self._is_forum_or_media_channel(parent):
+            try:
+                result = await self._call_discord_write_with_rate_limit_retry(
+                    lambda: parent.create_thread(
+                        name=thread_name,
+                        content=seed_content,
+                        auto_archive_duration=1440,
+                        reason=reason,
+                    ),
+                    operation_name="Discord handoff forum/media thread creation",
                 )
-                return str(thread.id)
-        except Exception as direct_error:
-            logger.debug(
-                "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
-                self.name, direct_error,
-            )
-
-        # Fallback: post a seed message and create the thread from it.
-        try:
-            send = getattr(parent, "send", None)
-            if send is None:
+            except Exception as error:
+                logger.warning(
+                    "[%s] Handoff forum/media create failed for parent %s "
+                    "(status=%s type=%s): %s",
+                    self.name,
+                    parent_chat_id,
+                    _discord_http_status(error),
+                    type(error).__name__,
+                    error,
+                    exc_info=True,
+                )
                 return None
-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
-            thread = await seed_msg.create_thread(
+            thread = self._thread_from_create_result(result)
+            if thread is None:
+                logger.warning(
+                    "[%s] Handoff forum/media create returned no thread for parent %s",
+                    self.name,
+                    parent_chat_id,
+                )
+                return None
+            self._cache_authoritative_message_channel(thread)
+            return str(thread.id)
+
+        send = getattr(parent, "send", None)
+        if not callable(send):
+            return None
+        try:
+            seed_message = await self._call_discord_write_with_rate_limit_retry(
+                lambda: send(seed_content),
+                operation_name="Discord handoff starter message send",
+            )
+        except Exception as error:
+            logger.warning(
+                "[%s] Handoff seed send failed for parent %s "
+                "(status=%s type=%s): %s",
+                self.name,
+                parent_chat_id,
+                _discord_http_status(error),
+                type(error).__name__,
+                error,
+                exc_info=True,
+            )
+            return None
+
+        thread, definitely_absent, failure = (
+            await self._create_message_thread_with_reconciliation(
+                seed_message,
                 name=thread_name,
                 auto_archive_duration=1440,
                 reason=reason,
+                operation_name="Discord handoff message-backed creation",
             )
+        )
+        if thread is not None:
             return str(thread.id)
-        except Exception as fallback_error:
-            logger.warning(
-                "[%s] Handoff thread: both create paths failed for parent %s: %s",
-                self.name, parent_chat_id, fallback_error,
-            )
-            return None
+        if definitely_absent:
+            await self._delete_owned_thread_seed(seed_message)
+        logger.warning(
+            "[%s] Handoff thread creation failed for parent %s: %s",
+            self.name,
+            parent_chat_id,
+            failure or "Discord did not confirm the thread",
+        )
+        return None
 
     def _self_contained_prompt_content(
         self, header: str, body: str, *, code_block: bool = False, tail: str = ""
@@ -9607,6 +10128,72 @@ async def _standalone_read_json_limited(resp: Any, limit_bytes: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+async def _standalone_non_idempotent_http_error(
+    operation_name: str,
+    resp: Any,
+) -> Dict[str, str]:
+    """Log a Discord response body and return only its safe failure category."""
+    body = await _standalone_read_text_limited(
+        resp,
+        _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
+    )
+    status = int(getattr(resp, "status", 0))
+    logger.error(
+        "%s failed (status=%s): %s",
+        operation_name,
+        status,
+        body,
+    )
+    return {
+        "error": _non_idempotent_discord_http_failure(
+            operation_name,
+            status,
+            getattr(resp, "headers", None),
+        )
+    }
+
+
+async def _standalone_forum_post_with_rate_limit_retry(
+    session: Any,
+    thread_url: str,
+    request_kwargs_factory: Callable[[], Dict[str, Any]],
+) -> tuple[Optional[dict], Optional[Dict[str, str]]]:
+    """Create a forum post, replaying only one definite HTTP 429 rejection."""
+    operation_name = "Discord forum thread creation"
+    for attempt in range(_DISCORD_REST_MAX_ATTEMPTS):
+        async with session.post(
+            thread_url,
+            **request_kwargs_factory(),
+        ) as resp:
+            if resp.status in {200, 201}:
+                data = await _standalone_read_json_limited(
+                    resp,
+                    _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
+                )
+                return data, None
+            if resp.status == 429 and attempt == 0:
+                body = await _standalone_read_text_limited(
+                    resp,
+                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
+                )
+                delay = _discord_retry_delay_from_headers(
+                    getattr(resp, "headers", None)
+                )
+                logger.warning(
+                    "%s was rate limited; replaying once in %.3fs: %s",
+                    operation_name,
+                    delay,
+                    body,
+                )
+                await asyncio.sleep(delay)
+                continue
+            return None, await _standalone_non_idempotent_http_error(
+                operation_name,
+                resp,
+            )
+    raise RuntimeError("unreachable Discord forum retry state")  # pragma: no cover
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -9707,64 +10294,101 @@ async def _standalone_send(
                         continue
                     valid_media.append(media_path)
 
-                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), **_sess_kw) as session:
-                    if valid_media:
-                        # Multipart: payload_json + files[N] creates a forum
-                        # thread with the starter message plus attachments in
-                        # a single API call.
-                        attachments_meta = [
-                            {"id": str(idx), "filename": os.path.basename(path)}
-                            for idx, path in enumerate(valid_media)
-                        ]
-                        starter_message = {"content": (caption or message), "attachments": attachments_meta}
-                        payload_json = json.dumps({"name": thread_name, "message": starter_message})
-
-                        form = aiohttp.FormData()
-                        form.add_field("payload_json", payload_json, content_type="application/json")
-
-                        try:
-                            for idx, media_path in enumerate(valid_media):
-                                with open(media_path, "rb") as fh:
-                                    form.add_field(
-                                        f"files[{idx}]",
-                                        fh.read(),
-                                        filename=os.path.basename(media_path),
-                                    )
-                            async with session.post(thread_url, headers=auth_headers, data=form, **_req_kw) as resp:
-                                if resp.status not in {200, 201}:
-                                    body = await _standalone_read_text_limited(
-                                        resp,
-                                        _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                    )
-                                    return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                                data = await _standalone_read_json_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                                )
-                        except Exception as e:
-                            return {"error": _standalone_sanitize_error(f"Discord forum thread upload failed: {e}")}
-                    else:
-                        # No media — simple JSON POST creates the thread with
-                        # just the text starter.
-                        async with session.post(
-                            thread_url,
-                            headers=json_headers,
-                            json={
-                                "name": thread_name,
-                                "message": {"content": message},
-                            },
-                            **_req_kw,
-                        ) as resp:
-                            if resp.status not in {200, 201}:
-                                body = await _standalone_read_text_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                )
-                                return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                            data = await _standalone_read_json_limited(
-                                resp,
-                                _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
+                try:
+                    async with aiohttp.ClientSession(
+                        timeout=aiohttp.ClientTimeout(total=60),
+                        **_sess_kw,
+                    ) as session:
+                        if valid_media:
+                            # Multipart: payload_json + files[N] creates a forum
+                            # thread with the starter message plus attachments in
+                            # a single API call.
+                            attachments_meta = [
+                                {"id": str(idx), "filename": os.path.basename(path)}
+                                for idx, path in enumerate(valid_media)
+                            ]
+                            starter_message = {
+                                "content": caption or message,
+                                "attachments": attachments_meta,
+                            }
+                            payload_json = json.dumps(
+                                {"name": thread_name, "message": starter_message}
                             )
+
+                            def _multipart_forum_request_kwargs() -> Dict[str, Any]:
+                                form = aiohttp.FormData()
+                                form.add_field(
+                                    "payload_json",
+                                    payload_json,
+                                    content_type="application/json",
+                                )
+                                for idx, media_path in enumerate(valid_media):
+                                    with open(media_path, "rb") as fh:
+                                        form.add_field(
+                                            f"files[{idx}]",
+                                            fh.read(),
+                                            filename=os.path.basename(media_path),
+                                        )
+                                return {
+                                    "headers": auth_headers,
+                                    "data": form,
+                                    **_req_kw,
+                                }
+
+                            data, forum_error = (
+                                await _standalone_forum_post_with_rate_limit_retry(
+                                    session,
+                                    thread_url,
+                                    _multipart_forum_request_kwargs,
+                                )
+                            )
+                        else:
+                            # No media — simple JSON POST creates the thread with
+                            # just the text starter.
+                            def _json_forum_request_kwargs() -> Dict[str, Any]:
+                                return {
+                                    "headers": json_headers,
+                                    "json": {
+                                        "name": thread_name,
+                                        "message": {"content": message},
+                                    },
+                                    **_req_kw,
+                                }
+
+                            data, forum_error = (
+                                await _standalone_forum_post_with_rate_limit_retry(
+                                    session,
+                                    thread_url,
+                                    _json_forum_request_kwargs,
+                                )
+                            )
+                        if forum_error is not None:
+                            return forum_error
+                        if data is None:
+                            logger.error(
+                                "Discord standalone forum create returned no payload"
+                            )
+                            return {
+                                "error": (
+                                    "Discord forum thread creation could not be "
+                                    "confirmed."
+                                )
+                            }
+                except Exception as error:
+                    logger.error(
+                        "Discord standalone forum create failed "
+                        "(status=%s type=%s): %s",
+                        _discord_http_status(error),
+                        type(error).__name__,
+                        error,
+                        exc_info=True,
+                    )
+                    return {
+                        "error": _non_idempotent_discord_write_failure(
+                            "Discord forum thread creation",
+                            error,
+                        )
+                    }
 
                 thread_id_created = data.get("id")
                 starter_msg_id = (data.get("message") or {}).get("id", thread_id_created)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -247,16 +247,19 @@ def _is_retryable_discord_read_error(error: Exception) -> bool:
     )
 
 
-def _discord_rest_retry_delay(error: Exception) -> float:
+def _discord_rest_retry_delay(
+    error: Optional[Exception] = None,
+    headers: Any = None,
+) -> float:
     """Return Discord's requested retry delay, or the short default backoff."""
-    candidates = [getattr(error, "retry_after", None)]
+    candidates = [getattr(error, "retry_after", None)] if error else []
     response = getattr(error, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers:
-        candidates.extend((
-            headers.get("Retry-After"),
-            headers.get("X-RateLimit-Reset-After"),
-        ))
+    for source in (getattr(response, "headers", None), headers):
+        if source:
+            candidates.extend((
+                source.get("Retry-After"),
+                source.get("X-RateLimit-Reset-After"),
+            ))
 
     for raw_delay in candidates:
         if raw_delay is None:
@@ -270,79 +273,41 @@ def _discord_rest_retry_delay(error: Exception) -> float:
     return _DISCORD_REST_RETRY_DELAY_SECONDS
 
 
-def _discord_retry_delay_from_headers(headers: Any) -> float:
-    """Return a standalone response's retry delay, or the short default."""
-    if headers:
-        for key in ("Retry-After", "X-RateLimit-Reset-After"):
-            try:
-                raw_delay = headers.get(key)
-                delay = float(raw_delay)
-            except (AttributeError, TypeError, ValueError):
-                continue
-            if math.isfinite(delay) and delay >= 0:
-                return delay
-    return _DISCORD_REST_RETRY_DELAY_SECONDS
-
-
 def _non_idempotent_discord_write_failure(
     operation_name: str,
-    error: Exception,
+    error: Optional[Exception] = None,
+    *,
+    status: Optional[int] = None,
+    headers: Any = None,
 ) -> str:
-    """Return a user-safe category for a write that cannot be reconciled."""
-    if _is_discord_rate_limit_error(error):
-        delay = _discord_rest_retry_delay(error)
+    """Return one user-safe category for SDK and standalone writes."""
+    status = _discord_http_status(error) if error is not None else status
+    if status == 429 or (
+        error is not None and _is_discord_rate_limit_error(error)
+    ):
+        delay = _discord_rest_retry_delay(error, headers)
         return (
             f"{operation_name} remained rate limited after one retry. "
             f"Retry after {delay:g} seconds."
         )
-    if _is_ambiguous_discord_write_error(error):
+    if (error is not None and _is_discord_transport_error(error)) or (
+        isinstance(status, int) and 500 <= status < 600
+    ):
         return (
             f"{operation_name} may have succeeded, but Discord did not confirm it. "
             "It was not retried to avoid creating a duplicate."
-        )
-    status = _discord_http_status(error)
-    if status in {401, 403}:
-        return (
-            f"{operation_name} was rejected. Check the bot's channel and thread "
-            "permissions."
-        )
-    if _is_permanent_discord_write_error(error):
-        return (
-            f"{operation_name} was rejected. Check the channel type, thread "
-            "settings, and bot permissions."
-        )
-    return (
-        f"{operation_name} could not be confirmed and was not retried to avoid "
-        "creating a duplicate."
-    )
-
-
-def _non_idempotent_discord_http_failure(
-    operation_name: str,
-    status: int,
-    headers: Any,
-) -> str:
-    """Return a user-safe category for a standalone non-idempotent POST."""
-    if status == 429:
-        retry_after = _discord_retry_delay_from_headers(headers)
-        return (
-            f"{operation_name} remained rate limited after one retry. "
-            f"Retry after {retry_after:g} seconds."
         )
     if status in {401, 403}:
         return (
             f"{operation_name} was rejected. Check the bot's channel and thread "
             "permissions."
         )
-    if 400 <= status < 500:
+    if (
+        error is not None and isinstance(error, (TypeError, ValueError))
+    ) or (isinstance(status, int) and 400 <= status < 500):
         return (
             f"{operation_name} was rejected. Check the channel type, thread "
             "settings, and bot permissions."
-        )
-    if 500 <= status < 600:
-        return (
-            f"{operation_name} may have succeeded, but Discord did not confirm it. "
-            "It was not retried to avoid creating a duplicate."
         )
     return (
         f"{operation_name} could not be confirmed and was not retried to avoid "
@@ -1501,22 +1466,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
 
             @self._client.event
-            async def on_thread_update(before, after):
-                adapter_self._invalidate_authoritative_channel(
-                    getattr(after, "id", None) or getattr(before, "id", None)
-                )
-
-            @self._client.event
-            async def on_thread_delete(thread):
-                adapter_self._invalidate_authoritative_channel(
-                    getattr(thread, "id", None)
-                )
-
-            @self._client.event
             async def on_thread_join(thread):
-                # discord.py dispatches THREAD_UPDATE as thread_join when the
-                # thread was absent from its Gateway cache. That is the exact
-                # partial-cache state this resolver repairs.
+                # THREAD_LIST_SYNC can replace a thread without a raw update.
                 adapter_self._invalidate_authoritative_channel(
                     getattr(thread, "id", None)
                 )
@@ -1541,6 +1492,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
             @self._client.event
             async def on_guild_remove(guild):
+                adapter_self._invalidate_authoritative_guild(
+                    getattr(guild, "id", None)
+                )
+
+            @self._client.event
+            async def on_guild_unavailable(guild):
+                # A later GUILD_CREATE refreshes discord.py's cache, but not
+                # REST objects retained by the adapter during the outage.
                 adapter_self._invalidate_authoritative_guild(
                     getattr(guild, "id", None)
                 )
@@ -1621,15 +1580,10 @@ class DiscordAdapter(BasePlatformAdapter):
     def _discord_message_preflight(
         self,
         message: Any,
-        *,
-        claim: bool,
     ) -> bool:
-        """Reject context-free provider events before authoritative REST I/O."""
+        """Atomically claim and reject context-free provider events."""
         message_id = str(getattr(message, "id", ""))
-        if claim:
-            if self._dedup.is_duplicate(message_id):
-                return False
-        elif self._dedup.contains(message_id):
+        if self._dedup.is_duplicate(message_id):
             return False
 
         author = getattr(message, "author", None)
@@ -1810,18 +1764,13 @@ class DiscordAdapter(BasePlatformAdapter):
             if getattr(guild, "id", None) == guild_id_int:
                 self._authoritative_message_channels.pop(cached_id, None)
 
-    @staticmethod
-    def _attach_authoritative_message_channel(message: Any, channel: Any) -> None:
-        """Attach a REST-resolved channel and guild to a discord.py message."""
-        message.channel = channel
-        message.guild = getattr(channel, "guild", None)
-
     async def _resolve_authoritative_channel(
         self,
         channel_id: Any,
         fallback_channel: Any = None,
         *,
         operation_name: str,
+        raise_transient_errors: bool = False,
     ) -> tuple[Any, bool]:
         """Resolve one type-sensitive channel through the per-client authority.
 
@@ -1887,6 +1836,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 operation_name,
                 error,
             )
+            if raise_transient_errors and _is_retryable_discord_read_error(error):
+                raise
             return fallback_channel, False
         if resolved is None:
             return fallback_channel, False
@@ -1904,64 +1855,62 @@ class DiscordAdapter(BasePlatformAdapter):
         self._cache_authoritative_message_channel(resolved)
         return resolved, True
 
-    async def _resolve_authoritative_message_channel(
+    async def _dispatch_discord_message(
         self,
         message: Any,
-    ) -> tuple[Any, bool]:
-        """Resolve reliable guild/channel context for an admitted message.
-
-        discord.py builds ``Message.channel`` from its Gateway guild cache and
-        does not use ``MESSAGE_CREATE.channel_type`` to repair a partial cache.
-        A projected or incomplete ``GUILD_CREATE`` can therefore materialize a
-        real thread as ``TextChannel`` and can leave ``Message.guild`` unset.
-        Resolve the delivered channel ID through REST before context-dependent
-        authorization or auto-thread routing. Context-free provider preflight
-        has already run, so rejected provider events do not cause REST I/O.
-        """
-        channel = getattr(message, "channel", None)
-        if channel is None:
-            return None, False
-        try:
-            channel_id = int(channel.id)
-        except (AttributeError, TypeError, ValueError):
-            return channel, False
-        resolved, authoritative = await self._resolve_authoritative_channel(
-            channel_id,
-            channel,
-            operation_name=f"message channel {channel_id} resolution",
-        )
-        if not authoritative:
-            return resolved, False
-        self._attach_authoritative_message_channel(message, resolved)
-        return resolved, True
-
-    async def _dispatch_discord_message(self, message: Any) -> bool:
-        """Apply Discord ingress policy and dispatch one live event."""
+        *,
+        recovered: bool = False,
+    ) -> bool:
+        """Resolve, authorize, and dispatch one claimed Discord event."""
         if not self._ready_event.is_set():
             try:
                 await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
             except asyncio.TimeoutError:
                 pass
-        if not self._discord_message_preflight(message, claim=True):
+        if not self._discord_message_preflight(message):
             return False
-        _channel, channel_context_authoritative = (
-            await self._resolve_authoritative_message_channel(message)
-        )
-        if not channel_context_authoritative:
+
+        message_id = str(getattr(message, "id", ""))
+        fallback_channel = getattr(message, "channel", None)
+        try:
+            channel_id = int(fallback_channel.id)
+        except (AttributeError, TypeError, ValueError):
+            channel_id = None
+        try:
+            channel, authoritative = await self._resolve_authoritative_channel(
+                channel_id,
+                fallback_channel,
+                operation_name=f"message channel {channel_id} resolution",
+                raise_transient_errors=True,
+            )
+        except asyncio.CancelledError:
+            self._dedup.discard(message_id)
+            raise
+        except Exception:
+            # Keep the reservation while REST is in flight so a racing live or
+            # recovery delivery cannot dispatch twice. Exhausted 429, 5xx, and
+            # transport failures are recoverable, so release it only now.
+            self._dedup.discard(message_id)
+            return False
+        if not authoritative:
             logger.warning(
-                "[%s] Refusing Discord message %s because authoritative "
-                "channel context could not be resolved",
+                "[%s] Refusing %sDiscord message %s because authoritative "
+                "channel context could not be resolved; keeping terminal claim",
                 self.name,
-                getattr(message, "id", "unknown"),
+                "recovered " if recovered else "",
+                message_id or "unknown",
             )
             return False
+
+        message.channel = channel
+        message.guild = getattr(channel, "guild", None)
         admitted, role_authorized = self._discord_message_context_admission(message)
         if not admitted:
             return False
         return await self._handle_message(
             message,
             role_authorized=role_authorized,
-            channel_context_authoritative=channel_context_authoritative,
+            recovered=recovered,
         )
 
     async def _cancel_bot_task(self) -> None:
@@ -2746,31 +2695,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
-        # The backfill scan performs only a non-claiming ``contains`` check.
-        # Claim exactly once here so a racing live Gateway event cannot dispatch
-        # the same message while this REST-recovered event is being authorized.
-        if not self._discord_message_preflight(message, claim=True):
-            return False
-        _channel, channel_context_authoritative = (
-            await self._resolve_authoritative_message_channel(message)
-        )
-        if not channel_context_authoritative:
-            logger.warning(
-                "[%s] Refusing recovered Discord message %s because authoritative "
-                "channel context could not be resolved",
-                self.name,
-                getattr(message, "id", "unknown"),
-            )
-            return False
-        admitted, role_authorized = self._discord_message_context_admission(message)
-        if not admitted:
-            return False
-        return await self._handle_message(
-            message,
-            role_authorized=role_authorized,
-            recovered=True,
-            channel_context_authoritative=channel_context_authoritative,
-        )
+        return await self._dispatch_discord_message(message, recovered=True)
 
     async def _iter_missed_message_backfill_candidates(self, channel_ids: set[str]):
         if not self._client:
@@ -3578,7 +3503,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
-            result = SendResult(success=False, error=str(e))
+            result = SendResult(
+                success=False,
+                error=_non_idempotent_discord_write_failure(
+                    "Discord message send",
+                    e,
+                ),
+            )
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,
@@ -3649,8 +3580,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 msg = await thread_channel.send(content=chunk)
                 message_ids.append(str(msg.id))
             except Exception as e:
-                warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
-                logger.warning("[%s] %s", self.name, warning)
+                logger.warning(
+                    "[%s] Failed to send follow-up chunk to forum thread %s: %s",
+                    self.name,
+                    thread_id,
+                    e,
+                )
+                warning = (
+                    f"Discord forum thread {thread_id} was created, but a "
+                    "follow-up chunk could not be delivered."
+                )
                 warnings.append(warning)
 
         raw_response: Dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
@@ -5719,7 +5658,11 @@ class DiscordAdapter(BasePlatformAdapter):
             }
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to get chat info for %s: %s", self.name, chat_id, e, exc_info=True)
-            return {"name": str(chat_id), "type": "dm", "error": str(e)}
+            return {
+                "name": str(chat_id),
+                "type": "unknown",
+                "error": "Could not retrieve Discord channel information.",
+            }
 
     async def _resolve_allowed_usernames(self) -> None:
         """
@@ -8472,7 +8415,6 @@ class DiscordAdapter(BasePlatformAdapter):
         role_authorized: bool = False,
         *,
         recovered: bool = False,
-        channel_context_authoritative: bool = True,
     ) -> bool:
         """Handle one Discord message and report whether it reached dispatch."""
         # In server channels (not DMs), require the bot to be @mentioned
@@ -8576,11 +8518,7 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
-                thread = (
-                    await self._auto_create_thread(message)
-                    if channel_context_authoritative
-                    else None
-                )
+                thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)
                     is_thread = True
@@ -10263,22 +10201,6 @@ def _derive_forum_thread_name(message: str) -> str:
     return first_line[:100]
 
 
-def _standalone_sanitize_error(text) -> str:
-    """Local copy of tools.send_message_tool._sanitize_error_text — strips bot
-    tokens from any error payload before bubbling it up.  Inlined so the
-    plugin doesn't introduce a hard dependency on send_message_tool internals.
-    """
-    s = str(text)
-    # Mask anything that looks like a Bot token in an Authorization header.
-    import re as _re_san
-    return _re_san.sub(
-        r"(Authorization:\s*Bot\s+)\S+",
-        r"\1***",
-        s,
-        flags=_re_san.IGNORECASE,
-    )
-
-
 def _standalone_close_response(resp: Any) -> None:
     close = getattr(resp, "close", None)
     if callable(close):
@@ -10372,10 +10294,10 @@ async def _standalone_non_idempotent_http_error(
         body,
     )
     return {
-        "error": _non_idempotent_discord_http_failure(
+        "error": _non_idempotent_discord_write_failure(
             operation_name,
-            status,
-            getattr(resp, "headers", None),
+            status=status,
+            headers=getattr(resp, "headers", None),
         )
     }
 
@@ -10403,8 +10325,8 @@ async def _standalone_forum_post_with_rate_limit_retry(
                     resp,
                     _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
                 )
-                delay = _discord_retry_delay_from_headers(
-                    getattr(resp, "headers", None)
+                delay = _discord_rest_retry_delay(
+                    headers=getattr(resp, "headers", None)
                 )
                 logger.warning(
                     "%s was rate limited; replaying once in %.3fs: %s",
@@ -10637,11 +10559,10 @@ async def _standalone_send(
             if message.strip() or not media_files:
                 async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
                     if resp.status not in {200, 201}:
-                        body = await _standalone_read_text_limited(
+                        return await _standalone_non_idempotent_http_error(
+                            "Discord message send",
                             resp,
-                            _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
                         )
-                        return {"error": f"Discord API error ({resp.status}): {body}"}
                     last_data = await _standalone_read_json_limited(
                         resp,
                         _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
@@ -10687,22 +10608,29 @@ async def _standalone_send(
                         form.add_field("files[0]", f, filename=filename)
                         async with session.post(url, headers=auth_headers, data=form, **_req_kw) as resp:
                             if resp.status not in {200, 201}:
-                                body = await _standalone_read_text_limited(
+                                media_error = await _standalone_non_idempotent_http_error(
+                                    "Discord media send",
                                     resp,
-                                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
                                 )
-                                warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error ({resp.status}): {body}")
-                                logger.error(warning)
-                                warnings.append(warning)
+                                warnings.append(media_error["error"])
                                 continue
                             last_data = await _standalone_read_json_limited(
                                 resp,
                                 _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
                             )
                 except Exception as e:
-                    warning = _standalone_sanitize_error(f"Failed to send media {media_path}: {e}")
-                    logger.error(warning)
-                    warnings.append(warning)
+                    logger.error(
+                        "Discord media send failed for %s: %s",
+                        media_path,
+                        e,
+                        exc_info=True,
+                    )
+                    warnings.append(
+                        _non_idempotent_discord_write_failure(
+                            "Discord media send",
+                            e,
+                        )
+                    )
 
         if last_data is None:
             error = "No deliverable text or media remained after processing"
@@ -10715,7 +10643,13 @@ async def _standalone_send(
             result["warnings"] = warnings
         return result
     except Exception as e:
-        return {"error": _standalone_sanitize_error(f"Discord send failed: {e}")}
+        logger.error("Discord standalone send failed: %s", e, exc_info=True)
+        return {
+            "error": _non_idempotent_discord_write_failure(
+                "Discord send",
+                e,
+            )
+        }
 
 
 # ── Plugin entry point ────────────────────────────────────────────────────────

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -388,14 +388,23 @@ def make_discord_message(
     if attachments is None:
         attachments = []
 
-    return SimpleNamespace(
+    message = SimpleNamespace(
         id=message_id, content=content, author=author, channel=channel,
         guild=getattr(channel, "guild", None),
         mentions=mentions, attachments=attachments,
         type=getattr(discord, "MessageType", SimpleNamespace()).default,
         reference=None, created_at=datetime.now(timezone.utc),
-        create_thread=AsyncMock(),
     )
+    if message.guild is None:
+        message.create_thread = AsyncMock()
+    else:
+        message.create_thread = AsyncMock(
+            return_value=make_fake_thread(
+                thread_id=message_id,
+                parent=channel,
+            )
+        )
+    return message
 
 
 def get_response_text(adapter) -> str | None:

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -84,10 +84,14 @@ class TestAutoThreadingPreservesCommand:
     async def test_command_detected_after_auto_thread(self, discord_adapter, bot_user, monkeypatch):
         """@mention /help in channel with auto-thread → thread created AND command dispatched."""
         monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
-        fake_thread = make_fake_thread(thread_id=90001, name="help")
         msg = make_discord_message(
             content=f"<@{BOT_USER_ID}> /help",
             mentions=[bot_user],
+        )
+        fake_thread = make_fake_thread(
+            thread_id=msg.id,
+            name="help",
+            parent=msg.channel,
         )
 
         # Simulate discord.py restoring the original raw content (with mention)

--- a/tests/gateway/test_discord_auto_thread_safety.py
+++ b/tests/gateway/test_discord_auto_thread_safety.py
@@ -53,15 +53,22 @@ class _FakeTextChannel:
 class _FakeThread(discord.Thread):
     """Minimal real ``discord.Thread`` subtype for routing checks."""
 
-    def __init__(self, channel_id: int, parent_type: discord.ChannelType):
+    def __init__(
+        self,
+        channel_id: int,
+        parent_type: discord.ChannelType,
+        *,
+        parent_id: int = 100,
+        guild_id: int = 1,
+    ):
         parent = SimpleNamespace(
-            id=100,
+            id=parent_id,
             name="parent",
             topic="Parent topic",
             type=parent_type,
         )
         guild = SimpleNamespace(
-            id=1,
+            id=guild_id,
             name="TestGuild",
             get_channel=lambda channel_id: parent if channel_id == parent.id else None,
         )
@@ -115,6 +122,7 @@ def adapter(monkeypatch):
     instance = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
     instance._client = SimpleNamespace(
         user=SimpleNamespace(id=99999, name="HermesBot"),
+        get_channel=MagicMock(return_value=None),
         fetch_channel=AsyncMock(),
     )
     instance._ready_event.set()
@@ -147,7 +155,12 @@ async def test_missing_guild_context_is_resolved_before_auto_thread(
     adapter._discord_message_admission = MagicMock(return_value=(True, False))
 
     message = _message(projected_channel, guild=None)
-    thread = SimpleNamespace(id=300, name="new-thread")
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=authoritative_channel.id,
+        guild_id=authoritative_guild.id,
+    )
 
     async def create_thread(**kwargs):
         if message.guild is None:
@@ -326,22 +339,141 @@ async def test_permanent_auto_thread_failures_are_not_retried_or_seeded(
 
     assert result is None
     message.create_thread.assert_awaited_once()
+    adapter._client.fetch_channel.assert_not_awaited()
     sleep.assert_not_awaited()
     channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_committed_timeout_reconciles_by_source_message_id(adapter, monkeypatch):
+    """A lost create response is accepted by authoritative known-ID read-back."""
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=channel.id,
+        guild_id=channel.guild.id,
+    )
+    message.create_thread = AsyncMock(
+        side_effect=TimeoutError("RAW_TIMEOUT_SENTINEL")
+    )
+    adapter._client.fetch_channel.return_value = thread
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    message.create_thread.assert_awaited_once()
+    adapter._client.fetch_channel.assert_awaited_once_with(message.id)
+    assert adapter._authoritative_message_channels[message.id] is thread
+    sleep.assert_not_awaited()
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_readback_404_allows_one_replay(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=channel.id,
+        guild_id=channel.guild.id,
+    )
+    message.create_thread = AsyncMock(
+        side_effect=[TimeoutError("RAW_TIMEOUT_SENTINEL"), thread]
+    )
+    adapter._client.fetch_channel.side_effect = _http_error(404)
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_count == 2
+    adapter._client.fetch_channel.assert_awaited_once_with(message.id)
+    sleep.assert_awaited_once_with(0.75)
+
+
+@pytest.mark.asyncio
+async def test_replay_400_reconciles_committed_thread(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=channel.id,
+        guild_id=channel.guild.id,
+    )
+    message.create_thread = AsyncMock(
+        side_effect=[
+            aiohttp.ClientConnectionError("RAW_NETWORK_SENTINEL"),
+            _http_error(400),
+        ]
+    )
+    adapter._client.fetch_channel.side_effect = [
+        _http_error(404),
+        thread,
+    ]
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_count == 2
+    assert adapter._client.fetch_channel.await_count == 2
+    sleep.assert_awaited_once_with(0.75)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "readback",
+    [
+        _FakeTextChannel(12345, guild=SimpleNamespace(id=1)),
+        _FakeThread(
+            12345,
+            discord.ChannelType.text,
+            parent_id=999,
+            guild_id=1,
+        ),
+    ],
+    ids=["wrong-type", "wrong-parent"],
+)
+async def test_unexpected_readback_fails_closed_without_replay(
+    adapter,
+    monkeypatch,
+    readback,
+):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    message.create_thread = AsyncMock(
+        side_effect=TimeoutError("RAW_TIMEOUT_SENTINEL")
+    )
+    adapter._client.fetch_channel.return_value = readback
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    message.create_thread.assert_awaited_once()
+    adapter._client.fetch_channel.assert_awaited_once_with(message.id)
+    sleep.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("error", "expected_delay"),
     [
-        (_http_error(500), 0.75),
-        (_http_error(503), 0.75),
-        (aiohttp.ClientConnectionError("connection lost"), 0.75),
-        (TimeoutError("request timed out"), 0.75),
+        (_http_error(429, retry_after="2.5"), 2.5),
+        (_TestRateLimited(retry_after=4.0), 4.0),
     ],
-    ids=["http-500", "http-503", "network", "timeout"],
+    ids=["http-429", "discord-rate-limited"],
 )
-async def test_transient_auto_thread_failures_retry_once(
+async def test_rate_limit_replay_honors_retry_after(
     adapter,
     monkeypatch,
     error,
@@ -351,57 +483,26 @@ async def test_transient_auto_thread_failures_retry_once(
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
     channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
     message = _message(channel, guild=channel.guild)
-    thread = SimpleNamespace(id=300, name="new-thread")
-    message.create_thread = AsyncMock(side_effect=[error, thread])
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=channel.id,
+        guild_id=channel.guild.id,
+    )
+    message.create_thread = AsyncMock(
+        side_effect=[error, thread]
+    )
 
     result = await adapter._auto_create_thread(message)
 
     assert result is thread
     assert message.create_thread.await_count == 2
+    adapter._client.fetch_channel.assert_not_awaited()
     sleep.assert_awaited_once_with(expected_delay)
-    channel.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_retry_honors_retry_after(adapter, monkeypatch):
-    sleep = AsyncMock()
-    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = SimpleNamespace(id=300, name="new-thread")
-    message.create_thread = AsyncMock(
-        side_effect=[_http_error(429, retry_after="2.5"), thread]
-    )
-
-    result = await adapter._auto_create_thread(message)
-
-    assert result is thread
-    assert message.create_thread.await_count == 2
-    sleep.assert_awaited_once_with(2.5)
-    channel.send.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_discord_rate_limited_retry_honors_retry_after(adapter, monkeypatch):
-    sleep = AsyncMock()
-    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = SimpleNamespace(id=300, name="new-thread")
-    message.create_thread = AsyncMock(
-        side_effect=[_TestRateLimited(retry_after=4.0), thread]
-    )
-
-    result = await adapter._auto_create_thread(message)
-
-    assert result is thread
-    assert message.create_thread.await_count == 2
-    sleep.assert_awaited_once_with(4.0)
-    channel.send.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_exhausted_transient_retries_never_create_duplicate_seeds(
+async def test_exhausted_message_rate_limit_is_absent_and_does_not_read_back(
     adapter,
     monkeypatch,
 ):
@@ -411,8 +512,14 @@ async def test_exhausted_transient_retries_never_create_duplicate_seeds(
     message = _message(channel, guild=channel.guild)
     message.create_thread = AsyncMock(
         side_effect=[
-            aiohttp.ClientConnectionError("first failure"),
-            aiohttp.ClientConnectionError("second failure"),
+            _TestHTTPException(
+                _FakeResponse(429, retry_after="1.25"),
+                "RAW_FIRST_429_SENTINEL",
+            ),
+            _TestHTTPException(
+                _FakeResponse(429, retry_after="3.5"),
+                "RAW_SECOND_429_SENTINEL",
+            ),
         ]
     )
 
@@ -420,21 +527,60 @@ async def test_exhausted_transient_retries_never_create_duplicate_seeds(
 
     assert result is None
     assert message.create_thread.await_count == 2
-    sleep.assert_awaited_once_with(0.75)
-    channel.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_not_awaited()
+    sleep.assert_awaited_once_with(1.25)
 
 
 @pytest.mark.asyncio
-async def test_slash_fallback_seed_is_honest_and_removed_if_orphaned(adapter):
-    seed = SimpleNamespace(
-        id=777,
-        create_thread=AsyncMock(side_effect=ValueError("missing guild")),
+async def test_replay_failure_final_404_proves_absence(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    message.create_thread = AsyncMock(
+        side_effect=[
+            TimeoutError("RAW_FIRST_SENTINEL"),
+            _http_error(400),
+        ]
+    )
+    adapter._client.fetch_channel.side_effect = [
+        _http_error(404),
+        _http_error(404),
+    ]
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    assert message.create_thread.await_count == 2
+    assert adapter._client.fetch_channel.await_count == 2
+    sleep.assert_awaited_once_with(0.75)
+
+
+def _owned_seed(parent, *, seed_id=777, create_result=None, create_error=None):
+    create_thread = AsyncMock(return_value=create_result)
+    if create_error is not None:
+        create_thread.side_effect = create_error
+    return SimpleNamespace(
+        id=seed_id,
+        channel=parent,
+        guild=parent.guild,
+        create_thread=create_thread,
         delete=AsyncMock(),
     )
-    parent = SimpleNamespace(
-        create_thread=AsyncMock(side_effect=RuntimeError("direct failed")),
-        send=AsyncMock(return_value=seed),
+
+
+@pytest.mark.asyncio
+async def test_slash_uses_one_message_backed_path_and_cleans_permanent_orphan(
+    adapter,
+):
+    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    parent.create_thread = AsyncMock()
+    seed = _owned_seed(
+        parent,
+        seed_id=777,
+        create_error=ValueError("RAW_INTERNAL_SENTINEL"),
     )
+    parent.send.return_value = seed
     interaction = SimpleNamespace(
         channel=parent,
         channel_id=200,
@@ -444,8 +590,181 @@ async def test_slash_fallback_seed_is_honest_and_removed_if_orphaned(adapter):
     result = await adapter._create_thread(interaction, name="Planning")
 
     assert "error" in result
+    assert "RAW_INTERNAL_SENTINEL" not in result["error"]
     parent.send.assert_awaited_once_with(
         "\U0001f9f5 Thread requested via Hermes: **Planning**"
     )
+    parent.create_thread.assert_not_awaited()
     seed.create_thread.assert_awaited_once()
     seed.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slash_exhausted_429_is_sanitized_and_cleans_owned_seed(
+    adapter,
+    monkeypatch,
+):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    seed = _owned_seed(parent)
+    seed.create_thread.side_effect = [
+        _TestHTTPException(
+            _FakeResponse(429, retry_after="1.25"),
+            "RAW_FIRST_SLASH_429_SENTINEL",
+        ),
+        _TestHTTPException(
+            _FakeResponse(429, retry_after="3.5"),
+            "RAW_SECOND_SLASH_429_SENTINEL",
+        ),
+    ]
+    parent.send.return_value = seed
+    interaction = SimpleNamespace(
+        channel=parent,
+        channel_id=parent.id,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Planning")
+
+    assert "remained rate limited after one retry" in result["error"]
+    assert "3.5 seconds" in result["error"]
+    assert "RAW_FIRST_SLASH_429_SENTINEL" not in result["error"]
+    assert "RAW_SECOND_SLASH_429_SENTINEL" not in result["error"]
+    assert seed.create_thread.await_count == 2
+    seed.delete.assert_awaited_once()
+    adapter._client.fetch_channel.assert_not_awaited()
+    sleep.assert_awaited_once_with(1.25)
+
+
+@pytest.mark.asyncio
+async def test_slash_keeps_owned_seed_when_ambiguous_outcome_is_not_absent(adapter):
+    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    parent.create_thread = AsyncMock()
+    seed = _owned_seed(
+        parent,
+        create_error=TimeoutError("RAW_TIMEOUT_SENTINEL"),
+    )
+    parent.send.return_value = seed
+    adapter._client.fetch_channel.return_value = _FakeThread(
+        seed.id,
+        discord.ChannelType.text,
+        parent_id=999,
+        guild_id=parent.guild.id,
+    )
+    interaction = SimpleNamespace(
+        channel=parent,
+        channel_id=parent.id,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Planning")
+
+    assert "error" in result
+    assert "RAW_TIMEOUT_SENTINEL" not in result["error"]
+    parent.send.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+    seed.create_thread.assert_awaited_once()
+    seed.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_uses_one_message_backed_path_and_cleans_permanent_orphan(
+    adapter,
+):
+    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    parent.create_thread = AsyncMock()
+    seed = _owned_seed(
+        parent,
+        create_error=ValueError("RAW_HANDOFF_SENTINEL"),
+    )
+    parent.send.return_value = seed
+    adapter._client.get_channel.return_value = parent
+
+    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
+
+    assert result is None
+    parent.send.assert_awaited_once_with("\U0001f9f5 Hermes handoff: **Planning**")
+    parent.create_thread.assert_not_awaited()
+    seed.create_thread.assert_awaited_once()
+    seed.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handoff_reconciles_committed_thread_without_deleting_seed(adapter):
+    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    parent.create_thread = AsyncMock()
+    seed = _owned_seed(
+        parent,
+        create_error=TimeoutError("RAW_HANDOFF_TIMEOUT_SENTINEL"),
+    )
+    parent.send.return_value = seed
+    thread = _FakeThread(
+        seed.id,
+        discord.ChannelType.text,
+        parent_id=parent.id,
+        guild_id=parent.guild.id,
+    )
+    adapter._client.get_channel.return_value = parent
+    adapter._client.fetch_channel.return_value = thread
+
+    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
+
+    assert result == str(seed.id)
+    parent.send.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+    seed.create_thread.assert_awaited_once()
+    seed.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_forum_create_is_never_retried(adapter, monkeypatch):
+    parent = SimpleNamespace(
+        id=200,
+        create_thread=AsyncMock(
+            side_effect=TimeoutError("RAW_FORUM_HANDOFF_SENTINEL")
+        ),
+        send=AsyncMock(),
+    )
+    adapter._client.get_channel.return_value = parent
+    monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _channel: True)
+
+    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
+
+    assert result is None
+    parent.create_thread.assert_awaited_once()
+    parent.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_forum_create_retries_one_429(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    thread = _FakeThread(
+        888,
+        discord.ChannelType.forum,
+        parent_id=200,
+        guild_id=1,
+    )
+    parent = SimpleNamespace(
+        id=200,
+        create_thread=AsyncMock(
+            side_effect=[
+                _TestHTTPException(
+                    _FakeResponse(429, retry_after="2.5"),
+                    "RAW_HANDOFF_429_SENTINEL",
+                ),
+                thread,
+            ]
+        ),
+        send=AsyncMock(),
+    )
+    adapter._client.get_channel.return_value = parent
+    monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _channel: True)
+
+    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
+
+    assert result == str(thread.id)
+    assert parent.create_thread.await_count == 2
+    parent.send.assert_not_awaited()
+    sleep.assert_awaited_once_with(2.5)

--- a/tests/gateway/test_discord_auto_thread_safety.py
+++ b/tests/gateway/test_discord_auto_thread_safety.py
@@ -8,6 +8,7 @@ import discord
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 import plugins.platforms.discord.adapter as discord_platform
 from plugins.platforms.discord.adapter import DiscordAdapter
 
@@ -76,6 +77,8 @@ class _FakeThread(discord.Thread):
         self.name = "existing-post"
         self.guild = guild
         self.parent_id = parent.id
+        self.send = AsyncMock()
+        self.fetch_message = AsyncMock()
 
     def history(self, *args, **kwargs):
         async def _empty():
@@ -83,6 +86,17 @@ class _FakeThread(discord.Thread):
             yield  # pragma: no cover - make this an async generator
 
         return _empty()
+
+
+class _FakeForumChannel(discord.ForumChannel):
+    """Minimal real ``discord.ForumChannel`` subtype for routing checks."""
+
+    def __init__(self, channel_id: int, guild=None):
+        self.id = channel_id
+        self.name = "ideas"
+        self.guild = guild or SimpleNamespace(id=1, name="TestGuild")
+        self.type = discord.ChannelType.forum
+        self.create_thread = AsyncMock()
 
 
 def _message(channel, *, guild=None):
@@ -107,6 +121,7 @@ def _message(channel, *, guild=None):
 
 @pytest.fixture
 def adapter(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
     monkeypatch.setattr(
         discord_platform.discord,
         "HTTPException",
@@ -152,7 +167,6 @@ async def test_missing_guild_context_is_resolved_before_auto_thread(
     authoritative_guild = SimpleNamespace(id=1, name="TestGuild")
     authoritative_channel = _FakeTextChannel(200, guild=authoritative_guild)
     adapter._client.fetch_channel.return_value = authoritative_channel
-    adapter._discord_message_admission = MagicMock(return_value=(True, False))
 
     message = _message(projected_channel, guild=None)
     thread = _FakeThread(
@@ -202,7 +216,6 @@ async def test_authoritative_thread_context_never_creates_nested_thread(
     projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
     authoritative_thread = _FakeThread(200, parent_type)
     adapter._client.fetch_channel.return_value = authoritative_thread
-    adapter._discord_message_admission = MagicMock(return_value=(True, False))
     adapter._auto_create_thread = AsyncMock()
 
     dispatched = await adapter._dispatch_discord_message(
@@ -231,9 +244,10 @@ async def test_recovered_projected_thread_resolves_before_thread_mention_gate(
     projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
     authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
     adapter._client.fetch_channel.return_value = authoritative_thread
-    adapter._discord_message_admission = MagicMock(return_value=(True, False))
     adapter._auto_create_thread = AsyncMock()
     adapter._threads.mark("200")
+    claim = MagicMock(side_effect=adapter._dedup.is_duplicate)
+    adapter._dedup.is_duplicate = claim
 
     dispatched = await adapter._dispatch_recovered_message(
         _message(projected_channel, guild=projected_channel.guild)
@@ -245,6 +259,7 @@ async def test_recovered_projected_thread_resolves_before_thread_mention_gate(
     event = adapter.handle_message.await_args.args[0]
     assert event.source.chat_type == "thread"
     assert event.source.chat_id == "200"
+    claim.assert_called_once_with("12345")
 
 
 @pytest.mark.asyncio
@@ -272,12 +287,140 @@ async def test_authoritative_channel_resolution_is_cached(adapter):
 
 
 @pytest.mark.asyncio
-async def test_channel_resolution_runs_only_after_admission(adapter):
-    adapter._discord_message_admission = MagicMock(return_value=(False, False))
-
-    dispatched = await adapter._dispatch_discord_message(
-        _message(_FakeTextChannel(200, guild=None), guild=None)
+async def test_channel_update_invalidates_cached_parent_and_child(adapter):
+    guild = SimpleNamespace(id=1, name="TestGuild")
+    cached_parent = _FakeForumChannel(100, guild=guild)
+    cached_thread = _FakeThread(
+        200,
+        discord.ChannelType.forum,
+        parent_id=cached_parent.id,
+        guild_id=guild.id,
     )
+    adapter._cache_authoritative_message_channel(cached_parent)
+    adapter._cache_authoritative_message_channel(cached_thread)
+
+    # Mirrors the on_guild_channel_update/delete handlers: the provider
+    # event invalidates both the changed parent and cached child context.
+    adapter._invalidate_authoritative_channel(100, include_children=True)
+
+    assert 100 not in adapter._authoritative_message_channels
+    assert 200 not in adapter._authoritative_message_channels
+    refreshed_thread = _FakeThread(
+        200,
+        discord.ChannelType.forum,
+        parent_id=300,
+        guild_id=guild.id,
+    )
+    adapter._client.fetch_channel.return_value = refreshed_thread
+    resolved, authoritative = await adapter._resolve_authoritative_channel(
+        200,
+        _FakeTextChannel(200, guild=guild),
+        operation_name="post-update channel resolution",
+    )
+
+    assert authoritative is True
+    assert resolved is refreshed_thread
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+
+
+@pytest.mark.asyncio
+async def test_thread_parent_update_refetches_and_applies_new_channel_policy(
+    adapter,
+    monkeypatch,
+):
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "100")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    old_thread = _FakeThread(
+        200,
+        discord.ChannelType.forum,
+        parent_id=100,
+    )
+    adapter._client.fetch_channel.return_value = old_thread
+    first = _message(_FakeTextChannel(200, guild=None), guild=None)
+
+    assert await adapter._dispatch_discord_message(first) is True
+
+    # Mirrors on_thread_update/raw_thread_update. The next event must use a
+    # new authoritative object rather than authorizing against parent 100.
+    adapter._invalidate_authoritative_channel(200)
+    new_thread = _FakeThread(
+        200,
+        discord.ChannelType.forum,
+        parent_id=300,
+    )
+    adapter._client.fetch_channel.return_value = new_thread
+    second = _message(_FakeTextChannel(200, guild=None), guild=None)
+    second.id = 12346
+
+    assert await adapter._dispatch_discord_message(second) is False
+    assert adapter._client.fetch_channel.await_count == 2
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_text_send_routes_authoritative_forum_and_reuses_cache(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_forum = _FakeForumChannel(200, guild=projected_channel.guild)
+    adapter._client.get_channel.return_value = projected_channel
+    adapter._client.fetch_channel.return_value = authoritative_forum
+    adapter._send_to_forum = AsyncMock(
+        return_value=SendResult(success=True, message_id="777")
+    )
+
+    first = await adapter.send("200", "first")
+    second = await adapter.send("200", "second")
+
+    assert first.success is True
+    assert second.success is True
+    assert adapter._send_to_forum.await_count == 2
+    projected_channel.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+
+
+@pytest.mark.asyncio
+async def test_stale_text_send_routes_authoritative_thread(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
+    authoritative_thread.send.return_value = SimpleNamespace(id=777)
+    adapter._client.get_channel.return_value = projected_channel
+    adapter._client.fetch_channel.return_value = authoritative_thread
+
+    result = await adapter.send("200", "reply in the existing post")
+
+    assert result.success is True
+    authoritative_thread.send.assert_awaited_once()
+    projected_channel.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+
+
+@pytest.mark.asyncio
+async def test_definitive_thread_id_send_does_not_add_rest_lookup(adapter):
+    thread = _FakeThread(200, discord.ChannelType.text)
+    thread.send.return_value = SimpleNamespace(id=777)
+    adapter._client.get_channel.return_value = thread
+
+    first = await adapter.send("200", "first")
+    second = await adapter.send("200", "second")
+
+    assert first.success is True
+    assert second.success is True
+    assert thread.send.await_count == 2
+    adapter._client.fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rejection", ["self", "bot", "type"])
+async def test_provider_preflight_rejections_do_not_fetch(adapter, rejection):
+    message = _message(_FakeTextChannel(200, guild=None), guild=None)
+    if rejection == "self":
+        message.author = adapter._client.user
+    elif rejection == "bot":
+        message.author.bot = True
+    else:
+        message.type = object()
+
+    dispatched = await adapter._dispatch_discord_message(message)
 
     assert dispatched is False
     adapter._client.fetch_channel.assert_not_awaited()
@@ -285,16 +428,79 @@ async def test_channel_resolution_runs_only_after_admission(adapter):
 
 
 @pytest.mark.asyncio
-async def test_unresolved_channel_context_fails_closed_with_one_honest_notice(
+async def test_resolved_guild_context_applies_guild_role_policy(adapter, monkeypatch):
+    """A partial guild=None event must not be evaluated under DM role policy."""
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._allowed_role_ids = {7}
+
+    projected_channel = _FakeTextChannel(200, guild=None)
+    authoritative_guild = SimpleNamespace(
+        id=1,
+        name="TestGuild",
+        get_member=lambda _user_id: None,
+    )
+    authoritative_channel = _FakeTextChannel(200, guild=authoritative_guild)
+    adapter._client.fetch_channel.return_value = authoritative_channel
+    message = _message(projected_channel, guild=None)
+    message.author.roles = [SimpleNamespace(id=7)]
+
+    dispatched = await adapter._dispatch_discord_message(message)
+
+    assert dispatched is True
+    assert message.guild is authoritative_guild
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolved_thread_parent_is_used_by_channel_authorization(
     adapter,
     monkeypatch,
+):
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "100")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    projected_channel = _FakeTextChannel(200, guild=None)
+    authoritative_thread = _FakeThread(
+        200,
+        discord.ChannelType.forum,
+        parent_id=100,
+    )
+    adapter._client.fetch_channel.return_value = authoritative_thread
+
+    dispatched = await adapter._dispatch_discord_message(
+        _message(projected_channel, guild=None)
+    )
+
+    assert dispatched is True
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "200"
+    assert event.source.parent_chat_id == "100"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_fetches"),
+    [
+        (_http_error(403), 1),
+        (_http_error(500), 2),
+    ],
+    ids=["forbidden", "exhausted-5xx"],
+)
+async def test_unresolved_ambiguous_context_fails_before_authorization(
+    adapter,
+    monkeypatch,
+    error,
+    expected_fetches,
 ):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
     monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
-    adapter._discord_message_admission = MagicMock(return_value=(True, False))
-    adapter._client.fetch_channel.side_effect = _http_error(403)
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", AsyncMock())
+    adapter._client.fetch_channel.side_effect = error
+    adapter._discord_message_context_admission = MagicMock()
     projected_channel = _FakeTextChannel(200, guild=None)
     message = _message(projected_channel, guild=None)
     message.create_thread = AsyncMock()
@@ -302,14 +508,32 @@ async def test_unresolved_channel_context_fails_closed_with_one_honest_notice(
     dispatched = await adapter._dispatch_discord_message(message)
 
     assert dispatched is False
-    adapter._client.fetch_channel.assert_awaited_once_with(200)
+    assert adapter._client.fetch_channel.await_count == expected_fetches
+    assert all(call.args == (200,) for call in adapter._client.fetch_channel.await_args_list)
+    adapter._discord_message_context_admission.assert_not_called()
     message.create_thread.assert_not_awaited()
     adapter.handle_message.assert_not_awaited()
-    projected_channel.send.assert_awaited_once()
-    notice = projected_channel.send.await_args.args[0]
-    assert "could not create" in notice.lower()
-    assert "thread" in notice.lower()
-    assert "thread created" not in notice.lower()
+    projected_channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_partial_type_value_is_not_trusted_without_authoritative_read(adapter):
+    partial = SimpleNamespace(
+        id=200,
+        type=discord.ChannelType.forum,
+        guild=SimpleNamespace(id=1),
+    )
+    adapter._client.fetch_channel.side_effect = _http_error(403)
+
+    resolved, authoritative = await adapter._resolve_authoritative_channel(
+        partial.id,
+        partial,
+        operation_name="partial forum resolution",
+    )
+
+    assert resolved is partial
+    assert authoritative is False
+    adapter._client.fetch_channel.assert_awaited_once_with(partial.id)
 
 
 @pytest.mark.asyncio
@@ -586,6 +810,7 @@ async def test_slash_uses_one_message_backed_path_and_cleans_permanent_orphan(
         channel_id=200,
         user=SimpleNamespace(display_name="Jezza"),
     )
+    adapter._client.fetch_channel.return_value = parent
 
     result = await adapter._create_thread(interaction, name="Planning")
 
@@ -597,6 +822,93 @@ async def test_slash_uses_one_message_backed_path_and_cleans_permanent_orphan(
     parent.create_thread.assert_not_awaited()
     seed.create_thread.assert_awaited_once()
     seed.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slash_stale_text_resolves_authoritative_forum(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_forum = _FakeForumChannel(200, guild=projected_channel.guild)
+    thread = _FakeThread(
+        888,
+        discord.ChannelType.forum,
+        parent_id=authoritative_forum.id,
+        guild_id=authoritative_forum.guild.id,
+    )
+    authoritative_forum.create_thread.return_value = thread
+    adapter._client.fetch_channel.return_value = authoritative_forum
+    interaction = SimpleNamespace(
+        channel=projected_channel,
+        channel_id=projected_channel.id,
+        guild_id=projected_channel.guild.id,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Planning")
+
+    assert result == {
+        "success": True,
+        "thread_id": str(thread.id),
+        "thread_name": thread.name,
+    }
+    authoritative_forum.create_thread.assert_awaited_once()
+    projected_channel.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_awaited_once_with(projected_channel.id)
+
+
+@pytest.mark.asyncio
+async def test_slash_stale_text_resolves_existing_thread_and_rejects_nested(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
+    adapter._client.fetch_channel.return_value = authoritative_thread
+    interaction = SimpleNamespace(
+        channel=projected_channel,
+        channel_id=projected_channel.id,
+        guild_id=projected_channel.guild.id,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Nested")
+
+    assert "nested thread" in result["error"].lower()
+    projected_channel.send.assert_not_awaited()
+    authoritative_thread.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_awaited_once_with(projected_channel.id)
+
+
+@pytest.mark.asyncio
+async def test_slash_existing_thread_rejects_nested_without_rest(adapter):
+    thread = _FakeThread(200, discord.ChannelType.text)
+    interaction = SimpleNamespace(
+        channel=thread,
+        channel_id=thread.id,
+        guild_id=thread.guild.id,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Nested")
+
+    assert "nested thread" in result["error"].lower()
+    thread.send.assert_not_awaited()
+    adapter._client.fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_interaction_resolution_reuses_authoritative_channel_cache(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_forum = _FakeForumChannel(200, guild=projected_channel.guild)
+    adapter._client.fetch_channel.return_value = authoritative_forum
+    interaction = SimpleNamespace(
+        channel=projected_channel,
+        channel_id=projected_channel.id,
+        guild_id=projected_channel.guild.id,
+    )
+
+    first = await adapter._resolve_interaction_channel(interaction)
+    second = await adapter._resolve_interaction_channel(interaction)
+
+    assert first is authoritative_forum
+    assert second is authoritative_forum
+    adapter._client.fetch_channel.assert_awaited_once_with(projected_channel.id)
 
 
 @pytest.mark.asyncio
@@ -624,6 +936,7 @@ async def test_slash_exhausted_429_is_sanitized_and_cleans_owned_seed(
         channel_id=parent.id,
         user=SimpleNamespace(display_name="Jezza"),
     )
+    adapter._client.fetch_channel.return_value = parent
 
     result = await adapter._create_thread(interaction, name="Planning")
 
@@ -633,7 +946,7 @@ async def test_slash_exhausted_429_is_sanitized_and_cleans_owned_seed(
     assert "RAW_SECOND_SLASH_429_SENTINEL" not in result["error"]
     assert seed.create_thread.await_count == 2
     seed.delete.assert_awaited_once()
-    adapter._client.fetch_channel.assert_not_awaited()
+    adapter._client.fetch_channel.assert_awaited_once_with(parent.id)
     sleep.assert_awaited_once_with(1.25)
 
 
@@ -646,12 +959,15 @@ async def test_slash_keeps_owned_seed_when_ambiguous_outcome_is_not_absent(adapt
         create_error=TimeoutError("RAW_TIMEOUT_SENTINEL"),
     )
     parent.send.return_value = seed
-    adapter._client.fetch_channel.return_value = _FakeThread(
-        seed.id,
-        discord.ChannelType.text,
-        parent_id=999,
-        guild_id=parent.guild.id,
-    )
+    adapter._client.fetch_channel.side_effect = [
+        parent,
+        _FakeThread(
+            seed.id,
+            discord.ChannelType.text,
+            parent_id=999,
+            guild_id=parent.guild.id,
+        ),
+    ]
     interaction = SimpleNamespace(
         channel=parent,
         channel_id=parent.id,
@@ -680,6 +996,7 @@ async def test_handoff_uses_one_message_backed_path_and_cleans_permanent_orphan(
     )
     parent.send.return_value = seed
     adapter._client.get_channel.return_value = parent
+    adapter._client.fetch_channel.return_value = parent
 
     result = await adapter.create_handoff_thread(str(parent.id), "Planning")
 
@@ -706,7 +1023,7 @@ async def test_handoff_reconciles_committed_thread_without_deleting_seed(adapter
         guild_id=parent.guild.id,
     )
     adapter._client.get_channel.return_value = parent
-    adapter._client.fetch_channel.return_value = thread
+    adapter._client.fetch_channel.side_effect = [parent, thread]
 
     result = await adapter.create_handoff_thread(str(parent.id), "Planning")
 
@@ -727,6 +1044,7 @@ async def test_handoff_forum_create_is_never_retried(adapter, monkeypatch):
         send=AsyncMock(),
     )
     adapter._client.get_channel.return_value = parent
+    adapter._client.fetch_channel.return_value = parent
     monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _channel: True)
 
     result = await adapter.create_handoff_thread(str(parent.id), "Planning")
@@ -760,6 +1078,7 @@ async def test_handoff_forum_create_retries_one_429(adapter, monkeypatch):
         send=AsyncMock(),
     )
     adapter._client.get_channel.return_value = parent
+    adapter._client.fetch_channel.return_value = parent
     monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _channel: True)
 
     result = await adapter.create_handoff_thread(str(parent.id), "Planning")

--- a/tests/gateway/test_discord_auto_thread_safety.py
+++ b/tests/gateway/test_discord_auto_thread_safety.py
@@ -1,0 +1,451 @@
+"""Safety contracts for Discord auto-thread routing and REST retries."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import discord
+import pytest
+
+from gateway.config import PlatformConfig
+import plugins.platforms.discord.adapter as discord_platform
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _FakeResponse:
+    def __init__(self, status: int, *, retry_after: str | None = None):
+        self.status = status
+        self.reason = "test response"
+        self.headers = {}
+        if retry_after is not None:
+            self.headers["Retry-After"] = retry_after
+
+
+class _TestHTTPException(Exception):
+    def __init__(self, response: _FakeResponse, message: str):
+        super().__init__(message)
+        self.response = response
+        self.status = response.status
+
+
+class _TestRateLimited(Exception):
+    def __init__(self, retry_after: float):
+        super().__init__(f"Retry in {retry_after} seconds")
+        self.retry_after = retry_after
+
+
+class _FakeTextChannel:
+    def __init__(self, channel_id: int, guild=None):
+        self.id = channel_id
+        self.name = "general"
+        self.guild = guild
+        self.topic = None
+        self.send = AsyncMock()
+
+    def history(self, *args, **kwargs):
+        async def _empty():
+            return
+            yield  # pragma: no cover - make this an async generator
+
+        return _empty()
+
+
+class _FakeThread(discord.Thread):
+    """Minimal real ``discord.Thread`` subtype for routing checks."""
+
+    def __init__(self, channel_id: int, parent_type: discord.ChannelType):
+        parent = SimpleNamespace(
+            id=100,
+            name="parent",
+            topic="Parent topic",
+            type=parent_type,
+        )
+        guild = SimpleNamespace(
+            id=1,
+            name="TestGuild",
+            get_channel=lambda channel_id: parent if channel_id == parent.id else None,
+        )
+        self.id = channel_id
+        self.name = "existing-post"
+        self.guild = guild
+        self.parent_id = parent.id
+
+    def history(self, *args, **kwargs):
+        async def _empty():
+            return
+            yield  # pragma: no cover - make this an async generator
+
+        return _empty()
+
+
+def _message(channel, *, guild=None):
+    return SimpleNamespace(
+        id=12345,
+        author=SimpleNamespace(
+            id=42,
+            display_name="Jezza",
+            name="Jezza",
+            bot=False,
+        ),
+        content="Hello from a projected channel",
+        channel=channel,
+        guild=guild,
+        attachments=[],
+        mentions=[],
+        reference=None,
+        created_at=None,
+        type=discord.MessageType.default,
+    )
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "HTTPException",
+        _TestHTTPException,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "RateLimited",
+        _TestRateLimited,
+        raising=False,
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    instance._client = SimpleNamespace(
+        user=SimpleNamespace(id=99999, name="HermesBot"),
+        fetch_channel=AsyncMock(),
+    )
+    instance._ready_event.set()
+    instance._text_batch_delay_seconds = 0
+    instance.handle_message = AsyncMock()
+    return instance
+
+
+def _http_error(status: int, *, retry_after: str | None = None) -> _TestHTTPException:
+    return _TestHTTPException(
+        _FakeResponse(status, retry_after=retry_after),
+        "test failure",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_guild_context_is_resolved_before_auto_thread(
+    adapter, monkeypatch
+):
+    """REST context repairs the discord.py ValueError precondition."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    projected_channel = _FakeTextChannel(200, guild=None)
+    authoritative_guild = SimpleNamespace(id=1, name="TestGuild")
+    authoritative_channel = _FakeTextChannel(200, guild=authoritative_guild)
+    adapter._client.fetch_channel.return_value = authoritative_channel
+    adapter._discord_message_admission = MagicMock(return_value=(True, False))
+
+    message = _message(projected_channel, guild=None)
+    thread = SimpleNamespace(id=300, name="new-thread")
+
+    async def create_thread(**kwargs):
+        if message.guild is None:
+            raise ValueError("This message does not have guild info attached.")
+        return thread
+
+    message.create_thread = AsyncMock(side_effect=create_thread)
+
+    dispatched = await adapter._dispatch_discord_message(message)
+
+    assert dispatched is True
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+    assert message.channel is authoritative_channel
+    assert message.guild is authoritative_guild
+    message.create_thread.assert_awaited_once()
+    projected_channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "parent_type",
+    [
+        discord.ChannelType.text,
+        discord.ChannelType.forum,
+        discord.ChannelType.media,
+    ],
+    ids=["text-thread", "forum-post", "media-post"],
+)
+async def test_authoritative_thread_context_never_creates_nested_thread(
+    adapter,
+    monkeypatch,
+    parent_type,
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_thread = _FakeThread(200, parent_type)
+    adapter._client.fetch_channel.return_value = authoritative_thread
+    adapter._discord_message_admission = MagicMock(return_value=(True, False))
+    adapter._auto_create_thread = AsyncMock()
+
+    dispatched = await adapter._dispatch_discord_message(
+        _message(projected_channel, guild=projected_channel.guild)
+    )
+
+    assert dispatched is True
+    adapter._auto_create_thread.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "200"
+    assert event.source.parent_chat_id == "100"
+
+
+@pytest.mark.asyncio
+async def test_recovered_projected_thread_resolves_before_thread_mention_gate(
+    adapter,
+    monkeypatch,
+):
+    """Reconnect recovery must apply thread gates to the REST-resolved type."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
+    adapter._client.fetch_channel.return_value = authoritative_thread
+    adapter._discord_message_admission = MagicMock(return_value=(True, False))
+    adapter._auto_create_thread = AsyncMock()
+    adapter._threads.mark("200")
+
+    dispatched = await adapter._dispatch_recovered_message(
+        _message(projected_channel, guild=projected_channel.guild)
+    )
+
+    assert dispatched is True
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+    adapter._auto_create_thread.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "200"
+
+
+@pytest.mark.asyncio
+async def test_authoritative_channel_resolution_is_cached(adapter):
+    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
+    adapter._client.fetch_channel.return_value = authoritative_thread
+    first = _message(projected_channel, guild=projected_channel.guild)
+    second = _message(projected_channel, guild=projected_channel.guild)
+
+    (
+        first_channel,
+        first_authoritative,
+    ) = await adapter._resolve_authoritative_message_channel(first)
+    (
+        second_channel,
+        second_authoritative,
+    ) = await adapter._resolve_authoritative_message_channel(second)
+
+    assert first_authoritative is True
+    assert second_authoritative is True
+    assert first_channel is authoritative_thread
+    assert second_channel is authoritative_thread
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+
+
+@pytest.mark.asyncio
+async def test_channel_resolution_runs_only_after_admission(adapter):
+    adapter._discord_message_admission = MagicMock(return_value=(False, False))
+
+    dispatched = await adapter._dispatch_discord_message(
+        _message(_FakeTextChannel(200, guild=None), guild=None)
+    )
+
+    assert dispatched is False
+    adapter._client.fetch_channel.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unresolved_channel_context_fails_closed_with_one_honest_notice(
+    adapter,
+    monkeypatch,
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter._discord_message_admission = MagicMock(return_value=(True, False))
+    adapter._client.fetch_channel.side_effect = _http_error(403)
+    projected_channel = _FakeTextChannel(200, guild=None)
+    message = _message(projected_channel, guild=None)
+    message.create_thread = AsyncMock()
+
+    dispatched = await adapter._dispatch_discord_message(message)
+
+    assert dispatched is False
+    adapter._client.fetch_channel.assert_awaited_once_with(200)
+    message.create_thread.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+    projected_channel.send.assert_awaited_once()
+    notice = projected_channel.send.await_args.args[0]
+    assert "could not create" in notice.lower()
+    assert "thread" in notice.lower()
+    assert "thread created" not in notice.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        ValueError("This message does not have guild info attached."),
+        _http_error(400),
+        _http_error(403),
+        _http_error(404),
+        RuntimeError("unexpected adapter failure"),
+    ],
+    ids=["missing-guild", "bad-request", "forbidden", "not-found", "unknown"],
+)
+async def test_permanent_auto_thread_failures_are_not_retried_or_seeded(
+    adapter,
+    monkeypatch,
+    error,
+):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    message.create_thread = AsyncMock(side_effect=error)
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    message.create_thread.assert_awaited_once()
+    sleep.assert_not_awaited()
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_delay"),
+    [
+        (_http_error(500), 0.75),
+        (_http_error(503), 0.75),
+        (aiohttp.ClientConnectionError("connection lost"), 0.75),
+        (TimeoutError("request timed out"), 0.75),
+    ],
+    ids=["http-500", "http-503", "network", "timeout"],
+)
+async def test_transient_auto_thread_failures_retry_once(
+    adapter,
+    monkeypatch,
+    error,
+    expected_delay,
+):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = SimpleNamespace(id=300, name="new-thread")
+    message.create_thread = AsyncMock(side_effect=[error, thread])
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(expected_delay)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_retry_honors_retry_after(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = SimpleNamespace(id=300, name="new-thread")
+    message.create_thread = AsyncMock(
+        side_effect=[_http_error(429, retry_after="2.5"), thread]
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(2.5)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_rate_limited_retry_honors_retry_after(adapter, monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    thread = SimpleNamespace(id=300, name="new-thread")
+    message.create_thread = AsyncMock(
+        side_effect=[_TestRateLimited(retry_after=4.0), thread]
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(4.0)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exhausted_transient_retries_never_create_duplicate_seeds(
+    adapter,
+    monkeypatch,
+):
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
+    message = _message(channel, guild=channel.guild)
+    message.create_thread = AsyncMock(
+        side_effect=[
+            aiohttp.ClientConnectionError("first failure"),
+            aiohttp.ClientConnectionError("second failure"),
+        ]
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    assert message.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(0.75)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slash_fallback_seed_is_honest_and_removed_if_orphaned(adapter):
+    seed = SimpleNamespace(
+        id=777,
+        create_thread=AsyncMock(side_effect=ValueError("missing guild")),
+        delete=AsyncMock(),
+    )
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("direct failed")),
+        send=AsyncMock(return_value=seed),
+    )
+    interaction = SimpleNamespace(
+        channel=parent,
+        channel_id=200,
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._create_thread(interaction, name="Planning")
+
+    assert "error" in result
+    parent.send.assert_awaited_once_with(
+        "\U0001f9f5 Thread requested via Hermes: **Planning**"
+    )
+    seed.create_thread.assert_awaited_once()
+    seed.delete.assert_awaited_once()

--- a/tests/gateway/test_discord_auto_thread_safety.py
+++ b/tests/gateway/test_discord_auto_thread_safety.py
@@ -1,5 +1,7 @@
 """Safety contracts for Discord auto-thread routing and REST retries."""
 
+import asyncio
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -153,6 +155,19 @@ def _http_error(status: int, *, retry_after: str | None = None) -> _TestHTTPExce
     )
 
 
+def _message_thread_source():
+    guild = SimpleNamespace(id=1, name="TestGuild")
+    channel = _FakeTextChannel(200, guild=guild)
+    message = _message(channel, guild=guild)
+    thread = _FakeThread(
+        message.id,
+        discord.ChannelType.text,
+        parent_id=channel.id,
+        guild_id=guild.id,
+    )
+    return channel, message, thread
+
+
 @pytest.mark.asyncio
 async def test_missing_guild_context_is_resolved_before_auto_thread(
     adapter, monkeypatch
@@ -263,30 +278,6 @@ async def test_recovered_projected_thread_resolves_before_thread_mention_gate(
 
 
 @pytest.mark.asyncio
-async def test_authoritative_channel_resolution_is_cached(adapter):
-    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
-    adapter._client.fetch_channel.return_value = authoritative_thread
-    first = _message(projected_channel, guild=projected_channel.guild)
-    second = _message(projected_channel, guild=projected_channel.guild)
-
-    (
-        first_channel,
-        first_authoritative,
-    ) = await adapter._resolve_authoritative_message_channel(first)
-    (
-        second_channel,
-        second_authoritative,
-    ) = await adapter._resolve_authoritative_message_channel(second)
-
-    assert first_authoritative is True
-    assert second_authoritative is True
-    assert first_channel is authoritative_thread
-    assert second_channel is authoritative_thread
-    adapter._client.fetch_channel.assert_awaited_once_with(200)
-
-
-@pytest.mark.asyncio
 async def test_channel_update_invalidates_cached_parent_and_child(adapter):
     guild = SimpleNamespace(id=1, name="TestGuild")
     cached_parent = _FakeForumChannel(100, guild=guild)
@@ -341,7 +332,7 @@ async def test_thread_parent_update_refetches_and_applies_new_channel_policy(
 
     assert await adapter._dispatch_discord_message(first) is True
 
-    # Mirrors on_thread_update/raw_thread_update. The next event must use a
+    # Mirrors on_raw_thread_update. The next event must use a
     # new authoritative object rather than authorizing against parent 100.
     adapter._invalidate_authoritative_channel(200)
     new_thread = _FakeThread(
@@ -402,10 +393,14 @@ async def test_definitive_thread_id_send_does_not_add_rest_lookup(adapter):
 
     first = await adapter.send("200", "first")
     second = await adapter.send("200", "second")
+    thread.send.side_effect = RuntimeError("RAW_SEND_SENTINEL")
+    failed = await adapter.send("200", "third")
 
     assert first.success is True
     assert second.success is True
-    assert thread.send.await_count == 2
+    assert failed.success is False
+    assert "RAW_SEND_SENTINEL" not in (failed.error or "")
+    assert thread.send.await_count == 3
     adapter._client.fetch_channel.assert_not_awaited()
 
 
@@ -481,18 +476,22 @@ async def test_resolved_thread_parent_is_used_by_channel_authorization(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("error", "expected_fetches"),
+    ("error", "expected_fetches", "claim_retained"),
     [
-        (_http_error(403), 1),
-        (_http_error(500), 2),
+        (_http_error(403), 1, True),
+        (_http_error(404), 1, True),
+        (_http_error(429, retry_after="0"), 2, False),
+        (_http_error(500), 2, False),
+        (TimeoutError("temporary network failure"), 2, False),
     ],
-    ids=["forbidden", "exhausted-5xx"],
+    ids=["forbidden", "not-found", "rate-limit", "server-error", "network"],
 )
 async def test_unresolved_ambiguous_context_fails_before_authorization(
     adapter,
     monkeypatch,
     error,
     expected_fetches,
+    claim_retained,
 ):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
@@ -510,10 +509,62 @@ async def test_unresolved_ambiguous_context_fails_before_authorization(
     assert dispatched is False
     assert adapter._client.fetch_channel.await_count == expected_fetches
     assert all(call.args == (200,) for call in adapter._client.fetch_channel.await_args_list)
+    assert adapter._dedup.contains(str(message.id)) is claim_retained
     adapter._discord_message_context_admission.assert_not_called()
     message.create_thread.assert_not_awaited()
     adapter.handle_message.assert_not_awaited()
     projected_channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transient_resolution_claim_blocks_race_then_allows_recovery(
+    adapter,
+    monkeypatch,
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", AsyncMock())
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+    authoritative_channel = _FakeTextChannel(
+        200,
+        guild=SimpleNamespace(id=1, name="TestGuild"),
+    )
+    fetch_count = 0
+
+    async def fetch_channel(_channel_id):
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            fetch_started.set()
+            await release_fetch.wait()
+        if fetch_count <= 2:
+            raise TimeoutError("temporary network failure")
+        return authoritative_channel
+
+    adapter._client.fetch_channel.side_effect = fetch_channel
+    projected_channel = _FakeTextChannel(200, guild=None)
+    first = asyncio.create_task(
+        adapter._dispatch_discord_message(_message(projected_channel, guild=None))
+    )
+    await fetch_started.wait()
+
+    racing_recovery = await adapter._dispatch_recovered_message(
+        _message(projected_channel, guild=None)
+    )
+    assert racing_recovery is False
+    assert fetch_count == 1
+
+    release_fetch.set()
+    assert await first is False
+    assert adapter._dedup.contains("12345") is False
+
+    recovered = await adapter._dispatch_recovered_message(
+        _message(projected_channel, guild=None)
+    )
+    assert recovered is True
+    assert fetch_count == 3
+    adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -555,8 +606,7 @@ async def test_permanent_auto_thread_failures_are_not_retried_or_seeded(
 ):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
+    channel, message, _thread = _message_thread_source()
     message.create_thread = AsyncMock(side_effect=error)
 
     result = await adapter._auto_create_thread(message)
@@ -573,14 +623,7 @@ async def test_committed_timeout_reconciles_by_source_message_id(adapter, monkey
     """A lost create response is accepted by authoritative known-ID read-back."""
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = _FakeThread(
-        message.id,
-        discord.ChannelType.text,
-        parent_id=channel.id,
-        guild_id=channel.guild.id,
-    )
+    channel, message, thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=TimeoutError("RAW_TIMEOUT_SENTINEL")
     )
@@ -600,14 +643,7 @@ async def test_committed_timeout_reconciles_by_source_message_id(adapter, monkey
 async def test_readback_404_allows_one_replay(adapter, monkeypatch):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = _FakeThread(
-        message.id,
-        discord.ChannelType.text,
-        parent_id=channel.id,
-        guild_id=channel.guild.id,
-    )
+    _channel, message, thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=[TimeoutError("RAW_TIMEOUT_SENTINEL"), thread]
     )
@@ -625,14 +661,7 @@ async def test_readback_404_allows_one_replay(adapter, monkeypatch):
 async def test_replay_400_reconciles_committed_thread(adapter, monkeypatch):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = _FakeThread(
-        message.id,
-        discord.ChannelType.text,
-        parent_id=channel.id,
-        guild_id=channel.guild.id,
-    )
+    _channel, message, thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=[
             aiohttp.ClientConnectionError("RAW_NETWORK_SENTINEL"),
@@ -673,8 +702,7 @@ async def test_unexpected_readback_fails_closed_without_replay(
 ):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
+    _channel, message, _thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=TimeoutError("RAW_TIMEOUT_SENTINEL")
     )
@@ -705,14 +733,7 @@ async def test_rate_limit_replay_honors_retry_after(
 ):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    thread = _FakeThread(
-        message.id,
-        discord.ChannelType.text,
-        parent_id=channel.id,
-        guild_id=channel.guild.id,
-    )
+    _channel, message, thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=[error, thread]
     )
@@ -726,41 +747,10 @@ async def test_rate_limit_replay_honors_retry_after(
 
 
 @pytest.mark.asyncio
-async def test_exhausted_message_rate_limit_is_absent_and_does_not_read_back(
-    adapter,
-    monkeypatch,
-):
-    sleep = AsyncMock()
-    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
-    message.create_thread = AsyncMock(
-        side_effect=[
-            _TestHTTPException(
-                _FakeResponse(429, retry_after="1.25"),
-                "RAW_FIRST_429_SENTINEL",
-            ),
-            _TestHTTPException(
-                _FakeResponse(429, retry_after="3.5"),
-                "RAW_SECOND_429_SENTINEL",
-            ),
-        ]
-    )
-
-    result = await adapter._auto_create_thread(message)
-
-    assert result is None
-    assert message.create_thread.await_count == 2
-    adapter._client.fetch_channel.assert_not_awaited()
-    sleep.assert_awaited_once_with(1.25)
-
-
-@pytest.mark.asyncio
 async def test_replay_failure_final_404_proves_absence(adapter, monkeypatch):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
-    channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    message = _message(channel, guild=channel.guild)
+    _channel, message, _thread = _message_thread_source()
     message.create_thread = AsyncMock(
         side_effect=[
             TimeoutError("RAW_FIRST_SENTINEL"),
@@ -793,32 +783,47 @@ def _owned_seed(parent, *, seed_id=777, create_result=None, create_error=None):
     )
 
 
+def _interaction(channel):
+    return SimpleNamespace(
+        channel=channel,
+        channel_id=channel.id,
+        guild_id=getattr(getattr(channel, "guild", None), "id", None),
+        user=SimpleNamespace(display_name="Jezza"),
+    )
+
+
 @pytest.mark.asyncio
-async def test_slash_uses_one_message_backed_path_and_cleans_permanent_orphan(
+@pytest.mark.parametrize(
+    ("path", "seed_content"),
+    [
+        ("slash", "\U0001f9f5 Thread requested via Hermes: **Planning**"),
+        ("handoff", "\U0001f9f5 Hermes handoff: **Planning**"),
+    ],
+)
+async def test_text_parent_uses_one_message_path_and_cleans_permanent_orphan(
     adapter,
+    path,
+    seed_content,
 ):
     parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
     parent.create_thread = AsyncMock()
     seed = _owned_seed(
         parent,
         seed_id=777,
-        create_error=ValueError("RAW_INTERNAL_SENTINEL"),
+        create_error=ValueError("RAW_THREAD_SENTINEL"),
     )
     parent.send.return_value = seed
-    interaction = SimpleNamespace(
-        channel=parent,
-        channel_id=200,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
     adapter._client.fetch_channel.return_value = parent
 
-    result = await adapter._create_thread(interaction, name="Planning")
+    if path == "slash":
+        result = await adapter._create_thread(_interaction(parent), name="Planning")
+        assert "error" in result
+        assert "RAW_THREAD_SENTINEL" not in result["error"]
+    else:
+        result = await adapter.create_handoff_thread(str(parent.id), "Planning")
+        assert result is None
 
-    assert "error" in result
-    assert "RAW_INTERNAL_SENTINEL" not in result["error"]
-    parent.send.assert_awaited_once_with(
-        "\U0001f9f5 Thread requested via Hermes: **Planning**"
-    )
+    parent.send.assert_awaited_once_with(seed_content)
     parent.create_thread.assert_not_awaited()
     seed.create_thread.assert_awaited_once()
     seed.delete.assert_awaited_once()
@@ -836,14 +841,11 @@ async def test_slash_stale_text_resolves_authoritative_forum(adapter):
     )
     authoritative_forum.create_thread.return_value = thread
     adapter._client.fetch_channel.return_value = authoritative_forum
-    interaction = SimpleNamespace(
-        channel=projected_channel,
-        channel_id=projected_channel.id,
-        guild_id=projected_channel.guild.id,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
 
-    result = await adapter._create_thread(interaction, name="Planning")
+    result = await adapter._create_thread(
+        _interaction(projected_channel),
+        name="Planning",
+    )
 
     assert result == {
         "success": True,
@@ -856,59 +858,23 @@ async def test_slash_stale_text_resolves_authoritative_forum(adapter):
 
 
 @pytest.mark.asyncio
-async def test_slash_stale_text_resolves_existing_thread_and_rejects_nested(adapter):
-    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    authoritative_thread = _FakeThread(200, discord.ChannelType.forum)
-    adapter._client.fetch_channel.return_value = authoritative_thread
-    interaction = SimpleNamespace(
-        channel=projected_channel,
-        channel_id=projected_channel.id,
-        guild_id=projected_channel.guild.id,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
-
-    result = await adapter._create_thread(interaction, name="Nested")
-
-    assert "nested thread" in result["error"].lower()
-    projected_channel.send.assert_not_awaited()
-    authoritative_thread.send.assert_not_awaited()
-    adapter._client.fetch_channel.assert_awaited_once_with(projected_channel.id)
-
-
-@pytest.mark.asyncio
-async def test_slash_existing_thread_rejects_nested_without_rest(adapter):
+@pytest.mark.parametrize("stale_projection", [False, True], ids=["thread", "stale-text"])
+async def test_slash_rejects_nested_thread(adapter, stale_projection):
     thread = _FakeThread(200, discord.ChannelType.text)
-    interaction = SimpleNamespace(
-        channel=thread,
-        channel_id=thread.id,
-        guild_id=thread.guild.id,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
+    channel = thread
+    if stale_projection:
+        channel = _FakeTextChannel(200, guild=thread.guild)
+        adapter._client.fetch_channel.return_value = thread
 
-    result = await adapter._create_thread(interaction, name="Nested")
+    result = await adapter._create_thread(_interaction(channel), name="Nested")
 
     assert "nested thread" in result["error"].lower()
     thread.send.assert_not_awaited()
-    adapter._client.fetch_channel.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_interaction_resolution_reuses_authoritative_channel_cache(adapter):
-    projected_channel = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    authoritative_forum = _FakeForumChannel(200, guild=projected_channel.guild)
-    adapter._client.fetch_channel.return_value = authoritative_forum
-    interaction = SimpleNamespace(
-        channel=projected_channel,
-        channel_id=projected_channel.id,
-        guild_id=projected_channel.guild.id,
-    )
-
-    first = await adapter._resolve_interaction_channel(interaction)
-    second = await adapter._resolve_interaction_channel(interaction)
-
-    assert first is authoritative_forum
-    assert second is authoritative_forum
-    adapter._client.fetch_channel.assert_awaited_once_with(projected_channel.id)
+    if stale_projection:
+        channel.send.assert_not_awaited()
+        adapter._client.fetch_channel.assert_awaited_once_with(channel.id)
+    else:
+        adapter._client.fetch_channel.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -931,14 +897,9 @@ async def test_slash_exhausted_429_is_sanitized_and_cleans_owned_seed(
         ),
     ]
     parent.send.return_value = seed
-    interaction = SimpleNamespace(
-        channel=parent,
-        channel_id=parent.id,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
     adapter._client.fetch_channel.return_value = parent
 
-    result = await adapter._create_thread(interaction, name="Planning")
+    result = await adapter._create_thread(_interaction(parent), name="Planning")
 
     assert "remained rate limited after one retry" in result["error"]
     assert "3.5 seconds" in result["error"]
@@ -968,13 +929,8 @@ async def test_slash_keeps_owned_seed_when_ambiguous_outcome_is_not_absent(adapt
             guild_id=parent.guild.id,
         ),
     ]
-    interaction = SimpleNamespace(
-        channel=parent,
-        channel_id=parent.id,
-        user=SimpleNamespace(display_name="Jezza"),
-    )
 
-    result = await adapter._create_thread(interaction, name="Planning")
+    result = await adapter._create_thread(_interaction(parent), name="Planning")
 
     assert "error" in result
     assert "RAW_TIMEOUT_SENTINEL" not in result["error"]
@@ -982,29 +938,6 @@ async def test_slash_keeps_owned_seed_when_ambiguous_outcome_is_not_absent(adapt
     parent.create_thread.assert_not_awaited()
     seed.create_thread.assert_awaited_once()
     seed.delete.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_handoff_uses_one_message_backed_path_and_cleans_permanent_orphan(
-    adapter,
-):
-    parent = _FakeTextChannel(200, guild=SimpleNamespace(id=1))
-    parent.create_thread = AsyncMock()
-    seed = _owned_seed(
-        parent,
-        create_error=ValueError("RAW_HANDOFF_SENTINEL"),
-    )
-    parent.send.return_value = seed
-    adapter._client.get_channel.return_value = parent
-    adapter._client.fetch_channel.return_value = parent
-
-    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
-
-    assert result is None
-    parent.send.assert_awaited_once_with("\U0001f9f5 Hermes handoff: **Planning**")
-    parent.create_thread.assert_not_awaited()
-    seed.create_thread.assert_awaited_once()
-    seed.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1035,27 +968,8 @@ async def test_handoff_reconciles_committed_thread_without_deleting_seed(adapter
 
 
 @pytest.mark.asyncio
-async def test_handoff_forum_create_is_never_retried(adapter, monkeypatch):
-    parent = SimpleNamespace(
-        id=200,
-        create_thread=AsyncMock(
-            side_effect=TimeoutError("RAW_FORUM_HANDOFF_SENTINEL")
-        ),
-        send=AsyncMock(),
-    )
-    adapter._client.get_channel.return_value = parent
-    adapter._client.fetch_channel.return_value = parent
-    monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _channel: True)
-
-    result = await adapter.create_handoff_thread(str(parent.id), "Planning")
-
-    assert result is None
-    parent.create_thread.assert_awaited_once()
-    parent.send.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_handoff_forum_create_retries_one_429(adapter, monkeypatch):
+@pytest.mark.parametrize("rate_limited", [False, True], ids=["timeout", "rate-limit"])
+async def test_handoff_forum_write_replay_boundary(adapter, monkeypatch, rate_limited):
     sleep = AsyncMock()
     monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
     thread = _FakeThread(
@@ -1064,17 +978,18 @@ async def test_handoff_forum_create_retries_one_429(adapter, monkeypatch):
         parent_id=200,
         guild_id=1,
     )
+    create_effect = TimeoutError("RAW_FORUM_HANDOFF_SENTINEL")
+    if rate_limited:
+        create_effect = [
+            _TestHTTPException(
+                _FakeResponse(429, retry_after="2.5"),
+                "RAW_HANDOFF_429_SENTINEL",
+            ),
+            thread,
+        ]
     parent = SimpleNamespace(
         id=200,
-        create_thread=AsyncMock(
-            side_effect=[
-                _TestHTTPException(
-                    _FakeResponse(429, retry_after="2.5"),
-                    "RAW_HANDOFF_429_SENTINEL",
-                ),
-                thread,
-            ]
-        ),
+        create_thread=AsyncMock(side_effect=create_effect),
         send=AsyncMock(),
     )
     adapter._client.get_channel.return_value = parent
@@ -1083,7 +998,12 @@ async def test_handoff_forum_create_retries_one_429(adapter, monkeypatch):
 
     result = await adapter.create_handoff_thread(str(parent.id), "Planning")
 
-    assert result == str(thread.id)
-    assert parent.create_thread.await_count == 2
     parent.send.assert_not_awaited()
-    sleep.assert_awaited_once_with(2.5)
+    if rate_limited:
+        assert result == str(thread.id)
+        assert parent.create_thread.await_count == 2
+        sleep.assert_awaited_once_with(2.5)
+    else:
+        assert result is None
+        parent.create_thread.assert_awaited_once()
+        sleep.assert_not_awaited()

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -230,16 +230,16 @@ async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monk
     assert {
         "on_guild_channel_update",
         "on_guild_channel_delete",
-        "on_thread_update",
-        "on_thread_delete",
         "on_thread_join",
         "on_thread_remove",
         "on_raw_thread_update",
         "on_raw_thread_delete",
         "on_guild_remove",
+        "on_guild_unavailable",
     } <= first_bot._events.keys()
-    cached_parent = SimpleNamespace(id=100)
-    cached_thread = SimpleNamespace(id=200, parent_id=100)
+    guild = SimpleNamespace(id=1)
+    cached_parent = SimpleNamespace(id=100, guild=guild)
+    cached_thread = SimpleNamespace(id=200, parent_id=100, guild=guild)
     adapter._cache_authoritative_message_channel(cached_parent)
     adapter._cache_authoritative_message_channel(cached_thread)
     await first_bot._events["on_guild_channel_update"](
@@ -248,6 +248,10 @@ async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monk
     )
     assert 100 not in adapter._authoritative_message_channels
     assert 200 not in adapter._authoritative_message_channels
+    adapter._cache_authoritative_message_channel(cached_parent)
+    adapter._cache_authoritative_message_channel(cached_thread)
+    await first_bot._events["on_guild_unavailable"](guild)
+    assert adapter._authoritative_message_channels == {}
 
     # Second connect WITHOUT disconnect — simulates an in-process reconnect.
     # Without the fix, first_bot would remain open (zombie), and both would

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -227,6 +227,27 @@ async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monk
     assert len(created) == 1
     first_bot = created[0]
     assert first_bot._closed is False, "first bot should still be open after connect()"
+    assert {
+        "on_guild_channel_update",
+        "on_guild_channel_delete",
+        "on_thread_update",
+        "on_thread_delete",
+        "on_thread_join",
+        "on_thread_remove",
+        "on_raw_thread_update",
+        "on_raw_thread_delete",
+        "on_guild_remove",
+    } <= first_bot._events.keys()
+    cached_parent = SimpleNamespace(id=100)
+    cached_thread = SimpleNamespace(id=200, parent_id=100)
+    adapter._cache_authoritative_message_channel(cached_parent)
+    adapter._cache_authoritative_message_channel(cached_thread)
+    await first_bot._events["on_guild_channel_update"](
+        cached_parent,
+        SimpleNamespace(id=100),
+    )
+    assert 100 not in adapter._authoritative_message_channels
+    assert 200 not in adapter._authoritative_message_channels
 
     # Second connect WITHOUT disconnect — simulates an in-process reconnect.
     # Without the fix, first_bot would remain open (zombie), and both would
@@ -621,4 +642,3 @@ class TestDiscordUnconfiguredNonRetryable:
         assert adapter.has_fatal_error is True
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
-

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -244,7 +244,6 @@ async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch
         message,
         role_authorized=False,
         recovered=True,
-        channel_context_authoritative=True,
     )
 
 
@@ -298,7 +297,6 @@ async def test_recovered_mention_reuses_live_auth_and_mention_gates(adapter, mon
         allowed,
         role_authorized=False,
         recovered=True,
-        channel_context_authoritative=True,
     )
 
 

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -90,7 +90,11 @@ def adapter(monkeypatch, tmp_path):
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
     bot_user = SimpleNamespace(id=999, bot=True, display_name="Hermes", name="hermes")
-    adapter._client = SimpleNamespace(user=bot_user, get_channel=lambda _id: None)
+    adapter._client = SimpleNamespace(
+        user=bot_user,
+        get_channel=lambda _id: None,
+        fetch_channel=AsyncMock(),
+    )
     adapter._ready_event.set()
     adapter._handle_message = AsyncMock(return_value=True)
     monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL", "true")
@@ -232,6 +236,7 @@ async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch
     monkeypatch.setattr(adapter, "_missed_message_backfill_max_dispatches", lambda: 10)
     monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
     monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    adapter._client.fetch_channel.return_value = message.channel
 
     await adapter._run_missed_message_backfill()
 
@@ -239,7 +244,7 @@ async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch
         message,
         role_authorized=False,
         recovered=True,
-        channel_context_authoritative=False,
+        channel_context_authoritative=True,
     )
 
 
@@ -285,6 +290,7 @@ async def test_recovered_mention_reuses_live_auth_and_mention_gates(adapter, mon
         "_is_allowed_user",
         lambda user_id, *_a, **_kw: user_id == str(allowed.author.id),
     )
+    adapter._client.fetch_channel.return_value = denied.channel
 
     assert await adapter._dispatch_recovered_message(denied) is False
     assert await adapter._dispatch_recovered_message(allowed) is True
@@ -292,7 +298,7 @@ async def test_recovered_mention_reuses_live_auth_and_mention_gates(adapter, mon
         allowed,
         role_authorized=False,
         recovered=True,
-        channel_context_authoritative=False,
+        channel_context_authoritative=True,
     )
 
 
@@ -387,6 +393,7 @@ async def test_send_offloads_final_delivery_ledger_write(adapter, monkeypatch):
     channel.send = AsyncMock(return_value=SimpleNamespace(id=9011))
     channel.fetch_message = AsyncMock()
     adapter._client.get_channel = lambda _channel_id: channel
+    adapter._client.fetch_channel.return_value = channel
 
     def slow_record(**_kwargs):
         import time
@@ -458,4 +465,3 @@ async def test_iter_candidates_keeps_latest_messages_when_window_exceeds_limit(a
         got.append(msg.id)
 
     assert got == [2, 3, 4]
-

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -239,6 +239,7 @@ async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch
         message,
         role_authorized=False,
         recovered=True,
+        channel_context_authoritative=False,
     )
 
 
@@ -291,6 +292,7 @@ async def test_recovered_mention_reuses_live_auth_and_mention_gates(adapter, mon
         allowed,
         role_authorized=False,
         recovered=True,
+        channel_context_authoritative=False,
     )
 
 
@@ -456,5 +458,4 @@ async def test_iter_candidates_keeps_latest_messages_when_window_exceeds_limit(a
         got.append(msg.id)
 
     assert got == [2, 3, 4]
-
 

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -87,6 +87,7 @@ def _make_discord_adapter(reply_to_mode: str = "first"):
     # the fetched Message via to_reference(fail_if_not_exists=False) so a
     # deleted target degrades to "send without reply chip" instead of a 400.
     mock_channel = AsyncMock()
+    mock_channel.id = 12345
     ref_message = MagicMock()
     ref_reference = MagicMock(name="MessageReference")
     ref_message.to_reference = MagicMock(return_value=ref_reference)
@@ -98,6 +99,7 @@ def _make_discord_adapter(reply_to_mode: str = "first"):
 
     mock_client = MagicMock()
     mock_client.get_channel = MagicMock(return_value=mock_channel)
+    mock_client.fetch_channel = AsyncMock(return_value=mock_channel)
 
     adapter._client = mock_client
     # Return the reference sentinel alongside so tests can assert identity.

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -68,7 +68,7 @@ def _voice_adapter(reference_obj, *, native_result=None, native_error=None):
         request.side_effect = native_error
     adapter._client = SimpleNamespace(
         get_channel=lambda _chat_id: channel,
-        fetch_channel=AsyncMock(),
+        fetch_channel=AsyncMock(return_value=channel),
         http=SimpleNamespace(request=request),
     )
     return adapter, channel, request
@@ -98,12 +98,13 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
         return sent_msgs[len(send_calls) - 2]
 
     channel = SimpleNamespace(
+        id=555,
         fetch_message=AsyncMock(return_value=ref_msg),
         send=AsyncMock(side_effect=fake_send),
     )
     adapter._client = SimpleNamespace(
         get_channel=lambda _chat_id: channel,
-        fetch_channel=AsyncMock(),
+        fetch_channel=AsyncMock(return_value=channel),
     )
 
     long_text = "A" * (adapter.MAX_MESSAGE_LENGTH + 50)
@@ -362,14 +363,14 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
         attachments=[SimpleNamespace(filename="clip.mp4", url="https://cdn.example/clip.mp4")],
     )
     channel = SimpleNamespace(
+        id=555,
         send=AsyncMock(return_value=sent_msg),
         type=0,
     )
     adapter._client = SimpleNamespace(
         get_channel=lambda _chat_id: channel,
-        fetch_channel=AsyncMock(),
+        fetch_channel=AsyncMock(return_value=channel),
     )
-    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: False)
 
     result = await adapter.send_video("555", str(video))
 
@@ -400,12 +401,11 @@ async def test_send_video_fails_loud_when_message_has_no_attachments(tmp_path, m
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     # Message id present, but no attachments — the silent-drop failure mode.
     sent_msg = SimpleNamespace(id=99, attachments=[])
-    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg), type=0)
+    channel = SimpleNamespace(id=555, send=AsyncMock(return_value=sent_msg), type=0)
     adapter._client = SimpleNamespace(
         get_channel=lambda _chat_id: channel,
-        fetch_channel=AsyncMock(),
+        fetch_channel=AsyncMock(return_value=channel),
     )
-    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: False)
 
     result = await adapter.send_video("555", str(video))
 
@@ -459,14 +459,14 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
         ),
     )
     forum_channel = SimpleNamespace(
-        id=7,
+        id=555,
         create_thread=AsyncMock(return_value=created_thread),
     )
     adapter._client = SimpleNamespace(
         get_channel=lambda _chat_id: forum_channel,
-        fetch_channel=AsyncMock(),
+        fetch_channel=AsyncMock(return_value=forum_channel),
     )
-    monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: True)
+    monkeypatch.setattr(adapter, "_is_forum_or_media_channel", lambda _ch: True)
 
     result = await adapter.send_video("555", str(video))
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -44,7 +44,15 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+class _RateLimitError(Exception):
+    def __init__(self, retry_after: float, sentinel: str):
+        super().__init__(sentinel)
+        self.status = 429
+        self.retry_after = retry_after
 
 
 def _voice_adapter(reference_obj, *, native_result=None, native_error=None):
@@ -140,6 +148,75 @@ class TestIsForumParent:
 
 
 @pytest.mark.asyncio
+async def test_forum_text_create_ambiguous_failure_is_not_retried_or_leaked():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(
+        side_effect=TimeoutError("RAW_FORUM_TEXT_SENTINEL")
+    )
+
+    result = await adapter._send_to_forum(forum_channel, "planning notes")
+
+    assert result.success is False
+    assert "may have succeeded" in (result.error or "")
+    assert "not retried" in (result.error or "")
+    assert "RAW_FORUM_TEXT_SENTINEL" not in (result.error or "")
+    forum_channel.create_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forum_text_create_retries_one_429(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    thread = SimpleNamespace(
+        id=777,
+        message=SimpleNamespace(id=800),
+        send=AsyncMock(),
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(
+        side_effect=[
+            _RateLimitError(2.5, "RAW_FIRST_429_SENTINEL"),
+            thread,
+        ]
+    )
+
+    result = await adapter._send_to_forum(forum_channel, "planning notes")
+
+    assert result.success is True
+    assert forum_channel.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(2.5)
+
+
+@pytest.mark.asyncio
+async def test_forum_text_create_exhausted_429_is_safe_and_bounded(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(
+        side_effect=[
+            _RateLimitError(1.25, "RAW_FIRST_429_SENTINEL"),
+            _RateLimitError(3.5, "RAW_SECOND_429_SENTINEL"),
+        ]
+    )
+
+    result = await adapter._send_to_forum(forum_channel, "planning notes")
+
+    assert result.success is False
+    assert "remained rate limited after one retry" in (result.error or "")
+    assert "3.5 seconds" in (result.error or "")
+    assert "RAW_FIRST_429_SENTINEL" not in (result.error or "")
+    assert "RAW_SECOND_429_SENTINEL" not in (result.error or "")
+    assert forum_channel.create_thread.await_count == 2
+    sleep.assert_awaited_once_with(1.25)
+
+
+@pytest.mark.asyncio
 async def test_forum_post_file_creates_thread_with_attachment():
     """_forum_post_file routes file-bearing sends to create_thread with file kwarg."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
@@ -175,6 +252,28 @@ async def test_forum_post_file_creates_thread_with_attachment():
     assert call_kwargs["content"] == "here is a photo"
     # Thread name derived from content's first line
     assert call_kwargs["name"] == "here is a photo"
+
+
+@pytest.mark.asyncio
+async def test_forum_file_create_ambiguous_failure_is_not_retried_or_leaked():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(
+        side_effect=TimeoutError("RAW_FORUM_FILE_SENTINEL")
+    )
+
+    result = await adapter._forum_post_file(
+        forum_channel,
+        content="planning diagram",
+        file=SimpleNamespace(filename="diagram.png"),
+    )
+
+    assert result.success is False
+    assert "may have succeeded" in (result.error or "")
+    assert "not retried" in (result.error or "")
+    assert "RAW_FORUM_FILE_SENTINEL" not in (result.error or "")
+    forum_channel.create_thread.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -376,5 +475,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -149,20 +149,28 @@ class TestIsForumParent:
 
 
 @pytest.mark.asyncio
-async def test_forum_text_create_ambiguous_failure_is_not_retried_or_leaked():
+@pytest.mark.parametrize("with_file", [False, True], ids=["text", "file"])
+async def test_forum_create_ambiguous_failure_is_not_retried_or_leaked(with_file):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     forum_channel = _discord_mod.ForumChannel()
     forum_channel.id = 999
     forum_channel.create_thread = AsyncMock(
-        side_effect=TimeoutError("RAW_FORUM_TEXT_SENTINEL")
+        side_effect=TimeoutError("RAW_FORUM_CREATE_SENTINEL")
     )
 
-    result = await adapter._send_to_forum(forum_channel, "planning notes")
+    if with_file:
+        result = await adapter._forum_post_file(
+            forum_channel,
+            content="planning diagram",
+            file=SimpleNamespace(filename="diagram.png"),
+        )
+    else:
+        result = await adapter._send_to_forum(forum_channel, "planning notes")
 
     assert result.success is False
     assert "may have succeeded" in (result.error or "")
     assert "not retried" in (result.error or "")
-    assert "RAW_FORUM_TEXT_SENTINEL" not in (result.error or "")
+    assert "RAW_FORUM_CREATE_SENTINEL" not in (result.error or "")
     forum_channel.create_thread.assert_awaited_once()
 
 
@@ -174,7 +182,7 @@ async def test_forum_text_create_retries_one_429(monkeypatch):
     thread = SimpleNamespace(
         id=777,
         message=SimpleNamespace(id=800),
-        send=AsyncMock(),
+        send=AsyncMock(side_effect=RuntimeError("RAW_FOLLOWUP_SENTINEL")),
     )
     forum_channel = _discord_mod.ForumChannel()
     forum_channel.id = 999
@@ -185,10 +193,14 @@ async def test_forum_text_create_retries_one_429(monkeypatch):
         ]
     )
 
-    result = await adapter._send_to_forum(forum_channel, "planning notes")
+    result = await adapter._send_to_forum(
+        forum_channel,
+        "x" * (adapter.MAX_MESSAGE_LENGTH + 1),
+    )
 
     assert result.success is True
     assert forum_channel.create_thread.await_count == 2
+    assert "RAW_FOLLOWUP_SENTINEL" not in result.raw_response["warnings"][0]
     sleep.assert_awaited_once_with(2.5)
 
 
@@ -253,28 +265,6 @@ async def test_forum_post_file_creates_thread_with_attachment():
     assert call_kwargs["content"] == "here is a photo"
     # Thread name derived from content's first line
     assert call_kwargs["name"] == "here is a photo"
-
-
-@pytest.mark.asyncio
-async def test_forum_file_create_ambiguous_failure_is_not_retried_or_leaked():
-    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-    forum_channel = _discord_mod.ForumChannel()
-    forum_channel.id = 999
-    forum_channel.create_thread = AsyncMock(
-        side_effect=TimeoutError("RAW_FORUM_FILE_SENTINEL")
-    )
-
-    result = await adapter._forum_post_file(
-        forum_channel,
-        content="planning diagram",
-        file=SimpleNamespace(filename="diagram.png"),
-    )
-
-    assert result.success is False
-    assert "may have succeeded" in (result.error or "")
-    assert "not retried" in (result.error or "")
-    assert "RAW_FORUM_FILE_SENTINEL" not in (result.error or "")
-    forum_channel.create_thread.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -322,6 +322,7 @@ async def test_handle_thread_create_slash_reports_success(adapter):
         followup=SimpleNamespace(send=AsyncMock()),
         response=SimpleNamespace(defer=AsyncMock()),
     )
+    adapter._client.fetch_channel.return_value = parent_channel
 
     await adapter._handle_thread_create_slash(interaction, "Planning", "Kickoff", 1440)
 
@@ -370,6 +371,7 @@ async def test_handle_thread_create_slash_uses_honest_default_seed(adapter):
         followup=SimpleNamespace(send=AsyncMock()),
         response=SimpleNamespace(defer=AsyncMock()),
     )
+    adapter._client.fetch_channel.return_value = channel
 
     await adapter._handle_thread_create_slash(interaction, "Planning", "", 1440)
 
@@ -468,11 +470,11 @@ async def test_auto_create_thread_strips_mention_syntax_from_name(adapter):
 
 @pytest.mark.asyncio
 async def test_rename_thread_edits_only_when_current_name_matches(adapter):
-    thread = SimpleNamespace(
-        id=999,
+    thread = _FakeThreadChannel(
+        channel_id=999,
         name="raw user prompt",
-        edit=AsyncMock(),
     )
+    thread.edit = AsyncMock()
     adapter._client.get_channel = lambda _id: thread
 
     result = await adapter.rename_thread(
@@ -639,4 +641,3 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
         f"Flat /skill command payload is ~{len(payload)} bytes — the whole "
         f"point of this design is that it stays small regardless of skill count"
     )
-

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -75,6 +75,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import discord  # noqa: E402
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 
 
@@ -291,8 +292,27 @@ async def test_slash_command_registration_stays_under_discord_limit(adapter):
 
 @pytest.mark.asyncio
 async def test_handle_thread_create_slash_reports_success(adapter):
-    created_thread = SimpleNamespace(id=555, name="Planning", send=AsyncMock())
-    parent_channel = SimpleNamespace(create_thread=AsyncMock(return_value=created_thread), send=AsyncMock())
+    guild = SimpleNamespace(id=1, name="TestGuild")
+    parent_channel = SimpleNamespace(
+        id=123,
+        guild=guild,
+        create_thread=AsyncMock(),
+        send=AsyncMock(),
+    )
+    created_thread = MagicMock(spec=[])
+    created_thread.id = 555
+    created_thread.name = "Planning"
+    created_thread.parent_id = parent_channel.id
+    created_thread.guild = guild
+    created_thread.__class__ = discord.Thread
+    seed_message = SimpleNamespace(
+        id=created_thread.id,
+        channel=parent_channel,
+        guild=guild,
+        create_thread=AsyncMock(return_value=created_thread),
+        delete=AsyncMock(),
+    )
+    parent_channel.send.return_value = seed_message
     interaction_channel = SimpleNamespace(parent=parent_channel)
     interaction = SimpleNamespace(
         channel=interaction_channel,
@@ -305,12 +325,13 @@ async def test_handle_thread_create_slash_reports_success(adapter):
 
     await adapter._handle_thread_create_slash(interaction, "Planning", "Kickoff", 1440)
 
-    parent_channel.create_thread.assert_awaited_once_with(
+    parent_channel.send.assert_awaited_once_with("Kickoff")
+    parent_channel.create_thread.assert_not_awaited()
+    seed_message.create_thread.assert_awaited_once_with(
         name="Planning",
         auto_archive_duration=1440,
         reason="Requested by Jezza via /thread",
     )
-    created_thread.send.assert_awaited_once_with("Kickoff")
     # Thread link shown to user
     interaction.followup.send.assert_awaited()
     args, kwargs = interaction.followup.send.await_args
@@ -319,13 +340,28 @@ async def test_handle_thread_create_slash_reports_success(adapter):
 
 
 @pytest.mark.asyncio
-async def test_handle_thread_create_slash_falls_back_to_seed_message(adapter):
-    created_thread = SimpleNamespace(id=555, name="Planning")
-    seed_message = SimpleNamespace(id=777, create_thread=AsyncMock(return_value=created_thread))
+async def test_handle_thread_create_slash_uses_honest_default_seed(adapter):
+    guild = SimpleNamespace(id=1, name="TestGuild")
     channel = SimpleNamespace(
-        create_thread=AsyncMock(side_effect=RuntimeError("direct failed")),
-        send=AsyncMock(return_value=seed_message),
+        id=123,
+        guild=guild,
+        create_thread=AsyncMock(),
+        send=AsyncMock(),
     )
+    created_thread = MagicMock(spec=[])
+    created_thread.id = 777
+    created_thread.name = "Planning"
+    created_thread.parent_id = channel.id
+    created_thread.guild = guild
+    created_thread.__class__ = discord.Thread
+    seed_message = SimpleNamespace(
+        id=created_thread.id,
+        channel=channel,
+        guild=guild,
+        create_thread=AsyncMock(return_value=created_thread),
+        delete=AsyncMock(),
+    )
+    channel.send.return_value = seed_message
     interaction = SimpleNamespace(
         channel=channel,
         channel_id=123,
@@ -335,9 +371,12 @@ async def test_handle_thread_create_slash_falls_back_to_seed_message(adapter):
         response=SimpleNamespace(defer=AsyncMock()),
     )
 
-    await adapter._handle_thread_create_slash(interaction, "Planning", "Kickoff", 1440)
+    await adapter._handle_thread_create_slash(interaction, "Planning", "", 1440)
 
-    channel.send.assert_awaited_once_with("Kickoff")
+    channel.send.assert_awaited_once_with(
+        "\U0001f9f5 Thread requested via Hermes: **Planning**"
+    )
+    channel.create_thread.assert_not_awaited()
     seed_message.create_thread.assert_awaited_once_with(
         name="Planning",
         auto_archive_duration=1440,
@@ -600,5 +639,4 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
         f"Flat /skill command payload is ~{len(payload)} bytes — the whole "
         f"point of this design is that it stays small regardless of skill count"
     )
-
 

--- a/tests/tools/test_discord_send_message_caption.py
+++ b/tests/tools/test_discord_send_message_caption.py
@@ -13,6 +13,8 @@ import tempfile
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from plugins.platforms.discord.adapter import _remember_channel_is_forum, _standalone_send
 
 
@@ -134,9 +136,10 @@ def test_no_caption_non_forum_keeps_separate_text():
         os.unlink(img)
 
 
-def test_standalone_forum_ambiguous_create_is_not_retried_or_leaked():
+@pytest.mark.parametrize("is_forum", [False, True], ids=["message", "forum"])
+def test_standalone_ambiguous_write_is_not_retried_or_leaked(is_forum):
     chat_id = "999000333"
-    _remember_channel_is_forum(chat_id, True)
+    _remember_channel_is_forum(chat_id, is_forum)
     session_ctx, calls = _session_with(
         [_resp(500, text_data="RAW_STANDALONE_FORUM_SENTINEL")]
     )
@@ -156,9 +159,18 @@ def test_standalone_forum_ambiguous_create_is_not_retried_or_leaked():
     assert "RAW_STANDALONE_FORUM_SENTINEL" not in result["error"]
 
 
-def test_standalone_forum_rate_limit_retries_once_after_retry_after():
+@pytest.mark.parametrize("exhausted", [False, True], ids=["success", "exhausted"])
+def test_standalone_forum_rate_limit_is_bounded_and_sanitized(exhausted):
     chat_id = "999000444"
     _remember_channel_is_forum(chat_id, True)
+    second = _resp(
+        429,
+        text_data="RAW_SECOND_RATE_LIMIT_SENTINEL",
+        headers={"Retry-After": "3.5"},
+    ) if exhausted else _resp(
+        201,
+        json_data={"id": "thread-1", "message": {"id": "message-1"}},
+    )
     session_ctx, calls = _session_with(
         [
             _resp(
@@ -166,10 +178,7 @@ def test_standalone_forum_rate_limit_retries_once_after_retry_after():
                 text_data="RAW_RATE_LIMIT_SENTINEL",
                 headers={"Retry-After": "2.25"},
             ),
-            _resp(
-                201,
-                json_data={"id": "thread-1", "message": {"id": "message-1"}},
-            ),
+            second,
         ]
     )
     sleep = AsyncMock()
@@ -186,49 +195,16 @@ def test_standalone_forum_rate_limit_retries_once_after_retry_after():
             )
         )
 
-    assert result["success"] is True
-    assert result["thread_id"] == "thread-1"
     assert len(calls) == 2
     sleep.assert_awaited_once_with(2.25)
-
-
-def test_standalone_forum_exhausted_rate_limit_is_bounded_and_sanitized():
-    chat_id = "999000555"
-    _remember_channel_is_forum(chat_id, True)
-    session_ctx, calls = _session_with(
-        [
-            _resp(
-                429,
-                text_data="RAW_FIRST_RATE_LIMIT_SENTINEL",
-                headers={"Retry-After": "1.25"},
-            ),
-            _resp(
-                429,
-                text_data="RAW_SECOND_RATE_LIMIT_SENTINEL",
-                headers={"Retry-After": "3.5"},
-            ),
-        ]
-    )
-    sleep = AsyncMock()
-
-    with patch("aiohttp.ClientSession", return_value=session_ctx), patch(
-        "plugins.platforms.discord.adapter.asyncio.sleep",
-        new=sleep,
-    ):
-        result = asyncio.run(
-            _standalone_send(
-                _pconfig(),
-                chat_id,
-                "forum planning notes",
-            )
-        )
-
-    assert len(calls) == 2
-    assert "remained rate limited after one retry" in result["error"]
-    assert "3.5 seconds" in result["error"]
-    assert "RAW_FIRST_RATE_LIMIT_SENTINEL" not in result["error"]
-    assert "RAW_SECOND_RATE_LIMIT_SENTINEL" not in result["error"]
-    sleep.assert_awaited_once_with(1.25)
+    if exhausted:
+        assert "remained rate limited after one retry" in result["error"]
+        assert "3.5 seconds" in result["error"]
+        assert "RAW_RATE_LIMIT_SENTINEL" not in result["error"]
+        assert "RAW_SECOND_RATE_LIMIT_SENTINEL" not in result["error"]
+    else:
+        assert result["success"] is True
+        assert result["thread_id"] == "thread-1"
 
 
 def test_standalone_forum_media_429_rebuilds_multipart_for_replay():

--- a/tests/tools/test_discord_send_message_caption.py
+++ b/tests/tools/test_discord_send_message_caption.py
@@ -16,9 +16,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from plugins.platforms.discord.adapter import _remember_channel_is_forum, _standalone_send
 
 
-def _resp(status, json_data=None, text_data=None):
+def _resp(status, json_data=None, text_data=None, headers=None):
     r = AsyncMock()
     r.status = status
+    r.headers = headers or {}
     body = json.dumps(json_data or {}).encode() if json_data is not None else (text_data or "").encode()
     r.json = AsyncMock(return_value=json_data or {})
     r.text = AsyncMock(return_value=text_data or "")
@@ -129,5 +130,147 @@ def test_no_caption_non_forum_keeps_separate_text():
         assert len(calls) == 2
         assert calls[0][1] == {"content": "hello"}
         assert calls[1][0].endswith("/messages")
+    finally:
+        os.unlink(img)
+
+
+def test_standalone_forum_ambiguous_create_is_not_retried_or_leaked():
+    chat_id = "999000333"
+    _remember_channel_is_forum(chat_id, True)
+    session_ctx, calls = _session_with(
+        [_resp(500, text_data="RAW_STANDALONE_FORUM_SENTINEL")]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=session_ctx):
+        result = asyncio.run(
+            _standalone_send(
+                _pconfig(),
+                chat_id,
+                "forum planning notes",
+            )
+        )
+
+    assert len(calls) == 1
+    assert "may have succeeded" in result["error"]
+    assert "not retried" in result["error"]
+    assert "RAW_STANDALONE_FORUM_SENTINEL" not in result["error"]
+
+
+def test_standalone_forum_rate_limit_retries_once_after_retry_after():
+    chat_id = "999000444"
+    _remember_channel_is_forum(chat_id, True)
+    session_ctx, calls = _session_with(
+        [
+            _resp(
+                429,
+                text_data="RAW_RATE_LIMIT_SENTINEL",
+                headers={"Retry-After": "2.25"},
+            ),
+            _resp(
+                201,
+                json_data={"id": "thread-1", "message": {"id": "message-1"}},
+            ),
+        ]
+    )
+    sleep = AsyncMock()
+
+    with patch("aiohttp.ClientSession", return_value=session_ctx), patch(
+        "plugins.platforms.discord.adapter.asyncio.sleep",
+        new=sleep,
+    ):
+        result = asyncio.run(
+            _standalone_send(
+                _pconfig(),
+                chat_id,
+                "forum planning notes",
+            )
+        )
+
+    assert result["success"] is True
+    assert result["thread_id"] == "thread-1"
+    assert len(calls) == 2
+    sleep.assert_awaited_once_with(2.25)
+
+
+def test_standalone_forum_exhausted_rate_limit_is_bounded_and_sanitized():
+    chat_id = "999000555"
+    _remember_channel_is_forum(chat_id, True)
+    session_ctx, calls = _session_with(
+        [
+            _resp(
+                429,
+                text_data="RAW_FIRST_RATE_LIMIT_SENTINEL",
+                headers={"Retry-After": "1.25"},
+            ),
+            _resp(
+                429,
+                text_data="RAW_SECOND_RATE_LIMIT_SENTINEL",
+                headers={"Retry-After": "3.5"},
+            ),
+        ]
+    )
+    sleep = AsyncMock()
+
+    with patch("aiohttp.ClientSession", return_value=session_ctx), patch(
+        "plugins.platforms.discord.adapter.asyncio.sleep",
+        new=sleep,
+    ):
+        result = asyncio.run(
+            _standalone_send(
+                _pconfig(),
+                chat_id,
+                "forum planning notes",
+            )
+        )
+
+    assert len(calls) == 2
+    assert "remained rate limited after one retry" in result["error"]
+    assert "3.5 seconds" in result["error"]
+    assert "RAW_FIRST_RATE_LIMIT_SENTINEL" not in result["error"]
+    assert "RAW_SECOND_RATE_LIMIT_SENTINEL" not in result["error"]
+    sleep.assert_awaited_once_with(1.25)
+
+
+def test_standalone_forum_media_429_rebuilds_multipart_for_replay():
+    chat_id = "999000666"
+    _remember_channel_is_forum(chat_id, True)
+    img = _tmpfile(".png")
+    try:
+        session_ctx, calls = _session_with(
+            [
+                _resp(
+                    429,
+                    text_data="RAW_MEDIA_RATE_LIMIT_SENTINEL",
+                    headers={"Retry-After": "0"},
+                ),
+                _resp(
+                    201,
+                    json_data={
+                        "id": "thread-media",
+                        "message": {"id": "message-media"},
+                    },
+                ),
+            ]
+        )
+        sleep = AsyncMock()
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), patch(
+            "plugins.platforms.discord.adapter.asyncio.sleep",
+            new=sleep,
+        ):
+            result = asyncio.run(
+                _standalone_send(
+                    _pconfig(),
+                    chat_id,
+                    "forum image",
+                    media_files=[(img, False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result["thread_id"] == "thread-media"
+        assert len(calls) == 2
+        assert calls[0][2] is not calls[1][2]
+        sleep.assert_awaited_once_with(0.0)
     finally:
         os.unlink(img)


### PR DESCRIPTION
## What changed

- Split Discord ingress into an atomic structural/provider preflight, authoritative channel resolution through the configured discord.py client, and context-dependent authorization exactly once. Ambiguous projected `TextChannel`/partial events fail closed before guild/DM, user/role, channel/parent, or mention policy and before agent dispatch when REST resolution cannot establish context.
- Treat the preflight dedup entry as an in-flight reservation: it remains claimed while REST is running so racing live/backfill deliveries cannot double-dispatch, but is discarded after exhausted transient 429, 5xx, network, or cancellation failures so a later delivery can recover. Permanent 403/404/provider-invalid outcomes remain terminally claimed.
- Attach the REST-resolved channel and guild before authorization and auto-thread routing. Existing text threads, forum posts, and media posts never attempt a nested thread, including reconnect/backfill delivery.
- Reuse one bounded per-client authoritative resolver/cache for message ingress, `/thread` interactions, handoff, rename, type-sensitive text/file/image/animation/voice/multi-image sends, and chat info. Real DM/thread/forum/media objects avoid unnecessary REST; ambiguous text/partial types are fetched once and cached.
- Invalidate retained REST context when a new client is installed, on READY, guild-channel update/delete (including cached children), raw thread update/delete, thread join/remove from thread-list/member sync, and guild unavailable/remove. Creation events are intentionally absent: a never-seen snowflake cannot have a positive retained entry to invalidate, and successful REST creation caches the returned object directly.
- Use the original user message as the only auto-thread starter. This removes the bot-authored `Thread created by Hermes` seed and the old retry loop that could emit two orphan seeds for one permanent failure.
- Reconcile ambiguous message-backed creates through `fetch_channel(message.id)` before replaying. Accept only a `discord.Thread` whose ID equals the source message ID and whose guild and parent match. A confirmed 404 permits one replay; an unexpected type/parent/guild fails closed. Reconciled threads populate the authoritative cache.
- Separate safe read retries from writes. Read-only REST calls retry 429, transport failures, and 5xx. Message-backed creates retry one definite 429 after Retry-After; network/timeouts/5xx use authoritative read-back before any replay, including a final read-back after a failed replay.
- Audit every thread-create write in `adapter.py`: auto-thread, `/thread`, handoff, text/file forum helpers, and standalone forum JSON/multipart. Text-channel `/thread` and handoff use one owned seed plus deterministic message-backed creation, never direct-create followed by fallback. Owned seeds are deleted only when this attempt's create is definitively rejected/absent.
- Forum/media creates have no resource ID before `POST /channels/{id}/threads`, so transport/timeouts/5xx are inherently non-idempotent and are not replayed. A received 429 is a definite rejection and is retried once after Retry-After; multipart requests rebuild the form for that replay. Exhausted 429s remain bounded at two attempts.
- Log provider/network exception detail server-side while returning only concise user-safe categories from every user-facing result changed here. Raw exception/response text does not reach `/thread`, auto-thread, forum helper, normal send, chat-info, or standalone results.

All resolution and reconciliation reads use `self._client.fetch_channel`, preserving the configured proxy/authorization transport.

## Root cause and reproduction

A partial or synthetic Gateway `GUILD_CREATE` can cache a real thread ID in `channels` as type 0 while omitting it from `threads`. discord.py 2.7.1 resolves `MESSAGE_CREATE` through the guild cache, and `Guild._resolve_channel()` checks `_channels` before `_threads`, so reconnect can stably materialize a real thread/forum post as `TextChannel`. Calling `Message.create_thread()` on a partial message with no attached guild raises `ValueError: This message does not have guild info attached.` before REST.

The previous `_auto_create_thread()` caught every exception, sent a bot seed, slept, and repeated the entire sequence. The permanent missing-guild error therefore produced two misleading seed messages from one gateway process.

The project and lockfile pin `discord.py[voice]==2.7.1`.

## Protocol and upstream contracts

- Discord's fixed docs state that Start Thread from Message returns a thread whose ID equals the source message ID and that a message can have only one thread: https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/resources/channel.mdx#L582-L587
- Discord's fixed rate-limit docs state that an exceeded limit returns 429 and clients should wait for Retry-After/`retry_after`: https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/topics/rate-limits.mdx#L47-L58
- Discord separates `GUILD_CREATE.channels` and `GUILD_CREATE.threads`: https://docs.discord.com/developers/events/gateway-events#guild-create-guild-create-extra-fields
- discord.py 2.7.1 raises the missing-guild `ValueError` before REST: https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/message.py#L1639-L1700
- `parse_message_create()` uses the guild cache and `_resolve_channel()` prefers `_channels` over `_threads`: https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/state.py#L536-L549 and https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/guild.py#L812-L816
- discord.py 2.7.1 mutates cached channels on `CHANNEL_UPDATE`, always emits raw thread update/delete before cache-dependent events, emits join/remove for thread sync/member changes, and distinguishes guild-unavailable from guild-remove: https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/state.py#L869-L935, https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/state.py#L974-L1095, and https://github.com/Rapptz/discord.py/blob/dfd1144b2246a7adafe3f1c64a4dd9bc2187fcee/discord/state.py#L1345-L1365

## Follow-up footprint

The review follow-up commit is `+336/-514` across 6 files. The PR moved from `+2755/-322` (net +2433) to `+2625/-370` (net +2255), deleting a net 178 lines while retaining the requested protocol and authorization coverage.

## Tests

Linux, Python 3.11, discord.py 2.7.1.

```text
scripts/run_tests.sh tests/gateway/test_discord_*.py tests/e2e/test_discord_adapter.py tests/tools/test_discord_send_message_caption.py -q
45 files, 276 tests passed, 0 failed

ruff check <all 10 changed Python files>
All checks passed!

git diff --check origin/main..HEAD
clean
```
