### PR TITLE
fix: preserve custom provider name in auxiliary task resolution (#76760)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7145,11 +7145,12 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.
-            return normalized in {
+            if normalized in {
                 "anthropic",
                 "copilot",
                 "copilot-acp",
@@ -7158,7 +7159,19 @@ def _resolve_task_provider_model(
                 "openai-codex",
                 "qwen-oauth",
                 "xai-oauth",
-            }
+            }:
+                return True
+        # Also preserve custom providers defined in config.yaml's providers:
+        # table — without this check, the provider name is rewritten to
+        # "custom" and downstream key_env resolution cannot find the entry.
+        if prov:
+            try:
+                from hermes_cli.runtime_provider import _get_named_custom_provider
+
+                return _get_named_custom_provider(prov) is not None
+            except Exception:
+                pass
+        return False
 
     if provider:
         provider, base_url = _expand_direct_api_alias(provider, base_url)


### PR DESCRIPTION
## Summary

`_preserve_provider_with_base_url()` only checked the built-in `PROVIDER_REGISTRY` via `get_provider()`, missing custom providers defined in config.yaml's `providers:` table. When a custom provider (with `base_url` + `key_env`) was used for auxiliary tasks like `vision_analyze`, the function returned `False`, causing the provider name to be rewritten to `"custom"`. Downstream `key_env` resolution then failed to find the original entry, falling back to the placeholder `"no-key-required"` → 401.

## Root Cause

In `agent/auxiliary_client.py`, `_resolve_task_provider_model()` calls `_preserve_provider_with_base_url()` at line 7180 to decide whether to keep the original provider name when a `base_url` is present. The function only checked:

1. Built-in providers via `get_provider()` (PROVIDER_REGISTRY)
2. A hardcoded fallback set of known providers

Custom providers from `config.yaml`'s `providers:` table were not checked, so their names were lost when rewritten to `"custom"`.

## Fix

Added a check for `_get_named_custom_provider()` from `hermes_cli.runtime_provider` so that config-defined custom providers are recognized and their names preserved through the resolution chain.

## Changes
- `agent/auxiliary_client.py`: Extended `_preserve_provider_with_base_url()` to also check custom providers from config

## Test Plan
- [ ] Configure a custom provider in config.yaml (`providers.myprovider` with `base_url` + `key_env`)
- [ ] Set `auxiliary.vision.provider: myprovider`
- [ ] Call `vision_analyze` — should use the correct API key (not `no-key-required`)
- [ ] Existing built-in providers still work as before
- [ ] `auto`/`custom`/empty providers still return `False` as before

Fixes #76760