### PR TITLE
fix(gateway): strip MEDIA: directives from auto-TTS voice replies (#76620)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18289,7 +18289,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            # Strip MEDIA:<path> attachment directives before synthesis so
+            # the voice reply never reads the internal local path aloud
+            # (#76620). Attachment delivery is handled separately by the
+            # final-text path.
+            _clean_text = _TOOL_MEDIA_RE.sub("", text)
+            tts_text = _strip_markdown_for_tts(_clean_text[:4000])
             if not tts_text:
                 return
 

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -120,3 +120,40 @@ def _make_event(platform: Platform, chat_id: str = "123", message_type: MessageT
         message_type=message_type,
         message_id="456",
     )
+
+
+class TestAutoVoiceReplyMediaStrip:
+    """#76620: auto-TTS must not read MEDIA:<path> attachment directives
+    aloud — the internal local path leaks into the synthesized voice reply."""
+
+    @pytest.mark.asyncio
+    async def test_media_directive_stripped_before_synthesis(self):
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.TELEGRAM)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM)
+        synthesized_texts = []
+
+        def fake_tts(*, text, output_path):
+            synthesized_texts.append(text)
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_bytes(b"fake audio")
+            return json.dumps({
+                "success": True,
+                "file_path": output_path,
+                "provider": "edge",
+                "voice_compatible": True,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+            await runner._send_voice_reply(
+                event,
+                r"MEDIA:C:\Users\someone\AppData\Local\Temp\shot.png" + "\n\nCapture ready.",
+            )
+
+        assert synthesized_texts
+        synthesized = synthesized_texts[0]
+        assert "MEDIA:" not in synthesized
+        assert "shot.png" not in synthesized
+        assert "Capture ready." in synthesized
+        adapter.send_voice.assert_awaited_once()


### PR DESCRIPTION
## Summary

When gateway auto-TTS is enabled, `_send_voice_reply` synthesized the raw reply text — so a `MEDIA:<absolute-path>` attachment directive was **read aloud** by the voice reply, revealing the internal local path. The attachment itself was delivered fine; only the synthesized audio leaked the path.

Fix: strip `MEDIA:` directives with the existing `_TOOL_MEDIA_RE` (the same extension-anchored matcher used by the auto-append path) before TTS synthesis. Attachment delivery is untouched (handled by the final-text path).

Single-file change (plus test). No public API change.

NOT doing X: not changing attachment extraction/delivery, not touching the TTS tool itself.

## Test plan

```
python -m pytest tests/gateway/test_auto_voice_reply_format.py -q
# 7 passed (6 existing + 1 new: a reply containing "MEDIA:C:\...\shot.png\n\nCapture ready."
# synthesizes "Capture ready." without the MEDIA path)
```
