### PR TITLE
fix(update): bound managed-Python uv subprocesses with timeouts (#76684)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -311,6 +311,13 @@ UV_SELF_UPDATE_INTERVAL_SECONDS = 7 * 24 * 3600
 # blackholed connection (no default timeout in uv's downloader path).
 UV_SELF_UPDATE_TIMEOUT_SECONDS = 60
 
+# Bounded wall-clock for uv subprocesses that download or resolve managed
+# Python builds. An unbounded run wedges `hermes update` forever on flaky
+# networks (zero CPU, zero network, no log output — issue #76684).
+UV_PYTHON_INSTALL_TIMEOUT_SECONDS = 300
+UV_PYTHON_FIND_TIMEOUT_SECONDS = 60
+UV_UV_INSTALL_TIMEOUT_SECONDS = 120
+
 
 def update_managed_uv(
     *,
@@ -528,23 +535,32 @@ def _attempt_install_generation(
     _make_world_traversable(generation)
 
     env = managed_python_env(project_root, install_dir=generation)
-    install = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "install",
-            request,
-            "--reinstall",
-            "--no-bin",
-            "--no-registry",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        install = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "install",
+                request,
+                "--reinstall",
+                "--no-bin",
+                "--no-registry",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python install timed out after %ss for %s",
+            UV_PYTHON_INSTALL_TIMEOUT_SECONDS, request,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if install.returncode != 0:
         logger.warning(
             "private Python install failed for %s (rc=%d): %s",
@@ -555,21 +571,30 @@ def _attempt_install_generation(
         _remove_tree(generation, boundary=python_root)
         return None
 
-    found = subprocess.run(
-        [
-            uv_bin,
-            "python",
-            "find",
-            request,
-            "--managed-python",
-            "--no-config",
-        ],
-        cwd=project_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        found = subprocess.run(
+            [
+                uv_bin,
+                "python",
+                "find",
+                request,
+                "--managed-python",
+                "--no-config",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=UV_PYTHON_FIND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "private Python lookup timed out after %ss for %s",
+            UV_PYTHON_FIND_TIMEOUT_SECONDS, request,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
     if found.returncode != 0 or not found.stdout.strip():
         logger.warning(
             "private Python lookup failed for %s (rc=%d): %s",
@@ -1275,12 +1300,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=UV_UV_INSTALL_TIMEOUT_SECONDS,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=UV_UV_INSTALL_TIMEOUT_SECONDS,
         )
     finally:
         try:
@@ -1297,6 +1324,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=UV_UV_INSTALL_TIMEOUT_SECONDS,
     )
 
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1100,3 +1100,61 @@ class TestVenvPythonUpdateBoundary:
             "/opt/hermes/venv/bin/python"
         )
 
+
+class TestAttemptInstallGenerationTimeouts:
+    """#76684: uv python install/find must be wall-clock bounded — an
+    unbounded subprocess wedges `hermes update` forever on flaky networks."""
+
+    def test_install_timeout_cleans_generation_and_returns_none(self, tmp_path):
+        import subprocess
+
+        from hermes_cli.managed_uv import _attempt_install_generation
+
+        python_root = tmp_path / ".hermes-runtime" / "python"
+        python_root.mkdir(parents=True)
+
+        with patch(
+            "hermes_cli.managed_uv.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="uv", timeout=300),
+        ):
+            result = _attempt_install_generation(
+                "uv",
+                "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        # The half-created generation directory must be cleaned up.
+        assert list(python_root.iterdir()) == []
+
+    def test_find_timeout_cleans_generation_and_returns_none(self, tmp_path):
+        import subprocess
+        from types import SimpleNamespace
+
+        from hermes_cli.managed_uv import _attempt_install_generation
+
+        python_root = tmp_path / ".hermes-runtime" / "python"
+        python_root.mkdir(parents=True)
+        ok_result = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        calls = {"n": 0}
+
+        def fake_run(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return ok_result  # install succeeds
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=60)  # find hangs
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run):
+            result = _attempt_install_generation(
+                "uv",
+                "3.11",
+                project_root=tmp_path,
+                python_root=python_root,
+                current=MagicMock(),
+            )
+
+        assert result is None
+        assert list(python_root.iterdir()) == []


### PR DESCRIPTION
## Summary

`hermes update` hangs indefinitely (41+ minutes, zero CPU / zero network / no log output) during managed-Python runtime provisioning on flaky networks. Root cause: `_attempt_install_generation()` runs `uv python install <req> --reinstall` and `uv python find` via `subprocess.run()` **without any `timeout=`**, and the uv bootstrap installer (`curl`/`sh`/`powershell`) is likewise unbounded.

Fix: add wall-clock bounds — `UV_PYTHON_INSTALL_TIMEOUT_SECONDS = 300`, `UV_PYTHON_FIND_TIMEOUT_SECONDS = 60`, `UV_UV_INSTALL_TIMEOUT_SECONDS = 120` — and treat `TimeoutExpired` exactly like a failed attempt: log, clean up the half-created generation dir, return `None` so the repair path reports failure instead of hanging forever.

Single-file change (plus 2 tests). No public API change.

NOT doing X: not changing which Python versions are attempted, not altering the retry/patch logic — only making every uv subprocess wall-clock bounded.

## Test plan

```
python -m pytest tests/hermes_cli/test_managed_uv.py -q
# 30 passed, 7 pre-existing failures on this Windows host (resolve_uv
# shebang-exec tests + venv-detection path tests — reproduce identically
# on unmodified main; unrelated to this change)
# New tests: install timeout cleans generation dir & returns None; find
# timeout after a successful install does the same.
```
