### PR TITLE
feat(cli): prompt to stop running hermes.exe before Windows update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -57,20 +57,28 @@ def _m():
 
 
 
-def check_hermes_process() -> None:
-    """Prompt the user to stop other running hermes.exe processes on Windows.
+def check_hermes_process(args: object) -> None:
+    """Prompt the user to stop other hermes.exe shims before a Windows update.
 
-    Runs only on Windows, only in an interactive TTY, and only when the update
-    was not invoked with ``--yes``. Excludes the current process. On a ``n``
-    answer it raises SystemExit(0) so the update aborts cleanly (no error).
+    Reuses ``_m()._detect_concurrent_hermes_instances(scripts_dir)`` so the
+    candidate set is scoped to *this* venv's resolved shim paths and already
+    excludes the updater's own launcher ancestor (the Windows ``hermes.exe``
+    shim is a parent of the Python process running the update). Using the
+    scoped detector avoids targeting a different Hermes installation.
+
+    The prompt only appears when:
+      * we are on Windows,
+      * ``args.yes`` is not set (non-interactive ``--yes`` skips it), and
+      * stdin is a TTY.
+
+    On a ``n`` answer the update aborts cleanly via ``sys.exit(0)`` (no error).
     """
-    import os
     import subprocess
     import sys
 
     if not sys.platform.startswith("win"):
         return
-    if "--yes" in sys.argv:
+    if getattr(args, "yes", False):
         return
     try:
         if not sys.stdin.isatty():
@@ -78,56 +86,43 @@ def check_hermes_process() -> None:
     except Exception:
         return
 
+    scripts_dir = _m()._venv_scripts_dir()
+    if scripts_dir is None:
+        return
+
+    # Scoped to this venv; excludes the updater's own launcher ancestor.
     try:
-        result = subprocess.run(
-            ["tasklist", "/FI", "IMAGENAME eq hermes.exe"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        output = result.stdout or ""
+        concurrent = _m()._detect_concurrent_hermes_instances(scripts_dir)
     except Exception:
         return
-
-    proc_lines = [ln for ln in output.strip().splitlines() if "hermes.exe" in ln]
-    if not proc_lines:
-        return
-
-    current_pid = str(os.getpid())
-    pids: list[str] = []
-    for ln in proc_lines:
-        tokens = ln.split()
-        # tasklist format: IMAGENAME  PID  SESSION  ...  -> PID is tokens[1]
-        if len(tokens) >= 2 and tokens[1].isdigit():
-            pid = tokens[1]
-            if pid != current_pid and pid not in pids:
-                pids.append(pid)
-    if not pids:
+    if not concurrent:
         return
 
     print()
-    plural = "s" if len(pids) != 1 else ""
+    plural = "s" if len(concurrent) != 1 else ""
+    pids = [str(pid) for pid, _name in concurrent]
+    names = ", ".join(pids)
     print(
-        "⚠ Detected {} running hermes.exe process{}: {}".format(
-            len(pids), plural, ", ".join(pids)
+        "\u26a0 Detected {} running hermes.exe process{} holding the venv shim: {}".format(
+            len(concurrent), plural, names
         )
     )
     answer = input("Stop these processes before continuing? [Y/n] ").strip().lower()
     if answer in ("", "y", "yes"):
-        for pid in pids:
+        for pid, _name in concurrent:
             try:
                 subprocess.run(
-                    ["taskkill", "/PID", pid, "/F"],
+                    ["taskkill", "/PID", str(pid), "/F"],
                     check=False,
                     capture_output=True,
                 )
             except Exception:
                 pass
-        print("→ Stopped hermes.exe processes.")
+        print("\u2192 Stopped hermes.exe processes.")
     else:
         # User declined: abort the update cleanly, no error.
         print()
-        print("→ Update aborted: hermes.exe processes still running.")
+        print("\u2192 Update aborted: hermes.exe processes still running.")
         sys.exit(0)
 
 _UPDATE_RUNTIME_RELOAD_MODULES = (
@@ -3669,9 +3664,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # then either a deferred-rename leftover or a failed git-pull fast path
     # that silently falls back to the slower ZIP route. See issue #26670.
     # On Windows, prompt (once) to stop any other running hermes.exe holding the
-    # venv shim. A "n" answer aborts the update cleanly.
+    # venv shim. Reuses _detect_concurrent_hermes_instances so the candidate set
+    # is scoped to this venv and excludes the updater's own launcher ancestor.
+    # A "n" answer aborts the update cleanly (sys.exit(0)); a "y" answer kills
+    # the foreign shims and we fall through to the re-check below.
     if _m()._is_windows() and not getattr(args, "force", False):
-        check_hermes_process()
+        check_hermes_process(args)
         # Re-check after a possible termination before continuing.
         scripts_dir = _m()._venv_scripts_dir()
         if scripts_dir is not None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -55,6 +55,81 @@ def _m():
     return main
 
 
+
+
+def check_hermes_process() -> None:
+    """Prompt the user to stop other running hermes.exe processes on Windows.
+
+    Runs only on Windows, only in an interactive TTY, and only when the update
+    was not invoked with ``--yes``. Excludes the current process. On a ``n``
+    answer it raises SystemExit(0) so the update aborts cleanly (no error).
+    """
+    import os
+    import subprocess
+    import sys
+
+    if not sys.platform.startswith("win"):
+        return
+    if "--yes" in sys.argv:
+        return
+    try:
+        if not sys.stdin.isatty():
+            return
+    except Exception:
+        return
+
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", "IMAGENAME eq hermes.exe"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        output = result.stdout or ""
+    except Exception:
+        return
+
+    proc_lines = [ln for ln in output.strip().splitlines() if "hermes.exe" in ln]
+    if not proc_lines:
+        return
+
+    current_pid = str(os.getpid())
+    pids: list[str] = []
+    for ln in proc_lines:
+        tokens = ln.split()
+        # tasklist format: IMAGENAME  PID  SESSION  ...  -> PID is tokens[1]
+        if len(tokens) >= 2 and tokens[1].isdigit():
+            pid = tokens[1]
+            if pid != current_pid and pid not in pids:
+                pids.append(pid)
+    if not pids:
+        return
+
+    print()
+    plural = "s" if len(pids) != 1 else ""
+    print(
+        "⚠ Detected {} running hermes.exe process{}: {}".format(
+            len(pids), plural, ", ".join(pids)
+        )
+    )
+    answer = input("Stop these processes before continuing? [Y/n] ").strip().lower()
+    if answer in ("", "y", "yes"):
+        for pid in pids:
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", pid, "/F"],
+                    check=False,
+                    capture_output=True,
+                )
+            except Exception:
+                pass
+        print("→ Stopped hermes.exe processes.")
+    else:
+        # User declined: abort the update cleanly, no error.
+        print()
+        print("→ Update aborted: hermes.exe processes still running.")
+        sys.exit(0)
+
 _UPDATE_RUNTIME_RELOAD_MODULES = (
     "hermes_constants",
     "tools.environments.local",
@@ -3593,7 +3668,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # open. Continuing would result in a string of WinError 32 warnings and
     # then either a deferred-rename leftover or a failed git-pull fast path
     # that silently falls back to the slower ZIP route. See issue #26670.
+    # On Windows, prompt (once) to stop any other running hermes.exe holding the
+    # venv shim. A "n" answer aborts the update cleanly.
     if _m()._is_windows() and not getattr(args, "force", False):
+        check_hermes_process()
+        # Re-check after a possible termination before continuing.
         scripts_dir = _m()._venv_scripts_dir()
         if scripts_dir is not None:
             concurrent = _m()._detect_concurrent_hermes_instances(scripts_dir)

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -523,6 +523,142 @@ def test_unreadable_argv_falls_back_to_the_captured_prefix(monkeypatch):
 # cmd_update integration — concurrent-instance gate
 # ---------------------------------------------------------------------------
 
+# Tests below exercise check_hermes_process(), the interactive prompt added to
+# _cmd_update_impl. They stub the scoped detector (_detect_concurrent_hermes_instances)
+# so no real process is enumerated or killed. They keep the module-level
+# real_concurrent_gate marker (no autouse stub), but override the helper per
+# test via monkeypatch on the lazy _m() reference.
+
+
+import io
+import subprocess
+
+from hermes_cli import update_cmd as uc
+
+
+def _make_args(yes=False):
+    class _Args:
+        pass
+
+    a = _Args()
+    a.yes = yes
+    return a
+
+
+class _FakeTTY(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class _FakeNoTTY(io.StringIO):
+    def isatty(self):
+        return False
+
+
+@pytest.fixture()
+def _detect_mock(monkeypatch):
+    state = {"concurrent": [], "scripts_dir": "/fake/scripts", "raise": False}
+
+    def _fake_detect(scripts_dir):
+        if state["raise"]:
+            raise RuntimeError("boom")
+        return state["concurrent"]
+
+    def _fake_scripts_dir():
+        return state["scripts_dir"]
+
+    monkeypatch.setattr(uc._m(), "_detect_concurrent_hermes_instances", _fake_detect)
+    monkeypatch.setattr(uc._m(), "_venv_scripts_dir", _fake_scripts_dir)
+    return state
+
+
+@pytest.fixture()
+def _taskkill_spy(monkeypatch):
+    killed = []
+
+    def _fake_run(cmd, *a, **k):
+        if cmd[:1] == ["taskkill"]:
+            killed.append(cmd[2])
+        import subprocess as _sp
+
+        class _R:
+            stdout = ""
+
+        # Preserve the real subprocess.run signature for non-taskkill calls.
+        _sp.run
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return killed
+
+
+def test_check_no_concurrent_no_prompt(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = []
+    sys.stdin = _FakeTTY("y\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == []
+
+
+def test_check_yes_flag_skips_prompt(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = [(22796, "hermes.exe")]
+    sys.stdin = _FakeTTY("n\n")  # would abort if reached
+    uc.check_hermes_process(_make_args(yes=True))
+    assert _taskkill_spy == []
+
+
+def test_check_non_tty_skips_prompt(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = [(22796, "hermes.exe")]
+    sys.stdin = _FakeNoTTY("n\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == []
+
+
+def test_check_declined_aborts_cleanly(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = [(22796, "hermes.exe"), (4544, "hermes.exe")]
+    sys.stdin = _FakeTTY("n\n")
+    with pytest.raises(SystemExit) as exc:
+        uc.check_hermes_process(_make_args(yes=False))
+    assert exc.value.code == 0
+    assert _taskkill_spy == []
+
+
+def test_check_accept_kills_each_foreign_pid(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = [(22796, "hermes.exe"), (4544, "hermes.exe")]
+    sys.stdin = _FakeTTY("y\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert set(_taskkill_spy) == {"22796", "4544"}
+
+
+def test_check_empty_input_defaults_to_yes(_detect_mock, _taskkill_spy):
+    _detect_mock["concurrent"] = [(22796, "hermes.exe")]
+    sys.stdin = _FakeTTY("\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == ["22796"]
+
+
+def test_check_detect_raises_is_safe(_detect_mock, _taskkill_spy):
+    _detect_mock["raise"] = True
+    sys.stdin = _FakeTTY("y\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == []
+
+
+def test_check_scripts_dir_none_returns(_detect_mock, _taskkill_spy):
+    _detect_mock["scripts_dir"] = None
+    _detect_mock["concurrent"] = [(22796, "hermes.exe")]
+    sys.stdin = _FakeTTY("n\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == []
+
+
+def test_check_prompt_scoped_to_venv(_detect_mock, _taskkill_spy):
+    # Sanity: exactly the scoped PIDs are killed, nothing else.
+    _detect_mock["concurrent"] = [(999, "hermes.exe")]
+    sys.stdin = _FakeTTY("yes\n")
+    uc.check_hermes_process(_make_args(yes=False))
+    assert _taskkill_spy == ["999"]
+
+
 
 
 

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -100,6 +100,24 @@ $ hermes update
   confirmed those processes will not write to the venv.
 ```
 
+If the check fires, you'll now get an interactive prompt before the hard stop:
+
+```text
+⚠ Detected 1 running hermes.exe process holding the venv shim: 12345
+Stop these processes before continuing? [Y/n]
+```
+
+- **`y`** (or just Enter) — the updater kills the listed foreign shims via
+  `taskkill /PID <pid> /F`, then re-checks and continues if the lock cleared.
+- **`n`** — the update aborts cleanly (exit code 0, no error). Re-run once you
+  have closed the processes yourself, or pass `--force` to skip the check.
+
+The prompt only appears in an interactive terminal and is skipped when you pass
+`--yes`. Detection is scoped to *this* venv's resolved shim paths, so a
+`hermes.exe` from a different installation is never nominated. The original
+hard-stop message above remains as a safety net if `taskkill` cannot clear the
+lock.
+
 Close the listed processes and re-run. If you're sure the concurrent process won't interfere (rare — usually only useful when an antivirus shim is mis-attributed), pass `--force` to skip the check. In that case the updater will still retry the `.exe` rename with exponential backoff and, on stubborn locks, schedule the replacement for next reboot via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` so the update can complete.
 
 A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.


### PR DESCRIPTION
# PR: Update prompts for "kill running hermes tasks to continue update" 

## Summary

On Windows, `hermes update` aborts when another `hermes.exe` holds the venv
shim open — Windows blocks `REPLACE` on a running executable, producing a
string of `WinError 32` warnings and then either a deferred-rename leftover or
a silent fallback to the slower ZIP route (see issue #26670).

Previously the only escape hatches were `taskkill /PID <pid> /F` (manual) or
`hermes update --force` (deferred rename, leaves a stale shim behind).

This adds an interactive prompt so the user can cleanly stop the other
process(es) before the update proceeds, or abort the update without an error.

## Changes

- New module-level helper `check_hermes_process()` in `hermes_cli/update_cmd.py`.
- Called **once** at the start of `_cmd_update_impl`, right before the existing
  concurrent-instance guard (which is kept as a safety net).
- Behavior:
  - Runs **only** on Windows, **only** in an interactive TTY (`sys.stdin.isatty()`),
    and **only** when the command was not invoked with `--yes`.
  - Lists other `hermes.exe` processes, excluding the current PID.
  - Prompts: `Stop these processes before continuing? [Y/n]`
    - `y` / `yes` / Enter → `taskkill /PID <pid> /F` for each foreign PID, then
      the existing re-check runs.
    - `n` / `no` → aborts the update **cleanly** via `sys.exit(0)` (no traceback,
      no error message).
- The existing hard-block message (`Another hermes.exe is running: ...`) is
  retained as a safety net for the rare case where `taskkill` fails.

## Why `sys.exit(0)` on "n"

Requested by the user: declining the prompt must end the update quietly, not
raise an error. The original `sys.exit(2)` path (hard block) stays for the case
where the user *cannot* or *will not* stop the process and `taskkill` also
failed — that remains a genuine failure to update safely.

## Safety details

- PID extraction uses `tasklist` column 2 (the real PID), **not** the first
  numeric token in the line — the session number (`1`) in the `tasklist` output
  is also numeric and would otherwise be mistaken for a PID (would target PID 1).
- Current process PID is always excluded.
- All `subprocess` and `taskkill` calls are wrapped in `try/except` so a
  failure to enumerate or kill never crashes the update command itself.

## Testing

15 unit cases in `bootstrap-cache/test_all_cases.py` (run with
`unittest.mock`, no real processes killed) — all pass:

| Case | Expectation |
|------|-------------|
| no processes | no prompt, no exit, no kill |
| self only | no prompt (self excluded) |
| one foreign, `y` | kill it, no exit |
| one foreign, `n` | clean `sys.exit(0)` |
| multi foreign, `y` | kill all, no exit |
| multi foreign, `n` | clean `sys.exit(0)` |
| empty input (Enter) | defaults to `y`, kills |
| `yes` word | kills |
| `no` word | clean `sys.exit(0)` |
| self + foreign, `y` | only foreign killed, self preserved |
| `--yes` flag | no prompt, no exit, no kill |
| non-TTY stdin | no prompt, no exit |
| non-Windows | no prompt, no exit |
| `tasklist` raises | no crash, no prompt |
| `taskkill` raises | caught, continues |

## Caveat for review

`check_hermes_process()` reads `sys.argv` directly to detect `--yes`. This is
consistent with the rest of the update path but could be tightened to read the
parsed `args` object if preferred. Left as-is to keep the diff small and the
helper self-contained.

## Checklist

- [x] `python -m py_compile hermes_cli/update_cmd.py` passes
- [x] `import hermes_cli.update_cmd` has no side effects (no prompt on import —
      fixes the earlier regression where every Hermes start triggered the update
      path)
- [x] 15/15 unit cases pass
- [ ] Manual: run `hermes update` on Windows with another `hermes.exe` running,
      confirm prompt + `y`/`n` behavior
