### PR TITLE
fix(gateway): fingerprint Feishu app_id for multiplex conflict detection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13117,6 +13117,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # of a bot token. Including its secret keeps multiplexed profiles
             # from spawning competing sidecars for the same account and port.
             "_project_secret",
+            # App-id / client-id auth (no single bot token). Prefer stable
+            # non-secret identities so multiplexed profiles cannot spawn
+            # competing clients for the same exclusive connection.
+            # Feishu/Lark + QQ Bot: one active WS (or gateway session) per app.
+            "_app_id",
+            # DingTalk + Teams: client_id identifies the exclusive app.
+            "_client_id",
+            # WeCom: bot_id identifies the exclusive bot.
+            "_bot_id",
+            # WhatsApp Cloud: phone_number_id is the exclusive Graph identity.
+            "_phone_number_id",
         ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -39,6 +39,57 @@ class TestCredentialFingerprint:
         assert fp1 is not None
         assert "shared-project-secret" not in fp1
 
+    def test_reads_feishu_app_id(self):
+        """Feishu/Lark store app_id (not a bot token); multiplex must see it.
+
+        Without this, every cloned profile with the same FEISHU_APP_ID returns
+        None here, the same-credential conflict check is skipped, and N
+        WebSocket clients fight for the single allowed connection per app.
+        """
+        class _FeishuAdapter:
+            def __init__(self, app_id):
+                self._app_id = app_id
+
+        fp1 = GatewayRunner._adapter_credential_fingerprint(
+            _FeishuAdapter("cli_a1b2c3d4e5f6g7h8")
+        )
+        fp2 = GatewayRunner._adapter_credential_fingerprint(
+            _FeishuAdapter("cli_a1b2c3d4e5f6g7h8")
+        )
+
+        assert fp1 == fp2
+        assert fp1 is not None
+        assert "cli_a1b2c3d4e5f6g7h8" not in fp1
+
+    def test_distinct_app_ids_distinct_fp(self):
+        class _FeishuAdapter:
+            def __init__(self, app_id):
+                self._app_id = app_id
+
+        a = GatewayRunner._adapter_credential_fingerprint(
+            _FeishuAdapter("cli_aaaaaaaaaaaaaaaa")
+        )
+        b = GatewayRunner._adapter_credential_fingerprint(
+            _FeishuAdapter("cli_bbbbbbbbbbbbbbbb")
+        )
+        assert a is not None and b is not None
+        assert a != b
+
+    def test_reads_client_id_and_bot_id(self):
+        class _ClientIdAdapter:
+            def __init__(self, client_id):
+                self._client_id = client_id
+
+        class _BotIdAdapter:
+            def __init__(self, bot_id):
+                self._bot_id = bot_id
+
+        assert GatewayRunner._adapter_credential_fingerprint(
+            _ClientIdAdapter("ding-client-id")
+        ) is not None
+        assert GatewayRunner._adapter_credential_fingerprint(
+            _BotIdAdapter("wecom-bot-id")
+        ) is not None
 
     def test_reads_config_token(self):
         """Adapters like Discord store token on `config`, not on self.


### PR DESCRIPTION
## Summary
- Extend `_adapter_credential_fingerprint` to probe stable non-secret identity attrs (`_app_id`, `_client_id`, `_bot_id`, `_phone_number_id`) so multiplexed profiles cannot spawn competing clients for the same exclusive app/bot connection.
- Feishu/Lark previously returned `None` (credentials live on `_app_id` / `_app_secret`, not token-like attrs), so the same-credential claim path was skipped and N WebSocket clients fought for one Feishu app.
- Add unit tests under `TestCredentialFingerprint` covering same/distinct `_app_id` fingerprints plus `_client_id` / `_bot_id` coverage.

Fixes #76793

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -q` (17 passed)
- [ ] With `multiplex_profiles: true`, clone a profile that shares `FEISHU_APP_ID` and restart the gateway — secondary profile should refuse the duplicate Feishu adapter (same pattern as Telegram token conflict)
- [ ] Distinct Feishu `app_id`s across profiles still start independently