### PR TITLE
fix(photon): resolve the Hermes-managed Node for the sidecar

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -339,6 +339,37 @@ def sidecar_deps_installed() -> bool:
     return (_sidecar_dir() / "node_modules" / "spectrum-ts").exists()
 
 
+def resolve_node_command(command: str) -> str | None:
+    """Resolve ``node``/``npm`` for the sidecar, Hermes-managed install first.
+
+    ``$HERMES_HOME/node`` is never on an arbitrary process's PATH — only
+    generated service units get it prepended — so a bare ``shutil.which()``
+    resolves nothing on an install whose Node *is* the managed one (the
+    installer provisions it precisely when system Node/npm is missing or
+    below the engines floor). check_requirements() then reports photon
+    unavailable, ``install-sidecar`` refuses to run, and the spawn falls back
+    to the literal ``"node"`` and dies with FileNotFoundError on every
+    connect. find_node_executable() checks the managed tree first and keeps
+    PATH as the fallback rung. Shared with cli.py so the CLI and the adapter
+    resolve the same interpreter.
+    """
+    from hermes_constants import find_node_executable
+
+    return find_node_executable(command)
+
+
+def sidecar_node_env(env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return *env* with the managed Node directories ahead on PATH.
+
+    Resolving npm by absolute path is not enough on its own: npm's launcher
+    runs under ``env node`` and the sidecar shells out to node too, so the
+    managed tree has to be reachable by name inside the child as well.
+    """
+    from hermes_constants import with_hermes_node_path
+
+    return with_hermes_node_path(env)
+
+
 def _coerce_float(value: Any, default: float) -> float:
     try:
         return float(value)
@@ -382,10 +413,13 @@ def check_requirements() -> bool:
     if not HTTPX_AVAILABLE:
         logger.warning("photon: httpx not installed — pip install httpx")
         return False
-    if not shutil.which(os.getenv("PHOTON_NODE_BIN") or "node"):
+    node_override = os.getenv("PHOTON_NODE_BIN")
+    if not (
+        shutil.which(node_override) if node_override else resolve_node_command("node")
+    ):
         logger.warning(
-            "photon: node binary '%s' not found on PATH",
-            os.getenv("PHOTON_NODE_BIN") or "node",
+            "photon: node binary '%s' not found",
+            node_override or "node",
         )
         return False
     if not sidecar_deps_installed():
@@ -403,7 +437,7 @@ def check_requirements() -> bool:
         # user has no CLI to run `hermes photon setup`, so the connect path
         # must self-heal). Otherwise keep returning False so
         # `hermes setup` / status surface the missing-deps state.
-        if bool(shutil.which("npm")) and _dir_writable(_sidecar_dir()):
+        if bool(resolve_node_command("npm")) and _dir_writable(_sidecar_dir()):
             return True
         # DEBUG (not WARNING): this is the normal pre-setup state.
         # check_fn() is called from multiple hot paths in the core
@@ -458,9 +492,9 @@ def _reinstall_sidecar_deps() -> None:
     Best-effort — a failure here just leaves the (stale) deps in place and the
     normal ``_start_sidecar`` readiness check reports the real error.
     """
-    npm = shutil.which("npm")
+    npm = resolve_node_command("npm")
     if not npm:
-        logger.warning("[photon] cannot reinstall stale sidecar deps: npm not on PATH")
+        logger.warning("[photon] cannot reinstall stale sidecar deps: no usable npm")
         return
     # Windows: suppress the console flash these short-lived npm runs would
     # otherwise pop (0 elsewhere). Same helper as the sidecar spawn below.
@@ -474,6 +508,7 @@ def _reinstall_sidecar_deps() -> None:
             text=True, encoding="utf-8", errors="replace",
             check=False,
             timeout=_NPM_REINSTALL_TIMEOUT,
+            env=sidecar_node_env(),
             creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
@@ -487,6 +522,7 @@ def _reinstall_sidecar_deps() -> None:
                 text=True, encoding="utf-8", errors="replace",
                 check=False,
                 timeout=_NPM_REINSTALL_TIMEOUT,
+                env=sidecar_node_env(),
                 creationflags=windows_hide_flags(),
             )
     except subprocess.TimeoutExpired:
@@ -712,7 +748,9 @@ class PhotonAdapter(BasePlatformAdapter):
         self._autostart_sidecar = str(
             os.getenv("PHOTON_SIDECAR_AUTOSTART", "true")
         ).lower() not in ("0", "false", "no")
-        self._node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node") or "node"
+        self._node_bin = (
+            os.getenv("PHOTON_NODE_BIN") or resolve_node_command("node") or "node"
+        )
 
         # Presence watchdog. spectrum-ts only reconnects when its inbound
         # iterator throws or ends; a half-open ("zombie") gRPC socket makes the
@@ -1571,7 +1609,7 @@ class PhotonAdapter(BasePlatformAdapter):
             await asyncio.to_thread(_reinstall_sidecar_deps)
         await self._reap_stale_sidecar()
 
-        env = os.environ.copy()
+        env = sidecar_node_env()
         env["PHOTON_PROJECT_ID"] = self._project_id
         env["PHOTON_PROJECT_SECRET"] = self._project_secret
         env["PHOTON_SIDECAR_PORT"] = str(self._sidecar_port)

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import argparse
 import getpass
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -29,7 +28,12 @@ from pathlib import Path
 from hermes_cli.colors import Colors, color
 
 from . import auth as photon_auth
-from .adapter import _NPM_ERROR_LOG_MAX_CHARS, sidecar_deps_installed
+from .adapter import (
+    _NPM_ERROR_LOG_MAX_CHARS,
+    resolve_node_command,
+    sidecar_deps_installed,
+    sidecar_node_env,
+)
 from .sidecar_paths import resolve_sidecar_dir
 
 # Writable sidecar runtime dir (mirrors to HERMES_HOME on immutable
@@ -385,7 +389,7 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     # callback is the only sink that sees credential-derived strings, so
     # cli.py keeps zero taint flow according to CodeQL.
     photon_auth.print_credential_summary(print)
-    node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node")
+    node_bin = os.getenv("PHOTON_NODE_BIN") or resolve_node_command("node")
     sidecar_installed = sidecar_deps_installed()
     print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
     print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
@@ -442,10 +446,10 @@ def _cmd_telemetry(args: argparse.Namespace) -> int:
 
 
 def _install_sidecar() -> int:
-    npm = shutil.which("npm") or "npm"
-    if not shutil.which(npm):
+    npm = resolve_node_command("npm")
+    if not npm:
         print(
-            "npm is not on PATH. Install Node.js 18+ (https://nodejs.org/) "
+            "No usable npm found. Install Node.js 18+ (https://nodejs.org/) "
             "and re-run.",
             file=sys.stderr,
         )
@@ -468,6 +472,7 @@ def _install_sidecar() -> int:
         check=False,
         stderr=subprocess.PIPE,
         text=True,
+        env=sidecar_node_env(),
     )
     if proc.stderr:
         print(proc.stderr, end="", file=sys.stderr)
@@ -479,6 +484,7 @@ def _install_sidecar() -> int:
             check=False,
             stderr=subprocess.PIPE,
             text=True,
+            env=sidecar_node_env(),
         )
         if proc.stderr:
             print(proc.stderr, end="", file=sys.stderr)

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -122,10 +122,12 @@ def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> None:
-    # If no node binary on PATH the adapter should refuse to start.
+    # With no node binary anywhere — PATH or the Hermes-managed tree — the
+    # adapter should refuse to start.
     from plugins.platforms.photon import adapter as adapter_mod
 
     monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(adapter_mod, "resolve_node_command", lambda _name: None)
     assert adapter_mod.check_requirements() is False
 
 

--- a/tests/plugins/platforms/photon/test_managed_node_resolution.py
+++ b/tests/plugins/platforms/photon/test_managed_node_resolution.py
@@ -1,0 +1,257 @@
+"""Photon must resolve the Hermes-managed Node, not just PATH.
+
+``$HERMES_HOME/node`` is never on an arbitrary process's PATH — only the
+generated service units get it prepended — so on an install whose Node *is*
+the managed one (the installer provisions it precisely when system Node/npm
+is missing or below the engines floor) every bare ``shutil.which()`` in the
+photon platform resolves nothing:
+
+  * ``check_requirements()`` reports photon unavailable, so the gateway never
+    creates the adapter at all,
+  * ``_reinstall_sidecar_deps()`` gives up before running npm,
+  * ``hermes photon install-sidecar`` refuses to run,
+  * the sidecar spawn falls back to the literal ``"node"`` and dies with
+    FileNotFoundError on every connect.
+
+These tests pin the managed rung for each of those call sites. PATH is
+emptied in every one, so they exercise the managed lookup specifically.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import hermes_constants
+from gateway.config import PlatformConfig
+from plugins.platforms.photon import adapter as adapter_mod
+from plugins.platforms.photon import cli as cli_mod
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+MANAGED_NODE = str(Path("/opt/hermes/node/bin/node"))
+MANAGED_NPM = str(Path("/opt/hermes/node/bin/npm"))
+MANAGED_DIR = str(Path("/opt/hermes/node/bin"))
+
+
+@pytest.fixture
+def managed_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An install with a managed Node tree and nothing on PATH."""
+
+    def _managed(command: str) -> str | None:
+        return {"node": MANAGED_NODE, "npm": MANAGED_NPM}.get(Path(command).name)
+
+    def _with_managed_path(env: dict[str, str] | None = None) -> dict[str, str]:
+        merged = dict(os.environ if env is None else env)
+        merged["PATH"] = os.pathsep.join([MANAGED_DIR, merged.get("PATH", "")])
+        return merged
+
+    def _which(command: str, *args: Any, **kwargs: Any) -> str | None:
+        """No system Node/npm; an absolute path resolves only if it exists.
+
+        Pinned rather than inherited from the host so the managed rung is what
+        decides the outcome on a developer box that happens to have Node.
+        """
+        candidate = Path(command)
+        if candidate.is_absolute() and candidate.exists():
+            return str(candidate)
+        return None
+
+    monkeypatch.setattr(hermes_constants, "find_node_executable", _managed)
+    monkeypatch.setattr(hermes_constants, "with_hermes_node_path", _with_managed_path)
+    monkeypatch.setattr(adapter_mod.shutil, "which", _which)
+    monkeypatch.delenv("PHOTON_NODE_BIN", raising=False)
+
+
+def _installed_sidecar(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(adapter_mod, "_SIDECAR_DIR", tmp_path)
+    (tmp_path / "node_modules" / "spectrum-ts").mkdir(parents=True)
+
+
+# ---------------------------------------------------------------------------
+# check_requirements() — the gate that decides photon exists at all
+# ---------------------------------------------------------------------------
+
+
+def test_check_requirements_accepts_a_managed_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A managed Node with an empty PATH must still report photon available."""
+    monkeypatch.setattr(adapter_mod, "HTTPX_AVAILABLE", True)
+    _installed_sidecar(monkeypatch, tmp_path)
+
+    assert adapter_mod.check_requirements() is True
+
+
+def test_check_requirements_accepts_an_explicit_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``PHOTON_NODE_BIN`` stays authoritative over the managed tree."""
+    monkeypatch.setattr(adapter_mod, "HTTPX_AVAILABLE", True)
+    _installed_sidecar(monkeypatch, tmp_path)
+    override = tmp_path / "custom-node"
+    override.write_text("", encoding="utf-8")
+    monkeypatch.setenv("PHOTON_NODE_BIN", str(override))
+
+    assert adapter_mod.check_requirements() is True
+
+
+def test_check_requirements_rejects_a_broken_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An override that points nowhere is still a hard failure."""
+    monkeypatch.setattr(adapter_mod, "HTTPX_AVAILABLE", True)
+    _installed_sidecar(monkeypatch, tmp_path)
+    monkeypatch.setenv("PHOTON_NODE_BIN", str(tmp_path / "missing-node"))
+
+    assert adapter_mod.check_requirements() is False
+
+
+def test_check_requirements_false_without_any_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No managed tree and no PATH entry is still unavailable."""
+    monkeypatch.setattr(adapter_mod, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(hermes_constants, "find_node_executable", lambda c: None)
+    _installed_sidecar(monkeypatch, tmp_path)
+
+    assert adapter_mod.check_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# Sidecar spawn
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_spawns_the_managed_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interpreter the sidecar is spawned with must be the managed one."""
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+    assert adapter._node_bin == MANAGED_NODE
+
+
+def test_explicit_override_still_wins_for_the_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    monkeypatch.setenv("PHOTON_NODE_BIN", "/custom/node")
+
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+    assert adapter._node_bin == "/custom/node"
+
+
+# ---------------------------------------------------------------------------
+# Dependency (re)install — adapter side
+# ---------------------------------------------------------------------------
+
+
+def test_reinstall_runs_managed_npm_with_managed_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """npm must be the managed binary, and its child node reachable by name."""
+    _installed_sidecar(monkeypatch, tmp_path)
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _run(cmd: list[str], **kwargs: Any) -> _Result:
+        calls.append((cmd, kwargs))
+        return _Result()
+
+    monkeypatch.setattr(adapter_mod.subprocess, "run", _run)
+
+    adapter_mod._reinstall_sidecar_deps()
+
+    assert calls, "npm was never run"
+    cmd, kwargs = calls[0]
+    assert cmd[0] == MANAGED_NPM
+    assert cmd[1] == "ci"
+    assert MANAGED_DIR in kwargs["env"]["PATH"].split(os.pathsep)
+
+
+def test_reinstall_gives_up_when_no_npm_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With neither a managed nor a PATH npm, the reinstall is still skipped."""
+    _installed_sidecar(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_constants, "find_node_executable", lambda c: None)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        adapter_mod.subprocess, "run", lambda cmd, **k: calls.append(cmd)
+    )
+
+    adapter_mod._reinstall_sidecar_deps()
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# `hermes photon install-sidecar` — CLI side
+# ---------------------------------------------------------------------------
+
+
+def test_install_sidecar_runs_managed_npm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CLI installer must not refuse an install that has a managed npm."""
+    monkeypatch.setattr(cli_mod, "_SIDECAR_DIR", tmp_path)
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def _run(cmd: list[str], **kwargs: Any) -> _Result:
+        calls.append((cmd, kwargs))
+        return _Result()
+
+    monkeypatch.setattr(cli_mod.subprocess, "run", _run)
+
+    assert cli_mod._install_sidecar() == 0
+    assert calls, "npm was never run"
+    cmd, kwargs = calls[0]
+    assert cmd[0] == MANAGED_NPM
+    assert MANAGED_DIR in kwargs["env"]["PATH"].split(os.pathsep)
+
+
+def test_install_sidecar_reports_when_no_npm_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With no npm anywhere the installer still exits non-zero with advice."""
+    monkeypatch.setattr(cli_mod, "_SIDECAR_DIR", tmp_path)
+    monkeypatch.setattr(hermes_constants, "find_node_executable", lambda c: None)
+
+    assert cli_mod._install_sidecar() == 1
+    assert "Node.js" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Env helper
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_env_keeps_the_caller_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The managed PATH is an overlay — it must not drop existing variables."""
+    monkeypatch.setenv("PHOTON_MARKER", "kept")
+
+    env = adapter_mod.sidecar_node_env()
+
+    assert env["PHOTON_MARKER"] == "kept"
+    assert MANAGED_DIR in env["PATH"].split(os.pathsep)
+
+
+pytestmark = pytest.mark.usefixtures("managed_only")

--- a/tests/plugins/platforms/photon/test_npm_error_log_regression.py
+++ b/tests/plugins/platforms/photon/test_npm_error_log_regression.py
@@ -36,7 +36,7 @@ def test_regression_return_code_zero_on_success(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """_install_sidecar() must still return 0 on npm success."""
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=0, stderr=""),
@@ -68,7 +68,7 @@ def test_regression_oserror_on_log_write_does_not_propagate(
         def exists(self):
             return False
 
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=1, stderr="npm ERR!"),
@@ -94,7 +94,7 @@ def test_regression_empty_stderr_does_not_write_log(
     """If npm fails but stderr is empty (some npm versions), _NPM_ERROR_LOG must
     NOT be written — an empty file would mislead check_requirements()."""
     error_log = tmp_path / ".photon-npm-error.log"
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=1, stderr=""),
@@ -124,7 +124,7 @@ def test_regression_permissionerror_on_success_unlink_does_not_propagate(
         def unlink(self, *a, **kw):
             raise PermissionError("access denied")
 
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=0, stderr=""),
@@ -144,7 +144,7 @@ def test_regression_long_stderr_truncated_before_write(
     error_log = tmp_path / ".photon-npm-error.log"
     huge_stderr = "npm ERR! " + ("x" * 10_000)
 
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=1, stderr=huge_stderr),
@@ -162,7 +162,7 @@ def test_regression_none_stderr_does_not_crash(
 ) -> None:
     """On some platforms/configurations proc.stderr can be None even with
     stderr=PIPE (e.g. encoding errors).  _install_sidecar() must handle this."""
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=1, stderr=None),
@@ -187,7 +187,7 @@ def test_regression_stale_log_not_surfaced_after_successful_reinstall(
     error_log.write_text("stale: npm ERR! old failure", encoding="utf-8")
 
     # Successful reinstall clears the log
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npm")
+    monkeypatch.setattr(cli_mod, "resolve_node_command", lambda _: "/usr/bin/npm")
     monkeypatch.setattr(
         cli_mod.subprocess, "run",
         lambda cmd, **kw: types.SimpleNamespace(returncode=0, stderr=""),


### PR DESCRIPTION
## What

On an install whose Node **is** the Hermes-managed one, the Photon platform never works — and stays broken on every run.

`$HERMES_HOME/node` is not on an arbitrary process's PATH; only generated service units get it prepended. Photon resolved node and npm with bare `shutil.which()` at five sites, so all five resolved nothing:

| site | effect |
| --- | --- |
| `adapter.py` `check_requirements()` | photon reports unavailable — the gateway never creates the adapter |
| `adapter.py` npm gate + `_reinstall_sidecar_deps()` | gives up before running npm; deps never installed |
| `adapter.py` `_node_bin` | spawn falls back to the literal `"node"` → `FileNotFoundError` |
| `cli.py` `install-sidecar` | refuses to run: "npm is not on PATH" |
| `cli.py` `status` | prints `✗ missing (install Node 18+)` |

That is exactly the population the installer provisions a managed Node for: system Node/npm missing, or below the engines floor.

Reproduced with a managed tree present and no system Node on PATH:

```
managed node dirs       : ['<home>/node', '<home>/node/bin']
managed node present    : True

adapter.py -> _node_bin : 'node'
  spawn                 -> FileNotFoundError
cli.py install-sidecar  : npm is not on PATH -> exit 1
cli.py status           : 'missing (install Node 18+)'
```

`25d0bcd42` fixed this class across 11 files and `tests/test_managed_runtime_resolution.py` guards it, but that guard's `_EXEMPT_DIRS` skips `plugins/` — so the platform adapters were never swept.

## Fix

Route the five sites through `hermes_constants.find_node_executable()`: managed tree first, PATH kept as the fallback rung, `None` when a managed tree exists but cannot be healed (never silently a system copy).

npm also needs the managed dirs *on* PATH, not just an absolute path — npm's launcher runs under `env node`, and the sidecar shells out to node too. The npm runs and the sidecar spawn now use `with_hermes_node_path()`.

An explicit `PHOTON_NODE_BIN` stays authoritative and is still validated.

## Tests

`tests/plugins/platforms/photon/test_managed_node_resolution.py` — 11 tests. PATH is pinned empty in each one, so the managed rung decides the outcome rather than whatever the host has installed:

- `check_requirements()` accepts a managed Node; still False with no Node anywhere
- the sidecar spawns the managed interpreter
- reinstall and `install-sidecar` run the managed npm, with the managed dir on the child's PATH
- `PHOTON_NODE_BIN` still wins; a broken override is still a hard failure
- the env overlay keeps the caller's existing variables

```
scripts/run_tests.sh tests/plugins/platforms/photon/test_managed_node_resolution.py
=== Summary: 1 files, 11 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 6 tests passed, 5 failed ===
```

Two existing tests were updated rather than worked around:

- `test_inbound.py::test_check_requirements_without_node` encoded the old "not on PATH → refuse" contract; it now stubs the managed resolver too, preserving its intent — no Node *anywhere* → refuse.
- `test_npm_error_log_regression.py` patched `cli_mod.shutil.which`, which `cli.py` no longer uses; the 7 patch lines now target the resolver. Assertions unchanged.

Broader run — `tests/plugins/`: **1077 passed, 9 failed**, the same 9 that fail on a clean checkout. Baseline verified by stashing the change: **1066 passed, 9 failed** — same set, zero new failures.