### PR TITLE
fix(cron): report completed one-shot manual runs

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -32,6 +32,35 @@ class TestCronjobRunExecutesImmediately:
         m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
         m_run.assert_called_once()                       # fired via the shared body
 
+    def test_run_reports_success_when_completed_oneshot_self_deletes(self):
+        """A successful finite one-shot is removed before the tool re-reads it.
+
+        The execution ledger remains authoritative after the job row is gone.
+        """
+        oneshot = {
+            **_JOB,
+            "schedule": {"kind": "once", "at": "2026-08-02T17:13:53+07:00"},
+            "repeat": {"times": 1, "completed": 0},
+        }
+        completed = {
+            "job_id": "job-run-1",
+            "status": "completed",
+            "error": None,
+        }
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=oneshot), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value=None), \
+             patch("cron.executions.latest_execution", return_value=completed):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is True
+        assert out["job"]["name"] == "manual run"
+        assert out["job"]["repeat"] == "once"
+        assert "execution_error" not in out["job"]
+
     def test_run_reconciles_external_provider_after_claimed_execution(self):
         """A direct run must re-arm Chronos after it advances next_run_at.
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -597,12 +597,23 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
         processed = run_one_job(job)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
+        refreshed = get_job(job_id)
+        if refreshed is not None:
+            ok = refreshed.get("last_status") == "ok"
+            run_error = refreshed.get("last_error")
+        else:
+            # Finite one-shots delete their job row in mark_job_run() after a
+            # completed dispatch.  The durable execution ledger remains the
+            # authoritative result once that row is gone.
+            from cron.executions import latest_execution
+
+            execution = latest_execution(job_id) or {}
+            ok = execution.get("status") == "completed"
+            run_error = execution.get("error")
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": run_error,
         }
 
     except Exception as e:
@@ -807,7 +818,9 @@ def cronjob(
             if exec_result.get("claimed", False):
                 _notify_provider_jobs_changed_safe()
             # Re-read so the response reflects the post-run last_run_at/last_status.
-            result = _format_job(get_job(job_id) or {"id": job_id})
+            # A successful finite one-shot self-deletes during mark_job_run().
+            # Preserve its original metadata in the manual-run response.
+            result = _format_job(get_job(str(job_id)) or job)
             result["executed"] = exec_result.get("claimed", False)
             result["execution_success"] = exec_result.get("success", False)
             if not exec_result.get("claimed", False):


### PR DESCRIPTION
## Summary

Fix `cronjob(action="run")` reporting `execution_success=false` after a successful finite one-shot run.

A finite one-shot removes its job row in `mark_job_run()` after completion. The manual-run path then re-read the deleted job, treated the missing `last_status` as failure, and formatted the response from an empty placeholder. This produced a false failure plus incorrect metadata (`name=<job id>`, `deliver=local`, `repeat=forever`) even though delivery had succeeded.

## Fix

- When the job row still exists, preserve the current `last_status` behavior.
- When a completed one-shot has removed its job row, read the durable execution ledger via `latest_execution(job_id)`.
- Preserve the original job metadata when formatting the post-run response.
- Add a focused regression test for the self-deleting one-shot case.

## Reproduction evidence

Observed on a `no_agent=True` one-shot delivered to Telegram:

- Scheduler log: delivery succeeded.
- Cron output artifact: expected non-empty payload was saved.
- Manual `cronjob(action="run")` response: `executed=true`, but incorrectly returned `execution_success=false` and fallback metadata.

No credentials or message payloads are included in this PR.

## Verification

- Focused regression demonstrated the original assertion failure.
- All 8 methods in `TestCronjobRunExecutesImmediately` pass after the fix.
- `python -m py_compile` passes for both changed files.
- `git diff --check` passes.

The production checkout does not include pytest, so the test methods were also executed directly using their existing `unittest.mock` seams. Upstream CI should run the normal pytest suite.

## Scope

Only these files are changed:

- `tools/cronjob_tools.py`
- `tests/tools/test_cronjob_run_immediate.py`
