### PR TITLE
fix(gateway): add Feishu _app_id to multiplex credential fingerprint (#76793)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13117,6 +13117,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # of a bot token. Including its secret keeps multiplexed profiles
             # from spawning competing sidecars for the same account and port.
             "_project_secret",
+            # Feishu/Lark authenticates with app_id/app_secret. Only one
+            # active WebSocket connection per app is allowed; without this,
+            # cloned profiles each start their own WS client and evict each
+            # other in a 1000-bye loop until all disconnect. (#76793)
+            "_app_id",
         ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():


### PR DESCRIPTION
Fixes #76793

## Summary

The multiplex credential-conflict guard (`_adapter_credential_fingerprint`) only inspects `token`/`bot_token`/`_token`/`api_token`/`_bot_token`/`_project_secret`. Feishu/Lark authenticates with `app_id`/`app_secret` stored as `_app_id`/`_app_secret` on the adapter — neither matches the fingerprint list, so cloned profiles each start their own WebSocket client against the same Feishu app. Feishu's server allows only one active WS connection per app, causing a 1000-bye eviction loop until all disconnect and the gateway silently stops receiving Feishu messages.

## Fix

Add `_app_id` to the fingerprint attribute list in `GatewayRunner._adapter_credential_fingerprint` (gateway/run.py). This makes the existing claim/conflict path reject duplicate Feishu adapters — matching the behavior already in place for Telegram bot tokens, Discord tokens, and Photon project secrets.

## Test Plan

- [ ] Verified `_app_id` is the correct attribute name on the Feishu adapter (line 1619)
- [ ] Single-line addition to the attribute list — zero regression risk
- [ ] Existing multiplex credential-fingerprint tests still pass