### PR TITLE
fix(gateway): deliver replies for telegram sessions viewed on desktop (#76767)

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -193,10 +193,22 @@ def record_obligation(
     chat_id: str,
     thread_id: Optional[str],
     content: str,
+    external_owner: bool = False,
 ) -> None:
-    """Record a final response as owed to the platform (state='pending')."""
+    """Record a final response as owed to the platform (state='pending').
+
+    ``external_owner=True`` stores the row WITHOUT an owner stamp (NULL pid),
+    marking it as produced by a foreign process (e.g. the desktop/TUI backend
+    continuing a session bound to this gateway's platform).  ``_owner_alive``
+    treats a NULL pid as dead, so any gateway can claim these rows with the
+    regular sweep — replies generated on non-gateway surfaces still reach the
+    bound chat (#76767).
+    """
     now = time.time()
-    pid, started = _owner_stamp()
+    if external_owner:
+        pid, started = None, None
+    else:
+        pid, started = _owner_stamp()
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
             """INSERT OR REPLACE INTO delivery_obligations

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10206,11 +10206,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
+    async def _delivery_watcher(self, interval: float = 5.0) -> None:
+        """Deliver obligations recorded by foreign (non-gateway) processes.
+
+        The desktop/TUI backend runs the agent in its own process when a
+        session bound to this gateway's platform is continued from the
+        desktop app.  It records the final response as an EXTERNAL delivery
+        obligation (NULL owner) in the shared ledger; ``sweep_recoverable``
+        treats NULL-owner rows as claimable, so this watcher picks them up
+        and sends them to the bound chat — the gap where replies rendered on
+        desktop never reached Telegram (#76767).
+
+        Also claims crash-recovery rows whose owner died since the last tick,
+        so redelivery no longer waits for the next gateway boot.
+        """
+        # Initial delay so adapters finish connecting before the first claim.
+        await asyncio.sleep(5)
+        while self._running:
+            try:
+                await self._redeliver_pending_obligations()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("delivery watcher tick error: %s", exc, exc_info=True)
+            await asyncio.sleep(interval)
+
     async def _redeliver_pending_obligations(self) -> int:
         """Redeliver final responses recorded in the delivery ledger by a
-        previous (now dead) gateway process.
+        previous (now dead) gateway process or by a foreign process
+        (desktop/TUI backend continuing a gateway-bound session).
 
-        Runs at startup BEFORE ``_schedule_resume_pending_sessions``. A
+        Runs at startup BEFORE ``_schedule_resume_pending_sessions`` and is
+        also ticked periodically by :meth:`_delivery_watcher`. A
         session with a recoverable obligation already produced its answer —
         the turn completed and only delivery is owed — so this method sends
         the stored text and clears ``resume_pending`` for that session,
@@ -11388,6 +11415,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
         self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
+
+        # Start background delivery watcher — claims external delivery
+        # obligations (recorded by the desktop/TUI backend for sessions it
+        # continued that are bound to this gateway's platforms) and sends
+        # them, so replies generated outside the gateway still reach the
+        # original chat (#76767).  The startup sweep only redelivers rows
+        # owned by dead processes; this watcher keeps foreign-owned rows
+        # flowing while the gateway runs.
+        self._spawn_supervised(self._delivery_watcher, "delivery_watcher")
 
         # Start background async-delegation watcher — drains completion events
         # from delegate_task(background=true) subagents and injects each

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -123,6 +123,62 @@ class TestSweep:
         assert dl.sweep_recoverable() == []
 
 
+class TestExternalOwner:
+    """Foreign-owned obligations (#76767): recorded WITHOUT an owner stamp
+    (NULL pid) by a non-gateway process (desktop/TUI backend continuing a
+    gateway-bound session).  ``_owner_alive`` treats NULL as dead, so any
+    gateway's sweep claims and delivers them while the desktop stays alive."""
+
+    def test_external_row_has_null_owner(self):
+        dl.record_obligation(
+            obligation_id="ext-1",
+            session_key="agent:main:telegram:dm:123",
+            platform="telegram",
+            chat_id="123",
+            thread_id=None,
+            content="reply from desktop",
+            external_owner=True,
+        )
+        with dl._connect() as conn:
+            row = conn.execute(
+                "SELECT owner_pid, owner_started_at, state FROM delivery_obligations "
+                "WHERE obligation_id=?",
+                ("ext-1",),
+            ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+        assert row[2] == "pending"
+
+    def test_external_row_claimed_by_sweep_while_recorder_alive(self):
+        dl.record_obligation(
+            obligation_id="ext-2",
+            session_key="agent:main:telegram:dm:123",
+            platform="telegram",
+            chat_id="123",
+            thread_id=None,
+            content="reply from desktop",
+            external_owner=True,
+        )
+        claimed = dl.sweep_recoverable(deliverable_platforms={"telegram"})
+        assert len(claimed) == 1
+        assert claimed[0]["obligation_id"] == "ext-2"
+        assert claimed[0]["needs_marker"] is False
+        # The claim re-stamped ownership to THIS process: no double-claim.
+        assert dl.sweep_recoverable() == []
+
+    def test_external_row_not_claimed_for_unconnected_platform(self):
+        dl.record_obligation(
+            obligation_id="ext-3",
+            session_key="agent:main:telegram:dm:123",
+            platform="telegram",
+            chat_id="123",
+            thread_id=None,
+            content="reply from desktop",
+            external_owner=True,
+        )
+        assert dl.sweep_recoverable(deliverable_platforms={"discord"}) == []
+
+
 class TestPrune:
     def test_old_delivered_rows_pruned(self):
         _record()
@@ -146,12 +202,13 @@ class TestGatewayRedeliverySweep:
     """Drive the real GatewayRunner._redeliver_pending_obligations."""
 
     @staticmethod
-    def _runner(adapter=None):
+    def _runner(adapter=None, platform=None):
         from gateway.config import Platform
         from gateway.run import GatewayRunner
 
+        platform = platform or Platform.SLACK
         runner = object.__new__(GatewayRunner)
-        runner.adapters = {Platform.SLACK: adapter} if adapter else {}
+        runner.adapters = {platform: adapter} if adapter else {}
         _store = MagicMock()
         _store.clear_resume_pending = AsyncMock()
         _store._store = None
@@ -220,6 +277,36 @@ class TestGatewayRedeliverySweep:
             )
 
         assert blocked_event_loop == []
+
+    @pytest.mark.asyncio
+    async def test_external_obligation_redelivered_while_recorder_alive(self):
+        """#76767: a desktop/TUI-recorded obligation (NULL owner) is claimed
+        and delivered by the gateway even though the recording process is
+        still alive — no crash involved."""
+        from gateway.config import Platform
+
+        dl.record_obligation(
+            obligation_id="ext-run-1",
+            session_key="agent:main:telegram:dm:123",
+            platform="telegram",
+            chat_id="123",
+            thread_id=None,
+            content="reply from desktop",
+            external_owner=True,
+        )
+        adapter = self._adapter()
+        runner = self._runner(adapter, platform=Platform.TELEGRAM)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        sent = adapter.send.call_args.kwargs
+        assert sent["chat_id"] == "123"
+        assert sent["content"] == "reply from desktop"  # no marker
+        assert _row("ext-run-1")["state"] == "delivered"
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            "agent:main:telegram:dm:123"
+        )
 
 
 class TestAttemptsOnlySpentOnRealSends:

--- a/tests/gateway/test_issue76767_tui_producer.py
+++ b/tests/gateway/test_issue76767_tui_producer.py
@@ -1,0 +1,195 @@
+"""TUI producer path for gateway-bound delivery obligations (#76767 / #76796).
+
+When a gateway-bound Telegram (or other platform) session is resumed from the
+desktop/TUI backend, the reply is generated in THIS process
+(``tui_gateway/server.py``), not in the gateway process — so the gateway never
+sees the turn, ``delivery_obligations`` stays empty and the reply is never sent
+to the bound chat (#76767).  The producer hook
+``tui_gateway/server.py::_record_bound_platform_delivery`` re-reads the stored
+session row's gateway routing fields (``source``/``chat_id``/``thread_id``/
+``session_key``) and records an EXTERNAL-owner obligation (NULL pid) that the
+gateway's delivery sweep claims and sends.
+
+These tests drive the real producer against a real ``SessionDB`` in a temp
+``profile_home`` (the same path the producer opens): they prove the exact
+routing fields land in the ledger, that the row is claimable by the gateway
+sweep, and the no-op guards (blank content, missing / non-gateway session key,
+unknown session row, missing chat id, disabled ledger).
+"""
+
+import pytest
+
+from gateway import delivery_ledger as dl
+from tui_gateway import server
+
+GATEWAY_KEY = "agent:main:telegram:dm:123"
+REPLY = "the final answer"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_ledger(tmp_path, monkeypatch):
+    """Isolated delivery_obligations db per test (same pattern as the other
+    delivery-ledger test files)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
+def _seed_gateway_session(
+    tmp_path,
+    *,
+    session_key=GATEWAY_KEY,
+    source="telegram",
+    chat_id="123",
+    thread_id=None,
+    content=REPLY,
+):
+    """Seed a temp profile_home state.db with a gateway-bound session row
+    (routing peer fields) plus one assistant reply row.
+
+    Returns ``(profile_home, message_id)`` — the same shape the desktop
+    session dict carries (``profile_home`` + ``session_key``).
+    """
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    db = SessionDB(db_path=profile_home / "state.db")
+    db.create_session(session_key, source=source)
+    db.record_gateway_session_peer(
+        session_key,
+        source=source,
+        session_key=session_key,
+        chat_id=chat_id,
+        thread_id=thread_id,
+    )
+    message_id = db.append_message(session_key, role="assistant", content=content)
+    db.close()
+    return profile_home, message_id
+
+
+def _tui_session(profile_home, *, session_key=GATEWAY_KEY):
+    """The session dict the TUI holds for a gateway-bound session."""
+    return {"session_key": session_key, "profile_home": str(profile_home)}
+
+
+def _all_obligation_ids():
+    with dl._connect() as conn:
+        return [
+            r[0]
+            for r in conn.execute(
+                "SELECT obligation_id FROM delivery_obligations"
+            ).fetchall()
+        ]
+
+
+def _ledger_row(obligation_id):
+    with dl._connect() as conn:
+        r = conn.execute(
+            """SELECT session_key, platform, chat_id, thread_id, content,
+                      state, owner_pid
+               FROM delivery_obligations WHERE obligation_id=?""",
+            (obligation_id,),
+        ).fetchone()
+    if r is None:
+        return None
+    return {
+        "session_key": r[0],
+        "platform": r[1],
+        "chat_id": r[2],
+        "thread_id": r[3],
+        "content": r[4],
+        "state": r[5],
+        "owner_pid": r[6],
+    }
+
+
+class TestTuiProducerRecordsExternalObligation:
+    """A gateway-origin TUI session records the expected external obligation
+    with the correct routing fields (platform/chat_id/thread_id/content)."""
+
+    @pytest.mark.parametrize("thread_id", [None, "topic-9"])
+    def test_routing_fields_land_in_ledger(self, tmp_path, thread_id):
+        profile_home, message_id = _seed_gateway_session(tmp_path, thread_id=thread_id)
+
+        server._record_bound_platform_delivery(_tui_session(profile_home), REPLY)
+
+        # Stable id: same turn (message ref) + same content re-records
+        # idempotently; proves the producer used the persisted assistant row
+        # as the per-turn message ref rather than the time fallback.
+        obligation_id = dl.compute_obligation_id(GATEWAY_KEY, str(message_id), REPLY)
+        row = _ledger_row(obligation_id)
+        assert row is not None
+        assert row["session_key"] == GATEWAY_KEY
+        assert row["platform"] == "telegram"
+        assert row["chat_id"] == "123"
+        assert row["thread_id"] == thread_id
+        assert row["content"] == REPLY
+        assert row["state"] == "pending"
+        # External owner: NULL pid, so the gateway's sweep treats it as dead
+        # and claims it while the desktop recorder stays alive (#76767).
+        assert row["owner_pid"] is None
+
+    def test_recorded_obligation_claimable_by_gateway_sweep(self, tmp_path):
+        profile_home, message_id = _seed_gateway_session(tmp_path)
+        server._record_bound_platform_delivery(_tui_session(profile_home), REPLY)
+
+        claimed = dl.sweep_recoverable(deliverable_platforms={"telegram"})
+
+        assert [c["obligation_id"] for c in claimed] == [
+            dl.compute_obligation_id(GATEWAY_KEY, str(message_id), REPLY)
+        ]
+        assert claimed[0]["content"] == REPLY
+        assert claimed[0]["needs_marker"] is False  # pending: send never started
+
+
+class TestTuiProducerNoOps:
+    """Guards: nothing is recorded for non-deliverable turns or sessions."""
+
+    def test_blank_content_is_noop(self, tmp_path):
+        profile_home, _ = _seed_gateway_session(tmp_path)
+        session = _tui_session(profile_home)
+        server._record_bound_platform_delivery(session, "")
+        server._record_bound_platform_delivery(session, "   \n  ")
+        server._record_bound_platform_delivery(session, None)
+        assert _all_obligation_ids() == []
+
+    def test_missing_session_key_is_noop(self, tmp_path):
+        profile_home, _ = _seed_gateway_session(tmp_path)
+        server._record_bound_platform_delivery(
+            {"profile_home": str(profile_home)}, REPLY
+        )
+        assert _all_obligation_ids() == []
+
+    def test_non_gateway_session_key_is_noop(self, tmp_path):
+        # A local (non ``agent:``) session key must never be recorded even
+        # when the row carries routing-looking fields.
+        profile_home, _ = _seed_gateway_session(
+            tmp_path, session_key="local-tui-1", source="tui", chat_id="C1"
+        )
+        server._record_bound_platform_delivery(
+            _tui_session(profile_home, session_key="local-tui-1"), REPLY
+        )
+        assert _all_obligation_ids() == []
+
+    def test_unknown_session_row_is_noop(self, tmp_path):
+        # session_key present, but no matching row in state.db: the producer
+        # cannot learn the routing fields, so it must not record.
+        profile_home, _ = _seed_gateway_session(tmp_path)
+        session = _tui_session(profile_home, session_key="agent:main:telegram:dm:999")
+        server._record_bound_platform_delivery(session, REPLY)
+        assert _all_obligation_ids() == []
+
+    def test_missing_chat_id_is_noop(self, tmp_path):
+        profile_home, _ = _seed_gateway_session(
+            tmp_path, session_key=GATEWAY_KEY, source="telegram", chat_id=""
+        )
+        server._record_bound_platform_delivery(_tui_session(profile_home), REPLY)
+        assert _all_obligation_ids() == []
+
+    def test_ledger_disabled_is_noop(self, tmp_path, monkeypatch):
+        profile_home, _ = _seed_gateway_session(tmp_path)
+        monkeypatch.setattr(dl, "ledger_enabled", lambda: False)
+        server._record_bound_platform_delivery(_tui_session(profile_home), REPLY)
+        assert _all_obligation_ids() == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9311,6 +9311,84 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _record_bound_platform_delivery(session: dict, content: Any) -> None:
+    """Record a delivery obligation for a reply generated on a gateway-bound
+    session via the desktop/TUI backend.
+
+    When a Telegram (or other gateway-platform) session is resumed/viewed from
+    the desktop app, the agent runs in THIS backend process (web_server), not
+    in the gateway process.  The reply is persisted to state.db — the desktop
+    renders it — but the gateway never learns of it, so nothing is delivered
+    to the bound chat and ``delivery_obligations`` stays empty (#76767).
+
+    Read the stored session row's gateway origin (``session_key``/``chat_id``/
+    ``thread_id``) and record an EXTERNAL-owner obligation: the gateway's
+    delivery sweep claims NULL-owner rows and sends them to the bound
+    platform, so the reply reaches the original chat.
+    """
+    text = str(content or "").strip()
+    if not text:
+        return
+    key = str(session.get("session_key") or "")
+    if not key:
+        return
+    try:
+        from gateway.delivery_ledger import (
+            compute_obligation_id,
+            ledger_enabled,
+            record_obligation,
+        )
+
+        if not ledger_enabled():
+            return
+        with _session_db(session) as db:
+            if db is None:
+                return
+            row = db.get_session(key)
+            if row:
+                gateway_key = str(row.get("session_key") or "")
+                platform = str(row.get("source") or "")
+                chat_id = str(row.get("chat_id") or "")
+                thread_id = row.get("thread_id")
+                # Stable per-turn message ref: the last persisted assistant
+                # row id (distinguishes turns in one session, like the
+                # gateway's inbound message id).
+                message_ref = ""
+                try:
+                    for m in reversed(db.get_messages(key, limit=100)):
+                        if m.get("role") == "assistant" and m.get("id"):
+                            message_ref = str(m["id"])
+                            break
+                except Exception:
+                    message_ref = ""
+        # Only gateway-bound sessions carry a gateway session_key
+        # (``agent:...:<platform>:...``) plus a real chat id.
+        if not gateway_key or not gateway_key.startswith("agent:"):
+            return
+        if not platform or not chat_id:
+            return
+        if not message_ref:
+            message_ref = f"desktop:{int(time.time())}"
+        obligation_id = compute_obligation_id(
+            gateway_key, message_ref, text
+        )
+        record_obligation(
+            obligation_id=obligation_id,
+            session_key=gateway_key,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            content=text,
+            external_owner=True,
+        )
+        logger.info(
+            "[tui_gateway] recorded delivery obligation for bound session %s -> %s:%s",
+            key, platform, chat_id,
+        )
+    except Exception:
+        logger.debug("bound-platform delivery obligation failed", exc_info=True)
+
+
 def _run_prompt_submit(
     rid,
     sid: str,
@@ -9830,6 +9908,15 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
+
+            # A reply generated on a session bound to a gateway platform
+            # (e.g. Telegram) must still reach that chat.  The desktop/TUI
+            # backend runs the agent in THIS process — the gateway never sees
+            # the turn, so no delivery obligation would be created and the
+            # reply would stay desktop-only (#76767).  Record an external
+            # obligation the gateway's delivery sweep claims and sends.
+            if status == "complete" and isinstance(raw, str) and raw.strip():
+                _record_bound_platform_delivery(session, raw)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge


### PR DESCRIPTION
## Problem

When a Telegram conversation is viewed/continued through the desktop app while the session stays bound to the Telegram gateway, assistant replies render in the desktop app but are **never delivered to the Telegram chat** — zero rows in `delivery_obligations`.

## Root cause

The desktop runs the agent in the backend web_server process (TUI gateway), not the messaging gateway process. `record_obligation()` only exists on the producer path of the messaging gateway (`gateway/platforms/base.py`), which never runs for desktop-triggered turns. The reply is persisted to `state.db` (so desktop renders it) but no delivery obligation is ever created, so the gateway never delivers it.

## Fix (3 layers)

- **`tui_gateway/server.py`**: after a turn bound to a gateway session completes, record a delivery obligation against the owning platform/chat via the shared ledger.
- **`gateway/delivery_ledger.py`**: `sweep_recoverable()` now claims rows whose owner process is alive but the origin platform is a desktop/TUI backend (the desktop process can never deliver to Telegram itself).
- **`gateway/run.py`**: periodic `_redeliver_pending_obligations()` sweep (not just at startup) so obligations created while the gateway runs are picked up and delivered.

## Verification

- New tests in `tests/gateway/test_delivery_ledger.py` (84 lines): obligation recorded for desktop-bound turns, sweep claims desktop-owned rows, redelivery path.
- Existing delivery ledger tests still pass.

Closes #76767