### PR TITLE
fix(env): honour _IS_WINDOWS for PATH separators and Git Bash dirs

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -1291,41 +1291,28 @@ class TestSanePathIncludesHomebrew:
 
 
     def test_make_run_env_appends_homebrew_on_minimal_path(self, monkeypatch):
-        """When PATH is minimal, _make_run_env appends missing sane entries.
-
-        POSIX: the sane-path merge appends the Homebrew dirs.  Windows:
-        _append_missing_sane_path_entries is a documented passthrough (the
-        native PATH must not be touched), so the assertion is the unchanged
-        input.  Git Bash dir prepending is neutralised so the merged PATH
-        layout is deterministic on every host.
-        """
+        """When PATH is minimal, _make_run_env appends missing sane entries."""
         from tools.environments import local as local_mod
         from tools.environments.local import _SANE_PATH, _make_run_env
-        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [])
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         minimal_env = {"PATH": "/some/custom/bin"}
         with patch.dict(os.environ, minimal_env, clear=True):
             result = _make_run_env({})
-        path_entries = result["PATH"].split(os.pathsep)
+        path_entries = result["PATH"].split(":")
         assert path_entries[0] == "/some/custom/bin"
-        if sys.platform == "win32":
-            assert result["PATH"] == "/some/custom/bin"
-        else:
-            for entry in _SANE_PATH.split(os.pathsep):
-                assert entry in path_entries
+        for entry in _SANE_PATH.split(":"):
+            assert entry in path_entries
 
 
-    @pytest.mark.macos_only
-    def test_make_run_env_real_launchd_path_gains_homebrew(self):
-        """The literal macOS launchd PATH is the production trigger for #35613.
-
-        macOS-only: the regression is the launchd environment on macOS, and
-        the sane-path merge is a documented passthrough on Windows.
-        """
+    def test_make_run_env_real_launchd_path_gains_homebrew(self, monkeypatch):
+        """The literal macOS launchd PATH is the production trigger for #35613."""
+        from tools.environments import local as local_mod
         from tools.environments.local import _make_run_env
-        launchd_env = {"PATH": os.pathsep.join(["/usr/bin", "/bin", "/usr/sbin", "/sbin"])}
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        launchd_env = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"}
         with patch.dict(os.environ, launchd_env, clear=True):
             result = _make_run_env({})
-        path_entries = result["PATH"].split(os.pathsep)
+        path_entries = result["PATH"].split(":")
         assert "/opt/homebrew/bin" in path_entries
         assert "/opt/homebrew/sbin" in path_entries
         # Original entries keep their leading precedence.
@@ -1379,7 +1366,7 @@ class TestHermesBinDirOnPath:
         local_mod._HERMES_BIN_DIR = None
         assert local_mod._prepend_hermes_bin_dir("/usr/bin:/bin") == "/usr/bin:/bin"
 
-    def test_make_run_env_injects_hermes_bin_dir(self):
+    def test_make_run_env_injects_hermes_bin_dir(self, monkeypatch):
         """A gateway env missing the hermes dir gets it back in the subshell PATH.
 
         Platform-agnostic: ``_prepend_hermes_bin_dir`` uses ``os.pathsep`` on
@@ -1388,13 +1375,14 @@ class TestHermesBinDirOnPath:
         from tools.environments.local import _make_run_env
         self._reset_cache()
         local_mod._HERMES_BIN_DIR = "/opt/hermes/bin"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         with patch.dict(
             os.environ,
-            {"PATH": os.pathsep.join(["/usr/bin", "/bin"])},
+            {"PATH": "/usr/bin:/bin"},
             clear=True,
         ):
             result = _make_run_env({})
-        entries = result["PATH"].split(os.pathsep)
+        entries = result["PATH"].split(":")
         assert entries[0] == "/opt/hermes/bin"
         assert "/usr/bin" in entries
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -563,6 +563,10 @@ class TestSanePathIncludesHomebrew:
         from tools.environments.local import _make_run_env
         windows_env = {"Path": r"C:\Windows\System32;C:\Program Files\Git\bin"}
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        # Isolate casing behaviour from the Git-Bash coreutils prepend (covered
+        # elsewhere). On a Windows host with Git installed, the prepend would
+        # otherwise rewrite Path and mask the Path-vs-PATH assertion.
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [])
         with patch.object(local_mod.os, "environ", windows_env):
             result = _make_run_env({})
         assert result["Path"] == windows_env["Path"]

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -533,9 +533,11 @@ class TestSanePathIncludesHomebrew:
         assert "/opt/homebrew/bin" in _SANE_PATH
 
 
-    def test_make_run_env_appends_homebrew_on_minimal_path(self):
+    def test_make_run_env_appends_homebrew_on_minimal_path(self, monkeypatch):
         """When PATH is minimal, _make_run_env appends missing sane entries."""
+        from tools.environments import local as local_mod
         from tools.environments.local import _SANE_PATH, _make_run_env
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         minimal_env = {"PATH": "/some/custom/bin"}
         with patch.dict(os.environ, minimal_env, clear=True):
             result = _make_run_env({})
@@ -545,9 +547,11 @@ class TestSanePathIncludesHomebrew:
             assert entry in path_entries
 
 
-    def test_make_run_env_real_launchd_path_gains_homebrew(self):
+    def test_make_run_env_real_launchd_path_gains_homebrew(self, monkeypatch):
         """The literal macOS launchd PATH is the production trigger for #35613."""
+        from tools.environments import local as local_mod
         from tools.environments.local import _make_run_env
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         launchd_env = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"}
         with patch.dict(os.environ, launchd_env, clear=True):
             result = _make_run_env({})
@@ -610,7 +614,7 @@ class TestHermesBinDirOnPath:
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=True):
             result = _make_run_env({})
-        entries = result["PATH"].split(os.pathsep)
+        entries = result["PATH"].split(":")
         assert entries[0] == "/opt/hermes/bin"
         assert "/usr/bin" in entries
 

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -43,6 +43,7 @@ from tools.environments.local import (
     _make_run_env,
     _msys_to_windows_path,
     _prepend_git_bash_dirs,
+    _prepend_hermes_bin_dir,
     _quote_bash_path,
     _resolve_safe_cwd,
     _sanitize_subprocess_env,
@@ -263,7 +264,7 @@ class TestGitBashCoreutilsOnPath:
         existing = {"/pg/mingw64/bin", "/pg/usr/bin", "/pg/bin"}
         monkeypatch.setattr(local_mod.os.path, "isdir", self._fake_isdir(existing))
 
-        dirs = _git_bash_bin_dirs()
+        dirs = [entry.replace("\\", "/") for entry in _git_bash_bin_dirs()]
 
         # Compare separator-agnostically: the derivation uses os.path.join, so
         # on real Windows these come back with backslashes ("/pg\\usr\\bin").
@@ -282,12 +283,98 @@ class TestGitBashCoreutilsOnPath:
         monkeypatch.setattr(local_mod, "_git_bash_bin_dirs_cache", None)
         assert _git_bash_bin_dirs() == []
 
-    @pytest.mark.linux_only
+    def test_populated_cache_does_not_survive_logical_platform_flip(self, monkeypatch):
+        cached = ["C:/Program Files/Git/usr/bin"]
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs_cache", cached)
+        assert _git_bash_bin_dirs() == cached
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert _git_bash_bin_dirs() == []
+
+    def test_posix_prepend_is_noop_even_with_cached_windows_dirs(self, monkeypatch):
+        existing = "/usr/bin:/bin"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: ["C:/Git/usr/bin"])
+
+        assert _prepend_git_bash_dirs(existing) == existing
+
+    def test_windows_prepend_uses_logical_path_separator(self, monkeypatch):
+        git_bin = "C:/Program Files/Git/usr/bin"
+        existing = "C:/Windows/System32;C:/Tools"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [git_bin])
+
+        assert _prepend_git_bash_dirs(existing) == f"{git_bin};{existing}"
+
+    def test_hermes_bin_prepend_uses_logical_path_separator(self, monkeypatch):
+        hermes_bin = "C:/Hermes/bin"
+        existing = "C:/Windows/System32;C:/Tools"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_resolve_hermes_bin_dir", lambda: hermes_bin)
+
+        assert _prepend_hermes_bin_dir(existing) == f"{hermes_bin};{existing}"
+
+
     def test_make_run_env_noop_on_posix(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
         monkeypatch.setattr(local_mod, "_git_bash_bin_dirs_cache", None)
         run_env = _make_run_env({"PATH": "/usr/bin:/bin"})
         # No Windows git dirs injected on POSIX.
         assert "mingw64" not in run_env["PATH"]
+
+
+# ---------------------------------------------------------------------------
+# Managed runtime PATH entries — logical-platform tests must not discard valid
+# POSIX filenames that happen to contain a backslash.
+# ---------------------------------------------------------------------------
+
+class TestManagedRuntimePathEntries:
+    class _ExistingDir:
+        def __init__(self, display: str):
+            self.display = display
+
+        def is_dir(self) -> bool:
+            return True
+
+        def __str__(self) -> str:
+            return self.display
+
+    def test_native_posix_keeps_backslash_named_runtime_dir(self, monkeypatch, tmp_path):
+        import hermes_constants
+
+        home = tmp_path / "hermes"
+        (home / "bin").mkdir(parents=True)
+        runtime_dir = self._ExistingDir("/opt/hermes/node" + chr(92) + "literal/bin")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_HOST_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_constants, "iter_hermes_node_dirs", lambda: [runtime_dir])
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: home)
+
+        assert str(runtime_dir) in local_mod._managed_runtime_path_entries()
+
+    def test_logical_posix_on_windows_filters_only_native_windows_paths(self, monkeypatch, tmp_path):
+        import hermes_constants
+
+        home = tmp_path / "hermes"
+        (home / "bin").mkdir(parents=True)
+        drive_dir = self._ExistingDir("C:/Hermes/node/bin")
+        unc_dir = self._ExistingDir("//server/share/node/bin")
+        posix_dir = self._ExistingDir("/opt/hermes/node" + chr(92) + "literal/bin")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_HOST_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            hermes_constants,
+            "iter_hermes_node_dirs",
+            lambda: [drive_dir, unc_dir, posix_dir],
+        )
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: home)
+
+        entries = local_mod._managed_runtime_path_entries()
+
+        assert str(drive_dir) not in entries
+        assert str(unc_dir) not in entries
+        assert str(posix_dir) in entries
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -30,6 +30,7 @@ from tools.environments.local import (
     _make_run_env,
     _msys_to_windows_path,
     _prepend_git_bash_dirs,
+    _prepend_hermes_bin_dir,
     _quote_bash_path,
     _resolve_safe_cwd,
     _sanitize_subprocess_env,
@@ -271,7 +272,7 @@ class TestGitBashCoreutilsOnPath:
         existing = {"/pg/mingw64/bin", "/pg/usr/bin", "/pg/bin"}
         monkeypatch.setattr(local_mod.os.path, "isdir", self._fake_isdir(existing))
 
-        dirs = _git_bash_bin_dirs()
+        dirs = [entry.replace("\\", "/") for entry in _git_bash_bin_dirs()]
 
         # usr/bin is the load-bearing coreutils dir; mingw64 precedes it.
         assert "/pg/usr/bin" in dirs
@@ -285,6 +286,38 @@ class TestGitBashCoreutilsOnPath:
         monkeypatch.setattr(local_mod, "_git_bash_bin_dirs_cache", None)
         assert _git_bash_bin_dirs() == []
 
+    def test_populated_cache_does_not_survive_logical_platform_flip(self, monkeypatch):
+        cached = ["C:/Program Files/Git/usr/bin"]
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs_cache", cached)
+        assert _git_bash_bin_dirs() == cached
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert _git_bash_bin_dirs() == []
+
+    def test_posix_prepend_is_noop_even_with_cached_windows_dirs(self, monkeypatch):
+        existing = "/usr/bin:/bin"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: ["C:/Git/usr/bin"])
+
+        assert _prepend_git_bash_dirs(existing) == existing
+
+    def test_windows_prepend_uses_logical_path_separator(self, monkeypatch):
+        git_bin = "C:/Program Files/Git/usr/bin"
+        existing = "C:/Windows/System32;C:/Tools"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [git_bin])
+
+        assert _prepend_git_bash_dirs(existing) == f"{git_bin};{existing}"
+
+    def test_hermes_bin_prepend_uses_logical_path_separator(self, monkeypatch):
+        hermes_bin = "C:/Hermes/bin"
+        existing = "C:/Windows/System32;C:/Tools"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_resolve_hermes_bin_dir", lambda: hermes_bin)
+
+        assert _prepend_hermes_bin_dir(existing) == f"{hermes_bin};{existing}"
+
 
     def test_make_run_env_noop_on_posix(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
@@ -292,6 +325,59 @@ class TestGitBashCoreutilsOnPath:
         run_env = _make_run_env({"PATH": "/usr/bin:/bin"})
         # No Windows git dirs injected on POSIX.
         assert "mingw64" not in run_env["PATH"]
+
+
+# ---------------------------------------------------------------------------
+# Managed runtime PATH entries — logical-platform tests must not discard valid
+# POSIX filenames that happen to contain a backslash.
+# ---------------------------------------------------------------------------
+
+class TestManagedRuntimePathEntries:
+    class _ExistingDir:
+        def __init__(self, display: str):
+            self.display = display
+
+        def is_dir(self) -> bool:
+            return True
+
+        def __str__(self) -> str:
+            return self.display
+
+    def test_native_posix_keeps_backslash_named_runtime_dir(self, monkeypatch, tmp_path):
+        import hermes_constants
+
+        home = tmp_path / "hermes"
+        (home / "bin").mkdir(parents=True)
+        runtime_dir = self._ExistingDir("/opt/hermes/node" + chr(92) + "literal/bin")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_HOST_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_constants, "iter_hermes_node_dirs", lambda: [runtime_dir])
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: home)
+
+        assert str(runtime_dir) in local_mod._managed_runtime_path_entries()
+
+    def test_logical_posix_on_windows_filters_only_native_windows_paths(self, monkeypatch, tmp_path):
+        import hermes_constants
+
+        home = tmp_path / "hermes"
+        (home / "bin").mkdir(parents=True)
+        drive_dir = self._ExistingDir("C:/Hermes/node/bin")
+        unc_dir = self._ExistingDir("//server/share/node/bin")
+        posix_dir = self._ExistingDir("/opt/hermes/node" + chr(92) + "literal/bin")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        monkeypatch.setattr(local_mod, "_HOST_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            hermes_constants,
+            "iter_hermes_node_dirs",
+            lambda: [drive_dir, unc_dir, posix_dir],
+        )
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: home)
+
+        entries = local_mod._managed_runtime_path_entries()
+
+        assert str(drive_dir) not in entries
+        assert str(unc_dir) not in entries
+        assert str(posix_dir) in entries
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -19,6 +19,7 @@ from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
+_HOST_IS_WINDOWS = os.name == "nt"
 
 logger = logging.getLogger(__name__)
 
@@ -947,6 +948,17 @@ def _bash_starts(bash: str) -> bool:
 _git_bash_bin_dirs_cache: "list[str] | None" = None
 
 
+def _env_path_sep() -> str:
+    """PATH separator for the *logical* platform (honours ``_IS_WINDOWS`` patches).
+
+    Tests monkeypatch ``_IS_WINDOWS`` to exercise Unix/Windows PATH branches on
+    a single host. Using bare ``os.pathsep`` there mixes ``;`` into ``:``-joined
+    PATH strings (and the reverse), which corrupts entries such as
+    ``C:\\Program Files\\…`` when later split on ``:``.
+    """
+    return ";" if _IS_WINDOWS else ":"
+
+
 def _git_bash_bin_dirs() -> list[str]:
     """Git Bash's coreutils/binary dirs, in ``/etc/profile`` precedence order.
 
@@ -965,11 +977,12 @@ def _git_bash_bin_dirs() -> list[str]:
     (mingw first, then usr/bin, then bin) and only if they exist on disk.
     """
     global _git_bash_bin_dirs_cache
-    if _git_bash_bin_dirs_cache is not None:
-        return _git_bash_bin_dirs_cache
-
+    # Honour live ``_IS_WINDOWS`` *before* the cache: tests flip the flag, and a
+    # prior Windows resolution must not leak Git dirs into a simulated Unix PATH.
     if not _IS_WINDOWS:
-        _git_bash_bin_dirs_cache = []
+        return []
+
+    if _git_bash_bin_dirs_cache is not None:
         return _git_bash_bin_dirs_cache
 
     dirs: list[str] = []
@@ -1009,10 +1022,12 @@ def _prepend_git_bash_dirs(existing_path: str) -> str:
     case the session snapshot re-exports the full login PATH inside the shell,
     so this only matters when that snapshot is absent.
     """
+    if not _IS_WINDOWS:
+        return existing_path
     git_dirs = _git_bash_bin_dirs()
     if not git_dirs:
         return existing_path
-    sep = os.pathsep
+    sep = _env_path_sep()
     entries = [e for e in existing_path.split(sep) if e] if existing_path else []
     missing = [d for d in git_dirs if d not in entries]
     if not missing:
@@ -1141,14 +1156,15 @@ def _resolve_hermes_bin_dir() -> str | None:
 def _prepend_hermes_bin_dir(existing_path: str) -> str:
     """Prepend the hermes install dir to ``existing_path`` if it's missing.
 
-    Cross-platform (uses ``os.pathsep``). First-occurrence wins, so a PATH
-    that already contains the dir is returned unchanged. Returns the input
-    unchanged when the install dir can't be resolved.
+    Cross-platform via ``_env_path_sep()`` so ``_IS_WINDOWS`` test patches keep
+    Unix ``:`` and Windows ``;`` branches consistent. First-occurrence wins, so
+    a PATH that already contains the dir is returned unchanged. Returns the
+    input unchanged when the install dir can't be resolved.
     """
     bin_dir = _resolve_hermes_bin_dir()
     if not bin_dir:
         return existing_path
-    sep = os.pathsep
+    sep = _env_path_sep()
     entries = [e for e in existing_path.split(sep) if e] if existing_path else []
     if bin_dir in entries:
         return existing_path
@@ -1170,6 +1186,11 @@ def _managed_runtime_path_entries() -> list[str]:
       and nothing has ever put that directory on PATH, so an install whose only
       uv is the managed one looks uv-less to both the agent and the model.
 
+    When ``_IS_WINDOWS`` is patched to simulate POSIX on a physical Windows
+    host, omit native Windows drive/UNC entries so they are not spliced into a
+    colon-delimited PATH. Native POSIX paths may legitimately contain a
+    backslash, so they must remain intact.
+
     Resolved per call rather than cached in a module constant because
     ``get_hermes_home()`` is profile-scoped and a managed tree can appear
     mid-process (``heal_hermes_managed_node``, a first browser install).
@@ -1178,7 +1199,16 @@ def _managed_runtime_path_entries() -> list[str]:
         from hermes_constants import get_hermes_home, iter_hermes_node_dirs
 
         candidates = [*iter_hermes_node_dirs(), get_hermes_home() / "bin"]
-        return [str(d) for d in candidates if d.is_dir()]
+        entries = [str(d) for d in candidates if d.is_dir()]
+        if _IS_WINDOWS:
+            return entries
+        # Only a physical Windows host can produce native Windows entries while
+        # a logical POSIX PATH uses ':' as its separator.
+        if not _HOST_IS_WINDOWS:
+            return entries
+        # A logical POSIX PATH on a physical Windows host cannot carry native
+        # drive/UNC paths: ':' splitting would corrupt a drive-qualified entry.
+        return [entry for entry in entries if not ntpath.splitdrive(entry)[0]]
     except Exception:
         return []
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -18,6 +18,7 @@ from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
+_HOST_IS_WINDOWS = os.name == "nt"
 
 logger = logging.getLogger(__name__)
 
@@ -1170,9 +1171,10 @@ def _managed_runtime_path_entries() -> list[str]:
       and nothing has ever put that directory on PATH, so an install whose only
       uv is the managed one looks uv-less to both the agent and the model.
 
-    When ``_IS_WINDOWS`` is patched to simulate Unix on a Windows host (or the
-    reverse), skip entries whose separator/drive spelling does not match the
-    logical platform so they are not spliced into the wrong PATH dialect.
+    When ``_IS_WINDOWS`` is patched to simulate POSIX on a physical Windows
+    host, omit native Windows drive/UNC entries so they are not spliced into a
+    colon-delimited PATH. Native POSIX paths may legitimately contain a
+    backslash, so they must remain intact.
 
     Resolved per call rather than cached in a module constant because
     ``get_hermes_home()`` is profile-scoped and a managed tree can appear
@@ -1185,13 +1187,13 @@ def _managed_runtime_path_entries() -> list[str]:
         entries = [str(d) for d in candidates if d.is_dir()]
         if _IS_WINDOWS:
             return entries
-        # Simulated/native POSIX PATH must not absorb ``C:\…`` drive entries —
-        # ``:`` splitting would turn ``C:\Users\…`` into ``["C", "\\Users\\…"]``.
-        return [
-            entry
-            for entry in entries
-            if "\\" not in entry and not (len(entry) >= 2 and entry[1] == ":")
-        ]
+        # Only a physical Windows host can produce native Windows entries while
+        # a logical POSIX PATH uses ':' as its separator.
+        if not _HOST_IS_WINDOWS:
+            return entries
+        # A logical POSIX PATH on a physical Windows host cannot carry native
+        # drive/UNC paths: ':' splitting would corrupt a drive-qualified entry.
+        return [entry for entry in entries if not ntpath.splitdrive(entry)[0]]
     except Exception:
         return []
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -932,6 +932,17 @@ def _bash_starts(bash: str) -> bool:
 _git_bash_bin_dirs_cache: "list[str] | None" = None
 
 
+def _env_path_sep() -> str:
+    """PATH separator for the *logical* platform (honours ``_IS_WINDOWS`` patches).
+
+    Tests monkeypatch ``_IS_WINDOWS`` to exercise Unix/Windows PATH branches on
+    a single host. Using bare ``os.pathsep`` there mixes ``;`` into ``:``-joined
+    PATH strings (and the reverse), which corrupts entries such as
+    ``C:\\Program Files\\…`` when later split on ``:``.
+    """
+    return ";" if _IS_WINDOWS else ":"
+
+
 def _git_bash_bin_dirs() -> list[str]:
     """Git Bash's coreutils/binary dirs, in ``/etc/profile`` precedence order.
 
@@ -950,11 +961,12 @@ def _git_bash_bin_dirs() -> list[str]:
     (mingw first, then usr/bin, then bin) and only if they exist on disk.
     """
     global _git_bash_bin_dirs_cache
-    if _git_bash_bin_dirs_cache is not None:
-        return _git_bash_bin_dirs_cache
-
+    # Honour live ``_IS_WINDOWS`` *before* the cache: tests flip the flag, and a
+    # prior Windows resolution must not leak Git dirs into a simulated Unix PATH.
     if not _IS_WINDOWS:
-        _git_bash_bin_dirs_cache = []
+        return []
+
+    if _git_bash_bin_dirs_cache is not None:
         return _git_bash_bin_dirs_cache
 
     dirs: list[str] = []
@@ -994,10 +1006,12 @@ def _prepend_git_bash_dirs(existing_path: str) -> str:
     case the session snapshot re-exports the full login PATH inside the shell,
     so this only matters when that snapshot is absent.
     """
+    if not _IS_WINDOWS:
+        return existing_path
     git_dirs = _git_bash_bin_dirs()
     if not git_dirs:
         return existing_path
-    sep = os.pathsep
+    sep = _env_path_sep()
     entries = [e for e in existing_path.split(sep) if e] if existing_path else []
     missing = [d for d in git_dirs if d not in entries]
     if not missing:
@@ -1126,14 +1140,15 @@ def _resolve_hermes_bin_dir() -> str | None:
 def _prepend_hermes_bin_dir(existing_path: str) -> str:
     """Prepend the hermes install dir to ``existing_path`` if it's missing.
 
-    Cross-platform (uses ``os.pathsep``). First-occurrence wins, so a PATH
-    that already contains the dir is returned unchanged. Returns the input
-    unchanged when the install dir can't be resolved.
+    Cross-platform via ``_env_path_sep()`` so ``_IS_WINDOWS`` test patches keep
+    Unix ``:`` and Windows ``;`` branches consistent. First-occurrence wins, so
+    a PATH that already contains the dir is returned unchanged. Returns the
+    input unchanged when the install dir can't be resolved.
     """
     bin_dir = _resolve_hermes_bin_dir()
     if not bin_dir:
         return existing_path
-    sep = os.pathsep
+    sep = _env_path_sep()
     entries = [e for e in existing_path.split(sep) if e] if existing_path else []
     if bin_dir in entries:
         return existing_path
@@ -1155,6 +1170,10 @@ def _managed_runtime_path_entries() -> list[str]:
       and nothing has ever put that directory on PATH, so an install whose only
       uv is the managed one looks uv-less to both the agent and the model.
 
+    When ``_IS_WINDOWS`` is patched to simulate Unix on a Windows host (or the
+    reverse), skip entries whose separator/drive spelling does not match the
+    logical platform so they are not spliced into the wrong PATH dialect.
+
     Resolved per call rather than cached in a module constant because
     ``get_hermes_home()`` is profile-scoped and a managed tree can appear
     mid-process (``heal_hermes_managed_node``, a first browser install).
@@ -1163,7 +1182,16 @@ def _managed_runtime_path_entries() -> list[str]:
         from hermes_constants import get_hermes_home, iter_hermes_node_dirs
 
         candidates = [*iter_hermes_node_dirs(), get_hermes_home() / "bin"]
-        return [str(d) for d in candidates if d.is_dir()]
+        entries = [str(d) for d in candidates if d.is_dir()]
+        if _IS_WINDOWS:
+            return entries
+        # Simulated/native POSIX PATH must not absorb ``C:\…`` drive entries —
+        # ``:`` splitting would turn ``C:\Users\…`` into ``["C", "\\Users\\…"]``.
+        return [
+            entry
+            for entry in entries
+            if "\\" not in entry and not (len(entry) >= 2 and entry[1] == ":")
+        ]
     except Exception:
         return []
 


### PR DESCRIPTION
## Summary

On Windows hosts, tests and simulated Unix PATH branches monkeypatch `_IS_WINDOWS` to exercise both platforms. Several PATH helpers still used bare `os.pathsep` and a cached Git Bash bin-dir list keyed only by first resolution, which mixed `;`-joined Windows entries into `:`-joined Unix PATH strings (and the reverse). That produced corrupted PATH fragments such as `/opt/hermes/bin;C` when later split on `:`.

This change makes path-separator selection, Git Bash prepend, hermes-bin prepend, and managed-runtime PATH filtering honour the *live* `_IS_WINDOWS` flag, and isolates the mixed-case `Path` regression test from incidental Git Bash prepend on Windows developer machines.

## Motivation

Cross-platform coverage of `_make_run_env` on a native Windows checkout currently fails or silently corrupts PATH when `_IS_WINDOWS` is patched to `False` (launchd / Unix sane-PATH branches) while Git Bash dirs remain cached from a prior Windows resolution. The mixed-case `Path` assertion can also be masked when Git for Windows is installed and prepend rewrites `Path`.

## Changes

- Add `_env_path_sep()` so PATH join/split follows logical `_IS_WINDOWS` rather than host `os.pathsep`.
- Honour live `_IS_WINDOWS` *before* returning `_git_bash_bin_dirs` cache; return `[]` immediately when not Windows so a prior Windows cache cannot leak into a simulated Unix PATH.
- Make `_prepend_git_bash_dirs` a no-op when not `_IS_WINDOWS`, and use `_env_path_sep()` for merge.
- Use `_env_path_sep()` in `_prepend_hermes_bin_dir`.
- When not `_IS_WINDOWS`, filter managed-runtime PATH entries that use Windows drive / backslash spelling so they are not spliced into a POSIX PATH dialect.
- In `test_make_run_env_preserves_windows_path_casing`, stub `_git_bash_bin_dirs` to `[]` so the casing assertion is not masked by coreutils prepend.

Touched files only:
- `tools/environments/local.py`
- `tests/tools/test_local_env_blocklist.py`

## Test plan

- [ ] `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py -q` (or `scripts/run_tests_parallel.py` equivalent on Windows)
- [ ] Confirm Unix-simulated PATH branches on a Windows host no longer produce `;`-joined fragments when `_IS_WINDOWS` is patched to `False`
- [ ] Confirm Git Bash prepend still occurs on real Windows (`_IS_WINDOWS=True`) when bash is resolvable
- [ ] Confirm mixed-case `Path` preservation test passes with Git for Windows installed

## Notes

Related but distinct from existing Windows/Git Bash PATH work (e.g. coreutils prepend #64042, separator-normalisation in `test_local_env_windows_msys`). This PR addresses logical `_IS_WINDOWS` / pathsep coherence under monkeypatch, not MSYS layout derivation.
