### PR TITLE
fix(auxiliary): keep named custom provider identity when base_url is set

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7145,7 +7145,17 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
+            # User-defined ``providers:`` / ``custom_providers:`` entries are
+            # not part of the built-in registry, but a named custom provider
+            # paired with an explicit base_url must keep its identity so
+            # resolve_provider_client lands in the named-custom arm (which
+            # honours the entry's own key_env / api_mode) instead of
+            # collapsing to anonymous "custom" and losing the key (#76602).
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+
+            return _get_named_custom_provider(normalized) is not None
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -123,6 +123,61 @@ class TestResolveProviderClientNamedCustom:
         # no-key-required should be used
 
 
+class TestNamedCustomProviderWithBaseUrl:
+    """A named custom provider paired with an explicit base_url must keep
+    its provider identity (not collapse to anonymous 'custom'), so the
+    named-custom arm can resolve the entry's key_env / api_mode.  Regression
+    for #76602: auxiliary vision with provider + base_url was downgraded to
+    'custom' and the request went out with an empty key → 401."""
+
+    def test_task_resolution_keeps_named_custom_identity(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "providers": {
+                "myrelay": {
+                    "name": "myrelay",
+                    "base_url": "https://relay.example.com/v1",
+                    "key_env": "MYRELAY_API_KEY",
+                },
+            },
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        # Simulate the second resolution pass inside resolve_vision_provider_client:
+        # explicit provider + base_url args, api_key left to the caller (None).
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            "vision", "myrelay", "gpt-4o-mini",
+            "https://relay.example.com/v1", None,
+        )
+        # Provider identity must be preserved — NOT collapsed to "custom".
+        assert provider == "myrelay"
+        assert model == "gpt-4o-mini"
+        assert base_url == "https://relay.example.com/v1"
+        assert api_key is None
+
+    def test_client_resolves_key_from_entry_key_env(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "providers": {
+                "myrelay": {
+                    "name": "myrelay",
+                    "base_url": "https://relay.example.com/v1",
+                    "key_env": "MYRELAY_API_KEY",
+                },
+            },
+        })
+        monkeypatch.setenv("MYRELAY_API_KEY", "sk-relay-secret")
+        from agent.auxiliary_client import resolve_provider_client
+        client, model = resolve_provider_client(
+            "myrelay",
+            model="gpt-4o-mini",
+            explicit_base_url="https://relay.example.com/v1",
+            explicit_api_key=None,
+        )
+        assert client is not None
+        assert "relay.example.com" in str(client.base_url)
+        assert client.api_key == "sk-relay-secret"
+
+
 
 class TestResolveProviderClientModelNormalization:
     """Direct-provider auxiliary routing should normalize models like main runtime."""


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a **named custom provider** (`providers:` / `custom_providers:` entry in config.yaml) paired with an explicit `base_url` in `auxiliary.vision` collapsed to anonymous `"custom"` during task resolution, so the request went out with an **empty api_key → 401 INVALID_API_KEY** from the endpoint — even though the provider entry declares a valid `key_env` and direct API calls with the same key succeed.

Root cause: `_preserve_provider_with_base_url()` only checked the **built-in provider registry** (`hermes_cli.providers.get_provider`), which explicitly does not include user-defined providers (those go through `resolve_provider_full`). As a result, the second resolution pass inside `resolve_vision_provider_client` downgraded the provider to `"custom"`, and `resolve_provider_client("custom", explicit_base_url=..., explicit_api_key=None)` fell into the anonymous-custom arm → `no-key-required` placeholder → 401.

## Changes Made

- `agent/auxiliary_client.py`: `_preserve_provider_with_base_url()` now falls back to `hermes_cli.runtime_provider._get_named_custom_provider()` when the built-in registry lookup misses — named custom providers keep their identity so the named-custom arm of `resolve_provider_client` resolves the entry's own `key_env` / `api_mode`.
- `tests/agent/test_auxiliary_named_custom_providers.py`: two regression tests —
  1. task resolution keeps the named custom provider identity (not collapsed to `"custom"`) when `base_url` is set;
  2. the resolved client uses the key from the entry's `key_env`.

## How to Test

Reproduction (before fix):
```yaml
# config.yaml
providers:
  myrelay:
    base_url: https://relay.example.com/v1
    key_env: MYRELAY_API_KEY
auxiliary:
  vision:
    provider: myrelay
    model: gpt-4o-mini
    base_url: https://relay.example.com/v1
```
`vision_analyze` → `401 INVALID_API_KEY` (request sent with empty key), while a direct API call with `MYRELAY_API_KEY` succeeds.

After fix: `vision_analyze` works; the request carries the key from `key_env`.

```bash
pytest tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_vision_resolved_args.py tests/agent/test_vision_routing_31179.py -q
# 31 passed
```

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Fixes #76602
- [x] Conventional commit message
- [x] Searched for existing PRs (none — issue #76602 is open, unassigned)
- [x] Tests added for the bug fix (red-green verified: revert fix → new test fails)
- [x] Tested on Linux (OpenCloudOS 9.4, Hermes v0.19.1 + current main)
