### PR TITLE
fix(desktop): do not sandwich structured mid-turn rows with inflight dump

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resume-structural-parts.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resume-structural-parts.test.ts
@@ -73,4 +73,70 @@ describe('reconcileResumeMessages — structural parts on a mid-turn switch', ()
 
     expect(assistant.parts.filter(p => p.type === 'tool-call')).toHaveLength(1)
   })
+
+  it('keeps live-tail structure when the flat dump is not a strict text extension', () => {
+    // Mid-turn sandwich path: cache holds reasoning/tools; resume returns a
+    // longer non-extending dump. Structure source must be live-tail.
+    const cached: ChatMessage[] = [
+      {
+        id: 'assistant-stream-1',
+        pending: true,
+        parts: [
+          { type: 'reasoning', text: 'thinking about tools' },
+          { type: 'tool-call', toolCallId: 'c1', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'partial' }
+        ],
+        role: 'assistant'
+      }
+    ]
+
+    const authoritative: ChatMessage[] = [
+      {
+        id: 'assistant-stream-1',
+        pending: true,
+        parts: [{ type: 'text', text: 'thinking about tools\nRan terminal\npartial and more dump' }],
+        role: 'assistant'
+      }
+    ]
+
+    const [assistant] = reconcileResumeMessages(authoritative, cached)
+
+    expect(assistant.parts.some(part => part.type === 'reasoning')).toBe(true)
+    expect(assistant.parts.some(part => part.type === 'tool-call')).toBe(true)
+    expect(assistant.parts.filter(part => part.type === 'text').map(part => ('text' in part ? part.text : ''))).toEqual([
+      'partial'
+    ])
+  })
+
+  it('does not graft historical structure onto a live text-only row after compression rewrote ordinals', () => {
+    // Previous cache still has a completed structured assistant at ordinal 0.
+    // Resume after compression returns a new live text-only assistant at the
+    // same role ordinal for an unrelated turn — must not inherit foreign parts.
+    const cached: ChatMessage[] = [
+      {
+        id: 'old-assistant',
+        parts: [
+          { type: 'reasoning', text: 'old thinking' },
+          { type: 'tool-call', toolCallId: 'old-call', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'old answer' }
+        ],
+        role: 'assistant'
+      }
+    ]
+
+    const authoritative: ChatMessage[] = [
+      {
+        id: 'assistant-stream-runtime-1',
+        pending: true,
+        parts: [{ type: 'text', text: 'brand new partial' }],
+        role: 'assistant'
+      }
+    ]
+
+    const [assistant] = reconcileResumeMessages(authoritative, cached)
+
+    expect(assistant.parts.some(part => part.type === 'reasoning')).toBe(false)
+    expect(assistant.parts.some(part => part.type === 'tool-call')).toBe(false)
+    expect(assistant.parts).toEqual([{ type: 'text', text: 'brand new partial' }])
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -730,4 +730,41 @@ describe('appendLiveSessionProjection', () => {
 
     expect(appendLiveSessionProjection(stored, { session_id: 'runtime-1' })).toBe(stored)
   })
+
+  it('does not sandwich a structured mid-turn row with the inflight flat dump (#76444)', () => {
+    const stored: ChatMessage[] = [
+      msg('stored-user', 'user', 'do the work'),
+      {
+        id: 'live-assistant',
+        role: 'assistant',
+        pending: true,
+        parts: [
+          { type: 'reasoning', text: 'thinking about tools' },
+          { type: 'tool-call', toolCallId: 'c1', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'partial' }
+        ]
+      }
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      inflight: {
+        user: 'do the work',
+        // Flat dump includes thinking chatter + tool narration — longer than
+        // the answer text alone, which is how the sandwich used to grow.
+        assistant: 'thinking about tools\nRan terminal\npartial and more dump',
+        streaming: true
+      }
+    })
+
+    const assistants = restored.filter(message => message.role === 'assistant')
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0].id).toBe('live-assistant')
+    expect(assistants[0].parts.some(part => part.type === 'reasoning')).toBe(true)
+    expect(assistants[0].parts.some(part => part.type === 'tool-call')).toBe(true)
+    // Answer text stays the structured row's text, not the dump.
+    expect(assistants[0].parts.filter(part => part.type === 'text').map(part => ('text' in part ? part.text : ''))).toEqual([
+      'partial'
+    ])
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -767,4 +767,36 @@ describe('appendLiveSessionProjection', () => {
       'partial'
     ])
   })
+
+  it('still projects inflight when only a completed historical tool reply has structure', () => {
+    // Older completed assistants keep reasoning/tool parts in the full
+    // transcript; they must not suppress a new turn's text projection.
+    const stored: ChatMessage[] = [
+      msg('old-user', 'user', 'previous task'),
+      {
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-call', toolCallId: 'old', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'done earlier' }
+        ]
+      },
+      msg('new-user', 'user', 'new task')
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      inflight: {
+        user: 'new task',
+        assistant: 'working on it',
+        streaming: true
+      }
+    })
+
+    expect(restored.map(message => message.id)).toContain('assistant-stream-runtime-1')
+    expect(restored.at(-1)).toMatchObject({
+      id: 'assistant-stream-runtime-1',
+      pending: true
+    })
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -282,10 +282,12 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
     //
-    // Live-tail identity: only treat structure as same-turn evidence when the
-    // cached row is still the in-flight stream (pending / stream id), not a
-    // historical completed assistant that merely shares a role ordinal after
-    // compression rewrote history (#76444 review).
+    // Live-tail identity: structure-only same-turn carry is allowed only when
+    // the *structure-bearing cached row* is still the in-flight stream
+    // (pending / stream id / interim). Marking only the text-only next row
+    // live is not enough — after compression a new live assistant can share a
+    // role ordinal with an unrelated historical structured row and must not
+    // inherit its reasoning/tool parts (#76444 review / salvage).
     const isLiveTailRow = (row: ChatMessage): boolean =>
       Boolean(row.pending) ||
       row.id.startsWith('assistant-stream-') ||
@@ -300,7 +302,7 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
         previous.role === 'assistant' &&
         hasStructuralParts(previous) &&
         !hasStructuralParts(message) &&
-        (isLiveTailRow(previous) || isLiveTailRow(message)))
+        isLiveTailRow(previous))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -282,10 +282,15 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
     //
-    // Structured local assistant + text-only live projection (gateway inflight
-    // dump) at the same ordinal is still the same turn even when answer text is
-    // still empty — without this the dump would drop structure and reappear as
-    // a plain-text sandwich (#76444).
+    // Live-tail identity: only treat structure as same-turn evidence when the
+    // cached row is still the in-flight stream (pending / stream id), not a
+    // historical completed assistant that merely shares a role ordinal after
+    // compression rewrote history (#76444 review).
+    const isLiveTailRow = (row: ChatMessage): boolean =>
+      Boolean(row.pending) ||
+      row.id.startsWith('assistant-stream-') ||
+      Boolean(row.interim)
+
     const sameTurn =
       sameText ||
       (nextText.length > 0 &&
@@ -294,7 +299,8 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
       (message.role === 'assistant' &&
         previous.role === 'assistant' &&
         hasStructuralParts(previous) &&
-        !hasStructuralParts(message))
+        !hasStructuralParts(message) &&
+        (isLiveTailRow(previous) || isLiveTailRow(message)))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)
@@ -559,20 +565,43 @@ export function appendLiveSessionProjection(
   // Keep a pending assistant boundary even before the first delta when a
   // queued user turn follows it. This preserves the two distinct turns.
   //
-  // When the transcript already holds a structured mid-turn assistant row
-  // (reasoning / tool-call parts from the live stream or journal), do NOT
-  // append a pure-text projection of `inflight.assistant` — that flat dump
-  // re-renders thinking as answer text and sandwiches the structured parts
-  // (#76444). Errors still force a projection so the failure is visible.
-  const lastAssistant = [...messages].reverse().find(message => message.role === 'assistant')
-  const turnAlreadyStructured = Boolean(lastAssistant && hasStructuralParts(lastAssistant))
+  // When the *current live turn* already holds a structured mid-turn assistant
+  // row (reasoning / tool-call from the live stream or journal), do NOT append
+  // a pure-text projection of `inflight.assistant` — that flat dump re-renders
+  // thinking as answer text and sandwiches the structured parts (#76444).
+  // Only inspect the live tail after the latest user run — never a completed
+  // historical tool-bearing reply earlier in the transcript (review feedback).
+  const liveStreamId = `assistant-stream-${sessionId}`
+  const liveAssistantOfCurrentTurn = (() => {
+    const byStreamId = messages.find(message => message.id === liveStreamId)
+    if (byStreamId) {
+      return byStreamId
+    }
+    // Assistants after the latest user row belong to this turn's tail.
+    if (latestUserIndex < 0) {
+      return null
+    }
+    for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
+      if (messages[index].role === 'assistant') {
+        return messages[index]
+      }
+    }
+    return null
+  })()
+  const turnAlreadyStructured = Boolean(
+    liveAssistantOfCurrentTurn &&
+      hasStructuralParts(liveAssistantOfCurrentTurn) &&
+      (liveAssistantOfCurrentTurn.pending ||
+        liveAssistantOfCurrentTurn.id === liveStreamId ||
+        liveAssistantOfCurrentTurn.interim)
+  )
 
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {
     if (turnAlreadyStructured && !inflightError) {
       // Structure is authoritative; skip the text-only dump row.
     } else {
       projected.push({
-        id: `assistant-stream-${sessionId}`,
+        id: liveStreamId,
         role: 'assistant',
         parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
         pending: inflightStreaming,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -46,6 +46,27 @@ function withAppendedText(message: ChatMessage, suffix: string): ChatMessage {
   return appended ? { ...message, parts } : message
 }
 
+/** Reasoning / tool-call parts that the gateway inflight dump cannot express. */
+function hasStructuralParts(message: ChatMessage): boolean {
+  return message.parts.some(part => part.type === 'reasoning' || part.type === 'tool-call')
+}
+
+/**
+ * True when `next` is a pure forward extension of the previous *answer* text.
+ * Empty previous answer never accepts a dump as an extension — that is how the
+ * mid-turn inflight flat dump used to sandwich structured rows (#76444).
+ */
+export function isStrictAnswerTextExtension(next: string, previous: string): boolean {
+  const n = next.trim()
+  const p = previous.trim()
+
+  if (!p || !n) {
+    return false
+  }
+
+  return n.startsWith(p)
+}
+
 /**
  * Carry structural parts an authoritative row cannot express.
  *
@@ -260,12 +281,35 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // for structural carry-over. Attachment refs and image re-appending stay on
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
+    //
+    // Structured local assistant + text-only live projection (gateway inflight
+    // dump) at the same ordinal is still the same turn even when answer text is
+    // still empty — without this the dump would drop structure and reappear as
+    // a plain-text sandwich (#76444).
     const sameTurn =
       sameText ||
-      (nextText.length > 0 && previousVisibleText.length > 0 && nextText.startsWith(previousVisibleText.trim()))
+      (nextText.length > 0 &&
+        previousVisibleText.length > 0 &&
+        isStrictAnswerTextExtension(nextText, previousVisibleText)) ||
+      (message.role === 'assistant' &&
+        previous.role === 'assistant' &&
+        hasStructuralParts(previous) &&
+        !hasStructuralParts(message))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)
+
+      // Never replace structured answer text with a non-extending flat dump.
+      if (
+        message.role === 'assistant' &&
+        hasStructuralParts(previous) &&
+        !hasStructuralParts(message) &&
+        !isStrictAnswerTextExtension(nextText, previousVisibleText)
+      ) {
+        const nonText = preserved.parts.filter(part => part.type !== 'text')
+        const priorAnswer = previous.parts.filter(part => part.type === 'text')
+        preserved = { ...preserved, parts: [...nonText, ...priorAnswer] }
+      }
     }
 
     if (
@@ -514,14 +558,27 @@ export function appendLiveSessionProjection(
 
   // Keep a pending assistant boundary even before the first delta when a
   // queued user turn follows it. This preserves the two distinct turns.
+  //
+  // When the transcript already holds a structured mid-turn assistant row
+  // (reasoning / tool-call parts from the live stream or journal), do NOT
+  // append a pure-text projection of `inflight.assistant` — that flat dump
+  // re-renders thinking as answer text and sandwiches the structured parts
+  // (#76444). Errors still force a projection so the failure is visible.
+  const lastAssistant = [...messages].reverse().find(message => message.role === 'assistant')
+  const turnAlreadyStructured = Boolean(lastAssistant && hasStructuralParts(lastAssistant))
+
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {
-    projected.push({
-      id: `assistant-stream-${sessionId}`,
-      role: 'assistant',
-      parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
-      pending: inflightStreaming,
-      ...(inflightError ? { error: inflightError } : {})
-    })
+    if (turnAlreadyStructured && !inflightError) {
+      // Structure is authoritative; skip the text-only dump row.
+    } else {
+      projected.push({
+        id: `assistant-stream-${sessionId}`,
+        role: 'assistant',
+        parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
+        pending: inflightStreaming,
+        ...(inflightError ? { error: inflightError } : {})
+      })
+    }
   }
 
   if (queuedUser) {

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -179,7 +179,9 @@ describe('recoverInFlightTurnJournal', () => {
   it('overlays the backend text-only projection instead of dropping local tool progress', () => {
     // Sweeper regression on #44339: a backend `inflight` assistant snapshot
     // (text only) used to mark the richer local tail "caught up" and delete
-    // locally recorded tool calls.
+    // locally recorded tool calls. After #76444, longer text wins only when it
+    // is a strict extension of the journal answer (flat thinking dumps must
+    // not replace structured answer text).
     journalEntry([
       user('u1', 'do the thing'),
       assistantWithTool('assistant-stream-old', 'local part', { pending: true })
@@ -187,7 +189,7 @@ describe('recoverInFlightTurnJournal', () => {
 
     const base = [
       user('db-u1', 'do the thing'),
-      assistant('assistant-stream-rt9', 'longer partial text from the backend snapshot', { pending: true })
+      assistant('assistant-stream-rt9', 'local part and more from the backend snapshot', { pending: true })
     ]
 
     const result = recoverInFlightTurnJournal('stored-1', base, { keepPending: true })
@@ -200,11 +202,33 @@ describe('recoverInFlightTurnJournal', () => {
     // Keeps the BASE projection row id so live deltas keep landing on it.
     expect(merged.id).toBe('assistant-stream-rt9')
     expect(result.streamId).toBe('assistant-stream-rt9')
-    // Journal structure survives; the longer backend text wins.
+    // Journal structure survives; strict-extension backend text wins.
     expect(merged.parts[0]).toMatchObject({ type: 'tool-call', toolName: 'terminal' })
-    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'longer partial text from the backend snapshot' })
+    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'local part and more from the backend snapshot' })
     // Still in flight — the journal must NOT be cleared.
     expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
+  })
+
+  it('keeps journal answer text when a longer flat dump is not a strict extension (#76444)', () => {
+    journalEntry([
+      user('u1', 'do the thing'),
+      assistantWithTool('assistant-stream-old', 'partial', { pending: true })
+    ])
+
+    const base = [
+      user('db-u1', 'do the thing'),
+      assistant(
+        'assistant-stream-rt9',
+        'thinking chatter\nRan terminal\npartial and unrelated dump longer than answer',
+        { pending: true }
+      )
+    ]
+
+    const result = recoverInFlightTurnJournal('stored-1', base, { keepPending: true })
+    const merged = result.messages.at(-1)!
+
+    expect(merged.parts[0]).toMatchObject({ type: 'tool-call', toolName: 'terminal' })
+    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'partial' })
   })
 
   it('keeps the journal text when it is longer than the projection text', () => {

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -254,6 +254,10 @@ function assistantTextLength(message: ChatMessage): number {
  * BASE row's id so live deltas keep appending to the row the stream handler
  * already targets.
  */
+function hasStructuralParts(message: ChatMessage): boolean {
+  return message.parts.some(part => part.type === 'reasoning' || part.type === 'tool-call')
+}
+
 function overlayProjectionRow(projection: ChatMessage, journalRow: ChatMessage): ChatMessage {
   // A projected error (retained failed turn) must survive the overlay.
   const error = journalRow.error ?? projection.error
@@ -271,7 +275,20 @@ function overlayProjectionRow(projection: ChatMessage, journalRow: ChatMessage):
 
   // Backend text is newer than the journal's last throttled write — swap it
   // into the journal's first text part, keeping tool calls and reasoning.
+  // When the journal already carries structure, only accept a *strict*
+  // extension of the answer text. A longer flat dump that starts with
+  // thinking chatter must not overwrite / insert as answer text (#76444).
   const projectionText = chatMessageText(projection)
+  const journalText = chatMessageText(journalRow).trim()
+
+  if (hasStructuralParts(journalRow)) {
+    const next = projectionText.trim()
+
+    if (!journalText || !next.startsWith(journalText)) {
+      return merged
+    }
+  }
+
   const parts: ChatMessagePart[] = []
   let textReplaced = false
 


### PR DESCRIPTION
## Summary
Gateway `inflight.assistant` is a flat string of mid-turn prose. On resume, Desktop projected it as answer text next to (or over) structured reasoning/tool-call parts — a growing plain-text sandwich.

## Changes
- `appendLiveSessionProjection`: skip text-only dump when the turn already has structure
- `reconcileResumeMessages`: treat structured local + text-only live projection as same turn; refuse non-extending dump as answer text
- `overlayProjectionRow`: strict answer-text extension when journal has structure
- Regression test for the sandwich case

## Test plan
- [x] unit test: structured mid-turn + flat dump → no extra assistant row, answer text unchanged
- [ ] manual: switch sessions mid-tool-turn; no thinking slab between tools and final

Fixes #76444