### PR TITLE
fix(tools): support Python 3.14 worker context in DaemonThreadPoolExecutor (#76621)

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import threading
 import time
+from unittest import mock
 
 from concurrent.futures.thread import _threads_queues
 
@@ -73,3 +74,32 @@ def _repo_root():
     import pathlib
 
     return pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_py314_worker_context_branch_spawns_worker_with_ctx():
+    """#76621: on Python 3.14 the executor exposes _create_worker_context
+    instead of _initializer/_initargs; _adjust_thread_count must pass the
+    context object to _worker rather than the removed attributes.
+
+    Simulate the 3.14 shape by attaching _create_worker_context to a real
+    pool instance and capturing the Thread constructor args (the thread is
+    never actually started, so the interpreter-local _worker signature is
+    irrelevant).
+    """
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    ctx = object()
+    pool._create_worker_context = lambda: ctx  # simulate 3.14 layout
+    try:
+        with mock.patch("tools.daemon_pool.threading.Thread") as thread_cls:
+            thread_cls.return_value.start = mock.Mock()
+            pool._adjust_thread_count()
+        thread_cls.assert_called_once()
+        _, kwargs = thread_cls.call_args
+        args = kwargs["args"]
+        # (executor_ref, ctx, work_queue) — 3.14 worker signature
+        assert len(args) == 3
+        assert args[1] is ctx
+        assert args[2] is pool._work_queue
+        assert kwargs["daemon"] is True
+    finally:
+        pool.shutdown(wait=True)

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -49,16 +49,32 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
-                daemon=True,
-            )
+            if hasattr(self, "_create_worker_context"):
+                # CPython 3.14+ removed _initializer/_initargs and replaced
+                # them with _create_worker_context(); the worker signature
+                # became (executor_reference, ctx, work_queue).  See issue
+                # #76621.
+                t = threading.Thread(
+                    name=thread_name,
+                    target=_worker,
+                    args=(
+                        weakref.ref(self, weakref_cb),
+                        self._create_worker_context(),
+                        self._work_queue,
+                    ),
+                    daemon=True,
+                )
+            else:
+                t = threading.Thread(
+                    name=thread_name,
+                    target=_worker,
+                    args=(
+                        weakref.ref(self, weakref_cb),
+                        self._work_queue,
+                        self._initializer,
+                        self._initargs,
+                    ),
+                    daemon=True,
+                )
             t.start()
             self._threads.add(t)


### PR DESCRIPTION
## Summary

`DaemonThreadPoolExecutor._adjust_thread_count` mirrors CPython 3.8–3.13's `ThreadPoolExecutor` implementation and reads `self._initializer` / `self._initargs`. CPython 3.14 removed those attributes in favor of `_create_worker_context()` (and changed `_worker`'s signature to `(executor_reference, ctx, work_queue)`), so the **first parallel tool batch** on Python 3.14 crashed with `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'`.

Fix: branch on `hasattr(self, '_create_worker_context')` — on 3.14+ pass the context object to `_worker`; on 3.8–3.13 the existing path is unchanged.

Single-file change (plus one new test). No public API change. No new imports.

NOT doing X: not touching shutdown/idle-reuse semantics — daemon workers and `_threads_queues` skip are preserved on both branches.

## Test plan

```
python -m pytest tests/tools/test_daemon_pool.py -q
# 4 passed (3 existing + 1 new: simulates the 3.14 layout via a fake
# _create_worker_context and asserts the Thread constructor receives
# (executor_ref, ctx, work_queue) with daemon=True)
```

Verified on Python 3.11 (3.8–3.13 branch). The 3.14 branch is exercised by the new unit test without depending on a 3.14 interpreter.
