### PR TITLE
fix(dashboard): cap unbounded memory growth (#76759)

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -126,6 +126,22 @@ class RegistryFull(Exception):
     pass
 
 
+def _bridge_alive(s: "PtySession") -> bool:
+    """True when the session's child process is still running.
+
+    Duck-typed: fake bridges used in tests may not implement ``is_alive``;
+    when the bridge doesn't expose it we conservatively treat the session as
+    alive and rely on the EOF path (``alive = False``) instead.
+    """
+    is_alive = getattr(s.bridge, "is_alive", None)
+    if is_alive is None:
+        return True
+    try:
+        return bool(is_alive())
+    except Exception:
+        return False
+
+
 async def run_reaper(registry: "PtySessionRegistry", *, interval: float = 60.0) -> None:
     """Periodically reap idle/dead keep-alive sessions. Cancelled on shutdown."""
     while True:
@@ -177,6 +193,14 @@ class PtySessionRegistry:
             if (not s.alive)
             or (not s.attached and s.last_detached_at is not None
                 and (now - s.last_detached_at) > self._ttl)
+            # The drain task sets ``alive = False`` only when it observes
+            # EOF on the PTY master.  If the child was killed externally
+            # (OOM killer, cgroup SIGKILL, manual kill) or the drain task
+            # itself died, the session would otherwise pin its bridge (fds)
+            # and registry slot forever — and every leaked TUI subprocess
+            # costs ~150-250 MB RSS in the dashboard's cgroup (#76759).
+            # Ask the bridge directly; the check is a cheap WNOHANG waitpid.
+            or (not _bridge_alive(s))
         ]
         for key in doomed:
             await self._sessions.pop(key).close()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -218,7 +218,8 @@ async def _lifespan(app: "FastAPI"):
         )
         cron_thread.start()
 
-    # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
+    # Reap idle/dead keep-alive PTY sessions in the background (bounded TTL,
+    # see PTY_REGISTRY above) so detached TUI subprocesses can't pile up.
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
 
     # Periodic authenticated self-test (feeds the ``dashboard`` component on
@@ -14203,10 +14204,41 @@ _PTY_READ_CHUNK_TIMEOUT = 0.2
 # Keep-alive PTY sessions: a terminal connecting with ``?attach=<token>`` is
 # bound to a process that survives disconnect/refresh and is reattachable.
 from hermes_cli.pty_session import PtySessionRegistry, RegistryFull, run_reaper  # noqa: E402
+#
+# The TTL and session cap bound how many TUI subprocesses (``node
+# ui-tui/dist/entry.js``, ~150-250 MB RSS each, plus their Python gateway
+# children) may linger in this process's cgroup after a chat tab detaches —
+# unbounded accumulation here is what OOM-kills the dashboard on long-lived
+# hosts (#76759).  Ops can tighten further via env without a code change.
+def _pty_registry_ttl() -> float:
+    """Keep-alive TTL in seconds: idle detached PTY sessions (and their TUI
+    subprocesses) are reaped after this.  Default 5 min — long enough to
+    survive a browser refresh, short enough to bound idle memory."""
+    raw = os.environ.get("HERMES_PTY_TTL_SECONDS")
+    if raw:
+        try:
+            return max(30.0, float(raw))
+        except ValueError:
+            pass
+    return 5 * 60
+
+
+def _pty_registry_max_sessions() -> int:
+    """Hard cap on concurrent keep-alive PTY sessions (one TUI subprocess
+    each).  When the cap is reached and nothing is reapable, new chat tabs
+    get a clean ``Chat unavailable`` instead of piling up subprocesses."""
+    raw = os.environ.get("HERMES_PTY_MAX_SESSIONS")
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return 8
+
 
 PTY_REGISTRY = PtySessionRegistry(
-    ttl=30 * 60,
-    max_sessions=16,
+    ttl=_pty_registry_ttl(),
+    max_sessions=_pty_registry_max_sessions(),
     buffer_cap=1 * 1024 * 1024,
     read_timeout=_PTY_READ_CHUNK_TIMEOUT,
 )

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -31,6 +31,7 @@ class FakeBridge:
         self.written = bytearray()
         self.closed = False
         self.resized = None
+        self._dead = False
 
     def read(self, timeout):
         if not self._chunks:
@@ -45,6 +46,12 @@ class FakeBridge:
 
     def close(self):
         self.closed = True
+
+    def is_alive(self):
+        return not self._dead
+
+    def kill(self):
+        self._dead = True
 
 
 class FakeWS:
@@ -143,3 +150,51 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
     except asyncio.CancelledError:
         pass
     assert calls["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_reap_reaps_dead_process_even_when_attached():
+    # Child killed externally (OOM killer / cgroup SIGKILL) before the drain
+    # task observed EOF: the session must still be reaped, otherwise its
+    # bridge (fds) and registry slot leak forever (#76759).
+    reg = make_registry(ttl=3600.0)
+    b = FakeBridge([b"", b"", b""])
+    s, _ = await reg.attach_or_spawn("tok", spawn=lambda: b)
+    await s.attach(FakeWS())                 # attached → old TTL rule keeps it
+    b.kill()                                 # process died without EOF
+    await reg.reap_idle(now=time.monotonic() + 7200)
+    assert "tok" not in reg._sessions
+    assert b.closed is True
+    await reg.close_all()
+
+
+@pytest.mark.asyncio
+async def test_reap_keeps_live_attached_session():
+    # A session with a live child must never be reaped, even past the TTL,
+    # because it may be mid-use (or reattach-ready).
+    reg = make_registry(ttl=1.0)
+    b = FakeBridge([b"", b""])
+    s, _ = await reg.attach_or_spawn("tok", spawn=lambda: b)
+    await s.attach(FakeWS())
+    await reg.reap_idle(now=time.monotonic() + 10)
+    assert "tok" in reg._sessions
+    await reg.close_all()
+
+
+@pytest.mark.asyncio
+async def test_reap_keeps_bridge_without_is_alive():
+    # Duck-typed bridges that don't implement is_alive() are treated as
+    # alive — the EOF path (alive=False) remains the reaper for those.
+    class BareBridge:
+        def read(self, timeout):
+            return b""
+
+        def close(self):
+            pass
+
+    reg = make_registry(ttl=1.0)
+    s, _ = await reg.attach_or_spawn("tok", spawn=lambda: BareBridge())
+    await s.attach(FakeWS())
+    await reg.reap_idle(now=time.monotonic() + 10)
+    assert "tok" in reg._sessions
+    await reg.close_all()


### PR DESCRIPTION
Closes #76759

## Problem

The dashboard (Web Admin Panel, `hermes dashboard`) is repeatedly OOM-killed: cgroup memory grows to 2.7–4.1 GB on an 8.4 GB host until the kernel kills it (~9 times in 4 days). The growth is dominated by leaked TUI subprocesses: each chat PTY session spawns `node --expose-gc ui-tui/dist/entry.js` (~150–250 MB RSS, plus its Python gateway child), and these accumulated without bound.

Two compounding causes in the keep-alive PTY subsystem (`hermes_cli/pty_session.py` / `web_server.py`):

1. **Oversized keep-alive bounds.** The registry kept detached sessions alive for a 30-minute TTL with a cap of 16 concurrent sessions — up to ~4 GB of idle TUI subprocesses in the worst case.
2. **Dead sessions were never reaped.** `reap_idle` only reaped sessions whose drain task observed EOF (`alive=False`) or that were detached past the TTL. A child killed externally (OOM killer, cgroup SIGKILL, manual kill) — or a crashed drain task — left the session pinning its bridge (fds) and registry slot forever.

## Fix

- **Reap dead processes regardless of attach state.** The reaper now asks the bridge directly (`is_alive()`, a cheap WNOHANG waitpid) and closes sessions whose child process is gone, even if the socket is still attached. Duck-typed bridges without `is_alive()` are conservatively kept (EOF path still applies).
- **Tighten the keep-alive bounds.** TTL dropped 30 min → 5 min (plenty for browser-refresh reattach, which happens in seconds) and the session cap 16 → 8, bounding worst-case idle TUI subprocess memory to roughly a quarter of the previous ceiling. Both are tunable via `HERMES_PTY_TTL_SECONDS` / `HERMES_PTY_MAX_SESSIONS` for memory-constrained deployments.

This addresses the "drop idle TUI subprocesses after a TTL" and "reap TUI children when their owning session closes" parts of the issue. The ops-side containment (`MemoryMax=` + `KillMode=process` in the systemd unit) remains a deployment concern outside the repo.

## Tests

Added 3 unit tests covering: dead-process session reaped even when attached, live attached session never reaped, and bridges without `is_alive()` kept. Full `tests/test_pty_session.py` + `tests/test_pty_keepalive_ws.py` suite passes (14 tests).