### PR TITLE
fix(cli): idempotent profile override on double import (#76704)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -640,7 +640,22 @@ def _apply_profile_override() -> None:
     # would silently redirect the default gateway into that profile — yielding a
     # duplicate gateway for the active profile and no real default gateway. See
     # the "Docker & Profiles & Dashboard" report.
-    if profile_name is None and not os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
+    #
+    # EXCEPTION 2: once an override has been applied in this process, the
+    # sticky fallback must not re-run. `python -m hermes_cli.main` executes the
+    # module body twice — first as __main__, then again under its real name
+    # when plugin discovery does `from hermes_cli.main import _AUX_TASKS`
+    # (hermes_cli/plugins.py). The second execution sees argv already stripped
+    # of -p, so without this guard it would re-read active_profile and silently
+    # re-home the process onto the sticky profile mid-boot (issue #76704).
+    # HERMES_PROFILE_OVERRIDE_APPLIED is set at the end of this function on
+    # first application and survives the re-execution (a module-level global
+    # would not — the second execution builds a fresh module namespace).
+    if (
+        profile_name is None
+        and not os.environ.get("HERMES_S6_SUPERVISED_CHILD")
+        and not os.environ.get("HERMES_PROFILE_OVERRIDE_APPLIED")
+    ):
         try:
             from hermes_constants import get_default_hermes_root
 
@@ -675,6 +690,15 @@ def _apply_profile_override() -> None:
             )
             return
         os.environ["HERMES_HOME"] = hermes_home
+        # Idempotence guard (issue #76704): mark the override as applied so a
+        # re-execution of this module body (the `python -m hermes_cli.main`
+        # double-import, or any re-run of the body in this process) skips the
+        # sticky active_profile fallback above. The flag lives in the process
+        # environment because it must survive module re-execution; it is NOT
+        # keyed by PID because os.execvpe preserves the PID and a deliberate
+        # re-exec that carries an explicit -p (e.g. the dashboard reroute)
+        # must still apply it — step 1 above is never suppressed.
+        os.environ["HERMES_PROFILE_OVERRIDE_APPLIED"] = "1"
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0 and profile_index is not None:
             start = profile_index + 1  # +1 because argv is sys.argv[1:]

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -41,6 +41,11 @@ def _run_apply_profile_override(
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
 
+    # _apply_profile_override sets HERMES_PROFILE_OVERRIDE_APPLIED via a
+    # direct os.environ write (which monkeypatch cannot undo), so each test
+    # must start from a clean slate or the flag leaks across tests.
+    monkeypatch.delenv("HERMES_PROFILE_OVERRIDE_APPLIED", raising=False)
+
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
     from hermes_cli.main import _apply_profile_override
@@ -97,6 +102,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         monkeypatch.setattr(Path, "home", lambda: root_home)
         monkeypatch.setenv("SUDO_USER", "hermes")
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE_OVERRIDE_APPLIED", raising=False)
         monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
         monkeypatch.setattr(sys, "argv", ["hermes", "-p", "elias", "gateway", "install", "--system"])
 
@@ -154,8 +160,97 @@ class TestSupervisedChildIgnoresStickyProfile:
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE_OVERRIDE_APPLIED", raising=False)
         monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
         monkeypatch.setattr(sys, "argv", ["hermes", "-p", "coder", "gateway", "run"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        assert result.endswith("coder")
+
+
+class TestDoubleImportIdempotenceGuard:
+    """Regression guard for issue #76704.
+
+    ``python -m hermes_cli.main`` executes the module body twice: first as
+    ``__main__``, then again under its real name when plugin discovery does
+    ``from hermes_cli.main import _AUX_TASKS``. The second execution sees
+    argv already stripped of ``-p``, so without an idempotence guard it
+    re-reads the sticky ``active_profile`` and silently re-homes the process
+    onto that profile mid-boot. The guard is an environment flag set on
+    first application and checked before the sticky fallback re-runs.
+    """
+
+    def test_double_import_second_execution_does_not_rehome(
+        self, tmp_path, monkeypatch
+    ):
+        """Simulate the ``-m`` double-import: first execution pins the
+        profile from argv, second execution (argv already stripped) must NOT
+        re-home onto the sticky active_profile."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("briefer")
+        (hermes_root / "profiles" / "briefer").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE_OVERRIDE_APPLIED", raising=False)
+
+        from hermes_cli.main import _apply_profile_override
+
+        # Execution #1 — module body as __main__: argv still carries -p.
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "-p", "default", "gateway", "run"]
+        )
+        _apply_profile_override()
+        assert os.environ["HERMES_HOME"] == str(hermes_root), (
+            "-p default must pin the root hermes home"
+        )
+        assert sys.argv == ["hermes", "gateway", "run"], "-p must be stripped"
+
+        # Execution #2 — module body re-executed under its real name:
+        # argv no longer carries -p. Must NOT fall back to the sticky
+        # active_profile (briefer) and re-home the process.
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "run"])
+        _apply_profile_override()
+        assert os.environ["HERMES_HOME"] == str(hermes_root), (
+            "second module execution must not re-home onto active_profile"
+        )
+
+    def test_sticky_fallback_still_applies_on_first_run(self, tmp_path, monkeypatch):
+        """A fresh process (no -p, no env flag) must still follow the sticky
+        active_profile — the guard is scoped to re-executions only."""
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="briefer",
+            argv=["hermes", "gateway", "run"],
+        )
+        assert result is not None
+        assert result.endswith("briefer")
+
+    def test_explicit_flag_wins_even_when_override_already_applied(
+        self, tmp_path, monkeypatch
+    ):
+        """A deliberate re-exec (os.execvpe preserves env and PID) that
+        carries an explicit ``-p`` must still apply it — the guard only
+        suppresses the sticky fallback, never an explicit flag."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("briefer")
+        (hermes_root / "profiles" / "briefer").mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "coder").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("HERMES_PROFILE_OVERRIDE_APPLIED", "1")
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "-p", "coder", "gateway", "run"]
+        )
 
         from hermes_cli.main import _apply_profile_override
         _apply_profile_override()


### PR DESCRIPTION
Closes #76704

## Problem

`python -m hermes_cli.main` double-imports the module: the body runs once as `__main__`, then a second time under its real name when plugin discovery does `from hermes_cli.main import _AUX_TASKS` (`hermes_cli/plugins.py`). The second execution runs `_apply_profile_override()` with `-p` already stripped from argv, so step 1.5 distrusts the root `HERMES_HOME`, step 2 re-reads the sticky `active_profile`, and the process is silently re-homed onto that profile mid-boot.

## Fix

Make `_apply_profile_override()` idempotent across module re-execution:

- An environment flag `HERMES_PROFILE_OVERRIDE_APPLIED` is set on first application (whenever `HERMES_HOME` is resolved and set). It survives module re-execution, which a module-level global cannot (the second execution builds a fresh module namespace).
- The flag suppresses only the sticky `active_profile` fallback (step 2) — the sole step that can change the process's profile identity without anyone asking. An explicit `-p` in argv (step 1) always wins and stays unguarded, so the deliberate dashboard re-exec (`os.execvpe` preserves env and PID) keeps working unchanged.
- The flag is intentionally **not** keyed by PID: `os.execvpe` preserves the PID, so a PID-keyed sentinel would wrongly suppress the legitimate re-exec's own override.

## Tests

- `test_double_import_second_execution_does_not_rehome`: simulates the `-m` shape (first execution pins the profile from argv, second execution sees stripped argv) and asserts the pin survives — fails on current main, passes with the fix.
- `test_sticky_fallback_still_applies_on_first_run`: a fresh process still follows `active_profile`.
- `test_explicit_flag_wins_even_when_override_already_applied`: a re-exec carrying explicit `-p` still applies it.

All 7 tests in `tests/hermes_cli/test_apply_profile_override.py` pass (4 pre-existing + 3 new), plus the related `test_dashboard_unified_launch.py` (2) and `test_gateway_command_line_matcher.py` (17).
