### PR TITLE
fix(test-runner): probe venvs with PYTHONPATH cleared

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -53,7 +53,12 @@ VENV_PYTHON=""
 SKIPPED_VENVS=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
+    # Probe under the same hermetic conditions the per-file subprocess will
+    # see (env -i below clears PYTHONPATH/PYTHONHOME). A parent-shell
+    # PYTHONPATH pointing at another venv's site-packages would otherwise
+    # make a pytest-less venv look usable, and every file would then die
+    # with "No module named pytest" after env -i drops the crutch.
+    if env -u PYTHONPATH -u PYTHONHOME "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/bin/python"
       break
@@ -65,7 +70,7 @@ for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agen
   # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
   # this branch — without it the canonical runner refuses to start.
   if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if env -u PYTHONPATH -u PYTHONHOME "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/Scripts/python.exe"
       break
@@ -83,7 +88,7 @@ fi
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
+    && env -u PYTHONPATH -u PYTHONHOME "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE
   # venv (no pytest) when inherited from a wrapped `hermes` binary rather
   # than the devShell hook.


### PR DESCRIPTION
## What

`scripts/run_tests.sh` probes candidate venvs for pytest with `python -c 'import pytest'` running in the **parent shell**, where an ambient `PYTHONPATH` pointing at another venv's site-packages can make a pytest-less venv look usable. The per-file subprocess then runs under `env -i` (which clears `PYTHONPATH`/`PYTHONHOME`), loses the crutch, and every file dies with `No module named pytest`.

This fix probes under the same hermetic conditions the subprocess will see — `env -u PYTHONPATH -u PYTHONHOME` — for all three paths: the POSIX venv layout, the Windows `Scripts/` layout, and the `HERMES_PYTHON` fallback.

## Verification

```bash
# With a deliberately poisoned PYTHONPATH pointing at a fake venv:
export PYTHONPATH=/tmp/fake-venv-site-packages
./scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q
# → Summary: 1 files, 2 tests passed, 0 failed
```

Also passes with a clean environment.