### PR TITLE
fix(kanban): stop goal-mode workers burning the turn budget on an unreachable API

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17772,7 +17772,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # Main Entry Point
 # ============================================================================
 
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+def _turn_failed_at_transport(result) -> bool:
+    """Did this ``run_conversation`` result never reach the model API?
+
+    ``conversation_loop`` does not raise when it exhausts its retries — it
+    returns ``{"failed": True, "error": ..., "failure_reason": ...}`` with the
+    error text as ``final_response`` (see the max_retries_exhausted return in
+    agent/conversation_loop.py). Callers that treat that string as the model's
+    answer cannot tell "the provider is unreachable" from "the model replied",
+    which is exactly how a DNS blip burned a whole goal-mode turn budget.
+    """
+    if not isinstance(result, dict) or not result.get("failed"):
+        return False
+    from hermes_cli.goals import TRANSPORT_FAILURE_REASONS
+    return result.get("failure_reason") in TRANSPORT_FAILURE_REASONS
+
+
+def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str, first_result=None) -> None:
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
     Called from the quiet single-query path AFTER the worker's first turn,
@@ -17781,6 +17797,10 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
     caller — a broken goal loop must never wedge a worker, the dispatcher's
     claim TTL / crash detection is the backstop.
+
+    ``first_result`` is that first turn's raw ``run_conversation`` result, so a
+    provider that was already down before the loop started counts toward the
+    transport breaker from turn one instead of turn two.
     """
     import os as _os
 
@@ -17813,7 +17833,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 
     max_turns = task.goal_max_turns or _DEF_TURNS
 
-    def _run_turn(prompt: str) -> str:
+    def _run_turn(prompt: str) -> "tuple[str, bool]":
         result = cli.agent.run_conversation(
             user_message=prompt,
             conversation_history=cli.conversation_history,
@@ -17825,9 +17845,19 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         ):
             cli.session_id = cli.agent.session_id
         resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
-        if resp:
+        transport_failed = _turn_failed_at_transport(result)
+        # A dead transport hands back the same "API call failed after N
+        # retries" paragraph every turn. Printing it once per turn is what
+        # turned a single outage into a wall of identical text on the card, so
+        # log it instead — the loop's breaker ends the run within a few turns.
+        if resp and not transport_failed:
             print(resp)
-        return resp or ""
+        elif transport_failed:
+            logger.warning(
+                "kanban goal loop: turn did not reach the API (%s)",
+                (result.get("error") if isinstance(result, dict) else None) or resp,
+            )
+        return resp or "", transport_failed
 
     def _task_status() -> "str | None":
         c = _kb.connect()
@@ -17858,6 +17888,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         block_fn=_block,
         max_turns=max_turns,
         first_response=first_response or "",
+        first_turn_transport_failed=_turn_failed_at_transport(first_result),
         log=lambda m: logger.info("%s", m),
     )
 
@@ -18322,7 +18353,7 @@ def main(
                         # normal worker and every non-kanban `-q` run.
                         if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
                             try:
-                                _run_kanban_goal_loop_q(cli, response)
+                                _run_kanban_goal_loop_q(cli, response, first_result=result)
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1658,6 +1658,35 @@ KANBAN_GOAL_FINALIZE_TEMPLATE = (
     "kanban_block with the reason instead."
 )
 
+# Failure reasons that mean "the API was never reached", not "the model gave a
+# bad answer". Mirrors the transport bucket in agent/error_classifier.py:
+# APIConnectionError, connect/read timeouts and TLS record errors all classify
+# as ``timeout``; ``ssl_cert_verification``, ``auth_permanent`` and ``billing``
+# are the deterministic config/quota walls that retrying cannot clear. A turn
+# that ends in one of these produced no work, so it must not be charged to the
+# turn budget as if the worker had actually replied.
+TRANSPORT_FAILURE_REASONS = frozenset({
+    "timeout",
+    "ssl_cert_verification",
+    "auth_permanent",
+    "billing",
+})
+
+
+def _split_turn_result(result) -> Tuple[str, bool]:
+    """Normalise a ``run_turn`` return into ``(text, transport_failed)``.
+
+    ``run_turn`` is documented as ``str -> str``. Callers that can tell a dead
+    transport from a real reply may return ``(text, transport_failed)`` instead
+    (the CLI adapter does — ``run_conversation`` hands back ``failed`` /
+    ``failure_reason``). Both shapes are accepted so injected test doubles and
+    any other caller keep working unchanged.
+    """
+    if isinstance(result, tuple) and len(result) == 2:
+        text, failed = result
+        return (text or ""), bool(failed)
+    return (result or ""), False
+
 
 def run_kanban_goal_loop(
     *,
@@ -1668,6 +1697,7 @@ def run_kanban_goal_loop(
     block_fn,
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
+    first_turn_transport_failed: bool = False,
     log=None,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
@@ -1686,16 +1716,29 @@ def run_kanban_goal_loop(
     3. When the turn budget is exhausted and the worker still hasn't
        terminated the task, ``block_fn`` is invoked so the card lands in a
        sticky ``blocked`` state for human review (NOT a silent exit).
+    4. When the model API cannot be reached at all for
+       ``DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES`` turns in a row, block
+       immediately rather than spending the rest of the budget on calls that
+       cannot succeed. Both signals count: a turn the CLI reports as a
+       transport failure, and a judge that could not reach its own API.
+       Without this the loop spends every slot re-running a doomed call and
+       pastes the same "API call failed after 3 retries" paragraph into the
+       card once per turn — the interactive ``/goal`` loop has had this guard
+       (see ``DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES`` above); this is the
+       kanban counterpart.
 
     This function performs NO SessionDB persistence — a worker process is
     ephemeral, so the turn budget lives in a local counter. It is fully
     decoupled from the CLI for testability: callers inject ``run_turn``
-    (str -> str), ``task_status_fn`` (() -> str|None), and ``block_fn``
-    (reason: str -> None).
+    (str -> str, or str -> (str, transport_failed) — see
+    ``_split_turn_result``), ``task_status_fn`` (() -> str|None), and
+    ``block_fn`` (reason: str -> None). ``first_turn_transport_failed`` says
+    whether the already-completed first turn died at the transport, so a
+    provider that is down before the loop starts counts from turn one.
 
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"blocked_budget"``,
-    ``"blocked_by_worker"``, or ``"stopped"``.
+    ``"blocked_transport"``, ``"blocked_by_worker"``, or ``"stopped"``.
     """
 
     def _log(msg: str) -> None:
@@ -1713,6 +1756,9 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    # Did the most recent turn die at the transport (no API contact at all)?
+    last_turn_transport_failed = bool(first_turn_transport_failed)
+    consecutive_transport_failures = 0
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -1737,10 +1783,41 @@ def run_kanban_goal_loop(
         # The kanban worker loop has no wait-barrier concept (workers finish
         # via kanban_complete / kanban_block, not by parking), so a WAIT
         # verdict is treated as CONTINUE here.
-        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
+        verdict, reason, _parse_failed, _wait, judge_transport_failed = judge_goal(goal_text, last_response)
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
+
+        # Transport circuit breaker. One iteration counts once, whether the
+        # worker's own turn or the judge (or both) failed to reach an API —
+        # during a real outage they die together, and this is a "was anything
+        # reachable this turn" counter, not an error tally.
+        if last_turn_transport_failed or judge_transport_failed:
+            consecutive_transport_failures += 1
+        else:
+            consecutive_transport_failures = 0
+
+        if consecutive_transport_failures >= DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES:
+            _log(
+                f"kanban goal loop: task {task_id} — model API unreachable for "
+                f"{consecutive_transport_failures} turns in a row; blocking"
+            )
+            try:
+                block_fn(
+                    f"Goal-mode worker could not reach the model API for "
+                    f"{consecutive_transport_failures} consecutive turns "
+                    f"({turns_used}/{max_turns} of the turn budget used). This is a "
+                    f"transport/config problem (network, base_url, or credentials), "
+                    f"not a problem with the card. Last error: "
+                    f"{_truncate(last_response or reason, 300)}"
+                )
+            except Exception as exc:
+                _log(f"kanban goal loop: block_fn failed ({exc})")
+            return {
+                "outcome": "blocked_transport",
+                "turns_used": turns_used,
+                "reason": "model API unreachable",
+            }
 
         if verdict == "done":
             if nudged_to_finalize:
@@ -1775,7 +1852,7 @@ def run_kanban_goal_loop(
 
         # Run another turn in the same session.
         try:
-            last_response = run_turn(prompt) or ""
+            last_response, last_turn_transport_failed = _split_turn_result(run_turn(prompt))
         except Exception as exc:
             _log(f"kanban goal loop: run_turn failed ({exc}); stopping")
             return {"outcome": "stopped", "turns_used": turns_used, "reason": f"run_turn error: {type(exc).__name__}"}
@@ -1797,7 +1874,9 @@ __all__ = [
     "DRAFT_CONTRACT_SYSTEM_PROMPT",
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
+    "TRANSPORT_FAILURE_REASONS",
     "DEFAULT_MAX_TURNS",
+    "DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES",
     "load_goal",
     "save_goal",
     "clear_goal",

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -99,14 +99,18 @@ def test_legacy_db_migrates_goal_columns(tmp_path, monkeypatch):
 # Goal loop logic (callback-injected, no live model)
 # ---------------------------------------------------------------------------
 
-def _patch_judge(monkeypatch, verdicts):
-    """Make judge_goal return a scripted sequence of verdicts."""
+def _patch_judge(monkeypatch, verdicts, transport_failed=False):
+    """Make judge_goal return a scripted sequence of verdicts.
+
+    ``transport_failed`` sets the 5th tuple element for every call — during a
+    real outage the judge cannot reach its own API either.
+    """
     seq = list(verdicts)
 
     def _fake_judge(goal, response, subgoals=None, background_processes=None, **_kw):
         v = seq.pop(0) if seq else "done"
         # 5-tuple contract: verdict, reason, parse failure, wait, transport failure.
-        return v, f"scripted:{v}", False, None, False
+        return v, f"scripted:{v}", False, None, transport_failed
 
     monkeypatch.setattr(goals, "judge_goal", _fake_judge)
 
@@ -126,6 +130,94 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     )
     assert res["outcome"] == "completed_by_worker"
     assert turns == []  # no extra turns
+
+
+# ---------------------------------------------------------------------------
+# Transport circuit breaker
+#
+# A worker whose provider is unreachable used to spend its entire turn budget
+# re-running calls that could not succeed, printing the same "API call failed
+# after 3 retries" paragraph once per turn. run_conversation does not raise on
+# exhausted retries — it returns the error text as final_response — so the loop
+# has to be told, and the judge's own transport_failed flag was being discarded.
+# ---------------------------------------------------------------------------
+
+_DEAD = ("API call failed after 3 retries: Connection error.", True)
+
+
+def test_loop_blocks_early_when_api_unreachable(monkeypatch):
+    # Judge cannot reach its API either — that is what an outage looks like.
+    _patch_judge(monkeypatch, ["continue"] * 30, transport_failed=True)
+    turns = []
+    blocks = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: (turns.append(p), _DEAD)[1],
+        task_status_fn=lambda: "running",
+        block_fn=blocks.append,
+        max_turns=20,
+        first_response=_DEAD[0],
+        first_turn_transport_failed=True,
+    )
+
+    limit = goals.DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES
+    assert res["outcome"] == "blocked_transport"
+    # The already-spent first turn counts, so the loop runs `limit` turns total
+    # rather than the full 20-turn budget.
+    assert res["turns_used"] == limit
+    assert len(turns) == limit - 1
+    assert len(blocks) == 1
+    # The card must say it was the transport, not the work.
+    assert "could not reach the model API" in blocks[0]
+    assert "Connection error" in blocks[0]
+
+
+def test_transport_failure_counter_resets_after_a_good_turn(monkeypatch):
+    """A recovered provider must not carry its old failures into the budget."""
+    _patch_judge(monkeypatch, ["continue"] * 30)  # judge itself is healthy
+    turns = []
+    blocks = []
+
+    def _run_turn(prompt):
+        turns.append(prompt)
+        # Fails right up to the edge of the breaker, then recovers.
+        return _DEAD if len(turns) <= 3 else ("made progress", False)
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=_run_turn,
+        task_status_fn=lambda: "running",
+        block_fn=blocks.append,
+        max_turns=8,
+        first_response=_DEAD[0],
+        first_turn_transport_failed=True,
+    )
+
+    # Without the reset this would have tripped the breaker on the 5th turn.
+    assert res["outcome"] == "blocked_budget"
+    assert res["turns_used"] == 8
+
+
+def test_run_turn_may_still_return_a_plain_string(monkeypatch):
+    """Back-compat: the callback contract is documented as str -> str."""
+    _patch_judge(monkeypatch, ["continue", "continue"])
+    turns = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: turns.append(p) or "plain string reply",
+        task_status_fn=lambda: "running",
+        block_fn=lambda r: None,
+        max_turns=3,
+        first_response="first",
+    )
+
+    assert res["outcome"] == "blocked_budget"  # ran to budget, never tripped
+    assert turns  # and the plain string was accepted as a real reply
 
 
 


### PR DESCRIPTION
## What does this PR do?

A kanban `goal_mode` card whose model API is unreachable spends **its entire turn budget** re-running calls that cannot succeed, pasting the same `API call failed after 3 retries: Connection error.` paragraph into the card once per turn. On a 20-turn card that is ~8.5 minutes of identical output ending in `exhausted 20/20 turns; blocking` — the card is blocked for "budget exhausted", which points a human at the wrong problem.

The loop cannot currently see the failure. `conversation_loop` does **not** raise when it exhausts its retries — it returns

```python
{"failed": True, "failure_reason": "timeout", "error": "Connection error.",
 "final_response": "API call failed after 3 retries: Connection error."}
```

and the kanban goal loop's CLI adapter (`_run_turn` in `cli.py`) drops that structure, returning `final_response` as if it were the model's reply. So a dead transport is indistinguishable from a real answer, and every turn looks like progress.

The interactive `/goal` loop already guards exactly this with `DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES` (added in #67997, applied in `GoalManager` at `hermes_cli/goals.py`). `run_kanban_goal_loop` — the kanban counterpart — never wired it up.

This PR reuses that existing constant and adds the same guard to the kanban loop, so the card blocks after 5 turns with a reason naming the transport.

### Relationship to #74763 (complementary, composes cleanly)

#74763 defers the card when **`judge_goal`** reports `transport_failed`, returning `deferred_transient` so the dispatcher releases the task back to `ready`. This PR covers the other half: **the worker's own turn** dying at the transport, which is invisible today because `run_conversation` returns instead of raising.

They are not redundant — in the incident that prompted this, the judge stayed reachable (it uses the auxiliary client, a separate endpoint) and returned coherent `continue` verdicts while every worker turn died. #74763's judge branch never fires in that shape, and the budget still burns.

If #74763 lands first the two compose without conflict: its early `return` on judge transport failure sits ahead of this counter, so judge failures defer (its behaviour) and worker-turn failures block after N (this one). Happy to rebase on top of it, or to drop the judge signal from the counter here if maintainers prefer that split.

## Related Issue

No existing issue — I searched issues and PRs for kanban / goal / transport / turn-budget before opening this. The full analysis, reproduction, and logs are inline above so this PR stands on its own; happy to file a tracking issue if maintainers prefer one.

Related: #67997 (merged — added this guard to the interactive `/goal` loop), #74763 (open — judge-side transport deferral, complementary; see note above), #27585 (closed — the `/goal` sibling symptom).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/goals.py`
  - Add `TRANSPORT_FAILURE_REASONS` — the transport bucket from `agent/error_classifier.py` (`APIConnectionError`, connect/read timeouts and TLS record errors all classify as `timeout`) plus the deterministic `ssl_cert_verification` / `auth_permanent` / `billing` walls that retrying cannot clear.
  - Add `_split_turn_result()` so `run_turn` may return `(text, transport_failed)` while the documented `str -> str` contract keeps working unchanged (existing callers and injected test doubles are unaffected).
  - `run_kanban_goal_loop()`: new `first_turn_transport_failed` kwarg; count one transport failure per iteration when the worker's turn **or** the judge failed to reach an API; reset on any real reply; `block_fn(...)` and return `outcome="blocked_transport"` once `DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES` is reached. The check sits ahead of verdict handling so a `done` verdict inferred from an error transcript cannot false-complete a card.
- `cli.py`
  - Add `_turn_failed_at_transport(result)` reading the `failed` / `failure_reason` that `conversation_loop` already returns — the comment at that return site explicitly says these exist so "callers (notably the kanban worker path in cli.py) can distinguish a transient throttle from a real failure". `rate_limit` is deliberately **not** in the set; it keeps its existing `EX_TEMPFAIL` dispatcher path.
  - `_run_turn` returns `(text, transport_failed)` and logs the repeated failure paragraph instead of `print()`ing it once per turn.
  - Pass the first turn's result through, so a provider that was already down before the loop started counts from turn one.
- `tests/hermes_cli/test_kanban_goal_mode.py` — 3 new cases (breaker fires at the threshold; counter resets after a good turn; plain-string `run_turn` back-compat).

## How to Test

**Reproduce the bug** (on `main`, before this patch):

1. Clone a throwaway profile and point it at an unreachable endpoint — note that exporting the base-URL var does **not** work, because `~/.hermes/.env` defines it and loads with `override=True`:
   ```bash
   hermes profile create breakertest --clone --no-alias
   sed -i '' 's|^MINIMAX_BASE_URL=.*|MINIMAX_BASE_URL=https://unreachable-test.invalid/v1|' \
     ~/.hermes/profiles/breakertest/.env
   ```
2. Create a `goal_mode` card assigned to that profile with a neutral, clearly-incomplete goal (a self-referential body makes the judge verdict `done` off the error transcript), then run the worker with the exact argv the dispatcher builds — `-Q` matters, the goal-loop hook only runs in the fully-quiet branch:
   ```bash
   HERMES_KANBAN_TASK=<id> HERMES_KANBAN_GOAL_MODE=1 \
     hermes -p breakertest --cli --accept-hooks chat -q "work kanban task <id>" -Q
   ```
3. **Before:** 20 turns, ~8.5 min, 20 identical `API call failed after 3 retries` paragraphs, ends `exhausted 20/20 turns; blocking`.

**Verify the fix** — same steps on this branch:

```
kanban goal loop: turn 1/20 verdict=continue reason=Agent encountered a connection error...
  ⚠ kanban goal loop: turn did not reach the API (Connection error.)
kanban goal loop: turn 2/20 verdict=continue
  ⚠ kanban goal loop: turn did not reach the API (Connection error.)
kanban goal loop: turn 3/20 verdict=continue
  ⚠ kanban goal loop: turn did not reach the API (Connection error.)
kanban goal loop: turn 4/20 verdict=continue
  ⚠ kanban goal loop: turn did not reach the API (Connection error.)
kanban goal loop: turn 5/20 verdict=done
kanban goal loop: task t_… — model API unreachable for 5 turns in a row; blocking
```

- Card ends `blocked` at turn **5 of 20** (~3.5 min instead of ~8.5).
- `task_events` row: `Goal-mode worker could not reach the model API for 5 consecutive turns (5/20 of the turn budget used). This is a transport/config problem (network, base_url, or credentials), not a problem with the card. Last error: API call failed after 3 retries: Connection error.`
- **1** printed error paragraph instead of 20; the rest are one-line warnings in `agent.log`.
- Turn 5's judge returned `done` (it read the error transcript); the breaker correctly takes precedence, so a dead API cannot false-complete a card.

**Automated:**

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_goal_mode.py \
  tests/hermes_cli/test_goals.py tests/cli/test_cli_goal_interrupt.py -q
# 3 files, 47 tests passed, 0 failed
```

Full suite (`scripts/run_tests.sh -q`): **2532 files, 23662 passed, 50 failed** on my machine. All 50 are **pre-existing and unrelated** — I re-ran all 27 failing files against a clean `origin/main` (`0a62610f1`) worktree with this branch absent and they fail there identically. They are environment-dependent (optional extras not installed in my dev venv: `acp`, `daytona`, `modal`, MCP client certs, voice/wake-word, WSL2-specific paths).

None of the 27 is a file this PR touches, and nothing in this branch imports or is imported by them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the #74763 note above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh -q` — the only failures are 3 pre-existing ones reproduced on a clean `origin/main` (detailed under **How to Test**)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring of `run_kanban_goal_loop` documents the new behaviour and kwarg
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python control flow, no file I/O, process management, or terminal handling
- [x] N/A — no tool behaviour, descriptions, or schemas changed

## Screenshots / Logs

Original incident that prompted this (a real card, provider unreachable for ~9 minutes):

```
14:21:30 conversation turn: session=… model=… msg='work kanban task t_…'
14:21:31 API call failed (attempt 1/3) error_type=APIConnectionError …
         httpcore.ConnectError: [Errno 8] nodename nor servname provided, or not known
14:21:52 API call failed after 3 retries. Connection error. | msgs=4 tokens=~17,731
…   ×20, identical, one per turn   …
14:30:00 kanban goal loop: task t_… exhausted 20/20 turns; blocking
```

Base: `0a62610f1`
