### PR TITLE
feat(dashboard): revoke basic-provider sessions (#76706)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -10,6 +10,8 @@ The routes:
   GET  /auth/login?provider=N → 302 to IDP, sets PKCE cookie
   GET  /auth/callback?code,state → completes login, sets session cookies
   POST /auth/logout        → clears cookies, best-effort revoke
+  POST /api/auth/revoke    → revoke one session lineage or all sessions
+                             server-side (auth-required; #76706)
   GET  /api/auth/providers → list registered providers (login bootstrap)
   GET  /api/auth/me        → current Session as JSON (auth-required)
 """
@@ -789,6 +791,99 @@ async def api_auth_me(request: Request):
         "provider": sess.provider,
         "expires_at": sess.expires_at,
     }
+
+
+# ---------------------------------------------------------------------------
+# Auth-required: session revocation (server-side kill switch)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/auth/revoke", name="auth_revoke")
+async def api_auth_revoke(request: Request):
+    """Revoke session(s) server-side. JSON counterpart of ``/auth/logout``.
+
+    ``/auth/logout`` clears the client's cookies and calls
+    ``revoke_session`` best-effort, but the stateless basic provider used
+    to have nothing to revoke — a captured refresh token stayed valid for
+    its full sliding 30-day window (issue #76706). Providers that opt in
+    keep a persisted revocation set keyed by token ``jti``, and this
+    endpoint drives it so an operator can kill a session (or every
+    session) without rotating the signing secret.
+
+    Request body (JSON, both optional):
+
+      * ``{"refresh_token": "..."}`` — revoke one session lineage. When
+        omitted, the caller's own refresh-token cookie is used.
+      * ``{"all": true}`` — revoke every session the providers can see.
+        Providers expose ``revoke_all_sessions`` for this; providers that
+        don't fall back to revoking the caller's own refresh token.
+
+    Best-effort per provider — mirrors ``/auth/logout``: failures are
+    logged, never raised. Auth-required (the gate rejects unauthenticated
+    ``/api/*`` requests before this handler runs).
+    """
+    sess = getattr(request.state, "session", None)
+    if sess is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    body: Dict[str, Any] = {}
+    try:
+        parsed = await request.json()
+        if isinstance(parsed, dict):
+            body = parsed
+    except Exception:  # noqa: BLE001 — malformed/absent body is not fatal
+        body = {}
+
+    revoke_all = bool(body.get("all"))
+    requested_rt = body.get("refresh_token") or ""
+    _at, cookie_rt = read_session_cookies(request)
+    rt = requested_rt or cookie_rt or ""
+
+    # Best-effort revoke. Try every provider so a session minted by any
+    # registered provider is revoked correctly. Failures are logged but
+    # never raised.
+    results: Dict[str, str] = {}
+    for provider in list_providers():
+        results[provider.name] = "ok"
+        try:
+            if revoke_all:
+                revoke_all_sessions = getattr(
+                    provider, "revoke_all_sessions", None
+                )
+                if callable(revoke_all_sessions):
+                    revoke_all_sessions()
+                elif rt:
+                    provider.revoke_session(refresh_token=rt)
+            elif rt:
+                provider.revoke_session(refresh_token=rt)
+        except Exception as e:  # noqa: BLE001 — best-effort
+            # Per-provider error is logged with detail; the response only
+            # carries a flag so internal paths/exceptions never leak.
+            results[provider.name] = "error"
+            _log.warning(
+                "dashboard-auth: revoke on %r failed: %s",
+                provider.name, e,
+            )
+
+    audit_log(
+        AuditEvent.REVOKE,
+        provider=(sess.provider if sess else "unknown"),
+        user_id=(sess.user_id if sess else ""),
+        ip=_client_ip(request),
+    )
+
+    resp = JSONResponse(
+        {"ok": True, "revoked_all": revoke_all, "providers": results}
+    )
+    if revoke_all or (rt and rt == cookie_rt):
+        # The caller's own session is gone (revoke-all kills everything;
+        # otherwise the revoked token was the caller's own). Drop the
+        # cookies so the SPA lands on /login cleanly instead of riding a
+        # doomed cookie until the next 401.
+        prefix = _prefix(request)
+        clear_session_cookies(resp, prefix=prefix)
+        clear_pkce_cookie(resp, prefix=prefix)
+    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_revoke_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_revoke_endpoint.py
@@ -1,0 +1,138 @@
+"""Tests for POST /api/auth/revoke (issue #76706).
+
+The revoke endpoint is the auth-required JSON counterpart of
+``/auth/logout``: it drives the providers' server-side revocation (for the
+basic provider, a persisted revocation set keyed by token ``jti``) so a
+captured refresh token can be killed without waiting out its sliding TTL.
+
+``revoke_all_sessions`` is a provider opt-in capability; providers without
+it fall back to revoking the caller's own refresh token (the same
+best-effort loop ``/auth/logout`` already runs).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+@pytest.fixture
+def gated_app():
+    """Configure web_server.app for gated mode + register the stub provider."""
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def _complete_stub_login(client) -> None:
+    """Walk the stub OAuth round trip so ``client`` carries a valid session."""
+    r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
+    assert r1.status_code == 302
+    state = r1.headers["location"].split("state=")[1]
+    r2 = client.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+    assert r2.status_code == 302
+
+
+class _RevokeTrackingProvider(StubAuthProvider):
+    """Stub that records revoke calls so tests can assert what ran."""
+
+    def __init__(self):
+        super().__init__()
+        self.revoked_tokens: list[str] = []
+        self.revoke_all_calls = 0
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        self.revoked_tokens.append(refresh_token)
+
+    def revoke_all_sessions(self) -> None:
+        self.revoke_all_calls += 1
+
+
+def test_revoke_requires_auth(gated_app):
+    """No session cookie → the gate rejects the request with 401."""
+    r = gated_app.post("/api/auth/revoke", json={"all": True})
+    assert r.status_code == 401
+
+
+def test_revoke_all_success_and_clears_cookies(gated_app):
+    """{all: true} succeeds and drops the caller's own session cookies.
+
+    The plain stub has no ``revoke_all_sessions``, so the endpoint falls
+    back to revoking the caller's own refresh token — the same best-effort
+    loop /auth/logout runs. Either way the caller's session is gone and the
+    cookies must be cleared so the SPA lands on /login cleanly.
+    """
+    _complete_stub_login(gated_app)
+    r = gated_app.post("/api/auth/revoke", json={"all": True})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["revoked_all"] is True
+    assert body["providers"] == {"stub": "ok"}
+
+    set_cookie = r.headers.get("set-cookie", "")
+    assert "hermes_session_rt=" in set_cookie, (
+        "revoke-all must clear the caller's refresh-token cookie; "
+        f"Set-Cookie was: {set_cookie!r}"
+    )
+
+
+def test_revoke_all_calls_provider_revoke_all(gated_app):
+    """Providers that opt into ``revoke_all_sessions`` get called with it."""
+    clear_providers()
+    tracking = _RevokeTrackingProvider()
+    register_provider(tracking)
+    _complete_stub_login(gated_app)
+
+    r = gated_app.post("/api/auth/revoke", json={"all": True})
+    assert r.status_code == 200
+    assert tracking.revoke_all_calls == 1
+    assert tracking.revoked_tokens == [], (
+        "revoke-all must use revoke_all_sessions, not per-token revoke"
+    )
+
+
+def test_revoke_specific_refresh_token(gated_app):
+    """{refresh_token: ...} revokes just that lineage, cookies untouched."""
+    clear_providers()
+    tracking = _RevokeTrackingProvider()
+    register_provider(tracking)
+    _complete_stub_login(gated_app)
+
+    r = gated_app.post(
+        "/api/auth/revoke", json={"refresh_token": "captured-token-abc"}
+    )
+    assert r.status_code == 200
+    assert tracking.revoked_tokens == ["captured-token-abc"]
+    body = r.json()
+    assert body["revoked_all"] is False
+    assert "hermes_session_rt=" not in r.headers.get("set-cookie", ""), (
+        "revoking a different session must not clear the caller's cookies"
+    )
+
+
+def test_revoke_without_body_revokes_own_cookie(gated_app):
+    """No body → the caller's own refresh-token cookie is revoked."""
+    _complete_stub_login(gated_app)
+    r = gated_app.post("/api/auth/revoke")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    # Own session revoked → cookies cleared (same as logout).
+    assert "hermes_session_rt=" in r.headers.get("set-cookie", "")

--- a/web/src/components/AuthWidget.tsx
+++ b/web/src/components/AuthWidget.tsx
@@ -13,6 +13,9 @@
  *     defaults to the bare provider key)
  *   - a logout button that POSTs /auth/logout and full-page-navigates to
  *     /login (the dashboard becomes inaccessible again)
+ *   - a "sign out all devices" button that POSTs /api/auth/revoke
+ *     ({"all": true}) — the server-side kill switch added for #76706 —
+ *     and full-page-navigates to /login once every session is revoked
  *
  * Failure modes:
  *   - 401 from /api/auth/me means we're not gated (or the gate is on but
@@ -26,7 +29,8 @@
 import { useEffect, useState } from "react";
 import { api, type AuthMeResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { LogOut } from "lucide-react";
+import { LogOut, ShieldOff } from "lucide-react";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 interface AuthWidgetProps {
   className?: string;
@@ -44,6 +48,9 @@ export function AuthWidget({ className }: AuthWidgetProps) {
   const [me, setMe] = useState<AuthMeResponse | null>(null);
   const [hidden, setHidden] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [confirmRevokeAll, setConfirmRevokeAll] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
 
   // Loopback / --insecure mode: the auth gate is off, so /api/auth/me is a
   // guaranteed 401. Don't fire the request at all — it only produces console
@@ -117,6 +124,22 @@ export function AuthWidget({ className }: AuthWidgetProps) {
     void api.logout();
   };
 
+  const handleRevokeAll = async () => {
+    setRevoking(true);
+    setRevokeError(null);
+    try {
+      await api.revokeAllSessions();
+      // Every session — including this one — is revoked server-side and the
+      // endpoint cleared our cookies. Land on the login page instead of
+      // riding a doomed cookie until the next 401.
+      window.location.assign("/login");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setRevokeError(msg);
+      setRevoking(false);
+    }
+  };
+
   // Prefer display_name → email → truncated user_id. Contract V1 only
   // populates user_id; the fallthroughs are forward-compat for a future
   // Portal that adds a userinfo endpoint (OQ-C1 in the plan).
@@ -141,20 +164,50 @@ export function AuthWidget({ className }: AuthWidgetProps) {
         <span className="truncate text-muted-foreground/70">
           via {me.provider}
         </span>
-      </div>
-      <button
-        type="button"
-        onClick={handleLogout}
-        className={cn(
-          "shrink-0 rounded p-1.5 text-muted-foreground/70",
-          "transition-colors hover:bg-current/10 hover:text-foreground",
-          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current/40",
+        {revokeError && (
+          <span className="truncate text-[0.6rem] text-destructive" title={revokeError}>
+            revoke failed
+          </span>
         )}
-        aria-label="Log out"
-        title="Log out"
-      >
-        <LogOut className="h-3.5 w-3.5" />
-      </button>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          onClick={() => setConfirmRevokeAll(true)}
+          className={cn(
+            "shrink-0 rounded p-1.5 text-muted-foreground/70",
+            "transition-colors hover:bg-current/10 hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current/40",
+          )}
+          aria-label="Sign out all devices"
+          title="Sign out all devices"
+        >
+          <ShieldOff className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={handleLogout}
+          className={cn(
+            "shrink-0 rounded p-1.5 text-muted-foreground/70",
+            "transition-colors hover:bg-current/10 hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current/40",
+          )}
+          aria-label="Log out"
+          title="Log out"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <ConfirmDialog
+        open={confirmRevokeAll}
+        title="Sign out all devices?"
+        description="This revokes every dashboard session, including this one. You will need to sign in again on every device."
+        confirmLabel="Sign out all devices"
+        destructive
+        loading={revoking}
+        onCancel={() => setConfirmRevokeAll(false)}
+        onConfirm={() => void handleRevokeAll()}
+      />
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -382,6 +382,20 @@ export const api = {
       window.location.assign("/login");
       return r;
     }),
+  /**
+   * Revoke every dashboard session server-side (issue #76706).
+   *
+   * POSTs the auth-required `/api/auth/revoke` endpoint with `{"all": true}`.
+   * The server revokes the caller's own session too and clears the session
+   * cookies, so on success the caller should full-page-navigate to /login
+   * (this device is signed out along with every other one).
+   */
+  revokeAllSessions: () =>
+    fetchJSON<RevokeAllResponse>("/api/auth/revoke", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ all: true }),
+    }),
   getSessions: (
     limit = 20,
     offset = 0,
@@ -1349,6 +1363,12 @@ export interface AuthMeResponse {
   org_id: string;
   provider: string;
   expires_at: number;
+}
+
+export interface RevokeAllResponse {
+  ok: boolean;
+  revoked_all: boolean;
+  providers: Record<string, string>;
 }
 
 export interface ActionResponse {


### PR DESCRIPTION
Closes #76706 (dashboard half)

## What changed

Adds the operator-facing **server-side session revoke** to the dashboard —
the endpoint and UI that drive the revocation set the basic provider now
keeps (token `jti` + persisted revoke set, landed alongside this PR).

### Backend (dashboard auth routes only)
- **`POST /api/auth/revoke`** (auth-required, JSON) — the server-side
  counterpart of `/auth/logout`. Body is optional and supports:
  - `{"all": true}` — revoke **every** session the providers can see.
    Providers that opt in expose `revoke_all_sessions`; providers that
    don't fall back to revoking the caller's own refresh token (the same
    best-effort loop `/auth/logout` already runs).
  - `{"refresh_token": "..."}` — revoke one session lineage.
  - no body — revoke the caller's own refresh-token cookie.
- Best-effort per provider, mirrors `/auth/logout`: failures are logged,
  never raised, and per-provider error detail stays in the log — the
  response only carries an `ok`/`error` flag so internal paths never leak.
- When the caller's own session is revoked (revoke-all, or revoking its
  own token), the response clears the session cookies so the SPA lands on
  `/login` cleanly instead of riding a doomed cookie until the next 401.
- Audit-logged as `revoke` (`AuditEvent.REVOKE`, pre-existing event).

### Frontend (React dashboard)
- `web/src/lib/api.ts` — `revokeAllSessions()` API client call
  (`POST /api/auth/revoke` with `{"all": true}`) + `RevokeAllResponse`.
- `web/src/components/AuthWidget.tsx` — new **"Sign out all devices"**
  button (shield icon) next to Log Out in the sidebar identity widget,
  backed by a destructive `ConfirmDialog`; on success the SPA navigates
  to `/login`.

### Tests
- `tests/hermes_cli/test_dashboard_auth_revoke_endpoint.py` — 5 tests:
  gate rejects unauthenticated requests (401); revoke-all succeeds and
  clears the caller's cookies; providers with `revoke_all_sessions` are
  called with it (and per-token revoke is not used); a specific
  `refresh_token` revokes only that lineage without clearing the caller's
  cookies; a bodyless call revokes the caller's own cookie.
- 5/5 pass; neighboring dashboard-auth suites still green
  (middleware/gate/audit/401-reauth: 54 passed).

## Why it matters
`/auth/logout` was a client-side-only action for the basic provider —
any captured refresh token stayed valid for its full sliding 30-day
window with no kill switch short of rotating the signing secret. With the
provider's revocation set in place, this endpoint gives operators a
per-session and a per-user "sign out everywhere" control without a global
secret rotation.

## Notes
- Works with any provider that implements the existing `revoke_session`
  contract; `revoke_all_sessions` is a new opt-in capability used when
  present (duck-typed, no protocol change required).
- The basic-provider `jti`/revocation-set backend change ships in the
  sibling PR for this issue.
