### PR TITLE
feat(gateway): dedicated alerts channel (#76780)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -611,6 +611,16 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Optional dedicated chat for gateway lifecycle (up/down/restart)
+    # notifications, separate from the home channel. When set, "♻️ Gateway
+    # online", "♻ Gateway restarted" and the home-channel "Gateway shutting
+    # down / restarting" broadcasts are sent here instead of the platform's
+    # home channel, keeping operator telemetry out of the conversational
+    # surface (cron deliveries, reminders, normal chat). When unset (None),
+    # behavior is unchanged: lifecycle pings go to the home channel, still
+    # toggled by ``gateway_restart_notification``. #76780.
+    lifecycle_chat_id: Optional[str] = None
+
     # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
@@ -643,6 +653,8 @@ class PlatformConfig:
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
         }
+        if self.lifecycle_chat_id is not None:
+            result["lifecycle_chat_id"] = self.lifecycle_chat_id
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
         if self.token:
@@ -680,6 +692,12 @@ class PlatformConfig:
         if _typing is None:
             _typing = extra.get("typing_indicator")
 
+        # lifecycle_chat_id takes the same two routes (top-level or bridged
+        # into extra by the shared-key loop in load_gateway_config()).
+        _lifecycle = data.get("lifecycle_chat_id")
+        if _lifecycle is None:
+            _lifecycle = extra.get("lifecycle_chat_id")
+
         # typing_status_text takes the same two routes (top-level or bridged
         # into extra); string passthrough, no coercion.
         _typing_text = data.get("typing_status_text")
@@ -702,6 +720,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
+            lifecycle_chat_id=str(_lifecycle) if _lifecycle is not None else None,
             channel_overrides=channel_overrides,
             extra=extra,
         )
@@ -1592,6 +1611,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "lifecycle_chat_id" in platform_cfg:
+                    bridged["lifecycle_chat_id"] = platform_cfg["lifecycle_chat_id"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9195,11 +9195,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ``RuntimeError: dictionary changed size during iteration`` —
         # observed in a user report during gateway shutdown.
         for platform, adapter in list(self.adapters.items()):
+            platform_cfg = self.config.platforms.get(platform)
+            lifecycle_chat_id = (
+                platform_cfg.lifecycle_chat_id if platform_cfg is not None else None
+            )
             home = self.config.get_home_channel(platform)
-            if not home or not home.chat_id:
+            # Lifecycle pings target the dedicated alerts channel when one is
+            # configured, falling back to the home channel. A platform with
+            # only lifecycle_chat_id (no home channel) still gets the ping —
+            # the alerts channel is the operator's dedicated surface for it.
+            if lifecycle_chat_id:
+                target_chat_id = str(lifecycle_chat_id)
+                target_thread_id = None
+            elif home and home.chat_id:
+                target_chat_id = str(home.chat_id)
+                target_thread_id = home.thread_id
+            else:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
             if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
                 logger.info(
                     "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
@@ -9207,26 +9220,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
-            dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+            dedup_key = (platform.value, target_chat_id, target_thread_id)
             if dedup_key in notified:
                 continue
 
             try:
                 metadata = self._thread_metadata_for_target(
                     platform,
-                    home.chat_id,
-                    home.thread_id,
+                    target_chat_id,
+                    target_thread_id,
                     adapter=adapter,
                 )
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await adapter.send(target_chat_id, msg, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await adapter.send(target_chat_id, msg)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
                         platform.value,
-                        home.chat_id,
+                        target_chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
@@ -9235,13 +9248,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info(
                     "Sent shutdown notification to home channel %s:%s",
                     platform.value,
-                    home.chat_id,
+                    target_chat_id,
                 )
             except Exception as e:
                 logger.debug(
                     "Failed to send shutdown notification to home channel %s:%s: %s",
                     platform.value,
-                    home.chat_id,
+                    target_chat_id,
                     e,
                 )
 
@@ -20382,7 +20395,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return True
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
-        """Notify the chat that initiated /restart that the gateway is back."""
+        """Notify the chat that initiated /restart that the gateway is back.
+
+        When the platform configures a dedicated ``lifecycle_chat_id``, the
+        confirmation is redirected there instead (see #76780); otherwise it
+        replies to the originating chat.
+        """
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
@@ -20415,15 +20433,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
+            # A dedicated alerts channel (lifecycle_chat_id) takes the restart
+            # ping too, so the confirmation lands where the operator watches
+            # lifecycle telemetry instead of the chat that typed /restart.
+            # The reply anchor is dropped because the message moves to a
+            # different chat than the one that initiated the restart.
+            lifecycle_chat_id = (
+                platform_cfg.lifecycle_chat_id if platform_cfg is not None else None
+            )
+            if lifecycle_chat_id:
+                deliver_chat_id = str(lifecycle_chat_id)
+                deliver_thread_id: Optional[str] = None
+                deliver_reply_to = None
+                deliver_chat_type: Optional[str] = None
+            else:
+                deliver_chat_id = str(chat_id)
+                deliver_thread_id = thread_id
+                deliver_reply_to = message_id
+                deliver_chat_type = chat_type
+
             metadata = self._thread_metadata_for_target(
                 platform,
-                chat_id,
-                thread_id,
-                chat_type=chat_type,
-                reply_to_message_id=message_id,
+                deliver_chat_id,
+                deliver_thread_id,
+                chat_type=deliver_chat_type,
+                reply_to_message_id=deliver_reply_to,
                 adapter=transport.adapter,
             )
-            if data.get("delivered_via_upstream_relay") is True:
+            if data.get("delivered_via_upstream_relay") is True and not lifecycle_chat_id:
                 metadata = dict(metadata or {})
                 if data.get("user_id"):
                     metadata["user_id"] = str(data["user_id"])
@@ -20431,7 +20468,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata["scope_id"] = str(data["scope_id"])
             result = await transport.send(
                 platform,
-                str(chat_id),
+                deliver_chat_id,
                 "♻ Gateway restarted successfully. Your session continues.",
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
@@ -20443,7 +20480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,
-                    chat_id,
+                    deliver_chat_id,
                     getattr(result, "error", "send returned success=False"),
                 )
                 return None
@@ -20451,9 +20488,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.info(
                 "Sent restart notification to %s:%s",
                 platform_str,
-                chat_id,
+                deliver_chat_id,
             )
-            return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
+            return str(platform_str), str(deliver_chat_id), deliver_thread_id
         except Exception as e:
             logger.warning("Restart notification failed: %s", e)
             return None
@@ -20476,8 +20513,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message = "♻️ Gateway online — Hermes is back and ready."
 
         for platform, platform_cfg in self.config.platforms.items():
+            # Lifecycle pings target the dedicated alerts channel when one is
+            # configured, falling back to the home channel. A platform with
+            # only lifecycle_chat_id (no home channel) still gets the ping —
+            # the alerts channel is the operator's dedicated surface for it.
+            lifecycle_chat_id = platform_cfg.lifecycle_chat_id
             home = platform_cfg.home_channel
-            if not home or not home.chat_id:
+            if lifecycle_chat_id:
+                target_chat_id = str(lifecycle_chat_id)
+                target_thread_id: Optional[str] = None
+            elif home and home.chat_id:
+                target_chat_id = str(home.chat_id)
+                target_thread_id = home.thread_id
+            else:
                 continue
 
             transport = resolve_delivery_transport(platform, self.config, self.adapters)
@@ -20491,38 +20539,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
 
-            target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+            target = (platform.value, target_chat_id, target_thread_id)
             if target in skipped or target in delivered:
                 continue
 
             try:
                 metadata = self._thread_metadata_for_target(
                     platform,
-                    home.chat_id,
-                    home.thread_id,
+                    target_chat_id,
+                    target_thread_id,
                     adapter=transport.adapter,
                 )
                 if transport.is_relay:
                     metadata = dict(metadata or {})
-                    if home.user_id:
-                        metadata["user_id"] = home.user_id
-                    if home.scope_id:
-                        metadata["scope_id"] = home.scope_id
+                    # Logical-owner metadata only applies to the home channel:
+                    # a bare lifecycle_chat_id has no user/scope provenance.
+                    if not lifecycle_chat_id:
+                        if home.user_id:
+                            metadata["user_id"] = home.user_id
+                        if home.scope_id:
+                            metadata["scope_id"] = home.scope_id
                 send_metadata = _non_conversational_metadata(metadata, platform=platform)
                 if send_metadata is not None or transport.is_relay:
                     result = await transport.send(
                         platform,
-                        str(home.chat_id),
+                        target_chat_id,
                         message,
                         metadata=send_metadata,
                     )
                 else:
-                    result = await transport.adapter.send(str(home.chat_id), message)
+                    result = await transport.adapter.send(target_chat_id, message)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",
                         platform.value,
-                        home.chat_id,
+                        target_chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
@@ -20531,13 +20582,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info(
                     "Sent home-channel startup notification to %s:%s",
                     platform.value,
-                    home.chat_id,
+                    target_chat_id,
                 )
             except Exception as exc:
                 logger.warning(
                     "Home-channel startup notification failed for %s:%s: %s",
                     platform.value,
-                    home.chat_id,
+                    target_chat_id,
                     exc,
                 )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10080,6 +10080,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         "reply_prefix", "reply_in_thread", "reply_to_mode",
         "unauthorized_dm_behavior", "notice_delivery", "require_mention",
         "channel_skill_bindings", "channel_prompts", "gateway_restart_notification",
+        "lifecycle_chat_id",
         "allow_from", "allow_admin_from", "dm_policy", "group_policy",
     }
     for _k, _v in _telegram_extra.items():

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -84,6 +84,28 @@ class TestPlatformConfigRoundtrip:
         assert restored.gateway_restart_notification is False
 
 
+    def test_lifecycle_chat_id_roundtrip(self):
+        pc = PlatformConfig(enabled=True, lifecycle_chat_id="-1003940233719")
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.lifecycle_chat_id == "-1003940233719"
+
+    def test_lifecycle_chat_id_defaults_to_none(self):
+        restored = PlatformConfig.from_dict(PlatformConfig(enabled=True).to_dict())
+        assert restored.lifecycle_chat_id is None
+
+    def test_lifecycle_chat_id_resolved_from_extra(self):
+        # Same bridge route as gateway_restart_notification: the shared-key
+        # loop in load_gateway_config copies a nested platforms.<plat> value
+        # into extra.
+        restored = PlatformConfig.from_dict(
+            {"extra": {"lifecycle_chat_id": "-1003940233719"}}
+        )
+        assert restored.lifecycle_chat_id == "-1003940233719"
+
+    def test_lifecycle_chat_id_coerced_to_str(self):
+        restored = PlatformConfig.from_dict({"lifecycle_chat_id": -1003940233719})
+        assert restored.lifecycle_chat_id == "-1003940233719"
+
     def test_typing_status_text_resolved_from_extra(self):
         # Same bridge route as typing_indicator: the shared-key loop copies a
         # nested platforms.<plat> value into extra.

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -247,6 +247,114 @@ async def test_relay_fronted_logical_home_gets_startup_notification(tmp_path, mo
 
 
 @pytest.mark.asyncio
+async def test_startup_notification_redirects_to_lifecycle_chat_id(tmp_path, monkeypatch):
+    """lifecycle_chat_id takes the startup ping away from the home channel."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_chat_id = "-1003940233719"
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="startup"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "-1003940233719", None)}
+    adapter.send.assert_called_once_with(
+        "-1003940233719",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+    # The home channel must NOT receive the ping.
+    assert "home-42" not in [c.args[0] for c in adapter.send.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_startup_notification_sends_with_lifecycle_chat_only(tmp_path, monkeypatch):
+    """A lifecycle_chat_id without a home channel still gets the startup ping."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_chat_id = "-1003940233719"
+    assert runner.config.platforms[Platform.TELEGRAM].home_channel is None
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="startup"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "-1003940233719", None)}
+    adapter.send.assert_called_once_with(
+        "-1003940233719",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_home_broadcast_redirects_to_lifecycle_chat_id():
+    """The home-channel shutdown broadcast goes to lifecycle_chat_id when set."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_chat_id = "-1003940233719"
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "-1003940233719",
+        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_home_broadcast_sends_with_lifecycle_chat_only():
+    """A lifecycle_chat_id without a home channel still gets the shutdown ping."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_chat_id = "-1003940233719"
+    assert runner.config.platforms[Platform.TELEGRAM].home_channel is None
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "-1003940233719",
+        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_notification_redirects_to_lifecycle_chat_id(tmp_path, monkeypatch):
+    """The /restart confirmation lands in the alerts channel when configured."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+        "chat_type": "dm",
+        "message_id": "m1",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_chat_id = "-1003940233719"
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="restart"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "-1003940233719", None)
+    adapter.send.assert_awaited_once_with(
+        "-1003940233719",
+        "♻ Gateway restarted successfully. Your session continues.",
+        metadata=None,
+    )
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_relay_restart_notification_uses_logical_platform_and_owner(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     notify_path = tmp_path / ".restart_notify.json"

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -704,6 +704,22 @@ gateway:
 
 Disable it on noisy or low-priority platforms while leaving it on for your primary chat. The notification is sent once per restart, regardless of how many sessions were in flight.
 
+#### Dedicated alerts channel
+
+If you want to keep the lifecycle pings but move them out of your conversational home channel, set a dedicated `lifecycle_chat_id` for the platform. When set, the "♻️ Gateway online", "♻ Gateway restarted" and home-channel "Gateway shutting down / restarting" notifications go to that chat instead of the home channel — while cron deliveries, reminders and normal chat stay on the home channel:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      home_channel:
+        chat_id: "123456789"           # conversational home (cron, reminders)
+      lifecycle_chat_id: "-1003940233719"  # dedicated low-noise alerts channel
+      gateway_restart_notification: true   # keep lifecycle pings on
+```
+
+When `lifecycle_chat_id` is omitted (the default), behavior is unchanged: lifecycle pings go to the home channel, still toggled by `gateway_restart_notification`. A platform with `lifecycle_chat_id` but no home channel still receives the lifecycle pings. Make sure the bot is a member of the alerts channel, or the pings will fail to deliver.
+
 ### Typing indicators
 
 While the agent is processing a message, the gateway shows a live typing status on platforms that support it — a "typing…" bubble on Telegram/Discord/Signal, or the "is thinking…" assistant status on Slack. This is controlled per-platform by the `typing_indicator` flag in `gateway-config.yaml`, which defaults to `true`:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -503,6 +503,22 @@ gateway:
 
 在嘈杂或低优先级的平台上禁用，同时在主要聊天上保持启用。无论有多少会话正在进行，每次重启只发送一次通知。
 
+#### 专用告警频道
+
+如果希望保留生命周期通知，但将它们移出日常对话的主频道，可以为平台设置专用的 `lifecycle_chat_id`。设置后，"♻️ Gateway online"、"♻ Gateway restarted" 以及主频道的"Gateway shutting down / restarting"通知将发送到该聊天，而不是主频道——cron 投递、提醒和正常对话仍留在主频道：
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      home_channel:
+        chat_id: "123456789"           # 对话主频道（cron、提醒）
+      lifecycle_chat_id: "-1003940233719"  # 专用低噪告警频道
+      gateway_restart_notification: true   # 保持生命周期通知开启
+```
+
+未设置 `lifecycle_chat_id`（默认）时行为不变：生命周期通知发送到主频道，仍由 `gateway_restart_notification` 控制。只有 `lifecycle_chat_id` 而没有主频道的平台仍会收到生命周期通知。请确保机器人是告警频道的成员，否则通知将无法送达。
+
 ### 正在输入指示器
 
 当 agent 正在处理消息时，网关会在支持的平台上显示实时的输入状态——Telegram/Discord/Signal 上的"正在输入……"气泡，或 Slack 上的"is thinking…"助手状态。这由 `gateway-config.yaml` 中每个平台的 `typing_indicator` 标志控制，默认为 `true`：


### PR DESCRIPTION
Closes #76780

## Summary

Adds a per-platform `lifecycle_chat_id` config key that redirects gateway lifecycle (up/down/restart) notifications to a dedicated alerts channel, separate from the conversational home channel.

Currently, "♻️ Gateway online", "♻ Gateway restarted" and the home-channel "Gateway shutting down / restarting" broadcasts are always sent to the platform's home channel, gated only by `gateway_restart_notification`. That forces an either/or: keep the pings in the operator's primary chat (clutter) or lose the up/down visibility entirely. This PR lets operators keep the lifecycle pings while moving them to a low-noise alerts channel — cron deliveries, reminders and normal chat stay on the home channel.

## Behavior

- When `lifecycle_chat_id` is set for a platform, the following go there **instead of** the home channel:
  - "♻️ Gateway online — Hermes is back and ready." (startup home-channel broadcast)
  - The home-channel "⚠️ Gateway shutting down / restarting" broadcast (active-session interrupt pings are unchanged — they still target the specific chat with the in-flight task)
  - "♻ Gateway restarted successfully. Your session continues." (the `/restart` confirmation; the reply anchor is dropped since the message moves to a different chat)
- When unset (default), behavior is unchanged: pings go to the home channel, still toggled by `gateway_restart_notification`.
- A platform with `lifecycle_chat_id` but no home channel still receives the lifecycle pings.

```yaml
gateway:
  platforms:
    telegram:
      home_channel:
        chat_id: "123456789"               # conversational home (cron, reminders)
      lifecycle_chat_id: "-1003940233719"  # dedicated low-noise alerts channel
      gateway_restart_notification: true   # keep lifecycle pings on
```

No env var — pure `config.yaml` (repo convention). Both `platforms.<name>.lifecycle_chat_id` and top-level `<name>.lifecycle_chat_id` are supported (mirrors the `gateway_restart_notification` bridge routes).

## Files changed

- `gateway/config.py` — new `PlatformConfig.lifecycle_chat_id` field (+ `to_dict`/`from_dict`, incl. the `extra` bridge route) and shared-key bridging in `load_gateway_config`
- `gateway/run.py` — redirect logic in `_send_home_channel_startup_notifications`, the shutdown home-channel broadcast, and `_send_restart_notification`
- `plugins/platforms/telegram/adapter.py` — `lifecycle_chat_id` added to `_GENERIC_MERGE_KEYS` so the plugin doesn't clobber the shared-key merge
- `tests/gateway/test_config.py` — roundtrip / bridge / coercion tests
- `tests/gateway/test_restart_notification.py` — redirect tests for startup, shutdown broadcast, and restart confirmation (home channel + lifecycle-only variants)
- `website/docs/user-guide/messaging/index.md` + zh-Hans translation — "Dedicated alerts channel" section

## Notes

- Make sure the bot is a member of the alerts channel, or the redirected pings will fail to deliver (logged, best-effort like all lifecycle pings).
- Active-session interrupt pings ("Your current task will be interrupted") are intentionally **not** redirected — they carry per-session resume hints and belong in the chat where the task runs.
