### PR TITLE
fix(desktop): resolve the composer key by zone, not document order

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -225,6 +225,16 @@ describe('resolveActive / keep-alive tab heal', () => {
     expect(mainSaw).toEqual(['main'])
   })
 
+  it('does not adopt a present-but-empty composer target as a routing key', () => {
+    // `[data-composer-target]` matches on attribute presence, so a surface
+    // stamped with an empty value is a candidate. Routing to '' would address a
+    // composer that cannot exist and drop the keystroke — fall back to main.
+    mountSurface('')
+    markActiveComposer('tile:closed')
+
+    expect(getActiveComposer()).toBe('main')
+  })
+
   it('holds an edit claim while the edit composer root is mounted', () => {
     const root = document.createElement('div')
     root.dataset.slot = 'aui_edit-composer-root'

--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 
 import {
   blurComposerInput,
@@ -50,6 +50,7 @@ afterEach(() => {
   // would otherwise decide the next one.
   markActiveComposer('main')
   $hoveredTreeGroup.set(null)
+  $activeTreeGroup.set(null)
 })
 
 describe('blurComposerInput', () => {
@@ -73,6 +74,19 @@ describe('blurComposerInput', () => {
     blurComposerInput()
 
     expect(document.activeElement).toBe(outside)
+  })
+
+  it('blurs the focused input when a split leaves several visible', () => {
+    // Both zones of a split are visible, so matching the first one and then
+    // testing it against activeElement no-ops for every zone but the leftmost.
+    const left = mountInput()
+    const right = mountInput()
+
+    right.focus()
+    blurComposerInput()
+
+    expect(document.activeElement).not.toBe(right)
+    expect(document.activeElement).not.toBe(left)
   })
 })
 
@@ -236,6 +250,98 @@ function mountZonedSurface(target: string, zone: string, hidden = false) {
 
   return surface
 }
+
+/**
+ * A split renders one chat surface per zone and BOTH are visible, so resolving
+ * "the" visible surface by first DOM match answers document order — always the
+ * leftmost zone. Work in the right-hand zone and the composer routing key is
+ * handed to the left one: Enter, type-to-focus, Esc, voice and soft `/` are all
+ * preventDefault'd and dropped in the pane the user is actually looking at.
+ */
+describe('visibleChatTarget / split-zone identity', () => {
+  /** Two visible chat surfaces, one per split zone. */
+  function mountSplit() {
+    mountZonedSurface('tile:left', 'zone-a')
+    mountZonedSurface('tile:right', 'zone-b')
+  }
+
+  it('releases the routing key into the active zone, not the leftmost surface', () => {
+    mountSplit()
+    $activeTreeGroup.set('zone-b')
+    markActiveComposer('edit')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('tile:right')
+  })
+
+  it('releases into zone-a when zone-a is the active zone', () => {
+    // The mirror of the case above: proves the resolver reads the zone rather
+    // than simply preferring the last-mounted surface.
+    mountSplit()
+    $activeTreeGroup.set('zone-a')
+    markActiveComposer('edit')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('tile:left')
+  })
+
+  it('prefers the hovered zone over the active one (ladder order)', () => {
+    mountSplit()
+    $activeTreeGroup.set('zone-a')
+    $hoveredTreeGroup.set('zone-b')
+    markActiveComposer('edit')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('tile:right')
+  })
+
+  it('falls through to the active zone when the hovered zone holds no chat surface', () => {
+    // Pointer parked on the sidebar / titlebar — a zone that cannot serve the
+    // verb must hand off to the next rung, not swallow the key.
+    mountSplit()
+    $hoveredTreeGroup.set('zone-sidebar')
+    $activeTreeGroup.set('zone-b')
+    markActiveComposer('edit')
+
+    releaseActiveComposer('edit')
+
+    expect(getActiveComposer()).toBe('tile:right')
+  })
+
+  it('still answers a visible surface when neither rung resolves', () => {
+    // Nothing hovered and nothing activated yet: there is no identity to
+    // resolve, so the fallback stays document order rather than null. Answering
+    // null would route the key at a possibly-buried 'main' and drop every
+    // keystroke — strictly worse than naming a surface the user can see.
+    mountSplit()
+    markActiveComposer('tile:closed')
+
+    expect(getActiveComposer()).toBe('tile:left')
+  })
+
+  it('heals a stale claim into the active zone rather than document order', () => {
+    // The reported repro: user works in the right zone, its claim goes stale
+    // (tab switch / tile close), and type-to-focus heals onto the left zone.
+    mountSplit()
+    $activeTreeGroup.set('zone-b')
+    markActiveComposer('tile:closed')
+
+    expect(getActiveComposer()).toBe('tile:right')
+  })
+
+  it('answers the only visible surface whatever the zone state says', () => {
+    // The non-split path must not start depending on the layout store.
+    mountZonedSurface('tile:only', 'zone-a')
+    $hoveredTreeGroup.set('zone-elsewhere')
+    $activeTreeGroup.set('zone-elsewhere')
+    markActiveComposer('tile:closed')
+
+    expect(getActiveComposer()).toBe('tile:only')
+  })
+})
 
 const collectModelMenuTargets = async (): Promise<string[]> => {
   const saw: string[] = []

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -67,8 +67,15 @@ interface SubmitDetail {
 
 let activeTarget: ComposerTarget = 'main'
 
-const composerTargetOf = (el: HTMLElement | undefined): ComposerTarget | null =>
-  (el?.dataset.composerTarget as ComposerTarget | undefined) ?? null
+const composerTargetOf = (el: HTMLElement | undefined): ComposerTarget | null => {
+  const target = el?.dataset.composerTarget
+
+  // Truthy rather than `?? null`: a present-but-empty `data-composer-target` is
+  // not a routing key, and letting `''` through would resolve `'active'` to a
+  // target no composer answers to — the exact class of dropped keystroke this
+  // resolver exists to prevent. Callers fall back to `'main'` on null.
+  return target ? (target as ComposerTarget) : null
+}
 
 /**
  * The chat surface currently on screen (`data-composer-target` hung off each

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -11,7 +11,7 @@
  */
 
 import { queryAllVisible, queryVisible } from '@/components/pane-shell/pane-visibility'
-import { $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
+import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 
 import type { InlineRefInput } from './inline-refs'
 import { RICH_INPUT_SLOT } from './rich-editor'
@@ -67,20 +67,51 @@ interface SubmitDetail {
 
 let activeTarget: ComposerTarget = 'main'
 
+const composerTargetOf = (el: HTMLElement | undefined): ComposerTarget | null =>
+  (el?.dataset.composerTarget as ComposerTarget | undefined) ?? null
+
 /**
  * The chat surface currently on screen (`data-composer-target` hung off each
  * ChatView). Inactive tabs stay mounted with `data-pane-hidden`, so this uses
  * the same visibility policy as every other document-wide surface lookup.
+ *
+ * A SPLIT renders one chat surface per zone and both are visible at once, so
+ * "the" visible surface is ambiguous there. Picking the first DOM match answers
+ * document order — always the leftmost zone — and every keystroke aimed at the
+ * other composer is preventDefault'd and dropped. Resolve a zone identity
+ * instead, through the same ladder the tab verbs use.
  */
 const visibleChatTarget = (): ComposerTarget | null => {
   if (typeof document === 'undefined') {
     return null
   }
 
-  const surface = queryVisible<HTMLElement>('[data-composer-target]')
-  const target = surface?.dataset.composerTarget
+  const surfaces = queryAllVisible<HTMLElement>('[data-composer-target]')
 
-  return target ? (target as ComposerTarget) : null
+  // Only a split can be ambiguous. Short-circuit the single-surface case (the
+  // overwhelmingly common one) before reading any store.
+  if (surfaces.length > 1) {
+    // The hovered → active ladder `tabTargetGroup` walks (pane-shell/tree/store),
+    // so the composer routing key can never disagree with ⌘1…⌘9 / ⌃Tab about
+    // which zone is "the" zone.
+    for (const zone of [$hoveredTreeGroup.get(), $activeTreeGroup.get()]) {
+      const hit = zone
+        ? surfaces.find(el => el.closest<HTMLElement>('[data-tree-group]')?.dataset.treeGroup === zone)
+        : undefined
+
+      if (hit) {
+        return composerTargetOf(hit)
+      }
+    }
+  }
+
+  // Deliberate last resort: document order, NOT null. With nothing hovered and
+  // nothing yet activated there is no identity to resolve, and answering null
+  // would send the routing key to a possibly-buried `'main'` and drop every
+  // keystroke — strictly worse than naming a surface the user can actually see.
+  // Keep this fallback; it reads like a missing guard, but removing it is a
+  // regression.
+  return composerTargetOf(surfaces[0])
 }
 
 /** True when `target` still has a live, on-screen subscriber. */
@@ -327,11 +358,14 @@ export const focusComposerInput = (el: HTMLElement | null) => {
 
 /** Drop focus from the main composer input (status-stack chrome, sidebar, etc.).
  *  Skips inactive tabs — they stay mounted, so an unscoped lookup can land on a
- *  background composer and leave the visible one focused. */
+ *  background composer and leave the visible one focused.
+ *
+ *  A split makes several inputs visible at once, so the identity has to come
+ *  from `activeElement` rather than document order: matching the first visible
+ *  input and then testing it against `activeElement` silently no-ops whenever
+ *  the caret sits in any zone but the leftmost. */
 export const blurComposerInput = () => {
-  const el = queryVisible(`[data-slot="${RICH_INPUT_SLOT}"]`)
-
-  if (el && document.activeElement === el) {
-    el.blur()
-  }
+  queryAllVisible<HTMLElement>(`[data-slot="${RICH_INPUT_SLOT}"]`)
+    .find(candidate => candidate === document.activeElement)
+    ?.blur()
 }


### PR DESCRIPTION
## This is a sibling follow-up to #73881 (commit `f12e6526a`)

- **What the parent covered:** `f12e6526a` introduced `visibleChatTarget()` so `'active'` heals onto *a* visible `[data-composer-target]` stamp instead of a buried keep-alive tab.
- **What the parent did NOT touch:** *which* of several simultaneously-visible surfaces wins. A split makes two visible at once, and the parent's `queryVisible()` lookup answers document order there.
- **What this adds:** a resolved zone identity for that pick, plus the same fix on the `blurComposerInput()` twin lookup.

## What does this PR do?

`visibleChatTarget()` resolved "the" on-screen chat surface with `queryVisible('[data-composer-target]')`. `queryVisible` filters `[data-pane-hidden]` and then returns the **first remaining DOM match** (`pane-visibility.ts:50-51` is literally `queryAllVisible(selector)[0] ?? null`). That is sound while one surface is visible — but `tree-split.tsx` renders one `TreeNode` per split child and each tree group marks its own active pane visible, so **a split has two visible chat surfaces at once**. The answer then degrades to document order: always the leftmost zone.

Both consumers decide which composer owns the keyboard:

- `resolveActive()` (`focus.ts:132`) — `const visible = visibleChatTarget() ?? 'main'`
- `releaseActiveComposer()` (`focus.ts:189`) — `activeTarget = visibleChatTarget() ?? 'main'`

**Symptom a user reports:** split the workspace, work in the right-hand zone, then close that tile (or let the claim go stale on a tab switch). The composer routing key is handed to the left zone's surface, so Enter, type-to-focus, Esc, Ctrl+B voice and soft `/` all land in the pane you are not looking at. Type-to-focus `preventDefault`s the keystroke *before* dispatching, so every character aimed at the surviving right-hand composer is swallowed and dropped.

This resolves a zone identity instead, walking the same **hovered → active** ladder `tabTargetGroup()` uses (`pane-shell/tree/store.ts:294`, iterating `[$hoveredTreeGroup.get(), $activeTreeGroup.get()]` at `:301`). That resolver already backs ⌘1…⌘9, ⌃Tab and the ⌘W family, so reusing it is what keeps the composer key from disagreeing with the tab verbs about which zone is "the" zone — rather than inventing a second notion of the focused surface.

Two deliberate choices, both pinned by tests:

- **The ladder is consulted only when more than one surface is visible.** The single-surface path short-circuits before reading any store, so the overwhelmingly common case costs nothing extra.
- **With neither rung resolving, the fallback stays document order, not `null`.** Nothing hovered and nothing yet activated means there is no identity to resolve; answering `null` would point the routing key at a possibly-buried `'main'` and drop every keystroke — strictly worse than naming a surface the user can actually see. There is a comment on the fallback saying so, because it reads like a missing guard.

This is the follow-up I offered on #76472 when @teknium1 raised the identical defect on the clarify-card shortcut path:

> `queryVisible()` only excludes `[data-pane-hidden]` and returns the first remaining DOM match. Two split chat groups can both be visible, so this picks document order rather than the focused/active chat surface; the other visible card then cannot receive its shortcut. Please resolve a focused card identity and add a two-visible-card regression test.

— https://github.com/NousResearch/hermes-agent/pull/76472#discussion_r3697096458

## Related Issue

No filed issue. This addresses @teknium1's inline review request on #76472 (linked above), applied to the sibling site in `app/chat/composer/focus.ts` that the same review thread flagged as the next occurrence.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/focus.ts`
  - `visibleChatTarget()` — resolve the surface through the hovered → active zone ladder when several are visible; short-circuit the single-surface case before any store read; keep the document-order last resort with a comment explaining why it is not `null`.
  - `blurComposerInput()` — take the identity from `document.activeElement` instead of the first visible match.
  - Import `$activeTreeGroup` alongside the already-imported `$hoveredTreeGroup`.
- `apps/desktop/src/app/chat/composer/focus.test.ts` — 8 regression tests (details below), reusing the file's existing `mountZonedSurface()` helper; reset `$activeTreeGroup` in `afterEach` beside `$hoveredTreeGroup`.

### Sibling-site coverage

Root cause: *picking one of several simultaneously-visible surfaces by document order instead of by a resolved identity.* Sweep run over the desktop renderer:

```
grep -rn "queryVisible\|queryAllVisible" apps/desktop/src --include='*.ts' --include='*.tsx' | grep -v '\.test\.'
```

**Fixed here (both sites sharing the cause):**

| Site | Defect |
| --- | --- |
| `focus.ts:80` `visibleChatTarget()` | picks the composer routing key by document order |
| `focus.ts:332` `blurComposerInput()` | matches the first visible input, then tests it against `activeElement` — so the guard silently no-ops whenever the caret sits in any zone but the leftmost, and chrome cannot release it |

**Cured transitively, no second edit:**

- `focus.ts:266` `composerTargetInHoveredZone()` — hovered rung only. Its call site is `composerTargetInHoveredZone() ?? resolveActive()` (`:292`), and `resolveActive()` now routes through the corrected resolver, so the active rung is restored without duplicating the ladder.

**Deliberately excluded (do not share the cause):**

- `focus.ts:102` — exact match on `[data-composer-target="<id>"]`; names one specific target, nothing to disambiguate.
- `focus.ts:109`, `focus.ts:287` — boolean "is any chat surface on screen" guards; they never pick an identity.
- `session-drag.ts:75`, `:131` — map over **all** visible anchors to build a geometry list; no single-element pick.
- `pane-visibility.ts:50` — the `queryVisible` primitive itself. First-match is its documented contract; changing it would alter every caller.
- `lib/keybinds/composer-focus-keys.ts:73` — same root cause, but already fixed under review in #76472 (`2541b63df`). Left untouched here so the two PRs cannot collide.

## How to Test

Reproduce manually:

1. Split the workspace so two chat zones are visible side by side.
2. Click into the **right-hand** zone's composer, then close that tile (or switch its tab so the claim goes stale).
3. Type a character, or press Esc / Ctrl+B.
4. **Before:** the keystroke is routed to the left zone's composer and dropped — the visible right-hand composer never focuses. **After:** the key lands in the zone you are working in.

Automated, from `apps/desktop/`:

```
npx vitest run --project ui src/app/chat/composer/focus.test.ts
npm run typecheck
npm run lint
```

**Fails-before / passes-after, verified by reverting only `focus.ts` to `origin/main` and re-running with the new tests in place** — 5 of the 8 new cases go red, with this output:

```
 × blurs the focused input when a split leaves several visible
 × releases the routing key into the active zone, not the leftmost surface
 × prefers the hovered zone over the active one (ladder order)
 × falls through to the active zone when the hovered zone holds no chat surface
 × heals a stale claim into the active zone rather than document order

AssertionError: expected <div …(2)></div> not to be <div …(2)></div> // Object.is equality
AssertionError: expected 'tile:left' to be 'tile:right' // Object.is equality
AssertionError: expected 'tile:left' to be 'tile:right' // Object.is equality
AssertionError: expected 'tile:left' to be 'tile:right' // Object.is equality
AssertionError: expected 'tile:left' to be 'tile:right' // Object.is equality

Tests  5 failed | 17 passed (22)
```

Restoring `focus.ts` returns the file to **22 passed (22)**.

The other 3 new cases are guards that pass on `main` by construction and are there to stop the fix from degenerating:

- **both directions** — zone-a active selects zone-a's surface *and* zone-b active selects zone-b's, so the resolver cannot pass by simply preferring the last-mounted surface;
- **neither rung resolving still returns a surface**, pinning the deliberate non-`null` fallback;
- **a single visible surface is unaffected by zone state**, pinning the short-circuit.

Results observed on this branch:

| Gate | Result |
| --- | --- |
| `vitest run --project ui src/app/chat/composer/focus.test.ts` | 22 passed (22) |
| `npm run test:ui` (full desktop UI suite) | **379 files, 3296 tests, 0 failures** |
| `npm run typecheck` | clean (exit 0) |
| `npm run lint` | 0 errors; 82 pre-existing `no-restricted-globals` warnings elsewhere in the repo, **0 on the two touched files** |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *not applicable: this is a TypeScript-only change in the desktop renderer. The equivalent gates are `npm run test:ui`, `npm run typecheck` and `npm run lint`, with results tabled above.*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the changed behavior is documented in the doc comments on both touched functions
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — N/A: renderer DOM logic with no platform-specific code paths. Verified on macOS only; not exercised on Windows or Linux.
- [x] N/A — no tool descriptions or schemas changed
