### PR TITLE
fix(desktop): sync project tile cwd to right rail

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -76,7 +76,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'openNewSessionTile' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -431,6 +431,71 @@ describe('startFreshSessionDraft', () => {
     expect(navigate).not.toHaveBeenCalled()
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+})
+
+describe('openNewSessionTile cwd routing', () => {
+  afterEach(() => {
+    cleanup()
+    setCurrentCwd('')
+    $sessionTiles.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('points the right rail at the project cwd when a center draft tile is created', async () => {
+    setCurrentCwd('/previous-session')
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        expect(params).toMatchObject({ cwd: '/project-folder' })
+
+        return {
+          info: { cwd: '/project-folder' },
+          session_id: 'runtime-project',
+          stored_session_id: 'stored-project'
+        } as never
+      }
+
+      return {} as never
+    })
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: '/project-folder', listed: false })
+    })
+
+    expect($currentCwd.get()).toBe('/project-folder')
+    expect($sessionTiles.get()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ storedSessionId: 'stored-project' })])
+    )
+    expect(revealTreePane).toHaveBeenCalledWith('session-tile:stored-project')
+  })
+
+  it('keeps split tile cwd out of the global right rail', async () => {
+    setCurrentCwd('/main-session')
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '/split-worktree' },
+          session_id: 'runtime-split',
+          stored_session_id: 'stored-split'
+        } as never
+      }
+
+      return {} as never
+    })
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('right', { cwd: '/split-worktree' })
+    })
+
+    expect($currentCwd.get()).toBe('/main-session')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -504,13 +504,17 @@ export function useSessionActions({
           upsertOptimisticSession(created, stored, null, null)
         }
 
-        // A tile lives in its OWN worktree — it must not publish its cwd/branch
-        // into the composer atoms the main pane renders from.
+        // A tile lives in its OWN worktree, so do not run the full foreground
+        // composer publish. Center tabs are the focused surface, though, and
+        // the right rail still keys off $currentCwd.
         const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false })
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
         openSessionTile(stored, dir)
         patchSessionTile(stored, { runtimeId: created.session_id })
+        if (dir === 'center' && runtimeInfo?.cwd) {
+          setCurrentCwd(runtimeInfo.cwd)
+        }
         revealTreePane(`session-tile:${stored}`)
 
         if (listed) {


### PR DESCRIPTION
Fixes #76696

When the main chat is already occupied, creating a new session from a Project "+" opens the session as a center tile. That path correctly creates the backend session with the project cwd, but applies runtime info with foreground: false, so the global $currentCwd atom used by the right-side file panel stays on the previous session.

This keeps the existing split-tile isolation behavior, but when a newly-created tile is opened in the center dock, it updates $currentCwd from the created session runtime cwd. That lets the right rail follow the focused project session immediately without running the full foreground composer publish for background/split tiles.

Regression coverage verifies:

- center draft tile creation points $currentCwd at the project cwd
- split/right tile creation still does not overwrite the main/right-rail cwd

Validation:

cd apps/desktop && npm test -- src/app/session/hooks/use-session-actions.test.tsx --run
cd apps/desktop && npm run typecheck

Result:

42 tests passed
typecheck passed