### PR TITLE
fix(provider): keep auxiliary key for custom providers (#76760)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7145,11 +7145,12 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.
-            return normalized in {
+            if normalized in {
                 "anthropic",
                 "copilot",
                 "copilot-acp",
@@ -7158,7 +7159,22 @@ def _resolve_task_provider_model(
                 "openai-codex",
                 "qwen-oauth",
                 "xai-oauth",
-            }
+            }:
+                return True
+        # Not a built-in: the provider may be a user-defined custom provider
+        # from the config ``providers:`` table (or the legacy
+        # ``custom_providers:`` list). Those entries carry their own
+        # base_url/key_env, so the identity must be preserved — otherwise the
+        # name is rewritten to bare "custom" below, the named-custom recovery
+        # in resolve_provider_client() can no longer find the entry, and the
+        # key_env is never resolved (request goes out with the placeholder
+        # "no-key-required" → 401). Issue #76760.
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+
+            return _get_named_custom_provider(normalized) is not None
+        except Exception:
+            return False
 
     if provider:
         provider, base_url = _expand_direct_api_alias(provider, base_url)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4168,6 +4168,102 @@ class TestCustomEndpointApiKeyInheritance:
         assert captured.get("api_key") == "no-key-required"
 
 
+class TestNamedCustomProviderKeyPreservation:
+    """Issue #76760: a custom provider from the config ``providers:`` table
+    (base_url + key_env) must keep its identity when an auxiliary task pairs
+    it with a base_url. ``_preserve_provider_with_base_url()`` previously only
+    checked the built-in PROVIDER_REGISTRY, so the name was rewritten to bare
+    "custom", the named-custom recovery in resolve_provider_client() could no
+    longer find the entry, and the request went out with the placeholder
+    ``no-key-required`` key → 401.
+    """
+
+    def test_preserve_provider_recognizes_providers_table_entry(self, monkeypatch):
+        """_resolve_task_provider_model must keep a providers: table entry's
+        identity when a base_url is present (not downgrade it to custom)."""
+        import agent.auxiliary_client as ac
+
+        fake_config = {
+            "providers": {
+                "myprovider": {
+                    "base_url": "https://api.myprovider.example/v1",
+                    "key_env": "MY_PROVIDER_API_KEY",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_config), \
+             patch("hermes_cli.config.load_config_readonly", return_value=fake_config), \
+             patch("hermes_cli.runtime_provider.load_config", return_value=fake_config):
+            provider, model, base_url, api_key, api_mode = ac._resolve_task_provider_model(
+                "vision", provider="myprovider", base_url="https://api.myprovider.example/v1"
+            )
+        assert provider == "myprovider", (
+            "providers: table entry must keep identity, got: " + repr(provider)
+        )
+
+    def test_unknown_provider_still_not_preserved(self, monkeypatch):
+        """A provider name that is neither built-in nor in providers: must
+        keep the old behavior (False → downgrade to custom)."""
+        import agent.auxiliary_client as ac
+
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={}), \
+             patch("hermes_cli.runtime_provider.load_config", return_value={}):
+            provider, model, base_url, api_key, api_mode = ac._resolve_task_provider_model(
+                "vision", provider="no-such-provider", base_url="https://example.com/v1"
+            )
+        assert provider == "custom"
+
+    def test_vision_resolves_key_env_for_providers_table_entry(self, monkeypatch):
+        """Full vision flow: auxiliary.vision.provider + base_url with a
+        providers: table entry must send the key_env-resolved key, not the
+        no-key-required placeholder."""
+        import agent.auxiliary_client as ac
+
+        monkeypatch.setenv("MY_PROVIDER_API_KEY", "sk-provider-table-key")
+        fake_config = {
+            "providers": {
+                "myprovider": {
+                    "base_url": "https://api.myprovider.example/v1",
+                    "key_env": "MY_PROVIDER_API_KEY",
+                }
+            },
+            "auxiliary": {
+                "vision": {
+                    "provider": "myprovider",
+                    "base_url": "https://api.myprovider.example/v1",
+                }
+            },
+        }
+        captured: dict = {}
+
+        def _capture_create(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("hermes_cli.config.load_config", return_value=fake_config), \
+             patch("hermes_cli.config.load_config_readonly", return_value=fake_config), \
+             patch("hermes_cli.runtime_provider.load_config", return_value=fake_config), \
+             patch.object(ac, "_create_openai_client", side_effect=_capture_create):
+            requested, model, base_url, api_key, api_mode = ac._resolve_task_provider_model(
+                "vision", None, None, None, None
+            )
+            provider, client, final_model = resolve_vision_provider_client(
+                provider=requested,
+                model=model,
+                base_url=base_url,
+                api_key=api_key,
+                async_mode=True,
+            )
+
+        assert provider == "myprovider", (
+            "provider identity must be preserved, got: " + repr(provider)
+        )
+        assert captured.get("api_key") == "sk-provider-table-key", (
+            "key_env-resolved key must be sent, got: " + repr(captured.get("api_key"))
+        )
+
+
 class TestMoaAggregatorStreamingBypass:
     def test_moa_aggregator_stream_bypasses_relay_for_codex_auxiliary_client(self, monkeypatch):
         """The MoA facade owns the streaming contract. For Codex Responses-shim


### PR DESCRIPTION
Closes #76760

## Problem

Auxiliary tasks (e.g. `vision_analyze`) fail with `401 INVALID_API_KEY` when
the task is configured with a **custom provider from the config `providers:`
table** (`base_url` + `key_env`). The request is sent with the placeholder key
`no-key-required` (15 chars) instead of the env-resolved key.

Root cause, in `agent/auxiliary_client.py`:

1. `_resolve_task_provider_model()` calls `_preserve_provider_with_base_url("myprovider")`,
   which only checks the **built-in** `PROVIDER_REGISTRY` (via `get_provider()`).
   Custom providers from the config `providers:` table are never found there, so
   it returns `False`.
2. The provider is then rewritten to the literal `"custom"` — **the original
   provider name is lost at this point**.
3. Downstream, `resolve_provider_client()` has an `original_provider` recovery
   path in its named-custom branch (which can resolve `key_env` via
   `_get_named_custom_provider()`), but the rewrite already replaced the name,
   so recovery cannot find the entry → `custom_entry = None`.
4. Key resolution fails and falls back to the placeholder `"no-key-required"`,
   which is sent with the request → the server returns 401.

## Fix

`_preserve_provider_with_base_url()` now falls back to checking the config
`providers:` table (and legacy `custom_providers:` list) via
`_get_named_custom_provider()` before deciding the provider cannot be
preserved. When the name matches a user-defined custom provider, the identity
is kept, so `resolve_provider_client()`'s named-custom branch can resolve the
entry's `key_env` and the real key is sent.

Behavior for unknown provider names is unchanged (still downgraded to
`"custom"`), and built-in providers still short-circuit on the registry check.

## Verification

- New regression tests in `tests/agent/test_auxiliary_client.py`
  (`TestNamedCustomProviderKeyPreservation`):
  - `providers:` table entry keeps its identity when paired with a base_url.
  - Unknown provider names still downgrade to `"custom"`.
  - Full vision flow resolves the `key_env` key instead of `no-key-required`.
- Full auxiliary-client suite: `222 passed`.
- `tests/hermes_cli/test_runtime_provider_resolution.py` +
  `tests/tui_gateway/test_custom_provider_session_persistence.py` +
  `tests/run_agent/test_callable_api_key.py`: `78 passed`.
