### PR TITLE
fix(cron): unwrap List[PlatformConfig] in _deliver_result

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1586,6 +1586,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
+        # Unwrap list-of-configs (multi-instance platforms like multiple Feishu
+        # bots) to the first enabled config. Union[PlatformConfig,
+        # List[PlatformConfig]] allows lists, but the rest of this function
+        # assumes a single PlatformConfig object.
+        if isinstance(pconfig, list):
+            pconfig = next((c for c in pconfig if getattr(c, "enabled", False)), pconfig[0] if pconfig else None)
+
         if not pconfig or not pconfig.enabled:
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -440,6 +440,42 @@ class TestDeliverResultErrorReturns:
         assert result is not None
         assert "not configured" in result
 
+    def test_multi_instance_platform_list_unwraps_to_enabled(self):
+        """Regression: platforms configured as List[PlatformConfig] (e.g. multiple
+        Feishu bots) must not crash with "'list' object has no attribute 'enabled'".
+
+        The type union ``Union[PlatformConfig, List[PlatformConfig]]`` allows lists,
+        but ``_deliver_result`` assumed a single object and called ``.enabled`` /
+        ``.extra`` directly on the list.
+        """
+        from gateway.config import Platform
+
+        disabled_cfg = MagicMock()
+        disabled_cfg.enabled = False
+        enabled_cfg = MagicMock()
+        enabled_cfg.enabled = True
+        enabled_cfg.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: [disabled_cfg, enabled_cfg]}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg):
+            job = {
+                "id": "multi-instance",
+                "deliver": "origin",
+                "origin": {"platform": "feishu", "chat_id": "oc_test"},
+            }
+            # Must not raise "'list' object has no attribute 'enabled'".
+            # Delivery may still fail (no live adapter/credentials), but the
+            # failure must NOT be an AttributeError on the list-of-configs path.
+            result = _deliver_result(job, "Output.")
+        # If it got past the pconfig.enabled check, result should be either
+        # None (success — unlikely without a real adapter) or a delivery error
+        # string that is NOT "not configured/enabled".
+        if result is not None:
+            assert "not configured" not in result, (
+                "List unwrap failed — the enabled config was not found"
+            )
+
 
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):


### PR DESCRIPTION
## Bug Description

When a platform is configured as multiple instances (e.g. multiple Feishu bots), every cron job delivery to that platform fails with:

```
'list' object has no attribute 'enabled'
```

This is set as `last_delivery_error` on every cron run, silently breaking all scheduled output delivery (daily reports, PR monitors, health checks) on multi-instance platforms.

## Root Cause

`GatewayConfig.platforms` is typed as `Dict[Platform, Union[PlatformConfig, List[PlatformConfig]]]` ([config.py L898](https://github.com/NousResearch/hermes-agent/blob/main/gateway/config.py#L898)), allowing list values for multi-instance platforms.

In `_deliver_result` ([scheduler.py L1582-1585](https://github.com/NousResearch/hermes-agent/blob/main/cron/scheduler.py#L1582-L1585)):

```python
pconfig = config.platforms.get(platform)   # ← can be List[PlatformConfig]
...
if not pconfig or not pconfig.enabled:      # ← crash: list has no .enabled
```

Two downstream sites also access `pconfig.extra` (L1622) and pass `pconfig` as a single object — both assume a scalar `PlatformConfig`.

## Fix

Unwrap the list to the first enabled `PlatformConfig` before the `.enabled` check:

```python
if isinstance(pconfig, list):
    pconfig = next(
        (c for c in pconfig if getattr(c, "enabled", False)),
        pconfig[0] if pconfig else None
    )
```

If none are enabled, fall back to `pconfig[0]` so the existing `not pconfig.enabled` path produces the correct "not configured/enabled" message rather than an `AttributeError`.

## How to Verify

1. Configure a platform with multiple instances (e.g. two Feishu bot configs in `platforms.feishu` as a list)
2. Create a cron job with `deliver: "feishu"` or `deliver: "origin"`
3. Before fix: `last_delivery_error` = `'list' object has no attribute 'enabled'`
4. After fix: delivery succeeds (or produces a meaningful error, not an AttributeError)

## Test Plan

- [x] Added regression test `test_multi_instance_platform_list_unwraps_to_enabled`
- [x] Full cron test suite: 768 tests passed, 0 failed
- [x] Manual verification: confirmed `load_gateway_config()` returns `List[PlatformConfig]` for multi-instance Feishu (6 configs), and the unwrap correctly picks the first enabled one

## Risk Assessment

**Low** — The unwrap is a pure passthrough when `pconfig` is already a single `PlatformConfig` (the common case). The `isinstance(list)` check adds zero overhead for non-list configs. The fallback logic (`pconfig[0] if pconfig else None`) preserves the existing error message path for empty/all-disabled lists.