### PR TITLE
fix(provider): mitigate 429 on large prompts (#76783)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2277,6 +2277,22 @@ def init_agent(
     agent._custom_providers = _custom_providers
     _merge_custom_provider_extra_body(agent, _custom_providers)
 
+    # system_prompt_mode compatibility option (#76783): custom providers
+    # backed by Gemini relays may reject long system content with HTTP 429
+    # RESOURCE_EXHAUSTED; "user" moves the runtime prompt into the first
+    # user message. Resolved once here and consumed by the chat-completions
+    # transport via agent._system_prompt_mode.
+    try:
+        from hermes_cli.config import get_custom_provider_system_prompt_mode
+
+        agent._system_prompt_mode = get_custom_provider_system_prompt_mode(
+            model=agent.model,
+            base_url=agent.base_url,
+            custom_providers=_custom_providers,
+        )
+    except Exception:
+        agent._system_prompt_mode = "system"
+
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:
         try:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1330,6 +1330,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
+            system_prompt_mode=getattr(agent, "_system_prompt_mode", "system"),
             ollama_num_ctx=agent._ollama_num_ctx,
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,
@@ -1362,6 +1363,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
+        system_prompt_mode=getattr(agent, "_system_prompt_mode", "system"),
         is_openrouter=_is_or,
         is_nous=_is_nous,
         is_qwen_portal=_is_qwen,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -344,6 +344,14 @@ class ChatCompletionsTransport(ProviderTransport):
         # Reached only when get_provider_profile() returned None.
         # Known providers always go through the profile path above.
 
+        # system_prompt_mode compatibility transform for custom providers
+        # (Gemini-backed relays, #76783). No-op for the default "system" mode.
+        _spm = params.get("system_prompt_mode")
+        if _spm and _spm != "system":
+            from providers.base import apply_system_prompt_mode
+
+            sanitized = apply_system_prompt_mode(sanitized, _spm)
+
         # Developer role swap for GPT-5/Codex models
         model_lower = params.get("model_lower", (model or "").lower())
         if (

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1326,7 +1326,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "ssl_ca_cert", "ssl_verify", "system_prompt_mode",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -1446,6 +1446,16 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    # system_prompt_mode: how the system prompt is represented on the wire
+    # ("system" | "developer" | "user").  "user" is an opt-in workaround for
+    # OpenAI-compatible relays backed by Gemini that reject long system
+    # content with HTTP 429 RESOURCE_EXHAUSTED (#76783).
+    system_prompt_mode = entry.get("system_prompt_mode")
+    if isinstance(system_prompt_mode, str) and system_prompt_mode.strip():
+        _spm = system_prompt_mode.strip().lower()
+        if _spm in ("system", "developer", "user"):
+            normalized["system_prompt_mode"] = _spm
+
     discover_models = entry.get("discover_models")
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
@@ -1501,6 +1511,7 @@ def _custom_provider_entry_to_provider_config(
         "extra_headers",
         "ssl_ca_cert",
         "ssl_verify",
+        "system_prompt_mode",
     ):
         if field in normalized:
             provider_entry[field] = normalized[field]
@@ -1780,6 +1791,70 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_system_prompt_mode(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Return the ``system_prompt_mode`` for a matching custom provider entry.
+
+    Resolves ``custom_providers[i].system_prompt_mode`` (or the equivalent
+    ``providers.<key>`` entry) for the entry whose normalized route identity
+    equals ``base_url``.  Model-scoped entries (``models.<model>``) take
+    precedence over provider-level ones.  Returns ``"system"`` (the default)
+    when no override applies.
+
+    ``"user"`` moves Hermes's full runtime prompt from the ``system`` message
+    into the first ``user`` message — an opt-in workaround for OpenAI-
+    compatible relays backed by Gemini that return HTTP 429 RESOURCE_EXHAUSTED
+    for long system content while accepting identical user content (#76783).
+    """
+    if not base_url:
+        return "system"
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return "system"
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return "system"
+
+    target_url = normalize_route_base_url(base_url)
+    if not target_url:
+        return "system"
+
+    fallback = "system"
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = normalize_route_base_url(entry.get("base_url"))
+        if not entry_url or entry_url != target_url:
+            continue
+        raw_mode = entry.get("system_prompt_mode")
+        if isinstance(raw_mode, str) and raw_mode.strip().lower() in (
+            "system",
+            "developer",
+            "user",
+        ):
+            fallback = raw_mode.strip().lower()
+        # Model-scoped override wins over the provider-level mode.
+        models = entry.get("models")
+        if model and isinstance(models, dict):
+            model_cfg = models.get(model)
+            if isinstance(model_cfg, dict):
+                model_mode = model_cfg.get("system_prompt_mode")
+                if (
+                    isinstance(model_mode, str)
+                    and model_mode.strip().lower() in ("system", "developer", "user")
+                ):
+                    return model_mode.strip().lower()
+    return fallback
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):
@@ -1885,6 +1960,7 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
+    "system_prompt_mode",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/providers/README.md
+++ b/providers/README.md
@@ -66,7 +66,7 @@ under `$HERMES_HOME/plugins/model-providers/` for a private plugin).
 | Hook | Purpose |
 |------|---------|
 | `get_hostname()` | URL-based detection — default derives from `base_url`. |
-| `prepare_messages(msgs)` | Provider-specific message preprocessing (Qwen normalises to list-of-parts, injects `cache_control`). |
+| `prepare_messages(msgs)` | Provider-specific message preprocessing (Qwen normalises to list-of-parts, injects `cache_control`; `system_prompt_mode` applies the developer-role swap or the #76783 Gemini-relay user-message transform). |
 | `build_extra_body(**ctx)` | Provider-specific `extra_body` (OpenRouter provider prefs, Gemini `thinking_config`). |
 | `build_api_kwargs_extras(**ctx)` | `(extra_body_additions, top_level_kwargs)` — Kimi puts reasoning_effort top-level, Qwen splits `enable_thinking`/`thinking_budget`. |
 | `fetch_models(*, api_key)` | Live catalog fetch — default hits `{models_url or base_url}/models` with Bearer auth. Override for no-REST providers (Bedrock), OAuth catalogs (Anthropic), or public catalogs (OpenRouter). |

--- a/providers/base.py
+++ b/providers/base.py
@@ -20,6 +20,110 @@ logger = logging.getLogger(__name__)
 # Sentinel for "omit temperature entirely" (Kimi: server manages it)
 OMIT_TEMPERATURE = object()
 
+# Valid values for ProviderProfile.system_prompt_mode.
+VALID_SYSTEM_PROMPT_MODES = ("system", "developer", "user")
+
+
+def _extract_text_content(content: Any) -> str:
+    """Flatten a message ``content`` value (string or multimodal part list) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def _short_system_identity(text: str, max_len: int = 200) -> str:
+    """Return a short system identity marker (first non-empty line of the prompt).
+
+    Some OpenAI-compatible relays (notably Gemini-backed ones, see #76783)
+    reject long ``systemInstruction`` content with HTTP 429 RESOURCE_EXHAUSTED
+    even when identical content as a user message succeeds.  When the runtime
+    prompt is moved to the first user message we still keep a brief real
+    system message so the model keeps its identity framing.
+    """
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            if len(line) <= max_len:
+                return line
+            cut = line[:max_len]
+            idx = cut.rfind(".")
+            if idx > 40:
+                return cut[: idx + 1]
+            return cut
+    return text[:max_len]
+
+
+def apply_system_prompt_mode(
+    messages: list[dict[str, Any]], mode: str | None
+) -> list[dict[str, Any]]:
+    """Apply a system-prompt compatibility mode to a message list.
+
+    Returns a new list; input messages are never mutated.  ``mode``:
+
+    * ``"system"`` (or None) — pass-through, full backward compatibility.
+    * ``"developer"`` — swap the first system message role to ``developer``
+      (equivalent to the model-name-based swap used for GPT-5/Codex).
+    * ``"user"`` — keep a short system identity marker and prepend the full
+      system prompt to the first user message.  Workaround for
+      OpenAI-compatible relays backed by Gemini that cannot reliably accept
+      Hermes's full runtime prompt as ``system`` content but accept the
+      identical content as a ``user`` message (#76783).  Handles both string
+      user content and multimodal part lists.
+
+    No-op (returns ``messages`` unchanged) when there is no leading system
+    message, the system content is empty, or there is no user message to
+    absorb the prompt into.
+    """
+    if mode not in VALID_SYSTEM_PROMPT_MODES or mode == "system":
+        return messages
+    if not messages:
+        return messages
+    first = messages[0]
+    if not isinstance(first, dict) or first.get("role") != "system":
+        return messages
+
+    out = list(messages)
+
+    if mode == "developer":
+        out[0] = {**first, "role": "developer"}
+        return out
+
+    # mode == "user"
+    sys_text = _extract_text_content(first.get("content", ""))
+    if not sys_text.strip():
+        return messages
+
+    out[0] = {**first, "content": _short_system_identity(sys_text)}
+    wrapper = (
+        "[Hermes runtime instructions]\n"
+        f"{sys_text}\n"
+        "[End runtime instructions]"
+    )
+    for i, msg in enumerate(out[1:], start=1):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        user_content = msg.get("content", "")
+        if isinstance(user_content, str):
+            new_content = wrapper if not user_content else f"{wrapper}\n\n{user_content}"
+        elif isinstance(user_content, list):
+            new_content = [{"type": "text", "text": wrapper}, *list(user_content)]
+        else:
+            continue
+        out[i] = {**msg, "content": new_content}
+        return out
+
+    return messages
+
 
 def _profile_user_agent() -> str:
     """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
@@ -93,6 +197,17 @@ class ProviderProfile:
     )
     # empty = use main model
 
+    # How the system prompt is represented on the wire:
+    #   "system"    (default) — first message role stays "system"
+    #   "developer" — first system message role becomes "developer"
+    #   "user"      — keep a short system identity marker, prepend the full
+    #                 system prompt to the first user message.  Opt-in
+    #                 workaround for OpenAI-compatible relays backed by Gemini
+    #                 that reject long systemInstruction content with HTTP 429
+    #                 RESOURCE_EXHAUSTED while identical user content succeeds
+    #                 (#76783).
+    system_prompt_mode: str = "system"
+
     # ── Hooks (override in subclass for complex providers) ───
 
     def get_hostname(self) -> str:
@@ -112,8 +227,13 @@ class ProviderProfile:
         """Provider-specific message preprocessing.
 
         Called AFTER codex field sanitization, BEFORE developer role swap.
-        Default: pass-through.
+        Default: pass-through, unless ``system_prompt_mode`` is set to a
+        non-default value, in which case the compatibility transformation
+        (developer role swap, or moving the system prompt into the first
+        user message for Gemini-backed relays, #76783) is applied here.
         """
+        if self.system_prompt_mode and self.system_prompt_mode != "system":
+            return apply_system_prompt_mode(messages, self.system_prompt_mode)
         return messages
 
     def build_extra_body(

--- a/tests/agent/test_chat_completions_system_prompt_mode.py
+++ b/tests/agent/test_chat_completions_system_prompt_mode.py
@@ -1,0 +1,64 @@
+"""Tests for system_prompt_mode in the chat-completions transport legacy path.
+
+Custom (unregistered) providers go through the legacy kwargs path. The
+``system_prompt_mode`` param must apply the same compatibility transform as
+the provider-profile ``prepare_messages`` hook (#76783).
+"""
+from __future__ import annotations
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+class TestLegacySystemPromptMode:
+
+    def _build(self, system_prompt_mode=None):
+        transport = ChatCompletionsTransport()
+        return transport.build_kwargs(
+            model="gemini-3.1-pro-low",
+            messages=[
+                {"role": "system", "content": "You are Hermes Agent.\nBig runtime prompt."},
+                {"role": "user", "content": "Hello"},
+            ],
+            tools=None,
+            base_url="http://localhost:9876/v1",
+            system_prompt_mode=system_prompt_mode,
+            is_custom_provider=True,
+        )
+
+    def test_default_system_mode_passes_through(self):
+        kwargs = self._build()  # None → default behavior
+        msgs = kwargs["messages"]
+        assert msgs[0]["role"] == "system"
+        assert msgs[0]["content"] == "You are Hermes Agent.\nBig runtime prompt."
+        assert msgs[1]["content"] == "Hello"
+
+    def test_user_mode_moves_prompt_to_first_user_message(self):
+        kwargs = self._build(system_prompt_mode="user")
+        msgs = kwargs["messages"]
+        assert msgs[0]["role"] == "system"
+        assert "Big runtime prompt." not in msgs[0]["content"]
+        assert "[Hermes runtime instructions]" in msgs[1]["content"]
+        assert msgs[1]["content"].endswith("Hello")
+
+    def test_developer_mode_swaps_first_role(self):
+        kwargs = self._build(system_prompt_mode="developer")
+        msgs = kwargs["messages"]
+        assert msgs[0]["role"] == "developer"
+        assert msgs[0]["content"] == "You are Hermes Agent.\nBig runtime prompt."
+
+    def test_input_not_mutated(self):
+        messages = [
+            {"role": "system", "content": "You are Hermes Agent.\nBig runtime prompt."},
+            {"role": "user", "content": "Hello"},
+        ]
+        transport = ChatCompletionsTransport()
+        transport.build_kwargs(
+            model="gemini-3.1-pro-low",
+            messages=messages,
+            tools=None,
+            base_url="http://localhost:9876/v1",
+            system_prompt_mode="user",
+            is_custom_provider=True,
+        )
+        assert messages[0]["content"] == "You are Hermes Agent.\nBig runtime prompt."
+        assert messages[1]["content"] == "Hello"

--- a/tests/hermes_cli/test_custom_provider_system_prompt_mode.py
+++ b/tests/hermes_cli/test_custom_provider_system_prompt_mode.py
@@ -1,0 +1,143 @@
+"""Regression tests for custom_providers system_prompt_mode resolution.
+
+Covers the fix for #76783 — an opt-in, provider-scoped compatibility mode
+that moves Hermes's full runtime prompt out of the ``system`` message into
+the first ``user`` message for OpenAI-compatible relays backed by Gemini
+that reject long system content with HTTP 429 RESOURCE_EXHAUSTED.
+"""
+from __future__ import annotations
+
+from hermes_cli.config import get_custom_provider_system_prompt_mode
+
+
+class TestGetCustomProviderSystemPromptMode:
+
+    def test_default_is_system(self):
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "gemini-3.1-pro-low", "https://example.invalid/v1", []
+            )
+            == "system"
+        )
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "gemini-3.1-pro-low", "https://example.invalid/v1", None
+            )
+            == "system"
+        )
+        assert get_custom_provider_system_prompt_mode("m", "", []) == "system"
+
+    def test_provider_level_mode(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "system_prompt_mode": "user",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "gemini-3.1-pro-low", "https://example.invalid/v1", custom
+            )
+            == "user"
+        )
+
+    def test_model_scoped_mode_wins_over_provider_level(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "system_prompt_mode": "user",
+                "models": {
+                    "gemini-3.1-pro-low": {"system_prompt_mode": "system"},
+                    "other-model": {"system_prompt_mode": "developer"},
+                },
+            }
+        ]
+        # model-scoped "system" overrides the provider-level "user"
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "gemini-3.1-pro-low", "https://example.invalid/v1", custom
+            )
+            == "system"
+        )
+        # other model keeps its own scoped mode
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "other-model", "https://example.invalid/v1", custom
+            )
+            == "developer"
+        )
+        # unscoped model falls back to provider-level mode
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "unlisted-model", "https://example.invalid/v1", custom
+            )
+            == "user"
+        )
+
+    def test_trailing_slash_insensitive(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1/",
+                "system_prompt_mode": "user",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "m", "https://example.invalid/v1", custom
+            )
+            == "user"
+        )
+        custom2 = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "system_prompt_mode": "user",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "m", "https://example.invalid/v1/", custom2
+            )
+            == "user"
+        )
+
+    def test_invalid_mode_values_fall_back_to_system(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "system_prompt_mode": "bogus",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "m", "https://example.invalid/v1", custom
+            )
+            == "system"
+        )
+
+    def test_wrong_base_url_does_not_match(self):
+        custom = [
+            {
+                "base_url": "https://other.invalid/v1",
+                "system_prompt_mode": "user",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "m", "https://example.invalid/v1", custom
+            )
+            == "system"
+        )
+
+    def test_mode_is_lowercased(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "system_prompt_mode": "User",
+            }
+        ]
+        assert (
+            get_custom_provider_system_prompt_mode(
+                "m", "https://example.invalid/v1", custom
+            )
+            == "user"
+        )

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -187,5 +187,81 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestSystemPromptMode:
+    """system_prompt_mode compatibility modes (#76783)."""
+
+    @staticmethod
+    def _profile(mode):
+        return ProviderProfile(name="test-relay", system_prompt_mode=mode)
+
+    def test_default_is_system_pass_through(self):
+        p = ProviderProfile(name="plain")
+        msgs = [{"role": "system", "content": "You are Hermes Agent."},
+                {"role": "user", "content": "hi"}]
+        assert p.prepare_messages(msgs) is msgs
+
+    def test_user_mode_moves_prompt_into_first_user_message(self):
+        p = self._profile("user")
+        runtime = "You are Hermes Agent, an intelligent AI assistant.\nLots of rules."
+        msgs = [
+            {"role": "system", "content": runtime},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        out = p.prepare_messages(msgs)
+        # system keeps a short identity marker
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == "You are Hermes Agent, an intelligent AI assistant."
+        # full prompt prepended to first user message
+        assert out[1]["role"] == "user"
+        assert "[Hermes runtime instructions]" in out[1]["content"]
+        assert runtime in out[1]["content"]
+        assert out[1]["content"].endswith("Hello")
+        # input not mutated
+        assert msgs[0]["content"] == runtime
+        assert msgs[1]["content"] == "Hello"
+
+    def test_user_mode_multimodal_user_content(self):
+        p = self._profile("user")
+        msgs = [
+            {"role": "system", "content": "You are Hermes Agent."},
+            {"role": "user",
+             "content": [{"type": "text", "text": "describe"},
+                         {"type": "image_url", "image_url": {"url": "data:x"}}]},
+        ]
+        out = p.prepare_messages(msgs)
+        assert isinstance(out[1]["content"], list)
+        assert out[1]["content"][0]["type"] == "text"
+        assert "[Hermes runtime instructions]" in out[1]["content"][0]["text"]
+        # original parts preserved in order after the prepended wrapper
+        assert out[1]["content"][1] == {"type": "text", "text": "describe"}
+        assert out[1]["content"][2]["type"] == "image_url"
+
+    def test_user_mode_no_user_message_is_noop(self):
+        p = self._profile("user")
+        msgs = [{"role": "system", "content": "You are Hermes Agent."}]
+        out = p.prepare_messages(msgs)
+        assert out == msgs
+
+    def test_developer_mode_swaps_role(self):
+        p = self._profile("developer")
+        msgs = [{"role": "system", "content": "You are Hermes Agent."},
+                {"role": "user", "content": "hi"}]
+        out = p.prepare_messages(msgs)
+        assert out[0]["role"] == "developer"
+        assert out[0]["content"] == "You are Hermes Agent."
+        assert msgs[0]["role"] == "system"  # input not mutated
+
+    def test_user_mode_requires_leading_system_message(self):
+        p = self._profile("user")
+        msgs = [{"role": "user", "content": "hi"}]
+        assert p.prepare_messages(msgs) == msgs
+
+    def test_empty_system_content_is_noop(self):
+        p = self._profile("user")
+        msgs = [{"role": "system", "content": ""}, {"role": "user", "content": "hi"}]
+        assert p.prepare_messages(msgs) == msgs
+
+
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1214,7 +1214,7 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, `system_prompt_mode`, and `enabled: false` to hide an entry without deleting it.
 
 :::note Legacy format
 Older configs used a top-level `custom_providers:` list instead. It still works — Hermes reads both — and `hermes update` auto-migrates it to the `providers:` dict (config v12). Field names differ slightly in the dict format: legacy `model` is `default_model`, and legacy `api_mode` is `transport`.
@@ -1247,6 +1247,22 @@ extra_body:
   chat_template_kwargs:
     enable_thinking: false
 ```
+
+### Gemini-backed relays: `system_prompt_mode: user`
+
+Some OpenAI-compatible relays backed by Gemini/Antigravity reject Hermes's full runtime prompt when it is sent as the `system` message, returning `HTTP 429 RESOURCE_EXHAUSTED` — even though the *identical* content succeeds when moved into the first `user` message. This appears to be a role-specific `systemInstruction` compatibility problem, not ordinary quota exhaustion. See [NousResearch/hermes-agent#76783](https://github.com/NousResearch/hermes-agent/issues/76783).
+
+For those endpoints, set `system_prompt_mode: user` on the matching custom provider (or on a specific model under `models.<id>`):
+
+```yaml
+providers:
+  gemini-relay:
+    api: http://localhost:9876/v1
+    default_model: gemini-3.1-pro-low
+    system_prompt_mode: user   # system | developer | user (default: system)
+```
+
+When set to `user`, Hermes keeps a short system identity marker and prepends the full runtime prompt (wrapped in `[Hermes runtime instructions]` / `[End runtime instructions]`) to the first user message. Multimodal user content (image parts) is preserved, and persisted conversation history is never mutated. `developer` swaps the first system message role to `developer` (equivalent to the model-name-based swap for GPT-5/Codex models). The default `system` leaves requests unchanged for full backward compatibility.
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 


### PR DESCRIPTION
## Summary

Closes #76783 — adds an opt-in, provider-scoped `system_prompt_mode` compatibility option so OpenAI-compatible relays backed by Gemini/Antigravity (which reject Hermes's full runtime prompt as `system` content with `HTTP 429 RESOURCE_EXHAUSTED`) can receive the identical prompt as the first `user` message, which their upstream accepts.

## Problem

Hermes always prepends the cached runtime prompt as a single `system` message. Custom relays backed by Gemini return `RESOURCE_EXHAUSTED` for large `systemInstruction` content while accepting the *same* content as a `user` message — a role-specific compatibility issue, not quota exhaustion (verified via a controlled reproduction matrix in the issue).

## Changes

- **`providers/base.py`** — new `ProviderProfile.system_prompt_mode` field (`system` | `developer` | `user`, default `system`) plus a shared `apply_system_prompt_mode()` helper:
  - `user` — keeps a short system identity marker and prepends the full runtime prompt (wrapped in `[Hermes runtime instructions]` / `[End runtime instructions]`) to the first user message; preserves multimodal part lists and never mutates the input.
  - `developer` — swaps the first system message role to `developer`.
  - `system` — pass-through, full backward compatibility.
  - `ProviderProfile.prepare_messages()` applies the transform for registered providers (the transport's profile path already calls it).
- **`agent/transports/chat_completions.py`** — the legacy path (custom/unregistered providers) honors the new `system_prompt_mode` param with the same transform.
- **`hermes_cli/config.py`** — `system_prompt_mode` accepted in `custom_providers` / `providers.<key>` entries (normalization, allowlists, v12 translation) and a `get_custom_provider_system_prompt_mode()` resolver (provider-level with per-model override via `models.<id>.system_prompt_mode`).
- **`agent/agent_init.py`** — resolves the mode once at init into `agent._system_prompt_mode`.
- **`agent/chat_completion_helpers.py`** — passes the resolved mode into both the profile and legacy transport paths.
- **Docs** — `website/docs/integrations/providers.md` + `providers/README.md`.
- **Tests** — 31 new assertions across `tests/providers/test_provider_profiles.py`, `tests/agent/test_chat_completions_system_prompt_mode.py`, `tests/hermes_cli/test_custom_provider_system_prompt_mode.py`.

## Usage

```yaml
providers:
  gemini-relay:
    api: http://localhost:9876/v1
    default_model: gemini-3.1-pro-low
    system_prompt_mode: user   # system | developer | user (default: system)
```

## Test Plan

- `pytest tests/providers/ tests/plugins/model_providers/ tests/hermes_cli/test_custom_provider_system_prompt_mode.py tests/agent/test_chat_completions_system_prompt_mode.py` — 263 passed.
- No behavior change for existing configs (default remains `system`).

Closes #76783
