### PR TITLE
fix(auxiliary): preserve user-defined provider identity when base_url is explicit (#76602)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6884,7 +6884,16 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
+            # User-defined providers in config.yaml's providers: section
+            # must also keep their identity (and api_key) when an explicit
+            # base_url is present — otherwise they are downgraded to the
+            # anonymous "custom" branch, which drops the configured key and
+            # every call 401s (#76602).
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+
+            return _get_named_custom_provider(normalized) is not None
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -408,3 +408,52 @@ class TestResolveProviderClientMainRuntimeCustom:
         assert model == "explicit-model"
         assert "explicit.example.com" in str(client.base_url)
         assert client.api_key == "sk-explicit"
+
+
+class TestVisionExplicitProviderWithBaseUrlPreservesNamedCustom:
+    """#76602: an explicit provider + base_url must keep the identity (and
+    api_key) of a user-defined provider from config.yaml's providers/
+    custom_providers section — not be downgraded to anonymous 'custom'."""
+
+    def test_vision_preserves_named_custom_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {"name": "agnes-ai.cn", "base_url": "https://api.agnes-ai.cn/v1", "api_key": "sk-test-123"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="agnes-ai.cn",
+            model="agnes-2.5-flash",
+            base_url="https://api.agnes-ai.cn/v1",
+            api_key=None,
+        )
+
+        assert provider == "agnes-ai.cn"
+        assert model == "agnes-2.5-flash"
+        assert client is not None
+        # The configured key must survive instead of the 'no-key-required'
+        # sentinel that produced 401s.
+        assert getattr(client, "api_key", None) == "sk-test-123"
+
+    def test_vision_unknown_provider_with_base_url_still_downgrades_to_custom(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {"name": "known-relay", "base_url": "http://relay.local/v1", "api_key": "k"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="totally-unknown-provider",
+            model="m",
+            base_url="http://unknown.local/v1",
+            api_key=None,
+        )
+
+        # Unknown providers keep the legacy anonymous-custom downgrade.
+        assert provider == "custom"
+        assert model == "m"


### PR DESCRIPTION
## Summary

`_preserve_provider_with_base_url()` only checked the **built-in provider registry** (`hermes_cli.providers.get_provider()`) plus a hardcoded allowlist — never user-defined providers from config.yaml's `providers:` / `custom_providers:` section. So an auxiliary task (e.g. `auxiliary.vision`) configured with a custom provider + explicit `base_url` was downgraded to the anonymous `"custom"` branch, which drops the configured `api_key` and falls back to the `"no-key-required"` sentinel → **every call 401s**, even though direct API calls with the same key succeed.

Fix: after the built-in registry check, also consult `_get_named_custom_provider(normalized)` so user-defined providers keep their identity (and key). Unknown providers still take the legacy anonymous-custom downgrade (covered by a new test).

Single-file change (plus tests). No public API change.

NOT doing X: not changing the anonymous-custom downgrade for genuinely unknown providers, not touching provider=None (config-only) resolution — that path already worked.

## Test plan

```
python -m pytest tests/agent/test_auxiliary_named_custom_providers.py -q
# 21 passed (19 existing + 2 new:
#  - explicit provider+base_url resolving to a named custom provider keeps
#    provider name and configured api_key
#  - unknown provider + base_url still downgrades to 'custom')
```
