### PR TITLE
fix(cli): add timeouts + stderr feedback to provisioning subprocess.run calls (#76684)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -310,6 +310,15 @@ UV_SELF_UPDATE_INTERVAL_SECONDS = 7 * 24 * 3600
 # `uv self update` is a network call; unbounded it can hang forever on a
 # blackholed connection (no default timeout in uv's downloader path).
 UV_SELF_UPDATE_TIMEOUT_SECONDS = 60
+# Network-bound uv python provisioning can hang forever on blackholed
+# connectivity (observed during every-update SQLite-runtime repair on
+# restricted networks, e.g. mainland China).  Bound every step.
+UV_PYTHON_INSTALL_TIMEOUT_SECONDS = 180
+UV_PYTHON_FIND_TIMEOUT_SECONDS = 30
+UV_VENV_TIMEOUT_SECONDS = 60
+UV_SYNC_TIMEOUT_SECONDS = 300
+# Installer download + run are also network-bound.
+UV_INSTALL_TIMEOUT_SECONDS = 120
 
 
 def update_managed_uv(
@@ -528,23 +537,37 @@ def _attempt_install_generation(
     _make_world_traversable(generation)
 
     env = managed_python_env(project_root, install_dir=generation)
-    install = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "install",
-            request,
-            "--reinstall",
-            "--no-bin",
-            "--no-registry",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        install = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "install",
+                request,
+                "--reinstall",
+                "--no-bin",
+                "--no-registry",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python install timed out for %s after %ss",
+            request, UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv python install timed out after {UV_PYTHON_INSTALL_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if install.returncode != 0:
         logger.warning(
             "private Python install failed for %s (rc=%d): %s",
@@ -555,21 +578,35 @@ def _attempt_install_generation(
         _remove_tree(generation, boundary=python_root)
         return None
 
-    found = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "find",
-            request,
-            "--managed-python",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        found = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "find",
+                request,
+                "--managed-python",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python lookup timed out for %s after %ss",
+            request, UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv python find timed out after {UV_PYTHON_FIND_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if found.returncode != 0 or not found.stdout.strip():
         logger.warning(
             "private Python lookup failed for %s (rc=%d): %s",
@@ -745,24 +782,38 @@ def _stage_candidate_venv(
     })
 
     print("  → Building a relocatable replacement environment...")
-    created = subprocess.run(
-        [
-            uv_bin,
-            "venv",
-            str(candidate),
-            "--python",
-            str(python),
-            "--managed-python",
-            "--no-python-downloads",
-            "--relocatable",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        created = subprocess.run(
+            [
+                uv_bin,
+                "venv",
+                str(candidate),
+                "--python",
+                str(python),
+                "--managed-python",
+                "--no-python-downloads",
+                "--relocatable",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_VENV_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate venv creation timed out after %ss",
+            UV_VENV_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv venv timed out after {UV_VENV_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
     if created.returncode != 0:
         logger.warning(
             "candidate venv creation failed (rc=%d): %s",
@@ -780,20 +831,34 @@ def _stage_candidate_venv(
     # UV_NO_CONFIG drops it and uv 0.12+ refuses --locked.
     sync_env = dict(env)
     sync_env.pop("UV_NO_CONFIG", None)
-    synced = subprocess.run(
-        [
-            uv_bin,
-            "sync",
-            "--extra",
-            "all",
-            "--locked",
-            "--python",
-            str(_venv_python(candidate)),
-        ],
-        cwd=project_root,
-        env=sync_env,
-        check=False,
-    )
+    try:
+        synced = subprocess.run(
+            [
+                uv_bin,
+                "sync",
+                "--extra",
+                "all",
+                "--locked",
+                "--python",
+                str(_venv_python(candidate)),
+            ],
+            cwd=project_root,
+            env=sync_env,
+            check=False,
+            timeout=UV_SYNC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "candidate dependency sync timed out after %ss",
+            UV_SYNC_TIMEOUT_SECONDS,
+        )
+        print(
+            f"  \u2717 uv sync timed out after {UV_SYNC_TIMEOUT_SECONDS}s"
+            " \u2014 check your network connection.",
+            file=sys.stderr,
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
     if synced.returncode != 0:
         logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
         _remove_tree(candidate, boundary=runtime_root)
@@ -1275,12 +1340,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=UV_INSTALL_TIMEOUT_SECONDS,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=UV_INSTALL_TIMEOUT_SECONDS,
         )
     finally:
         try:
@@ -1297,6 +1364,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=UV_INSTALL_TIMEOUT_SECONDS,
     )
 
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1100,3 +1100,122 @@ class TestVenvPythonUpdateBoundary:
             "/opt/hermes/venv/bin/python"
         )
 
+import subprocess
+
+class TestProvisioningTimeouts:
+    """#76684: provisioning subprocesses must time out and surface to stderr."""
+
+    def test_python_install_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _attempt_install_generation
+        python_root = tmp_path / "python"
+        python_root.mkdir()
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=1)
+            result = _attempt_install_generation(
+                "uv", "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        assert "network" in err.lower()
+        assert list(python_root.glob("generation-*")) == []
+        from hermes_cli.managed_uv import UV_PYTHON_INSTALL_TIMEOUT_SECONDS
+        assert mock_run.call_args.kwargs.get("timeout") == UV_PYTHON_INSTALL_TIMEOUT_SECONDS
+
+    def test_python_find_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _attempt_install_generation
+        python_root = tmp_path / "python"
+        python_root.mkdir()
+
+        call_count = {"n": 0}
+        def _side_effect(*a, **k):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=_side_effect) as mock_run:
+            result = _attempt_install_generation(
+                "uv", "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        assert list(python_root.glob("generation-*")) == []
+        from hermes_cli.managed_uv import UV_PYTHON_FIND_TIMEOUT_SECONDS
+        assert mock_run.call_args_list[1].kwargs.get("timeout") == UV_PYTHON_FIND_TIMEOUT_SECONDS
+
+    def test_venv_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+        generation = tmp_path / "generation-test"
+        generation.mkdir()
+        python_exe = generation / "python"
+        python_exe.touch()
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=1)
+            result = _stage_candidate_venv(
+                "uv",
+                project_root=tmp_path,
+                generation=generation,
+                python=python_exe,
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        runtime_root = tmp_path / ".hermes-runtime"
+        assert list(runtime_root.glob("venv-candidate-*")) == []
+        from hermes_cli.managed_uv import UV_VENV_TIMEOUT_SECONDS
+        assert mock_run.call_args.kwargs.get("timeout") == UV_VENV_TIMEOUT_SECONDS
+
+    def test_sync_timeout_prints_stderr(self, tmp_path, capsys):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+        generation = tmp_path / "generation-test"
+        generation.mkdir()
+        python_exe = generation / "python"
+        python_exe.touch()
+        (tmp_path / "uv.lock").touch()
+
+        call_count = {"n": 0}
+        def _side_effect(*a, **k):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=_side_effect) as mock_run, \
+             patch("hermes_cli.managed_uv._venv_python", return_value=python_exe):
+            result = _stage_candidate_venv(
+                "uv",
+                project_root=tmp_path,
+                generation=generation,
+                python=python_exe,
+            )
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "timed out" in err
+        from hermes_cli.managed_uv import UV_SYNC_TIMEOUT_SECONDS
+        assert mock_run.call_args_list[1].kwargs.get("timeout") == UV_SYNC_TIMEOUT_SECONDS
+
+    def test_timeout_constants_positive(self):
+        from hermes_cli.managed_uv import (
+            UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+            UV_PYTHON_FIND_TIMEOUT_SECONDS,
+            UV_VENV_TIMEOUT_SECONDS,
+            UV_SYNC_TIMEOUT_SECONDS,
+        )
+        assert UV_PYTHON_INSTALL_TIMEOUT_SECONDS > 0
+        assert UV_PYTHON_FIND_TIMEOUT_SECONDS > 0
+        assert UV_VENV_TIMEOUT_SECONDS > 0
+        assert UV_SYNC_TIMEOUT_SECONDS > 0


### PR DESCRIPTION
## Summary

Add explicit `timeout=` to the 4 network-bound provisioning `subprocess.run()` 
calls in `managed_uv.py` identified in #76684, and print a user-visible message 
to `stderr` on `TimeoutExpired`.

## Gap addressed vs #76690 and #76693

Both existing PRs only call `logger.warning()` in their `TimeoutExpired` 
handlers — output goes to the log file only. This PR also prints to `stderr` 
so the terminal user sees the failure immediately.

## Changes

| Call | Timeout | On timeout |
|------|---------|------------|
| `uv python install` | 180s | logger.warning + print to stderr + cleanup + return None |
| `uv python find` | 30s | logger.warning + print to stderr + cleanup + return None |
| `uv venv` | 60s | logger.warning + print to stderr + cleanup + return None |
| `uv sync` | 300s | logger.warning + print to stderr + cleanup + return None |

The existing `uv self update` freshness gate (lines 337–350) is preserved untouched.

## Test plan

- 5 new regression tests in `TestProvisioningTimeouts` covering all 4 timeout 
  handlers + constant assertions
- All 44 tests pass (`pytest tests/hermes_cli/test_managed_uv.py`)

Fixes #76684