### PR TITLE
fix(cron): restore HERMES_CRON_SESSION after run_job to stop gateway approval leak (#76748)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3011,6 +3011,7 @@ def run_job(
     # Mark this as a cron session so the approval system can apply cron_mode.
     # This env var is process-wide and persists for the lifetime of the
     # scheduler process — every job this process runs is a cron job.
+    _prev_cron_session_flag = os.environ.get("HERMES_CRON_SESSION")
     os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
@@ -3763,6 +3764,16 @@ def run_job(
         # clear_session_vars also clears _SESSION_CWD internally, so no
         # separate clear_session_cwd() call is needed.
         clear_session_vars(_ctx_tokens)
+
+        # Restore the cron-session flag. Without this, the process-global
+        # HERMES_CRON_SESSION=1 leaks into later live gateway turns and
+        # _is_gateway_approval_context() misclassifies them as cron,
+        # failing closed instead of rendering platform approval controls
+        # (#76748).
+        if _prev_cron_session_flag is None:
+            os.environ.pop("HERMES_CRON_SESSION", None)
+        else:
+            os.environ["HERMES_CRON_SESSION"] = _prev_cron_session_flag
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/tests/cron/test_cron_session_flag_restore.py
+++ b/tests/cron/test_cron_session_flag_restore.py
@@ -1,0 +1,64 @@
+"""#76748: HERMES_CRON_SESSION must be scoped to the cron job, not leak into
+later live gateway turns.
+
+cron.scheduler.run_job sets the process-global HERMES_CRON_SESSION=1 and
+never restores it; _is_gateway_approval_context() then misclassifies later
+live gateway MCP elicitations as cron and fails them closed instead of
+rendering platform approval controls.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+from cron.scheduler import run_job
+
+
+def test_run_job_restores_cron_session_flag_after_failure(monkeypatch):
+    """A failing cron job must not leave HERMES_CRON_SESSION set."""
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setattr(
+        "cron.scheduler._build_job_prompt",
+        lambda job, prerun_script=None: "hello",
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock())
+    monkeypatch.setattr(
+        "gateway.session_context.set_session_vars",
+        lambda **kw: ["tok"],
+    )
+
+    class BoomAgent:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("run_agent.AIAgent", BoomAgent)
+
+    ok, _doc, _resp, _err = run_job({"id": "test-job", "name": "t", "prompt": "hello"})
+
+    assert ok is False
+    assert "HERMES_CRON_SESSION" not in os.environ
+
+
+def test_run_job_restores_cron_session_flag_preserving_prior_value(monkeypatch):
+    """If the flag was already set before the job ran, the prior value must be
+    restored, not deleted."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "prior")
+    monkeypatch.setattr(
+        "cron.scheduler._build_job_prompt",
+        lambda job, prerun_script=None: "hello",
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock())
+    monkeypatch.setattr(
+        "gateway.session_context.set_session_vars",
+        lambda **kw: ["tok"],
+    )
+
+    class BoomAgent:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("run_agent.AIAgent", BoomAgent)
+
+    ok, _doc, _resp, _err = run_job({"id": "test-job", "name": "t", "prompt": "hello"})
+
+    assert ok is False
+    assert os.environ.get("HERMES_CRON_SESSION") == "prior"


### PR DESCRIPTION
## Summary

`cron.scheduler.run_job()` sets the process-global `HERMES_CRON_SESSION=1` and never restores it. In a gateway process that also handles live messaging turns, the flag survives after the cron run, so `tools.approval._is_gateway_approval_context()` misclassifies a later live gateway MCP elicitation as cron — with no interactive stdin the approval fails closed as denied instead of rendering platform approval controls (Discord/Telegram/etc.).

Fix: save the prior value before setting the flag, and restore it in `run_job`'s existing `finally` block (the same one that restores `TERMINAL_CWD` and clears session context). The flag is now scoped to the job — including failure paths.

Single-file change (plus tests). No public API change.

NOT doing X: not touching approval policy itself, not changing `_is_gateway_approval_context()` semantics — only the leak that made the flag stick around after the job.

## Test plan

```
python -m pytest tests/cron/test_cron_session_flag_restore.py -q
# 2 passed — a failing run_job leaves HERMES_CRON_SESSION unset, and a
# pre-existing flag value is restored rather than deleted
```
