### PR TITLE
fix(hermes_cli): bound plugin hook callbacks without blocking on timeout

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2062,6 +2062,16 @@ DEFAULT_CONFIG = {
     #         table_formatting skill instead of emitting a Markdown table.
     "platform_hints": {},
 
+    # Plugin system settings. ``enabled`` / ``disabled`` are written by
+    # ``hermes plugins enable|disable`` and intentionally omitted here so an
+    # empty default does not clobber a user's allow-list on merge.
+    "plugins": {
+        # Wall-clock cap (seconds) for a single in-process Python plugin hook
+        # callback. Shell hooks keep their own per-entry ``timeout``. Set to 0
+        # to disable the cap (sync call on the agent thread). Capped at 600.
+        "hook_callback_timeout": 30,
+    },
+
     # Shell-script hooks — declarative bridge that invokes shell scripts
     # on plugin-hook events (pre_tool_call, post_tool_call, pre_llm_call,
     # subagent_stop, etc.).  Each entry maps an event name to a list of

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1261,6 +1261,58 @@ class PluginContext:
 
 
 # ---------------------------------------------------------------------------
+# Hook callback timeout (non-blocking abandon)
+# ---------------------------------------------------------------------------
+
+# Wall-clock cap for a single Python plugin hook callback. Shell hooks already
+# enforce their own subprocess timeout; this bounds in-process callbacks so a
+# blocking plugin cannot wedge the agent loop indefinitely.
+_HOOK_CALLBACK_TIMEOUT_SECS = 30.0
+
+
+def _call_hook_callback(cb: Callable[..., Any], timeout: float, **kwargs: Any) -> Any:
+    """Run *cb* with a timeout that does not wait for the worker on expiry.
+
+    PR #6622 wrapped callbacks in ``ThreadPoolExecutor`` and used
+    ``future.result(timeout=…)`` inside a ``with`` block. On timeout the
+    context-manager ``shutdown(wait=True)`` still joined the stuck worker, so
+    the caller hung anyway. Here we start a **daemon** thread and wait only on
+    an ``Event``; on timeout we return control immediately and abandon the
+    thread (Python cannot forcibly kill it).
+    """
+    if timeout <= 0:
+        return cb(**kwargs)
+
+    outcome: Dict[str, Any] = {}
+    failure: Dict[str, Exception] = {}
+    done = threading.Event()
+
+    def _runner() -> None:
+        try:
+            outcome["value"] = cb(**kwargs)
+        except Exception as exc:
+            failure["exc"] = exc
+        finally:
+            done.set()
+
+    cb_name = getattr(cb, "__name__", "callback")
+    thread = threading.Thread(
+        target=_runner,
+        name=f"hermes-hook-{cb_name}"[:40],
+        daemon=True,
+    )
+    thread.start()
+    if not done.wait(timeout=timeout):
+        # Do not join — that would reintroduce the #6622 hang.
+        raise TimeoutError(
+            f"Hook callback did not complete within {timeout:g}s"
+        )
+    if "exc" in failure:
+        raise failure["exc"]
+    return outcome.get("value")
+
+
+# ---------------------------------------------------------------------------
 # PluginManager
 # ---------------------------------------------------------------------------
 
@@ -1912,7 +1964,9 @@ class PluginManager:
         """Call all registered callbacks for *hook_name*.
 
         Each callback is wrapped in its own try/except so a misbehaving
-        plugin cannot break the core agent loop.
+        plugin cannot break the core agent loop. Callbacks that exceed
+        ``_HOOK_CALLBACK_TIMEOUT_SECS`` are skipped without waiting for the
+        abandoned worker thread (see :func:`_call_hook_callback`).
 
         Returns a list of non-``None`` return values from callbacks.
 
@@ -1933,9 +1987,18 @@ class PluginManager:
         results: List[Any] = []
         for cb in callbacks:
             try:
-                ret = cb(**kwargs)
+                ret = _call_hook_callback(
+                    cb, _HOOK_CALLBACK_TIMEOUT_SECS, **kwargs
+                )
                 if ret is not None:
                     results.append(ret)
+            except TimeoutError:
+                logger.warning(
+                    "Hook '%s' callback %s timed out after %gs — skipping",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    _HOOK_CALLBACK_TIMEOUT_SECS,
+                )
             except Exception as exc:
                 logger.warning(
                     "Hook '%s' callback %s raised: %s",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1264,10 +1264,54 @@ class PluginContext:
 # Hook callback timeout (non-blocking abandon)
 # ---------------------------------------------------------------------------
 
-# Wall-clock cap for a single Python plugin hook callback. Shell hooks already
-# enforce their own subprocess timeout; this bounds in-process callbacks so a
-# blocking plugin cannot wedge the agent loop indefinitely.
+# Default wall-clock cap for a single Python plugin hook callback. Overridden
+# by ``plugins.hook_callback_timeout`` in config.yaml (see DEFAULT_CONFIG).
+# Shell hooks already enforce their own subprocess timeout.
 _HOOK_CALLBACK_TIMEOUT_SECS = 30.0
+_MAX_HOOK_CALLBACK_TIMEOUT_SECS = 600.0
+
+
+def _resolve_hook_callback_timeout() -> float:
+    """Return the effective hook-callback timeout in seconds.
+
+    Reads ``plugins.hook_callback_timeout`` via the cached readonly config
+    loader. Falls back to ``_HOOK_CALLBACK_TIMEOUT_SECS``. Values ``<= 0``
+    disable the threaded timeout (sync call). Values above
+    ``_MAX_HOOK_CALLBACK_TIMEOUT_SECS`` are clamped.
+    """
+    timeout = _HOOK_CALLBACK_TIMEOUT_SECS
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        plugins_cfg = (load_config_readonly() or {}).get("plugins")
+        if isinstance(plugins_cfg, dict) and "hook_callback_timeout" in plugins_cfg:
+            raw = plugins_cfg.get("hook_callback_timeout")
+            if raw is not None:
+                timeout = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "plugins.hook_callback_timeout is not a number; using default %gs",
+            _HOOK_CALLBACK_TIMEOUT_SECS,
+        )
+        timeout = _HOOK_CALLBACK_TIMEOUT_SECS
+    except Exception:
+        timeout = _HOOK_CALLBACK_TIMEOUT_SECS
+
+    if timeout < 0:
+        logger.warning(
+            "plugins.hook_callback_timeout=%g is negative; using default %gs",
+            timeout,
+            _HOOK_CALLBACK_TIMEOUT_SECS,
+        )
+        return _HOOK_CALLBACK_TIMEOUT_SECS
+    if timeout > _MAX_HOOK_CALLBACK_TIMEOUT_SECS:
+        logger.warning(
+            "plugins.hook_callback_timeout=%g exceeds max %gs; clamping",
+            timeout,
+            _MAX_HOOK_CALLBACK_TIMEOUT_SECS,
+        )
+        return _MAX_HOOK_CALLBACK_TIMEOUT_SECS
+    return timeout
 
 
 def _call_hook_callback(cb: Callable[..., Any], timeout: float, **kwargs: Any) -> Any:
@@ -1965,8 +2009,9 @@ class PluginManager:
 
         Each callback is wrapped in its own try/except so a misbehaving
         plugin cannot break the core agent loop. Callbacks that exceed
-        ``_HOOK_CALLBACK_TIMEOUT_SECS`` are skipped without waiting for the
-        abandoned worker thread (see :func:`_call_hook_callback`).
+        ``plugins.hook_callback_timeout`` (default 30s) are skipped without
+        waiting for the abandoned worker thread (see
+        :func:`_call_hook_callback`).
 
         Returns a list of non-``None`` return values from callbacks.
 
@@ -1985,11 +2030,10 @@ class PluginManager:
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
+        timeout = _resolve_hook_callback_timeout()
         for cb in callbacks:
             try:
-                ret = _call_hook_callback(
-                    cb, _HOOK_CALLBACK_TIMEOUT_SECS, **kwargs
-                )
+                ret = _call_hook_callback(cb, timeout, **kwargs)
                 if ret is not None:
                     results.append(ret)
             except TimeoutError:
@@ -1997,7 +2041,7 @@ class PluginManager:
                     "Hook '%s' callback %s timed out after %gs — skipping",
                     hook_name,
                     getattr(cb, "__name__", repr(cb)),
-                    _HOOK_CALLBACK_TIMEOUT_SECS,
+                    timeout,
                 )
             except Exception as exc:
                 logger.warning(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import importlib.metadata
 import importlib.util
 import inspect
@@ -41,6 +42,7 @@ import logging
 import os
 import sys
 import threading
+import time
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -213,6 +215,62 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_completed",
     "kanban_task_blocked",
 }
+
+# Timeout coverage is an allowlist for the agent-turn hot path, not every
+# entry in VALID_HOOKS. The goal is to stop a hung Python plugin callback from
+# wedging the conversation loop (#76821) without joining the worker (avoids
+# the #6622 ThreadPoolExecutor shutdown hang). Hooks not listed below run
+# synchronously to completion.
+#
+# Intentionally unbounded (no hook_callback_timeout wrapper):
+#   - on_session_finalize / on_session_reset — infrequent teardown / session
+#     swap; finalize is a last-chance flush where fail-open abandon can lose
+#     state. (on_session_start/end stay bounded — they sit on the common
+#     session-boundary path.)
+#   - subagent_start — observer only; blocking delegation belongs in
+#     pre_tool_call. Lower frequency than tool/LLM hooks.
+#   - pre_gateway_dispatch — policy gate (skip/rewrite/allow). Abandoning is
+#     unsafe either way (fail-open skips auth-like checks; fail-closed can
+#     drop legitimate messages). Prefer finish-or-exception fallthrough.
+#   - pre_approval_request / post_approval_response — observers only (cannot
+#     veto); the approval UX already has its own timeout; not on the tool
+#     loop hot path.
+#   - kanban_task_* — fire after the board DB commit, observers only, in
+#     dispatcher/worker processes; kanban has its own heartbeat/stale reclaim.
+# Abandon-without-join also leaves a daemon thread that may still mutate
+# shared state — safer for value-returning observers than for gates/flushes.
+#
+# Bounded hooks: timeout is fail-open (abandon/skip, agent continues).
+_HOOK_TIMEOUT_BOUNDED_HOOKS: Set[str] = {
+    "post_tool_call",
+    "transform_terminal_output",
+    "transform_tool_result",
+    "transform_llm_output",
+    "pre_llm_call",
+    "post_llm_call",
+    "pre_api_request",
+    "post_api_request",
+    "api_request_error",
+    "pre_verify",
+    "on_session_start",
+    "on_session_end",
+}
+
+# Policy hooks: timeout / still-running must fail closed (block the tool).
+# Skipping would let the tool run without a completed policy decision.
+_HOOK_TIMEOUT_FAIL_CLOSED_HOOKS: Set[str] = {"pre_tool_call"}
+
+# Documented parent-thread serialization contract — never move the callback
+# body onto a timeout worker (see website/docs/user-guide/features/hooks.md).
+_HOOK_CALLER_THREAD_HOOKS: Set[str] = {"subagent_stop"}
+
+# After a timeout, suppress re-firing the same callback for this long so a
+# repeatedly invoked hung hook cannot accumulate abandoned daemon threads.
+_HOOK_TIMEOUT_SUPPRESSION_SECONDS = 60.0
+
+_PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE = (
+    "pre_tool_call plugin callback timed out or is still running"
+)
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
@@ -1314,46 +1372,22 @@ def _resolve_hook_callback_timeout() -> float:
     return timeout
 
 
-def _call_hook_callback(cb: Callable[..., Any], timeout: float, **kwargs: Any) -> Any:
-    """Run *cb* with a timeout that does not wait for the worker on expiry.
-
-    PR #6622 wrapped callbacks in ``ThreadPoolExecutor`` and used
-    ``future.result(timeout=…)`` inside a ``with`` block. On timeout the
-    context-manager ``shutdown(wait=True)`` still joined the stuck worker, so
-    the caller hung anyway. Here we start a **daemon** thread and wait only on
-    an ``Event``; on timeout we return control immediately and abandon the
-    thread (Python cannot forcibly kill it).
-    """
-    if timeout <= 0:
-        return cb(**kwargs)
-
-    outcome: Dict[str, Any] = {}
-    failure: Dict[str, Exception] = {}
-    done = threading.Event()
-
-    def _runner() -> None:
-        try:
-            outcome["value"] = cb(**kwargs)
-        except Exception as exc:
-            failure["exc"] = exc
-        finally:
-            done.set()
-
-    cb_name = getattr(cb, "__name__", "callback")
-    thread = threading.Thread(
-        target=_runner,
-        name=f"hermes-hook-{cb_name}"[:40],
-        daemon=True,
+def _hook_uses_callback_timeout(hook_name: str, timeout: float) -> bool:
+    """Whether *hook_name* should run under the non-blocking timeout path."""
+    if timeout <= 0 or hook_name in _HOOK_CALLER_THREAD_HOOKS:
+        return False
+    return (
+        hook_name in _HOOK_TIMEOUT_BOUNDED_HOOKS
+        or hook_name in _HOOK_TIMEOUT_FAIL_CLOSED_HOOKS
     )
-    thread.start()
-    if not done.wait(timeout=timeout):
-        # Do not join — that would reintroduce the #6622 hang.
-        raise TimeoutError(
-            f"Hook callback did not complete within {timeout:g}s"
-        )
-    if "exc" in failure:
-        raise failure["exc"]
-    return outcome.get("value")
+
+
+def _pre_tool_call_timeout_block() -> Dict[str, str]:
+    """Fail-closed directive when a policy callback times out or is still running."""
+    return {
+        "action": "block",
+        "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1386,6 +1420,13 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # In-flight / recently-timed-out hook callbacks. Keyed by
+        # (hook_name, id(cb)) so a stuck policy hook cannot spawn a new
+        # abandoned daemon thread on every subsequent fire.
+        self._hook_running_callbacks: Dict[tuple, object] = {}
+        self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
+        self._hook_timeout_lock = threading.Lock()
+        self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
 
     # -----------------------------------------------------------------------
     # Public
@@ -1416,6 +1457,9 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
+            with self._hook_timeout_lock:
+                self._hook_running_callbacks.clear()
+                self._hook_timeout_suppressed_until.clear()
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty
@@ -2008,10 +2052,18 @@ class PluginManager:
         """Call all registered callbacks for *hook_name*.
 
         Each callback is wrapped in its own try/except so a misbehaving
-        plugin cannot break the core agent loop. Callbacks that exceed
-        ``plugins.hook_callback_timeout`` (default 30s) are skipped without
-        waiting for the abandoned worker thread (see
-        :func:`_call_hook_callback`).
+        plugin cannot break the core agent loop.
+
+        Hot-path / observer hooks in ``_HOOK_TIMEOUT_BOUNDED_HOOKS`` and the
+        policy hook ``pre_tool_call`` are bounded by
+        ``plugins.hook_callback_timeout`` (default 30s). On timeout the worker
+        is abandoned (not joined) so we do not reintroduce the #6622 hang.
+        Timed-out or still-running ``pre_tool_call`` callbacks fail closed
+        with a block directive; other bounded hooks fail open (skip).
+
+        ``subagent_stop`` (and any hook in ``_HOOK_CALLER_THREAD_HOOKS``)
+        always runs on the caller thread to preserve the documented parent-
+        thread serialization contract.
 
         Returns a list of non-``None`` return values from callbacks.
 
@@ -2031,23 +2083,91 @@ class PluginManager:
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
         timeout = _resolve_hook_callback_timeout()
+        use_timeout = _hook_uses_callback_timeout(hook_name, timeout)
+        fail_closed = hook_name in _HOOK_TIMEOUT_FAIL_CLOSED_HOOKS
+
         for cb in callbacks:
+            callback_name = getattr(cb, "__name__", repr(cb))
+            callback_key = (hook_name, id(cb))
             try:
-                ret = _call_hook_callback(cb, timeout, **kwargs)
+                if use_timeout:
+                    token = object()
+                    now = time.monotonic()
+                    with self._hook_timeout_lock:
+                        suppressed_until = self._hook_timeout_suppressed_until.get(
+                            callback_key
+                        )
+                        running = callback_key in self._hook_running_callbacks
+                        if (
+                            suppressed_until is not None and suppressed_until > now
+                        ) or running:
+                            logger.warning(
+                                "Hook '%s' callback %s skipped after previous "
+                                "timeout or while still running",
+                                hook_name,
+                                callback_name,
+                            )
+                            if fail_closed:
+                                results.append(_pre_tool_call_timeout_block())
+                            continue
+                        if suppressed_until is not None:
+                            self._hook_timeout_suppressed_until.pop(callback_key, None)
+                        self._hook_running_callbacks[callback_key] = token
+
+                    context = contextvars.copy_context()
+                    done = threading.Event()
+                    outcome: Dict[str, Any] = {}
+                    failure: Dict[str, Exception] = {}
+
+                    def _runner(
+                        _cb: Callable[..., Any] = cb,
+                        _key: tuple = callback_key,
+                        _token: object = token,
+                    ) -> None:
+                        try:
+                            outcome["value"] = context.run(_cb, **kwargs)
+                        except Exception as exc:
+                            failure["exc"] = exc
+                        finally:
+                            with self._hook_timeout_lock:
+                                if self._hook_running_callbacks.get(_key) is _token:
+                                    self._hook_running_callbacks.pop(_key, None)
+                            done.set()
+
+                    thread = threading.Thread(
+                        target=_runner,
+                        name=f"hermes-hook-{callback_name}"[:40],
+                        daemon=True,
+                    )
+                    thread.start()
+                    if not done.wait(timeout=timeout):
+                        # Do not join — that would reintroduce the #6622 hang.
+                        with self._hook_timeout_lock:
+                            self._hook_timeout_suppressed_until[callback_key] = (
+                                time.monotonic()
+                                + self._hook_timeout_suppression_seconds
+                            )
+                        logger.warning(
+                            "Hook '%s' callback %s timed out after %gs — skipping",
+                            hook_name,
+                            callback_name,
+                            timeout,
+                        )
+                        if fail_closed:
+                            results.append(_pre_tool_call_timeout_block())
+                        continue
+                    if "exc" in failure:
+                        raise failure["exc"]
+                    ret = outcome.get("value")
+                else:
+                    ret = cb(**kwargs)
                 if ret is not None:
                     results.append(ret)
-            except TimeoutError:
-                logger.warning(
-                    "Hook '%s' callback %s timed out after %gs — skipping",
-                    hook_name,
-                    getattr(cb, "__name__", repr(cb)),
-                    timeout,
-                )
             except Exception as exc:
                 logger.warning(
                     "Hook '%s' callback %s raised: %s",
                     hook_name,
-                    getattr(cb, "__name__", repr(cb)),
+                    callback_name,
                     exc,
                 )
         return results

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -982,6 +982,13 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "type": "boolean",
         "description": "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout.",
     },
+    "plugins.hook_callback_timeout": {
+        "type": "number",
+        "description": (
+            "Wall-clock cap (seconds) for a single in-process Python plugin "
+            "hook callback. 0 disables the cap; values above 600 are clamped."
+        ),
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
@@ -1019,6 +1026,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `telemetry.shared_metrics.enabled` is the only schema-surfaced telemetry
     # field — fold it into security alongside the other privacy-posture toggles.
     "telemetry": "security",
+    # `plugins.hook_callback_timeout` is the only schema-surfaced plugins field
+    # (`enabled`/`disabled` are list allow-lists omitted from DEFAULT_CONFIG) —
+    # fold it into the agent tab rather than spawning a one-field orphan category.
+    "plugins": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -985,8 +985,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "plugins.hook_callback_timeout": {
         "type": "number",
         "description": (
-            "Wall-clock cap (seconds) for a single in-process Python plugin "
-            "hook callback. 0 disables the cap; values above 600 are clamped."
+            "Wall-clock cap (seconds) for timeout-bounded in-process Python "
+            "plugin hook callbacks (hot-path observers + pre_tool_call). "
+            "Timed-out pre_tool_call fails closed. 0 disables the cap; "
+            "values above 600 are clamped. Caller-thread hooks such as "
+            "subagent_stop are never moved onto a timeout worker."
         ),
     },
 }

--- a/tests/agent/test_subagent_stop_hook.py
+++ b/tests/agent/test_subagent_stop_hook.py
@@ -2,7 +2,8 @@
 
 Covers wire-up from tools.delegate_tool.delegate_task:
   * fires once per child in both single-task and batch modes
-  * runs on the parent thread (no re-entrancy for hook authors)
+  * is dispatched from the parent thread (no child-pool re-entrancy);
+    callback bodies may run on a hermes-hook-* timeout worker
   * carries child_role when the agent exposes _delegate_role
   * carries child_role=None when _delegate_role is not set (pre-M3)
   * exposes a detached, metadata-only tool_call_history
@@ -108,10 +109,19 @@ class TestSingleTask:
         assert payload["duration_ms"] == 5000
 
     def test_fires_on_parent_thread(self):
+        """Dispatch is marshalled to the parent; callback may use a timeout worker."""
         captured = _register_capturing_hook()
         main_thread = threading.current_thread()
+        dispatch_threads = []
+        real_invoke = plugins.invoke_hook
 
-        with patch("tools.delegate_tool._run_single_child") as mock_run:
+        def _tracking_invoke(hook_name, **kwargs):
+            if hook_name == "subagent_stop":
+                dispatch_threads.append(threading.current_thread())
+            return real_invoke(hook_name, **kwargs)
+
+        with patch("tools.delegate_tool._run_single_child") as mock_run, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=_tracking_invoke):
             mock_run.return_value = {
                 "task_index": 0, "status": "completed",
                 "summary": "x", "api_calls": 1, "duration_seconds": 0.1,
@@ -119,7 +129,11 @@ class TestSingleTask:
             }
             delegate_task(goal="go", parent_agent=_make_parent())
 
-        assert captured[0]["_thread"] is main_thread
+        assert dispatch_threads and all(t is main_thread for t in dispatch_threads)
+        cb_thread = captured[0]["_thread"]
+        # Default plugins.hook_callback_timeout > 0 runs the body on a
+        # hermes-hook-* daemon worker; timeout 0 keeps it on the caller.
+        assert cb_thread is main_thread or cb_thread.name.startswith("hermes-hook-")
 
     def test_payload_includes_parent_session_id(self):
         captured = _register_capturing_hook()
@@ -169,10 +183,19 @@ class TestBatchMode:
         assert roles == ["role-a", "role-b", "role-c"]
 
     def test_all_fires_on_parent_thread(self):
+        """Batch stop hooks are dispatched from the parent, not child workers."""
         captured = _register_capturing_hook()
         main_thread = threading.current_thread()
+        dispatch_threads = []
+        real_invoke = plugins.invoke_hook
 
-        with patch("tools.delegate_tool._run_single_child") as mock_run:
+        def _tracking_invoke(hook_name, **kwargs):
+            if hook_name == "subagent_stop":
+                dispatch_threads.append(threading.current_thread())
+            return real_invoke(hook_name, **kwargs)
+
+        with patch("tools.delegate_tool._run_single_child") as mock_run, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=_tracking_invoke):
             mock_run.side_effect = [
                 {"task_index": 0, "status": "completed",
                  "summary": "A", "api_calls": 1, "duration_seconds": 1.0,
@@ -186,8 +209,11 @@ class TestBatchMode:
                 parent_agent=_make_parent(),
             )
 
+        assert len(dispatch_threads) == 2
+        assert all(t is main_thread for t in dispatch_threads)
         for payload in captured:
-            assert payload["_thread"] is main_thread
+            cb_thread = payload["_thread"]
+            assert cb_thread is main_thread or cb_thread.name.startswith("hermes-hook-")
 
 
 # ── payload shape ─────────────────────────────────────────────────────────

--- a/tests/agent/test_subagent_stop_hook.py
+++ b/tests/agent/test_subagent_stop_hook.py
@@ -2,8 +2,8 @@
 
 Covers wire-up from tools.delegate_tool.delegate_task:
   * fires once per child in both single-task and batch modes
-  * is dispatched from the parent thread (no child-pool re-entrancy);
-    callback bodies may run on a hermes-hook-* timeout worker
+  * is dispatched from the parent thread (no child-pool re-entrancy)
+    and callback bodies stay on that caller thread
   * carries child_role when the agent exposes _delegate_role
   * carries child_role=None when _delegate_role is not set (pre-M3)
   * exposes a detached, metadata-only tool_call_history
@@ -109,7 +109,7 @@ class TestSingleTask:
         assert payload["duration_ms"] == 5000
 
     def test_fires_on_parent_thread(self):
-        """Dispatch is marshalled to the parent; callback may use a timeout worker."""
+        """Dispatch and callback body stay on the parent/caller thread."""
         captured = _register_capturing_hook()
         main_thread = threading.current_thread()
         dispatch_threads = []
@@ -131,9 +131,7 @@ class TestSingleTask:
 
         assert dispatch_threads and all(t is main_thread for t in dispatch_threads)
         cb_thread = captured[0]["_thread"]
-        # Default plugins.hook_callback_timeout > 0 runs the body on a
-        # hermes-hook-* daemon worker; timeout 0 keeps it on the caller.
-        assert cb_thread is main_thread or cb_thread.name.startswith("hermes-hook-")
+        assert cb_thread is main_thread
 
     def test_payload_includes_parent_session_id(self):
         captured = _register_capturing_hook()
@@ -212,8 +210,7 @@ class TestBatchMode:
         assert len(dispatch_threads) == 2
         assert all(t is main_thread for t in dispatch_threads)
         for payload in captured:
-            cb_thread = payload["_thread"]
-            assert cb_thread is main_thread or cb_thread.name.startswith("hermes-hook-")
+            assert payload["_thread"] is main_thread
 
 
 # ── payload shape ─────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -377,7 +377,7 @@ class TestPluginHooks:
         import time
 
         monkeypatch.setattr(
-            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 0.15
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.15
         )
 
         hold = threading.Event()
@@ -410,7 +410,7 @@ class TestPluginHooks:
 
     def test_hook_callback_within_timeout_returns_value(self, monkeypatch):
         monkeypatch.setattr(
-            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 1.0
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
         )
         mgr = PluginManager()
         mgr._hooks["pre_llm_call"] = [lambda **_kw: {"context": "hi"}]
@@ -420,7 +420,7 @@ class TestPluginHooks:
 
     def test_hook_exception_still_isolated_under_timeout_path(self, monkeypatch):
         monkeypatch.setattr(
-            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 1.0
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
         )
 
         def boom(**_kwargs):
@@ -429,6 +429,23 @@ class TestPluginHooks:
         mgr = PluginManager()
         mgr._hooks["post_tool_call"] = [boom, lambda **_kw: "survived"]
         assert mgr.invoke_hook("post_tool_call") == ["survived"]
+
+    def test_hook_callback_timeout_reads_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"hook_callback_timeout": 0.12}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.config as config_mod
+
+        config_mod._LOAD_CONFIG_CACHE.clear()
+        config_mod._RAW_CONFIG_CACHE.clear()
+
+        import hermes_cli.plugins as plugins_mod
+
+        assert plugins_mod._resolve_hook_callback_timeout() == 0.12
 
 
 class TestPreToolCallBlocking:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -367,6 +368,67 @@ class TestPluginHooks:
         )
         assert results == [{"seen": 2, "mc": 5, "tc": 3}]
 
+    def test_hook_timeout_does_not_block_caller(self, monkeypatch):
+        """A hung callback must be abandoned without joining the worker.
+
+        Regression for the #6622 approach: ThreadPoolExecutor + result(timeout)
+        inside a ``with`` still waits on shutdown after TimeoutError.
+        """
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 0.15
+        )
+
+        hold = threading.Event()
+        started = threading.Event()
+
+        def blocker(**_kwargs):
+            started.set()
+            hold.wait(timeout=10.0)
+            return "late"
+
+        def fast(**_kwargs):
+            return {"ok": True}
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [blocker, fast]
+
+        t0 = time.monotonic()
+        results = mgr.invoke_hook(
+            "post_tool_call",
+            tool_name="terminal",
+            args={},
+            result="{}",
+        )
+        elapsed = time.monotonic() - t0
+
+        assert started.wait(timeout=1.0)
+        assert results == [{"ok": True}]
+        assert elapsed < 1.0, f"caller blocked for {elapsed:.2f}s after timeout"
+        hold.set()
+
+    def test_hook_callback_within_timeout_returns_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 1.0
+        )
+        mgr = PluginManager()
+        mgr._hooks["pre_llm_call"] = [lambda **_kw: {"context": "hi"}]
+        assert mgr.invoke_hook("pre_llm_call", session_id="s1") == [
+            {"context": "hi"}
+        ]
+
+    def test_hook_exception_still_isolated_under_timeout_path(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins._HOOK_CALLBACK_TIMEOUT_SECS", 1.0
+        )
+
+        def boom(**_kwargs):
+            raise RuntimeError("plugin blew up")
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [boom, lambda **_kw: "survived"]
+        assert mgr.invoke_hook("post_tool_call") == ["survived"]
 
 
 class TestPreToolCallBlocking:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -447,6 +447,135 @@ class TestPluginHooks:
 
         assert plugins_mod._resolve_hook_callback_timeout() == 0.12
 
+    def test_subagent_stop_stays_on_caller_thread(self, monkeypatch):
+        """Caller-thread hooks must not move the body onto a timeout worker."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
+        )
+        seen = {}
+
+        def capture(**_kwargs):
+            seen["thread"] = threading.current_thread()
+            return "ok"
+
+        mgr = PluginManager()
+        mgr._hooks["subagent_stop"] = [capture]
+        caller = threading.current_thread()
+        assert mgr.invoke_hook("subagent_stop", parent_session_id="p1") == ["ok"]
+        assert seen["thread"] is caller
+
+    def test_hung_callback_suppresses_repeat_fires(self, monkeypatch):
+        """A still-running timed-out callback must not spawn another worker."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+
+        hold = threading.Event()
+        starts = []
+
+        def blocker(**_kwargs):
+            starts.append(1)
+            hold.wait(timeout=10.0)
+            return "late"
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [blocker]
+
+        t0 = time.monotonic()
+        assert mgr.invoke_hook("post_tool_call") == []
+        assert mgr.invoke_hook("post_tool_call") == []
+        elapsed = time.monotonic() - t0
+
+        assert len(starts) == 1
+        assert elapsed < 1.0
+        hold.set()
+
+    def test_pre_tool_call_timeout_fail_closed(self, monkeypatch):
+        """Timed-out pre_tool_call must return a block directive, not allow."""
+        import time
+
+        from hermes_cli.plugins import (
+            _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE,
+            resolve_pre_tool_block,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+
+        hold = threading.Event()
+
+        def hung_policy(**_kwargs):
+            hold.wait(timeout=10.0)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [hung_policy]
+
+        import hermes_cli.plugins as plugins_mod
+
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        t0 = time.monotonic()
+        msg = resolve_pre_tool_block("web_search", {"query": "x"})
+        elapsed = time.monotonic() - t0
+
+        assert msg == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+        assert elapsed < 1.0
+
+        # Still-running / suppression window must also fail closed.
+        msg2 = resolve_pre_tool_block("web_search", {"query": "y"})
+        assert msg2 == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+        hold.set()
+
+    def test_pre_tool_call_timeout_does_not_reach_tool_handler(self, monkeypatch):
+        """E2E: timed-out pre_tool_call blocks handle_function_call before dispatch."""
+        import json
+
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+
+        hold = threading.Event()
+
+        def hung_policy(**_kwargs):
+            hold.wait(timeout=10.0)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [hung_policy]
+
+        import hermes_cli.plugins as plugins_mod
+
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        dispatch_calls = []
+
+        def _dispatch(name, args, **kwargs):
+            dispatch_calls.append((name, args))
+            return json.dumps({"ok": True})
+
+        mock_registry = MagicMock()
+        mock_registry.dispatch.side_effect = _dispatch
+
+        with patch("model_tools.registry", mock_registry):
+            from model_tools import handle_function_call
+
+            result = handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                session_id="s1",
+            )
+
+        assert dispatch_calls == []
+        assert _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE in result
+        hold.set()
+
 
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -962,7 +962,7 @@ def register(ctx):
 
 ### `subagent_stop`
 
-Fires **once per child agent** after `delegate_task` finishes. Whether you delegated a single task or a batch of three, this hook fires once for each child, serialised on the parent thread.
+Fires **once per child agent** after `delegate_task` finishes. Whether you delegated a single task or a batch of three, this hook fires once for each child. Dispatch is serialised on the parent thread after child futures drain; with the default `plugins.hook_callback_timeout`, each Python callback body may run on a short-lived `hermes-hook-*` worker.
 
 **Callback signature:**
 
@@ -981,7 +981,7 @@ def my_callback(parent_session_id: str, child_role: str | None,
 | `tool_call_history` | `list[dict]` | Ordered metadata-only tool calls: `tool_name`, bounded `tool_input`, `input_bytes`, `output_bytes`, and `status`; raw inputs and outputs are excluded |
 | `duration_ms` | `int` | Wall-clock time spent running the child, in milliseconds |
 
-**Fires:** In `tools/delegate_tool.py`, after `ThreadPoolExecutor.as_completed()` drains all child futures. Firing is marshalled to the parent thread so hook authors don't have to reason about concurrent callback execution.
+**Fires:** In `tools/delegate_tool.py`, after `ThreadPoolExecutor.as_completed()` drains all child futures. `invoke_hook("subagent_stop", ...)` is marshalled to the parent thread so authors don't see child-pool re-entrancy; individual Python callbacks may still execute on a timeout worker (see `plugins.hook_callback_timeout`).
 
 **Return value:** Ignored.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -382,6 +382,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
+- If a Python plugin callback **blocks** longer than `plugins.hook_callback_timeout` (default 30s, set `0` to disable, max 600), it is abandoned and skipped so the agent loop continues. Shell hooks keep their own per-entry `timeout`.
 - Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -382,7 +382,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- If a Python plugin callback **blocks** longer than `plugins.hook_callback_timeout` (default 30s, set `0` to disable, max 600), it is abandoned and skipped so the agent loop continues. Shell hooks keep their own per-entry `timeout`.
+- If a Python plugin callback on a **timeout-bounded** hook (hot-path observers such as `post_tool_call` / `pre_llm_call`, plus the policy hook `pre_tool_call`) **blocks** longer than `plugins.hook_callback_timeout` (default 30s, set `0` to disable, max 600), it is abandoned without joining the worker so the agent loop continues. Timed-out or still-running `pre_tool_call` callbacks **fail closed** (block the tool); other bounded hooks fail open (skip). Hooks with a documented caller-thread contract (`subagent_stop`) are never moved onto a timeout worker. Shell hooks keep their own per-entry `timeout`.
 - Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
@@ -435,6 +435,8 @@ return {"action": "block", "message": "Reason the tool call was blocked"}
 ```
 
 The agent short-circuits the tool with `message` as the error returned to the model. The first matching block directive wins (Python plugins registered first, then shell hooks). Any other return value is ignored, so existing observer-only callbacks keep working unchanged.
+
+If a `pre_tool_call` callback exceeds `plugins.hook_callback_timeout` (or is still running from a previous timed-out fire), Hermes **fails closed**: the tool is blocked with a timeout message rather than proceeding without a policy decision.
 
 **Use cases:** Logging, audit trails, tool call counters, blocking dangerous operations, rate limiting, per-user policy enforcement.
 
@@ -962,7 +964,7 @@ def register(ctx):
 
 ### `subagent_stop`
 
-Fires **once per child agent** after `delegate_task` finishes. Whether you delegated a single task or a batch of three, this hook fires once for each child. Dispatch is serialised on the parent thread after child futures drain; with the default `plugins.hook_callback_timeout`, each Python callback body may run on a short-lived `hermes-hook-*` worker.
+Fires **once per child agent** after `delegate_task` finishes. Whether you delegated a single task or a batch of three, this hook fires once for each child. Dispatch is serialised on the parent thread after child futures drain, and each Python callback body runs on that same caller thread (not on a timeout worker).
 
 **Callback signature:**
 
@@ -981,7 +983,7 @@ def my_callback(parent_session_id: str, child_role: str | None,
 | `tool_call_history` | `list[dict]` | Ordered metadata-only tool calls: `tool_name`, bounded `tool_input`, `input_bytes`, `output_bytes`, and `status`; raw inputs and outputs are excluded |
 | `duration_ms` | `int` | Wall-clock time spent running the child, in milliseconds |
 
-**Fires:** In `tools/delegate_tool.py`, after `ThreadPoolExecutor.as_completed()` drains all child futures. `invoke_hook("subagent_stop", ...)` is marshalled to the parent thread so authors don't see child-pool re-entrancy; individual Python callbacks may still execute on a timeout worker (see `plugins.hook_callback_timeout`).
+**Fires:** In `tools/delegate_tool.py`, after `ThreadPoolExecutor.as_completed()` drains all child futures. `invoke_hook("subagent_stop", ...)` is marshalled to the parent thread so authors don't see child-pool re-entrancy, and callbacks stay on that caller thread.
 
 **Return value:** Ignored.
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -153,6 +153,10 @@ plugins:
     - disk-cleanup
   disabled:       # optional deny-list — always wins if a name appears in both
     - noisy-plugin
+  # Optional: wall-clock cap (seconds) for in-process Python plugin hook
+  # callbacks. Default 30; set 0 to disable; values above 600 are clamped.
+  # Shell hooks keep their own per-entry timeout under the top-level hooks: key.
+  hook_callback_timeout: 30
 ```
 
 Three ways to flip state:

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -153,8 +153,11 @@ plugins:
     - disk-cleanup
   disabled:       # optional deny-list — always wins if a name appears in both
     - noisy-plugin
-  # Optional: wall-clock cap (seconds) for in-process Python plugin hook
-  # callbacks. Default 30; set 0 to disable; values above 600 are clamped.
+  # Optional: wall-clock cap (seconds) for timeout-bounded in-process Python
+  # plugin hook callbacks (hot-path observers + pre_tool_call). Default 30;
+  # set 0 to disable; values above 600 are clamped. Timed-out pre_tool_call
+  # callbacks fail closed (block the tool). Caller-thread hooks such as
+  # subagent_stop are never moved onto a timeout worker.
   # Shell hooks keep their own per-entry timeout under the top-level hooks: key.
   hook_callback_timeout: 30
 ```


### PR DESCRIPTION
## What does this PR do?

Bounds in-process Python plugin hook callbacks so a blocking plugin cannot wedge the agent loop indefinitely.

`invoke_hook` already isolated exceptions per callback, but ran callbacks synchronously with no wall-clock timeout. This adds a non-blocking timeout: each callback runs on a daemon thread; the caller waits only on an `Event`. On timeout the worker is abandoned (not joined), so we do not reintroduce the #6622 hang where `ThreadPoolExecutor` shutdown waited for the stuck callback after `future.result(timeout=...)`.

Timeout is configurable via `plugins.hook_callback_timeout` (default 30s, `0` disables, max 600s). Shell hooks keep their own per-entry subprocess timeout.

## Related Issue

Fixes #76821

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` - `_call_hook_callback` / `_resolve_hook_callback_timeout`; `invoke_hook` uses daemon-thread timeout without joining on expiry
- `hermes_cli/config_defaults.py` - `plugins.hook_callback_timeout` default (30)
- `tests/hermes_cli/test_plugins.py` - hung-callback abandon regression, config read, exception isolation under timeout path
- `website/docs/user-guide/features/hooks.md` / `plugins.md` - document the timeout and config key

## How to Test

1. `pytest tests/hermes_cli/test_plugins.py -q` (or `scripts/run_tests.sh tests/hermes_cli/test_plugins.py -q`)
2. Register a plugin hook that `time.sleep(60)` in `post_tool_call`; set `plugins.hook_callback_timeout: 1` in config.yaml; confirm the agent turn continues after ~1s with a timeout warning in logs
3. Confirm a normal fast callback still returns its value within the timeout
4. Confirm a raising callback is still logged and skipped, and later callbacks still run

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_plugins.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A (`plugins.enabled` / this key are documented in plugins.md; example file has shell `hooks:` only)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
