### PR TITLE
fix(desktop): preserve live Windows host PATH

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -186,6 +186,24 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
 })
 
+test('Windows backend PATH keeps live host entries ahead of stale process extras', () => {
+  const env = buildDesktopBackendEnv({
+    hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
+    venvRoot: 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv',
+    currentEnv: {
+      Path: 'C:\\Stale\\Desktop\\bin;C:\\Windows\\System32'
+    },
+    hostPath: 'C:\\Windows\\System32;C:\\Host\\GitHubCLI;C:\\Host\\Git\\bin',
+    platform: 'win32',
+    pathModule: path.win32
+  })
+
+  const entries = env.Path.split(';')
+  assert.ok(entries.indexOf('C:\\Host\\GitHubCLI') >= 0)
+  assert.ok(entries.indexOf('C:\\Host\\GitHubCLI') < entries.indexOf('C:\\Stale\\Desktop\\bin'))
+  assert.equal(entries.filter(entry => entry.toLowerCase() === 'c:\\windows\\system32').length, 1)
+})
+
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {
   assert.equal(appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }), '/a:/b:/c')
 })

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -36,7 +36,7 @@ function currentPathValue(env = process.env, platform = process.platform) {
   return env?.[key] || ''
 }
 
-function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
+function appendUniquePathEntries(entries, { delimiter = path.delimiter, caseInsensitive = false }: any = {}) {
   const seen = new Set()
   const ordered = []
 
@@ -48,11 +48,13 @@ function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
     const parts = Array.isArray(entry) ? entry : String(entry).split(delimiter)
 
     for (const part of parts) {
-      if (!part || seen.has(part)) {
+      const comparisonKey = caseInsensitive ? part.toLowerCase() : part
+
+      if (!part || seen.has(comparisonKey)) {
         continue
       }
 
-      seen.add(part)
+      seen.add(comparisonKey)
       ordered.push(part)
     }
   }
@@ -92,6 +94,7 @@ function buildDesktopBackendPath({
   hermesHome,
   venvRoot,
   currentPath = '',
+  hostPath = '',
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
 }: any = {}) {
@@ -100,7 +103,10 @@ function buildDesktopBackendPath({
   const venvBin = venvRoot ? pathModule.join(venvRoot, platform === 'win32' ? 'Scripts' : 'bin') : null
   const saneEntries = platform === 'win32' ? [] : POSIX_SANE_PATH_ENTRIES
 
-  return appendUniquePathEntries([hermesNodeDirs, venvBin, currentPath, saneEntries], { delimiter })
+  return appendUniquePathEntries([hermesNodeDirs, venvBin, hostPath, currentPath, saneEntries], {
+    delimiter,
+    caseInsensitive: platform === 'win32'
+  })
 }
 
 function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {
@@ -122,6 +128,7 @@ function buildDesktopBackendEnv({
   hermesHome,
   pythonPathEntries = [],
   venvRoot,
+  hostPath = '',
   currentEnv = process.env,
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
@@ -142,6 +149,7 @@ function buildDesktopBackendEnv({
     [key]: buildDesktopBackendPath({
       hermesHome,
       venvRoot,
+      hostPath,
       currentPath: currentPathValue(currentEnv, platform),
       platform,
       pathModule

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -244,7 +244,7 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
-import { readWindowsUserEnvVar } from './windows-user-env'
+import { readWindowsHostPath, readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
@@ -577,6 +577,17 @@ function resolveHermesHome() {
 }
 
 const HERMES_HOME = resolveHermesHome()
+
+function buildDesktopBackendEnvironment(options) {
+  return buildDesktopBackendEnv({
+    ...options,
+    // Electron launched from Explorer can retain the login-time PATH while
+    // Windows' live User/Machine PATH has changed since then. Keep the live
+    // host entries ahead of stale process extras, while buildDesktopBackendEnv
+    // still prepends Hermes-managed paths.
+    hostPath: IS_WINDOWS ? readWindowsHostPath() || '' : ''
+  })
+}
 
 function pathWithHermesManagedNode(...entries) {
   const managed = hermesManagedNodePathEntries(HERMES_HOME).filter(directoryExists)
@@ -1867,7 +1878,7 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
     canImportHermesCli,
     getVenvPython,
     getVenvSitePackagesEntries,
-    buildDesktopBackendEnv,
+    buildDesktopBackendEnv: buildDesktopBackendEnvironment,
     hermesHome: HERMES_HOME,
     resolvePath: (...segments) => path.resolve(...segments),
     dirname: p => path.dirname(p),
@@ -3836,7 +3847,7 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
     label,
     command,
     args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
+    env: buildDesktopBackendEnvironment({
       hermesHome: HERMES_HOME,
       pythonPathEntries: [root, ...getVenvSitePackagesEntries(venvRoot)],
       venvRoot
@@ -3860,7 +3871,7 @@ function createActiveBackend(backendArgs) {
     label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
     command,
     args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
+    env: buildDesktopBackendEnvironment({
       hermesHome: HERMES_HOME,
       pythonPathEntries: [ACTIVE_HERMES_ROOT, ...getVenvSitePackagesEntries(VENV_ROOT)],
       venvRoot: VENV_ROOT

--- a/apps/desktop/electron/windows-user-env.test.ts
+++ b/apps/desktop/electron/windows-user-env.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar } from './windows-user-env'
+import {
+  expandWindowsEnvRefs,
+  parseRegQueryValue,
+  readWindowsHostPath,
+  readWindowsUserEnvVar
+} from './windows-user-env'
 
 // ── parseRegQueryValue ─────────────────────────────────────────────────────
 
@@ -84,4 +89,43 @@ test('readWindowsUserEnvVar returns null when reg exits non-zero (value missing)
 test('readWindowsUserEnvVar returns null for an empty value', () => {
   const exec = () => '    HERMES_HOME    REG_SZ    \r\n'
   assert.equal(readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', exec }), null)
+})
+
+test('readWindowsHostPath combines live machine and user PATH in Windows order', () => {
+  const calls = []
+
+  const exec = (cmd, args) => {
+    calls.push([cmd, args])
+
+    if (args[1].startsWith('HKLM\\')) {
+      return 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\r\n'
+        + '    Path    REG_EXPAND_SZ    %SystemRoot%\\system32;C:\\Host\\System\r\n'
+    }
+
+    return 'HKEY_CURRENT_USER\\Environment\r\n'
+      + '    Path    REG_SZ    C:\\Host\\User;C:\\Host\\GitHubCLI\r\n'
+  }
+
+  const path = readWindowsHostPath({
+    platform: 'win32',
+    env: { SystemRoot: 'C:\\Windows' },
+    exec
+  })
+
+  assert.equal(path, 'C:\\Windows\\system32;C:\\Host\\System;C:\\Host\\User;C:\\Host\\GitHubCLI')
+  assert.deepEqual(calls, [
+    ['reg', ['query', 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', '/v', 'Path']],
+    ['reg', ['query', 'HKCU\\Environment', '/v', 'Path']]
+  ])
+})
+
+test('readWindowsHostPath is a no-op off Windows', () => {
+  let spawned = false
+  const exec = () => {
+    spawned = true
+    return ''
+  }
+
+  assert.equal(readWindowsHostPath({ platform: 'linux', exec }), null)
+  assert.equal(spawned, false)
 })

--- a/apps/desktop/electron/windows-user-env.ts
+++ b/apps/desktop/electron/windows-user-env.ts
@@ -53,20 +53,20 @@ function expandWindowsEnvRefs(value, env = process.env) {
   })
 }
 
-// Read a User-scoped env var from HKCU\Environment. Windows-only: returns null
-// off-Windows (without spawning), on any spawn error, when `reg` exits non-zero
-// (the value doesn't exist), or when the value is empty.
-function readWindowsUserEnvVar(
+type WindowsEnvReadOptions = {
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  exec?: typeof execFileSync | ((file?: string, args?: any) => string)
+}
+
+function readWindowsRegistryEnvVar(
+  keyPath: string,
   name,
   {
     platform = process.platform,
     env = process.env,
     exec = execFileSync
-  }: {
-    platform?: NodeJS.Platform
-    env?: NodeJS.ProcessEnv
-    exec?: typeof execFileSync | ((file?: string, args?: any) => string)
-  } = {}
+  }: WindowsEnvReadOptions = {}
 ) {
   if (platform !== 'win32' || !name) {
     return null
@@ -75,13 +75,12 @@ function readWindowsUserEnvVar(
   let stdout
 
   try {
-    stdout = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
+    stdout = exec('reg', ['query', keyPath, '/v', name], {
       encoding: 'utf8',
       windowsHide: true,
       timeout: 5000
     })
   } catch {
-    // `reg` missing, or value absent (reg exits 1) — caller falls back.
     return null
   }
 
@@ -96,4 +95,30 @@ function readWindowsUserEnvVar(
   return expanded || null
 }
 
-export { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar }
+// Read a User-scoped env var from HKCU\Environment. Windows-only: returns null
+// off-Windows (without spawning), on any spawn error, when `reg` exits non-zero
+// (the value doesn't exist), or when the value is empty.
+function readWindowsUserEnvVar(name, options: WindowsEnvReadOptions = {}) {
+  return readWindowsRegistryEnvVar('HKCU\\Environment', name, options)
+}
+
+const WINDOWS_MACHINE_ENV_KEY = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+
+// Return the live effective Windows PATH rather than the environment snapshot
+// inherited by an Explorer-launched Electron process. Windows composes the
+// machine PATH before the user PATH; keeping that order preserves normal
+// command-resolution precedence while allowing newly-installed user tools to
+// become visible without restarting Windows.
+function readWindowsHostPath({ platform = process.platform, env = process.env, exec = execFileSync }: WindowsEnvReadOptions = {}) {
+  if (platform !== 'win32') {
+    return null
+  }
+
+  const machinePath = readWindowsRegistryEnvVar(WINDOWS_MACHINE_ENV_KEY, 'Path', { platform, env, exec })
+  const userPath = readWindowsRegistryEnvVar('HKCU\\Environment', 'Path', { platform, env, exec })
+  const entries = [machinePath, userPath].filter(Boolean)
+
+  return entries.length ? entries.join(';') : null
+}
+
+export { expandWindowsEnvRefs, parseRegQueryValue, readWindowsHostPath, readWindowsUserEnvVar }

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -293,6 +293,23 @@ class TestGitBashCoreutilsOnPath:
         # No Windows git dirs injected on POSIX.
         assert "mingw64" not in run_env["PATH"]
 
+    def test_make_run_env_merges_windows_path_case_variants(self, monkeypatch):
+        """Desktop/Python PATH overlays must not hide the inherited host PATH."""
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", None)
+        monkeypatch.setattr(local_mod, "_prepend_git_bash_dirs", lambda value: value)
+
+        host_path = r"C:\Host\GitHubCLI;C:\Windows\System32"
+        with patch.object(local_mod.os, "environ", {"Path": host_path}):
+            run_env = _make_run_env({"PATH": r"C:\Hermes\venv\Scripts"})
+
+        path_keys = [key for key in run_env if key.lower() == "path"]
+        assert path_keys == ["Path"]
+        merged_path = run_env["Path"]
+        assert merged_path.startswith(r"C:\Hermes\venv\Scripts;")
+        assert r"C:\Host\GitHubCLI" in merged_path
+        assert r"C:\Windows\System32" in merged_path
+
 
 # ---------------------------------------------------------------------------
 # Command wrapping — native Windows cwd must be Git Bash-friendly for cd

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -978,6 +978,10 @@ def _git_bash_bin_dirs() -> list[str]:
         os.path.join(root, "usr", "bin"),
         os.path.join(root, "bin"),
     ):
+        # These entries are exported to Git Bash, where forward slashes are
+        # the stable spelling even when Python discovered the native path with
+        # Windows separators.  os.path.isdir accepts either spelling.
+        candidate = candidate.replace("\\", "/")
         if os.path.isdir(candidate) and candidate not in dirs:
             dirs.append(candidate)
 
@@ -1265,6 +1269,59 @@ def _path_env_key(run_env: dict) -> str | None:
     return None
 
 
+def _merge_windows_path_env(base_env: dict, extra_env: dict) -> dict:
+    """Merge Windows PATH case-insensitively without losing either value.
+
+    ``os.environ`` and Electron's environment overlay can spell the same
+    Windows variable as ``Path`` and ``PATH``. Python dictionaries preserve
+    both spellings even though CreateProcess and Git Bash treat them as one
+    variable; leaving both entries makes the effective winner undefined and
+    can hide the inherited host PATH behind a Hermes-only overlay.
+
+    Explicit extra values lead so Hermes-managed directories retain their
+    intended precedence. The inherited value follows so host-installed tools
+    remain discoverable. All other environment keys keep normal overlay
+    semantics.
+    """
+    merged = dict(base_env)
+    if not _IS_WINDOWS:
+        merged.update(extra_env)
+        return merged
+
+    base_path_keys = [key for key in merged if key.lower() == "path"]
+    extra_path_keys = [key for key in extra_env if key.lower() == "path"]
+    path_keys = [*base_path_keys, *extra_path_keys]
+
+    merged.update(extra_env)
+    if not path_keys:
+        return merged
+
+    path_key = base_path_keys[0] if base_path_keys else extra_path_keys[0]
+    path_values = [
+        str(extra_env[key])
+        for key in extra_path_keys
+        if extra_env[key] is not None and str(extra_env[key])
+    ] + [
+        str(base_env[key])
+        for key in base_path_keys
+        if base_env[key] is not None and str(base_env[key])
+    ]
+
+    entries: list[str] = []
+    seen: set[str] = set()
+    for value in path_values:
+        for entry in value.split(";"):
+            comparison_key = entry.casefold()
+            if entry and comparison_key not in seen:
+                seen.add(comparison_key)
+                entries.append(entry)
+
+    for key in path_keys:
+        merged.pop(key, None)
+    merged[path_key] = ";".join(entries)
+    return merged
+
+
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
@@ -1276,7 +1333,7 @@ def _make_run_env(env: dict) -> dict:
         _is_passthrough = lambda _: False  # noqa: E731
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
-    merged = dict(os.environ | env)
+    merged = _merge_windows_path_env(os.environ, env)
     run_env = {}
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):


### PR DESCRIPTION
## Summary
- refresh the native Windows Desktop backend PATH from the live Machine and User registry values instead of relying only on Electron's login-time environment snapshot
- preserve Hermes-managed Node and virtualenv precedence while retaining host-installed executable directories
- collapse Windows `Path`/`PATH` case variants before local terminal execution so a Hermes overlay cannot hide the inherited host PATH
- keep POSIX and remote terminal behavior unchanged

## Root cause
Electron launched from Explorer can retain a stale login-time PATH. At the Desktop-to-Python boundary, Windows PATH could also be represented by both `Path` and `PATH`; Python treats those as distinct keys even though Windows process creation does not, leaving the effective child PATH ambiguous.

## Verification
- `npm run --workspace apps/desktop test:desktop:platforms -- electron/windows-user-env.test.ts electron/backend-env.test.ts` — 23 passed
- `HERMES_PYTHON=/c/Users/[user]/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/tools/test_local_env_windows_msys.py tests/tools/test_env_passthrough.py tests/tools/test_windows_native_support.py -q` — 98 passed
- `git diff --check origin/main...HEAD` — passed

## Broader-suite note
The worker also ran the full Desktop platform suite: 918 passed, 2 skipped, with 17 unrelated pre-existing failures in Windows/POSIX path-assumption, SSH, update-relaunch, and temp-permission tests. Changed PATH-focused tests passed.
