### PR TITLE
fix(mcp): read the elicitation schema under the SDK's real field name

### DIFF
--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -249,3 +249,51 @@ class TestElicitationHandlerContextBridge:
             result = asyncio.run(handler(context=None, params=params))
 
         assert result.action == "decline"
+
+
+class TestRequestedSchemaFieldName:
+    """The requested schema must be read off the *real* SDK model.
+
+    Every other test in this file builds a duck-typed ``SimpleNamespace``
+    stand-in for the params object. That keeps them cheap, but it means none
+    of them can catch the handler reading a field name the SDK model does not
+    actually have -- the stand-in simply has whatever name the test wrote.
+
+    The SDK spells this field ``requestedSchema`` on mcp 1.x and
+    ``requested_schema`` on 2.0 (which renamed model fields to snake_case and
+    kept camelCase only as a serialization alias, which pydantic does not
+    expose to attribute access). Constructing with the camelCase spelling
+    works on both -- 2.0 accepts it as the alias -- so this test pins the
+    behaviour to the real model on whichever SDK is installed.
+    """
+
+    def test_real_sdk_params_schema_reaches_the_consent_description(self):
+        from mcp.types import ElicitRequestFormParams
+
+        params = ElicitRequestFormParams(
+            message="authorize a payment of $0.50",
+            requestedSchema={
+                "type": "object",
+                "properties": {
+                    "card_number": {
+                        "type": "string",
+                        "description": "card to charge",
+                    },
+                },
+            },
+        )
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            captured["description"] = kwargs.get("description") or (
+                args[1] if len(args) > 1 else ""
+            )
+            return "decline"
+
+        with patch("tools.approval.request_elicitation_consent", _capture):
+            asyncio.run(handler(context=None, params=params))
+
+        # An empty schema renders the generic "Approval requested by ..."
+        # fallback, so the field name is what proves the schema was read.
+        assert "card_number" in (captured.get("description") or ""), captured

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1730,7 +1730,19 @@ class ElicitationHandler:
         message = getattr(params, "message", "") or (
             f"MCP server '{self.server_name}' is requesting your approval"
         )
-        schema = getattr(params, "requested_schema", {}) or {}
+        # The SDK model spells this field ``requestedSchema`` on mcp 1.x (the
+        # pinned version) and ``requested_schema`` on 2.0, which renamed model
+        # fields to snake_case and kept camelCase only as a serialization
+        # alias -- and pydantic aliases do not apply to attribute access. A
+        # single-spelling read therefore returns the ``{}`` default on the
+        # other generation, and _format_elicitation_schema_summary degrades to
+        # its generic "Approval requested by ..." line, so the user is asked to
+        # approve without being told which fields the server wants.
+        schema = (
+            getattr(params, "requestedSchema", None)
+            or getattr(params, "requested_schema", None)
+            or {}
+        )
         description = _format_elicitation_schema_summary(schema, self.server_name)
 
         logger.info(


### PR DESCRIPTION
## What

`ElicitationHandler` reads the elicitation schema off the wrong field name, so **the approval
prompt never tells the user which fields an MCP server is asking for.** They are asked to approve a
data request with the request elided.

`tools/mcp_tool.py` does:

```python
schema = getattr(params, "requested_schema", {}) or {}
```

On the pinned SDK (`mcp==1.28.1`) the model field is spelled **`requestedSchema`**:

```
$ python -c "import mcp.types as t; print(list(t.ElicitRequestFormParams.model_fields))"
['task', 'meta', 'mode', 'message', 'requestedSchema']
```

So the `getattr` always misses and returns the `{}` default.
`_format_elicitation_schema_summary({})` then takes its no-properties branch and returns the
generic fallback line, discarding the schema entirely.

## Impact

The user-visible symptom, from the new test's failure output on unmodified `main`:

```
AssertionError: {'description': "Approval requested by MCP server 'pay'."}
assert 'card_number' in "Approval requested by MCP server 'pay'."
```

That string is the whole prompt. A server requesting `card_number` renders identically to one
requesting a nickname — the field list, types, and per-field descriptions that
`_format_elicitation_schema_summary` exists to produce are never reached.

This is a consent-integrity problem rather than a crash: the approval flow works, it just asks the
user to approve blind. Elicitation is the path servers use for things like payment authorization,
which is exactly where "what is being requested" needs to survive to the prompt.

## Why the tests didn't catch it

Every test in `tests/tools/test_mcp_elicitation.py` builds a duck-typed stand-in:

```python
def _form_params(message="please confirm", schema=None):
    """Build a stand-in for ElicitRequestFormParams.

    We use a plain object (not the SDK type directly) so the test doesn't
    couple to optional Pydantic validation -- the handler reads fields via
    getattr() and tolerates duck-typed inputs.
    """
    from types import SimpleNamespace
    return SimpleNamespace(
        mode="form",
        message=message,
        requested_schema=schema or {},
    )
```

The stand-in has whatever field name the test wrote, so it agrees with the handler and the
assertion passes. Nothing in the file ever constructs the real model, which is the only thing that
could have disagreed. The existing comment even explains the choice ("so the test doesn't couple to
optional Pydantic validation") — reasonable in isolation, but it means a field-name mismatch is
structurally invisible to this suite.

The fix therefore adds one test that constructs the **real** `ElicitRequestFormParams`, leaving the
cheap stand-ins alone for everything else.

## The fix

Read both spellings:

```python
schema = (
    getattr(params, "requestedSchema", None)
    or getattr(params, "requested_schema", None)
    or {}
)
```

Both, rather than just correcting to `requestedSchema`, because mcp 2.0 renames this field to
`requested_schema` (it renamed every model field to snake_case and kept camelCase only as a
serialization alias, which pydantic does not expose to attribute access). Reading both is correct
on either SDK generation, so this does not become wrong again on the next bump — verified against
real `1.28.1` and `2.0.0` installs.

## Relationship to #76736 — found there, independent of it

I found this while porting the tree to the mcp 2.x SDK in #76736, because that work required
diffing every SDK model field name across both generations. **It is not part of that PR and does
not depend on it:**

- It is a defect on `main` **as pinned today**, reproducible on `mcp==1.28.1` with no other changes.
  #76736 is unmerged and may stay that way; this stands alone either way.
- #76736 does **not** touch this line. I had briefly included this fix there, then removed it
  precisely so a bug fix wasn't riding inside a dependency migration (CONTRIBUTING: "one logical
  change per PR").
- The two branches **merge cleanly in either order** — confirmed with `git merge-tree` against both
  tips, no conflicts. #76736's only addition to this test file lands inside
  `TestElicitationHandlerFormMode`; this PR appends a separate class at the end.
- The dual read stays correct after #76736 lands, which is why it is a dual read rather than a
  straight correction to the 1.x name.

If #76736 merges first, this fix is still wanted: `main` would then be on 2.0 where
`requested_schema` happens to be right, but the dual read is what keeps the path correct for anyone
resolving an older `mcp` from the optional `[mcp]` extra, and the regression test is what stops the
duck-typed-only coverage from hiding the next rename.

## How to test

```bash
uv sync --locked --python 3.11 --extra all --extra dev   # resolves mcp==1.28.1
python -m pytest tests/tools/test_mcp_elicitation.py -q
```

`TestRequestedSchemaFieldName` fails on `main` and passes with this change. To see it as a user,
point Hermes at an MCP server that sends a form-mode elicitation and compare the approval prompt
before/after — before, it reads `Approval requested by MCP server '<name>'.` regardless of what was
requested; after, it lists the fields with their types and descriptions.

Full runs on this branch at `mcp==1.28.1`:

| file | result |
|---|---|
| `tests/tools/test_mcp_elicitation.py` | 13 passed |
| `tests/tools/test_mcp_tool.py` | 90 passed |
| `tests/tools/test_approval.py` | 90 passed |
| `tests/tools/test_mcp_oauth.py` | 44 passed |
| `tests/tools/test_mcp_capability_gating.py` | 16 passed |
| `tests/tools/test_mcp_structured_content.py` | 3 passed |
| `tests/tools/test_mcp_dynamic_discovery.py` | 6 passed |

`tests/test_mcp_serve.py` shows 1 pre-existing failure
(`TestEventBridgePollE2E::test_new_conversation_after_baseline_is_delivered`, a `state.db`
mtime-granularity flake). This branch does not touch `mcp_serve.py`, and the same test fails on
unmodified `upstream/main`.

`ruff check` passes on both changed files.

**Platforms:** Linux (x86_64, Python 3.11). Two `getattr` calls and a test — no file I/O, process,
or terminal handling, so no platform-specific surface.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
