### PR TITLE
fix(curator): same-run created umbrellas are valid consolidation destinations (#76588)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -614,6 +614,37 @@ def _needle_in_path_component(needle: str, path: str) -> bool:
     return False
 
 
+def _created_skill_names_from_tool_calls(tool_calls: List[Dict[str, Any]]) -> Set[str]:
+    """Return skill names the model created earlier in this run.
+
+    A same-run ``skill_manage action=create`` umbrella is a legitimate
+    consolidation destination even when the post-run snapshot misses it
+    (``added`` can come back empty for bookkeeping reasons). Without this
+    seed, ``_reconcile_classification`` judged every ``absorbed_into``
+    declaration targeting a freshly-created umbrella as a hallucination
+    and misfiled the deleted skill as pruned (#76588).
+    """
+    names: Set[str] = set()
+    for tc in tool_calls or []:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("name") or (tc.get("function") or {}).get("name", "")
+        if fn != "skill_manage":
+            continue
+        raw = tc.get("arguments") or {}
+        args = raw if isinstance(raw, dict) else {}
+        if isinstance(raw, str):
+            try:
+                args = json.loads(raw)
+            except Exception:
+                args = {}
+        if not isinstance(args, dict):
+            continue
+        if args.get("action") == "create" and args.get("name"):
+            names.add(str(args["name"]))
+    return names
+
+
 def _classify_removed_skills(
     removed: List[str],
     added: List[str],
@@ -666,8 +697,14 @@ def _classify_removed_skills(
 
     # Build a set of "destination" skill names: anything still present after
     # the run plus anything newly added this run. A removed skill being
-    # referenced from one of these is the consolidation signal.
-    destinations = set(after_names) | set(added or [])
+    # referenced from one of these is the consolidation signal. Same-run
+    # created umbrellas are also destinations even when the post-run
+    # snapshot misses them (#76588).
+    destinations = (
+        set(after_names)
+        | set(added or [])
+        | _created_skill_names_from_tool_calls(tool_calls)
+    )
 
     for name in removed:
         if not name:
@@ -1044,7 +1081,13 @@ def _build_rename_summary(
         tool_calls=tool_calls,
     )
     model_block = _parse_structured_summary(model_final)
-    destinations = set(after_names) | set(added)
+    # Same-run created umbrellas are valid destinations even when the
+    # post-run snapshot missed them (#76588).
+    destinations = (
+        set(after_names)
+        | set(added)
+        | _created_skill_names_from_tool_calls(tool_calls)
+    )
     absorbed_declarations = _extract_absorbed_into_declarations(tool_calls)
     classification = _reconcile_classification(
         removed=removed,
@@ -1169,7 +1212,13 @@ def _write_run_report(
         tool_calls=llm_meta.get("tool_calls", []) or [],
     )
     model_block = _parse_structured_summary(llm_meta.get("final", "") or "")
-    destinations = set(after_names) | set(added or [])
+    # Same-run created umbrellas are valid destinations even when the
+    # post-run snapshot missed them (#76588).
+    destinations = (
+        set(after_names)
+        | set(added or [])
+        | _created_skill_names_from_tool_calls(llm_meta.get("tool_calls", []) or [])
+    )
     # Authoritative signal: extract per-delete `absorbed_into` declarations
     # from this run's tool calls. These beat both the YAML summary block and
     # the substring heuristic — the model is telling us directly, at the

--- a/tests/agent/test_curator_classification.py
+++ b/tests/agent/test_curator_classification.py
@@ -520,3 +520,62 @@ def test_rename_summary_mixed_consolidation_and_pruning(curator_env):
 
 
 
+
+
+def test_same_run_created_umbrella_is_valid_destination(curator_env):
+    """#76588: absorbed_into pointing at an umbrella created earlier in the
+    SAME run must classify as consolidated even when the post-run snapshot
+    reports added=[] and misses the umbrella."""
+    calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "create", "name": "external-coding-agents",
+            "content": "# External coding agents\nAbsorbs claude-code, codex, opencode guides.\n",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "claude-code",
+            "absorbed_into": "external-coding-agents",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "opencode",
+            "absorbed_into": "external-coding-agents",
+        })},
+    ]
+    result = curator_env._classify_removed_skills(
+        removed=["claude-code", "opencode"],
+        added=[],  # bookkeeping defect: umbrella not recorded as added
+        after_names={"keeper"},  # umbrella also missing from post-run snapshot
+        tool_calls=calls,
+    )
+    consolidated = {e["name"]: e["into"] for e in result["consolidated"]}
+    assert consolidated.get("claude-code") == "external-coding-agents"
+    assert consolidated.get("opencode") == "external-coding-agents"
+    assert result["pruned"] == []
+
+
+def test_reconcile_accepts_same_run_created_umbrella(curator_env):
+    """End-to-end reconcile: the absorbed_into declaration is authoritative
+    once the same-run-created umbrella is seeded into destinations."""
+    calls = [
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "create", "name": "kanban-workflow",
+            "content": "# Kanban workflow\n",
+        })},
+        {"name": "skill_manage", "arguments": json.dumps({
+            "action": "delete", "name": "kanban-orchestrator",
+            "absorbed_into": "kanban-workflow",
+        })},
+    ]
+    classification = curator_env._reconcile_classification(
+        removed=["kanban-orchestrator"],
+        heuristic={"consolidated": [], "pruned": []},
+        model_block={"consolidations": [], "prunings": []},
+        destinations=(
+            {"keeper"}
+            | set([])
+            | curator_env._created_skill_names_from_tool_calls(calls)
+        ),
+        absorbed_declarations=curator_env._extract_absorbed_into_declarations(calls),
+    )
+    consolidated = {e["name"]: e["into"] for e in classification["consolidated"]}
+    assert consolidated.get("kanban-orchestrator") == "kanban-workflow"
+    assert classification["pruned"] == []


### PR DESCRIPTION
## Summary

When the curator's consolidation pass creates the umbrella **and** deletes the source skills in the same run, the post-run snapshot can miss the freshly-created umbrella (`added: []`, absent from `after_names`). `_reconcile_classification` then judged every `absorbed_into=<umbrella>` delete declaration as a "hallucinated missing umbrella" and misfiled the skill as **pruned** — permanently removing it with no `.archive/` record.

Fix: seed `destinations` with skill names created earlier in the same run via `skill_manage action=create` (`_created_skill_names_from_tool_calls`), applied at all three `destinations` computation sites. The model's authoritative `absorbed_into` declaration is now honored even when the bookkeeping snapshot missed the umbrella.

Single-file change (plus 2 regression tests). No public API change.

NOT doing X: not changing the `absorbed_into=""` (explicit prune) path, not changing archive/recovery behavior — only the classification of same-run-created destinations.

## Test plan

```
python -m pytest tests/agent/test_curator_classification.py -q
# 15 passed (13 existing + 2 new:
#  - heuristic classifies absorbed_into→same-run-created umbrella as consolidated
#  - _reconcile_classification honors the declaration once destinations are seeded)
```
