### PR TITLE
fix(telegram): route forwarded channel media through effective_message (#76615)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8959,18 +8959,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -8980,8 +8981,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -111,9 +111,18 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
 
 
 def _make_update(msg):
-    """Wrap a message in a mock Update."""
+    """Wrap a message in a mock Update.
+
+    ``effective_message`` mirrors python-telegram-bot semantics: for a
+    normal message it is the same object as ``update.message``, while
+    channel posts are exposed only via ``effective_message`` (with
+    ``update.message`` being None).  Handlers route through
+    ``_effective_update_message()``, so both must be set explicitly —
+    a MagicMock attribute access would otherwise return an auto-mock.
+    """
     update = MagicMock()
     update.message = msg
+    update.effective_message = msg
     return update
 
 
@@ -564,3 +573,42 @@ class TestSendVideo:
 
         call_kwargs = connected_adapter._bot.send_video.call_args[1]
         assert call_kwargs["message_thread_id"] == 789
+
+
+# ---------------------------------------------------------------------------
+# TestForwardedChannelMedia (#76615)
+# ---------------------------------------------------------------------------
+
+class TestForwardedChannelMedia:
+    """Media forwarded from a channel arrives with update.message=None and
+    the real payload on update.effective_message; the handler must route
+    through _effective_update_message() instead of dropping the update."""
+
+    @pytest.mark.asyncio
+    async def test_forwarded_channel_photo_is_delivered(self, adapter):
+        photo = _make_photo()
+        msg = _make_message(photo=photo)
+        # Channel-post shape: message is None, payload lives on effective_message.
+        update = MagicMock()
+        update.message = None
+        update.effective_message = msg
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event is not None
+        assert event.message_type == MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_forwarded_channel_document_is_delivered(self, adapter):
+        doc = _make_document()
+        msg = _make_message(document=doc)
+        update = MagicMock()
+        update.message = None
+        update.effective_message = msg
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event is not None
+        assert event.message_type == MessageType.DOCUMENT


### PR DESCRIPTION
## Summary

`_handle_media_message` guarded on `update.message` and returned silently when it was `None`. Media **forwarded from channels** arrives with the real payload on `update.effective_message` (`update.message` is `None`), so forwarded photos/documents were never delivered to the agent — no log, no error.

Fix: resolve `msg = self._effective_update_message(update)` at the top (mirroring the text handler at ~line 8695) and use it for the auth / should-process / observe checks. The rest of the function already worked off a `msg` variable.

Also fixed the test helper to set `effective_message` explicitly (MagicMock would otherwise return an auto-mock, silently breaking effective-message routing).

Single-file change (plus tests). No public API change.

NOT doing X: not touching `_handle_text_message` (already correct), not changing download/cache flow.

## Test plan

```
python -m pytest tests/gateway/test_telegram_documents.py -q
# 19 passed (17 existing + 2 new: forwarded channel photo + document
# arrive with update.message=None / effective_message=<msg> and are
# delivered as PHOTO/DOCUMENT events)
```
