### PR TITLE
fix(agent): honor explicit api mode on fallback entries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1824,7 +1824,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        # An explicit api_mode/transport on the chain entry is the user's
+        # declared transport for that route and wins over every heuristic
+        # below.  Without this, a custom-provider entry pointing at a relay
+        # that only speaks Responses (e.g. gpt-5.x behind a local gateway)
+        # was silently downgraded to chat_completions: _provider_model_requires_responses_api()
+        # deliberately returns False for provider="custom", so the declared
+        # codex_responses mode was dropped and requests went to
+        # POST /v1/chat/completions.  Mirrors the auxiliary fallback path,
+        # which already honors entry["api_mode"] / entry["transport"].
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        _fb_declared_api_mode = _parse_api_mode(
+            fb.get("api_mode") or fb.get("transport")
+        )
+        if _fb_declared_api_mode:
+            fb_api_mode = _fb_declared_api_mode
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
             # Portal is dual-wire: anthropic/* must land on /v1/messages.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2034,32 +2034,30 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = resolve_entry_api_key(fb)
-        # Determine api_mode from the ORIGINAL base_url (before URL transformation).
-        # resolve_provider_client() calls _to_openai_base_url() which can rewrite
-        # a dual-surface /anthropic base to /v1, losing the Anthropic wire signal
-        # from the client's post-rewrite base_url. Pre-compute here so detection
-        # sees the URL the user actually configured. (#79787)
-        #
-        # An explicit ``api_mode`` on the fallback entry always wins — including
-        # an explicit "chat_completions" — and suppresses all re-detection below.
-        fb_api_mode_explicit = bool(str(fb.get("api_mode") or "").strip())
-        fb_api_mode = "chat_completions"
-        if fb_api_mode_explicit:
-            fb_api_mode = str(fb.get("api_mode")).strip()
-        elif fb_provider == "anthropic":
-            # Provider-name check must not be gated on fb_base_url_hint:
-            # an entry that names provider: anthropic without an explicit
-            # base_url uses the provider's default endpoint and must still
-            # resolve to anthropic_messages, not chat_completions.
-            fb_api_mode = "anthropic_messages"
-        elif fb_base_url_hint:
-            _orig_url = fb_base_url_hint.rstrip("/").lower()
-            if (
-                _orig_url.endswith("/anthropic")
-                or base_url_hostname(fb_base_url_hint) == "api.anthropic.com"
-            ):
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        # Parse the documented api_mode/transport aliases before client
+        # construction: the resolver may choose a specialized wrapper from
+        # this declaration, so runtime transport selection must reuse it.
+        fb_declared_api_mode = _parse_api_mode(
+            fb.get("api_mode") or fb.get("transport")
+        )
+        fb_api_mode_explicit = fb_declared_api_mode is not None
+
+        # Determine api_mode from the ORIGINAL base_url (before URL
+        # transformation). resolve_provider_client() can rewrite a dual-surface
+        # /anthropic base to /v1, losing the user's wire-format signal.
+        fb_api_mode = fb_declared_api_mode or "chat_completions"
+        if not fb_api_mode_explicit:
+            if fb_provider == "anthropic":
                 fb_api_mode = "anthropic_messages"
-        
+            elif fb_base_url_hint:
+                _orig_url = fb_base_url_hint.rstrip("/").lower()
+                if (
+                    _orig_url.endswith("/anthropic")
+                    or base_url_hostname(fb_base_url_hint) == "api.anthropic.com"
+                ):
+                    fb_api_mode = "anthropic_messages"
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
@@ -2069,8 +2067,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
-            explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint,
+            explicit_base_url=fb_base_url_hint or "",
+            explicit_api_key=fb_api_key_hint or "",
             api_mode=fb_api_mode)
         if fb_client is None:
             logger.warning(
@@ -2090,7 +2088,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         # Re-determine api_mode from provider / resolved base URL / model when
         # the pre-computed pass above landed on the default and the user did
-        # not pin api_mode explicitly. An explicit fb.api_mode (even
+        # not pin api_mode explicitly. An explicit api_mode or transport (even
         # "chat_completions") must never be overridden here.
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4874,6 +4874,86 @@ class TestFallbackAnthropicProvider:
         assert agent._use_prompt_caching is True
 
 
+class TestFallbackExplicitApiMode:
+    """An explicit api_mode on a fallback entry must win over heuristics."""
+
+    def _activate(self, agent, entry):
+        agent._fallback_activated = False
+        agent._fallback_model = entry
+        agent._fallback_chain = [entry]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = entry.get("base_url") or "https://example.invalid/v1"
+        mock_client.api_key = "test-key-1234567890"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            return agent._try_activate_fallback()
+
+    def test_custom_provider_honors_declared_codex_responses(self, agent):
+        """provider=custom + gpt-5.x must not be downgraded to chat_completions.
+
+        ``_provider_model_requires_responses_api`` returns False for
+        provider="custom" on purpose, so without honoring the declared
+        api_mode the request lands on POST /v1/chat/completions.
+        """
+        result = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "api_mode": "codex_responses",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+
+    def test_transport_alias_is_accepted(self, agent):
+        result = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "transport": "codex_responses",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+
+    def test_declared_chat_completions_overrides_openai_url_heuristic(self, agent):
+        """A relay on api.openai.com that only speaks chat completions."""
+        result = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        })
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+
+    def test_invalid_api_mode_falls_back_to_autodetection(self, agent):
+        result = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "not-a-real-mode",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+
+    def test_no_declared_api_mode_keeps_existing_behavior(self, agent):
+        result = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+        })
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5333,6 +5333,92 @@ class TestFallbackAnthropicProvider:
         assert agent._use_prompt_caching is True
 
 
+class TestFallbackExplicitApiMode:
+    """An explicit api_mode on a fallback entry must win over heuristics."""
+
+    def _activate(self, agent, entry):
+        agent._fallback_activated = False
+        agent._fallback_model = entry
+        agent._fallback_chain = [entry]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = entry.get("base_url") or "https://example.invalid/v1"
+        mock_client.api_key = "test-key-1234567890"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ) as mock_resolve:
+            result = agent._try_activate_fallback()
+        return result, mock_resolve
+
+    def test_custom_provider_honors_declared_codex_responses(self, agent):
+        """provider=custom + gpt-5.x must not be downgraded to chat_completions.
+
+        ``_provider_model_requires_responses_api`` returns False for
+        provider="custom" on purpose, so without honoring the declared
+        api_mode the request lands on POST /v1/chat/completions.
+        """
+        result, resolve = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "api_mode": "codex_responses",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+        assert resolve.call_args.kwargs["api_mode"] == "codex_responses"
+
+    def test_transport_alias_is_accepted(self, agent):
+        result, resolve = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "transport": "codex_responses",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+        assert resolve.call_args.kwargs["api_mode"] == "codex_responses"
+
+    def test_declared_chat_completions_overrides_openai_url_heuristic(self, agent):
+        """A relay on api.openai.com that only speaks chat completions."""
+        result, resolve = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        })
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+        assert resolve.call_args.kwargs["api_mode"] == "chat_completions"
+
+    def test_invalid_api_mode_falls_back_to_autodetection(self, agent):
+        result, resolve = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "not-a-real-mode",
+        })
+
+        assert result is True
+        assert agent.api_mode == "codex_responses"
+        assert resolve.call_args.kwargs["api_mode"] == "chat_completions"
+
+    def test_no_declared_api_mode_keeps_existing_behavior(self, agent):
+        result, resolve = self._activate(agent, {
+            "provider": "custom",
+            "model": "gpt-5.6-sol",
+            "base_url": "http://127.0.0.1:3000/v1",
+        })
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+        assert resolve.call_args.kwargs["api_mode"] == "chat_completions"
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (


### PR DESCRIPTION
## Summary

Honor an explicitly configured `api_mode` (or its `transport` alias) when the main agent activates a fallback provider. Explicit configuration now takes precedence over provider/URL/model heuristics, matching the existing auxiliary fallback behavior.

## Bug

A fallback entry such as:

```yaml
fallback_providers:
  - provider: custom
    model: gpt-5.6-sol
    base_url: http://127.0.0.1:3000/v1
    api_mode: codex_responses
```

was activated with `agent.api_mode == "chat_completions"`, causing requests to be sent to `POST /v1/chat/completions` instead of `POST /v1/responses`.

The main fallback path discarded the entry-level transport declaration and recomputed the mode from heuristics. Since `_provider_model_requires_responses_api()` deliberately returns `False` for generic `custom` providers, the configured Responses route was silently downgraded.

## Fix

- Parse `api_mode` / `transport` with the shared `_parse_api_mode()` validator.
- Use a valid explicit mode before running automatic provider/URL/model detection.
- Preserve existing auto-detection for omitted or invalid values.

## Tests

Added regression coverage for:

- `custom` + GPT-5.6 + explicit `codex_responses`
- the `transport` alias
- explicit `chat_completions` overriding URL heuristics
- invalid mode falling back to auto-detection
- unchanged behavior when no mode is declared

Validation:

```text
7 passed, 227 deselected
```

The full `test_run_agent.py` run currently has 3 unrelated baseline failures in this checkout because the optional `openai` module is unavailable; the same three fail with this change stashed.