### PR TITLE
fix(test-runner): probe venvs with PYTHONPATH cleared

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -53,7 +53,12 @@ VENV_PYTHON=""
 SKIPPED_VENVS=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
+    # Probe under the same hermetic conditions the per-file subprocess will
+    # see (env -i below clears PYTHONPATH/PYTHONHOME). A parent-shell
+    # PYTHONPATH pointing at another venv's site-packages would otherwise
+    # make a pytest-less venv look usable, and every file would then die
+    # with "No module named pytest" after env -i drops the crutch.
+    if env -u PYTHONPATH -u PYTHONHOME "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/bin/python"
       break
@@ -65,7 +70,7 @@ for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agen
   # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
   # this branch — without it the canonical runner refuses to start.
   if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if env -u PYTHONPATH -u PYTHONHOME "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/Scripts/python.exe"
       break
@@ -83,7 +88,7 @@ fi
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
+    && env -u PYTHONPATH -u PYTHONHOME "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE
   # venv (no pytest) when inherited from a wrapped `hermes` binary rather
   # than the devShell hook.


### PR DESCRIPTION
## Problem

`scripts/run_tests.sh` picks the first venv whose python can `import pytest`,
but the probe runs in the **parent shell environment**, while the per-file
test subprocesses run under `env -i` (which clears `PYTHONPATH`/`PYTHONHOME`).

If the parent shell has `PYTHONPATH` pointing at another venv's
site-packages (e.g. a repo + dev-venv path exported by a wrapping runtime),
a pytest-less venv — like a bare `uv`-created `.venv` — passes the probe by
importing pytest from the *other* venv. The runner then selects it, every
per-file subprocess dies with:

```
/path/to/.venv/bin/python: No module named pytest
```

and the run reports `0 tests passed` (which the runner now correctly flags as
"NO TESTS RAN", but the root cause is the probe-vs-run env mismatch).

## Fix

Run the probe under the same hermetic conditions the subprocess will see:

```sh
env -u PYTHONPATH -u PYTHONHOME "$candidate/bin/python" -c 'import pytest'
```

applied to the POSIX venv layout, the native Windows `Scripts/` layout, and
the `HERMES_PYTHON` fallback. A venv that only imports pytest via a parent
`PYTHONPATH` is exactly the venv that will fail at runtime, so skipping it is
correct.

## Verification

On a machine with a polluted parent `PYTHONPATH`:

- Before: runner selected `.venv` (no pytest of its own) → every file failed
  with `No module named pytest`.
- After: runner prints `▶ skipping venv without pytest: .../.venv`, selects
  the real dev venv, and tests pass:

```
scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_body_update.py -q
→ 2 files, 9 tests passed, 0 failed
```
