### PR TITLE
feat(tui/slash): /widgets subcommand family (list/reload/load/unload/update)

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
@@ -25,13 +25,38 @@ widgets.
 1. Use `write_file` to create `~/.hermes/tui-widgets/<name>.mjs` (see
    `templates/clock.mjs` for a complete working widget).
 2. If the TUI is running it hot-loads the file within ~a second (the
-   widgets directory is watched); `/widgets-reload` forces a rescan.
+   widgets directory is watched); `/widgets reload` forces a full rescan
+   (`/widgets-reload` still works as an alias).
 3. The widget's id becomes its slash command automatically (`/<id>`), with
    its `help` in the `/` completion popover. No other registration exists.
 4. Auto-open (no command needed): end `register(sdk)` with
    `sdk.openWidget(app, app.init(''))` — the widget docks itself the moment
    the file loads. Only do this when the user asked for it; note it re-docks
-   on every `/widgets-reload`.
+   on every `/widgets reload`.
+
+### Managing widgets (`/widgets`)
+
+```
+/widgets                      # short usage
+/widgets list                 # id, open/loaded, source file (or built-in)
+/widgets reload               # rescan $HERMES_HOME/tui-widgets (all files)
+/widgets reload <id|file>     # hot-reload one file
+/widgets load /path/to.mjs    # load from outside the widgets dir
+/widgets unload <id>          # unregister + dismiss from dock
+/widgets update [id]          # signal refresh bus (see onWidgetRefresh)
+```
+
+Aliases: `ls`→list, `rl`→reload, `rm`→unload, `up`→update. `/widgets-reload`
+routes to full `reload`.
+
+For forced data refresh without re-import, subscribe in `register(sdk)`:
+
+```js
+sdk.onWidgetRefresh((id) => {
+  if (id && id !== 'my-app') return
+  // re-fetch and sdk.updateWidget(app, ...)
+})
+```
 
 ## Quick Reference
 
@@ -52,7 +77,8 @@ export default function register(sdk) {
 }
 ```
 
-`sdk` contents: `defineWidgetApp`, `openWidget`, `updateWidget`, `isCtrl`,
+`sdk` contents: `defineWidgetApp`, `openWidget`, `updateWidget`,
+`onWidgetRefresh`, `requestWidgetRefresh`, `isCtrl`,
 `React`, `h` (createElement — no JSX in .mjs), components `Box`, `Text`,
 `Dialog`, `Overlay`, `WidgetGrid`, `GridAreas`, and loaders `Shimmer`,
 `ShimmerRows`, `useShimmerPhase` — use `ShimmerRows` for loading phases
@@ -131,7 +157,7 @@ Contract essentials:
 
 ## Verification
 
-Run `/widgets-reload` — the transcript line must list the file under
+Run `/widgets reload` — the transcript line must list the file under
 `loaded:`. Then `/<id>`: an ambient widget appears docked right, above the
 status bar, while the composer keeps accepting input; `/<id>` again removes
-it.
+it. `/widgets list` should show the id as `loaded` (or `open` while docked).

--- a/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
@@ -49,7 +49,10 @@ widgets.
 Aliases: `ls`→list, `rl`→reload, `rm`→unload, `up`→update. `/widgets-reload`
 routes to full `reload`.
 
-For forced data refresh without re-import, subscribe in `register(sdk)`:
+For forced data refresh without re-import, subscribe in `register(sdk)`.
+The loader owns those subscriptions per source file and disposes them on
+reload, unload, and delete-sync so `/widgets update` does not stack stale
+callbacks:
 
 ```js
 sdk.onWidgetRefresh((id) => {

--- a/ui-tui/src/__tests__/userWidgets.test.ts
+++ b/ui-tui/src/__tests__/userWidgets.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -21,6 +21,34 @@ export default function register(sdk) {
   sdk.defineWidgetApp({
     id: '${id}',
     help: '${help}',
+    mode: 'ambient',
+    init: arg => ({ arg }),
+    reduce: state => state,
+    render: ({ state, t }) => sdk.h(sdk.Text, { color: t.color.label }, state.arg)
+  })
+}
+`
+
+const widgetWithRefresh = (id: string) => `
+export default function register(sdk) {
+  sdk.onWidgetRefresh(() => {})
+  sdk.defineWidgetApp({
+    id: '${id}',
+    help: 'refresh',
+    mode: 'ambient',
+    init: arg => ({ arg }),
+    reduce: state => state,
+    render: ({ state, t }) => sdk.h(sdk.Text, { color: t.color.label }, state.arg)
+  })
+}
+`
+
+const widgetWithSiblingImport = (id: string) => `
+import { label } from './lib/helper.mjs'
+export default function register(sdk) {
+  sdk.defineWidgetApp({
+    id: '${id}',
+    help: label,
     mode: 'ambient',
     init: arg => ({ arg }),
     reduce: state => state,
@@ -72,20 +100,60 @@ describe('user widget loading', () => {
     expect(getWidgetApp('soon-gone')).toBeUndefined()
   })
 
-  it('reloadWidgetFile re-imports one file by app id', async () => {
+  it('reloadWidgetFile re-imports one file by app id and keeps it docked', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
 
     await writeFile(join(dir, 'solo.mjs'), widgetSource('solo-app', 'v1'))
     await loadUserWidgets(dir)
     expect(getWidgetApp('solo-app')?.help).toBe('v1')
+    expect(launchWidget('solo-app', 'docked')).toBeNull()
+    expect(getOverlayState().ambient.some(a => a.appId === 'solo-app' && a.state.arg === 'docked')).toBe(true)
 
     await writeFile(join(dir, 'solo.mjs'), widgetSource('solo-app', 'v2'))
     const result = await reloadWidgetFile('solo-app', dir)
 
     expect(result.loaded).toEqual(['solo.mjs'])
-    expect(result.removed).toContain('solo-app')
-    expect(result.added).toContain('solo-app')
+    expect(result.removed).not.toContain('solo-app')
+    expect(result.added).not.toContain('solo-app')
     expect(getWidgetApp('solo-app')?.help).toBe('v2')
+    expect(getOverlayState().ambient.some(a => a.appId === 'solo-app' && a.state.arg === 'docked')).toBe(true)
+  })
+
+  it('failed reload keeps the prior registration and dock state', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
+
+    await writeFile(join(dir, 'keep.mjs'), widgetSource('keep-app', 'good'))
+    await loadUserWidgets(dir)
+    expect(launchWidget('keep-app', 'stay')).toBeNull()
+
+    await writeFile(join(dir, 'keep.mjs'), 'export default 42')
+    const result = await reloadWidgetFile('keep-app', dir)
+
+    expect(result.errors).toMatchObject([{ file: 'keep.mjs' }])
+    expect(result.loaded).toEqual([])
+    expect(getWidgetApp('keep-app')?.help).toBe('good')
+    expect(getOverlayState().ambient.some(a => a.appId === 'keep-app')).toBe(true)
+  })
+
+  it('preserves sibling relative imports during reload', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
+    const lib = join(dir, 'lib')
+
+    await mkdir(lib, { recursive: true })
+    await writeFile(join(lib, 'helper.mjs'), 'export const label = "sibling-help"\n')
+    await writeFile(join(dir, 'main.mjs'), widgetWithSiblingImport('sibling-app'))
+
+    const first = await loadUserWidgets(dir)
+
+    expect(first.errors).toEqual([])
+    expect(getWidgetApp('sibling-app')?.help).toBe('sibling-help')
+
+    await writeFile(join(lib, 'helper.mjs'), 'export const label = "sibling-v2"\n')
+    const result = await reloadWidgetFile('sibling-app', dir)
+
+    expect(result.errors).toEqual([])
+    expect(result.loaded).toEqual(['main.mjs'])
+    expect(getWidgetApp('sibling-app')?.help).toBe('sibling-v2')
   })
 
   it('loadWidgetPath registers from an absolute path outside the widgets dir', async () => {
@@ -100,7 +168,7 @@ describe('user widget loading', () => {
     expect(launchWidget('external-app', 'x')).toBeNull()
   })
 
-  it('unloadWidgetApp dismisses dock + unregisters', async () => {
+  it('unloadWidgetApp dismisses dock + stays unloaded across scans', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
 
     await writeFile(join(dir, 'bye.mjs'), widgetSource('bye-app'))
@@ -113,6 +181,31 @@ describe('user widget loading', () => {
     expect(r.ok).toBe(true)
     expect(getWidgetApp('bye-app')).toBeUndefined()
     expect(getOverlayState().ambient.some(a => a.appId === 'bye-app')).toBe(false)
+
+    const scan = await loadUserWidgets(dir)
+
+    expect(scan.added).not.toContain('bye-app')
+    expect(getWidgetApp('bye-app')).toBeUndefined()
+
+    const reenabled = await reloadWidgetFile('bye-app', dir)
+
+    expect(reenabled.added).toContain('bye-app')
+    expect(getWidgetApp('bye-app')).toBeDefined()
+  })
+
+  it('reload disposes prior onWidgetRefresh listeners from register()', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
+
+    await writeFile(join(dir, 'bus.mjs'), widgetWithRefresh('bus-app'))
+    await loadUserWidgets(dir)
+
+    const afterFirst = requestWidgetRefresh()
+
+    await reloadWidgetFile('bus-app', dir)
+    const afterReload = requestWidgetRefresh()
+
+    // One register() subscription should remain owned by the file, not stack.
+    expect(afterReload).toBe(afterFirst)
   })
 
   it('requestWidgetRefresh notifies subscribers with optional id', () => {

--- a/ui-tui/src/__tests__/userWidgets.test.ts
+++ b/ui-tui/src/__tests__/userWidgets.test.ts
@@ -5,15 +5,22 @@ import { join } from 'path'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
-import { launchWidget } from '../sdk/host.js'
+import { closeWidget, launchWidget } from '../sdk/host.js'
 import { getWidgetApp } from '../sdk/registry.js'
-import { loadUserWidgets } from '../sdk/userWidgets.js'
+import {
+  loadUserWidgets,
+  loadWidgetPath,
+  onWidgetRefresh,
+  reloadWidgetFile,
+  requestWidgetRefresh,
+  unloadWidgetApp
+} from '../sdk/userWidgets.js'
 
-const WIDGET = `
+const widgetSource = (id: string, help = 'from disk') => `
 export default function register(sdk) {
   sdk.defineWidgetApp({
-    id: 'test-user-widget',
-    help: 'from disk',
+    id: '${id}',
+    help: '${help}',
     mode: 'ambient',
     init: arg => ({ arg }),
     reduce: state => state,
@@ -34,7 +41,7 @@ describe('user widget loading', () => {
   it('loads .mjs from disk, registers, dispatches, and reports broken files', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
 
-    await writeFile(join(dir, 'good.mjs'), WIDGET)
+    await writeFile(join(dir, 'good.mjs'), widgetSource('test-user-widget'))
     await writeFile(join(dir, 'broken.mjs'), 'export default 42')
     await writeFile(join(dir, 'ignored.txt'), 'not a widget')
 
@@ -54,7 +61,7 @@ describe('user widget loading', () => {
     const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
     const file = join(dir, 'gone.mjs')
 
-    await writeFile(file, WIDGET.replace('test-user-widget', 'soon-gone'))
+    await writeFile(file, widgetSource('soon-gone'))
     await loadUserWidgets(dir)
     expect(getWidgetApp('soon-gone')).toBeDefined()
 
@@ -63,5 +70,87 @@ describe('user widget loading', () => {
 
     expect(result.removed).toEqual(['soon-gone'])
     expect(getWidgetApp('soon-gone')).toBeUndefined()
+  })
+
+  it('reloadWidgetFile re-imports one file by app id', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
+
+    await writeFile(join(dir, 'solo.mjs'), widgetSource('solo-app', 'v1'))
+    await loadUserWidgets(dir)
+    expect(getWidgetApp('solo-app')?.help).toBe('v1')
+
+    await writeFile(join(dir, 'solo.mjs'), widgetSource('solo-app', 'v2'))
+    const result = await reloadWidgetFile('solo-app', dir)
+
+    expect(result.loaded).toEqual(['solo.mjs'])
+    expect(result.removed).toContain('solo-app')
+    expect(result.added).toContain('solo-app')
+    expect(getWidgetApp('solo-app')?.help).toBe('v2')
+  })
+
+  it('loadWidgetPath registers from an absolute path outside the widgets dir', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-ext-'))
+    const file = join(dir, 'external.mjs')
+
+    await writeFile(file, widgetSource('external-app'))
+    const result = await loadWidgetPath(file)
+
+    expect(result.added).toEqual(['external-app'])
+    expect(getWidgetApp('external-app')).toBeDefined()
+    expect(launchWidget('external-app', 'x')).toBeNull()
+  })
+
+  it('unloadWidgetApp dismisses dock + unregisters', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tui-widgets-'))
+
+    await writeFile(join(dir, 'bye.mjs'), widgetSource('bye-app'))
+    await loadUserWidgets(dir)
+    expect(launchWidget('bye-app', 'x')).toBeNull()
+    expect(getOverlayState().ambient.some(a => a.appId === 'bye-app')).toBe(true)
+
+    const r = unloadWidgetApp('bye-app')
+
+    expect(r.ok).toBe(true)
+    expect(getWidgetApp('bye-app')).toBeUndefined()
+    expect(getOverlayState().ambient.some(a => a.appId === 'bye-app')).toBe(false)
+  })
+
+  it('requestWidgetRefresh notifies subscribers with optional id', () => {
+    const seen: (null | string)[] = []
+    const stop = onWidgetRefresh(id => seen.push(id))
+
+    expect(requestWidgetRefresh()).toBeGreaterThanOrEqual(1)
+    expect(requestWidgetRefresh('weather')).toBeGreaterThanOrEqual(1)
+    stop()
+    expect(seen).toEqual([null, 'weather'])
+  })
+})
+
+describe('closeWidget by id', () => {
+  it('dismisses an ambient dock entry without touching other apps', async () => {
+    const { defineWidgetApp } = await import('../sdk/registry.js')
+
+    defineWidgetApp({
+      help: 'a',
+      id: 'close-a',
+      mode: 'ambient',
+      init: () => ({}),
+      reduce: s => s,
+      render: () => null
+    })
+    defineWidgetApp({
+      help: 'b',
+      id: 'close-b',
+      mode: 'ambient',
+      init: () => ({}),
+      reduce: s => s,
+      render: () => null
+    })
+
+    launchWidget('close-a', 'x')
+    launchWidget('close-b', 'x')
+    closeWidget('close-a')
+
+    expect(getOverlayState().ambient.map(a => a.appId)).toEqual(['close-b'])
   })
 })

--- a/ui-tui/src/app/slash/commands/debug.ts
+++ b/ui-tui/src/app/slash/commands/debug.ts
@@ -5,11 +5,19 @@ import { terminalBackgroundHex } from '@hermes/ink'
 
 import { formatBytes, performHeapDump } from '../../../lib/memory.js'
 import { launchWidget } from '../../../sdk/host.js'
-import { listWidgetApps } from '../../../sdk/registry.js'
-import { loadUserWidgets } from '../../../sdk/userWidgets.js'
+import { getWidgetApp, listWidgetApps } from '../../../sdk/registry.js'
+import {
+  listWidgetSources,
+  loadUserWidgets,
+  loadWidgetPath,
+  reloadWidgetFile,
+  requestWidgetRefresh,
+  unloadWidgetApp
+} from '../../../sdk/userWidgets.js'
 import { detectLightMode } from '../../../theme.js'
+import { getOverlayState } from '../../overlayStore.js'
 import { getUiState } from '../../uiStore.js'
-import type { SlashCommand } from '../types.js'
+import type { SlashCommand, SlashRunCtx } from '../types.js'
 
 /** The registry IS the catalog: every registered widget app becomes a slash
  *  command carrying the app's own help/usage — nothing hardcoded per app.
@@ -26,22 +34,162 @@ export const widgetAppCommands: SlashCommand[] = listWidgetApps().map(app => ({
   }
 }))
 
+const WIDGETS_USAGE = 'Usage: /widgets (list|reload|load|unload|update) [target]'
+
+const formatLoadResult = (
+  label: string,
+  r: {
+    added: string[]
+    errors: { file: string; message: string }[]
+    loaded: string[]
+    removed: string[]
+  }
+): string => {
+  const parts = [
+    r.loaded.length ? `loaded: ${r.loaded.join(', ')}` : 'no user widgets found',
+    r.added.length ? `added: ${r.added.join(', ')}` : '',
+    r.removed.length ? `removed: ${r.removed.join(', ')}` : '',
+    ...r.errors.map(e => `${e.file}: ${e.message}`)
+  ].filter(Boolean)
+
+  return `${label} — ${parts.join(' · ')}`
+}
+
+const runWidgetsList = (ctx: SlashRunCtx): void => {
+  const sources = listWidgetSources()
+  const overlay = getOverlayState()
+
+  const open = new Set([...overlay.ambient.map(a => a.appId), ...(overlay.widget ? [overlay.widget.appId] : [])])
+
+  if (!sources.length) {
+    ctx.transcript.sys('widgets (0): none registered')
+
+    return
+  }
+
+  const lines = sources.map(s => {
+    const src = s.file ?? 'built-in'
+    const state = open.has(s.id) ? 'open' : 'loaded'
+    const help = getWidgetApp(s.id)?.help
+
+    return `  ${s.id}  [${state}]  ${src}${help ? `  - ${help}` : ''}`
+  })
+
+  ctx.transcript.sys(`widgets (${sources.length}):\n${lines.join('\n')}`)
+}
+
+const runWidgetsReload = async (target: string, ctx: SlashRunCtx): Promise<void> => {
+  if (!target) {
+    const r = await loadUserWidgets()
+
+    if (!ctx.stale()) {
+      ctx.transcript.sys(formatLoadResult('widgets reloaded', r))
+    }
+
+    return
+  }
+
+  const r = await reloadWidgetFile(target)
+
+  if (!ctx.stale()) {
+    ctx.transcript.sys(formatLoadResult(`widgets reload ${target}`, r))
+  }
+}
+
+const runWidgetsLoad = async (target: string, ctx: SlashRunCtx): Promise<void> => {
+  if (!target) {
+    ctx.transcript.sys('usage: /widgets load <path-to.mjs>')
+
+    return
+  }
+
+  const r = await loadWidgetPath(target)
+
+  if (!ctx.stale()) {
+    ctx.transcript.sys(formatLoadResult('widgets load', r))
+  }
+}
+
+const runWidgetsUnload = (target: string, ctx: SlashRunCtx): void => {
+  if (!target) {
+    ctx.transcript.sys('usage: /widgets unload <id>')
+
+    return
+  }
+
+  const r = unloadWidgetApp(target)
+
+  ctx.transcript.sys(r.ok ? `widgets: unloaded ${target}` : `widgets: ${r.reason}`)
+}
+
+const runWidgetsUpdate = (target: string, ctx: SlashRunCtx): void => {
+  if (target && !getWidgetApp(target)) {
+    ctx.transcript.sys(`widgets: unknown widget app: ${target}`)
+
+    return
+  }
+
+  const listeners = requestWidgetRefresh(target || undefined)
+  const overlay = getOverlayState()
+
+  const active = [...overlay.ambient.map(a => a.appId), ...(overlay.widget ? [overlay.widget.appId] : [])]
+
+  const scope = target || 'all'
+  const activeNote = active.length ? ` · docked: ${active.join(', ')}` : ''
+
+  ctx.transcript.sys(
+    `widgets: update ${scope} — signaled ${listeners} listener${listeners === 1 ? '' : 's'}${activeNote}`
+  )
+}
+
+const WIDGET_SUBCOMMANDS: Record<string, (target: string, ctx: SlashRunCtx) => void | Promise<void>> = {
+  list: (_target, ctx) => runWidgetsList(ctx),
+  ls: (_target, ctx) => runWidgetsList(ctx),
+  load: (target, ctx) => void runWidgetsLoad(target, ctx),
+  reload: (target, ctx) => void runWidgetsReload(target, ctx),
+  rl: (target, ctx) => void runWidgetsReload(target, ctx),
+  rm: (target, ctx) => runWidgetsUnload(target, ctx),
+  unload: (target, ctx) => runWidgetsUnload(target, ctx),
+  up: (target, ctx) => runWidgetsUpdate(target, ctx),
+  update: (target, ctx) => runWidgetsUpdate(target, ctx)
+}
+
+const runWidgetsFamily = (arg: string, ctx: SlashRunCtx): void => {
+  const [rawSub, ...rest] = (arg ?? '').trim().split(/\s+/).filter(Boolean)
+  const sub = rawSub?.toLowerCase()
+
+  if (!sub) {
+    ctx.transcript.sys(WIDGETS_USAGE)
+
+    return
+  }
+
+  const handler = WIDGET_SUBCOMMANDS[sub]
+
+  if (!handler) {
+    ctx.transcript.sys(WIDGETS_USAGE)
+
+    return
+  }
+
+  void handler(rest.join(' ').trim(), ctx)
+}
+
 export const debugCommands: SlashCommand[] = [
   ...widgetAppCommands,
 
   {
+    help: 'list / reload / load / unload / update widget apps',
+    name: 'widgets',
+    usage: WIDGETS_USAGE,
+    run: (arg, ctx) => runWidgetsFamily(arg, ctx)
+  },
+
+  // Backward-compat alias for the old flat command.
+  {
     help: 'rescan $HERMES_HOME/tui-widgets and (re)register user widget apps',
     name: 'widgets-reload',
-    run: (_arg, ctx) => {
-      void loadUserWidgets().then(({ errors, loaded }) => {
-        const parts = [
-          loaded.length ? `loaded: ${loaded.join(', ')}` : 'no user widgets found',
-          ...errors.map(e => `${e.file}: ${e.message}`)
-        ]
-
-        ctx.transcript.sys(`widgets — ${parts.join(' · ')}`)
-      })
-    }
+    run: (_arg, ctx) => void runWidgetsReload('', ctx)
   },
 
   {

--- a/ui-tui/src/sdk/host.tsx
+++ b/ui-tui/src/sdk/host.tsx
@@ -69,9 +69,31 @@ export function launchWidget(id: string, arg = ''): null | string {
   return null
 }
 
-/** Close the MODAL app. Ambient apps dismiss via their launch toggle, so a
- *  modal's Esc can't collaterally clear the dock. */
-export const closeWidget = () => patchOverlayState({ widget: null })
+/** Close widgets.
+ *  - no id: close the MODAL app only (Esc path; ambient stays docked)
+ *  - with id: dismiss that app from the modal slot and/or ambient dock */
+export function closeWidget(id?: string): void {
+  if (!id) {
+    patchOverlayState({ widget: null })
+
+    return
+  }
+
+  const overlay = $overlayState.get()
+  const patch: { ambient?: ActiveWidget[]; widget?: null } = {}
+
+  if (overlay.widget?.appId === id) {
+    patch.widget = null
+  }
+
+  if (overlay.ambient.some(active => active.appId === id)) {
+    patch.ambient = withoutApp(overlay.ambient, id)
+  }
+
+  if (patch.widget !== undefined || patch.ambient !== undefined) {
+    patchOverlayState(patch)
+  }
+}
 
 /** Programmatic, TYPED launch — bypasses string parsing. Apps use this to
  *  stack each other (the host swaps the active modal app). */

--- a/ui-tui/src/sdk/index.ts
+++ b/ui-tui/src/sdk/index.ts
@@ -67,3 +67,13 @@ export {
   type WidgetRenderCtx
 } from './types.js'
 export { loadUserWidgets, type UserWidgetLoadResult, widgetSdk, type WidgetSdk } from './userWidgets.js'
+export {
+  findWidgetFile,
+  listWidgetSources,
+  loadWidgetPath,
+  onWidgetRefresh,
+  reloadWidgetFile,
+  requestWidgetRefresh,
+  unloadWidgetApp,
+  type WidgetSource
+} from './userWidgets.js'

--- a/ui-tui/src/sdk/userWidgets.ts
+++ b/ui-tui/src/sdk/userWidgets.ts
@@ -77,6 +77,8 @@ const refreshListeners = new Set<WidgetRefreshListener>()
 const refreshByFile = new Map<string, Set<WidgetRefreshListener>>()
 /** File key whose register() is currently executing (if any). */
 let currentImportFileKey: null | string = null
+/** Listeners collected during the in-flight register(); promoted only on success. */
+let refreshIncoming: null | Set<WidgetRefreshListener> = null
 
 const disposeRefreshForFile = (fileKey: string): void => {
   const owned = refreshByFile.get(fileKey)
@@ -90,6 +92,18 @@ const disposeRefreshForFile = (fileKey: string): void => {
   }
 
   refreshByFile.delete(fileKey)
+}
+
+const disposeRefreshIncoming = (): void => {
+  if (!refreshIncoming) {
+    return
+  }
+
+  for (const listener of refreshIncoming) {
+    refreshListeners.delete(listener)
+  }
+
+  refreshIncoming = null
 }
 
 const enableSource = (fileKey: string, appIds: string[] = []): void => {
@@ -112,20 +126,16 @@ export function onWidgetRefresh(listener: WidgetRefreshListener): () => void {
   refreshListeners.add(listener)
 
   const owner = currentImportFileKey
+  const incoming = refreshIncoming
 
-  if (owner) {
-    let owned = refreshByFile.get(owner)
-
-    if (!owned) {
-      owned = new Set()
-      refreshByFile.set(owner, owned)
-    }
-
-    owned.add(listener)
+  if (incoming) {
+    incoming.add(listener)
   }
 
   return () => {
     refreshListeners.delete(listener)
+    incoming?.delete(listener)
+    refreshIncoming?.delete(listener)
 
     if (owner) {
       refreshByFile.get(owner)?.delete(listener)
@@ -223,9 +233,19 @@ async function importWidgetModule(absPath: string): Promise<{ default?: (sdk: Wi
   }
 }
 
+export interface ImportRegisterOptions {
+  /** Clear unload marks for this source after a successful register (explicit load/reload). */
+  reenable?: boolean
+}
+
 /** Import + register one file. Keeps prior apps docked on successful replace;
  *  restores prior definitions if register() fails after a partial apply. */
-async function importRegister(absPath: string, fileKey: string, result: UserWidgetLoadResult): Promise<void> {
+async function importRegister(
+  absPath: string,
+  fileKey: string,
+  result: UserWidgetLoadResult,
+  options: ImportRegisterOptions = {}
+): Promise<void> {
   const previous = fileApps.get(fileKey) ?? []
   const previousDefs = new Map<string, WidgetApp<never>>()
 
@@ -259,13 +279,12 @@ async function importRegister(absPath: string, fileKey: string, result: UserWidg
     return
   }
 
-  // Drop prior refresh ownership for this source only after the module parsed.
-  disposeRefreshForFile(fileKey)
-
   const registeredIds: string[] = []
   const priorImportOwner = currentImportFileKey
+  const priorIncoming = refreshIncoming
 
   currentImportFileKey = fileKey
+  refreshIncoming = new Set()
 
   try {
     const sdk: WidgetSdk = {
@@ -279,6 +298,10 @@ async function importRegister(absPath: string, fileKey: string, result: UserWidg
 
     mod.default(sdk)
   } catch (error) {
+    disposeRefreshIncoming()
+    refreshIncoming = priorIncoming
+    currentImportFileKey = priorImportOwner
+
     // Roll back any ids this register touched and restore prior definitions.
     for (const id of new Set(registeredIds)) {
       if (previousDefs.has(id)) {
@@ -301,15 +324,27 @@ async function importRegister(absPath: string, fileKey: string, result: UserWidg
     recordParentLifecycle(`user widget ${fileKey} failed to load: ${message}`)
 
     return
-  } finally {
-    currentImportFileKey = priorImportOwner
   }
 
-  // Successful register: re-enable this source and strip disabled flags.
-  enableSource(fileKey, registeredIds)
+  currentImportFileKey = priorImportOwner
+
+  // Successful register: drop prior owned refresh listeners, keep the new set.
+  const incoming = refreshIncoming
+
+  disposeRefreshForFile(fileKey)
+
+  if (incoming && incoming.size) {
+    refreshByFile.set(fileKey, incoming)
+  }
+
+  refreshIncoming = priorIncoming
+
+  // Explicit load/reload clears unload marks only after success.
+  if (options.reenable) {
+    enableSource(fileKey, registeredIds)
+  }
 
   // Drop apps this file no longer defines (id rename / multi-app shrink).
-  // Do not dispose refresh here — new listeners were just bound by register().
   for (const id of previous) {
     if (registeredIds.includes(id) || claimedElsewhere(fileKey, id)) {
       continue
@@ -445,9 +480,8 @@ export async function reloadWidgetFile(target: string, dir = widgetsDir()): Prom
     return emitLoadResult(result)
   }
 
-  // Explicit reload re-enables a previously unloaded source.
-  enableSource(fileKey, fileApps.get(fileKey) ?? [])
-  await importRegister(abs, fileKey, result)
+  // Explicit reload re-enables a previously unloaded source after success.
+  await importRegister(abs, fileKey, result, { reenable: true })
 
   return emitLoadResult(result)
 }
@@ -471,8 +505,7 @@ export async function loadWidgetPath(path: string): Promise<UserWidgetLoadResult
     return emitLoadResult(result)
   }
 
-  enableSource(abs, fileApps.get(abs) ?? [])
-  await importRegister(abs, abs, result)
+  await importRegister(abs, abs, result, { reenable: true })
 
   return emitLoadResult(result)
 }
@@ -528,7 +561,7 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
     // No directory: fall through so previously-loaded files still delete-sync.
   }
 
-  for (const [file, ids] of fileApps) {
+  for (const [file, ids] of [...fileApps.entries()]) {
     // External loads use absolute keys and persist until `/widgets unload`.
     if (isAbsolute(file)) {
       continue
@@ -558,6 +591,13 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
     }
 
     disabledFiles.delete(file)
+
+    for (const [id, source] of [...disabledAppSource.entries()]) {
+      if (source === file) {
+        disabledAppIds.delete(id)
+        disabledAppSource.delete(id)
+      }
+    }
   }
 
   for (const file of files) {

--- a/ui-tui/src/sdk/userWidgets.ts
+++ b/ui-tui/src/sdk/userWidgets.ts
@@ -1,7 +1,7 @@
 import { watch } from 'fs'
-import { readdir } from 'fs/promises'
-import { homedir } from 'os'
-import { dirname, join } from 'path'
+import { access, readdir, readFile, rm, writeFile } from 'fs/promises'
+import { homedir, tmpdir } from 'os'
+import { basename, dirname, isAbsolute, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 
 import { Box, Text } from '@hermes/ink'
@@ -14,8 +14,8 @@ import { GridAreas, WidgetGrid } from '../components/widgetGrid.js'
 import { gauge, hbars, sparkline, sparkRows } from '../lib/charts.js'
 import { recordParentLifecycle } from '../lib/parentLog.js'
 
-import { openWidget, updateWidget } from './host.js'
-import { defineWidgetApp, listWidgetApps, removeWidgetApp } from './registry.js'
+import { closeWidget, openWidget, updateWidget } from './host.js'
+import { defineWidgetApp, getWidgetApp, listWidgetApps, removeWidgetApp } from './registry.js'
 import { isCtrl } from './types.js'
 
 /**
@@ -30,6 +30,53 @@ import { isCtrl } from './types.js'
  * with the TUI's privileges. Load errors log and skip — a broken widget
  * never takes the TUI down.
  */
+
+const widgetsDir = () => join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'tui-widgets')
+
+export interface UserWidgetLoadResult {
+  /** App ids newly registered by this scan. */
+  added: string[]
+  errors: { file: string; message: string }[]
+  loaded: string[]
+  /** App ids unregistered because their file disappeared. */
+  removed: string[]
+}
+
+export interface WidgetSource {
+  file: null | string
+  id: string
+}
+
+/** Which app ids each user file registered — the delete-sync source of
+ *  truth (file gone on the next scan ⇒ its apps unregister). Absolute-path
+ *  keys are external loads (via `/widgets load`) and skip delete-sync. */
+const fileApps = new Map<string, string[]>()
+
+const listeners = new Set<(result: UserWidgetLoadResult) => void>()
+
+/** Manual refresh bus for `/widgets update`. Widgets subscribe in register()
+ *  or inside a component effect. `id` is null when every widget should refresh. */
+type WidgetRefreshListener = (id: null | string) => void
+const refreshListeners = new Set<WidgetRefreshListener>()
+
+export function onWidgetRefresh(listener: WidgetRefreshListener): () => void {
+  refreshListeners.add(listener)
+
+  return () => {
+    refreshListeners.delete(listener)
+  }
+}
+
+/** Notify refresh subscribers. Returns the listener count at fire time. */
+export function requestWidgetRefresh(id?: string): number {
+  const target = id?.trim() ? id.trim() : null
+
+  for (const listener of refreshListeners) {
+    listener(target)
+  }
+
+  return refreshListeners.size
+}
 
 /** Everything a user widget may touch, passed INTO its register() — user
  *  files have no resolvable import path to the bundle. */
@@ -49,7 +96,9 @@ export const widgetSdk = {
   h: React.createElement,
   hbars,
   isCtrl,
+  onWidgetRefresh,
   openWidget,
+  requestWidgetRefresh,
   sparkRows,
   sparkline,
   updateWidget,
@@ -57,23 +106,6 @@ export const widgetSdk = {
 } as const
 
 export type WidgetSdk = typeof widgetSdk
-
-const widgetsDir = () => join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'tui-widgets')
-
-export interface UserWidgetLoadResult {
-  /** App ids newly registered by this scan. */
-  added: string[]
-  errors: { file: string; message: string }[]
-  loaded: string[]
-  /** App ids unregistered because their file disappeared. */
-  removed: string[]
-}
-
-/** Which app ids each user file registered — the delete-sync source of
- *  truth (file gone on the next scan ⇒ its apps unregister). */
-const fileApps = new Map<string, string[]>()
-
-const listeners = new Set<(result: UserWidgetLoadResult) => void>()
 
 /** Subscribe to scan results — the app layer announces loads in the
  *  transcript so a hot-loaded widget is VISIBLY live (silent success is
@@ -84,11 +116,234 @@ export function onUserWidgets(listener: (result: UserWidgetLoadResult) => void):
   return () => listeners.delete(listener)
 }
 
+const emptyResult = (): UserWidgetLoadResult => ({ added: [], errors: [], loaded: [], removed: [] })
+
+const emitLoadResult = (result: UserWidgetLoadResult): UserWidgetLoadResult => {
+  if (result.added.length) {
+    recordParentLifecycle(`user widgets registered: ${result.added.join(', ')}`)
+  }
+
+  for (const listener of listeners) {
+    listener(result)
+  }
+
+  return result
+}
+
+/** Import one on-disk .mjs via a unique temp path so ESM loaders (Node query
+ *  bust and Vitest/vite-node) always re-execute after edits. */
+async function importRegister(absPath: string, fileKey: string, result: UserWidgetLoadResult): Promise<void> {
+  const before = new Set(listWidgetApps().map(app => app.id))
+  const previous = fileApps.get(fileKey) ?? []
+
+  const tmp = join(
+    tmpdir(),
+    `hermes-widget-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.mjs`
+  )
+
+  try {
+    const src = await readFile(absPath, 'utf8')
+
+    await writeFile(tmp, src)
+
+    const mod = (await import(pathToFileURL(tmp).href)) as {
+      default?: (sdk: WidgetSdk) => void
+    }
+
+    if (typeof mod.default !== 'function') {
+      throw new Error('default export must be register(sdk)')
+    }
+
+    mod.default(widgetSdk)
+    result.loaded.push(fileKey)
+
+    const added = listWidgetApps()
+      .map(app => app.id)
+      .filter(id => !before.has(id))
+
+    // First registration of this file, or new ids from a multi-app file.
+    if (added.length) {
+      fileApps.set(fileKey, [...new Set([...previous, ...added])])
+      result.added.push(...added)
+
+      return
+    }
+
+    // Re-import of existing ids (hot reload): keep prior attribution.
+    if (previous.length) {
+      fileApps.set(fileKey, previous)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    result.errors.push({ file: fileKey, message })
+    recordParentLifecycle(`user widget ${fileKey} failed to load: ${message}`)
+  } finally {
+    await rm(tmp, { force: true }).catch(() => {})
+  }
+}
+
+/** Resolve a user target (app id, basename, or basename.mjs) to a fileApps key. */
+export function findWidgetFile(target: string): null | string {
+  const needle = target.trim()
+
+  if (!needle) {
+    return null
+  }
+
+  if (fileApps.has(needle)) {
+    return needle
+  }
+
+  if (!needle.endsWith('.mjs') && fileApps.has(`${needle}.mjs`)) {
+    return `${needle}.mjs`
+  }
+
+  const base = basename(needle)
+
+  for (const [file, ids] of fileApps) {
+    if (ids.includes(needle)) {
+      return file
+    }
+
+    if (file === base || basename(file) === base) {
+      return file
+    }
+
+    if (basename(file, '.mjs') === needle || basename(file, '.mjs') === base.replace(/\.mjs$/, '')) {
+      return file
+    }
+  }
+
+  return null
+}
+
+/** Catalog entry: every registered app plus its user-file source (if any). */
+export function listWidgetSources(): WidgetSource[] {
+  const byId = new Map<string, string>()
+
+  for (const [file, ids] of fileApps) {
+    for (const id of ids) {
+      byId.set(id, file)
+    }
+  }
+
+  return listWidgetApps().map(app => ({ file: byId.get(app.id) ?? null, id: app.id }))
+}
+
+/** Hot-reload one user widget file (or the file that owns `target` id). */
+export async function reloadWidgetFile(target: string, dir = widgetsDir()): Promise<UserWidgetLoadResult> {
+  const result = emptyResult()
+  const key = findWidgetFile(target)
+  let abs: null | string = null
+  let fileKey: null | string = key
+
+  if (key && isAbsolute(key)) {
+    abs = key
+  } else if (key) {
+    abs = join(dir, key)
+  } else {
+    // Allow reload by on-disk basename before it is attributed (first load).
+    const candidate = target.endsWith('.mjs') ? target : `${target}.mjs`
+    const path = isAbsolute(target) ? resolve(target) : join(dir, basename(candidate))
+
+    try {
+      await access(path)
+      abs = path
+      fileKey = isAbsolute(target) ? path : basename(path)
+    } catch {
+      result.errors.push({ file: target, message: `no widget file found for '${target}'` })
+
+      return emitLoadResult(result)
+    }
+  }
+
+  if (!abs || !fileKey) {
+    result.errors.push({ file: target, message: `no widget file found for '${target}'` })
+
+    return emitLoadResult(result)
+  }
+
+  // Drop prior ids owned solely by this file so a rename does not leave ghosts.
+  const previous = fileApps.get(fileKey) ?? []
+
+  for (const id of previous) {
+    const claimedElsewhere = [...fileApps.entries()].some(([k, ids]) => k !== fileKey && ids.includes(id))
+
+    if (!claimedElsewhere) {
+      closeWidget(id)
+      removeWidgetApp(id)
+      result.removed.push(id)
+    }
+  }
+
+  fileApps.delete(fileKey)
+  await importRegister(abs, fileKey, result)
+
+  return emitLoadResult(result)
+}
+
+/** Load a .mjs widget from an arbitrary path (dev copy, backup, template). */
+export async function loadWidgetPath(path: string): Promise<UserWidgetLoadResult> {
+  const result = emptyResult()
+  const abs = resolve(path.trim())
+
+  try {
+    await access(abs)
+  } catch {
+    result.errors.push({ file: abs, message: 'file not found' })
+
+    return emitLoadResult(result)
+  }
+
+  if (!abs.endsWith('.mjs')) {
+    result.errors.push({ file: abs, message: 'widget files must end in .mjs' })
+
+    return emitLoadResult(result)
+  }
+
+  await importRegister(abs, abs, result)
+
+  return emitLoadResult(result)
+}
+
+/** Unregister one app, dismiss it from the dock/modal, and drop file attribution. */
+export function unloadWidgetApp(id: string): { ok: boolean; reason?: string } {
+  const appId = id.trim()
+
+  if (!appId) {
+    return { ok: false, reason: 'missing app id' }
+  }
+
+  if (!getWidgetApp(appId)) {
+    return { ok: false, reason: `unknown widget app: ${appId}` }
+  }
+
+  closeWidget(appId)
+  removeWidgetApp(appId)
+
+  for (const [file, ids] of [...fileApps.entries()]) {
+    if (!ids.includes(appId)) {
+      continue
+    }
+
+    const next = ids.filter(x => x !== appId)
+
+    if (next.length) {
+      fileApps.set(file, next)
+    } else {
+      fileApps.delete(file)
+    }
+  }
+
+  return { ok: true }
+}
+
 /** Scan + import + register, diffing the registry per file. Cache-busted so
  *  edits reload without restarting the TUI (last-writer-wins shadows stale
  *  definitions). Files that vanished unregister their apps. */
 export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoadResult> {
-  const result: UserWidgetLoadResult = { added: [], errors: [], loaded: [], removed: [] }
+  const result = emptyResult()
 
   let files: string[] = []
 
@@ -99,10 +354,17 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
   }
 
   for (const [file, ids] of fileApps) {
+    // External loads use absolute keys and persist until `/widgets unload`.
+    if (isAbsolute(file)) {
+      continue
+    }
+
     if (!files.includes(file)) {
       fileApps.delete(file)
 
       for (const id of ids) {
+        closeWidget(id)
+
         if (removeWidgetApp(id)) {
           result.removed.push(id)
         }
@@ -111,46 +373,10 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
   }
 
   for (const file of files) {
-    const before = new Set(listWidgetApps().map(app => app.id))
-
-    try {
-      const mod = (await import(`${pathToFileURL(join(dir, file)).href}?t=${Date.now()}`)) as {
-        default?: (sdk: WidgetSdk) => void
-      }
-
-      if (typeof mod.default !== 'function') {
-        throw new Error('default export must be register(sdk)')
-      }
-
-      mod.default(widgetSdk)
-      result.loaded.push(file)
-
-      const ids = listWidgetApps()
-        .map(app => app.id)
-        .filter(id => !before.has(id))
-
-      // Re-registrations of existing ids keep their prior file attribution.
-      if (ids.length) {
-        fileApps.set(file, ids)
-        result.added.push(...ids)
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-
-      result.errors.push({ file, message })
-      recordParentLifecycle(`user widget ${file} failed to load: ${message}`)
-    }
+    await importRegister(join(dir, file), file, result)
   }
 
-  if (result.added.length) {
-    recordParentLifecycle(`user widgets registered: ${result.added.join(', ')}`)
-  }
-
-  for (const listener of listeners) {
-    listener(result)
-  }
-
-  return result
+  return emitLoadResult(result)
 }
 
 let watching = false

--- a/ui-tui/src/sdk/userWidgets.ts
+++ b/ui-tui/src/sdk/userWidgets.ts
@@ -1,5 +1,5 @@
 import { watch } from 'fs'
-import { access, readdir, readFile, rm, writeFile } from 'fs/promises'
+import { access, cp, mkdtemp, readdir, rm } from 'fs/promises'
 import { homedir, tmpdir } from 'os'
 import { basename, dirname, isAbsolute, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
@@ -16,6 +16,7 @@ import { recordParentLifecycle } from '../lib/parentLog.js'
 
 import { closeWidget, openWidget, updateWidget } from './host.js'
 import { defineWidgetApp, getWidgetApp, listWidgetApps, removeWidgetApp } from './registry.js'
+import type { WidgetApp } from './types.js'
 import { isCtrl } from './types.js'
 
 /**
@@ -32,6 +33,11 @@ import { isCtrl } from './types.js'
  */
 
 const widgetsDir = () => join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'tui-widgets')
+
+/** Marker segment for same-dir cache-bust copies — excluded from directory scans. */
+const RELOAD_MARKER = '.__hermes_reload_'
+
+const isUserWidgetFile = (name: string): boolean => name.endsWith('.mjs') && !name.includes(RELOAD_MARKER)
 
 export interface UserWidgetLoadResult {
   /** App ids newly registered by this scan. */
@@ -52,18 +58,82 @@ export interface WidgetSource {
  *  keys are external loads (via `/widgets load`) and skip delete-sync. */
 const fileApps = new Map<string, string[]>()
 
+/** Files skipped by automatic scans until an explicit load/reload. */
+const disabledFiles = new Set<string>()
+
+/** App ids removed via unload while their source file may still exist. */
+const disabledAppIds = new Set<string>()
+
+/** Last known source file for a disabled app id (reload-by-id after unload). */
+const disabledAppSource = new Map<string, string>()
+
 const listeners = new Set<(result: UserWidgetLoadResult) => void>()
 
 /** Manual refresh bus for `/widgets update`. Widgets subscribe in register()
  *  or inside a component effect. `id` is null when every widget should refresh. */
 type WidgetRefreshListener = (id: null | string) => void
 const refreshListeners = new Set<WidgetRefreshListener>()
+/** Listeners owned by a source file (subscribed during that file's register). */
+const refreshByFile = new Map<string, Set<WidgetRefreshListener>>()
+/** File key whose register() is currently executing (if any). */
+let currentImportFileKey: null | string = null
+
+const disposeRefreshForFile = (fileKey: string): void => {
+  const owned = refreshByFile.get(fileKey)
+
+  if (!owned) {
+    return
+  }
+
+  for (const listener of owned) {
+    refreshListeners.delete(listener)
+  }
+
+  refreshByFile.delete(fileKey)
+}
+
+const enableSource = (fileKey: string, appIds: string[] = []): void => {
+  disabledFiles.delete(fileKey)
+
+  for (const id of appIds) {
+    disabledAppIds.delete(id)
+    disabledAppSource.delete(id)
+  }
+
+  for (const [id, file] of [...disabledAppSource.entries()]) {
+    if (file === fileKey) {
+      disabledAppIds.delete(id)
+      disabledAppSource.delete(id)
+    }
+  }
+}
 
 export function onWidgetRefresh(listener: WidgetRefreshListener): () => void {
   refreshListeners.add(listener)
 
+  const owner = currentImportFileKey
+
+  if (owner) {
+    let owned = refreshByFile.get(owner)
+
+    if (!owned) {
+      owned = new Set()
+      refreshByFile.set(owner, owned)
+    }
+
+    owned.add(listener)
+  }
+
   return () => {
     refreshListeners.delete(listener)
+
+    if (owner) {
+      refreshByFile.get(owner)?.delete(listener)
+    }
+
+    for (const owned of refreshByFile.values()) {
+      owned.delete(listener)
+    }
   }
 }
 
@@ -130,56 +200,146 @@ const emitLoadResult = (result: UserWidgetLoadResult): UserWidgetLoadResult => {
   return result
 }
 
-/** Import one on-disk .mjs via a unique temp path so ESM loaders (Node query
- *  bust and Vitest/vite-node) always re-execute after edits. */
-async function importRegister(absPath: string, fileKey: string, result: UserWidgetLoadResult): Promise<void> {
-  const before = new Set(listWidgetApps().map(app => app.id))
-  const previous = fileApps.get(fileKey) ?? []
+const claimedElsewhere = (fileKey: string, id: string): boolean =>
+  [...fileApps.entries()].some(([key, ids]) => key !== fileKey && ids.includes(id))
 
-  const tmp = join(
-    tmpdir(),
-    `hermes-widget-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.mjs`
-  )
+/** Cache-bust by staging the source directory into a unique temp tree.
+ *  Relative imports keep a real directory base (unlike a lone /tmp entry
+ *  copy), and every path is a fresh URL so Node/Vitest re-execute helpers. */
+async function importWidgetModule(absPath: string): Promise<{ default?: (sdk: WidgetSdk) => void }> {
+  const stageRoot = await mkdtemp(join(tmpdir(), 'hermes-widget-'))
 
   try {
-    const src = await readFile(absPath, 'utf8')
+    await cp(dirname(absPath), stageRoot, {
+      filter: src => !basename(src).includes(RELOAD_MARKER),
+      recursive: true
+    })
 
-    await writeFile(tmp, src)
+    const staged = join(stageRoot, basename(absPath))
 
-    const mod = (await import(pathToFileURL(tmp).href)) as {
-      default?: (sdk: WidgetSdk) => void
+    return (await import(pathToFileURL(staged).href)) as { default?: (sdk: WidgetSdk) => void }
+  } finally {
+    await rm(stageRoot, { force: true, recursive: true }).catch(() => {})
+  }
+}
+
+/** Import + register one file. Keeps prior apps docked on successful replace;
+ *  restores prior definitions if register() fails after a partial apply. */
+async function importRegister(absPath: string, fileKey: string, result: UserWidgetLoadResult): Promise<void> {
+  const previous = fileApps.get(fileKey) ?? []
+  const previousDefs = new Map<string, WidgetApp<never>>()
+
+  for (const id of previous) {
+    const app = getWidgetApp(id)
+
+    if (app) {
+      previousDefs.set(id, app)
     }
+  }
 
-    if (typeof mod.default !== 'function') {
-      throw new Error('default export must be register(sdk)')
-    }
+  let mod: { default?: (sdk: WidgetSdk) => void }
 
-    mod.default(widgetSdk)
-    result.loaded.push(fileKey)
-
-    const added = listWidgetApps()
-      .map(app => app.id)
-      .filter(id => !before.has(id))
-
-    // First registration of this file, or new ids from a multi-app file.
-    if (added.length) {
-      fileApps.set(fileKey, [...new Set([...previous, ...added])])
-      result.added.push(...added)
-
-      return
-    }
-
-    // Re-import of existing ids (hot reload): keep prior attribution.
-    if (previous.length) {
-      fileApps.set(fileKey, previous)
-    }
+  try {
+    mod = await importWidgetModule(absPath)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
 
     result.errors.push({ file: fileKey, message })
     recordParentLifecycle(`user widget ${fileKey} failed to load: ${message}`)
+
+    return
+  }
+
+  if (typeof mod.default !== 'function') {
+    const message = 'default export must be register(sdk)'
+
+    result.errors.push({ file: fileKey, message })
+    recordParentLifecycle(`user widget ${fileKey} failed to load: ${message}`)
+
+    return
+  }
+
+  // Drop prior refresh ownership for this source only after the module parsed.
+  disposeRefreshForFile(fileKey)
+
+  const registeredIds: string[] = []
+  const priorImportOwner = currentImportFileKey
+
+  currentImportFileKey = fileKey
+
+  try {
+    const sdk: WidgetSdk = {
+      ...widgetSdk,
+      defineWidgetApp: <S,>(app: WidgetApp<S>) => {
+        registeredIds.push(app.id)
+
+        return defineWidgetApp(app)
+      }
+    }
+
+    mod.default(sdk)
+  } catch (error) {
+    // Roll back any ids this register touched and restore prior definitions.
+    for (const id of new Set(registeredIds)) {
+      if (previousDefs.has(id)) {
+        defineWidgetApp(previousDefs.get(id)!)
+      } else {
+        closeWidget(id)
+        removeWidgetApp(id)
+      }
+    }
+
+    for (const [id, app] of previousDefs) {
+      if (!registeredIds.includes(id)) {
+        defineWidgetApp(app)
+      }
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+
+    result.errors.push({ file: fileKey, message })
+    recordParentLifecycle(`user widget ${fileKey} failed to load: ${message}`)
+
+    return
   } finally {
-    await rm(tmp, { force: true }).catch(() => {})
+    currentImportFileKey = priorImportOwner
+  }
+
+  // Successful register: re-enable this source and strip disabled flags.
+  enableSource(fileKey, registeredIds)
+
+  // Drop apps this file no longer defines (id rename / multi-app shrink).
+  // Do not dispose refresh here — new listeners were just bound by register().
+  for (const id of previous) {
+    if (registeredIds.includes(id) || claimedElsewhere(fileKey, id)) {
+      continue
+    }
+
+    closeWidget(id)
+    removeWidgetApp(id)
+    result.removed.push(id)
+  }
+
+  // Honor per-app unload while the file still loads siblings.
+  const keptIds = registeredIds.filter(id => {
+    if (!disabledAppIds.has(id)) {
+      return true
+    }
+
+    closeWidget(id)
+    removeWidgetApp(id)
+    result.removed.push(id)
+
+    return false
+  })
+
+  fileApps.set(fileKey, keptIds)
+  result.loaded.push(fileKey)
+
+  for (const id of keptIds) {
+    if (!previous.includes(id)) {
+      result.added.push(id)
+    }
   }
 }
 
@@ -211,6 +371,27 @@ export function findWidgetFile(target: string): null | string {
     }
 
     if (basename(file, '.mjs') === needle || basename(file, '.mjs') === base.replace(/\.mjs$/, '')) {
+      return file
+    }
+  }
+
+  const disabledSource = disabledAppSource.get(needle)
+
+  if (disabledSource) {
+    return disabledSource
+  }
+
+  // Disabled sources still resolve so reload can re-enable them.
+  if (disabledFiles.has(needle)) {
+    return needle
+  }
+
+  if (!needle.endsWith('.mjs') && disabledFiles.has(`${needle}.mjs`)) {
+    return `${needle}.mjs`
+  }
+
+  for (const file of disabledFiles) {
+    if (file === base || basename(file) === base || basename(file, '.mjs') === needle) {
       return file
     }
   }
@@ -264,20 +445,8 @@ export async function reloadWidgetFile(target: string, dir = widgetsDir()): Prom
     return emitLoadResult(result)
   }
 
-  // Drop prior ids owned solely by this file so a rename does not leave ghosts.
-  const previous = fileApps.get(fileKey) ?? []
-
-  for (const id of previous) {
-    const claimedElsewhere = [...fileApps.entries()].some(([k, ids]) => k !== fileKey && ids.includes(id))
-
-    if (!claimedElsewhere) {
-      closeWidget(id)
-      removeWidgetApp(id)
-      result.removed.push(id)
-    }
-  }
-
-  fileApps.delete(fileKey)
+  // Explicit reload re-enables a previously unloaded source.
+  enableSource(fileKey, fileApps.get(fileKey) ?? [])
   await importRegister(abs, fileKey, result)
 
   return emitLoadResult(result)
@@ -302,12 +471,14 @@ export async function loadWidgetPath(path: string): Promise<UserWidgetLoadResult
     return emitLoadResult(result)
   }
 
+  enableSource(abs, fileApps.get(abs) ?? [])
   await importRegister(abs, abs, result)
 
   return emitLoadResult(result)
 }
 
-/** Unregister one app, dismiss it from the dock/modal, and drop file attribution. */
+/** Unregister one app, dismiss it from the dock/modal, and remember the
+ *  source so automatic rescans do not immediately re-register it. */
 export function unloadWidgetApp(id: string): { ok: boolean; reason?: string } {
   const appId = id.trim()
 
@@ -321,18 +492,22 @@ export function unloadWidgetApp(id: string): { ok: boolean; reason?: string } {
 
   closeWidget(appId)
   removeWidgetApp(appId)
+  disabledAppIds.add(appId)
 
   for (const [file, ids] of [...fileApps.entries()]) {
     if (!ids.includes(appId)) {
       continue
     }
 
+    disabledAppSource.set(appId, file)
     const next = ids.filter(x => x !== appId)
 
     if (next.length) {
       fileApps.set(file, next)
     } else {
       fileApps.delete(file)
+      disabledFiles.add(file)
+      disposeRefreshForFile(file)
     }
   }
 
@@ -348,7 +523,7 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
   let files: string[] = []
 
   try {
-    files = (await readdir(dir)).filter(f => f.endsWith('.mjs')).sort()
+    files = (await readdir(dir)).filter(isUserWidgetFile).sort()
   } catch {
     // No directory: fall through so previously-loaded files still delete-sync.
   }
@@ -361,8 +536,12 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
 
     if (!files.includes(file)) {
       fileApps.delete(file)
+      disabledFiles.delete(file)
+      disposeRefreshForFile(file)
 
       for (const id of ids) {
+        disabledAppIds.delete(id)
+        disabledAppSource.delete(id)
         closeWidget(id)
 
         if (removeWidgetApp(id)) {
@@ -372,7 +551,20 @@ export async function loadUserWidgets(dir = widgetsDir()): Promise<UserWidgetLoa
     }
   }
 
+  // Drop disable records for files that no longer exist on disk.
+  for (const file of [...disabledFiles]) {
+    if (isAbsolute(file) || files.includes(file)) {
+      continue
+    }
+
+    disabledFiles.delete(file)
+  }
+
   for (const file of files) {
+    if (disabledFiles.has(file)) {
+      continue
+    }
+
     await importRegister(join(dir, file), file, result)
   }
 


### PR DESCRIPTION
## Summary

`/widgets-reload` was a single flat debug command: rescan the whole `tui-widgets/` dir or nothing. No list, no single-file hot-reload, no unload without deleting the file, no external path load, no way to poke ambient data refresh.

This implements the `/widgets <verb> [target]` family from #69288.

## Changes

- `ui-tui/src/app/slash/commands/debug.ts`: `/widgets` with `list|ls`, `reload|rl`, `load`, `unload|rm`, `update|up`; bare `/widgets` prints usage; `/widgets-reload` kept as full-rescan alias
- `ui-tui/src/sdk/userWidgets.ts`: `listWidgetSources`, `findWidgetFile`, `reloadWidgetFile`, `loadWidgetPath`, `unloadWidgetApp`, `onWidgetRefresh` / `requestWidgetRefresh`; temp-path import so reloads re-execute under Node and Vitest; external absolute loads skip delete-sync
- `ui-tui/src/sdk/host.tsx`: `closeWidget(id?)` — no arg still closes modal only; with id dismisses modal and/or ambient
- `ui-tui/src/sdk/index.ts`: export the new helpers
- `skills/.../tui-widgets.md`: document the family + refresh bus
- tests: load/reload/unload/path/refresh + ambient `closeWidget(id)`

## Related

- Closes #69288
- Complements #69277 (automatic refresh lifecycle); `/widgets update` is the manual signal
- Complements #70649 / #76654 (completion of TUI-local slash names) — `/widgets` is now in `SLASH_COMMANDS`

## Validation

- `npm run typecheck` (ui-tui)
- `vitest` `userWidgets.test.ts` + `widgetSdk.test.ts` (18 passed)
