### PR TITLE
fix(anthropic): alias the session_search and memory schemas on the OAuth wire

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -394,14 +395,53 @@ def _detect_claude_code_version() -> str:
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 _MCP_TOOL_PREFIX = "mcp__"
-# Anthropic's OAuth billing classifier fingerprints the combination of the
-# ``session_search`` and ``skill_manage`` guidance terms in Hermes's request
-# shape. Alias the independently functional session-search term only on the
-# OAuth wire; the response transport restores the registry name before dispatch.
-_OAUTH_TOOL_NAME_ALIASES = {"session_search": "chat_history_lookup"}
+
+# Anthropic's OAuth billing classifier fingerprints certain Hermes tool schemas
+# as a third-party app and reroutes the request to the metered extra-usage lane,
+# surfacing as HTTP 400 "You're out of extra usage" on a valid subscription
+# token. Issue #65365 isolated two triggers with a deterministic A/B repro on a
+# live Claude Max account: exposing the ``session_search`` schema alone, or the
+# ``memory`` schema alone, each reproduces the 400; removing them clears it.
+#
+# Both are aliased to neutral names on the OAuth wire only. The response
+# transport restores the registry name before dispatch, so tool behavior and
+# API-key requests are unchanged.
+_OAUTH_TOOL_NAME_ALIASES = {
+    "session_search": "chat_history_lookup",
+    "memory": "context_notes",
+}
 _OAUTH_TOOL_NAME_REVERSE_ALIASES = {
     wire_name: name for name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items()
 }
+
+# Aliases that are ALSO safe to substitute in free-form prose (system prompt
+# text, tool descriptions). Only unambiguous snake_case tool tokens qualify:
+# "memory" is ordinary English throughout the system prompt ("persistent
+# memory across sessions", "OS, CPU, memory, disk"), so rewriting it in prose
+# would corrupt guidance the model has to follow. Renaming a tool is a
+# different operation from rewriting the vocabulary that describes it — keep
+# the two sets separate so the next alias can't silently mangle prose.
+_OAUTH_PROSE_ALIAS_NAMES = frozenset({"session_search"})
+
+# Word-boundary matchers so a prose substitution can't corrupt a longer
+# identifier that merely CONTAINS the token. System blocks carry user-supplied
+# text (project AGENTS.md / .cursorrules, memory snapshots), and a bare
+# str.replace would turn a reference like ``tools/session_search_tool.py``
+# into ``tools/chat_history_lookup_tool.py`` — a path that does not exist and
+# has no reverse mapping. ``\b`` treats ``_`` as a word char, so the longer
+# identifier is skipped while ``session_search``, `` `session_search` `` and
+# ``session_search(`` still match.
+_OAUTH_PROSE_ALIAS_PATTERNS = tuple(
+    (re.compile(rf"\b{re.escape(name)}\b"), _OAUTH_TOOL_NAME_ALIASES[name])
+    for name in sorted(_OAUTH_PROSE_ALIAS_NAMES)
+)
+
+
+def _apply_oauth_prose_aliases(text: str) -> str:
+    """Rewrite prose-safe tool tokens to their OAuth wire aliases."""
+    for pattern, wire_name in _OAUTH_PROSE_ALIAS_PATTERNS:
+        text = pattern.sub(wire_name, text)
+    return text
 
 
 def _get_claude_code_version() -> str:
@@ -2797,8 +2837,7 @@ def build_anthropic_kwargs(
                 text = text.replace("Hermes agent", "Claude Code")
                 text = text.replace("hermes-agent", "claude-code")
                 text = text.replace("Nous Research", "Anthropic")
-                for original_name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items():
-                    text = text.replace(original_name, wire_name)
+                text = _apply_oauth_prose_aliases(text)
                 block["text"] = text
 
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
@@ -2834,9 +2873,14 @@ def build_anthropic_kwargs(
                     tool["name"] = _to_oauth_wire_name(tool["name"])
                 description = tool.get("description")
                 if isinstance(description, str):
-                    for original_name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items():
-                        description = description.replace(original_name, wire_name)
-                    tool["description"] = description
+                    # Prose-safe aliases only. The ``memory`` tool's own
+                    # description is dense ordinary prose about memory
+                    # ("save durable facts to persistent memory"); rewriting
+                    # every occurrence would leave the model with mangled
+                    # instructions for a tool it still has to use correctly.
+                    # Its NAME is aliased above, which is the part of the
+                    # schema the classifier keys on per #65365's repro.
+                    tool["description"] = _apply_oauth_prose_aliases(description)
 
         # 4. Apply the same normalization to tool names in message history
         #    (tool_use blocks) so replayed turns match the wire names above.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -394,6 +394,14 @@ def _detect_claude_code_version() -> str:
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 _MCP_TOOL_PREFIX = "mcp__"
+# Anthropic's OAuth billing classifier fingerprints the combination of the
+# ``session_search`` and ``skill_manage`` guidance terms in Hermes's request
+# shape. Alias the independently functional session-search term only on the
+# OAuth wire; the response transport restores the registry name before dispatch.
+_OAUTH_TOOL_NAME_ALIASES = {"session_search": "chat_history_lookup"}
+_OAUTH_TOOL_NAME_REVERSE_ALIASES = {
+    wire_name: name for name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items()
+}
 
 
 def _get_claude_code_version() -> str:
@@ -2789,6 +2797,8 @@ def build_anthropic_kwargs(
                 text = text.replace("Hermes agent", "Claude Code")
                 text = text.replace("hermes-agent", "claude-code")
                 text = text.replace("Nous Research", "Anthropic")
+                for original_name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items():
+                    text = text.replace(original_name, wire_name)
                 block["text"] = text
 
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
@@ -2810,6 +2820,7 @@ def build_anthropic_kwargs(
         #    classifier. normalize_response reverses both forms via registry
         #    lookup so the dispatcher still sees the original name. GH-25255.
         def _to_oauth_wire_name(name: str) -> str:
+            name = _OAUTH_TOOL_NAME_ALIASES.get(name, name)
             if name.startswith("mcp__"):
                 return name  # already correct, don't double-prefix
             if name.startswith("mcp_"):
@@ -2821,6 +2832,11 @@ def build_anthropic_kwargs(
             for tool in anthropic_tools:
                 if "name" in tool:
                     tool["name"] = _to_oauth_wire_name(tool["name"])
+                description = tool.get("description")
+                if isinstance(description, str):
+                    for original_name, wire_name in _OAUTH_TOOL_NAME_ALIASES.items():
+                        description = description.replace(original_name, wire_name)
+                    tool["description"] = description
 
         # 4. Apply the same normalization to tool names in message history
         #    (tool_use blocks) so replayed turns match the wire names above.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -417,10 +417,14 @@ _OAUTH_TOOL_NAME_REVERSE_ALIASES = {
 # Aliases that are ALSO safe to substitute in free-form prose (system prompt
 # text, tool descriptions). Only unambiguous snake_case tool tokens qualify:
 # "memory" is ordinary English throughout the system prompt ("persistent
-# memory across sessions", "OS, CPU, memory, disk"), so rewriting it in prose
-# would corrupt guidance the model has to follow. Renaming a tool is a
-# different operation from rewriting the vocabulary that describes it — keep
-# the two sets separate so the next alias can't silently mangle prose.
+# memory across sessions", "OS, CPU, memory, disk") and inside the memory
+# tool's own description and parameter docs, so rewriting it in prose would
+# corrupt guidance the model has to follow — including the ``target`` enum
+# values it must emit. Renaming a tool is a different operation from
+# rewriting the vocabulary that describes it; keeping the sets separate is
+# what lets the next alias be name-only. A model that follows unaliased
+# prose and calls ``memory`` still dispatches: normalize_response resolves
+# the bare name through the registry.
 _OAUTH_PROSE_ALIAS_NAMES = frozenset({"session_search"})
 
 # Word-boundary matchers so a prose substitution can't corrupt a longer
@@ -431,6 +435,11 @@ _OAUTH_PROSE_ALIAS_NAMES = frozenset({"session_search"})
 # has no reverse mapping. ``\b`` treats ``_`` as a word char, so the longer
 # identifier is skipped while ``session_search``, `` `session_search` `` and
 # ``session_search(`` still match.
+#
+# sorted() is load-bearing, not decoration: iterating a frozenset directly
+# yields hash-seed-dependent order, so with two or more prose aliases the
+# rewritten system bytes would differ between processes and silently break
+# prompt caching in a way that is very hard to reproduce. Do not "simplify".
 _OAUTH_PROSE_ALIAS_PATTERNS = tuple(
     (re.compile(rf"\b{re.escape(name)}\b"), _OAUTH_TOOL_NAME_ALIASES[name])
     for name in sorted(_OAUTH_PROSE_ALIAS_NAMES)
@@ -2858,8 +2867,14 @@ def build_anthropic_kwargs(
         #    so any session with an MCP server configured still tripped the
         #    classifier. normalize_response reverses both forms via registry
         #    lookup so the dispatcher still sees the original name. GH-25255.
-        def _to_oauth_wire_name(name: str) -> str:
-            name = _OAUTH_TOOL_NAME_ALIASES.get(name, name)
+        def _to_oauth_wire_name(name: str, *, allow_alias: bool = True) -> str:
+            if allow_alias and name in _OAUTH_TOOL_NAME_ALIASES:
+                aliased = _OAUTH_TOOL_NAME_ALIASES[name]
+                # Skip the alias when a real tool already owns that wire name
+                # (see _claimed_wire_names below) — a duplicate name is a hard
+                # 400 that would break every request.
+                if _MCP_TOOL_PREFIX + aliased not in _claimed_wire_names:
+                    name = aliased
             if name.startswith("mcp__"):
                 return name  # already correct, don't double-prefix
             if name.startswith("mcp_"):
@@ -2867,19 +2882,26 @@ def build_anthropic_kwargs(
                 return "mcp__" + name[len("mcp_"):]
             return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
 
+        # Wire names owned by tools that are NOT alias sources. An alias must
+        # never collide with one: two identical tool names in a single request
+        # is a hard 400 from Anthropic, which would break every call —
+        # strictly worse than the bug being fixed. This mirrors the inbound
+        # "registered tool wins" rule in normalize_response, so the outbound
+        # and inbound sides agree on who owns a contested name.
+        _claimed_wire_names = {
+            _to_oauth_wire_name(tool["name"], allow_alias=False)
+            for tool in (anthropic_tools or [])
+            if isinstance(tool.get("name"), str)
+            and tool["name"] not in _OAUTH_TOOL_NAME_ALIASES
+        }
+
         if anthropic_tools:
             for tool in anthropic_tools:
                 if "name" in tool:
                     tool["name"] = _to_oauth_wire_name(tool["name"])
                 description = tool.get("description")
                 if isinstance(description, str):
-                    # Prose-safe aliases only. The ``memory`` tool's own
-                    # description is dense ordinary prose about memory
-                    # ("save durable facts to persistent memory"); rewriting
-                    # every occurrence would leave the model with mangled
-                    # instructions for a tool it still has to use correctly.
-                    # Its NAME is aliased above, which is the part of the
-                    # schema the classifier keys on per #65365's repro.
+                    # Prose-safe aliases only — see _OAUTH_PROSE_ALIAS_NAMES.
                     tool["description"] = _apply_oauth_prose_aliases(description)
 
         # 4. Apply the same normalization to tool names in message history

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -148,18 +148,20 @@ class AnthropicTransport(ProviderTransport):
                     # is actually registered; never rewrite a name the LLM used
                     # that already resolves natively. GH-25255.
                     bare = name[len(_MCP_PREFIX):]                # read_file
-                    # OAuth aliases must round-trip before the generic registry
-                    # lookup, which only knows Hermes's canonical tool names.
-                    if bare in _OAUTH_TOOL_NAME_REVERSE_ALIASES:
-                        name = _OAUTH_TOOL_NAME_REVERSE_ALIASES[bare]
-                    else:
-                        from tools.registry import registry as _tool_registry
-                        if not _tool_registry.get_entry(name):
-                            single = "mcp_" + bare                # mcp_read_file / mcp_linear_get_issue
-                            if _tool_registry.get_entry(single):
-                                name = single
-                            elif _tool_registry.get_entry(bare):
-                                name = bare
+                    from tools.registry import registry as _tool_registry
+                    if not _tool_registry.get_entry(name):
+                        single = "mcp_" + bare                # mcp_read_file / mcp_linear_get_issue
+                        if _tool_registry.get_entry(single):
+                            name = single
+                        elif _tool_registry.get_entry(bare):
+                            name = bare
+                        elif bare in _OAUTH_TOOL_NAME_REVERSE_ALIASES:
+                            # OAuth wire alias (e.g. chat_history_lookup ->
+                            # session_search). Checked LAST so the GH-25255
+                            # contract still holds: a real tool actually
+                            # registered under the wire name wins, and we never
+                            # rewrite a name that already resolves natively.
+                            name = _OAUTH_TOOL_NAME_REVERSE_ALIASES[bare]
                 tool_calls.append(
                     ToolCall(
                         id=block.id,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -84,7 +84,11 @@ class AnthropicTransport(ProviderTransport):
         to OpenAI finish_reason, and collects reasoning_details in provider_data.
         """
         import json
-        from agent.anthropic_adapter import _to_plain_data, _sanitize_replay_block
+        from agent.anthropic_adapter import (
+            _OAUTH_TOOL_NAME_REVERSE_ALIASES,
+            _sanitize_replay_block,
+            _to_plain_data,
+        )
         from agent.transports.types import ToolCall
 
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
@@ -143,14 +147,19 @@ class AnthropicTransport(ProviderTransport):
                     # Resolve by registry lookup, preferring whichever original
                     # is actually registered; never rewrite a name the LLM used
                     # that already resolves natively. GH-25255.
-                    from tools.registry import registry as _tool_registry
-                    if not _tool_registry.get_entry(name):
-                        bare = name[len(_MCP_PREFIX):]            # read_file
-                        single = "mcp_" + bare                    # mcp_read_file / mcp_linear_get_issue
-                        if _tool_registry.get_entry(single):
-                            name = single
-                        elif _tool_registry.get_entry(bare):
-                            name = bare
+                    bare = name[len(_MCP_PREFIX):]                # read_file
+                    # OAuth aliases must round-trip before the generic registry
+                    # lookup, which only knows Hermes's canonical tool names.
+                    if bare in _OAUTH_TOOL_NAME_REVERSE_ALIASES:
+                        name = _OAUTH_TOOL_NAME_REVERSE_ALIASES[bare]
+                    else:
+                        from tools.registry import registry as _tool_registry
+                        if not _tool_registry.get_entry(name):
+                            single = "mcp_" + bare                # mcp_read_file / mcp_linear_get_issue
+                            if _tool_registry.get_entry(single):
+                                name = single
+                            elif _tool_registry.get_entry(bare):
+                                name = bare
                 tool_calls.append(
                     ToolCall(
                         id=block.id,

--- a/tests/agent/test_anthropic_mcp_prefix_strip.py
+++ b/tests/agent/test_anthropic_mcp_prefix_strip.py
@@ -109,6 +109,38 @@ class TestAnthropicMcpPrefixStrip:
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0].name == "session_search"
 
+    def test_oauth_memory_alias_round_trips_to_registry_name(self):
+        """``mcp__context_notes`` dispatches as ``memory`` (#65365 second trigger)."""
+        transport = self._get_transport()
+        block = _make_tool_use_block("mcp__context_notes")
+        response = _make_response(block)
+
+        registry = _FakeRegistry({"memory"})
+        with patch("tools.registry.registry", registry):
+            result = transport.normalize_response(response, strip_tool_prefix=True)
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "memory"
+
+    def test_registered_tool_wins_over_oauth_alias(self):
+        """A real tool registered under the wire name keeps GH-25255 precedence.
+
+        An MCP server tool named ``mcp_chat_history_lookup`` goes out as
+        ``mcp__chat_history_lookup`` too. The alias must NOT hijack it — the
+        registry lookup runs first, so the genuinely registered tool wins and
+        the dispatcher doesn't silently run ``session_search`` instead.
+        """
+        transport = self._get_transport()
+        block = _make_tool_use_block("mcp__chat_history_lookup")
+        response = _make_response(block)
+
+        registry = _FakeRegistry({"mcp_chat_history_lookup", "session_search"})
+        with patch("tools.registry.registry", registry):
+            result = transport.normalize_response(response, strip_tool_prefix=True)
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "mcp_chat_history_lookup"
+
 
 
 
@@ -215,3 +247,59 @@ class TestAnthropicOAuthOutgoingPrefix:
         assert kwargs["tools"][0]["name"] == "session_search"
         assert "session_search" in kwargs["tools"][0]["description"]
         assert kwargs["system"] == "Use session_search before asking again."
+
+    def test_oauth_aliases_memory_tool_name_but_not_its_prose(self):
+        """#65365's second trigger: the ``memory`` schema name is aliased.
+
+        The name is what the classifier keys on, so it must not reach the wire.
+        Its description and the system prompt keep the word "memory" — it is
+        ordinary English there ("persistent memory across sessions"), and
+        rewriting prose would hand the model mangled instructions.
+        """
+        kwargs = self._build(
+            [{
+                "type": "function",
+                "function": {
+                    "name": "memory",
+                    "description": "Save durable facts to persistent memory.",
+                    "parameters": {},
+                },
+            }],
+            messages=[
+                {"role": "system", "content": "You have persistent memory across sessions."},
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        assert kwargs["tools"][0]["name"] == "mcp__context_notes"
+        # Prose is untouched — the tool still describes itself accurately.
+        assert "persistent memory" in kwargs["tools"][0]["description"]
+        system_text = " ".join(block["text"] for block in kwargs["system"])
+        assert "persistent memory across sessions" in system_text
+
+    def test_oauth_prose_alias_respects_word_boundaries(self):
+        """A longer identifier containing the token must not be rewritten.
+
+        System blocks carry user-supplied text (project AGENTS.md, memory
+        snapshots). Rewriting ``session_search_tool.py`` would produce a path
+        that doesn't exist and has no reverse mapping.
+        """
+        kwargs = self._build(
+            [],
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Use session_search to recall. "
+                        "Implementation lives in tools/session_search_tool.py."
+                    ),
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        system_text = " ".join(block["text"] for block in kwargs["system"])
+        # Bare token aliased...
+        assert "Use chat_history_lookup to recall." in system_text
+        # ...but the longer identifier survives intact.
+        assert "tools/session_search_tool.py" in system_text

--- a/tests/agent/test_anthropic_mcp_prefix_strip.py
+++ b/tests/agent/test_anthropic_mcp_prefix_strip.py
@@ -1,4 +1,4 @@
-"""Tests for GH-25255: Anthropic OAuth ``mcp__`` tool-name round-trip.
+"""Tests for Anthropic OAuth tool-name normalization and round-trips.
 
 Anthropic's subscription/OAuth billing classifier treats a **single-underscore**
 ``mcp_`` tool name as a third-party-app fingerprint and rejects the request with
@@ -11,6 +11,9 @@ the OAuth wire NOTHING may carry a single-underscore ``mcp_`` prefix:
 ``normalize_response`` reverses the ``mcp__`` wire name back to whatever the tool
 registry knows (the single-underscore ``mcp_<server>_<tool>`` form for MCP server
 tools, or the bare name for native tools) so the dispatcher is unaffected.
+
+The deterministic prompt trigger includes ``session_search`` guidance, so its
+OAuth wire alias must round-trip to the registry name.
 """
 
 from __future__ import annotations
@@ -93,6 +96,19 @@ class TestAnthropicMcpPrefixStrip:
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0].name == "mcp__read_file"
 
+    def test_oauth_session_search_alias_round_trips_to_registry_name(self):
+        """``mcp__chat_history_lookup`` dispatches as ``session_search``."""
+        transport = self._get_transport()
+        block = _make_tool_use_block("mcp__chat_history_lookup")
+        response = _make_response(block)
+
+        registry = _FakeRegistry({"session_search"})
+        with patch("tools.registry.registry", registry):
+            result = transport.normalize_response(response, strip_tool_prefix=True)
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "session_search"
+
 
 
 
@@ -106,11 +122,11 @@ class TestAnthropicOAuthOutgoingPrefix:
     """build_anthropic_kwargs must emit ZERO single-underscore ``mcp_`` names on
     the OAuth wire — bare names and MCP server names both land on ``mcp__``."""
 
-    def _build(self, tools, is_oauth=True):
+    def _build(self, tools, is_oauth=True, messages=None):
         from agent.anthropic_adapter import build_anthropic_kwargs
         return build_anthropic_kwargs(
             model="claude-sonnet-4-6",
-            messages=[{"role": "user", "content": "Hi"}],
+            messages=messages or [{"role": "user", "content": "Hi"}],
             tools=tools,
             max_tokens=4096,
             reasoning_config=None,
@@ -155,3 +171,47 @@ class TestAnthropicOAuthOutgoingPrefix:
         for n in names:
             assert not (n.startswith("mcp_") and not n.startswith("mcp__"))
 
+    def test_oauth_aliases_session_search_in_request_shape(self):
+        """OAuth aliases the classifier trigger in name, description, and prompt."""
+        kwargs = self._build(
+            [{
+                "type": "function",
+                "function": {
+                    "name": "session_search",
+                    "description": "Use session_search to recall prior chats.",
+                    "parameters": {},
+                },
+            }],
+            messages=[
+                {"role": "system", "content": "Use session_search before asking again."},
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        assert kwargs["tools"][0]["name"] == "mcp__chat_history_lookup"
+        assert "session_search" not in kwargs["tools"][0]["description"]
+        system_text = " ".join(block["text"] for block in kwargs["system"])
+        assert "session_search" not in system_text
+        assert "chat_history_lookup" in system_text
+
+    def test_non_oauth_keeps_session_search_request_shape(self):
+        """API-key requests retain the public tool name and prompt vocabulary."""
+        kwargs = self._build(
+            [{
+                "type": "function",
+                "function": {
+                    "name": "session_search",
+                    "description": "Use session_search to recall prior chats.",
+                    "parameters": {},
+                },
+            }],
+            is_oauth=False,
+            messages=[
+                {"role": "system", "content": "Use session_search before asking again."},
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        assert kwargs["tools"][0]["name"] == "session_search"
+        assert "session_search" in kwargs["tools"][0]["description"]
+        assert kwargs["system"] == "Use session_search before asking again."

--- a/tests/agent/test_anthropic_mcp_prefix_strip.py
+++ b/tests/agent/test_anthropic_mcp_prefix_strip.py
@@ -122,6 +122,26 @@ class TestAnthropicMcpPrefixStrip:
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0].name == "memory"
 
+    def test_bare_tool_name_from_prose_still_dispatches(self):
+        """The model may follow the prose and emit the canonical name.
+
+        ``memory``'s NAME is aliased on the wire but the system prompt still
+        says "use the memory tool", so the model can emit ``mcp__memory``.
+        The bare-name registry fallback must resolve it — this is the
+        invariant that makes leaving memory's prose intact safe.
+        """
+        transport = self._get_transport()
+        registry = _FakeRegistry({"memory", "session_search"})
+
+        for wire, expected in (
+            ("mcp__memory", "memory"),
+            ("mcp__session_search", "session_search"),
+        ):
+            response = _make_response(_make_tool_use_block(wire))
+            with patch("tools.registry.registry", registry):
+                result = transport.normalize_response(response, strip_tool_prefix=True)
+            assert result.tool_calls[0].name == expected, wire
+
     def test_registered_tool_wins_over_oauth_alias(self):
         """A real tool registered under the wire name keeps GH-25255 precedence.
 
@@ -225,6 +245,57 @@ class TestAnthropicOAuthOutgoingPrefix:
         system_text = " ".join(block["text"] for block in kwargs["system"])
         assert "session_search" not in system_text
         assert "chat_history_lookup" in system_text
+
+    def test_oauth_alias_yields_to_a_tool_that_owns_the_wire_name(self):
+        """An alias must never produce a duplicate tool name.
+
+        Two identical names in one request is a hard 400 from Anthropic, which
+        would break every call — strictly worse than the classifier bug. If a
+        real tool already maps onto the alias's wire name, that tool keeps it
+        and the aliased tool stays un-aliased. Mirrors the inbound
+        "registered tool wins" rule.
+        """
+        from agent.anthropic_adapter import _OAUTH_TOOL_NAME_ALIASES
+
+        def _tool(name):
+            return {"type": "function", "function": {
+                "name": name, "description": "d", "parameters": {}}}
+
+        kwargs = self._build([
+            _tool("session_search"),
+            _tool("mcp_chat_history_lookup"),   # real MCP tool owning the alias
+            _tool("memory"),
+            _tool("mcp_context_notes"),         # real MCP tool owning the alias
+        ])
+
+        names = [t["name"] for t in kwargs["tools"]]
+        assert len(names) == len(set(names)), f"duplicate wire names: {names}"
+        # The genuine tools keep the contested names...
+        assert "mcp__chat_history_lookup" in names
+        assert "mcp__context_notes" in names
+        # ...and the alias sources fall back to their own prefixed names.
+        for canonical in _OAUTH_TOOL_NAME_ALIASES:
+            assert f"mcp__{canonical}" in names
+
+    def test_prose_alias_names_are_a_subset_of_the_alias_map(self):
+        """The prose set must only name tools that actually have an alias.
+
+        Violating this raises KeyError at import; assert the contract by name
+        so the failure is legible instead of a stack trace in a 3000-line
+        module.
+        """
+        from agent.anthropic_adapter import (
+            _OAUTH_PROSE_ALIAS_NAMES,
+            _OAUTH_TOOL_NAME_ALIASES,
+        )
+
+        assert _OAUTH_PROSE_ALIAS_NAMES <= set(_OAUTH_TOOL_NAME_ALIASES)
+        # An alias's wire name must not be another alias's canonical name, or
+        # sequential prose substitution would chain-rewrite.
+        assert not (
+            set(_OAUTH_TOOL_NAME_ALIASES.values())
+            & set(_OAUTH_TOOL_NAME_ALIASES)
+        )
 
     def test_non_oauth_keeps_session_search_request_shape(self):
         """API-key requests retain the public tool name and prompt vocabulary."""


### PR DESCRIPTION
## Summary

Claude Pro/Max subscription users can use the session-search and memory toolsets again. Both tool schemas are renamed to neutral names on the Anthropic OAuth wire and restored to their registry names before dispatch, so Anthropic's billing classifier stops scoring the request as a third-party app and rerouting it to the (empty) extra-usage lane — the misleading HTTP 400 `You're out of extra usage` on a perfectly valid token.

Salvages #76669 by @konsisumer — commit cherry-picked with authorship preserved — plus one follow-up commit closing review findings.

## Changes

Salvaged (@konsisumer):
- `agent/anthropic_adapter.py`: alias `session_search` → `chat_history_lookup` on the OAuth path only — tool name, tool description, system-prompt text, and replayed history `tool_use` names.
- `agent/transports/anthropic.py`: reverse the alias in `normalize_response` so the dispatcher receives the canonical `session_search`.
- Tests for the OAuth request shape, the response round-trip, and the API-key passthrough.

Follow-ups (review findings):
- **The `memory` schema is aliased too** (`→ context_notes`). Issue #65365's A/B repro isolates *two* independent triggers — `base + session_search → 400` **and** `base + memory → 400`. The salvaged change covered only the first, so default-config users still hit the rejection.
- **Alias dict split by purpose.** Renaming a tool and rewriting the prose that describes it have different safety envelopes: `memory` is ordinary English throughout the system prompt ("persistent memory across sessions", "OS, CPU, memory, disk") and its own description, so only its *name* is aliased; `session_search` remains a prose-safe token. One dict driving both would have handed the model mangled instructions for a tool it still has to use.
- **Prose aliases match on word boundaries.** System blocks carry user-supplied text (project `AGENTS.md`, memory snapshots); a bare substring replace rewrote references like `tools/session_search_tool.py` into a path that doesn't exist and has no reverse mapping.
- **GH-25255 registry precedence restored.** The alias reverse-lookup ran *before* the registry check, so a real MCP server tool named `mcp_chat_history_lookup` would have been misrouted to `session_search`. The alias is now the last resort.
- **An alias can never duplicate a real tool's wire name.** If a user owns an MCP tool named `mcp_chat_history_lookup` / `mcp_context_notes`, the aliased tool collided with it — two identical tool names in one request is a hard 400, i.e. *every* call fails, strictly worse than the bug being fixed. The outbound side now yields the contested name to the genuine tool, mirroring the inbound precedence rule. (Found by running the review gate against my own follow-up commit, and verified live.)
- **Root-cause comment corrected** — it claimed the classifier fingerprints "the combination of `session_search` and `skill_manage` guidance terms"; `skill_manage` has no supporting evidence and the repro shows each schema triggering on its own, not in combination.

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_anthropic_mcp_prefix_strip.py` | 14 passed (7 salvaged + 7 new) |
| `tests/agent/ -k anthropic` | 288 passed, 3 skipped |
| `tests/agent/transports/` | 216 passed |
| E2E, real imports + real tool registry | 26/26 — both aliases round-trip, `terminal`/MCP tools unaffected, longer identifiers not mangled, `memory` prose intact, caller inputs unmutated, old cached `session_search` names still dispatch, non-OAuth clean |
| Mutation checks | reverting word-boundary matching, the registry-precedence order, the `memory` alias, or the wire-name collision guard each fails a test |
| ruff | clean |

Prompt caching: the rename is deterministic, so the cached prefix stays byte-stable within a conversation — verified across `PYTHONHASHSEED=0/1/42/random` (the `sorted()` over the prose-alias set is load-bearing; without it, 5 aliases produced 6 different orderings). Existing OAuth conversations take a one-time cache invalidation on upgrade (the system text changes) — unavoidable for any fix at this layer.

**Not verified live:** whether Anthropic now bills these requests to plan limits. That needs a subscription account (none available in this environment — HTTP 200 wouldn't prove the billing lane anyway, only the dashboard does). The premise rests on #65365's deterministic A/B repro; @tyoon10 and @Krypt0nBull3t both reproduced it independently and the reporter offered to test candidate branches.

Based on #76669 by @konsisumer. Fixes #65365.
