### PR TITLE
fix(dashboard): BasicAuthProvider redirects to password login instead of raising

### DIFF
--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -226,10 +226,14 @@ class BasicAuthProvider(DashboardAuthProvider):
 
     # ---- OAuth methods: not used (pure-password provider) ------------------
 
+    supports_session = True
+
     def start_login(self, *, redirect_uri: str) -> LoginStart:
-        raise NotImplementedError(
-            "BasicAuthProvider is password-only; there is no OAuth redirect "
-            "flow. The login page POSTs to /auth/password-login instead."
+        # BasicAuthProvider is password-only (not OAuth). Redirect to the
+        # password login form directly instead of raising NotImplementedError.
+        return LoginStart(
+            redirect_url=f"/auth/password-login?redirect_uri={redirect_uri}",
+            cookie_payload={},
         )
 
     def complete_login(

--- a/tests/plugins/dashboard_auth/test_basic_provider.py
+++ b/tests/plugins/dashboard_auth/test_basic_provider.py
@@ -129,10 +129,14 @@ class TestProvider:
         p = self._make(basic)
         p.revoke_session(refresh_token="anything")  # must not raise
 
-    def test_oauth_methods_raise_not_implemented(self, basic):
+    def test_start_login_redirects_to_password_login(self, basic):
         p = self._make(basic)
-        with pytest.raises(NotImplementedError):
-            p.start_login(redirect_uri="https://x/auth/callback")
+        start = p.start_login(redirect_uri="https://x/auth/callback")
+        assert start.redirect_url.startswith("/auth/password-login")
+        assert "redirect_uri=https://x/auth/callback" in start.redirect_url
+
+    def test_complete_login_raises_not_implemented(self, basic):
+        p = self._make(basic)
         with pytest.raises(NotImplementedError):
             p.complete_login(
                 code="c", state="s", code_verifier="v", redirect_uri="r"


### PR DESCRIPTION
## What changed and why

`BasicAuthProvider.start_login()` raises `NotImplementedError` because BasicAuth is password-only (no OAuth redirect flow). This breaks dashboard flows that assume a redirect-style login start — e.g. profile-scoped provider logins and health-probe auth paths that call `start_login()` generically across providers.

Instead of erroring, redirect to the existing password login form (`/auth/password-login`) preserving `redirect_uri`, and set `supports_session = True` so callers can rely on session-based auth.

## How to test

1. Configure dashboard with basic auth (scrypt password hash).
2. Call the provider start_login path (or open the dashboard login flow).
3. Previously: 500 / NotImplementedError. Now: redirects to the password login form with redirect_uri intact.

## Platforms tested

- WSL2 (Linux) + dashboard web UI

Fixes the dashboard auth flow locally; no related open issue found on search.