### PR TITLE
fix(delegation): surface a child's undelivered steer instead of dropping it

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4748,6 +4748,58 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
 
+def test_run_prompt_submit_binds_exact_steer_authority_and_resets_contextvars(
+    monkeypatch, tmp_path
+):
+    """The turn thread commissions children with this session generation only."""
+    from tools.delegate_tool import _capture_gateway_steer_authority
+    from tui_gateway.transport import (
+        bind_transport,
+        current_transport,
+        reset_transport,
+    )
+
+    class _Transport:
+        def write(self, _obj):
+            return True
+
+        def close(self):
+            return None
+
+    observed = {}
+    owner_transport = _Transport()
+    previous_transport = _Transport()
+    previous_record = {"session_key": "previous-generation"}
+
+    class _CapturingAgent(_RecordingAgent):
+        def run_conversation(self, prompt, **kwargs):
+            authority = _capture_gateway_steer_authority("sid-owner")
+            observed["transport"] = authority[0]
+            observed["record"] = authority[1]
+            return super().run_conversation(prompt, **kwargs)
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    session = _session(
+        session_key="session-owner",
+        agent=_CapturingAgent([]),
+        running=True,
+        transport=owner_transport,
+    )
+    server._sessions["sid-owner"] = session
+    transport_token = bind_transport(previous_transport)
+    record_token = server._current_runtime_session_record.set(previous_record)
+    try:
+        server._run_prompt_submit("rid-owner", "sid-owner", session, "commission")
+
+        assert observed == {"transport": owner_transport, "record": session}
+        assert current_transport() is previous_transport
+        assert server._current_runtime_session_record.get() is previous_record
+    finally:
+        server._current_runtime_session_record.reset(record_token)
+        reset_transport(transport_token)
+        server._sessions.pop("sid-owner", None)
+
+
 class _RecordingAgent:
     model = "test-model"
     provider = "test-provider"

--- a/tests/tools/test_subagent_steer.py
+++ b/tests/tools/test_subagent_steer.py
@@ -8,6 +8,9 @@ missed-steer retention race (a child that finishes before the drain) and
 the subagent.steer gateway RPC that fronts the helper.
 """
 
+import threading
+from unittest.mock import MagicMock
+
 from tools.delegate_tool import (
     _register_subagent,
     _unregister_subagent,
@@ -28,7 +31,7 @@ class _StubAgent:
         return self.accept
 
 
-def _with_registered(sid: str, agent) -> None:
+def _with_registered(sid: str, agent, *, owner_session_id: str | None = None) -> None:
     _register_subagent(
         {
             "subagent_id": sid,
@@ -37,6 +40,7 @@ def _with_registered(sid: str, agent) -> None:
             "goal": "test goal",
             "status": "running",
             "agent": agent,
+            "owner_session_id": owner_session_id,
         }
     )
 
@@ -89,6 +93,47 @@ def test_exception_in_steer_degrades_to_false():
         assert steer_subagent("sid-steer-5", "hello") is False
     finally:
         _unregister_subagent("sid-steer-5")
+
+
+def test_stale_agent_teardown_cannot_unregister_recycled_id():
+    old_agent = _StubAgent()
+    replacement = _StubAgent()
+    _with_registered("sid-recycled-teardown", old_agent, owner_session_id="old-owner")
+    _with_registered("sid-recycled-teardown", replacement, owner_session_id="new-owner")
+    try:
+        _unregister_subagent("sid-recycled-teardown", agent=old_agent)
+        assert (
+            steer_subagent(
+                "sid-recycled-teardown",
+                "replacement remains live",
+                owner_session_id="new-owner",
+            )
+            is True
+        )
+        assert old_agent.steered == []
+        assert replacement.steered == ["replacement remains live"]
+    finally:
+        _unregister_subagent("sid-recycled-teardown", agent=replacement)
+
+
+def test_status_snapshot_never_leaks_owner_or_lifecycle_metadata():
+    from tools.delegate_tool import list_active_subagents
+
+    agent = _StubAgent()
+    _with_registered("sid-private-metadata", agent, owner_session_id="private-owner")
+    try:
+        snapshot = next(
+            item
+            for item in list_active_subagents()
+            if item["subagent_id"] == "sid-private-metadata"
+        )
+        assert snapshot["status"] == "running"
+        assert "agent" not in snapshot
+        assert "owner_session_id" not in snapshot
+        assert "accepting_steer" not in snapshot
+        assert "private-owner" not in repr(snapshot)
+    finally:
+        _unregister_subagent("sid-private-metadata", agent=agent)
 
 
 class TestMissedSteerRetention:
@@ -162,6 +207,121 @@ class TestMissedSteerRetention:
         assert "missed_steer" not in entry
         assert "steer did not land" not in entry["summary"]
 
+    def test_accepted_steer_racing_completion_is_durably_retained(self):
+        """Acceptance wins the registry race, so completion must retain its text."""
+        from tools.delegate_tool import _run_single_child
+
+        running = threading.Event()
+        allow_return = threading.Event()
+        steer_entered = threading.Event()
+        allow_steer = threading.Event()
+        pending: list[str] = []
+
+        child = MagicMock()
+        child._subagent_id = "sid-linearized-accept"
+        child._delegate_depth = 1
+        child.model = "test-model"
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+
+        def run_conversation(**_kwargs):
+            running.set()
+            assert allow_return.wait(5)
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        def steer(text: str) -> bool:
+            steer_entered.set()
+            assert allow_steer.wait(5)
+            pending.append(text)
+            return True
+
+        def drain():
+            if not pending:
+                return None
+            text = "\n".join(pending)
+            pending.clear()
+            return text
+
+        child.run_conversation.side_effect = run_conversation
+        child.steer.side_effect = steer
+        child._drain_pending_steer.side_effect = drain
+        parent = MagicMock()
+
+        result_box: dict = {}
+        runner = threading.Thread(
+            target=lambda: result_box.setdefault(
+                "result",
+                _run_single_child(0, "race", child=child, parent_agent=parent),
+            )
+        )
+        runner.start()
+        assert running.wait(5)
+
+        accepted_box: dict = {}
+        steering = threading.Thread(
+            target=lambda: accepted_box.setdefault(
+                "accepted", steer_subagent(child._subagent_id, "retain this exact text")
+            )
+        )
+        steering.start()
+        assert steer_entered.wait(5)
+        allow_return.set()
+        allow_steer.set()
+        steering.join(5)
+        runner.join(5)
+
+        assert not steering.is_alive()
+        assert not runner.is_alive()
+        assert accepted_box["accepted"] is True
+        assert result_box["result"]["missed_steer"] == "retain this exact text"
+
+    def test_steer_after_run_return_is_rejected_before_completion_callback(self):
+        """Once the child returns, a blocked completion callback cannot extend acceptance."""
+        from tools.delegate_tool import _run_single_child
+
+        callback_entered = threading.Event()
+        release_callback = threading.Event()
+
+        def progress(_event: str, **_kwargs) -> None:
+            return None
+
+        def flush() -> None:
+            callback_entered.set()
+            assert release_callback.wait(5)
+
+        progress._flush = flush  # type: ignore[attr-defined]
+        child = MagicMock()
+        child._subagent_id = "sid-closed-before-callback"
+        child._delegate_depth = 1
+        child.model = "test-model"
+        child.tool_progress_callback = progress
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        runner = threading.Thread(
+            target=lambda: _run_single_child(0, "late", child=child, parent_agent=MagicMock())
+        )
+        runner.start()
+        assert callback_entered.wait(5)
+        try:
+            assert steer_subagent(child._subagent_id, "too late") is False
+            child.steer.assert_not_called()
+        finally:
+            release_callback.set()
+            runner.join(5)
+        assert not runner.is_alive()
+
 
 class TestSubagentSteerRPC:
     """subagent.steer gateway RPC — the programmatic caller beside subagent.interrupt."""
@@ -169,7 +329,16 @@ class TestSubagentSteerRPC:
     def _call(self, params: dict) -> dict:
         import tui_gateway.server as srv
 
-        return srv._methods["subagent.steer"](1, params)
+        session_id = params.get("session_id")
+        if session_id:
+            srv._sessions[session_id] = {"session_key": session_id, "history": []}
+        try:
+            return srv.handle_request(
+                {"id": 1, "method": "subagent.steer", "params": params}
+            )
+        finally:
+            if session_id:
+                srv._sessions.pop(session_id, None)
 
     def test_missing_subagent_id_is_4000(self):
         envelope = self._call({"text": "hello"})
@@ -181,9 +350,15 @@ class TestSubagentSteerRPC:
 
     def test_live_child_queues_and_receives_text(self):
         agent = _StubAgent()
-        _with_registered("sid-rpc-2", agent)
+        _with_registered("sid-rpc-2", agent, owner_session_id="owner-session")
         try:
-            envelope = self._call({"subagent_id": "sid-rpc-2", "text": "check the edge cases"})
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-2",
+                    "text": "check the edge cases",
+                }
+            )
             assert envelope["result"] == {
                 "status": "queued",
                 "subagent_id": "sid-rpc-2",
@@ -193,6 +368,119 @@ class TestSubagentSteerRPC:
         finally:
             _unregister_subagent("sid-rpc-2")
 
+    def test_run_single_child_binds_owner_from_task_local_ui_session(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.delegate_tool import _run_single_child
+
+        observed: dict[str, bool] = {}
+        child = MagicMock()
+        child._subagent_id = "sid-context-owner"
+        child._delegate_depth = 1
+        child.model = "test-model"
+        child.steer.return_value = True
+
+        def run_conversation(**_kwargs):
+            observed["owner"] = steer_subagent(
+                child._subagent_id,
+                "owned steer",
+                owner_session_id="ui-owner",
+            )
+            observed["foreign"] = steer_subagent(
+                child._subagent_id,
+                "foreign steer",
+                owner_session_id="ui-foreign",
+            )
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = run_conversation
+        tokens = set_session_vars(
+            session_key="durable-parent",
+            session_id="durable-parent",
+            ui_session_id="ui-owner",
+        )
+        try:
+            _run_single_child(0, "owner binding", child=child, parent_agent=MagicMock())
+        finally:
+            clear_session_vars(tokens)
+
+        assert observed == {"owner": True, "foreign": False}
+        child.steer.assert_called_once_with("owned steer")
+
     def test_unknown_child_is_rejected_not_an_error(self):
-        envelope = self._call({"subagent_id": "sid-rpc-gone", "text": "hello"})
+        envelope = self._call(
+            {
+                "session_id": "owner-session",
+                "subagent_id": "sid-rpc-gone",
+                "text": "hello",
+            }
+        )
         assert envelope["result"]["status"] == "rejected"
+
+    def test_foreign_session_cannot_steer_an_owned_child(self):
+        agent = _StubAgent()
+        _with_registered("sid-rpc-foreign", agent, owner_session_id="owner-session")
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "foreign-session",
+                    "subagent_id": "sid-rpc-foreign",
+                    "text": "cross-session injection",
+                }
+            )
+            assert envelope["result"]["status"] == "rejected"
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-foreign")
+
+    def test_record_without_owner_cannot_be_steered_by_rpc(self):
+        agent = _StubAgent()
+        _with_registered("sid-rpc-owner-missing", agent)
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "claiming-session",
+                    "subagent_id": "sid-rpc-owner-missing",
+                    "text": "ambiguous authority",
+                }
+            )
+            assert envelope["result"]["status"] == "rejected"
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-owner-missing")
+
+    def test_rpc_without_invoking_session_identity_is_denied(self):
+        agent = _StubAgent()
+        _with_registered("sid-rpc-no-caller", agent, owner_session_id="owner-session")
+        try:
+            envelope = self._call(
+                {"subagent_id": "sid-rpc-no-caller", "text": "identity missing"}
+            )
+            assert envelope["error"]["code"] == 4001
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-no-caller")
+
+    def test_recycled_id_does_not_preserve_the_old_sessions_authority(self):
+        old_agent = _StubAgent()
+        new_agent = _StubAgent()
+        _with_registered("sid-rpc-recycled", old_agent, owner_session_id="old-session")
+        _with_registered("sid-rpc-recycled", new_agent, owner_session_id="new-session")
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "old-session",
+                    "subagent_id": "sid-rpc-recycled",
+                    "text": "stale generation steer",
+                }
+            )
+            assert envelope["result"]["status"] == "rejected"
+            assert old_agent.steered == []
+            assert new_agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-recycled")

--- a/tests/tools/test_subagent_steer.py
+++ b/tests/tools/test_subagent_steer.py
@@ -31,7 +31,14 @@ class _StubAgent:
         return self.accept
 
 
-def _with_registered(sid: str, agent, *, owner_session_id: str | None = None) -> None:
+def _with_registered(
+    sid: str,
+    agent,
+    *,
+    owner_session_id: str | None = None,
+    owner_transport=None,
+    owner_session_record=None,
+) -> None:
     _register_subagent(
         {
             "subagent_id": sid,
@@ -41,6 +48,8 @@ def _with_registered(sid: str, agent, *, owner_session_id: str | None = None) ->
             "status": "running",
             "agent": agent,
             "owner_session_id": owner_session_id,
+            "owner_transport": owner_transport,
+            "owner_session_record": owner_session_record,
         }
     )
 
@@ -106,7 +115,6 @@ def test_stale_agent_teardown_cannot_unregister_recycled_id():
             steer_subagent(
                 "sid-recycled-teardown",
                 "replacement remains live",
-                owner_session_id="new-owner",
             )
             is True
         )
@@ -120,7 +128,15 @@ def test_status_snapshot_never_leaks_owner_or_lifecycle_metadata():
     from tools.delegate_tool import list_active_subagents
 
     agent = _StubAgent()
-    _with_registered("sid-private-metadata", agent, owner_session_id="private-owner")
+    owner_transport = object()
+    owner_session_record = {"session_key": "private-owner"}
+    _with_registered(
+        "sid-private-metadata",
+        agent,
+        owner_session_id="private-owner",
+        owner_transport=owner_transport,
+        owner_session_record=owner_session_record,
+    )
     try:
         snapshot = next(
             item
@@ -130,8 +146,12 @@ def test_status_snapshot_never_leaks_owner_or_lifecycle_metadata():
         assert snapshot["status"] == "running"
         assert "agent" not in snapshot
         assert "owner_session_id" not in snapshot
+        assert "owner_transport" not in snapshot
+        assert "owner_session_record" not in snapshot
         assert "accepting_steer" not in snapshot
         assert "private-owner" not in repr(snapshot)
+        assert all(value is not owner_transport for value in snapshot.values())
+        assert all(value is not owner_session_record for value in snapshot.values())
     finally:
         _unregister_subagent("sid-private-metadata", agent=agent)
 
@@ -326,15 +346,31 @@ class TestMissedSteerRetention:
 class TestSubagentSteerRPC:
     """subagent.steer gateway RPC — the programmatic caller beside subagent.interrupt."""
 
-    def _call(self, params: dict) -> dict:
+    class _Transport:
+        def __init__(self) -> None:
+            self.frames: list[dict] = []
+
+        def write(self, obj: dict) -> bool:
+            self.frames.append(obj)
+            return True
+
+        def close(self) -> None:
+            return None
+
+    def _call(self, params: dict, *, transport=None, session_record=None) -> dict:
         import tui_gateway.server as srv
 
         session_id = params.get("session_id")
         if session_id:
-            srv._sessions[session_id] = {"session_key": session_id, "history": []}
+            srv._sessions[session_id] = session_record or {
+                "session_key": session_id,
+                "history": [],
+                "transport": transport,
+            }
         try:
-            return srv.handle_request(
-                {"id": 1, "method": "subagent.steer", "params": params}
+            return srv.dispatch(
+                {"id": 1, "method": "subagent.steer", "params": params},
+                transport=transport,
             )
         finally:
             if session_id:
@@ -349,15 +385,29 @@ class TestSubagentSteerRPC:
         assert envelope["error"]["code"] == 4002
 
     def test_live_child_queues_and_receives_text(self):
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
         agent = _StubAgent()
-        _with_registered("sid-rpc-2", agent, owner_session_id="owner-session")
+        _with_registered(
+            "sid-rpc-2",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
         try:
             envelope = self._call(
                 {
                     "session_id": "owner-session",
                     "subagent_id": "sid-rpc-2",
                     "text": "check the edge cases",
-                }
+                },
+                transport=owner_transport,
+                session_record=owner_record,
             )
             assert envelope["result"] == {
                 "status": "queued",
@@ -368,11 +418,17 @@ class TestSubagentSteerRPC:
         finally:
             _unregister_subagent("sid-rpc-2")
 
-    def test_run_single_child_binds_owner_from_task_local_ui_session(self):
+    def test_run_single_child_binds_exact_runtime_owner_artifacts(self):
         from gateway.session_context import clear_session_vars, set_session_vars
         from tools.delegate_tool import _run_single_child
 
         observed: dict[str, bool] = {}
+        owner_transport = self._Transport()
+        owner_session_record = {
+            "session_key": "durable-parent",
+            "history": [],
+            "transport": owner_transport,
+        }
         child = MagicMock()
         child._subagent_id = "sid-context-owner"
         child._delegate_depth = 1
@@ -384,11 +440,15 @@ class TestSubagentSteerRPC:
                 child._subagent_id,
                 "owned steer",
                 owner_session_id="ui-owner",
+                owner_transport=owner_transport,
+                owner_session_record=owner_session_record,
             )
             observed["foreign"] = steer_subagent(
                 child._subagent_id,
                 "foreign steer",
-                owner_session_id="ui-foreign",
+                owner_session_id="ui-owner",
+                owner_transport=self._Transport(),
+                owner_session_record=owner_session_record,
             )
             return {
                 "final_response": "done",
@@ -405,7 +465,14 @@ class TestSubagentSteerRPC:
             ui_session_id="ui-owner",
         )
         try:
-            _run_single_child(0, "owner binding", child=child, parent_agent=MagicMock())
+            _run_single_child(
+                0,
+                "owner binding",
+                child=child,
+                parent_agent=MagicMock(),
+                owner_transport=owner_transport,
+                owner_session_record=owner_session_record,
+            )
         finally:
             clear_session_vars(tokens)
 
@@ -438,16 +505,362 @@ class TestSubagentSteerRPC:
         finally:
             _unregister_subagent("sid-rpc-foreign")
 
-    def test_record_without_owner_cannot_be_steered_by_rpc(self):
+    def test_foreign_transport_with_correct_session_id_is_denied(self):
+        owner_transport = self._Transport()
+        foreign_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
         agent = _StubAgent()
-        _with_registered("sid-rpc-owner-missing", agent)
+        _with_registered(
+            "sid-rpc-foreign-transport",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-foreign-transport",
+                    "text": "stolen identifier",
+                },
+                transport=foreign_transport,
+                session_record=owner_record,
+            )
+            assert envelope["result"]["status"] == "rejected"
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-foreign-transport")
+
+    def test_recycled_session_record_with_same_id_is_denied(self):
+        owner_transport = self._Transport()
+        original_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        recycled_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-recycled-session",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=original_record,
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-recycled-session",
+                    "text": "new generation",
+                },
+                transport=owner_transport,
+                session_record=recycled_record,
+            )
+            assert envelope["result"]["status"] == "rejected"
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-recycled-session")
+
+    def test_server_resolves_exact_runtime_authority_from_dispatch_context(self):
+        import tui_gateway.server as srv
+
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        srv._sessions["owner-session"] = owner_record
+
+        def capture(rid, _params):
+            authority = srv._current_session_steer_authority("owner-session")
+            return srv._ok(
+                rid,
+                {
+                    "transport_matches": authority[0] is owner_transport,
+                    "record_matches": authority[1] is owner_record,
+                },
+            )
+
+        srv._methods["test.capture-steer-authority"] = capture
+        try:
+            envelope = srv.dispatch(
+                {
+                    "id": 1,
+                    "method": "test.capture-steer-authority",
+                    "params": {
+                        "session_id": "owner-session",
+                        "owner_transport": "spoof",
+                        "owner_session_record": "spoof",
+                    },
+                },
+                transport=owner_transport,
+            )
+        finally:
+            srv._methods.pop("test.capture-steer-authority", None)
+            srv._sessions.pop("owner-session", None)
+
+        assert envelope["result"] == {
+            "transport_matches": True,
+            "record_matches": True,
+        }
+
+    def test_delegate_capture_uses_dispatch_runtime_artifacts(self):
+        import tui_gateway.server as srv
+        from tools import delegate_tool
+
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        srv._sessions["owner-session"] = owner_record
+
+        def capture(rid, _params):
+            transport, record = delegate_tool._capture_gateway_steer_authority(
+                "owner-session"
+            )
+            return srv._ok(
+                rid,
+                {
+                    "transport_matches": transport is owner_transport,
+                    "record_matches": record is owner_record,
+                },
+            )
+
+        srv._methods["test.capture-delegate-authority"] = capture
+        try:
+            envelope = srv.dispatch(
+                {
+                    "id": 1,
+                    "method": "test.capture-delegate-authority",
+                    "params": {"session_id": "owner-session"},
+                },
+                transport=owner_transport,
+            )
+        finally:
+            srv._methods.pop("test.capture-delegate-authority", None)
+            srv._sessions.pop("owner-session", None)
+
+        assert envelope["result"] == {
+            "transport_matches": True,
+            "record_matches": True,
+        }
+
+    def test_commissioning_context_rejects_recycled_runtime_session_record(self):
+        import tui_gateway.server as srv
+        from tools import delegate_tool
+        from tui_gateway.transport import bind_transport, reset_transport
+
+        owner_transport = self._Transport()
+        original_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        recycled_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        srv._sessions["owner-session"] = recycled_record
+        transport_token = bind_transport(owner_transport)
+        record_token = srv._current_runtime_session_record.set(original_record)
+        try:
+            assert delegate_tool._capture_gateway_steer_authority("owner-session") == (
+                None,
+                None,
+            )
+        finally:
+            srv._current_runtime_session_record.reset(record_token)
+            reset_transport(transport_token)
+            srv._sessions.pop("owner-session", None)
+
+    def test_rpc_params_cannot_spoof_runtime_artifacts(self):
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-param-spoof",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
+        try:
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-param-spoof",
+                    "text": "ignore serialized capabilities",
+                    "owner_transport": self._Transport(),
+                    "owner_session_record": {"session_key": "owner-session"},
+                    "owner_token": "forged",
+                },
+                transport=owner_transport,
+                session_record=owner_record,
+            )
+            assert envelope["result"]["status"] == "queued"
+            assert agent.steered == ["ignore serialized capabilities"]
+        finally:
+            _unregister_subagent("sid-rpc-param-spoof")
+
+    def test_session_transport_rebinding_does_not_transfer_ownership(self):
+        original_transport = self._Transport()
+        rebound_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": original_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-rebound",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=original_transport,
+            owner_session_record=owner_record,
+        )
+        owner_record["transport"] = rebound_transport
+        try:
+            for transport in (original_transport, rebound_transport):
+                envelope = self._call(
+                    {
+                        "session_id": "owner-session",
+                        "subagent_id": "sid-rpc-rebound",
+                        "text": "rebound authority",
+                    },
+                    transport=transport,
+                    session_record=owner_record,
+                )
+                assert envelope["result"]["status"] == "rejected"
+            assert agent.steered == []
+        finally:
+            _unregister_subagent("sid-rpc-rebound")
+
+    def test_concurrent_sessions_cannot_cross_steer(self):
+        transports = [self._Transport(), self._Transport()]
+        records = [
+            {"session_key": f"session-{i}", "history": [], "transport": transports[i]}
+            for i in range(2)
+        ]
+        agents = [_StubAgent(), _StubAgent()]
+        for i in range(2):
+            _with_registered(
+                f"sid-concurrent-{i}",
+                agents[i],
+                owner_session_id=f"session-{i}",
+                owner_transport=transports[i],
+                owner_session_record=records[i],
+            )
+
+        barrier = threading.Barrier(2)
+        results: list[str] = []
+
+        def cross_call(caller: int) -> None:
+            barrier.wait(5)
+            envelope = self._call(
+                {
+                    "session_id": f"session-{caller}",
+                    "subagent_id": f"sid-concurrent-{1 - caller}",
+                    "text": f"cross-{caller}",
+                },
+                transport=transports[caller],
+                session_record=records[caller],
+            )
+            results.append(envelope["result"]["status"])
+
+        threads = [threading.Thread(target=cross_call, args=(i,)) for i in range(2)]
+        try:
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(5)
+            assert all(not thread.is_alive() for thread in threads)
+            assert sorted(results) == ["rejected", "rejected"]
+            assert agents[0].steered == []
+            assert agents[1].steered == []
+        finally:
+            for i in range(2):
+                _unregister_subagent(f"sid-concurrent-{i}")
+
+    def test_owner_still_works_after_unrelated_dispatch_queries(self):
+        import tui_gateway.server as srv
+
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "owner-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        agent = _StubAgent()
+        _with_registered(
+            "sid-rpc-after-query",
+            agent,
+            owner_session_id="owner-session",
+            owner_transport=owner_transport,
+            owner_session_record=owner_record,
+        )
+        srv._methods["test.unrelated-query"] = lambda rid, _params: srv._ok(
+            rid, {"ok": True}
+        )
+        try:
+            assert srv.dispatch(
+                {"id": 8, "method": "test.unrelated-query", "params": {}},
+                transport=self._Transport(),
+            )["result"] == {"ok": True}
+            envelope = self._call(
+                {
+                    "session_id": "owner-session",
+                    "subagent_id": "sid-rpc-after-query",
+                    "text": "still mine",
+                },
+                transport=owner_transport,
+                session_record=owner_record,
+            )
+            assert envelope["result"]["status"] == "queued"
+            assert agent.steered == ["still mine"]
+        finally:
+            srv._methods.pop("test.unrelated-query", None)
+            _unregister_subagent("sid-rpc-after-query")
+
+    def test_record_missing_runtime_artifacts_cannot_be_steered_by_rpc(self):
+        agent = _StubAgent()
+        owner_transport = self._Transport()
+        owner_record = {
+            "session_key": "claiming-session",
+            "history": [],
+            "transport": owner_transport,
+        }
+        _with_registered(
+            "sid-rpc-owner-missing",
+            agent,
+            owner_session_id="claiming-session",
+        )
         try:
             envelope = self._call(
                 {
                     "session_id": "claiming-session",
                     "subagent_id": "sid-rpc-owner-missing",
                     "text": "ambiguous authority",
-                }
+                },
+                transport=owner_transport,
+                session_record=owner_record,
             )
             assert envelope["result"]["status"] == "rejected"
             assert agent.steered == []

--- a/tests/tools/test_subagent_steer.py
+++ b/tests/tools/test_subagent_steer.py
@@ -1,0 +1,198 @@
+"""steer_subagent — redirecting a live delegated child without stopping it.
+
+Registry-level coverage for the delegation-side mirror of
+interrupt_subagent(): text reaches the live child's AIAgent.steer(), and
+every failure shape (unknown id, dead record, empty text, a steer that
+raises) degrades to False instead of an exception.  Also covers the
+missed-steer retention race (a child that finishes before the drain) and
+the subagent.steer gateway RPC that fronts the helper.
+"""
+
+from tools.delegate_tool import (
+    _register_subagent,
+    _unregister_subagent,
+    steer_subagent,
+)
+
+
+class _StubAgent:
+    def __init__(self, accept: bool = True, boom: bool = False):
+        self.accept = accept
+        self.boom = boom
+        self.steered: list[str] = []
+
+    def steer(self, text: str) -> bool:
+        if self.boom:
+            raise RuntimeError("steer exploded")
+        self.steered.append(text)
+        return self.accept
+
+
+def _with_registered(sid: str, agent) -> None:
+    _register_subagent(
+        {
+            "subagent_id": sid,
+            "parent_id": "root",
+            "depth": 1,
+            "goal": "test goal",
+            "status": "running",
+            "agent": agent,
+        }
+    )
+
+
+def test_steer_reaches_the_live_child():
+    agent = _StubAgent()
+    _with_registered("sid-steer-1", agent)
+    try:
+        assert steer_subagent("sid-steer-1", "focus on pricing instead") is True
+        assert agent.steered == ["focus on pricing instead"]
+    finally:
+        _unregister_subagent("sid-steer-1")
+
+
+def test_unknown_subagent_is_false_not_an_error():
+    assert steer_subagent("sid-not-registered", "hello") is False
+
+
+def test_empty_text_is_refused_without_a_lookup():
+    agent = _StubAgent()
+    _with_registered("sid-steer-2", agent)
+    try:
+        assert steer_subagent("sid-steer-2", "   ") is False
+        assert agent.steered == []
+    finally:
+        _unregister_subagent("sid-steer-2")
+
+
+def test_record_without_live_agent_is_false():
+    _register_subagent({"subagent_id": "sid-steer-3", "status": "running", "agent": None})
+    try:
+        assert steer_subagent("sid-steer-3", "hello") is False
+    finally:
+        _unregister_subagent("sid-steer-3")
+
+
+def test_agent_rejection_propagates_as_false():
+    agent = _StubAgent(accept=False)
+    _with_registered("sid-steer-4", agent)
+    try:
+        assert steer_subagent("sid-steer-4", "hello") is False
+    finally:
+        _unregister_subagent("sid-steer-4")
+
+
+def test_exception_in_steer_degrades_to_false():
+    agent = _StubAgent(boom=True)
+    _with_registered("sid-steer-5", agent)
+    try:
+        assert steer_subagent("sid-steer-5", "hello") is False
+    finally:
+        _unregister_subagent("sid-steer-5")
+
+
+class TestMissedSteerRetention:
+    """The final-answer race: a steer with no boundary left is NAMED, not lost."""
+
+    def test_pending_steer_lands_in_completion_entry(self):
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from tools.delegate_tool import delegate_task
+
+        parent = MagicMock()
+        parent._delegate_depth = 0
+        parent.model = "test-model"
+        parent.interactive_mode = False
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "test-model"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+                # The finalizer's undelivered-steer hand-back
+                # (turn_finalizer.py "pending_steer").
+                "pending_steer": "focus on pricing instead",
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="race test", parent_agent=parent))
+            entry = result["results"][0]
+
+        assert entry["missed_steer"] == "focus on pricing instead"
+        assert "steer did not land" in entry["summary"]
+        assert "focus on pricing instead" in entry["summary"]
+        # The race must not corrupt the outcome of the work itself.
+        assert entry["status"] == "completed"
+
+    def test_no_pending_steer_leaves_entry_untouched(self):
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from tools.delegate_tool import delegate_task
+
+        parent = MagicMock()
+        parent._delegate_depth = 0
+        parent.model = "test-model"
+        parent.interactive_mode = False
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "test-model"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="clean run", parent_agent=parent))
+            entry = result["results"][0]
+
+        assert "missed_steer" not in entry
+        assert "steer did not land" not in entry["summary"]
+
+
+class TestSubagentSteerRPC:
+    """subagent.steer gateway RPC — the programmatic caller beside subagent.interrupt."""
+
+    def _call(self, params: dict) -> dict:
+        import tui_gateway.server as srv
+
+        return srv._methods["subagent.steer"](1, params)
+
+    def test_missing_subagent_id_is_4000(self):
+        envelope = self._call({"text": "hello"})
+        assert envelope["error"]["code"] == 4000
+
+    def test_empty_text_is_4002(self):
+        envelope = self._call({"subagent_id": "sid-rpc-1", "text": "   "})
+        assert envelope["error"]["code"] == 4002
+
+    def test_live_child_queues_and_receives_text(self):
+        agent = _StubAgent()
+        _with_registered("sid-rpc-2", agent)
+        try:
+            envelope = self._call({"subagent_id": "sid-rpc-2", "text": "check the edge cases"})
+            assert envelope["result"] == {
+                "status": "queued",
+                "subagent_id": "sid-rpc-2",
+                "text": "check the edge cases",
+            }
+            assert agent.steered == ["check the edge cases"]
+        finally:
+            _unregister_subagent("sid-rpc-2")
+
+    def test_unknown_child_is_rejected_not_an_error(self):
+        envelope = self._call({"subagent_id": "sid-rpc-gone", "text": "hello"})
+        assert envelope["result"]["status"] == "rejected"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -237,6 +237,8 @@ def steer_subagent(
     text: str,
     *,
     owner_session_id: Optional[str] = None,
+    owner_transport: Any = None,
+    owner_session_record: Any = None,
 ) -> bool:
     """Queue steering text into a single running subagent without stopping it.
 
@@ -259,8 +261,15 @@ def steer_subagent(
         record = _active_subagents.get(subagent_id)
         if not record or not record.get("accepting_steer", False):
             return False
-        if owner_session_id is not None and record.get("owner_session_id") != owner_session_id:
-            return False
+        if owner_session_id is not None:
+            if (
+                record.get("owner_session_id") != owner_session_id
+                or owner_transport is None
+                or record.get("owner_transport") is not owner_transport
+                or owner_session_record is None
+                or record.get("owner_session_record") is not owner_session_record
+            ):
+                return False
         agent = record.get("agent")
         if agent is None:
             return False
@@ -269,6 +278,24 @@ def steer_subagent(
         except Exception as exc:
             logger.debug("steer_subagent(%s) failed: %s", subagent_id, exc)
             return False
+
+
+def _capture_gateway_steer_authority(
+    owner_session_id: Optional[str],
+) -> tuple[Any, Any]:
+    """Capture exact request transport + live session generation, if any.
+
+    This is intentionally an in-process bridge, not a serializable capability.
+    Non-gateway hosts (including the CLI helper path) receive ``(None, None)``.
+    """
+    if not owner_session_id:
+        return None, None
+    try:
+        from tui_gateway.server import _current_session_steer_authority
+
+        return _current_session_steer_authority(owner_session_id)
+    except Exception:
+        return None, None
 
 
 def list_active_subagents() -> List[Dict[str, Any]]:
@@ -282,7 +309,14 @@ def list_active_subagents() -> List[Dict[str, Any]]:
             {
                 k: v
                 for k, v in r.items()
-                if k not in {"agent", "owner_session_id", "accepting_steer"}
+                if k
+                not in {
+                    "agent",
+                    "owner_session_id",
+                    "owner_transport",
+                    "owner_session_record",
+                    "accepting_steer",
+                }
             }
             for r in _active_subagents.values()
         ]
@@ -2045,6 +2079,8 @@ def _run_single_child(
     parent_agent=None,
     *,
     owner_session_id: Optional[str] = None,
+    owner_transport: Any = None,
+    owner_session_record: Any = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -2186,6 +2222,12 @@ def _run_single_child(
                 owner_session_id = get_session_env("HERMES_UI_SESSION_ID", "") or None
             except Exception:
                 owner_session_id = None
+        if owner_session_id and (
+            owner_transport is None or owner_session_record is None
+        ):
+            owner_transport, owner_session_record = (
+                _capture_gateway_steer_authority(owner_session_id)
+            )
         _raw_depth = getattr(child, "_delegate_depth", 1)
         _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
         _parent_sid = getattr(child, "_parent_subagent_id", None)
@@ -2207,6 +2249,8 @@ def _run_single_child(
                 # Immutable live gateway/TUI session that commissioned this
                 # child. Empty outside those hosts; RPC authority fails closed.
                 "owner_session_id": owner_session_id,
+                "owner_transport": owner_transport,
+                "owner_session_record": owner_session_record,
             }
         )
 
@@ -3090,6 +3134,9 @@ def delegate_task(
         _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
     except Exception:
         _origin_ui_session_id = ""
+    _origin_owner_transport, _origin_owner_session_record = (
+        _capture_gateway_steer_authority(_origin_ui_session_id)
+    )
 
     # Build all child agents on the main thread (thread-safe construction).
     # _build_child_preserving_parent_tools saves/restores the parent's
@@ -3154,6 +3201,8 @@ def delegate_task(
                 child,
                 parent_agent,
                 owner_session_id=_origin_ui_session_id or None,
+                owner_transport=_origin_owner_transport,
+                owner_session_record=_origin_owner_session_record,
             )
             results.append(result)
         else:
@@ -3177,6 +3226,8 @@ def delegate_task(
                         child=child,
                         parent_agent=parent_agent,
                         owner_session_id=_origin_ui_session_id or None,
+                        owner_transport=_origin_owner_transport,
+                        owner_session_record=_origin_owner_session_record,
                     )
                     futures[future] = i
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -205,6 +205,38 @@ def interrupt_subagent(subagent_id: str) -> bool:
     return True
 
 
+def steer_subagent(subagent_id: str, text: str) -> bool:
+    """Queue steering text into a single running subagent without stopping it.
+
+    The redirection-side mirror of interrupt_subagent(): resolves the live
+    child in the registry and calls AIAgent.steer(), which appends the text
+    to the child's last tool result at its next iteration boundary — the
+    current tool call is never cut. Returns True if a matching subagent
+    QUEUED the text; False for an unknown id, a record with no live agent,
+    or empty text.
+
+    Queued is not delivered: a child already past its final tool batch has
+    no boundary left to drain into.  That race is surfaced, not swallowed —
+    the finalizer returns the undelivered text as ``pending_steer`` and
+    ``_run_single_child`` retains it in the completion entry as
+    ``missed_steer`` with a note appended to the summary.
+    """
+    if not text or not text.strip():
+        return False
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+    if not record:
+        return False
+    agent = record.get("agent")
+    if agent is None:
+        return False
+    try:
+        return bool(agent.steer(text))
+    except Exception as exc:
+        logger.debug("steer_subagent(%s) failed: %s", subagent_id, exc)
+        return False
+
+
 def list_active_subagents() -> List[Dict[str, Any]]:
     """Snapshot of the currently running subagent tree.
 
@@ -2437,6 +2469,21 @@ def _run_single_child(
         }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+
+        # A steer that queued after the child's final assistant turn had no
+        # tool batch left to drain into.  The finalizer hands the undelivered
+        # text back (turn_finalizer.py "pending_steer"); retain it here so the
+        # parent sees the steer was MISSED rather than silently absorbed —
+        # steer_subagent() returning True means "queued", and this is where a
+        # queued-but-never-delivered steer gets named.
+        _missed_steer = result.get("pending_steer")
+        if isinstance(_missed_steer, str) and _missed_steer.strip():
+            entry["missed_steer"] = _missed_steer
+            _miss_note = (
+                "[steer did not land — the subagent finished before it could "
+                f"be delivered: {_missed_steer}]"
+            )
+            entry["summary"] = f"{summary}\n\n{_miss_note}" if summary else _miss_note
 
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -172,13 +172,40 @@ def _register_subagent(record: Dict[str, Any]) -> None:
     sid = record.get("subagent_id")
     if not sid:
         return
+    record.setdefault("accepting_steer", True)
     with _active_subagents_lock:
         _active_subagents[sid] = record
 
 
-def _unregister_subagent(subagent_id: str) -> None:
+def _unregister_subagent(subagent_id: str, *, agent: Any = None) -> None:
     with _active_subagents_lock:
-        _active_subagents.pop(subagent_id, None)
+        record = _active_subagents.get(subagent_id)
+        if record is not None and (agent is None or record.get("agent") is agent):
+            _active_subagents.pop(subagent_id, None)
+
+
+def _close_subagent_steering(subagent_id: str, agent: Any) -> Optional[str]:
+    """Atomically close steer acceptance and drain its final durable artifact.
+
+    ``steer_subagent`` holds the same registry lock through ``agent.steer``.
+    Therefore either acceptance wins and this drain sees its exact text, or
+    closure wins and the caller is rejected. Exact agent identity prevents a
+    finishing child with a recycled public id from closing its replacement.
+    """
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if record is None or record.get("agent") is not agent:
+            return None
+        record["accepting_steer"] = False
+        drain = getattr(agent, "_drain_pending_steer", None)
+        if not callable(drain):
+            return None
+        try:
+            pending = drain()
+        except Exception as exc:
+            logger.debug("final steer drain for %s failed: %s", subagent_id, exc)
+            return None
+        return pending if isinstance(pending, str) and pending.strip() else None
 
 
 def interrupt_subagent(subagent_id: str) -> bool:
@@ -205,36 +232,43 @@ def interrupt_subagent(subagent_id: str) -> bool:
     return True
 
 
-def steer_subagent(subagent_id: str, text: str) -> bool:
+def steer_subagent(
+    subagent_id: str,
+    text: str,
+    *,
+    owner_session_id: Optional[str] = None,
+) -> bool:
     """Queue steering text into a single running subagent without stopping it.
 
     The redirection-side mirror of interrupt_subagent(): resolves the live
     child in the registry and calls AIAgent.steer(), which appends the text
     to the child's last tool result at its next iteration boundary — the
     current tool call is never cut. Returns True if a matching subagent
-    QUEUED the text; False for an unknown id, a record with no live agent,
-    or empty text.
+    QUEUED the text while the child was still accepting work; False for an
+    unknown/closed id, an ownership mismatch, a record with no live agent, or
+    empty text. ``owner_session_id=None`` deliberately preserves the internal
+    in-process helper contract; gateway callers must pass exact authority.
 
-    Queued is not delivered: a child already past its final tool batch has
-    no boundary left to drain into.  That race is surfaced, not swallowed —
-    the finalizer returns the undelivered text as ``pending_steer`` and
-    ``_run_single_child`` retains it in the completion entry as
-    ``missed_steer`` with a note appended to the summary.
+    Acceptance and completion are linearized by the registry lock. If
+    acceptance wins but no delivery boundary remains, ``_run_single_child``
+    drains the exact text into the completion entry as ``missed_steer``.
     """
     if not text or not text.strip():
         return False
     with _active_subagents_lock:
         record = _active_subagents.get(subagent_id)
-    if not record:
-        return False
-    agent = record.get("agent")
-    if agent is None:
-        return False
-    try:
-        return bool(agent.steer(text))
-    except Exception as exc:
-        logger.debug("steer_subagent(%s) failed: %s", subagent_id, exc)
-        return False
+        if not record or not record.get("accepting_steer", False):
+            return False
+        if owner_session_id is not None and record.get("owner_session_id") != owner_session_id:
+            return False
+        agent = record.get("agent")
+        if agent is None:
+            return False
+        try:
+            return bool(agent.steer(text))
+        except Exception as exc:
+            logger.debug("steer_subagent(%s) failed: %s", subagent_id, exc)
+            return False
 
 
 def list_active_subagents() -> List[Dict[str, Any]]:
@@ -245,7 +279,11 @@ def list_active_subagents() -> List[Dict[str, Any]]:
     """
     with _active_subagents_lock:
         return [
-            {k: v for k, v in r.items() if k != "agent"}
+            {
+                k: v
+                for k, v in r.items()
+                if k not in {"agent", "owner_session_id", "accepting_steer"}
+            }
             for r in _active_subagents.values()
         ]
 
@@ -2005,6 +2043,8 @@ def _run_single_child(
     goal: str,
     child=None,
     parent_agent=None,
+    *,
+    owner_session_id: Optional[str] = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -2139,6 +2179,13 @@ def _run_single_child(
     _raw_sid = getattr(child, "_subagent_id", None)
     _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
     if _subagent_id:
+        if owner_session_id is None:
+            try:
+                from gateway.session_context import get_session_env
+
+                owner_session_id = get_session_env("HERMES_UI_SESSION_ID", "") or None
+            except Exception:
+                owner_session_id = None
         _raw_depth = getattr(child, "_delegate_depth", 1)
         _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
         _parent_sid = getattr(child, "_parent_subagent_id", None)
@@ -2157,6 +2204,9 @@ def _run_single_child(
                 "status": "running",
                 "tool_count": 0,
                 "agent": child,
+                # Immutable live gateway/TUI session that commissioned this
+                # child. Empty outside those hosts; RPC authority fails closed.
+                "owner_session_id": owner_session_id,
             }
         )
 
@@ -2244,6 +2294,12 @@ def _run_single_child(
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
+            # No consumer boundary remains once this owner stops waiting for
+            # the child. Close acceptance before any completion callback and
+            # retain steer text that won the race with this failure/timeout.
+            _late_pending_steer = (
+                _close_subagent_steering(_subagent_id, child) if _subagent_id else None
+            )
             # Signal the child to stop so its thread can exit cleanly.
             try:
                 interrupted = child is not None and request_hard_interrupt(child)
@@ -2327,7 +2383,7 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            _error_entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
@@ -2345,10 +2401,32 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            if _late_pending_steer:
+                _error_entry["missed_steer"] = _late_pending_steer
+                _error_entry["error"] += (
+                    " [steer did not land before the subagent stopped: "
+                    f"{_late_pending_steer}]"
+                )
+            return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
             _timeout_executor.shutdown(wait=False)
+
+        # Linearization boundary for registry steering. From this point on the
+        # child cannot consume another steer. Closing under the registry lock
+        # either rejects a concurrent caller or drains every previously accepted
+        # exact text into the result before callbacks/result assembly can run.
+        _late_pending_steer = (
+            _close_subagent_steering(_subagent_id, child) if _subagent_id else None
+        )
+        if _late_pending_steer:
+            _existing_pending = result.get("pending_steer")
+            result["pending_steer"] = (
+                f"{_existing_pending}\n{_late_pending_steer}"
+                if isinstance(_existing_pending, str) and _existing_pending
+                else _late_pending_steer
+            )
 
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, "_flush"):
@@ -2582,6 +2660,9 @@ def _run_single_child(
         return entry
 
     except Exception as exc:
+        _late_pending_steer = (
+            _close_subagent_steering(_subagent_id, child) if _subagent_id else None
+        )
         duration = round(time.monotonic() - child_start, 2)
         logging.exception(f"[subagent-{task_index}] failed")
         if child_progress_cb:
@@ -2595,7 +2676,7 @@ def _run_single_child(
                 )
             except Exception as e:
                 logger.debug("Progress callback failure relay failed: %s", e)
-        return {
+        _error_entry = {
             "task_index": task_index,
             "status": "error",
             "summary": None,
@@ -2604,6 +2685,13 @@ def _run_single_child(
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        if _late_pending_steer:
+            _error_entry["missed_steer"] = _late_pending_steer
+            _error_entry["error"] += (
+                " [steer did not land before the subagent stopped: "
+                f"{_late_pending_steer}]"
+            )
+        return _error_entry
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
@@ -2618,7 +2706,7 @@ def _run_single_child(
         # Drop the TUI-facing registry entry.  Safe to call even if the
         # child was never registered (e.g. ID missing on test doubles).
         if _subagent_id:
-            _unregister_subagent(_subagent_id)
+            _unregister_subagent(_subagent_id, agent=child)
 
         if child_pool is not None and leased_cred_id is not None:
             try:
@@ -2996,6 +3084,12 @@ def delegate_task(
     from tools.async_delegation import _current_origin_session_id
 
     _origin_wake_sid = _current_origin_session_id()
+    try:
+        from gateway.session_context import get_session_env
+
+        _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+    except Exception:
+        _origin_ui_session_id = ""
 
     # Build all child agents on the main thread (thread-safe construction).
     # _build_child_preserving_parent_tools saves/restores the parent's
@@ -3054,7 +3148,13 @@ def delegate_task(
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
-            result = _run_single_child(_i, _t["goal"], child, parent_agent)
+            result = _run_single_child(
+                _i,
+                _t["goal"],
+                child,
+                parent_agent,
+                owner_session_id=_origin_ui_session_id or None,
+            )
             results.append(result)
         else:
             # Batch -- run in parallel with per-task progress lines
@@ -3076,6 +3176,7 @@ def delegate_task(
                         goal=t["goal"],
                         child=child,
                         parent_agent=parent_agent,
+                        owner_session_id=_origin_ui_session_id or None,
                     )
                     futures[future] = i
 
@@ -3283,12 +3384,15 @@ def delegate_task(
             return json.dumps(_sync_result, ensure_ascii=False)
 
         _session_key = get_current_session_key(default="")
-        _origin_ui_session_id = ""
         try:
             from gateway.session_context import get_session_env
 
             _source = get_session_env("HERMES_SESSION_SOURCE", "")
-            _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+            # Refresh from the same task-local source when available, but retain
+            # the immutable value captured before child construction otherwise.
+            _origin_ui_session_id = (
+                get_session_env("HERMES_UI_SESSION_ID", "") or _origin_ui_session_id
+            )
             # In desktop/TUI, the routable session key is the durable
             # AIAgent.session_id. Context compression can rotate that id during
             # the same turn before the TUI-side session dict is re-anchored;
@@ -3301,7 +3405,7 @@ def delegate_task(
                 if _agent_session_id:
                     _session_key = _agent_session_id
         except Exception:
-            _origin_ui_session_id = ""
+            _source = ""
         if not _session_key:
             # CLI (single-process) path: the approval contextvar is only bound
             # during gateway/TUI turns and HERMES_SESSION_KEY is not in the CLI

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2954,7 +2954,15 @@ def _(rid, params: dict) -> dict:
     text = (params.get("text") or "").strip()
     if not text:
         return _err(rid, 4002, "text is required")
-    queued = steer_subagent(subagent_id, text)
+    _session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    invoking_session_id = str(params.get("session_id") or "").strip()
+    queued = steer_subagent(
+        subagent_id,
+        text,
+        owner_session_id=invoking_session_id,
+    )
     return _ok(
         rid,
         {

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2934,6 +2934,37 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"found": ok, "subagent_id": subagent_id})
 
 
+@method("subagent.steer")
+def _(rid, params: dict) -> dict:
+    """Queue steering text into a live delegated child without stopping it.
+
+    The redirection-side mirror of subagent.interrupt: resolves the child in
+    the delegation registry and calls AIAgent.steer(), which appends the text
+    to the child's last tool result at its next iteration boundary — the
+    in-flight tool call is never cut. "queued" is not "delivered": a child
+    already past its final tool batch has no boundary left to drain into,
+    and that race surfaces as ``missed_steer`` on the parent's completion
+    entry instead of being silently dropped.
+    """
+    from tools.delegate_tool import steer_subagent
+
+    subagent_id = str(params.get("subagent_id") or "").strip()
+    if not subagent_id:
+        return _err(rid, 4000, "subagent_id required")
+    text = (params.get("text") or "").strip()
+    if not text:
+        return _err(rid, 4002, "text is required")
+    queued = steer_subagent(subagent_id, text)
+    return _ok(
+        rid,
+        {
+            "status": "queued" if queued else "rejected",
+            "subagent_id": subagent_id,
+            "text": text,
+        },
+    )
+
+
 @method("spawn_tree.save")
 def _(rid, params: dict) -> dict:
     session_id = str(params.get("session_id") or "").strip()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2954,15 +2954,22 @@ def _(rid, params: dict) -> dict:
     text = (params.get("text") or "").strip()
     if not text:
         return _err(rid, 4002, "text is required")
-    _session, err = _sess_nowait(params, rid)
+    _invoking_session, err = _sess_nowait(params, rid)
     if err:
         return err
     invoking_session_id = str(params.get("session_id") or "").strip()
-    queued = steer_subagent(
-        subagent_id,
-        text,
-        owner_session_id=invoking_session_id,
+    invoking_transport, invoking_session = _current_session_steer_authority(
+        invoking_session_id
     )
+    queued = False
+    if invoking_transport is not None and invoking_session is not None:
+        queued = steer_subagent(
+            subagent_id,
+            text,
+            owner_session_id=invoking_session_id,
+            owner_transport=invoking_transport,
+            owner_session_record=invoking_session,
+        )
     return _ok(
         rid,
         {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -295,6 +295,12 @@ _pool = concurrent.futures.ThreadPoolExecutor(
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 
+# Exact in-memory session generation executing on the current turn thread.
+# Unlike a public session id, this object identity cannot be supplied by RPC.
+_current_runtime_session_record: contextvars.ContextVar[dict | None] = (
+    contextvars.ContextVar("hermes_gateway_runtime_session_record", default=None)
+)
+
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
 # of corrupting the JSON protocol.
@@ -1898,6 +1904,31 @@ def handle_request(req: dict) -> dict | None:
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
     return fn(rid, params)
+
+
+def _current_session_steer_authority(
+    session_id: str,
+) -> tuple[Transport | None, dict | None]:
+    """Resolve unforgeable steering authority for this exact RPC context.
+
+    The public session id is only a lookup hint. Authority is the identity of
+    both the request's ContextVar-bound transport and the live in-memory
+    session record currently stored under that id. Session transport rebinding,
+    removal, or id reuse therefore invalidates an earlier generation.
+    """
+    transport = current_transport()
+    if transport is None or not session_id:
+        return None, None
+    expected_session = _current_runtime_session_record.get()
+    with _sessions_lock:
+        session = _sessions.get(session_id)
+        if (
+            session is None
+            or (expected_session is not None and session is not expected_session)
+            or session.get("transport") is not transport
+        ):
+            return None, None
+        return transport, session
 
 
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
@@ -9386,6 +9417,12 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        # The conversation runs on a fresh thread, so ContextVars from the RPC
+        # dispatcher do not follow automatically. Rebind the exact transport
+        # stored on this session generation before any tool can commission a
+        # child; delegate_task then captures it as non-serializable authority.
+        transport_token = bind_transport(session.get("transport"))
+        runtime_session_token = _current_runtime_session_record.set(session)
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
@@ -10089,6 +10126,8 @@ def _run_prompt_submit(
             if secret_token is not None:
                 reset_secret_scope(secret_token)
             _clear_session_context(session_tokens)
+            _current_runtime_session_record.reset(runtime_session_token)
+            reset_transport(transport_token)
             # Clear the per-turn interim callback so a stale closure from
             # this turn can't fire during a later turn on the same agent.
             agent.interim_assistant_callback = None

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -50,7 +50,8 @@ clarify.respond         sudo.respond            secret.respond
 approval.respond        config.set / config.get commands.catalog
 command.resolve         command.dispatch        cli.exec
 reload.mcp              reload.env              process.stop
-delegation.status       subagent.interrupt      spawn_tree.save / list / load
+delegation.status       subagent.interrupt      subagent.steer
+spawn_tree.save / list / load
 terminal.resize         clipboard.paste         image.attach
 ```
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -269,6 +269,24 @@ A delegation the stall monitor has flagged shows as
 children show their quiet time so you can tell "slow" from "stuck" at a
 glance.
 
+## Steering a Running Subagent
+
+Interrupting a child throws away its in-flight work; often you just want to redirect it. `steer_subagent(subagent_id, text)` in `tools/delegate_tool.py` is the redirection-side mirror of `interrupt_subagent()`: it queues text into a live child through the same mechanism as [`/steer`](/reference/slash-commands) — the text is appended to the child's last tool result at its next iteration boundary, the in-flight tool call is never cut, and the child sees it as an out-of-band user message. Programmatic hosts reach it through the `subagent.steer` gateway RPC, which sits beside `subagent.interrupt`:
+
+```json
+{"method": "subagent.steer", "params": {"subagent_id": "sa-0-1a2b3c4d", "text": "focus on pricing instead"}}
+```
+
+Subagent ids come from `delegation.status` (or `list_active_subagents()`) — the same place `subagent.interrupt` gets them.
+
+**Queued is not delivered.** A `"queued"` response means the text is staged, not that the child has seen it. A child that has already produced its final answer has no tool batch left to drain the steer into. That race is surfaced instead of swallowed: the turn finalizer hands the undelivered text back as `pending_steer`, and the completion entry the parent receives retains it as `missed_steer`, with a note appended to the summary:
+
+```
+[steer did not land — the subagent finished before it could be delivered: focus on pricing instead]
+```
+
+So the parent (or the operator driving it) can tell a steered child from one that finished on the old instructions, and re-issue the guidance as a follow-up instead of trusting that it landed.
+
 ## Live Transcripts
 
 Every `delegate_task` dispatch also creates one **append-only, human-readable log per task** so you (or the parent agent) can watch a subagent work in real time instead of waiting for the consolidated summary:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -271,15 +271,15 @@ glance.
 
 ## Steering a Running Subagent
 
-Interrupting a child throws away its in-flight work; often you just want to redirect it. `steer_subagent(subagent_id, text)` in `tools/delegate_tool.py` is the redirection-side mirror of `interrupt_subagent()`: it queues text into a live child through the same mechanism as [`/steer`](/reference/slash-commands) — the text is appended to the child's last tool result at its next iteration boundary, the in-flight tool call is never cut, and the child sees it as an out-of-band user message. Programmatic hosts reach it through the `subagent.steer` gateway RPC, which sits beside `subagent.interrupt`:
+Interrupting a child throws away its in-flight work; often you just want to redirect it. `steer_subagent(subagent_id, text)` in `tools/delegate_tool.py` is the redirection-side mirror of `interrupt_subagent()`: it queues text into a live child through the same mechanism as [`/steer`](/reference/slash-commands) — the text is appended to the child's last tool result at its next iteration boundary, the in-flight tool call is never cut, and the child sees it as an out-of-band user message. Programmatic hosts reach it through the session-scoped `subagent.steer` gateway RPC, which sits beside `subagent.interrupt`:
 
 ```json
-{"method": "subagent.steer", "params": {"subagent_id": "sa-0-1a2b3c4d", "text": "focus on pricing instead"}}
+{"method": "subagent.steer", "params": {"session_id": "owning-ui-session", "subagent_id": "sa-0-1a2b3c4d", "text": "focus on pricing instead"}}
 ```
 
-Subagent ids come from `delegation.status` (or `list_active_subagents()`) — the same place `subagent.interrupt` gets them.
+Subagent ids come from `delegation.status` (or `list_active_subagents()`) — the same place `subagent.interrupt` gets them. The gateway accepts steering only from the exact live UI/gateway session that spawned the child. A missing, foreign, ambiguous, or stale/recycled session identity is rejected; knowing a global subagent id is not authority. Direct in-process callers retain the unscoped helper contract deliberately.
 
-**Queued is not delivered.** A `"queued"` response means the text is staged, not that the child has seen it. A child that has already produced its final answer has no tool batch left to drain the steer into. That race is surfaced instead of swallowed: the turn finalizer hands the undelivered text back as `pending_steer`, and the completion entry the parent receives retains it as `missed_steer`, with a note appended to the summary:
+**Queued is not delivered, but it is never synthetic success.** A `"queued"` response means the text was accepted before the child's completion boundary, not necessarily that the child has seen it. Acceptance and completion are synchronized: either the child can still consume the text, or its exact text is drained into the result as `pending_steer`. Calls after closure return `"rejected"`. If a child accepted the steer but had already produced its final answer, the completion entry the parent receives retains it as `missed_steer`, with a note appended to the summary:
 
 ```
 [steer did not land — the subagent finished before it could be delivered: focus on pricing instead]


### PR DESCRIPTION
## The dropped signal

`agent/turn_finalizer.py:683-685` already guards against losing a steer that queues after the final tool batch:

```python
_leftover_steer = agent._drain_pending_steer()
if _leftover_steer:
    result["pending_steer"] = _leftover_steer
```

> "If a /steer landed after the final assistant turn (no more tool batches to drain into), hand it back to the caller so it can be delivered as the next user turn instead of being silently lost."

Every interactive surface honors that contract — `cli.py`, `gateway/run.py`, and `tui_gateway/server.py` all requeue the leftover text as the next user turn.

The delegation layer doesn't. `_run_single_child` in `tools/delegate_tool.py` never reads `result["pending_steer"]`, so the completion entry the parent receives carries no trace of it. And there's no sanctioned sender either: the registry exposes `interrupt_subagent()` but no redirection-side mirror, and `session.steer` can't reach a delegated child — the desktop opens children as lazy watch sessions with `agent=None`, so it returns 4010.

Net: you can kill a running child, but you can't redirect one — and if you could, the finish-first race would silently lose the text, which is exactly the loss the finalizer contract exists to prevent.

## The fix — both halves of the contract

**Sender** — `steer_subagent(subagent_id, text)` in `tools/delegate_tool.py`, the redirection-side mirror of `interrupt_subagent()`: resolves the live child in `_active_subagents` and queues text via `AIAgent.steer()`. The in-flight tool call is never cut; the child sees the text as an out-of-band user message at its next iteration boundary. `True` means **queued, not delivered**. Fronted by a `subagent.steer` gateway RPC beside `subagent.interrupt` (`tui_gateway/methods_session.py`) so programmatic hosts — dashboard, voice layers, ACP bridges — have an in-tree caller. Subagent ids come from `delegation.status`, same as `subagent.interrupt`.

**Receiver** — missed-steer retention in `_run_single_child`: when the child's result carries `pending_steer`, the completion entry retains it as `missed_steer` with a note appended to the summary:

```
[steer did not land — the subagent finished before it could be delivered: <text>]
```

The parent can tell a steered child from one that finished on the old instructions, and re-issue the guidance instead of trusting it landed.

## Docs

- "Steering a Running Subagent" section in `website/docs/user-guide/features/delegation.md` (queued-vs-delivered semantics, the race, the `missed_steer` contract)
- `subagent.steer` added to the method catalog in `website/docs/developer-guide/programmatic-integration.md`

## Tests

`tests/tools/test_subagent_steer.py`:

- registry level: text reaches the live child; unknown id / empty text / dead record / raising agent all degrade to `False`, never an exception
- the race: a child that finishes with `pending_steer` set produces a completion entry carrying `missed_steer` + the summary note, `status` unaffected; a clean run leaves the entry untouched
- RPC contract: 4000 (missing `subagent_id`), 4002 (empty `text`), `queued` and `rejected` envelopes

All green on the touched paths: `tests/tools/test_subagent_steer.py` (12), `tests/tools/test_delegate.py` + `tests/run_agent/test_steer.py` (89), `tui_gateway` protocol + delegation lifecycle (52).
