### PR TITLE
fix(feishu): fingerprint app credentials for multiplex guard (#76793)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13117,6 +13117,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # of a bot token. Including its secret keeps multiplexed profiles
             # from spawning competing sidecars for the same account and port.
             "_project_secret",
+            # Feishu/Lark authenticates with an app_id/app_secret pair rather
+            # than a single token (one active WebSocket connection per app).
+            # app_id is stable, log-safe, and already used as the adapter's
+            # _app_lock_identity, so including it lets the multiplex guard
+            # refuse cloned profiles competing for the same Feishu app.
+            "_app_id",
         ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -39,6 +39,38 @@ class TestCredentialFingerprint:
         assert fp1 is not None
         assert "shared-project-secret" not in fp1
 
+    def test_reads_feishu_app_id(self):
+        """Feishu/Lark authenticates via app_id/app_secret, not a token.
+
+        Without _app_id in the fingerprint attribute list, every Feishu
+        adapter in a multiplexed gateway returns None here and the
+        same-credential conflict check is silently skipped — N profiles
+        spawn WebSocket clients against the same app, which evict each
+        other in a 1000 bye loop until all go offline.
+        """
+        class _FeishuAdapter:
+            def __init__(self):
+                self._app_id = "cli_a1b2c3"
+                self._app_secret = "top-secret"
+
+        fp1 = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter())
+        fp2 = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter())
+
+        assert fp1 is not None
+        assert fp1 == fp2  # same app -> same fingerprint -> conflict detected
+        assert "cli_a1b2c3" not in fp1  # log-safe, never the raw credential
+
+    def test_distinct_feishu_app_ids_distinct_fp(self):
+        class _FeishuAdapter:
+            def __init__(self, app_id):
+                self._app_id = app_id
+                self._app_secret = "s"
+
+        fp_a = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter("app-A"))
+        fp_b = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter("app-B"))
+
+        assert fp_a is not None and fp_b is not None
+        assert fp_a != fp_b
 
     def test_reads_config_token(self):
         """Adapters like Discord store token on `config`, not on self.


### PR DESCRIPTION
Closes #76793

## Problem

In multiplex mode (`multiplex_profiles: true`), the same-credential conflict guard does not cover platforms that authenticate with an `app_id` / `app_secret` pair (Feishu/Lark). When several served profiles each carry the same Feishu credentials, every profile starts its own Feishu WebSocket client against the **same app**. Feishu only allows one active WebSocket connection per app, so the clients evict each other in a rapid `1000 bye` loop until all disconnect and stop reconnecting — the gateway then silently stops receiving inbound Feishu messages while the process stays `active (running)`.

Telegram is protected (duplicated bot tokens are detected and refused); Feishu is not, because its credential is not included in the fingerprint.

## Root cause

`_adapter_credential_fingerprint` (`gateway/run.py`) inspects only token-style attributes (`token`, `bot_token`, `_token`, `api_token`, `_bot_token`, `_project_secret`). The Feishu adapter stores its credential as `self._app_id` / `self._app_secret` (`plugins/platforms/feishu/adapter.py`), so the fingerprint returns `None` and the conflict check is silently skipped — every profile's Feishu adapter starts.

Easy to hit in practice because `hermes profile create --clone` copies the source profile's `.env` (including `FEISHU_APP_ID` / `FEISHU_APP_SECRET`) into every cloned profile.

## Fix

Add `_app_id` to the fingerprint attribute list. `app_id` is stable, log-safe, and already used as the adapter's `_app_lock_identity` — it identifies the Feishu app, of which only one WebSocket connection may be active. Two profiles claiming the same `app_id` now produce the same fingerprint and the existing guard refuses the duplicate, exactly as it does for Telegram bot tokens.

## Tests

- `test_reads_feishu_app_id` — same `_app_id` on two adapters yields the same fingerprint (conflict detected), and the raw credential never appears in the fingerprint.
- `test_distinct_feishu_app_ids_distinct_fp` — different apps yield different fingerprints.

Suite: `tests/gateway/test_multiplex_adapter_registry.py` (16 passed).
