### PR TITLE
fix(codex): resume app-server threads and stop double-sending the final reply

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -625,11 +625,28 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 
 
 def _codex_thread_meta_key(agent) -> Optional[str]:
-    """state_meta key holding the codex thread id for this Hermes session."""
+    """state_meta key holding the codex thread id for this conversation.
+
+    Keyed on the LINEAGE ROOT rather than the raw session_id. Context
+    compression rotates session_id to a fresh segment linked by
+    parent_session_id, so keying on the tip would open a new — empty —
+    codex thread every time compression fired, which is precisely the
+    amnesia this exists to prevent. A genuinely new session (daily reset,
+    idle expiry) has no parent, so it is its own root and correctly starts
+    a fresh thread.
+    """
     session_id = getattr(agent, "session_id", None)
     if not session_id:
         return None
-    return f"codex_app_server:thread:{session_id}"
+    root = session_id
+    resolver = getattr(getattr(agent, "_session_db", None),
+                       "get_conversation_root", None)
+    if callable(resolver):
+        try:
+            root = resolver(session_id) or session_id
+        except Exception:
+            logger.debug("conversation-root lookup failed", exc_info=True)
+    return f"codex_app_server:thread:{root}"
 
 
 def _load_codex_thread_id(agent) -> Optional[str]:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,7 +20,7 @@ import json
 import logging
 import time
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
@@ -615,6 +615,83 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+# ---------------------------------------------------------------------------
+# Codex thread continuity + final-send de-duplication
+#
+# Both of these exist because the codex_app_server runtime is an early-return
+# path that bypasses conversation_loop, so the bookkeeping that path normally
+# does for the gateway has to be done explicitly here.
+# ---------------------------------------------------------------------------
+
+
+def _codex_thread_meta_key(agent) -> Optional[str]:
+    """state_meta key holding the codex thread id for this Hermes session."""
+    session_id = getattr(agent, "session_id", None)
+    if not session_id:
+        return None
+    return f"codex_app_server:thread:{session_id}"
+
+
+def _load_codex_thread_id(agent) -> Optional[str]:
+    """The codex thread this session used last, if any.
+
+    Persisted rather than kept on the agent because the gateway drops its
+    cached AIAgent between most inbound messages — the in-memory session
+    object is precisely what does NOT survive to the next turn.
+
+    Persistence-isolated agents (the background skill/memory review fork,
+    which shares the parent's session_id) deliberately get None: the curator
+    must never adopt — or later overwrite — the user's live thread.
+    """
+    db = getattr(agent, "_session_db", None)
+    key = _codex_thread_meta_key(agent)
+    if db is None or key is None or getattr(agent, "_persist_disabled", False):
+        return None
+    try:
+        return db.get_meta(key) or None
+    except Exception:
+        logger.debug("codex thread-id lookup failed", exc_info=True)
+        return None
+
+
+def _save_codex_thread_id(agent, thread_id: Optional[str]) -> None:
+    """Remember the codex thread so the next AIAgent can resume it."""
+    db = getattr(agent, "_session_db", None)
+    key = _codex_thread_meta_key(agent)
+    if not thread_id or db is None or key is None:
+        return
+    if getattr(agent, "_persist_disabled", False):
+        return
+    try:
+        if db.get_meta(key) != thread_id:
+            db.set_meta(key, thread_id)
+    except Exception:
+        logger.debug("codex thread-id persist failed", exc_info=True)
+
+
+def _final_text_was_previewed(agent, final_text: Optional[str]) -> bool:
+    """True when the interim path already put the final answer on screen.
+
+    Codex emits its final answer as a completed ``agentMessage``, which the
+    event bridge forwards to ``_emit_interim_assistant_message`` — so the
+    text reaches the user before the gateway's own final send. The gateway
+    suppresses that second send only when the result reports
+    ``response_previewed`` (it then re-verifies the exact text against what
+    the stream consumer actually delivered, so a false positive here cannot
+    swallow a reply the user never saw).
+    """
+    if not final_text:
+        return False
+    checker = getattr(agent, "_interim_text_was_delivered", None)
+    if not callable(checker):
+        return False
+    try:
+        return bool(checker(final_text))
+    except Exception:
+        logger.debug("interim-delivery lookup failed", exc_info=True)
+        return False
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -682,6 +759,7 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            resume_thread_id=_load_codex_thread_id(agent),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
@@ -731,6 +809,7 @@ def run_codex_app_server_turn(
                 else {}
             ),
             "error": str(exc),
+            "response_previewed": False,
         }
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
@@ -760,6 +839,12 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+
+    # Remember the thread so the NEXT AIAgent for this session resumes it
+    # instead of opening an empty one. Written after every turn (cheap,
+    # and a no-op when unchanged) so a thread codex rotated mid-session
+    # is still the one we come back to.
+    _save_codex_thread_id(agent, turn.thread_id)
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which
@@ -884,6 +969,11 @@ def run_codex_app_server_turn(
         # would re-INSERT the already-flushed user turn (append_message has no
         # dedup), reintroducing the #860 / #42039 duplicate-write bug.
         "agent_persisted": True,
+        # Without this the gateway cannot tell that the completed
+        # agentMessage already reached the user via the interim path, so
+        # it sends the identical text a second time — every reply arrived
+        # twice, once plain and once as a quoted reply.
+        "response_previewed": _final_text_was_previewed(agent, turn.final_text),
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
         **usage_result,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -281,6 +281,7 @@ class CodexAppServerSession:
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
+        resume_thread_id: Optional[str] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
@@ -295,6 +296,9 @@ class CodexAppServerSession:
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
+        # Codex thread to re-open on first use, carrying this Hermes
+        # session's transcript across AIAgent instances. None = start fresh.
+        self._resume_thread_id = resume_thread_id
         self._client_factory = client_factory or CodexAppServerClient
 
         self._client: Optional[CodexAppServerClient] = None
@@ -327,6 +331,15 @@ class CodexAppServerSession:
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
         )
+        # Re-open this session's previous thread before considering a new
+        # one. The conversation transcript lives INSIDE the codex thread
+        # (turn/start carries only the newest user message), so a fresh
+        # thread here is indistinguishable from amnesia — and the gateway
+        # drops its cached AIAgent between most inbound messages, which
+        # made that the common path rather than the rare one.
+        resumed = self._try_resume_thread()
+        if resumed is not None:
+            return resumed
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
         #   1. `thread/start.permissions` is gated behind the experimentalApi
@@ -371,6 +384,57 @@ class CodexAppServerSession:
             self._cwd,
         )
         return self._thread_id
+
+    def _try_resume_thread(self) -> Optional[str]:
+        """Re-open the codex thread this Hermes session used last time.
+
+        Returns the resumed thread id, or None when there is nothing to
+        resume or the rollout is unusable (expired, pruned, written by an
+        incompatible codex build). A failed resume must never fail the
+        user's turn: the caller falls through to ``thread/start`` and the
+        conversation simply begins fresh, which is the pre-resume
+        behavior.
+        """
+        if not self._resume_thread_id:
+            return None
+        assert self._client is not None
+        try:
+            result = self._client.request(
+                "thread/resume",
+                {"threadId": self._resume_thread_id},
+                timeout=15,
+            )
+        except Exception as exc:
+            logger.warning(
+                "codex thread/resume failed for %s (%s) — starting a fresh "
+                "thread; prior conversation context is lost",
+                str(self._resume_thread_id)[:8],
+                exc,
+            )
+            return None
+        # Cross-fill thread.id/sessionId for the same reason thread/start
+        # does: codex versions have serialized the id under either key.
+        thread_obj = result.get("thread") or {}
+        thread_id = (
+            thread_obj.get("id")
+            or thread_obj.get("sessionId")
+            or result.get("sessionId")
+            or result.get("threadId")
+        )
+        if not thread_id:
+            logger.warning(
+                "codex thread/resume returned no thread id (payload keys: "
+                "%s) — starting a fresh thread",
+                sorted(result.keys()),
+            )
+            return None
+        self._thread_id = thread_id
+        logger.info(
+            "codex app-server thread resumed: id=%s cwd=%s",
+            str(thread_id)[:8],
+            self._cwd,
+        )
+        return thread_id
 
     def close(self) -> None:
         if self._closed:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -895,4 +895,79 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
+# ---- thread resume (conversation memory across AIAgent restarts) ----
 
+class TestThreadResume:
+    """With codex_app_server the transcript lives inside the codex thread —
+    turn/start carries only the newest user message. Whenever the gateway
+    drops its cached AIAgent (which happens on most inbound messages) a
+    fresh thread/start meant the model lost every prior turn. These pin the
+    resume path that carries the thread across AIAgent instances."""
+
+    def test_resume_thread_id_resumes_instead_of_starting(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                assert params == {"threadId": "thread-prior-042"}
+                return {"thread": {"id": "thread-prior-042"}}
+            if method == "thread/start":
+                raise AssertionError("must not open a fresh thread when resuming")
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="thread-prior-042")
+        assert s.ensure_started() == "thread-prior-042"
+        assert [m for (m, _) in client.requests] == ["thread/resume"]
+
+    def test_resume_failure_falls_back_to_a_fresh_thread(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                raise session_mod.CodexAppServerError(
+                    code=-32600, message="invalid session id"
+                )
+            if method == "thread/start":
+                return {"thread": {"id": "thread-fake-001"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="rolled-away")
+        # An expired//pruned rollout must degrade to a new thread rather than
+        # failing the user's turn outright.
+        assert s.ensure_started() == "thread-fake-001"
+        assert [m for (m, _) in client.requests] == ["thread/resume", "thread/start"]
+
+    def test_no_resume_id_starts_a_fresh_thread(self):
+        client = FakeClient()
+        s = make_session(client)
+        assert s.ensure_started() == "thread-fake-001"
+        assert [m for (m, _) in client.requests] == ["thread/start"]
+
+    def test_resume_is_attempted_only_once(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                return {"thread": {"id": "thread-prior-042"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="thread-prior-042")
+        s.ensure_started()
+        s.ensure_started()
+        assert [m for (m, _) in client.requests].count("thread/resume") == 1
+
+    def test_resume_accepts_session_id_key(self):
+        """Codex versions have serialized the id under either key."""
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                return {"thread": {"sessionId": "thread-prior-099"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="thread-prior-099")
+        assert s.ensure_started() == "thread-prior-099"

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -786,3 +786,141 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
+class TestFinalResponsePreviewFlag:
+    """Codex emits its final answer as a completed agentMessage, which the
+    event bridge hands to _emit_interim_assistant_message — so the text is
+    already on screen before the gateway performs its own final send. The
+    gateway suppresses that second send only when the result reports
+    response_previewed (it then re-verifies the exact text against what was
+    actually delivered). This early-return path used to omit the key
+    entirely, so every reply reached the user twice: once plain, once as a
+    quoted reply.
+    """
+
+    @staticmethod
+    def _previewing_session(monkeypatch, *, preview: bool):
+        """Fake codex turn that optionally replays the bridge's behavior of
+        surfacing the completed agentMessage through the interim path."""
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            final = f"echo: {user_input}"
+            if preview:
+                # Exactly what make_codex_app_server_event_bridge does on
+                # item/completed for an agentMessage.
+                self._agent_for_test._emit_interim_assistant_message(
+                    {"role": "assistant", "content": final}
+                )
+            return TurnResult(
+                final_text=final,
+                projected_messages=[{"role": "assistant", "content": final}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-1"
+        )
+
+    def _run(self, monkeypatch, *, preview: bool):
+        self._previewing_session(monkeypatch, preview=preview)
+        agent = _make_codex_agent()
+        delivered = []
+        # _emit_interim_assistant_message is a no-op without a UI callback,
+        # which is what the gateway installs when interim messages are on.
+        agent.interim_assistant_callback = (
+            lambda text, already_streamed=False: delivered.append(text)
+        )
+        monkeypatch.setattr(
+            CodexAppServerSession, "_agent_for_test", agent, raising=False
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello there")
+        return result, delivered
+
+    def test_previewed_true_when_interim_already_delivered_final_text(self, monkeypatch):
+        result, delivered = self._run(monkeypatch, preview=True)
+        assert delivered == ["echo: hello there"]  # user already saw it
+        assert result["response_previewed"] is True
+
+    def test_previewed_false_when_final_text_was_not_delivered(self, monkeypatch):
+        result, delivered = self._run(monkeypatch, preview=False)
+        assert delivered == []
+        assert result["response_previewed"] is False
+
+    def test_result_always_carries_the_key(self, fake_session):
+        # The gateway reads this with .get(), so a missing key is
+        # indistinguishable from "not previewed" and silently reintroduces
+        # the double send.
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello there")
+        assert "response_previewed" in result
+
+
+class TestCodexThreadMetaKey:
+    """The persisted thread must survive a compression-driven session
+    rotation, or the fix quietly stops working on long conversations."""
+
+    def test_key_follows_the_lineage_root_not_the_rotated_segment(self):
+        from agent import codex_runtime
+
+        class FakeDB:
+            def get_conversation_root(self, sid):
+                assert sid == "segment-3"
+                return "root-session"
+
+        agent = SimpleNamespace(session_id="segment-3", _session_db=FakeDB())
+        assert (codex_runtime._codex_thread_meta_key(agent)
+                == "codex_app_server:thread:root-session")
+
+    def test_falls_back_to_session_id_without_a_resolver(self):
+        from agent import codex_runtime
+
+        agent = SimpleNamespace(session_id="solo", _session_db=None)
+        assert (codex_runtime._codex_thread_meta_key(agent)
+                == "codex_app_server:thread:solo")
+
+    def test_lineage_lookup_failure_degrades_to_session_id(self):
+        from agent import codex_runtime
+
+        class BoomDB:
+            def get_conversation_root(self, sid):
+                raise RuntimeError("db gone")
+
+        agent = SimpleNamespace(session_id="solo", _session_db=BoomDB())
+        assert (codex_runtime._codex_thread_meta_key(agent)
+                == "codex_app_server:thread:solo")
+
+    def test_no_session_id_means_no_persistence(self):
+        from agent import codex_runtime
+
+        agent = SimpleNamespace(session_id=None, _session_db=None)
+        assert codex_runtime._codex_thread_meta_key(agent) is None
+
+    def test_review_fork_never_reads_or_writes_the_users_thread(self):
+        from agent import codex_runtime
+
+        class FakeDB:
+            def __init__(self):
+                self.writes = []
+
+            def get_conversation_root(self, sid):
+                return sid
+
+            def get_meta(self, key):
+                return "thread-belonging-to-the-user"
+
+            def set_meta(self, key, value):
+                self.writes.append((key, value))
+
+        db = FakeDB()
+        fork = SimpleNamespace(
+            session_id="shared-with-parent", _session_db=db, _persist_disabled=True
+        )
+        assert codex_runtime._load_codex_thread_id(fork) is None
+        codex_runtime._save_codex_thread_id(fork, "curator-thread")
+        assert db.writes == []


### PR DESCRIPTION
## Summary

Two bugs in the `codex_app_server` runtime, both stemming from it being an
early-return path that bypasses `conversation_loop` — so bookkeeping that path
normally does for the gateway simply never happens.

Found while debugging a Telegram deployment where the bot answered everything
twice and had no memory of the preceding message.

### 1. The agent loses the whole conversation whenever its `AIAgent` is dropped

With this runtime the transcript lives **inside the codex thread** —
`turn/start` sends `{threadId, input: [newest message]}` and nothing else. But
`ensure_started()` unconditionally called `thread/start`, so every new
`CodexAppServerSession` opened an *empty* thread.

The gateway drops its cached `AIAgent` between most inbound messages
(`_evict_cached_agent`, config-signature changes, session recovery), which made
this the common path rather than a rare one. Hermes faithfully restored history
from `state.db` into `agent.messages` and then never sent it to codex.

In the logs it looks like this — same session, consecutive messages:

```
conversation turn: … history=10   # reused thread, context intact
…
conversation turn: … history=4
codex app-server thread started: id=019fbf93   # ← new, empty thread
```

…and the model asks the user to clarify a topic it had written 8k characters
about ninety seconds earlier.

Fix: persist the thread id per conversation in `state_meta` and re-open it with
`thread/resume` (available since codex 0.144.6). A failed resume logs and falls
through to `thread/start`, so an expired or pruned rollout degrades to today's
behaviour instead of failing the turn.

The key is the **lineage root**, not the raw `session_id`: context compression
rotates `session_id` to a new segment, and keying on the tip would open a fresh
empty thread every time compression fired. Persistence-isolated agents (the
background review fork, which shares the parent's `session_id`) neither read nor
write the key, so the curator can't adopt or clobber the user's thread.

### 2. Every reply is delivered twice

Codex emits its final answer as a completed `agentMessage`, which
`make_codex_app_server_event_bridge` forwards to
`_emit_interim_assistant_message` — so the text reaches the user *before* the
gateway's own final send.

The gateway already guards against this: `_stream_confirmed_final_delivery()`
suppresses the second send, but only when the result reports
`response_previewed`, and it then re-verifies the exact text via
`has_delivered_text()`. The `chat_completions` path sets this through
`agent._response_was_previewed`; this path never set it and omitted the key
entirely, so suppression could never fire.

Result: every answer arrived twice — once plain from the interim path, once as
a quoted reply from the final send.

Fix: report `response_previewed` from what the interim path actually delivered.
Because the gateway still verifies the exact text against the stream consumer
before suppressing, a false positive here cannot swallow a reply the user never
saw. The crash path reports `False` explicitly.

## Testing

13 new tests covering both fixes:

- `TestThreadResume` — resume instead of start; fall back to a fresh thread when
  resume fails; no resume id still starts fresh; resume attempted once; tolerate
  `id` vs `sessionId` cross-fill
- `TestFinalResponsePreviewFlag` — previewed true/false driven through the real
  `_emit_interim_assistant_message` path, plus the key always being present
- `TestCodexThreadMetaKey` — keyed on lineage root; fallbacks; the review fork
  never touching the key

`tests/agent/transports` + `tests/run_agent` pass (2512 passed, 4 skipped).

Also verified live against codex 0.144.6: a second `AIAgent` on the same session
resumes the first one's thread and recalls a fact planted in the earlier turn.
