### PR TITLE
fix(tools): support Python 3.14 ThreadPoolExecutor internals in DaemonThreadPoolExecutor

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,12 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation with two changes:
         # daemon=True and no _threads_queues registration.
+        # Python >= 3.14 reworked the pool internals: `_initializer`/`_initargs`
+        # instance attributes were removed and `_worker` now takes a
+        # WorkerContext (`self._create_worker_context()`); < 3.14 keeps the old
+        # 4-arg `_worker` contract. Branch on the new API so both work.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +53,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_create_worker_context"):
+                # CPython 3.14+: WorkerContext-based worker signature
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # CPython 3.8–3.13
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
### Problem

`DaemonThreadPoolExecutor._adjust_thread_count()` in `tools/daemon_pool.py` mirrors the
CPython 3.8–3.13 implementation: it passes 4 positional args to
`concurrent.futures.thread._worker` and reads `self._initializer` / `self._initargs`.

Python 3.14 reworked the pool internals:
- `_initializer` and `_initargs` instance attributes were removed (replaced by `_initializer_failed`),
- `_worker` signature changed to `(executor_reference, ctx, work_queue)` using a `WorkerContext`
  created via `self._create_worker_context()`.

On Python 3.14 the first worker spawn raises:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

Because this pool backs concurrent tool execution (`tool_executor.py`), background memory
sync (`memory_manager.py`), and subagent timeout wrappers (`subagent_lifecycle.py`), the
failure surfaced as:

```
Error executing tool: Error during OpenAI-compatible API call #N: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

on concurrent tools (search_files / web_search / web_extract / delegate_task) while serial
tools (terminal) kept working. Reproducible on Python 3.14.4.

### Fix

Branch on the new API in `_adjust_thread_count()`:

- if `self._create_worker_context` exists (Python >= 3.14): pass `(weakref, self._create_worker_context(), self._work_queue)` — the new WorkerContext signature;
- otherwise (Python 3.8–3.13): keep the existing 4-argument contract.

Daemon semantics are preserved in both paths (`daemon=True`, no `_threads_queues` registration).

### Verification

On Python 3.14.4, in the hermes venv:

```python
from tools.daemon_pool import DaemonThreadPoolExecutor
ex = DaemonThreadPoolExecutor(max_workers=4)
futures = [ex.submit(lambda x: x * 2, i) for i in range(8)]
assert [f.result() for f in futures] == [0, 2, 4, 6, 8, 10, 12, 14]
assert len(ex._threads) == 4
```

All 8 jobs complete, 4 daemon workers spawn, no AttributeError. After restarting the
gateways, search/web tools work normally again.