### PR TITLE
fix(buzz): subscribe to newly joined channels

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -77,7 +77,7 @@ _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
-# kind 44100 is Buzz's channel-membership event — used for live DM discovery.
+# kind 44100 is Buzz's channel-membership event — used for live conversation discovery.
 _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
@@ -777,8 +777,7 @@ class BuzzAdapter(BasePlatformAdapter):
         await websocket.send(json.dumps(request, separators=(",", ":")))
 
     async def _subscribe_websocket(self, websocket) -> Dict[str, Optional[str]]:
-        """Subscribe to every watched conversation plus membership events
-        (kind 44100 p-tagged to us) for live DM discovery."""
+        """Subscribe to watched conversations and live membership events."""
         subscriptions: Dict[str, Optional[str]] = {}
         for index, channel_id in enumerate(list(self._channel_state)):
             subscription_id = f"hermes-buzz-{index}"
@@ -798,16 +797,47 @@ class BuzzAdapter(BasePlatformAdapter):
             subscriptions[_WS_MEMBERSHIP_SUB_ID] = None
         return subscriptions
 
+    @staticmethod
+    def _membership_channel_id(event: dict) -> str:
+        """Extract the channel UUID from a relay-signed membership event."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return ""
+        for tag in tags:
+            if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == "h":
+                return str(tag[1]).strip()
+        return ""
+
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        """Subscribe live when this identity joins a channel or fresh DM."""
+        membership_at = int(event.get("created_at") or time.time())
+        self._membership_since = max(self._membership_since, membership_at)
         before = set(self._channel_state)
         await self._discover_dms(seed=False)
+
+        # ``_discover_dms`` intentionally ignores real community channels so
+        # they cannot be misclassified as mention-free DMs.  A relay-signed
+        # kind-44100 event is stronger evidence: its ``h`` tag identifies the
+        # channel this identity just joined.  Follow it in automatic mode, or
+        # only when it is present in the explicit BUZZ_CHANNELS allowlist.
+        membership_channel = self._membership_channel_id(event)
+        channel_is_allowed = not self.channels or membership_channel in self.channels
+        if (
+            membership_channel
+            and channel_is_allowed
+            and membership_channel not in self._channel_state
+        ):
+            self._channel_state[membership_channel] = {
+                "chat_type": "group",
+                "last_ts": membership_at,
+                "seen": OrderedDict(),
+            }
+            self._channel_names.setdefault(membership_channel, membership_channel)
+
         for channel_id in self._channel_state:
             if channel_id in before:
                 continue
-            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
+            subscription_id = f"hermes-buzz-membership-{len(subscriptions)}"
             subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
             logger.info("Buzz: subscribed to new conversation %s", channel_id)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -9,6 +9,7 @@ lifecycle as wired into BuzzAdapter.
 import asyncio
 import json
 import time
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,6 +30,7 @@ SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
 # BIP-340 test vector 0 private key
 TEST_PRIVATE_KEY = "00" * 31 + "03"
 CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+NEW_CHANNEL = "462f7626-db2d-4450-bf5a-ea22637c48c0"
 
 
 def _make_adapter(extra=None):
@@ -119,3 +121,71 @@ async def test_websocket_auth_raises_on_rejection():
         await adapter._authenticate_websocket(RejectingWs())
 
 
+def _membership_event(channel_id=NEW_CHANNEL, *, created_at=2_000):
+    return {
+        "id": "membership-event",
+        "pubkey": "b" * 64,
+        "content": "",
+        "created_at": created_at,
+        "kind": 44100,
+        "tags": [["p", SELF_PUBKEY], ["h", channel_id]],
+    }
+
+
+@pytest.mark.asyncio
+async def test_membership_event_subscribes_new_channel_in_automatic_mode():
+    adapter = _make_adapter()
+    adapter._discover_dms = AsyncMock()
+    websocket = _FakeWebSocket()
+    subscriptions = {"hermes-buzz-membership": None}
+
+    await adapter._handle_membership_event(
+        websocket,
+        subscriptions,
+        _membership_event(),
+    )
+
+    state = adapter._channel_state[NEW_CHANNEL]
+    assert state["chat_type"] == "group"
+    assert state["last_ts"] == 2_000
+    assert NEW_CHANNEL in subscriptions.values()
+    assert websocket.sent[-1] == [
+        "REQ",
+        next(key for key, value in subscriptions.items() if value == NEW_CHANNEL),
+        {"kinds": [9], "#h": [NEW_CHANNEL], "since": 1_999},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_membership_event_respects_explicit_channel_allowlist():
+    adapter = _make_adapter({"channels": [CHANNEL]})
+    adapter._discover_dms = AsyncMock()
+    websocket = _FakeWebSocket()
+    subscriptions = {"hermes-buzz-membership": None}
+
+    await adapter._handle_membership_event(
+        websocket,
+        subscriptions,
+        _membership_event(),
+    )
+
+    assert NEW_CHANNEL not in adapter._channel_state
+    assert NEW_CHANNEL not in subscriptions.values()
+    assert websocket.sent == []
+
+
+@pytest.mark.asyncio
+async def test_membership_event_subscribes_explicitly_allowed_channel():
+    adapter = _make_adapter({"channels": [NEW_CHANNEL]})
+    adapter._discover_dms = AsyncMock()
+    websocket = _FakeWebSocket()
+    subscriptions = {"hermes-buzz-membership": None}
+
+    await adapter._handle_membership_event(
+        websocket,
+        subscriptions,
+        _membership_event(),
+    )
+
+    assert NEW_CHANNEL in adapter._channel_state
+    assert NEW_CHANNEL in subscriptions.values()


### PR DESCRIPTION
## What changed

- Extract the channel UUID from relay-signed Buzz `kind:44100` membership events.
- Subscribe the WebSocket transport to a newly joined community channel immediately.
- Keep an explicit `BUZZ_CHANNELS` list authoritative; automatic discovery only applies when that list is empty.
- Start the new subscription at the membership timestamp so prior channel history is not replayed.

## Root cause

`_handle_membership_event()` called `_discover_dms()` and subscribed anything it added. That helper intentionally excludes real community channels to avoid misclassifying them as mention-free DMs, so a channel joined after gateway startup never entered `_channel_state`. The gateway only saw it after a restart rebuilt the initial channel list.

## User impact

With automatic Buzz channel discovery enabled, adding the Hermes identity to a public, private, or ephemeral channel now makes the running gateway listen immediately. Users no longer need to restart the gateway after each channel addition.

## Validation

- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` (30 passed)
- `.venv/bin/ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_websocket.py`
- `git diff --check`
