### PR TITLE
fix(ci): restore Desktop E2E runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,15 +112,7 @@ jobs:
     # + `hermes serve` backend, which never import anything under tests/.
     # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
     # single job in the workflow — while still running the full pytest lanes.
-    #
-    # ⛔ TEMPORARILY DISABLED (Aug 2, 2026, Teknium) — the suite is red on
-    # every PR and on main itself since the Aug 1 night engines/npm churn
-    # (#76499 → #76562 → #76575): the mock-backend Electron window never
-    # gets a title, so boot/chat/setup/interim specs all fail identically
-    # regardless of the PR's diff (verified on #76573 and the docs-only
-    # #76582). Tracking issue: #76627 (assigned: Ari). To re-enable,
-    # delete the `false &&` below — nothing else changed.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
+    if: needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true'
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,7 @@ jobs:
     # + `hermes serve` backend, which never import anything under tests/.
     # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
     # single job in the workflow — while still running the full pytest lanes.
-    #
-    # ⛔ TEMPORARILY DISABLED (Aug 2, 2026, Teknium) — the suite is red on
-    # every PR and on main itself since the Aug 1 night engines/npm churn
-    # (#76499 → #76562 → #76575): the mock-backend Electron window never
-    # gets a title, so boot/chat/setup/interim specs all fail identically
-    # regardless of the PR's diff (verified on #76573 and the docs-only
-    # #76582). Tracking issue: #76627 (assigned: Ari). To re-enable,
-    # delete the `false &&` below — nothing else changed.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
+    if: needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true'
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -39,7 +39,9 @@ jobs:
       # ── Node ───────────────────────────────────────────────────────────
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 26
+          # Electron's Playwright harness is verified on Node 22.  Keep the
+          # npm 12 install below so workspace resolution matches the rest of CI.
+          node-version: 22
           cache: npm
 
       - name: grab npm 12


### PR DESCRIPTION
## What does this PR do?

Restores the last known-good Node 22 runner for the Desktop Playwright harness while retaining npm 12 for workspace resolution, then re-enables the Desktop E2E job. This confines the rollback to the Electron/Playwright compatibility boundary instead of reverting the project-wide Node 26 migration.

## Related Issue

Fixes #76627

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/e2e-desktop.yml`: run the Electron Playwright job on Node 22, the toolchain from the last known-green configuration, while preserving npm 12.
- `.github/workflows/ci.yml`: remove the temporary `false &&` guard so Desktop E2E runs again for production Python and frontend changes.

## How to Test

1. Open a PR that changes production Python or frontend code and confirm the `Desktop E2E / Playwright E2E (Linux)` job is scheduled rather than skipped.
2. Confirm the mock-backend boot, chat, setup, and interim-message specs pass on the Node 22/npm 12 runner.
3. On main, confirm the same job passes and refreshes the visual-snapshot cache only after all specs are green.
4. Locally, use Node 22 with npm 12, run `npm ci`, then run `npm --workspace apps/desktop run build`.

### What platforms tested on

- macOS (darwin-arm64): Node v22.23.2 with npm v12.0.2; `npm ci` and the Desktop production build passed.
- Linux CI: pending the re-enabled `Desktop E2E / Playwright E2E (Linux)` run. This sandbox prevents binding the E2E mock server to `127.0.0.1`, so Playwright cannot be exercised locally.

The configured broad pytest command was also attempted with the project venv, but collection stops in the unmodified `tests/gateway/test_teams.py` assertion before test execution.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — this change restores the CI runner and its existing visual-snapshot checks.

<!-- autocontrib:worker-id=issue-new-0d10627a kind=pr-open -->