### PR TITLE
fix(desktop): order Review request ownership

### DIFF
--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -26,6 +26,7 @@ import {
   createOrOpenPr,
   generateCommitMessage,
   openReview,
+  openReviewForPath,
   pushChanges,
   refreshReview,
   refreshShipInfo,
@@ -49,6 +50,18 @@ vi.mock('./coding-status', () => ({ refreshRepoStatus: vi.fn() }))
 
 function file(path: string, over: Partial<HermesReviewFile> = {}): HermesReviewFile {
   return { path, status: 'modified', staged: false, added: 1, removed: 0, ...over } as HermesReviewFile
+}
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
 }
 
 type ReviewStub = Record<string, ReturnType<typeof vi.fn>>
@@ -98,6 +111,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
@@ -172,6 +187,78 @@ describe('refreshReview', () => {
     expect($reviewIsRepo.get()).toBe(true)
     expect($reviewLoading.get()).toBe(false)
   })
+
+  it('keeps a new repository loading when the previous request rejects during the debounce gap', async () => {
+    vi.useFakeTimers()
+
+    const repoA = deferred<{ files: HermesReviewFile[] }>()
+    const repoB = deferred<{ files: HermesReviewFile[] }>()
+
+    const review = stubReview({
+      list: vi.fn((cwd: string) => (cwd === '/repo-a' ? repoA.promise : repoB.promise))
+    })
+
+    $reviewOpen.set(true)
+    $currentCwd.set('/repo-a')
+
+    const staleRefresh = refreshReview()
+    expect($reviewLoading.get()).toBe(true)
+
+    $currentCwd.set('/repo-b')
+    expect($reviewLoading.get()).toBe(true)
+
+    repoA.reject(new Error('repo A disappeared'))
+    await staleRefresh
+
+    expect($reviewLoading.get()).toBe(true)
+    expect($reviewFiles.get()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(review.list).toHaveBeenLastCalledWith('/repo-b', 'uncommitted', null)
+
+    repoB.resolve({ files: [file('b.ts')] })
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    expect($reviewFiles.get().map(entry => entry.path)).toEqual(['b.ts'])
+    expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('does not let an older list response clear a newer direct selection', async () => {
+    const pendingList = deferred<{ files: HermesReviewFile[] }>()
+    stubReview({ list: vi.fn(() => pendingList.promise), diff: vi.fn(async () => 'new diff') })
+    $reviewOpen.set(true)
+
+    const staleRefresh = refreshReview()
+    await selectReviewFile(file('b.ts'))
+
+    pendingList.resolve({ files: [file('a.ts')] })
+    await staleRefresh
+
+    expect($reviewSelectedPath.get()).toBe('b.ts')
+    expect($reviewDiff.get()).toBe('new diff')
+  })
+
+  it('does not let an older finally clear a newer in-flight refresh spinner', async () => {
+    const first = deferred<{ files: HermesReviewFile[] }>()
+    const second = deferred<{ files: HermesReviewFile[] }>()
+    let call = 0
+    stubReview({ list: vi.fn(() => (++call === 1 ? first.promise : second.promise)) })
+    $reviewOpen.set(true)
+
+    const staleRefresh = refreshReview()
+    const currentRefresh = refreshReview()
+
+    first.reject(new Error('older request failed'))
+    await staleRefresh
+    expect($reviewLoading.get()).toBe(true)
+
+    second.resolve({ files: [file('current.ts')] })
+    await currentRefresh
+
+    expect($reviewFiles.get().map(entry => entry.path)).toEqual(['current.ts'])
+    expect($reviewLoading.get()).toBe(false)
+  })
 })
 
 describe('$reviewMaxChurn', () => {
@@ -213,6 +300,25 @@ describe('selectReviewFile / clearReviewSelection', () => {
 
     expect($reviewSelectedPath.get()).toBe('a.ts')
     expect($reviewDiff.get()).toBeNull()
+  })
+
+  it('does not let an older same-path diff overwrite a newer selection request', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    let call = 0
+    stubReview({ diff: vi.fn(() => (++call === 1 ? first.promise : second.promise)) })
+
+    const staleSelection = selectReviewFile(file('a.ts'))
+    const currentSelection = selectReviewFile(file('a.ts'))
+
+    second.resolve('current diff')
+    await currentSelection
+    first.resolve('stale diff')
+    await staleSelection
+
+    expect($reviewSelectedPath.get()).toBe('a.ts')
+    expect($reviewDiff.get()).toBe('current diff')
+    expect($reviewDiffLoading.get()).toBe(false)
   })
 
   it('clears path, diff and loading', () => {
@@ -293,6 +399,27 @@ describe('view state', () => {
 
     expect($reviewScopeCwd.get()).toBe('/tile')
     expect(review.list).not.toHaveBeenCalled()
+  })
+
+  it('keeps openReviewForPath ownership when a debounced refresh was already pending', async () => {
+    vi.useFakeTimers()
+    const directList = deferred<{ files: HermesReviewFile[] }>()
+    const review = stubReview({ list: vi.fn(() => directList.promise), diff: vi.fn(async () => 'target diff') })
+    $reviewOpen.set(true)
+
+    // A repository move arms the debounce before the direct file-open intent.
+    $currentCwd.set('/repo-next')
+    const openTarget = openReviewForPath('/repo-next/target.ts')
+
+    expect(review.list).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+
+    directList.resolve({ files: [file('target.ts')] })
+    await openTarget
+
+    expect(review.list).toHaveBeenCalledTimes(1)
+    expect($reviewSelectedPath.get()).toBe('target.ts')
+    expect($reviewDiff.get()).toBe('target diff')
   })
 })
 

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -455,9 +455,10 @@ describe('view state', () => {
 
     // A repository move arms the debounce before the direct file-open intent.
     $currentCwd.set('/repo-next')
-    const openTarget = openReviewForPath('/repo-next/target.ts')
+    const openTarget = openReviewForPath('/repo-next/target.ts', '/repo-next', 'tile:project-b')
 
     expect(review.list).toHaveBeenCalledTimes(1)
+    expect($reviewScopeTarget.get()).toBe('tile:project-b')
     await vi.advanceTimersByTimeAsync(100)
 
     directList.resolve({ files: [file('target.ts')] })

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -27,6 +27,7 @@ import {
   createOrOpenPr,
   generateCommitMessage,
   openReview,
+  openReviewForPath,
   pushChanges,
   refreshReview,
   refreshShipInfo,
@@ -54,6 +55,18 @@ vi.mock('./coding-status', () => ({ refreshRepoStatus: vi.fn(), repoStatusForCwd
 
 function file(path: string, over: Partial<HermesReviewFile> = {}): HermesReviewFile {
   return { path, status: 'modified', staged: false, added: 1, removed: 0, ...over } as HermesReviewFile
+}
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
 }
 
 type ReviewStub = Record<string, ReturnType<typeof vi.fn>>
@@ -104,6 +117,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
@@ -178,6 +193,78 @@ describe('refreshReview', () => {
     expect($reviewIsRepo.get()).toBe(true)
     expect($reviewLoading.get()).toBe(false)
   })
+
+  it('keeps a new repository loading when the previous request rejects during the debounce gap', async () => {
+    vi.useFakeTimers()
+
+    const repoA = deferred<{ files: HermesReviewFile[] }>()
+    const repoB = deferred<{ files: HermesReviewFile[] }>()
+
+    const review = stubReview({
+      list: vi.fn((cwd: string) => (cwd === '/repo-a' ? repoA.promise : repoB.promise))
+    })
+
+    $reviewOpen.set(true)
+    $currentCwd.set('/repo-a')
+
+    const staleRefresh = refreshReview()
+    expect($reviewLoading.get()).toBe(true)
+
+    $currentCwd.set('/repo-b')
+    expect($reviewLoading.get()).toBe(true)
+
+    repoA.reject(new Error('repo A disappeared'))
+    await staleRefresh
+
+    expect($reviewLoading.get()).toBe(true)
+    expect($reviewFiles.get()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(review.list).toHaveBeenLastCalledWith('/repo-b', 'uncommitted', null)
+
+    repoB.resolve({ files: [file('b.ts')] })
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    expect($reviewFiles.get().map(entry => entry.path)).toEqual(['b.ts'])
+    expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('does not let an older list response clear a newer direct selection', async () => {
+    const pendingList = deferred<{ files: HermesReviewFile[] }>()
+    stubReview({ list: vi.fn(() => pendingList.promise), diff: vi.fn(async () => 'new diff') })
+    $reviewOpen.set(true)
+
+    const staleRefresh = refreshReview()
+    await selectReviewFile(file('b.ts'))
+
+    pendingList.resolve({ files: [file('a.ts')] })
+    await staleRefresh
+
+    expect($reviewSelectedPath.get()).toBe('b.ts')
+    expect($reviewDiff.get()).toBe('new diff')
+  })
+
+  it('does not let an older finally clear a newer in-flight refresh spinner', async () => {
+    const first = deferred<{ files: HermesReviewFile[] }>()
+    const second = deferred<{ files: HermesReviewFile[] }>()
+    let call = 0
+    stubReview({ list: vi.fn(() => (++call === 1 ? first.promise : second.promise)) })
+    $reviewOpen.set(true)
+
+    const staleRefresh = refreshReview()
+    const currentRefresh = refreshReview()
+
+    first.reject(new Error('older request failed'))
+    await staleRefresh
+    expect($reviewLoading.get()).toBe(true)
+
+    second.resolve({ files: [file('current.ts')] })
+    await currentRefresh
+
+    expect($reviewFiles.get().map(entry => entry.path)).toEqual(['current.ts'])
+    expect($reviewLoading.get()).toBe(false)
+  })
 })
 
 describe('$reviewMaxChurn', () => {
@@ -219,6 +306,25 @@ describe('selectReviewFile / clearReviewSelection', () => {
 
     expect($reviewSelectedPath.get()).toBe('a.ts')
     expect($reviewDiff.get()).toBeNull()
+  })
+
+  it('does not let an older same-path diff overwrite a newer selection request', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    let call = 0
+    stubReview({ diff: vi.fn(() => (++call === 1 ? first.promise : second.promise)) })
+
+    const staleSelection = selectReviewFile(file('a.ts'))
+    const currentSelection = selectReviewFile(file('a.ts'))
+
+    second.resolve('current diff')
+    await currentSelection
+    first.resolve('stale diff')
+    await staleSelection
+
+    expect($reviewSelectedPath.get()).toBe('a.ts')
+    expect($reviewDiff.get()).toBe('current diff')
+    expect($reviewDiffLoading.get()).toBe(false)
   })
 
   it('clears path, diff and loading', () => {
@@ -339,6 +445,27 @@ describe('view state', () => {
 
     expect($reviewScopeCwd.get()).toBe('/tile')
     expect(review.list).not.toHaveBeenCalled()
+  })
+
+  it('keeps openReviewForPath ownership when a debounced refresh was already pending', async () => {
+    vi.useFakeTimers()
+    const directList = deferred<{ files: HermesReviewFile[] }>()
+    const review = stubReview({ list: vi.fn(() => directList.promise), diff: vi.fn(async () => 'target diff') })
+    $reviewOpen.set(true)
+
+    // A repository move arms the debounce before the direct file-open intent.
+    $currentCwd.set('/repo-next')
+    const openTarget = openReviewForPath('/repo-next/target.ts')
+
+    expect(review.list).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+
+    directList.resolve({ files: [file('target.ts')] })
+    await openTarget
+
+    expect(review.list).toHaveBeenCalledTimes(1)
+    expect($reviewSelectedPath.get()).toBe('target.ts')
+    expect($reviewDiff.get()).toBe('target diff')
   })
 })
 

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -104,6 +104,7 @@ const repoCwd = reviewRepoCwd
 type ReviewBridge = NonNullable<NonNullable<NonNullable<Window['hermesDesktop']>['git']>['review']>
 let reviewRefreshSeq = 0
 let reviewRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let reviewSelectionSeq = 0
 let shipInfoSeq = 0
 let shipInfoLastCheckedAt = 0
 
@@ -118,22 +119,33 @@ function reviewCtx(): { cwd: string; review: ReviewBridge } | null {
 
 // ── Reads ────────────────────────────────────────────────────────────────────
 
-export async function refreshReview(): Promise<void> {
+export async function refreshReview(): Promise<boolean> {
+  // A direct refresh supersedes an already-queued debounce for the same live
+  // context. Without this, openReviewForPath() can start a list request only
+  // for the timer to overtake it before the requested file is selected.
+  if (reviewRefreshTimer) {
+    clearTimeout(reviewRefreshTimer)
+    reviewRefreshTimer = null
+  }
+
+  const intentCwd = repoCwd()
   const ctx = reviewCtx()
   const seq = (reviewRefreshSeq += 1)
+  const selectionSeq = reviewSelectionSeq
+  const ownsList = () => seq === reviewRefreshSeq && repoCwd() === intentCwd
 
   if (!$reviewOpen.get() || !ctx) {
-    $reviewFiles.set([])
-    $reviewIsRepo.set(Boolean(ctx))
+    if (ownsList()) {
+      $reviewFiles.set([])
+      $reviewIsRepo.set(Boolean(ctx))
 
-    // Critical: clear loading on the no-cwd / not-a-repo path too. It's set
-    // true (optimistically) before a refresh is scheduled, so skipping it here
-    // strands the pane on a forever-skeleton for a fresh, detached chat.
-    if (seq === reviewRefreshSeq) {
+      // Critical: clear loading on the no-cwd / not-a-repo path too. It's set
+      // true (optimistically) before a refresh is scheduled, so skipping it here
+      // strands the pane on a forever-skeleton for a fresh, detached chat.
       $reviewLoading.set(false)
     }
 
-    return
+    return ownsList()
   }
 
   const { cwd, review } = ctx
@@ -145,8 +157,8 @@ export async function refreshReview(): Promise<void> {
     const result = await review.list(cwd, 'uncommitted', null)
 
     // Ignore a result that resolved after the cwd moved on.
-    if (seq !== reviewRefreshSeq || repoCwd() !== cwd) {
-      return
+    if (!ownsList()) {
+      return false
     }
 
     // Hide dep/build/cache dirs and OS noise even when the repo tracks them —
@@ -158,20 +170,26 @@ export async function refreshReview(): Promise<void> {
     // Drop the selection if the file is gone (staged away, reverted) so the diff
     // pane doesn't strand on a ghost; otherwise lazily fetch its diff so a
     // restored (persisted) selection re-renders on boot.
-    const selected = $reviewSelectedPath.get()
-    const selectedFile = selected ? files.find(file => file.path === selected) : null
+    if (selectionSeq === reviewSelectionSeq) {
+      const selected = $reviewSelectedPath.get()
+      const selectedFile = selected ? files.find(file => file.path === selected) : null
 
-    if (selected && !selectedFile) {
-      clearReviewSelection()
-    } else if (selectedFile && $reviewDiff.get() === null) {
-      void selectReviewFile(selectedFile)
+      if (selected && !selectedFile) {
+        clearReviewSelection()
+      } else if (selectedFile && $reviewDiff.get() === null) {
+        void selectReviewFile(selectedFile)
+      }
     }
+
+    return true
   } catch {
-    if (seq === reviewRefreshSeq) {
+    if (ownsList()) {
       $reviewFiles.set([])
     }
+
+    return ownsList()
   } finally {
-    if (seq === reviewRefreshSeq) {
+    if (ownsList()) {
       $reviewLoading.set(false)
     }
   }
@@ -186,6 +204,11 @@ function scheduleReviewRefresh(): void {
     clearTimeout(reviewRefreshTimer)
   }
 
+  // Scheduling is itself a newer list intent. Invalidate in-flight work now,
+  // not when the debounce fires, so an older catch/finally cannot mutate the
+  // repository that is waiting for the timer.
+  reviewRefreshSeq += 1
+
   reviewRefreshTimer = setTimeout(() => {
     reviewRefreshTimer = null
     void refreshReview()
@@ -193,12 +216,19 @@ function scheduleReviewRefresh(): void {
 }
 
 export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
+  const seq = (reviewSelectionSeq += 1)
   $reviewSelectedPath.set(file.path)
 
+  const intentCwd = repoCwd()
   const ctx = reviewCtx()
 
+  const ownsSelection = () =>
+    seq === reviewSelectionSeq && $reviewSelectedPath.get() === file.path && repoCwd() === intentCwd
+
   if (!ctx) {
-    $reviewDiff.set(null)
+    if (ownsSelection()) {
+      $reviewDiff.set(null)
+    }
 
     return
   }
@@ -208,21 +238,22 @@ export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
   try {
     const diff = await ctx.review.diff(ctx.cwd, file.path, 'uncommitted', null, file.staged)
 
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiff.set(diff || '')
     }
   } catch {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiff.set('')
     }
   } finally {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiffLoading.set(false)
     }
   }
 }
 
 export function clearReviewSelection(): void {
+  reviewSelectionSeq += 1
   $reviewSelectedPath.set(null)
   $reviewDiff.set(null)
   $reviewDiffLoading.set(false)
@@ -367,7 +398,12 @@ export async function openReviewForPath(
   scopeTarget = 'main'
 ): Promise<void> {
   revealReview(scopeCwd, scopeTarget)
-  await refreshReview()
+  const cwd = repoCwd()
+  const refreshed = await refreshReview()
+
+  if (!refreshed || repoCwd() !== cwd) {
+    return
+  }
 
   const file = matchReviewFile($reviewFiles.get(), path)
 

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -99,6 +99,7 @@ const repoCwd = reviewRepoCwd
 type ReviewBridge = NonNullable<NonNullable<NonNullable<Window['hermesDesktop']>['git']>['review']>
 let reviewRefreshSeq = 0
 let reviewRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let reviewSelectionSeq = 0
 let shipInfoSeq = 0
 let shipInfoLastCheckedAt = 0
 
@@ -113,22 +114,33 @@ function reviewCtx(): { cwd: string; review: ReviewBridge } | null {
 
 // ── Reads ────────────────────────────────────────────────────────────────────
 
-export async function refreshReview(): Promise<void> {
+export async function refreshReview(): Promise<boolean> {
+  // A direct refresh supersedes an already-queued debounce for the same live
+  // context. Without this, openReviewForPath() can start a list request only
+  // for the timer to overtake it before the requested file is selected.
+  if (reviewRefreshTimer) {
+    clearTimeout(reviewRefreshTimer)
+    reviewRefreshTimer = null
+  }
+
+  const intentCwd = repoCwd()
   const ctx = reviewCtx()
   const seq = (reviewRefreshSeq += 1)
+  const selectionSeq = reviewSelectionSeq
+  const ownsList = () => seq === reviewRefreshSeq && repoCwd() === intentCwd
 
   if (!$reviewOpen.get() || !ctx) {
-    $reviewFiles.set([])
-    $reviewIsRepo.set(Boolean(ctx))
+    if (ownsList()) {
+      $reviewFiles.set([])
+      $reviewIsRepo.set(Boolean(ctx))
 
-    // Critical: clear loading on the no-cwd / not-a-repo path too. It's set
-    // true (optimistically) before a refresh is scheduled, so skipping it here
-    // strands the pane on a forever-skeleton for a fresh, detached chat.
-    if (seq === reviewRefreshSeq) {
+      // Critical: clear loading on the no-cwd / not-a-repo path too. It's set
+      // true (optimistically) before a refresh is scheduled, so skipping it here
+      // strands the pane on a forever-skeleton for a fresh, detached chat.
       $reviewLoading.set(false)
     }
 
-    return
+    return ownsList()
   }
 
   const { cwd, review } = ctx
@@ -140,8 +152,8 @@ export async function refreshReview(): Promise<void> {
     const result = await review.list(cwd, 'uncommitted', null)
 
     // Ignore a result that resolved after the cwd moved on.
-    if (seq !== reviewRefreshSeq || repoCwd() !== cwd) {
-      return
+    if (!ownsList()) {
+      return false
     }
 
     // Hide dep/build/cache dirs and OS noise even when the repo tracks them —
@@ -153,20 +165,26 @@ export async function refreshReview(): Promise<void> {
     // Drop the selection if the file is gone (staged away, reverted) so the diff
     // pane doesn't strand on a ghost; otherwise lazily fetch its diff so a
     // restored (persisted) selection re-renders on boot.
-    const selected = $reviewSelectedPath.get()
-    const selectedFile = selected ? files.find(file => file.path === selected) : null
+    if (selectionSeq === reviewSelectionSeq) {
+      const selected = $reviewSelectedPath.get()
+      const selectedFile = selected ? files.find(file => file.path === selected) : null
 
-    if (selected && !selectedFile) {
-      clearReviewSelection()
-    } else if (selectedFile && $reviewDiff.get() === null) {
-      void selectReviewFile(selectedFile)
+      if (selected && !selectedFile) {
+        clearReviewSelection()
+      } else if (selectedFile && $reviewDiff.get() === null) {
+        void selectReviewFile(selectedFile)
+      }
     }
+
+    return true
   } catch {
-    if (seq === reviewRefreshSeq) {
+    if (ownsList()) {
       $reviewFiles.set([])
     }
+
+    return ownsList()
   } finally {
-    if (seq === reviewRefreshSeq) {
+    if (ownsList()) {
       $reviewLoading.set(false)
     }
   }
@@ -181,6 +199,11 @@ function scheduleReviewRefresh(): void {
     clearTimeout(reviewRefreshTimer)
   }
 
+  // Scheduling is itself a newer list intent. Invalidate in-flight work now,
+  // not when the debounce fires, so an older catch/finally cannot mutate the
+  // repository that is waiting for the timer.
+  reviewRefreshSeq += 1
+
   reviewRefreshTimer = setTimeout(() => {
     reviewRefreshTimer = null
     void refreshReview()
@@ -188,12 +211,19 @@ function scheduleReviewRefresh(): void {
 }
 
 export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
+  const seq = (reviewSelectionSeq += 1)
   $reviewSelectedPath.set(file.path)
 
+  const intentCwd = repoCwd()
   const ctx = reviewCtx()
 
+  const ownsSelection = () =>
+    seq === reviewSelectionSeq && $reviewSelectedPath.get() === file.path && repoCwd() === intentCwd
+
   if (!ctx) {
-    $reviewDiff.set(null)
+    if (ownsSelection()) {
+      $reviewDiff.set(null)
+    }
 
     return
   }
@@ -203,21 +233,22 @@ export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
   try {
     const diff = await ctx.review.diff(ctx.cwd, file.path, 'uncommitted', null, file.staged)
 
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiff.set(diff || '')
     }
   } catch {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiff.set('')
     }
   } finally {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (ownsSelection()) {
       $reviewDiffLoading.set(false)
     }
   }
 }
 
 export function clearReviewSelection(): void {
+  reviewSelectionSeq += 1
   $reviewSelectedPath.set(null)
   $reviewDiff.set(null)
   $reviewDiffLoading.set(false)
@@ -347,7 +378,12 @@ function matchReviewFile(files: readonly HermesReviewFile[], path: string): Herm
  */
 export async function openReviewForPath(path: string, scopeCwd: null | string = null): Promise<void> {
   revealReview(scopeCwd)
-  await refreshReview()
+  const cwd = repoCwd()
+  const refreshed = await refreshReview()
+
+  if (!refreshed || repoCwd() !== cwd) {
+    return
+  }
 
   const file = matchReviewFile($reviewFiles.get(), path)
 


### PR DESCRIPTION
Fixes #76532

## Problem

Desktop Review used a generation only after a list request started. A repository switch could queue a debounced refresh without invalidating the old request, allowing that request's `catch` or `finally` to clear the new repository's files or loading state. Selection reconciliation was also path-only, so an older list or same-path diff could overwrite newer user intent.

The related `openReviewForPath()` path could be overtaken by an already-pending debounce: its direct list request became stale, returned before selecting the requested file, and the later request had no record of that target.

## Fix

- Invalidate active list ownership as soon as a refresh is scheduled.
- Let a direct refresh absorb a redundant pending debounce.
- Bind list success, error, loading cleanup, and selection reconciliation to both the list generation and repository cwd.
- Give Review selection/diff requests their own generation and cwd ownership, including same-path reselections.
- Stop `openReviewForPath()` when its direct refresh no longer owns the requested repository.
- Preserve current main's originating composer target while applying the ownership checks.

## Regression coverage

The deferred-promise tests cover:

- an old repository rejection during the new repository's debounce gap;
- an older list response trying to clear a newer direct selection;
- an older `finally` racing a genuinely newer in-flight refresh;
- a pending debounce overtaking `openReviewForPath()`;
- two same-path diff requests resolving in reverse order;
- the current-main composer target surviving the direct file-open path.

## Validation

- focused Review store suite: 45 passed
- complete Desktop UI suite: 5,185 passed across 550 files
- Desktop renderer, Electron, and E2E TypeScript checks: passed
- full Desktop lint: passed with no errors
- production Electron build: passed
- existing-PR publish gate, public identity/privacy checks, `git diff --check`, and gitleaks: passed

Sibling-path audit: all direct Review selection and loading writes remain inside `review.ts`; selection mutation now flows through the guarded select/clear functions, and every scheduled list trigger invalidates older ownership before its debounce.

Current head: `4bea55bc6db8cfc24d18fb8d46209d3edfcd3dd1`
