### PR TITLE
fix(desktop): keep mid-turn messages visible and timestamped

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -15,7 +15,7 @@ import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import type { ClientSessionState } from '@/app/types'
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { textPart } from '@/lib/chat-messages'
+import { liveUserCorrectionInsertionIndex, textPart } from '@/lib/chat-messages'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { clearClarifyRequest } from '@/store/clarify'
@@ -290,16 +290,14 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         const message = {
           id: messageId,
           role: 'user' as const,
-          parts: [textPart(text)]
+          parts: [textPart(text)],
+          timestamp: Math.floor(Date.now() / 1000)
         }
 
-        const streamIndex = state.streamId ? state.messages.findIndex(candidate => candidate.id === state.streamId) : -1
-
-        const lastAssistantIndex = state.messages.map(candidate => candidate.role).lastIndexOf('assistant')
-        const insertionIndex = streamIndex >= 0 ? streamIndex : lastAssistantIndex
+        const insertionIndex = liveUserCorrectionInsertionIndex(state.messages, state.streamId)
 
         const messages =
-          insertionIndex >= 0
+          insertionIndex < state.messages.length
             ? [...state.messages.slice(0, insertionIndex), message, ...state.messages.slice(insertionIndex)]
             : [...state.messages, message]
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2156,6 +2156,49 @@ describe('usePromptActions redirectPrompt', () => {
     })
   })
 
+  it('appends the redirect bubble at the live tail when the active stream id is missing', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T12:00:00Z'))
+
+    try {
+      const requestGateway = vi.fn(async () => ({ status: 'redirected' }) as never)
+      const capturedStates: Record<string, unknown>[] = []
+      let handle: HarnessHandle | null = null
+
+      await actRender(
+        <Harness
+          onReady={h => (handle = h)}
+          onSeedState={state => capturedStates.push(state)}
+          refreshSessions={async () => undefined}
+          requestGateway={requestGateway}
+          seedMessages={[
+            { id: 'u1', role: 'user', parts: [textPart('first prompt')] },
+            { id: 'a1', role: 'assistant', parts: [textPart('first answer')] },
+            { id: 'u2', role: 'user', parts: [textPart('second prompt')] },
+            { id: 'a2', role: 'assistant', parts: [textPart('second answer')] }
+          ]}
+        />
+      )
+
+      expect(await handle!.redirectPrompt('tail nudge')).toBe(true)
+
+      const messages = capturedStates.at(-1)?.messages as Array<{ id: string; parts: unknown[]; timestamp?: number }>
+      expect(messages.map(message => message.id)).toEqual([
+        'u1',
+        'a1',
+        'u2',
+        'a2',
+        expect.stringMatching(/^user-/)
+      ])
+      expect(messages.at(-1)).toMatchObject({
+        parts: [{ type: 'text', text: 'tail nudge' }],
+        timestamp: 1785672000
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resumes the stored session and retries once when session.redirect reports "session not found"', async () => {
     const STORED_SESSION_ID = 'stored-db-xyz789'
     const RECOVERED_SESSION_ID = 'rt-recovered-456'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -5,7 +5,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
-import { type ChatMessage, textPart } from '@/lib/chat-messages'
+import { type ChatMessage, liveUserCorrectionInsertionIndex, textPart } from '@/lib/chat-messages'
 import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { triggerHaptic } from '@/lib/haptics'
@@ -261,22 +261,16 @@ export function usePromptActions({
           const message: ChatMessage = {
             id: messageId,
             role,
-            parts: [textPart(body)]
+            parts: [textPart(body)],
+            timestamp: Math.floor(Date.now() / 1000)
           }
 
-          const streamIndex =
-            options.insertBeforeActiveReply && state.streamId
-              ? state.messages.findIndex(candidate => candidate.id === state.streamId)
-              : -1
-
-          const lastAssistantIndex = options.insertBeforeActiveReply
-            ? state.messages.map(candidate => candidate.role).lastIndexOf('assistant')
-            : -1
-
-          const insertionIndex = streamIndex >= 0 ? streamIndex : lastAssistantIndex
+          const insertionIndex = options.insertBeforeActiveReply
+            ? liveUserCorrectionInsertionIndex(state.messages, state.streamId)
+            : state.messages.length
 
           const messages =
-            insertionIndex >= 0
+            insertionIndex < state.messages.length
               ? [...state.messages.slice(0, insertionIndex), message, ...state.messages.slice(insertionIndex)]
               : [...state.messages, message]
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -320,7 +320,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         id: optimisticId,
         role: 'user',
         parts: [textPart(bubbleText || (attachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
-        attachmentRefs
+        attachmentRefs,
+        timestamp: Math.floor(Date.now() / 1000)
       })
 
       const releaseBusy = () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
@@ -1087,6 +1087,33 @@ describe('appendLiveSessionProjection', () => {
       'newest prompt'
     ])
     expect(restored[3]).toMatchObject({ id: 'assistant-stream-runtime-1', pending: true })
+  })
+
+  it('timestamps every synthetic live projection row with the current time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T12:00:00Z'))
+
+    try {
+      const restored = appendLiveSessionProjection([], {
+        session_id: 'runtime-1',
+        inflight: {
+          user: 'current prompt',
+          corrections: ['mid-turn correction'],
+          assistant: 'partial answer',
+          streaming: true
+        },
+        queued: { user: 'queued prompt' }
+      })
+
+      expect(restored.map(message => [message.id, message.timestamp])).toEqual([
+        ['user-inflight-runtime-1', 1785672000],
+        ['user-inflight-correction-0-runtime-1', 1785672000],
+        ['assistant-stream-runtime-1', 1785672000],
+        ['user-queued-runtime-1', 1785672000]
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not duplicate a persisted inflight user after consecutive canceled user turns', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -650,6 +650,7 @@ export function appendLiveSessionProjection(
   }
 
   const sessionId = projection.session_id || 'session'
+  const projectedAt = Math.floor(Date.now() / 1000)
   const projected: ChatMessage[] = []
   // A turn normally persists its user row before inference begins. session.resume
   // then returns that stored row *and* the still-live inflight projection; adding
@@ -677,7 +678,8 @@ export function appendLiveSessionProjection(
     projected.push({
       id: `user-inflight-${sessionId}`,
       role: 'user',
-      parts: [textPart(inflightUser)]
+      parts: [textPart(inflightUser)],
+      timestamp: projectedAt
     })
   }
 
@@ -693,7 +695,8 @@ export function appendLiveSessionProjection(
     projected.push({
       id: `user-inflight-correction-${index}-${sessionId}`,
       role: 'user',
-      parts: [textPart(correction)]
+      parts: [textPart(correction)],
+      timestamp: projectedAt
     })
   }
 
@@ -744,6 +747,7 @@ export function appendLiveSessionProjection(
         role: 'assistant',
         parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
         pending: inflightStreaming,
+        timestamp: projectedAt,
         ...(inflightError ? { error: inflightError } : {})
       })
     }
@@ -753,7 +757,8 @@ export function appendLiveSessionProjection(
     projected.push({
       id: `user-queued-${sessionId}`,
       role: 'user',
-      parts: [textPart(queuedUser)]
+      parts: [textPart(queuedUser)],
+      timestamp: projectedAt
     })
   }
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -31,6 +31,16 @@ export type ChatMessage = {
   reactions?: MessageReaction[]
 }
 
+export function liveUserCorrectionInsertionIndex(messages: ChatMessage[], streamId?: null | string): number {
+  if (!streamId) {
+    return messages.length
+  }
+
+  const streamIndex = messages.findIndex(candidate => candidate.id === streamId)
+
+  return streamIndex >= 0 ? streamIndex : messages.length
+}
+
 export type GatewayEventPayload = {
   text?: string
   rendered?: string

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { type ChatMessage, liveUserCorrectionInsertionIndex, textPart } from '@/lib/chat-messages'
 import type { ComposerAttachment } from '@/store/composer'
 
 import {
@@ -198,5 +199,36 @@ describe('messageCreatedAt', () => {
   it('treats a zero / non-finite timestamp as absent', () => {
     expect(messageCreatedAt({ timestamp: 0 }, NOW).getTime()).toBe(NOW)
     expect(messageCreatedAt({ timestamp: Number.NaN }, NOW).getTime()).toBe(NOW)
+  })
+})
+
+describe('liveUserCorrectionInsertionIndex', () => {
+  const message = (id: string, role: ChatMessage['role'], text: string): ChatMessage => ({
+    id,
+    role,
+    parts: [textPart(text)]
+  })
+
+  it('inserts before the active streaming assistant when streamId is current', () => {
+    const messages = [
+      message('u1', 'user', 'first prompt'),
+      message('a1', 'assistant', 'first answer'),
+      message('u2', 'user', 'second prompt'),
+      message('stream-current', 'assistant', 'partial answer')
+    ]
+
+    expect(liveUserCorrectionInsertionIndex(messages, 'stream-current')).toBe(3)
+  })
+
+  it('appends to the live tail when streamId is missing or stale', () => {
+    const messages = [
+      message('u1', 'user', 'first prompt'),
+      message('a1', 'assistant', 'first answer'),
+      message('u2', 'user', 'second prompt'),
+      message('a2', 'assistant', 'second answer')
+    ]
+
+    expect(liveUserCorrectionInsertionIndex(messages, null)).toBe(4)
+    expect(liveUserCorrectionInsertionIndex(messages, 'missing-stream')).toBe(4)
   })
 })


### PR DESCRIPTION
Fixes #76553

Mid-turn redirects could be accepted by the backend while the desktop transcript made the user bubble hard to find. The optimistic insertion path tried to place the correction before the active assistant stream, but when streamId was missing or stale it fell back to the last assistant message anywhere in the transcript. In a longer chat that could splice the new user bubble above old assistant content instead of keeping it at the live tail.

This changes the correction insertion contract:

- if the current streamId is present, insert immediately before that active stream
- if streamId is missing or stale, append at the live tail
- use the same helper for the main composer and session tile steer path

The same live-message pipeline also minted synthetic/optimistic rows without timestamps. Current main already avoids parsing arbitrary id digits as dates, but these rows should still carry real display timestamps so projected inflight prompts, corrections, assistant streams, queued prompts, normal optimistic submits, and tile steers all render with sane ages.

Regression coverage includes:

- active stream insertion still happens before the current assistant stream
- missing/stale streamId appends correction bubbles at the live tail
- live projection rows all carry the current unix-second timestamp
- redirect optimistic bubbles carry a timestamp
- existing id-derived epoch fallback protection remains covered

Validation:

cd apps/desktop && npm test -- src/lib/chat-runtime.test.ts src/app/session/hooks/use-session-actions/utils.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx --run
cd apps/desktop && npm run typecheck

Result:

178 tests passed
typecheck passed