### PR TITLE
feat(gateway): add YAML-only user-systemd scope

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -963,6 +963,13 @@ platform_toolsets:
 # =============================================================================
 # Gateway Platform Settings
 # =============================================================================
+# Optional user-systemd gateway instance namespace. Missing or null preserves the
+# default service name. See the messaging guide for validation and change rules.
+gateway:
+  # Optional user-systemd instance namespace.
+  # Produces hermes-gateway-<scope>[-<profile>].
+  systemd_scope: null
+
 # Optional per-platform messaging settings.
 # Platform-specific knobs live under `extra`.
 #

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2406,6 +2406,9 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Optional user-systemd instance namespace for isolated Hermes roots.
+        "systemd_scope": None,
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -94,8 +95,8 @@ class ProfileGatewayProcess:
     pid: int
 
 
-def _get_service_pids() -> set:
-    """Return PIDs currently managed by systemd or launchd gateway services.
+def _discover_service_pids() -> tuple[set, bool]:
+    """Return service-managed gateway PIDs and whether discovery was complete.
 
     Used to avoid killing freshly-restarted service processes when sweeping
     for stale manual gateway processes after a service restart.  Relies on the
@@ -103,6 +104,7 @@ def _get_service_pids() -> set:
     returns (true for both systemd and launchd in practice).
     """
     pids: set = set()
+    complete = True
 
     # --- systemd (Linux): user and system scopes ---
     if supports_systemd_services():
@@ -121,9 +123,13 @@ def _get_service_pids() -> set:
                     text=True, encoding='utf-8', errors='replace',
                     timeout=5,
                 )
+                if result.returncode != 0:
+                    complete = False
+                    continue
                 for line in result.stdout.strip().splitlines():
                     parts = line.split()
                     if not parts or not parts[0].endswith(".service"):
+                        complete = False
                         continue
                     svc = parts[0]
                     try:
@@ -133,13 +139,16 @@ def _get_service_pids() -> set:
                             text=True, encoding='utf-8', errors='replace',
                             timeout=5,
                         )
+                        if show.returncode != 0:
+                            complete = False
+                            continue
                         pid = int(show.stdout.strip())
                         if pid > 0:
                             pids.add(pid)
                     except (ValueError, subprocess.TimeoutExpired):
-                        pass
+                        complete = False
             except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass
+                complete = False
 
     # --- launchd (macOS) ---
     if is_macos():
@@ -152,25 +161,45 @@ def _get_service_pids() -> set:
                 timeout=5,
             )
             if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
+                output = result.stdout.strip()
+                if not output:
+                    complete = False
                 else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
+                    # Try plist format first (macOS 26+): "PID" = <N>;
+                    pid = _parse_launchd_pid_from_list_output(output)
+                    if pid is not None and pid > 0:
+                        pids.add(pid)
+                    else:
+                        # Fall back to legacy tab-separated format:
+                        # "PID\tStatus\tLabel"
+                        matched_label = False
+                        for line in output.splitlines():
+                            parts = line.split()
+                            if len(parts) >= 3 and parts[2] == label:
+                                matched_label = True
+                                try:
+                                    pid = int(parts[0])
+                                    if pid > 0:
+                                        pids.add(pid)
+                                except ValueError:
+                                    if parts[0] != "-":
+                                        complete = False
+                        if (
+                            not matched_label
+                            and f'"Label" = "{label}"' not in output
+                        ):
+                            complete = False
+            elif result.returncode not in (3, 113):
+                complete = False
         except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+            complete = False
 
+    return pids, complete
+
+
+def _get_service_pids() -> set:
+    """Return the service-managed PIDs found by the best-effort discovery view."""
+    pids, _ = _discover_service_pids()
     return pids
 
 
@@ -588,7 +617,9 @@ def _filter_venv_launcher_stubs(pids: list[int]) -> list[int]:
 
 
 def find_gateway_pids(
-    exclude_pids: set | None = None, all_profiles: bool = False
+    exclude_pids: set | None = None,
+    all_profiles: bool = False,
+    known_service_pids: set | None = None,
 ) -> list:
     """Find PIDs of running gateway processes.
 
@@ -600,6 +631,8 @@ def find_gateway_pids(
             needs this because a code update affects every profile.
             When ``False`` (default), only PIDs belonging to the current
             Hermes profile are returned.
+        known_service_pids: A complete service-manager snapshot already
+            collected by the caller, avoiding a redundant discovery probe.
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
@@ -610,7 +643,10 @@ def find_gateway_pids(
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
+    service_pids = (
+        _get_service_pids() if known_service_pids is None else known_service_pids
+    )
+    for pid in service_pids or ():
         _append_unique_pid(pids, pid, _exclude)
     try:
         include_restart_managers = not supports_systemd_services()
@@ -982,6 +1018,47 @@ def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
             value = body.split("=", 1)[1].strip().strip('"')
             return value or None
     return None
+
+
+def _assert_scoped_systemd_unit_owner(system: bool = False) -> None:
+    """Return unless a scoped unit exists and its persisted home mismatches."""
+    if _resolve_systemd_scope() is None:
+        return
+
+    unit_path = get_systemd_unit_path(system=system)
+    if not unit_path.exists() and not unit_path.is_symlink():
+        return
+
+    persisted_home = _hermes_home_from_systemd_unit_file(system=system)
+    active_home = Path(get_hermes_home()).resolve()
+    if not persisted_home:
+        raise ScopedSystemdUnitOwnershipError(
+            f"Refusing to use scoped gateway unit {unit_path}: it has no "
+            "persisted HERMES_HOME. Uninstall the old unit before changing "
+            "gateway.systemd_scope."
+        )
+
+    try:
+        persisted_path = Path(persisted_home).expanduser().resolve()
+    except (OSError, ValueError):
+        persisted_path = None
+    if persisted_path != active_home:
+        raise ScopedSystemdUnitOwnershipError(
+            f"Refusing to use scoped gateway unit {unit_path}: its persisted "
+            f"HERMES_HOME ({persisted_home}) does not match the active home "
+            f"({active_home}). Uninstall the old unit before changing "
+            "gateway.systemd_scope."
+        )
+
+
+def _assert_scoped_systemd_user_scope(
+    system: bool, scope: str | None = None
+) -> None:
+    if system and (scope if scope is not None else _resolve_systemd_scope()) is not None:
+        raise ScopedSystemdRequiresUserError(
+            "gateway.systemd_scope is supported only with user-systemd services. "
+            "Remove the setting before using --system, or use a user service."
+        )
 
 
 def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
@@ -1475,7 +1552,10 @@ def _gateway_list() -> None:
 
 
 def kill_gateway_processes(
-    force: bool = False, exclude_pids: set | None = None, all_profiles: bool = False
+    force: bool = False,
+    exclude_pids: set | None = None,
+    all_profiles: bool = False,
+    standalone_only: bool = False,
 ) -> int:
     """Kill any running gateway processes. Returns count killed.
 
@@ -1485,11 +1565,38 @@ def kill_gateway_processes(
             restarted and should not be killed).
         all_profiles: When ``True``, kill across all profiles.  Passed
             through to :func:`find_gateway_pids`.
+        standalone_only: Exclude service-managed PIDs and require complete
+            discovery snapshots before scanning and terminating candidates.
     """
-    pids = find_gateway_pids(exclude_pids=exclude_pids, all_profiles=all_profiles)
+    protected_service_pids: set = set()
+    if standalone_only:
+        service_pids, complete = _discover_service_pids()
+        if not complete:
+            return 0
+        protected_service_pids.update(service_pids)
+        exclude_pids = set(exclude_pids or set()) | service_pids
+    if standalone_only:
+        pids = find_gateway_pids(
+            exclude_pids=exclude_pids,
+            all_profiles=all_profiles,
+            known_service_pids=service_pids,
+        )
+    else:
+        pids = find_gateway_pids(
+            exclude_pids=exclude_pids,
+            all_profiles=all_profiles,
+        )
     killed = 0
 
+    if standalone_only:
+        service_pids, complete = _discover_service_pids()
+        if not complete:
+            return 0
+        protected_service_pids.update(service_pids)
+
     for pid in pids:
+        if standalone_only and pid in protected_service_pids:
+            continue
         try:
             terminate_pid(pid, force=force)
             killed += 1
@@ -1722,6 +1829,26 @@ def _windows_gateway_should_absorb_console_controls() -> bool:
 
 _SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+_SYSTEMD_SCOPE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+
+
+def _resolve_systemd_scope() -> str | None:
+    """Return the validated user-systemd scope from the active config."""
+    config = read_raw_config()
+    gateway_config = config.get("gateway", {}) if isinstance(config, dict) else {}
+    raw_scope = (
+        gateway_config.get("systemd_scope")
+        if isinstance(gateway_config, dict)
+        else None
+    )
+    if raw_scope is None:
+        return None
+    if not isinstance(raw_scope, str) or _SYSTEMD_SCOPE_RE.fullmatch(raw_scope) is None:
+        raise ValueError(
+            "Invalid gateway.systemd_scope: expected 1-128 lowercase characters "
+            "from [a-z0-9_-], starting with a letter or digit."
+        )
+    return raw_scope
 
 
 def _profile_suffix() -> str:
@@ -1802,10 +1929,14 @@ def get_service_name() -> str:
     Profile ``~/.hermes/profiles/coder`` returns ``hermes-gateway-coder``.
     Any other HERMES_HOME appends a short hash for uniqueness.
     """
+    parts = [_SERVICE_BASE]
+    scope = _resolve_systemd_scope()
     suffix = _profile_suffix()
-    if not suffix:
-        return _SERVICE_BASE
-    return f"{_SERVICE_BASE}-{suffix}"
+    if scope:
+        parts.append(scope)
+    if suffix:
+        parts.append(suffix)
+    return "-".join(parts)
 
 
 def get_systemd_unit_path(system: bool = False) -> Path:
@@ -1843,6 +1974,14 @@ class SystemScopeRequiresRootError(RuntimeError):
 
     def __str__(self) -> str:
         return self.args[0] if self.args else ""
+
+
+class ScopedSystemdUnitOwnershipError(RuntimeError):
+    """Raised when a scoped unit is not owned by the active Hermes home."""
+
+
+class ScopedSystemdRequiresUserError(RuntimeError):
+    """Raised when a configured scope would select a systemd system unit."""
 
 
 def _user_dbus_socket_path() -> Path:
@@ -3088,6 +3227,7 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
         return False
+    _assert_scoped_systemd_unit_owner(system=system)
 
     # The gate below funnels through ``systemd_unit_is_current``, which is the
     # single HERMES_HOME-sync chokepoint (adopts the unit's pinned home before
@@ -3192,12 +3332,17 @@ def _ensure_linger_enabled() -> None:
 
 
 def _select_systemd_scope(system: bool = False) -> bool:
+    scope = _resolve_systemd_scope()
     if system:
+        _assert_scoped_systemd_user_scope(system=True, scope=scope)
         return True
-    return (
+    selected_system = (
         get_systemd_unit_path(system=True).exists()
         and not get_systemd_unit_path(system=False).exists()
     )
+    if selected_system:
+        _assert_scoped_systemd_user_scope(system=True, scope=scope)
+    return selected_system
 
 
 def _system_scope_wizard_would_need_root(system: bool = False) -> bool:
@@ -3261,6 +3406,9 @@ def systemd_install(
     enable_on_startup: bool = True,
     non_interactive: bool = False,
 ):
+    scope = _resolve_systemd_scope()
+    _assert_scoped_systemd_user_scope(system, scope=scope)
+    _assert_scoped_systemd_unit_owner(system=system)
     if system:
         _require_root_for_system_service("install")
 
@@ -3345,6 +3493,7 @@ def systemd_uninstall(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
         _require_root_for_system_service("uninstall")
+    _assert_scoped_systemd_unit_owner(system=system)
 
     _run_systemctl(["stop", get_service_name()], system=system, check=False, timeout=90)
     _run_systemctl(
@@ -3391,6 +3540,7 @@ def systemd_stop(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
         _require_root_for_system_service("stop")
+    _assert_scoped_systemd_unit_owner(system=system)
     _require_service_installed("stop", system=system)
     _sync_hermes_home_from_systemd_unit(system=system)
     try:
@@ -6685,6 +6835,9 @@ def gateway_command(args):
         print_error("User systemd not reachable:")
         for line in str(e).splitlines():
             print(f"  {line}")
+        sys.exit(1)
+    except ScopedSystemdRequiresUserError as e:
+        print(str(e))
         sys.exit(1)
     except SystemScopeRequiresRootError as e:
         # The direct ``hermes gateway install|uninstall|start|stop|restart``

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1708,12 +1708,17 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     old_home = os.environ.get("HERMES_HOME")
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
-        from hermes_cli.gateway import get_service_name, get_launchd_plist_path
+        from hermes_cli.gateway import (
+            _assert_scoped_systemd_unit_owner,
+            get_launchd_plist_path,
+            get_service_name,
+        )
 
         if _platform.system() == "Linux":
             svc_name = get_service_name()
             svc_file = Path.home() / ".config" / "systemd" / "user" / f"{svc_name}.service"
             if svc_file.exists():
+                _assert_scoped_systemd_unit_owner(system=False)
                 subprocess.run(
                     ["systemctl", "--user", "disable", svc_name],
                     capture_output=True, check=False, timeout=10,

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -196,13 +196,11 @@ def uninstall_gateway_service():
 
     # 1. Kill any standalone gateway processes (all platforms, including Termux)
     try:
-        from hermes_cli.gateway import kill_gateway_processes, find_gateway_pids
-        pids = find_gateway_pids()
-        if pids:
-            killed = kill_gateway_processes()
-            if killed:
-                log_success(f"Killed {killed} running gateway process(es)")
-                stopped_something = True
+        from hermes_cli.gateway import kill_gateway_processes
+        killed = kill_gateway_processes(standalone_only=True)
+        if killed:
+            log_success(f"Killed {killed} running gateway process(es)")
+            stopped_something = True
     except Exception as e:
         log_warn(f"Could not check for gateway processes: {e}")
 
@@ -220,6 +218,8 @@ def uninstall_gateway_service():
             from hermes_cli.gateway import (
                 get_systemd_unit_path,
                 get_service_name,
+                _assert_scoped_systemd_unit_owner,
+                _assert_scoped_systemd_user_scope,
                 _systemctl_cmd,
             )
             svc_name = get_service_name()
@@ -231,11 +231,13 @@ def uninstall_gateway_service():
 
                 scope = "system" if is_system else "user"
                 try:
+                    _assert_scoped_systemd_user_scope(system=is_system)
                     if is_system and os.geteuid() != 0:  # windows-footgun: ok — Linux systemd uninstall path, guarded by `if system == "Linux"` above
                         log_warn(f"System gateway service exists at {unit_path} "
                                  f"but needs sudo to remove")
                         continue
 
+                    _assert_scoped_systemd_unit_owner(system=is_system)
                     cmd = _systemctl_cmd(is_system)
                     subprocess.run(cmd + ["stop", svc_name],
                                    capture_output=True, check=False)

--- a/tests/hermes_cli/test_gateway_systemd_scope.py
+++ b/tests/hermes_cli/test_gateway_systemd_scope.py
@@ -1,0 +1,340 @@
+"""Focused contract tests for YAML-scoped Hermes systemd gateway names."""
+
+import sys
+
+import pytest
+import yaml
+
+from hermes_cli import gateway
+from hermes_cli import profiles as profiles_cli
+from hermes_cli import uninstall as uninstall_cli
+
+
+_MISSING = object()
+
+
+def _configure_home(monkeypatch, tmp_path, *, profile=None, scope=_MISSING):
+    root = tmp_path / "hermes-root"
+    home = root / "profiles" / profile if profile else root
+    home.mkdir(parents=True)
+    config = {"gateway": {}}
+    if scope is not _MISSING:
+        config["gateway"]["systemd_scope"] = scope
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return root, home
+
+
+def _write_unit(path, owner=_MISSING):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    environment = "" if owner is _MISSING else f'Environment="HERMES_HOME={owner}"\n'
+    path.write_text(f"[Service]\n{environment}", encoding="utf-8")
+
+
+def _block(monkeypatch, target, attribute):
+    calls = []
+    monkeypatch.setattr(
+        target, attribute, lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    return calls
+
+
+def _assert_owner_refusal(call, *, path=None, calls=None):
+    original = path.read_bytes() if path is not None else None
+    with pytest.raises(RuntimeError, match="HERMES_HOME"):
+        call()
+    if path is not None:
+        assert path.read_bytes() == original
+    if calls is not None:
+        assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("profile", "scope", "expected"),
+    [
+        (None, _MISSING, "hermes-gateway"),
+        ("personal-main", None, "hermes-gateway-personal-main"),
+        (None, "team_a", "hermes-gateway-team_a"),
+        ("personal-main", "team_a", "hermes-gateway-team_a-personal-main"),
+        (None, "yaml-scope", "hermes-gateway-yaml-scope"),
+        (None, "a" * 128, f"hermes-gateway-{'a' * 128}"),
+    ],
+)
+def test_service_name_composes_scope_and_profile(
+    monkeypatch, tmp_path, profile, scope, expected
+):
+    _configure_home(monkeypatch, tmp_path, profile=profile, scope=scope)
+    monkeypatch.setenv("HERMES_GATEWAY_SYSTEMD_SCOPE", "environment-scope")
+    assert gateway.get_service_name() == expected
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [42, True, "", " ", "UPPER", "a.b", "../escape", "a/b", "-leading", "a" * 129],
+)
+def test_invalid_systemd_scope_is_rejected(scope, monkeypatch, tmp_path):
+    _configure_home(monkeypatch, tmp_path, scope=scope)
+    with pytest.raises(ValueError, match=r"gateway\.systemd_scope"):
+        gateway.get_service_name()
+
+
+def test_install_validates_scope_before_legacy_cleanup_or_mutation(
+    monkeypatch, tmp_path
+):
+    _configure_home(monkeypatch, tmp_path, scope="../invalid")
+    legacy_dir = tmp_path / "legacy-user-units"
+    legacy_dir.mkdir()
+    legacy_unit = legacy_dir / "hermes.service"
+    legacy_unit.write_text(
+        "[Service]\nExecStart=python -m hermes_cli.main gateway run\n", encoding="utf-8"
+    )
+    before, unit_path = legacy_unit.read_bytes(), tmp_path / "current.service"
+    monkeypatch.setattr(
+        gateway, "_legacy_unit_search_paths", lambda: [(False, legacy_dir)]
+    )
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    calls = _block(monkeypatch, gateway, "_run_systemctl")
+    with pytest.raises(ValueError, match=r"gateway\.systemd_scope"):
+        gateway.systemd_install(force=True, non_interactive=True)
+    assert legacy_unit.read_bytes() == before and not unit_path.exists() and calls == []
+
+
+@pytest.mark.parametrize(
+    "owner_case", ["matching", "mismatched", "missing", "symlink", "dangling"]
+)
+def test_scoped_unit_owner_uses_canonical_persisted_home(
+    monkeypatch, tmp_path, owner_case
+):
+    if sys.platform == "win32" and owner_case == "symlink":
+        pytest.skip("symlink canonicalization is POSIX-only")
+    _, active_home = _configure_home(monkeypatch, tmp_path, scope="shared")
+    if owner_case == "symlink":
+        link_home = tmp_path / "active-link"
+        link_home.symlink_to(active_home, target_is_directory=True)
+        monkeypatch.setenv("HERMES_HOME", str(link_home))
+    path = tmp_path / "systemd/user" / "hermes-gateway-shared.service"
+    if owner_case == "dangling":
+        target = tmp_path / "missing.service"
+        path.parent.mkdir(parents=True)
+        path.symlink_to(target)
+    else:
+        owner = active_home if owner_case in {"matching", "symlink"} else _MISSING
+        if owner_case == "mismatched":
+            owner = tmp_path / "other-root/profiles/personal-main"
+        _write_unit(path, owner)
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: path)
+    if owner_case == "dangling":
+        calls = _block(monkeypatch, gateway, "_run_systemctl")
+        with pytest.raises(RuntimeError, match="HERMES_HOME"):
+            gateway.systemd_install(force=True, non_interactive=True)
+        assert path.is_symlink() and not target.exists() and calls == []
+    elif owner_case in {"matching", "symlink"}:
+        assert gateway._assert_scoped_systemd_unit_owner() is None
+    else:
+        _assert_owner_refusal(gateway._assert_scoped_systemd_unit_owner, path=path)
+
+
+@pytest.mark.parametrize("operation", ["refresh", "stop", "uninstall"])
+def test_gateway_lifecycle_checks_scoped_owner_before_side_effects(
+    monkeypatch, tmp_path, operation
+):
+    _configure_home(monkeypatch, tmp_path, scope="shared")
+    path = tmp_path / "systemd/user" / "hermes-gateway-shared.service"
+    _write_unit(path, tmp_path / "other-root/profiles/personal-main")
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: path)
+    calls = _block(monkeypatch, gateway, "_run_systemctl")
+    if operation == "refresh":
+        monkeypatch.setattr(
+            gateway,
+            "systemd_unit_is_current",
+            lambda system=False: pytest.fail("ownership must precede comparison"),
+        )
+        call = gateway.refresh_systemd_unit_if_needed
+    elif operation == "stop":
+        call = gateway.systemd_stop
+    else:
+        call = gateway.systemd_uninstall
+    _assert_owner_refusal(
+        call, path=path if operation == "uninstall" else None, calls=calls
+    )
+
+
+def test_second_root_cannot_overwrite_a_scoped_unit(monkeypatch, tmp_path):
+    _, first = _configure_home(
+        monkeypatch, tmp_path / "first", profile="personal-main", scope="shared"
+    )
+    path = tmp_path / "systemd/user" / "hermes-gateway-shared-personal-main.service"
+    _write_unit(path, first)
+    _, second = _configure_home(
+        monkeypatch, tmp_path / "second", profile="personal-main", scope="shared"
+    )
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: path)
+    monkeypatch.setattr(
+        gateway,
+        "generate_systemd_unit",
+        lambda **kwargs: '[Service]\nEnvironment="HERMES_HOME=/home/second"\n',
+    )
+    calls = _block(monkeypatch, gateway, "_run_systemctl")
+    _assert_owner_refusal(
+        lambda: gateway.systemd_install(force=True, non_interactive=True),
+        path=path,
+        calls=calls,
+    )
+    assert second != first
+
+
+@pytest.mark.parametrize("cleanup", ["profile", "full"])
+def test_direct_cleanup_checks_scoped_owner_before_systemctl_calls(
+    monkeypatch, tmp_path, cleanup
+):
+    if cleanup == "profile":
+        _, active = _configure_home(
+            monkeypatch, tmp_path, profile="personal-main", scope="shared"
+        )
+        path = (
+            tmp_path
+            / "host-home/.config/systemd/user"
+            / "hermes-gateway-shared-personal-main.service"
+        )
+        monkeypatch.setattr(profiles_cli.Path, "home", lambda: tmp_path / "host-home")
+        monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: path)
+        _write_unit(path, tmp_path / "other-root/profiles/personal-main")
+        calls = _block(monkeypatch, profiles_cli.subprocess, "run")
+        profiles_cli._cleanup_gateway_service("personal-main", active)
+    else:
+        _configure_home(monkeypatch, tmp_path, scope="shared")
+        path = tmp_path / "systemd/user" / "hermes-gateway-shared.service"
+        _write_unit(path, tmp_path / "other-root/profiles/personal-main")
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **kwargs: [])
+        monkeypatch.setattr(
+            gateway, "_discover_service_pids", lambda: (set(), True)
+        )
+        monkeypatch.setattr(
+            gateway,
+            "get_systemd_unit_path",
+            lambda system=False: (
+                path if not system else tmp_path / "absent-system.service"
+            ),
+        )
+        calls = _block(monkeypatch, uninstall_cli.subprocess, "run")
+        assert uninstall_cli.uninstall_gateway_service() is False
+    assert calls == []
+
+
+def test_full_uninstall_kills_standalone_but_not_service_managed_gateway(
+    monkeypatch, tmp_path
+):
+    _configure_home(monkeypatch, tmp_path, scope="shared")
+    managed_pid, standalone_pid, late_managed_pid = 4101, 4102, 4103
+    service_pid_checks = 0
+
+    def _service_pids():
+        nonlocal service_pid_checks
+        service_pid_checks += 1
+        if service_pid_checks == 1:
+            return {managed_pid}, True
+        if service_pid_checks == 2:
+            return {late_managed_pid}, True
+        return set(), True
+
+    monkeypatch.setattr(gateway, "_discover_service_pids", _service_pids)
+    monkeypatch.setattr(
+        gateway,
+        "_scan_gateway_pids",
+        lambda *args, **kwargs: [late_managed_pid, standalone_pid],
+    )
+    killed = []
+    monkeypatch.setattr(
+        gateway,
+        "terminate_pid",
+        lambda pid, force=False: killed.append(pid),
+    )
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+
+    assert uninstall_cli.uninstall_gateway_service() is True
+    assert killed == [standalone_pid]
+    assert service_pid_checks == 2
+
+
+def test_standalone_only_aborts_when_service_pid_discovery_times_out(
+    monkeypatch, tmp_path
+):
+    _configure_home(monkeypatch, tmp_path, scope="shared")
+    candidate_pid = 4201
+
+    def _timeout(command, **kwargs):
+        raise gateway.subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway.subprocess, "run", _timeout)
+    monkeypatch.setattr(
+        gateway,
+        "_scan_gateway_pids",
+        lambda *args, **kwargs: [candidate_pid],
+    )
+    killed = []
+    monkeypatch.setattr(
+        gateway,
+        "terminate_pid",
+        lambda pid, force=False: killed.append(pid),
+    )
+
+    assert gateway._get_service_pids() == set()
+    assert gateway.kill_gateway_processes(standalone_only=True) == 0
+    assert killed == []
+
+
+def test_full_uninstall_rejects_scoped_system_unit_before_mutation(
+    monkeypatch, tmp_path
+):
+    _, active_home = _configure_home(monkeypatch, tmp_path, scope="shared")
+    user_path = tmp_path / "absent-user.service"
+    system_path = tmp_path / "system/hermes-gateway-shared.service"
+    _write_unit(system_path, active_home)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda **kwargs: [])
+    monkeypatch.setattr(gateway, "_discover_service_pids", lambda: (set(), True))
+    monkeypatch.setattr(
+        gateway,
+        "get_systemd_unit_path",
+        lambda system=False: system_path if system else user_path,
+    )
+    monkeypatch.setattr(uninstall_cli.os, "geteuid", lambda: 0)
+    calls = _block(monkeypatch, uninstall_cli.subprocess, "run")
+
+    assert uninstall_cli.uninstall_gateway_service() is False
+    assert system_path.exists()
+    assert calls == []
+
+
+def test_scoped_systemd_install_rejects_explicit_system_scope(monkeypatch, tmp_path):
+    _configure_home(monkeypatch, tmp_path, scope="shared")
+    calls = _block(monkeypatch, gateway, "_run_systemctl")
+    with pytest.raises(gateway.ScopedSystemdRequiresUserError, match="user-systemd"):
+        gateway.systemd_install(system=True)
+    assert calls == []
+
+
+@pytest.mark.parametrize("selection", ["explicit", "automatic"])
+def test_scoped_systemd_selector_rejects_system_scope(monkeypatch, tmp_path, selection):
+    _configure_home(monkeypatch, tmp_path, scope="shared")
+    system_path, user_path = tmp_path / "system.service", tmp_path / "user.service"
+    if selection == "automatic":
+        system_path.write_text("[Service]\n", encoding="utf-8")
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: system_path if system else user_path)  # fmt: skip
+    with pytest.raises(gateway.ScopedSystemdRequiresUserError, match="user-systemd"):
+        gateway._select_systemd_scope(system=selection == "explicit")
+
+
+def test_gateway_command_presents_scoped_systemd_error(monkeypatch, capsys):
+    def fail(_args):
+        raise gateway.ScopedSystemdRequiresUserError("user-systemd")
+
+    monkeypatch.setattr(gateway, "_gateway_command_inner", fail)
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.gateway_command(object())
+    assert exc_info.value.code == 1 and "user-systemd" in capsys.readouterr().out

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -162,6 +162,32 @@ hermes gateway status       # Check default service status
 hermes gateway status --system         # Linux only: inspect the system service explicitly
 ```
 
+### Optional Linux systemd scope
+
+When one machine hosts multiple Hermes roots that use the same profile name, set a
+unique `gateway.systemd_scope` in each root's `config.yaml`:
+
+```yaml title="~/.hermes/config.yaml"
+gateway:
+  systemd_scope: team_a
+```
+
+The value must be 1–128 characters, start with a lowercase letter or digit, and
+contain only lowercase letters, digits, `_`, or `-`. Hermes uses it
+deterministically in the user-service name:
+`hermes-gateway-<scope>[-<profile>]`. An omitted or `null` scope preserves the
+existing service name, and the setting is read from YAML configuration only.
+
+Scoped services are supported only as systemd user services. A scoped
+`--system` installation is rejected. Before writing, controlling, or removing an
+existing scoped unit, Hermes verifies that its persisted `HERMES_HOME` resolves to
+the active root. If another root owns the unit, the operation is refused without
+changing it, preventing cross-root collisions.
+
+To change an installed scope, first restore the old scope and run
+`hermes gateway uninstall`, then set the new scope and run
+`hermes gateway install`.
+
 ### Optional Linux event-loop watchdog
 
 A systemd-managed gateway can opt into process recovery when Python's asyncio


### PR DESCRIPTION
## What does this PR do?

Adds a YAML-only `gateway.systemd_scope` setting for Linux deployments that run independent Hermes roots with the same profile names.

The scope is validated and composed into the existing deterministic unit name as `hermes-gateway-<scope>[-<profile>]`. Missing or `null` preserves the current service names. Scoped services are user-systemd only, and existing units must persist a canonical `HERMES_HOME` matching the active root before Hermes may replace, control, or remove them.

Full uninstall also keeps its standalone-process cleanup without terminating service-managed gateway PIDs, including a service PID that changes during discovery. Inconclusive service-manager discovery fails closed before the standalone termination sweep. A configured scope is rejected before the direct full-uninstall path can mutate a system-scoped unit.

## Related Issue

- This is the narrower replacement for the closed [custom systemd unit-name PR](https://github.com/NousResearch/hermes-agent/pull/76461).
- [Gateway install overwrites custom systemd service configuration](https://github.com/NousResearch/hermes-agent/issues/7186) concerns preserving hand-edited unit contents; this change instead provides deterministic isolation between Hermes roots.
- [Profile commands miss service-managed gateways](https://github.com/NousResearch/hermes-agent/issues/20254) and the related [service-detection PR](https://github.com/NousResearch/hermes-agent/pull/20488) cover adjacent gateway lifecycle behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the nullable `gateway.systemd_scope` config key and conservative validation in `hermes_cli/config_defaults.py` and `hermes_cli/gateway.py`.
- Composed scoped unit names without changing legacy names when the setting is absent.
- Added canonical `HERMES_HOME` ownership checks before scoped unit replacement, control, and deletion.
- Rejected scoped system services at the existing central user-scope guard, including direct full-uninstall cleanup.
- Protected full uninstall's standalone gateway sweep from service-managed PIDs, service PID churn, and incomplete service-manager discovery.
- Added focused lifecycle, ownership, naming, and platform-boundary tests.
- Documented the public YAML setting in `cli-config.yaml.example` and `website/docs/user-guide/messaging/index.md`.

## How to Test

1. Run the focused systemd-scope tests:

   ```bash
   python -m pytest tests/hermes_cli/test_gateway_systemd_scope.py -q
   ```

   Expected: 35 tests pass.

2. Run the affected gateway, profile, and uninstall suites:

   ```bash
   python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_service_paths.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_uninstall_dry_run.py tests/hermes_cli/test_uninstall_node_symlinks.py tests/hermes_cli/test_gui_uninstall.py -q
   ```

   Expected: 137 tests pass.

3. Run lint and cross-platform guards:

   ```bash
   ruff check hermes_cli/config_defaults.py hermes_cli/gateway.py hermes_cli/profiles.py hermes_cli/uninstall.py tests/hermes_cli/test_gateway_systemd_scope.py
   python scripts/check-windows-footguns.py --diff main
   git diff --check main
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Fresh full-suite comparison (`209730507` vs. `0a62610f1`): `23,951 passed / 65 failed` vs. `23,915 passed / 66 failed`; both had the same 11 collection/import/timeout files, and the only failure delta was one unrelated test that passed on the candidate retry. The remaining 35-pass delta is the new scope suite.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, with automated user- and system-scope lifecycle coverage

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `cli-config.yaml.example` and the messaging guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows behavior is unchanged, incomplete launchd discovery also fails closed for the destructive standalone sweep, and the Windows guard passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## Screenshots / Logs

N/A — no UI changes.
