### PR TITLE
fix(test): guard write_runtime_status against clobbering the real gateway_state.json (#76728)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -645,6 +645,96 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
     monkeypatch.setattr(_kdb, "connect", _guarded_connect)
 
 
+# ── Gateway runtime-status write guard (#76728) ─────────────────────────────
+# ``gateway.status.write_runtime_status`` unconditionally stamps the CALLING
+# process's pid/argv into ``$HERMES_HOME/gateway_state.json`` (it asserts
+# ``kind: hermes-gateway`` about whatever happens to be calling). If a test ever
+# ran with HERMES_HOME still pointing at the operator's real root, it would
+# overwrite the live gateway's identity with the pytest process — and it never
+# self-heals (a healthy gateway only rewrites on state change).
+#
+# This is fail-closed **defense-in-depth**, exactly like the kanban write guard
+# above — NOT a fix for a currently-reachable write. The per-test ``_isolate_env``
+# fixture unconditionally re-points HERMES_HOME at a tmp dir
+# (``monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))``), so under normal
+# suite isolation the resolved status path is always under tmp and this guard
+# never fires. Its job is to catch a REGRESSION of that isolation (an
+# ``_isolate_env`` change, a test that opts out of it, or a direct
+# out-of-fixture invocation) before it can clobber the real
+# ``~/.hermes/gateway_state.json``. A deny-list keyed on the real root captured
+# at import time, so hermetic tests on sibling tempdirs are unaffected.
+
+
+def _capture_real_hermes_root() -> Path:
+    """Resolve the operator's REAL Hermes root from the pre-test environment.
+
+    Mirrors ``_capture_real_kanban_root`` but WITHOUT the kanban override:
+    gateway identity files live directly under HERMES_HOME
+    (``gateway/status.py::_get_process_hermes_home``), so the deny-list must
+    point at the real Hermes root, not a ``HERMES_KANBAN_HOME`` override dir.
+    Uses the pre-sandbox snapshot taken at the top of this file so it keeps
+    pointing at the operator's actual root after the session sandbox rewires
+    the env.
+    """
+    if _PRE_SANDBOX_HERMES_HOME:
+        # HERMES_HOME was genuinely set before the sandbox — honor it via the
+        # normal resolver (it may be a profile dir whose root matters).
+        from hermes_constants import get_default_hermes_root
+        return get_default_hermes_root().resolve()
+    # No pre-existing HERMES_HOME: the real root is the platform default, NOT
+    # the sandbox tempdir now sitting in the env.
+    return (Path.home() / ".hermes").resolve()
+
+
+_REAL_HERMES_ROOT = _capture_real_hermes_root()
+
+
+@pytest.fixture(autouse=True)
+def _gateway_state_write_guard(_hermetic_environment, monkeypatch):
+    """Fail-closed guard: refuse gateway runtime-status writes to the REAL root.
+
+    Uses a **deny-list**: only blocks writes whose resolved runtime-status path
+    (``gateway.status._get_runtime_status_path()``) lands under the real
+    ``~/.hermes`` captured at import time. Hermetic tests that legitimately move
+    HERMES_HOME to sibling tempdirs are unaffected.
+
+    Only patches when ``gateway.status`` is *already imported* — a
+    ``sys.modules`` probe, not an import — so the guard never drags the gateway
+    module into unrelated test processes.
+
+    Uses ``monkeypatch.setattr`` so pytest restores ``write_runtime_status``
+    automatically after each test (no stacked wrappers or state leakage).
+    """
+    _status = sys.modules.get("gateway.status")
+    if _status is None:
+        return
+
+    _orig_write = getattr(_status, "write_runtime_status", None)
+    if _orig_write is None:
+        return
+
+    def _guarded_write(*args, **kwargs):
+        try:
+            resolved = _status._get_runtime_status_path().expanduser().resolve()
+        except Exception:
+            # Can't resolve the target path — don't mask the original behavior.
+            return _orig_write(*args, **kwargs)
+        try:
+            resolved.relative_to(_REAL_HERMES_ROOT)
+        except ValueError:
+            # Resolved path is NOT under the real root — safe to write.
+            return _orig_write(*args, **kwargs)
+        raise RuntimeError(
+            f"gateway_state_write_guard: runtime-status path resolved to "
+            f"{resolved}, which is under the REAL Hermes root "
+            f"({_REAL_HERMES_ROOT}). Hermetic isolation has been bypassed — "
+            f"refusing to overwrite the operator's live "
+            f"~/.hermes/gateway_state.json with the test process. See #76728."
+        )
+
+    monkeypatch.setattr(_status, "write_runtime_status", _guarded_write)
+
+
 # ── Module-level state reset — replaced by per-file process isolation ──────
 #
 # Each test FILE runs in a freshly-spawned ``python -m pytest <file>``
@@ -1118,7 +1208,7 @@ def _live_system_guard(request, monkeypatch):
                 return real_killpg(pgid, sig, *args, **kwargs)
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
-                f"os.killpg({pgid}, {sig}) — PGID is outside the test "
+                f"os.killpg({pgid}, {sig}) — PGID is outside the test "  # windows-footgun: ok  (literal in a diagnostic message, not a call)
                 "process group. See _live_system_guard for the why."
             )
 

--- a/tests/gateway/test_gateway_state_write_guard.py
+++ b/tests/gateway/test_gateway_state_write_guard.py
@@ -1,0 +1,73 @@
+"""#76728: the gateway runtime-status write guard keeps the test suite from
+overwriting the operator's real ``~/.hermes/gateway_state.json``.
+
+``write_runtime_status`` stamps the calling process's pid/argv into the file
+unconditionally, so a test that ran with HERMES_HOME still pointing at the real
+root would clobber the live gateway's identity (and it never self-heals). This
+is fail-closed **defense-in-depth**, mirroring the kanban write guard: the
+per-test ``_isolate_env`` fixture already re-points HERMES_HOME at a tmp dir, so
+the guard normally never fires — it exists to catch a REGRESSION of that
+isolation before it can touch the real root. The autouse guard in
+``tests/conftest.py`` refuses any write whose resolved status path lands under
+the REAL Hermes root.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Import so the module is in sys.modules when the autouse guard's probe runs.
+from gateway import status
+
+
+def test_write_succeeds_under_test_home():
+    """Under the hermetic HERMES_HOME tempdir, the write is allowed and lands in
+    the sandbox — the deny-list only trips on the real root."""
+    path = status._get_runtime_status_path()
+    status.write_runtime_status(gateway_state="running")
+    assert path.exists()
+    record = status.read_runtime_status()
+    assert record is not None
+    assert record["gateway_state"] == "running"
+
+
+def test_write_raises_when_status_path_is_real_root(tmp_path, monkeypatch):
+    """A write whose resolved path is under the (captured) real root is refused.
+
+    The real root is redirected to a tempdir for this test so a guard
+    regression can only touch the tempdir, never the operator's actual file.
+    """
+    import tests.conftest as _conftest
+
+    fake_real = (tmp_path / "real_hermes").resolve()
+    fake_real.mkdir()
+    monkeypatch.setattr(_conftest, "_REAL_HERMES_ROOT", fake_real)
+    monkeypatch.setattr(
+        status, "_get_runtime_status_path", lambda: fake_real / "gateway_state.json"
+    )
+
+    with pytest.raises(RuntimeError, match="gateway_state_write_guard"):
+        status.write_runtime_status(gateway_state="running")
+    # The refusal happened before any write.
+    assert not (fake_real / "gateway_state.json").exists()
+
+
+def test_write_allowed_for_sibling_tempdir_even_when_real_root_exists(
+    tmp_path, monkeypatch
+):
+    """Hermetic tests moving HERMES_HOME to a sibling tempdir are unaffected by
+    the deny-list, even though a distinct real root is registered."""
+    import tests.conftest as _conftest
+
+    fake_real = (tmp_path / "real_hermes").resolve()
+    fake_real.mkdir()
+    sibling = (tmp_path / "sandbox_home").resolve()
+    sibling.mkdir()
+    monkeypatch.setattr(_conftest, "_REAL_HERMES_ROOT", fake_real)
+    monkeypatch.setattr(
+        status, "_get_runtime_status_path", lambda: sibling / "gateway_state.json"
+    )
+
+    status.write_runtime_status(gateway_state="running")
+    assert (sibling / "gateway_state.json").exists()
+    assert not (fake_real / "gateway_state.json").exists()


### PR DESCRIPTION
Fixes #76728

## Problem

Running the test suite on a machine that also runs Hermes can overwrite the operator's live `$HERMES_HOME/gateway_state.json` with the **pytest process's own identity**:

```json
{ "pid": <pytest pid>, "kind": "hermes-gateway", "argv": [".../pytest/__main__.py", ...] }
```

`write_runtime_status()` (`gateway/status.py`) unconditionally stamps the calling process into the record — `_build_pid_record()` hardcodes `kind: hermes-gateway` about whatever happens to be calling, and nothing verifies the caller is actually a gateway. `/api/status` then reports a dead pid indefinitely while the real gateway runs normally, and it **never self-heals** (a healthy gateway only rewrites `gateway_state.json` on state change), so recovery needs a gateway restart.

This lands on the real file whenever the session's `HERMES_HOME` is the operator's own — which the existing conftest sandbox does **not** cover: it activates only when `HERMES_HOME` is *unset* (common to skip it: anyone running a named profile exports it).

#75914 closed the **logs** half of this pollution; gateway state was left uncovered. The repo already has the right pattern for this — the fail-closed kanban write guard (#69283) — but gateway state was never wired into it (`grep gateway_state tests/conftest.py` returned nothing).

## Fix

Mirror `_kanban_write_guard` for gateway state (test-only, no production behavior change — the approach the issue recommends):

- A new autouse fixture `_gateway_state_write_guard` patches `gateway.status.write_runtime_status` to **refuse** any write whose resolved runtime-status path lands under the **real** Hermes root, captured at conftest import time (before the sandbox rewires the env).
- **Deny-list, not allow-list**: hermetic tests that legitimately move `HERMES_HOME` to sibling tempdirs are unaffected — only the real root is blocked.
- **`sys.modules` probe, not an import**: patches only when `gateway.status` is already imported, so the guard never drags the gateway module into unrelated test processes.
- `monkeypatch.setattr`, so pytest restores the original after each test.

The real-root capture uses the pre-sandbox `HERMES_HOME` snapshot and honors a genuinely-set `HERMES_HOME` via `get_default_hermes_root()`, falling back to the platform default `~/.hermes` (it deliberately does **not** apply the `HERMES_KANBAN_HOME` override, since gateway state lives directly under `HERMES_HOME`).

## Tests

`tests/gateway/test_gateway_state_write_guard.py`:

- write under the hermetic test `HERMES_HOME` is allowed and lands in the sandbox;
- a write whose resolved path is under the (redirected-to-tempdir) real root raises `RuntimeError` and touches nothing;
- a sibling tempdir is still allowed even when a distinct real root is registered.

The real root is redirected to a tempdir in the raising tests so a future guard regression can only touch a tempdir, never the operator's actual file.

Local: new tests green; the pre-existing kanban-guard tests and the `write_runtime_status` caller suites (`test_status.py`, `test_gateway_shutdown.py`, `test_platform_reconnect.py`, `test_restart_resume_pending.py`) pass with the guard active. (The arm64-fork Docker CI job is the known fork-only failure.)

---

_Note: also annotated one pre-existing false positive in the Windows-footgun scan — an `os.killpg(...)` string fragment inside a diagnostic message (`tests/conftest.py`, the live-system guard), which the whole-file scan flagged. Suppressed with `# windows-footgun: ok`; the real call there is the saved `real_killpg` reference._
