### PR TITLE
fix(auxiliary): don't pin OAuth pool tokens from read-only peek (aux Codex 401s)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6960,15 +6960,22 @@ def _get_cached_client(
                 effective = _compat_model(cached_client, model, cached_default)
                 return cached_client, effective
     # Build outside the lock.
-    # For pool-backed api_key providers, derive the active API key from the
+    # For pool-backed API-key providers, derive the active API key from the
     # pool entry rather than from env vars.  resolve_api_key_provider_credentials
     # always prefers env vars (first-entry bias), which bypasses pool rotation:
     # after key #1 is marked exhausted the retry would still get key #1 from
     # the env var and fail again, causing the retry2_err handler to mark key #2.
+    #
+    # Do not do this for OAuth entries.  ``peek()`` is deliberately read-only:
+    # it neither refreshes an expired access token nor rotates away from one.
+    # Passing that token as ``explicit_api_key`` bypasses the OAuth provider's
+    # normal select+refresh path and pins both the first request and its retry
+    # to the same stale credential (observed as repeated Codex aux 401s while
+    # the main Codex route remains healthy).
     effective_api_key = api_key
     if not effective_api_key:
         _pe = _peek_pool_entry(_normalize_aux_provider(provider))
-        if _pe is not None:
+        if _pe is not None and getattr(_pe, "auth_type", None) == "api_key":
             _pk = _pool_runtime_api_key(_pe)
             if _pk:
                 effective_api_key = _pk

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -778,6 +778,68 @@ class TestBuildCodexClient:
         assert second_model == "gpt-5.4"
         assert mock_openai.call_count == 2
 
+    def test_cached_client_does_not_pin_oauth_peek_token(self):
+        """OAuth must reach the provider's select+refresh path, not peek().
+
+        Regression: _get_cached_client() borrowed a read-only peeked Codex
+        access token and forwarded it as explicit_api_key.  An expired first
+        pool entry was therefore retried verbatim after 401 even though later
+        entries and the singleton token were healthy.
+        """
+        import agent.auxiliary_client as aux
+
+        oauth_entry = MagicMock(
+            auth_type="oauth",
+            runtime_api_key="stale-oauth-token",
+        )
+        fake_client = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._peek_pool_entry", return_value=oauth_entry),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fake_client, "gpt-5.6-luna"),
+            ) as mock_resolve,
+        ):
+            aux.shutdown_cached_clients()
+            try:
+                client, model = aux._get_cached_client(
+                    "openai-codex", "gpt-5.6-luna"
+                )
+            finally:
+                aux.shutdown_cached_clients()
+
+        assert client is fake_client
+        assert model == "gpt-5.6-luna"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] is None
+
+    def test_cached_client_still_pins_api_key_pool_entry(self):
+        """The first-entry-bias fix remains active for API-key providers."""
+        import agent.auxiliary_client as aux
+
+        api_key_entry = MagicMock(
+            auth_type="api_key",
+            runtime_api_key="rotated-api-key",
+        )
+        fake_client = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._peek_pool_entry", return_value=api_key_entry),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fake_client, "test-model"),
+            ) as mock_resolve,
+        ):
+            aux.shutdown_cached_clients()
+            try:
+                client, model = aux._get_cached_client("openrouter", "test-model")
+            finally:
+                aux.shutdown_cached_clients()
+
+        assert client is fake_client
+        assert model == "test-model"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "rotated-api-key"
+
 
 class TestResolveProviderClientUniversalModelFallback:
     """resolve_provider_client() picks a sensible model when callers pass none (#31845).


### PR DESCRIPTION
Fixes #76788

## Problem

`_get_cached_client()` borrows a **read-only peeked** pool token and forwards it as `explicit_api_key`. That shortcut exists to defeat env-var first-entry bias for **API-key** pools (after key #1 is marked exhausted, the retry would otherwise pull key #1 from the env var again). It was applied unconditionally, so **OAuth** entries hit it too.

`peek()` is deliberately read-only — it neither refreshes an expired access token nor rotates away from one. Handing that token to the client as an explicit key bypasses the OAuth provider's normal select+refresh path and pins **both the first request and its retry** to the same stale credential.

Result: every auxiliary task on `openai-codex` 401s while the main Codex route stays healthy (the main route does not use this helper).

The user-visible edge is approvals. `_smart_approve()` fails closed to `"escalate"` on any exception, so a dead aux route silently downgrades `approvals.mode: smart` into `manual` — every harmless command starts prompting the user, with no error surfaced.

## Change

One condition: only pin the peeked key when the pool entry is `auth_type == "api_key"`.

```diff
-        if _pe is not None:
+        if _pe is not None and getattr(_pe, "auth_type", None) == "api_key":
```

OAuth entries now fall through to `resolve_provider_client()` with `explicit_api_key=None` and take the provider's select+refresh path. The first-entry-bias fix is unchanged for API-key pools.

## Tests

Two regression tests in `tests/agent/test_auxiliary_client.py`:

- `test_cached_client_does_not_pin_oauth_peek_token` — an OAuth pool entry must reach `resolve_provider_client()` with `explicit_api_key is None`.
- `test_cached_client_still_pins_api_key_pool_entry` — an API-key entry still forwards the rotated key, so the original fix is not regressed.

```
tests/agent/test_auxiliary_client.py      170 passed, 1 failed
tests/hermes_cli/test_auth_codex_provider.py    11 passed
```

The single failure is `TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`, a wall-clock assertion (`assert (t1 - t0) < 0.14`). It fails identically on unmodified `0a62610f1`, so it is pre-existing and unrelated to this change.

## Verification

Reproduced the 401 on the affected setup, applied the change, and confirmed the aux Codex route recovers and smart approvals resolve correctly again (benign commands auto-approve, `rm -rf /` and `sudo rm -rf ~` deny).

## Risk

Low, and narrowing. API-key providers keep the existing behavior; OAuth providers stop receiving an explicit key they should never have been given. No config or schema change.
