### PR TITLE
fix(desktop): register classic default skin palette in Appearance

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -91,6 +91,26 @@ describe('ingestBackendSkin', () => {
     expect($pendingSkinApply.get()).toBe('default')
   })
 
+  it('lets the provider resolve and keep default (not retired → nous)', async () => {
+    // skinPref / normalizeSkin must accept `default` once the backend registers
+    // it; RETIRED_SKINS no longer includes default (#76743 review).
+    const { skinPref } = await import('./context')
+    const { resolveTheme } = await import('./user-themes')
+
+    ingestBackendSkin(
+      {
+        name: 'default',
+        description: 'Classic Hermes — gold and kawaii',
+        colors: { background: '#1a1a2e', ui_accent: '#FFBF00', banner_text: '#FFF8DC' }
+      },
+      { apply: false }
+    )
+
+    expect(resolveTheme('default')?.name).toBe('default')
+    skinPref.assign('work', 'default')
+    expect(skinPref.resolve('work')).toBe('default')
+  })
+
   it('does not apply default on the connect-time seed', () => {
     ingestBackendSkin(skin('default'), { apply: false })
 

--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -74,19 +74,32 @@ describe('ingestBackendSkin', () => {
     expect($pendingSkinApply.get()).toBeNull()
   })
 
-  it('never registers default in the backend store (desktop keeps its own palette)', () => {
-    ingestBackendSkin(skin('default'), { apply: true })
+  it('registers the classic default skin so Appearance can select gold/navy (#76579)', () => {
+    ingestBackendSkin(
+      {
+        name: 'default',
+        description: 'Classic Hermes — gold and kawaii',
+        colors: { background: '#1a1a2e', ui_accent: '#FFBF00', banner_text: '#FFF8DC' }
+      },
+      { apply: true }
+    )
 
-    expect($backendThemes.get().default).toBeUndefined()
+    const registered = $backendThemes.get().default
+    expect(registered?.name).toBe('default')
+    expect(registered?.label).toBe('Classic Hermes')
+    expect(registered?.description).toContain('gold')
+    expect($pendingSkinApply.get()).toBe('default')
   })
 
   it('does not apply default on the connect-time seed', () => {
     ingestBackendSkin(skin('default'), { apply: false })
 
     expect($pendingSkinApply.get()).toBeNull()
+    // Seed still registers the palette so the theme grid can show it.
+    expect($backendThemes.get().default?.name).toBe('default')
   })
 
-  it('applies a runtime switch back to default (repaints the desktop to its own default)', () => {
+  it('applies a runtime switch back to default (classic gold palette)', () => {
     ingestBackendSkin(skin('neon'), { apply: false }) // gateway.ready seed on some skin
     ingestBackendSkin(skin('default'), { apply: true }) // Hermes switched back to default
 

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -56,24 +56,35 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
     return
   }
 
-  // `default` is "no opinion" on the PALETTE — the desktop keeps its own default
-  // (nous), so we never register a converted theme under `default`. It is still a
-  // valid apply TARGET though: a runtime switch back to `default` must repaint the
-  // desktop to its own default (setTheme normalizes `default` → nous). So we only
-  // skip the registry step here and let it flow through the apply logic below.
-  // Built-in names (mono/slate/…) already have a hand-tuned desktop palette — we
-  // never shadow it, but the name is still a valid apply target.
-  if (name !== 'default' && !BUILTIN_THEMES[name]) {
+  // Built-in names (mono/slate/…) already have a hand-tuned desktop palette —
+  // never shadow them, but they remain valid apply targets. The CLI `default`
+  // skin ("Classic Hermes — gold and kawaii") is *not* a desktop built-in, so
+  // we register the converted palette under `default` and let it appear in the
+  // Appearance grid / `/skin list` (#76579). Desktop's own boot default remains
+  // `nous` via DEFAULT_SKIN_NAME; selecting `default` paints the classic gold.
+  if (!BUILTIN_THEMES[name]) {
     const theme = skinToDesktopTheme(skin as HermesSkin)
 
     if (!theme) {
       return
     }
 
+    // Prefer the CLI description for the classic default skin so the grid
+    // shows "Classic Hermes — gold and kawaii" rather than a bare "Default".
+    const description =
+      name === 'default' && typeof (skin as HermesSkin).description === 'string'
+        ? String((skin as HermesSkin).description).trim() || theme.description
+        : theme.description
+    const label =
+      name === 'default'
+        ? 'Classic Hermes'
+        : theme.label
+    const registered = { ...theme, description, label }
+
     const current = $backendThemes.get()
 
-    if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
-      $backendThemes.set({ ...current, [name]: theme })
+    if (JSON.stringify(current[name]) !== JSON.stringify(registered)) {
+      $backendThemes.set({ ...current, [name]: registered })
     }
   }
 

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -2,7 +2,8 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
-import { ThemeProvider } from './context'
+import { ThemeProvider, useTheme } from './context'
+import { DEFAULT_SKIN_NAME } from './presets'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -11,7 +12,20 @@ const bloomberg = (foreground: string) => ({
   colors: { background: '#000000', ui_text: foreground, ui_accent: '#ff8000' }
 })
 
+const classicDefault = {
+  name: 'default',
+  description: 'Classic Hermes — gold and kawaii',
+  colors: { background: '#1a1a2e', ui_accent: '#FFBF00', ui_text: '#FFF8DC', banner_text: '#FFF8DC' }
+}
+
 const cssVar = (name: string) => window.document.documentElement.style.getPropertyValue(name)
+
+/** Probe so tests can call setTheme through the real provider path (not only skinPref). */
+function ThemeProbe({ onReady }: { onReady: (api: ReturnType<typeof useTheme>) => void }) {
+  const api = useTheme()
+  onReady(api)
+  return null
+}
 
 describe('ThemeProvider ← backend skin sync', () => {
   beforeEach(() => {
@@ -32,6 +46,44 @@ describe('ThemeProvider ← backend skin sync', () => {
 
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
     expect(cssVar('--theme-background-seed')).toBe('#000000')
+  })
+
+  it('keeps setTheme(default) active and paints Classic Hermes (#76579 / #76743)', () => {
+    // Review salvage: selecting registered `default` must go through setTheme /
+    // normalizeSkin (not only resolveTheme/skinPref) and must NOT collapse to nous.
+    let latest: ReturnType<typeof useTheme> | null = null
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe onReady={api => {
+          latest = api
+        }} />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin(classicDefault, { apply: false }))
+
+    expect(latest).not.toBeNull()
+    // Boot default remains nous until the user (or Appearance) selects classic.
+    expect(DEFAULT_SKIN_NAME).toBe('nous')
+
+    act(() => {
+      latest!.setTheme('default')
+    })
+
+    // Active selection stays `default` (not retired → nous). deriveTheme may
+    // mode-suffix the seed (default-light / Classic Hermes Light); the
+    // selection key and painted palette are what Appearance must preserve.
+    expect(latest!.themeName).toBe('default')
+    expect(latest!.themeName).not.toBe(DEFAULT_SKIN_NAME)
+    expect(latest!.theme.label.toLowerCase()).toContain('classic hermes')
+    expect(latest!.availableThemes.some(t => t.name === 'default' && t.label === 'Classic Hermes')).toBe(
+      true
+    )
+    // Classic gold palette reaches CSS (ui_accent / ui_text → primary / foreground).
+    // Light-mode derivation may mix the navy background; accent/text stay gold.
+    expect(cssVar('--theme-foreground').toLowerCase()).toBe('#fff8dc')
+    expect(cssVar('--theme-primary').toLowerCase()).toBe('#ffbf00')
   })
 
   it('repaints an in-place edit of the ACTIVE skin (same name, new palette)', () => {

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { skinPref, ThemeProvider, useTheme } from './context'
-import { everforestTheme } from './presets'
+import { DEFAULT_SKIN_NAME, everforestTheme } from './presets'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -12,7 +12,20 @@ const bloomberg = (foreground: string) => ({
   colors: { background: '#000000', ui_text: foreground, ui_accent: '#ff8000' }
 })
 
+const classicDefault = {
+  name: 'default',
+  description: 'Classic Hermes — gold and kawaii',
+  colors: { background: '#1a1a2e', ui_accent: '#FFBF00', ui_text: '#FFF8DC', banner_text: '#FFF8DC' }
+}
+
 const cssVar = (name: string) => window.document.documentElement.style.getPropertyValue(name)
+
+/** Probe so tests can call setTheme through the real provider path (not only skinPref). */
+function ThemeProbe({ onReady }: { onReady: (api: ReturnType<typeof useTheme>) => void }) {
+  const api = useTheme()
+  onReady(api)
+  return null
+}
 
 describe('ThemeProvider ← backend skin sync', () => {
   beforeEach(() => {
@@ -33,6 +46,44 @@ describe('ThemeProvider ← backend skin sync', () => {
 
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
     expect(cssVar('--theme-background-seed')).toBe('#000000')
+  })
+
+  it('keeps setTheme(default) active and paints Classic Hermes (#76579 / #76743)', () => {
+    // Review salvage: selecting registered `default` must go through setTheme /
+    // normalizeSkin (not only resolveTheme/skinPref) and must NOT collapse to nous.
+    let latest: ReturnType<typeof useTheme> | null = null
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe onReady={api => {
+          latest = api
+        }} />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin(classicDefault, { apply: false }))
+
+    expect(latest).not.toBeNull()
+    // Boot default remains nous until the user (or Appearance) selects classic.
+    expect(DEFAULT_SKIN_NAME).toBe('nous')
+
+    act(() => {
+      latest!.setTheme('default')
+    })
+
+    // Active selection stays `default` (not retired → nous). deriveTheme may
+    // mode-suffix the seed (default-light / Classic Hermes Light); the
+    // selection key and painted palette are what Appearance must preserve.
+    expect(latest!.themeName).toBe('default')
+    expect(latest!.themeName).not.toBe(DEFAULT_SKIN_NAME)
+    expect(latest!.theme.label.toLowerCase()).toContain('classic hermes')
+    expect(latest!.availableThemes.some(t => t.name === 'default' && t.label === 'Classic Hermes')).toBe(
+      true
+    )
+    // Classic gold palette reaches CSS (ui_accent / ui_text → primary / foreground).
+    // Light-mode derivation may mix the navy background; accent/text stay gold.
+    expect(cssVar('--theme-foreground').toLowerCase()).toBe('#fff8dc')
+    expect(cssVar('--theme-primary').toLowerCase()).toBe('#ffbf00')
   })
 
   it('repaints an in-place edit of the ACTIVE skin (same name, new palette)', () => {

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -35,7 +35,9 @@ const PROFILE_MODES_KEY = 'hermes-desktop-profile-modes-v1'
 // Last active profile, recorded so the boot-time paint can pick that profile's
 // theme before the gateway reports which profile actually launched.
 const LAST_PROFILE_KEY = 'hermes-desktop-active-profile-v1'
-const RETIRED_SKINS = new Set(['nous-light', 'default', 'gold'])
+// `default` is the live CLI classic skin (Classic Hermes gold) once registered
+// by backend-sync — not retired. `gold` remains a legacy alias (see use-skin-command).
+const RETIRED_SKINS = new Set(['nous-light', 'gold'])
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -40,7 +40,9 @@ const PROFILE_MODES_KEY = 'hermes-desktop-profile-modes-v1'
 const LAST_PROFILE_KEY = 'hermes-desktop-active-profile-v1'
 // Skins that no longer exist. A profile still pointing at one falls back to
 // DEFAULT_SKIN_NAME rather than painting a name nothing resolves.
-const RETIRED_SKINS = new Set(['nous-light', 'default', 'gold'])
+// `default` is the live CLI classic skin (Classic Hermes gold) once registered
+// by backend-sync — not retired. `gold` remains a legacy alias (see use-skin-command).
+const RETIRED_SKINS = new Set(['nous-light', 'gold'])
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 

--- a/apps/desktop/src/themes/use-skin-command.ts
+++ b/apps/desktop/src/themes/use-skin-command.ts
@@ -2,12 +2,13 @@ import { useCallback } from 'react'
 
 import { useTheme } from './context'
 
-// Retired skin names land on the canonical Nous skin so old muscle memory works.
+// Retired skin names land on a still-shipped theme so old muscle memory works.
+// `default` is intentionally NOT aliased: when the backend registers the classic
+// Hermes gold palette under that name (#76579) it must be selectable.
 const ALIASES: Record<string, string> = {
   ares: 'ember',
-  default: 'nous',
-  gold: 'nous',
-  hermes: 'nous',
+  gold: 'default',
+  hermes: 'default',
   'nous-light': 'nous'
 }
 


### PR DESCRIPTION
## Summary
`display.skin=default` (Classic Hermes gold/kawaii) was never registered in the desktop theme store and `/skin default` aliased to `nous`, so the official gold palette was invisible unless the skin was forked to a non-default name.

## Changes
- Register converted `default` skins in `$backendThemes` with label "Classic Hermes"
- Stop aliasing `default` to `nous` in the skin command (map gold/hermes to default)
- Update backend-sync regression tests

## Test plan
- [ ] Appearance theme grid shows Classic Hermes when backend default skin is seeded
- [ ] Selecting default paints gold/navy, not silent nous remapping
- backend-sync unit tests updated

Fixes #76579