### PR TITLE
fix(daemon): resolve console script in service/spawn/generator paths (#76705)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -48,6 +48,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from hermes_cli.hermes_argv import resolve_hermes_argv
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -653,7 +654,7 @@ def find_profile_gateway_processes(
 
 
 def _gateway_run_args_for_profile(profile: str) -> list[str]:
-    args = [get_python_path(), "-m", "hermes_cli.main"]
+    args = resolve_hermes_argv(get_python_path())
     if profile != "default":
         args.extend(["--profile", profile])
     args.extend(["gateway", "run", "--replace"])
@@ -2867,6 +2868,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries.extend(_build_wsl_interop_paths(path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)
+        # Resolve the console script next to the (remapped) interpreter so the
+        # unit never hardcodes `python -m hermes_cli.main` (#76705).
+        hermes_exec = " ".join(resolve_hermes_argv(python_path, prefer_interpreter_sibling=True))
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
@@ -2877,7 +2881,7 @@ StartLimitIntervalSec=0
 Type={systemd_type}
 {systemd_watchdog_directives}User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
+ExecStart={hermes_exec}{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2910,6 +2914,9 @@ WantedBy=multi-user.target
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)
+    # Resolve the console script next to the interpreter so the unit never
+    # hardcodes `python -m hermes_cli.main` (#76705).
+    hermes_exec = " ".join(resolve_hermes_argv(python_path, prefer_interpreter_sibling=True))
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
@@ -2918,7 +2925,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type={systemd_type}
-{systemd_watchdog_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
+{systemd_watchdog_directives}ExecStart={hermes_exec}{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -3927,12 +3934,15 @@ def _launchd_unsupported_marker_exists() -> bool:
 
 
 def _gateway_run_command() -> list[str]:
-    """Build the `python -m hermes_cli.main [--profile X] gateway run --replace` argv.
+    """Build the hermes CLI gateway-run argv for a detached launch.
 
     Profile-aware: honors the active HERMES_HOME via `_profile_arg()` so the
     detached fallback launches into the same profile as the CLI invocation.
+    Resolves the ``hermes`` console script (interpreter-bound sibling first)
+    instead of hardcoding ``python -m hermes_cli.main``, falling back to the
+    ``-m`` form only when no shim exists (#76705).
     """
-    cmd = [get_python_path(), "-m", "hermes_cli.main"]
+    cmd = resolve_hermes_argv(get_python_path(), prefer_interpreter_sibling=True)
     profile_arg = _profile_arg()
     if profile_arg:
         cmd.extend(profile_arg.split())
@@ -4029,11 +4039,12 @@ def generate_launchd_plist() -> str:
         )
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
+    # Build ProgramArguments array, including --profile when using a named
+    # profile. Resolves the console script next to the interpreter instead of
+    # hardcoding `python -m hermes_cli.main` (#76705).
     prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
+        f"<string>{part}</string>"
+        for part in resolve_hermes_argv(python_path, prefer_interpreter_sibling=True)
     ]
     if profile_arg:
         for part in profile_arg.split():

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -44,6 +44,7 @@ from hermes_cli._subprocess_compat import (
     windows_detach_flags_without_breakaway,
     windows_hide_flags,
 )
+from hermes_cli.hermes_argv import resolve_hermes_argv
 
 # Short timeouts: schtasks occasionally wedges and we don't want to hang forever.
 _SCHTASKS_TIMEOUT_S = 15
@@ -218,12 +219,15 @@ def _launch_elevated_gateway_command(command: str, extra_args: list[str] | None 
     the parent shell before this point.
     """
     _assert_windows()
-    args = ["-m", "hermes_cli.main", *_current_profile_cli_args(), "gateway", command]
+    # Resolve the console script (interpreter-bound sibling first, `-m`
+    # fallback) instead of hardcoding `python -m hermes_cli.main` (#76705).
+    invocation = resolve_hermes_argv()
+    elevated_python = invocation[0]
+    args = [*invocation[1:], *_current_profile_cli_args(), "gateway", command]
     if extra_args:
         args.extend(extra_args)
     params = subprocess.list2cmdline(args)
     cwd = str(Path(__file__).resolve().parent.parent)
-    elevated_python = sys.executable
     try:
         result = ctypes.windll.shell32.ShellExecuteW(
             None,
@@ -421,7 +425,9 @@ def _build_gateway_cmd_script(
     ]
     lines.append(f'set "PYTHONPATH={";".join([*pythonpath_entries, "%PYTHONPATH%"])}"')
 
-    prog_args = [python_exe_path, "-m", "hermes_cli.main"]
+    # Resolve the console script next to the interpreter instead of
+    # hardcoding `python -m hermes_cli.main` (#76705).
+    prog_args = resolve_hermes_argv(python_exe_path, prefer_interpreter_sibling=True)
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])
@@ -475,7 +481,9 @@ def _build_gateway_vbs_script(
     """
     python_exe_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
 
-    prog_args = [python_exe_path, "-m", "hermes_cli.main"]
+    # Resolve the console script next to the interpreter instead of
+    # hardcoding `python -m hermes_cli.main` (#76705).
+    prog_args = resolve_hermes_argv(python_exe_path, prefer_interpreter_sibling=True)
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])
@@ -801,7 +809,9 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     hermes_home = str(Path(get_hermes_home()))
     profile_arg = _profile_arg(hermes_home)
 
-    argv = [python_exe, "-m", "hermes_cli.main"]
+    # Resolve the console script next to the interpreter instead of
+    # hardcoding `python -m hermes_cli.main` (#76705).
+    argv = resolve_hermes_argv(python_exe, prefer_interpreter_sibling=True)
     if profile_arg:
         argv.extend(profile_arg.split())
     argv.extend(["gateway", "run"])

--- a/hermes_cli/hermes_argv.py
+++ b/hermes_cli/hermes_argv.py
@@ -1,0 +1,82 @@
+"""Shared resolution of the Hermes CLI executable for spawn/service paths.
+
+Every daemon, spawn and service-definition generator used to hardcode
+``python -m hermes_cli.main``. Executing the module as ``__main__`` means a
+later ``from hermes_cli.main import ...`` cannot find it under its real name
+in ``sys.modules``, so the import machinery re-executes the module body —
+including its import-time side effects (see #76705).
+
+This helper resolves the ``hermes`` console script instead, falling back to
+the ``-m`` form only when no shim is available.  For service definitions the
+interpreter-bound sibling (``Path(interpreter).with_name("hermes")``) is
+preferred over ``shutil.which``: a launchd/systemd job runs with a minimal
+PATH, so a PATH lookup can miss the shim entirely or resolve a *different*
+Hermes install than the interpreter that generated the unit.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def _interpreter_sibling(interpreter: str) -> str | None:
+    """Return the console-script shim next to ``interpreter``, if any.
+
+    On Windows pip installs ``hermes.exe`` next to ``python.exe``; on POSIX
+    the shim is a bare ``hermes`` script.
+    """
+    interp = Path(interpreter)
+    names = ["hermes", "hermes.exe"] if sys.platform == "win32" else ["hermes"]
+    for name in names:
+        candidate = interp.with_name(name)
+        if candidate.is_file():
+            if sys.platform == "win32" or os.access(candidate, os.X_OK):
+                return str(candidate)
+    return None
+
+
+def resolve_hermes_argv(
+    interpreter: str | None = None,
+    *,
+    prefer_interpreter_sibling: bool = False,
+) -> list[str]:
+    """Resolve the Hermes CLI invocation as argv parts.
+
+    Priority:
+      1. ``Path(interpreter).with_name("hermes")`` — the console-script shim
+         belonging to the exact interpreter/venv that is running (or, for a
+         remapped system-unit interpreter, the target user's shim).  This is
+         interpreter-bound and independent of PATH, which matters for
+         launchd/systemd jobs that run with a minimal PATH.
+      2. ``shutil.which("hermes")`` — PATH lookup (interactive spawn paths).
+         On Windows, implicit ``.cmd`` / ``.bat`` shims are declined because
+         they are not safe as argv[0] for Popen/exec.
+      3. ``[interpreter, "-m", "hermes_cli.main"]`` — fallback when no shim
+         resolves (pip ``--target`` installs, zipapps, embedded
+         interpreters).
+
+    With ``prefer_interpreter_sibling=True`` (service definitions), the PATH
+    lookup is skipped entirely: a launchd/systemd job runs with a minimal
+    PATH, so ``shutil.which`` can miss the shim or resolve a *different*
+    Hermes install than the interpreter that generated the unit.  The
+    sibling is the interpreter-bound answer, and ``-m`` is the fallback.
+
+    Returns argv parts ready for ``Popen`` / ``execvpe`` / plist emission.
+    """
+    interp = interpreter or sys.executable
+
+    sibling = _interpreter_sibling(interp)
+    if sibling:
+        return [sibling]
+
+    if not prefer_interpreter_sibling:
+        path_bin = shutil.which("hermes")
+        if path_bin and not (
+            sys.platform == "win32" and path_bin.lower().endswith((".cmd", ".bat"))
+        ):
+            return [path_bin]
+
+    return [interp, "-m", "hermes_cli.main"]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -87,6 +87,9 @@ import sys
 # the full recovery path below.
 from hermes_cli import _early_recovery as _early_recovery_mod
 
+# Stdlib-only helper; safe to import even on a corrupted venv.
+from hermes_cli.hermes_argv import resolve_hermes_argv
+
 try:
     _early_recovery_mod.recover_if_needed()
 except Exception:
@@ -10266,8 +10269,12 @@ def cmd_dashboard(args):
             f"Routing to the machine dashboard (profile '{_launch_profile}' "
             f"preselected). Use --isolated for a dedicated per-profile server."
         )
+        # Resolve the hermes console script (interpreter-bound sibling first,
+        # `-m` fallback) so the re-exec does not hardcode `python -m
+        # hermes_cli.main` — a service running the console script with no -p
+        # must not re-exec itself back into the -m shape (#76705).
         reexec_argv = [
-            sys.executable, "-m", "hermes_cli.main",
+            *resolve_hermes_argv(),
             "-p", "default",
             # Preserve the lean serve path across the re-exec so a named-profile
             # `serve` doesn't silently rebuild the UI as `dashboard`.
@@ -10317,7 +10324,7 @@ def cmd_dashboard(args):
             proc = subprocess.Popen(reexec_argv, env=env)
             sys.exit(proc.wait())
         else:
-            os.execvpe(sys.executable, reexec_argv, env)
+            os.execvpe(reexec_argv[0], reexec_argv, env)
 
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 
 from hermes_cli.colors import Colors, color
+from hermes_cli.hermes_argv import resolve_hermes_argv
 
 def log_info(msg: str):
     print(f"{color('→', Colors.CYAN)} {msg}")
@@ -454,16 +455,17 @@ def _uninstall_profile(profile) -> None:
     service names, unit paths, and plist paths are all derived from the
     current HERMES_HOME and can't be easily switched in-process.
     """
-    import sys as _sys
     name = profile.name
     profile_home = profile.path
 
     log_info(f"Uninstalling profile '{name}'...")
 
     # 1. Stop and remove this profile's gateway service.
-    #    Use `python -m hermes_cli.main` so we don't depend on a `hermes`
-    #    wrapper that may be half-removed mid-uninstall.
-    hermes_invocation = [_sys.executable, "-m", "hermes_cli.main", "--profile", name]
+    #    Resolve the `hermes` console script (interpreter-bound sibling first)
+    #    instead of hardcoding `python -m hermes_cli.main`; the helper falls
+    #    back to the `-m` form when the shim is absent, so a wrapper that may
+    #    be half-removed mid-uninstall does not break the invocation (#76705).
+    hermes_invocation = [*resolve_hermes_argv(), "--profile", name]
     for subcmd in ("stop", "uninstall"):
         try:
             subprocess.run(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.hermes_argv import resolve_hermes_argv
 from hermes_constants import venv_python_path
 
 logger = logging.getLogger(__name__)
@@ -4220,7 +4221,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if _skip_desktop_build:
                 print("  ✓ Desktop app up to date")
             else:
-                _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
+                _desktop_build_cmd = [*resolve_hermes_argv(), "desktop", "--build-only"]
                 # Capture the (very loud) Electron/vite build output into
                 # update.log instead of streaming it to the terminal. On the rare
                 # nonzero exit, retry once after waiting again for the venv — this

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -81,6 +81,7 @@ from hermes_cli.config import (
     write_platform_config_field,
     _deep_merge,
 )
+from hermes_cli.hermes_argv import resolve_hermes_argv
 from plugins.memory.config_schema import (
     ProviderConfigSchema,
     ProviderField,
@@ -3699,8 +3700,9 @@ def _dashboard_spawn_executable() -> str:
 def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
-    Uses the running interpreter's ``hermes_cli.main`` module so the action
-    inherits the same venv/PYTHONPATH the web server is using.
+    Resolves the ``hermes`` console script (interpreter-bound sibling first,
+    ``-m`` fallback) so the action inherits the same venv/PYTHONPATH the web
+    server is using without hardcoding ``python -m hermes_cli.main`` (#76705).
     """
     log_file_name = _ACTION_LOG_FILES[name]
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -3710,7 +3712,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
     )
 
-    cmd = [_dashboard_spawn_executable(), "-m", "hermes_cli.main", *subcommand]
+    cmd = [*resolve_hermes_argv(_dashboard_spawn_executable()), *subcommand]
 
     # The dashboard runs *inside* the gateway process, so os.environ carries
     # _HERMES_GATEWAY=1. Inheriting it makes a spawned `hermes gateway restart`

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -48,7 +48,13 @@ class TestUnifiedDashboardRouting:
 
         assert len(execs) == 1
         exe, argv, env = execs[0]
-        assert exe == sys.executable
+        # The re-exec resolves the hermes console script (interpreter-bound
+        # sibling first, `-m` fallback) instead of hardcoding
+        # `python -m hermes_cli.main` (#76705).
+        from hermes_cli.hermes_argv import resolve_hermes_argv
+        resolved = resolve_hermes_argv()
+        assert argv[: len(resolved)] == resolved
+        assert exe == resolved[0]
         # Pinned to the default profile + launching profile preselected.
         assert "-p" in argv and argv[argv.index("-p") + 1] == "default"
         assert "--open-profile" in argv

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -124,9 +124,13 @@ def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
 
 
 def test_elevated_gateway_command_uses_hidden_console_python(monkeypatch):
-    """UAC handoff launches console python with SW_HIDE — a single hidden
-    console, not console-less pythonw (#54220/#56747), and no visible
-    elevated cmd.exe window left open."""
+    """UAC handoff launches the resolved hermes console script with SW_HIDE —
+    a single hidden console, not console-less pythonw (#54220/#56747), and no
+    visible elevated cmd.exe window left open.
+
+    The console script is resolved via resolve_hermes_argv() (interpreter-bound
+    sibling first, `-m` fallback) instead of hardcoding `python -m
+    hermes_cli.main` (#76705)."""
     calls = []
 
     class FakeShell32:
@@ -139,7 +143,11 @@ def test_elevated_gateway_command_uses_hidden_console_python(monkeypatch):
 
     monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
     monkeypatch.setattr(gateway_windows, "_current_profile_cli_args", lambda: ["--profile", "alice"])
-    monkeypatch.setattr(gateway_windows.sys, "executable", r"C:\Hermes\venv\Scripts\python.exe")
+    monkeypatch.setattr(
+        gateway_windows,
+        "resolve_hermes_argv",
+        lambda: [r"C:\Hermes\venv\Scripts\hermes.exe"],
+    )
     monkeypatch.setattr(gateway_windows.ctypes, "windll", FakeWindll(), raising=False)
 
     assert gateway_windows._launch_elevated_gateway_command("install", ["--start-now", "--elevated-handoff"])
@@ -147,8 +155,10 @@ def test_elevated_gateway_command_uses_hidden_console_python(monkeypatch):
     assert len(calls) == 1
     _hwnd, verb, executable, params, cwd, show = calls[0]
     assert verb == "runas"
-    assert executable == r"C:\Hermes\venv\Scripts\python.exe"
+    # Resolved console script, not `python -m hermes_cli.main` (#76705).
+    assert executable == r"C:\Hermes\venv\Scripts\hermes.exe"
     assert "--profile alice gateway install --start-now --elevated-handoff" in params
+    assert "-m" not in params and "hermes_cli.main" not in params
     assert show == 0
     assert cwd
 
@@ -198,12 +208,26 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
 
 
 def test_gateway_vbs_script_is_console_less(monkeypatch):
-    """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
-    (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""
+    """The .vbs launcher must avoid cmd.exe entirely and Run the hidden
+    console interpreter (issue #45599 fix A: no console -> no logon
+    CTRL_CLOSE_EVENT / 0xC000013A).
+
+    The interpreter argv is resolved via resolve_hermes_argv() — mocked here
+    to the `-m` fallback shape so the test stays deterministic on POSIX CI
+    (where a Windows-style interpreter path has no sibling shim); the real
+    resolver prefers the interpreter-bound console script when one exists
+    (#76705)."""
     monkeypatch.setattr(
         gateway_windows,
         "_resolve_detached_python",
         lambda exe: (r"C:\venv\Scripts\pythonw.exe", Path(r"C:\venv"), []),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "resolve_hermes_argv",
+        lambda interp=None, prefer_interpreter_sibling=False: [
+            r"C:\venv\Scripts\pythonw.exe", "-m", "hermes_cli.main",
+        ],
     )
     content = gateway_windows._build_gateway_vbs_script(
         r"C:\venv\Scripts\python.exe",


### PR DESCRIPTION
Closes #76705 (parts 1–3 — the mechanical, safe ones; part 4 documented below as follow-up)

## Summary

Every daemon, spawn and service-definition generator hardcoded `python -m hermes_cli.main`. Executing the module as `__main__` means a later `from hermes_cli.main import …` (e.g. `hermes_cli/plugins.py`) cannot find it under its real name in `sys.modules`, so the import machinery **re-executes the module body** — including `_apply_profile_override()` at `hermes_cli/main.py:684`, which can silently re-home a running daemon onto the sticky `active_profile`.

This PR replaces the hardcoded `-m` shape with **console-script resolution** in all service/spawn/generator paths, with the `-m` form kept only as a fallback when no shim resolves (pip `--target` installs, zipapps, embedded interpreters).

### New shared helper — `hermes_cli/hermes_argv.py`

Three near-duplicate resolvers already existed (`relaunch.py`, `kanban_db.py`, `gateway/run.py`); this adds the shared primitive they all encode rather than a fourth copy, per the placement constraint in `kanban_db.py:8854` (helper must live in `hermes_cli`, below `gateway` in the dependency order).

`resolve_hermes_argv()` tries, in order:
1. **`Path(interpreter).with_name("hermes")`** — the console-script shim belonging to the exact interpreter/venv that is running. Interpreter-bound and PATH-independent, which is what launchd/systemd jobs need (minimal PATH — `shutil.which` can miss the shim or resolve a *different* install than the interpreter that generated the unit).
2. **`shutil.which("hermes")`** — PATH lookup for interactive spawn paths (Windows `.cmd`/`.bat` shims declined, they are unsafe as argv[0]).
3. **`[interpreter, "-m", "hermes_cli.main"]`** — fallback.

For *service definitions specifically* (`prefer_interpreter_sibling=True`), the PATH lookup is skipped entirely: sibling → `-m`, never `which`.

### Sites converted (13 previously-unguarded)

**Service definitions / generators**
- `hermes_cli/gateway.py` — `_gateway_run_args_for_profile()` (per-profile respawn)
- `hermes_cli/gateway.py` — systemd user + system `ExecStart` (both templates)
- `hermes_cli/gateway.py` — `_gateway_run_command()` (detached launchd fallback)
- `hermes_cli/gateway.py` — `generate_launchd_plist()` `ProgramArguments`

**Spawn paths**
- `hermes_cli/web_server.py` — `_spawn_hermes_action()` (every dashboard action: gateway restart click + webhook/WhatsApp/Telegram auto-restarts)
- `hermes_cli/main.py` — machine-dashboard re-exec `os.execvpe` (also now execs `reexec_argv[0]`, matching the resolved argv)
- `hermes_cli/gateway_windows.py` — elevated UAC handoff, `gateway.cmd`, `gateway.vbs`, detached spawn
- `hermes_cli/uninstall.py` — profile uninstall gateway stop/uninstall
- `hermes_cli/update_cmd.py` — desktop `--build-only` spawn

When no shim exists, every site falls back to exactly the previous `-m` argv, so behavior is unchanged for non-shim installs.

### Tests
- `tests/hermes_cli/test_dashboard_unified_launch.py` — re-exec test now asserts the resolved console-script argv (`argv[:len(resolved)] == resolved`, `exe == resolved[0]`) instead of `exe == sys.executable`.
- `tests/hermes_cli/test_gateway_windows.py` — elevated-handoff and VBS tests mock `resolve_hermes_argv` deterministically (POSIX CI has no Windows sibling shim) and assert the resolved script is used, not `-m`.
- `tests/hermes_cli/test_gateway_service.py`, `test_systemd_*`, `test_web_server.py`, `test_dashboard_admin_endpoints.py`, `test_update_gateway_launcher_refresh.py` — all green.

## Follow-ups (out of scope for this PR — needs shape agreement)

- **Part 4 — launchd plist hardening**: `generate_launchd_plist()` still omits `Umask`/`SoftResourceLimits` (launchd's default soft `RLIMIT_NOFILE=256` is far below shell grants; a leaking daemon dies while staying alive → `KeepAlive` never fires) and bakes a frozen snapshot of the generating shell's PATH. The generator is authoritative and reverts operator hand-edits (`launchd_plist_is_current` compares normalized text), so this must land as one agreed change.
- **Part 2 — emit `["-p", <name>]` unconditionally in service definitions**: both profile-arg helpers map "default" to an empty arg list, which is exactly the state that lets `_apply_profile_override()` fall through to the sticky `active_profile`. Needs a separate explicit-pinning path (do **not** change `_profile_cli_args` in place — its interactive callers rely on "no flag" meaning "inherit").
- **Part 3 — flush stdio before the re-exec** in `hermes_cli/main.py`: `os.execvpe` discards buffered stdout, so the "Routing to the machine dashboard…" diagnostic is lost under a service manager. Guard against `sys.stdout is None` (windowless/detached launches).
