### PR TITLE
docs(profiles): --clone copies memory files; align guide + test (#76658)

### DIFF
--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -142,6 +142,9 @@ class TestCreateProfile:
         (default_home / "config.yaml").write_text("model: test")
         (default_home / ".env").write_text("KEY=val")
         (default_home / "SOUL.md").write_text("Be helpful.")
+        (default_home / "memories").mkdir()
+        (default_home / "memories" / "MEMORY.md").write_text("remembered fact A")
+        (default_home / "memories" / "USER.md").write_text("user fact B")
 
         profile_dir = create_profile("coder", clone_config=True, no_alias=True)
 
@@ -150,6 +153,9 @@ class TestCreateProfile:
         assert cloned_config["model"] == "test"
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
+        # Memory files are cloned too (#4845, docs parity for #76658).
+        assert (profile_dir / "memories" / "MEMORY.md").read_text() == "remembered fact A"
+        assert (profile_dir / "memories" / "USER.md").read_text() == "user fact B"
 
 
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -50,7 +50,7 @@ You can also set or auto-generate the description later with `hermes profile des
 hermes profile create work --clone
 ```
 
-Copies your current profile's `config.yaml`, `.env`, `SOUL.md`, and skills into the new profile. Same API keys, model, and capabilities, but fresh sessions and memory. Edit `~/.hermes/profiles/work/.env` for different API keys, or `~/.hermes/profiles/work/SOUL.md` for a different personality.
+Copies your current profile's `config.yaml`, `.env`, `SOUL.md`, skills, and memory files (`memories/MEMORY.md` / `memories/USER.md`) into the new profile. Same API keys, model, capabilities, and remembered facts, but fresh sessions. Edit `~/.hermes/profiles/work/.env` for different API keys, or `~/.hermes/profiles/work/SOUL.md` for a different personality. To start with completely fresh memory, delete the profile's `memories/` directory after cloning, or use `--clone-all` and clear it there too.
 
 ### Clone everything (`--clone-all`)
 


### PR DESCRIPTION
## Summary

`create_profile(..., clone_config=True)` has copied `memories/MEMORY.md` and `memories/USER.md` since #4845, but:

- `website/docs/user-guide/profiles.md` still says `--clone` gives you "fresh sessions **and memory**"
- `tests/hermes_cli/test_profiles.py::test_clone_config_copies_files` never asserted the memory behavior, so the drift went unnoticed

Fix: update the guide to document that memory files are carried over (with instructions for starting fresh), and extend the clone test to assert both memory files are copied.

Docs + test only. No runtime code change.

NOT doing X: not changing the clone behavior itself — memory copy is intentional (#4845 profile-scoped memory isolation), only the docs were wrong.

## Test plan

```
python -m pytest tests/hermes_cli/test_profiles.py -q -k clone
# 2 passed — test_clone_config_copies_files now asserts MEMORY.md/USER.md
```
