### PR TITLE
fix(desktop): drain backend children to completion before quitting

### DIFF
--- a/apps/desktop/electron/backend-quit-drain.test.ts
+++ b/apps/desktop/electron/backend-quit-drain.test.ts
@@ -24,19 +24,23 @@ test('captures every live pooled backend even though the pool is about to be cle
   // snapshot up-front and keep those handles.
   const poolA = alive()
   const poolB = alive()
+
   const targets = collectBackendDrainTargets(undefined, [
     { process: poolA },
     { process: poolB },
   ])
+
   assert.deepEqual(targets, [poolA, poolB])
 })
 
 test('dedupes a primary that also appears in the pool snapshot', () => {
   const shared = alive()
+
   const targets = collectBackendDrainTargets(shared, [
     { process: shared },
     { process: alive() },
   ])
+
   assert.strictEqual(targets.length, 2)
 })
 

--- a/apps/desktop/electron/backend-quit-drain.test.ts
+++ b/apps/desktop/electron/backend-quit-drain.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { collectBackendDrainTargets } from './backend-quit-drain'
+import type { BackendChildLike } from './backend-quit-drain'
+
+const alive = (extra: Partial<BackendChildLike> = {}): BackendChildLike => ({
+  exitCode: null,
+  signalCode: null,
+  ...extra,
+})
+
+test('captures the primary backend as a drain target when alive', () => {
+  const primary = alive()
+  const targets = collectBackendDrainTargets(primary, [])
+  assert.deepEqual(targets, [primary])
+})
+
+test('captures every live pooled backend even though the pool is about to be cleared', () => {
+  // Regression for the orphan-on-quit bug: stopAllPoolBackends() deletes the
+  // backendPool map entries before SIGTERM, so a caller that reads the pool
+  // AFTER clearing gets nothing to wait on. The helper must take its pool
+  // snapshot up-front and keep those handles.
+  const poolA = alive()
+  const poolB = alive()
+  const targets = collectBackendDrainTargets(undefined, [
+    { process: poolA },
+    { process: poolB },
+  ])
+  assert.deepEqual(targets, [poolA, poolB])
+})
+
+test('dedupes a primary that also appears in the pool snapshot', () => {
+  const shared = alive()
+  const targets = collectBackendDrainTargets(shared, [
+    { process: shared },
+    { process: alive() },
+  ])
+  assert.strictEqual(targets.length, 2)
+})
+
+test('skips already-exited children (no point waiting on them)', () => {
+  const dead = alive({ exitCode: 0, signalCode: null })
+  const liveChild = alive()
+  const targets = collectBackendDrainTargets(dead, [{ process: liveChild }])
+  assert.deepEqual(targets, [liveChild])
+})
+
+test('returns an empty list when there is nothing to drain', () => {
+  assert.deepEqual(collectBackendDrainTargets(undefined, []), [])
+  assert.deepEqual(collectBackendDrainTargets(null, [{ process: null }]), [])
+})

--- a/apps/desktop/electron/backend-quit-drain.ts
+++ b/apps/desktop/electron/backend-quit-drain.ts
@@ -1,0 +1,53 @@
+/**
+ * Backend quit-drain decision logic (pure — no Electron side effects here).
+ *
+ * The desktop's `before-quit` handler must wait for the hermes backend
+ * processes to actually exit before Electron tears down, or the SIGTERM races
+ * ahead and leaves stray `hermes serve` orphans. The one trap: the child
+ * handles must be captured BEFORE `stopAllPoolBackends()` runs, because it
+ * deletes every backendPool entry (and thus the reference to each pool child)
+ * before sending SIGTERM.
+ *
+ * This module exposes the pure computation so the drain behavior is unit-testable
+ * without booting Electron.
+ */
+
+/**
+ * A handle to a backend child process. Only `exitCode`/`signalCode`/`killed`
+ * are read here, so a real ChildProcess or a minimal test stub both work.
+ */
+export interface BackendChildLike {
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
+  killed?: boolean
+}
+
+/**
+ * Compute the set of backend children that must be waited on during quit.
+ *
+ * @param primaryProcess The primary (window) backend process handle, if any.
+ * @param poolEntries    A snapshot of the current backendPool entries
+ *                       (profile -> { process, ... }). Callers MUST pass this
+ *                       before calling stopAllPoolBackends(), since that
+ *                       clears the pool.
+ * @returns A deduplicated list of still-alive children to drain.
+ */
+export function collectBackendDrainTargets(
+  primaryProcess: BackendChildLike | null | undefined,
+  poolEntries: ReadonlyArray<{ process: BackendChildLike | null | undefined }>,
+): BackendChildLike[] {
+  const seen = new Set<BackendChildLike>()
+  const out: BackendChildLike[] = []
+
+  for (const child of [primaryProcess, ...poolEntries.map(e => e.process)]) {
+    if (!child || seen.has(child)) {
+      continue
+    }
+    seen.add(child)
+    // Already-exited handles need no waiting; only live ones are targets.
+    if (child.exitCode === null && child.signalCode === null) {
+      out.push(child)
+    }
+  }
+  return out
+}

--- a/apps/desktop/electron/backend-quit-drain.ts
+++ b/apps/desktop/electron/backend-quit-drain.ts
@@ -43,11 +43,14 @@ export function collectBackendDrainTargets(
     if (!child || seen.has(child)) {
       continue
     }
+
     seen.add(child)
+
     // Already-exited handles need no waiting; only live ones are targets.
     if (child.exitCode === null && child.signalCode === null) {
       out.push(child)
     }
   }
+
   return out
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { collectBackendDrainTargets } from './backend-quit-drain'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -7260,6 +7261,9 @@ const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PA
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
 let sshQuitTeardownDone = false
+// One-shot latch so the re-entrant app.quit() that ends the backend drain
+// (below) doesn't re-enter before-quit and reschedule the same drain forever.
+let backendQuitDrainScheduled = false
 
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
@@ -11996,8 +12000,41 @@ app.on('before-quit', event => {
     disposeTerminalSession(id)
   }
 
-  stopBackendChild(backendConnectionState.getProcess())
-  stopAllPoolBackends()
+  // Drain the backend children to completion before letting Electron exit,
+  // so the SIGTERM we send below actually takes effect instead of the child
+  // being orphaned when the process tears down. The tricky part: capture the
+  // still-alive children BEFORE calling stopAllPoolBackends(), because it
+  // deletes every backendPool entry (and thus the handle) before killing.
+  const primaryChild = backendConnectionState.getProcess()
+  const drainTargets = collectBackendDrainTargets(primaryChild, [...backendPool.values()])
+
+  // Only intervene when there is at least one live backend to wait on — a quit
+  // with nothing running must proceed immediately (no artificial delay).
+  if (!backendQuitDrainScheduled && drainTargets.length > 0) {
+    backendQuitDrainScheduled = true
+    event.preventDefault()
+
+    // Cmd-Q should still feel instant even though the actual exit is deferred
+    // for up to ~5s while the backend drains.
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.hide()
+      }
+    }
+
+    stopBackendChild(primaryChild)
+    stopAllPoolBackends()
+
+    void Promise.allSettled(drainTargets.map(child => waitForBackendExit(child)))
+      .then(() => {
+        // Re-enter quit. The latch above is now set, so before-quit runs its
+        // remaining teardown but does NOT re-schedule this drain.
+        app.quit()
+      })
+  } else {
+    stopBackendChild(primaryChild)
+    stopAllPoolBackends()
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -34,6 +34,7 @@ import nodePty from 'node-pty'
 import { classifyActiveRuntime } from './active-runtime-state'
 import { collectBackendDrainTargets } from './backend-quit-drain'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
+import { QuitBarrier } from './quit-barrier'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -7264,6 +7265,11 @@ let sshQuitTeardownDone = false
 // One-shot latch so the re-entrant app.quit() that ends the backend drain
 // (below) doesn't re-enter before-quit and reschedule the same drain forever.
 let backendQuitDrainScheduled = false
+// All async work that must finish before Electron actually exits. The SSH
+// deferral and the backend drain both register here so a single quit barrier
+// waits for ALL of them; a re-entrant app.quit() cannot bypass another
+// outstanding wait by re-entering before-quit early.
+const quitBarrier = new QuitBarrier()
 
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
@@ -11940,20 +11946,21 @@ app.on('before-quit', event => {
   }
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
-    event.preventDefault()
     sshBootstrapCoordinator.cancelAll()
     const scopes = [...sshConnections.keys()]
 
-    const pending = Promise.allSettled([
-      ...scopes.map(scope => teardownSshConnection(scope || null)),
-      ...sshBootstrapCoordinator.promises()
-    ])
-
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
-      await sshBootstrapCoordinator.forceCleanupAll()
-      sshQuitTeardownDone = true
-      app.quit()
-    })
+    quitBarrier.add(
+      Promise.race([
+        Promise.allSettled([
+          ...scopes.map(scope => teardownSshConnection(scope || null)),
+          ...sshBootstrapCoordinator.promises()
+        ]),
+        new Promise(resolve => setTimeout(resolve, 4_000))
+      ]).then(async () => {
+        await sshBootstrapCoordinator.forceCleanupAll()
+        sshQuitTeardownDone = true
+      })
+    )
   }
 
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).
@@ -12008,12 +12015,26 @@ app.on('before-quit', event => {
   const primaryChild = backendConnectionState.getProcess()
   const drainTargets = collectBackendDrainTargets(primaryChild, [...backendPool.values()])
 
-  // Only intervene when there is at least one live backend to wait on — a quit
-  // with nothing running must proceed immediately (no artificial delay).
+  // Only defer the quit when there is at least one live backend to wait on —
+  // a quit with nothing running proceeds immediately (no artificial delay).
   if (!backendQuitDrainScheduled && drainTargets.length > 0) {
     backendQuitDrainScheduled = true
-    event.preventDefault()
+    for (const child of drainTargets) {
+      quitBarrier.add(waitForBackendExit(child))
+    }
+  }
 
+  stopBackendChild(primaryChild)
+  stopAllPoolBackends()
+
+  // Single guard: if any async teardown (SSH or backend) is pending, hold the
+  // quit here and re-enter once ALL of it has settled. The SSH branch and the
+  // backend drain register into the same `quitBarrier`, so a re-entrant
+  // app.quit() cannot bypass another outstanding wait — the barrier re-quits
+  // only after every promise has settled or reached its bound.
+  const barrier = quitBarrier.arm()
+  if (barrier) {
+    event.preventDefault()
     // Cmd-Q should still feel instant even though the actual exit is deferred
     // for up to ~5s while the backend drains.
     for (const win of BrowserWindow.getAllWindows()) {
@@ -12022,18 +12043,11 @@ app.on('before-quit', event => {
       }
     }
 
-    stopBackendChild(primaryChild)
-    stopAllPoolBackends()
-
-    void Promise.allSettled(drainTargets.map(child => waitForBackendExit(child)))
-      .then(() => {
-        // Re-enter quit. The latch above is now set, so before-quit runs its
-        // remaining teardown but does NOT re-schedule this drain.
-        app.quit()
-      })
-  } else {
-    stopBackendChild(primaryChild)
-    stopAllPoolBackends()
+    void barrier.then(() => {
+      // Both SSH and backend latches are now set, so this re-entrant
+      // before-quit runs the remaining teardown but does NOT re-schedule them.
+      app.quit()
+    })
   }
 })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,9 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { collectBackendDrainTargets } from './backend-quit-drain'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
-import { QuitBarrier } from './quit-barrier'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -46,6 +44,7 @@ import {
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
+import { collectBackendDrainTargets } from './backend-quit-drain'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -161,6 +160,7 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import { QuitBarrier } from './quit-barrier'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
@@ -12019,6 +12019,7 @@ app.on('before-quit', event => {
   // a quit with nothing running proceeds immediately (no artificial delay).
   if (!backendQuitDrainScheduled && drainTargets.length > 0) {
     backendQuitDrainScheduled = true
+
     for (const child of drainTargets) {
       quitBarrier.add(waitForBackendExit(child))
     }
@@ -12033,8 +12034,10 @@ app.on('before-quit', event => {
   // app.quit() cannot bypass another outstanding wait — the barrier re-quits
   // only after every promise has settled or reached its bound.
   const barrier = quitBarrier.arm()
+
   if (barrier) {
     event.preventDefault()
+
     // Cmd-Q should still feel instant even though the actual exit is deferred
     // for up to ~5s while the backend drains.
     for (const win of BrowserWindow.getAllWindows()) {

--- a/apps/desktop/electron/quit-barrier.test.ts
+++ b/apps/desktop/electron/quit-barrier.test.ts
@@ -7,10 +7,12 @@ import { QuitBarrier } from './quit-barrier'
 function deferred<T = void>() {
   let resolve!: (v: T) => void
   let reject!: (e: unknown) => void
+
   const promise = new Promise<T>((res, rej) => {
     resolve = res
     reject = rej
   })
+
   return { promise, resolve, reject }
 }
 

--- a/apps/desktop/electron/quit-barrier.test.ts
+++ b/apps/desktop/electron/quit-barrier.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { QuitBarrier } from './quit-barrier'
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+test('arm() waits for every registered promise before resolving', async () => {
+  const barrier = new QuitBarrier()
+  const ssh = deferred()
+  const backend = deferred()
+  barrier.add(ssh.promise)
+  barrier.add(backend.promise)
+
+  const armed = barrier.arm()
+  assert.ok(armed, 'barrier should arm when there is pending work')
+
+  let settled = false
+  void armed.then(() => {
+    settled = true
+  })
+  // Neither promise resolved yet — the barrier must still be pending.
+  await Promise.resolve()
+  assert.strictEqual(settled, false, 'barrier resolved before all work settled')
+
+  // SSH tears down first — the barrier must NOT re-quit yet (backend pending).
+  ssh.resolve()
+  await Promise.resolve()
+  assert.strictEqual(settled, false, 'barrier resolved after only SSH settled')
+
+  // Both settled — now the single re-quit may fire.
+  backend.resolve()
+  await armed
+  assert.strictEqual(settled, true)
+})
+
+test('re-entrant arm() returns null and cannot bypass an outstanding wait', () => {
+  const barrier = new QuitBarrier()
+  const slow = deferred()
+  barrier.add(slow.promise)
+
+  const first = barrier.arm()
+  assert.ok(first)
+
+  // A re-entrant before-quit tries to arm again — must be refused (no double
+  // schedule), and work added after arming is dropped so the barrier stays the
+  // single source of truth.
+  assert.strictEqual(barrier.arm(), null)
+  barrier.add(deferred().promise) // must be ignored
+  assert.strictEqual(barrier.isEmpty, true, 'post-arm adds must be ignored')
+  assert.strictEqual(barrier.arm(), null)
+})
+
+test('arm() resolves immediately (no artificial delay) when nothing is pending', () => {
+  const barrier = new QuitBarrier()
+  assert.strictEqual(barrier.arm(), null, 'empty barrier should be null, not wait')
+})
+
+test('allSettled semantics: a rejected wait still releases the barrier', async () => {
+  const barrier = new QuitBarrier()
+  barrier.add(Promise.reject(new Error('backend SIGKILL failed')))
+  const armed = barrier.arm()
+  assert.ok(armed)
+  // Even a rejected promise releases the barrier (SIGKILL fallback hit its
+  // bound, so there is nothing left to wait on) — it must not re-quit hang.
+  await armed
+})

--- a/apps/desktop/electron/quit-barrier.ts
+++ b/apps/desktop/electron/quit-barrier.ts
@@ -26,6 +26,7 @@ export class QuitBarrier {
       // snapshotted by the armed barrier.
       return
     }
+
     this.pending.push(work)
   }
 
@@ -45,9 +46,11 @@ export class QuitBarrier {
     if (this.armed || this.pending.length === 0) {
       return null
     }
+
     this.armed = true
     const batch = this.pending
     this.pending = []
+
     return Promise.allSettled(batch).then(() => undefined)
   }
 }

--- a/apps/desktop/electron/quit-barrier.ts
+++ b/apps/desktop/electron/quit-barrier.ts
@@ -1,0 +1,53 @@
+/**
+ * QuitBarrier — coordinates all async work that must complete before Electron
+ * actually exits (SSH teardown, backend process drain).
+ *
+ * The race this prevents: multiple exit paths each call `event.preventDefault()`
+ * and each schedule their own `app.quit()` re-entry in the same `before-quit`
+ * invocation. Whichever path's promise resolves first re-enters `before-quit`,
+ * sees the other path's latch already set, and lets Electron exit while the
+ * other wait is still pending — orphaning whatever that path was draining.
+ *
+ * QuitBarrier fixes it: every path registers its pending promise, then `arm()`
+ * snapshots ALL of them, holds the quit once, and re-enters `app.quit()` only
+ * after every registered promise has settled (or reached its own timeout
+ * bound). A re-entrant quit cannot bypass an outstanding wait because the
+ * barrier already snapped the full set and the second `app.quit()` runs with
+ * the pending list empty.
+ */
+export class QuitBarrier {
+  private pending: Promise<unknown>[] = []
+  private armed = false
+
+  /** Register async work that must finish before quit completes. */
+  add(work: Promise<unknown>): void {
+    if (this.armed) {
+      // A re-entrant before-quit must not re-schedule work that was already
+      // snapshotted by the armed barrier.
+      return
+    }
+    this.pending.push(work)
+  }
+
+  get isEmpty(): boolean {
+    return this.pending.length === 0
+  }
+
+  /**
+   * Arm the barrier exactly once. Snaps the current pending set, resets the
+   * accumulator, and returns a promise that resolves when every snapshotted
+   * promise has settled. `null` if there is nothing to wait on.
+   *
+   * Repeated calls return `null` after the first arm — a re-entrant
+   * `before-quit` can't double-arm.
+   */
+  arm(): Promise<void> | null {
+    if (this.armed || this.pending.length === 0) {
+      return null
+    }
+    this.armed = true
+    const batch = this.pending
+    this.pending = []
+    return Promise.allSettled(batch).then(() => undefined)
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Drain primary + pooled backend children to completion before Electron fully exits, instead of fire-and-forget SIGTERM that orphaned slow-exiting hermes serve processes.

## Related Issue

Fixes #76245 — reported stray hermes serve orphans on Desktop quit: before-quit sent SIGTERM fire-and-forget so a slow-exiting backend child was orphaned. Now the desktop captures live children before clearing the pool and waits (5s bounded) for each to exit before finishing quit.

## Changes Made

- `fix/desktop-backend-quit-drain` — 5 file(s) changed vs base:
  - `apps/desktop/electron/backend-quit-drain.test.ts`
  - `apps/desktop/electron/backend-quit-drain.ts`
  - `apps/desktop/electron/main.ts`
  - `apps/desktop/electron/quit-barrier.test.ts`
  - `apps/desktop/electron/quit-barrier.ts`

Two-file change: (1) backend-quit-drain.ts helper captures primary+pool children before stopAllPoolBackends clears the pool; (2) quit-barrier.ts coordinates SSH teardown + backend drain into a single shutdown barrier so no re-entrant app.quit() bypasses an outstanding wait. main.ts before-quit registers both into the barrier and re-quits once all settle.

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: vitest electron: drain helper + QuitBarrier regression. Drain: sabotage leg loses pool children -> 3 fail, fixed 5/5. Barrier: SSH+slow backend test asserts single re-quit after both settle (4/4). Full electron 80 files/942 pass; tsc 0 errors.
2. Duplicate check: 45 potential matches reviewed — none covers this change.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: vitest electron: drain helper + QuitBarrier regression. Drain: sabotage leg loses pool children -> 3 fail, fixed 5/5. Barrier: SSH+slow backend test asserts single re-quit after both settle (4/4). Full electron 80 files/942 pass; tsc 0 errors.
```
