### PR TITLE
fix(desktop): count calendar days for the relative next-run label (#76725)

### DIFF
--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { calendarBucket, DAY, formatAgo, HOUR, MINUTE, nominalDayStart, SECOND, sessionBucketLabel } from './time'
+import { calendarBucket, DAY, formatAgo, HOUR, MINUTE, nominalDayStart, relativeDayCount, relativeTime, SECOND, sessionBucketLabel } from './time'
 
 const labels = {
   ageNow: 'now',
@@ -120,5 +120,37 @@ describe('sessionBucketLabel', () => {
     // en-US default in the test env: month name, plus year for the prior year.
     expect(labelAt(2026, 2, 3)).toBe('March')
     expect(labelAt(2025, 11, 3)).toBe('December 2025')
+  })
+})
+
+describe('relativeDayCount', () => {
+  // Build local-time instants so the assertions are timezone-independent:
+  // both relativeDayCount and its Date(...).setHours use local time.
+  const at = (year: number, month: number, day: number, hour = 0) =>
+    new Date(year, month, day, hour).getTime()
+
+  it('counts calendar-date changes, not 24h buckets', () => {
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 3, 10))).toBe(1)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 4, 2))).toBe(2)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 1, 23))).toBe(-1)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 2, 23))).toBe(0)
+  })
+
+  it('#76725: an evening "now" to an early target two dates out is 2, not 1', () => {
+    // Aug 2 20:00 -> Aug 4 02:00 is ~30h (rounds to 1 by 24h buckets) but two
+    // calendar dates away — the */3 schedule case from the issue.
+    expect(relativeDayCount(at(2026, 7, 2, 20), at(2026, 7, 4, 2))).toBe(2)
+  })
+})
+
+describe('relativeTime day-word (#76725)', () => {
+  const at = (year: number, month: number, day: number, hour = 0) =>
+    new Date(year, month, day, hour).getTime()
+
+  it('does not label a two-calendar-day-out run the same as a genuine next-day run', () => {
+    const nextDay = relativeTime(at(2026, 7, 3, 10), at(2026, 7, 2, 10)) // real "tomorrow"
+    const twoDaysOut = relativeTime(at(2026, 7, 4, 2), at(2026, 7, 2, 20)) // #76725 repro
+    // Before the fix both rounded to 1 day and read identically ("tomorrow").
+    expect(twoDaysOut).not.toBe(nextDay)
   })
 })

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -9,6 +9,8 @@ import {
   HOUR,
   MINUTE,
   nominalDayStart,
+  relativeDayCount,
+  relativeTime,
   SECOND,
   sessionBucketLabel
 } from './time'
@@ -147,5 +149,37 @@ describe('sessionBucketLabel', () => {
     }
 
     expect(sessionBucketLabel(monthYearBucket, labels)).toBe(fmtMonthYear.format(monthYearBucket.at))
+  })
+})
+
+describe('relativeDayCount', () => {
+  // Build local-time instants so the assertions are timezone-independent:
+  // both relativeDayCount and its Date(...).setHours use local time.
+  const at = (year: number, month: number, day: number, hour = 0) =>
+    new Date(year, month, day, hour).getTime()
+
+  it('counts calendar-date changes, not 24h buckets', () => {
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 3, 10))).toBe(1)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 4, 2))).toBe(2)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 1, 23))).toBe(-1)
+    expect(relativeDayCount(at(2026, 7, 2, 10), at(2026, 7, 2, 23))).toBe(0)
+  })
+
+  it('#76725: an evening "now" to an early target two dates out is 2, not 1', () => {
+    // Aug 2 20:00 -> Aug 4 02:00 is ~30h (rounds to 1 by 24h buckets) but two
+    // calendar dates away — the */3 schedule case from the issue.
+    expect(relativeDayCount(at(2026, 7, 2, 20), at(2026, 7, 4, 2))).toBe(2)
+  })
+})
+
+describe('relativeTime day-word (#76725)', () => {
+  const at = (year: number, month: number, day: number, hour = 0) =>
+    new Date(year, month, day, hour).getTime()
+
+  it('does not label a two-calendar-day-out run the same as a genuine next-day run', () => {
+    const nextDay = relativeTime(at(2026, 7, 3, 10), at(2026, 7, 2, 10)) // real "tomorrow"
+    const twoDaysOut = relativeTime(at(2026, 7, 4, 2), at(2026, 7, 2, 20)) // #76725 repro
+    // Before the fix both rounded to 1 day and read identically ("tomorrow").
+    expect(twoDaysOut).not.toBe(nextDay)
   })
 })

--- a/apps/desktop/src/lib/time.ts
+++ b/apps/desktop/src/lib/time.ts
@@ -33,6 +33,10 @@ export const fmtMonthYear = new Intl.DateTimeFormat(undefined, { month: 'long', 
 // ── Relative time ──────────────────────────────────────────────────────────
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'short' })
 
+// Whole calendar days from `nowMs` to `targetMs` in local time (negative for the
+// past). Compares local midnights via DST-safe Date field math, so the result is
+// the number of date changes between the two instants — NOT the raw span rounded
+// to 24 h buckets.
 // Localized bidirectional "in 5 min" / "2 hr ago" — coarsest sensible unit so a
 // daily job reads "in 14 hr", not "in 840 min".
 export function relativeTime(targetMs: number, nowMs = Date.now()): string {
@@ -52,7 +56,14 @@ export function relativeTime(targetMs: number, nowMs = Date.now()): string {
     return rtf.format(sign * Math.round(abs / HOUR), 'hour')
   }
 
-  return rtf.format(sign * Math.round(abs / DAY), 'day')
+  // At day granularity, numeric:'auto' renders ±1/0 as the calendar words
+  // "tomorrow"/"yesterday"/"today", which a reader interprets as CALENDAR days.
+  // Rounding the raw span by 24 h buckets (Math.round(abs / DAY)) mislabels a
+  // target that is two calendar dates away but only ~30 h out — it crosses two
+  // local midnights yet rounds to 1, so `numeric:'auto'` prints "tomorrow" for a
+  // date that is actually two days from now (#76725). Count whole calendar days
+  // between the local dates instead so the word matches the date shown alongside.
+  return rtf.format(relativeDayCount(nowMs, targetMs), 'day')
 }
 
 // A dated divider bucket below the sidebar's unlabelled "recent" head cluster
@@ -82,6 +93,13 @@ export const startOfLocalDay = (ms: number): number => {
   const d = new Date(ms)
 
   return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+}
+
+// Whole calendar days between the local dates of two instants (sign: target
+// relative to now). Reuses startOfLocalDay so local-midnight semantics stay
+// centralized in one helper.
+export function relativeDayCount(nowMs: number, targetMs: number): number {
+  return Math.round((startOfLocalDay(targetMs) - startOfLocalDay(nowMs)) / DAY)
 }
 
 // The human day doesn't end at midnight — it ends when you sleep. Sessions


### PR DESCRIPTION
Fixes #76725

## Problem

On the Cronjobs page, a job whose next run is **two calendar dates** away is labelled **"tomorrow"**. Repro from the issue — a `0 2 */3 * *` job (every 3 days at 02:00):

- ✅ `Next run: Aug 4, 2:00 AM` — correct (absolute, from `next_run_at`)
- ❌ `tomorrow` — wrong (today is 8/2, so "tomorrow" reads as 8/3, but the run is 8/4)

## Root cause

The desktop sidebar renders the relative label via `relativeTime()` (`apps/desktop/src/lib/time.ts`), used at `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx:199`. Its day branch was:

```ts
return rtf.format(sign * Math.round(abs / DAY), 'day')
```

`Intl.RelativeTimeFormat` is configured with `numeric: 'auto'`, so `format(1, 'day')` renders the **calendar word** "tomorrow" (and `2` → "in 2 days", `0` → "today"). But the value fed in is the raw span rounded to **24 h buckets**. A next run ~30 h out (e.g. an evening "now" → 02:00 two dates later) crosses two local midnights yet `Math.round(30h / 24h) === 1`, so it prints "tomorrow" for a date that is actually two days away. The word and the absolute date it sits beside disagree.

## Fix

Add `relativeDayCount(nowMs, targetMs)` — the number of whole **calendar days** between the two instants, computed from local midnights with DST-safe `Date` field math (the same idiom the file already uses in `startOfLocalDay` / `calendarBucket`) — and feed that to the day-unit formatter:

```ts
return rtf.format(relativeDayCount(nowMs, targetMs), 'day')
```

Now the calendar word matches the calendar date shown next to it: a genuine next-day run reads "tomorrow", a two-dates-out run reads "in 2 days". Sub-day granularity (minutes/hours) is unchanged.

## Tests

`apps/desktop/src/lib/time.test.ts`:

- `relativeDayCount` counts date changes, not 24 h buckets (±1, 2, 0, and the #76725 evening→+30 h = 2 case);
- `relativeTime` no longer labels a two-calendar-day-out run identically to a genuine next-day run (before the fix both rounded to 1 and read "tomorrow").

Tests use `new Date(y, m, d, h)` local-time construction so they are timezone-independent. Local: `vitest` green (14), `eslint` clean, and `time.ts` typechecks (the only `tsc` errors are the pre-existing missing-dep `frimousse`/`bippy` ones in unrelated files). The arm64-fork Docker CI job is the known fork-only failure.
