### PR TITLE
feat(scope): isolate progress and artifacts by conversation thread

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10044,6 +10044,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_blueprint_command(cmd_original)
         elif canonical == "curator":
             self._handle_curator_command(cmd_original)
+        elif canonical == "scope":
+            self._handle_scope_command(cmd_original)
         elif canonical == "kanban":
             self._handle_kanban_command(cmd_original)
         elif canonical == "skills":

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1438,7 +1438,26 @@ def create_job(
         jobs.append(job)
         save_jobs(jobs)
 
+    _auto_link_scope(job["id"])
     return job
+
+
+def _auto_link_scope(job_id: str) -> None:
+    """Best-effort: link a newly created cron job to the current thread's
+    scope, if one has already been created. Never raises, never creates a
+    scope implicitly. See hermes_scope.py / docs/design/thread-scope-isolation.md."""
+    if not job_id:
+        return
+    try:
+        import hermes_scope
+
+        scope_id = hermes_scope.resolve_current_scope_id()
+        if scope_id:
+            hermes_scope.link_artifact(scope_id, "cron_job_ids", job_id)
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "Scope auto-link skipped for cron job_id=%s", job_id, exc_info=True
+        )
 
 
 def get_job(job_id: str) -> Optional[Dict[str, Any]]:

--- a/docs/design/thread-scope-isolation.md
+++ b/docs/design/thread-scope-isolation.md
@@ -214,6 +214,21 @@ thread so the scope is chat-level. Gateway restart is a non-event for scope,
 since the manifest lives on disk under the profile directory, independent of
 process lifetime.
 
+**Known gap, not yet closed:** `build_session_key()` already unifies a
+Discord channel-initiating message with its later real-thread follow-ups
+via `prospective_thread_id` (same `session_key` for both — see
+`gateway/session.py:1136-1146`). `hermes_scope`'s own identity normalization
+does not yet inherit that continuity: it reads `HERMES_SESSION_THREAD_ID`
+fresh each call, which is unset during the initiating-message turn and only
+populated once the real thread exists, so a scope touched during that
+narrow window and one touched afterward are, today, two different identity
+tuples. Documented and exercised by
+`tests/gateway/test_discord_scope_isolation.py::TestProspectiveThreadContinuity::test_KNOWN_GAP_scope_identity_does_not_yet_track_prospective_continuity`
+so a future fix (bridging `prospective_thread_id` through session env, or
+resolving scope from the DB session row's already-unified `thread_id`
+instead of live env each time) has a test that flips from documenting the
+gap to proving it closed.
+
 ### 6. CLI surface
 
 New file `hermes_cli/scope.py`, mirroring `hermes_cli/curator.py`'s

--- a/docs/design/thread-scope-isolation.md
+++ b/docs/design/thread-scope-isolation.md
@@ -1,0 +1,267 @@
+# Design: Thread-Scope Isolation
+
+**Status:** draft — implementation in progress on `feat/thread-scope-isolation`.
+**Severity:** P2 — Hermes reports unrelated work as progress on the conversation the user is actually asking about; this erodes trust in any status/progress answer.
+
+## Root cause
+
+A progress question asked in one Discord thread was answered using evidence
+that did not belong to that thread: broad `session_search` summaries and
+`tmux`/branch activity from *other* threads that happen to share the same git
+repository. The failure has two independent causes that compound:
+
+1. **`session_search` has no notion of "this conversation."**
+   `_discover()` / `_list_recent_sessions()` (`tools/session_search_tool.py`)
+   query across the *entire profile* database. Nothing scopes the search to
+   the session that is asking. A conversation summary from a different
+   thread reads, to the model, exactly like a summary of its own past work.
+
+2. **Repository proximity is mistaken for ownership.** `process_registry.py`
+   tracks tmux/terminal sessions by `session_key`, and `async_delegations`
+   tracks delegations by `origin_session` — both already carry *some*
+   identity — but nothing aggregates "what does *this* conversation own" into
+   one place the agent can check before answering a status question. So the
+   agent falls back to "what's active in this repo right now," which is
+   correct for *a* thread, not necessarily *this* thread.
+
+Neither cause is a missing individual identity field — `gateway/session.py`
+already resolves precise per-thread session keys, and several subsystems
+already stamp their own identity fields. The gap is a missing **aggregation
+layer**: nothing durably answers "what artifacts, in flight or completed,
+belong to this specific scope of work" in a way that's queried by default and
+fails closed when it doesn't know.
+
+## Existing building blocks (do not duplicate)
+
+Confirmed by codebase research before writing this doc — see file:line
+references throughout. This design **extends** these rather than growing new
+parallel machinery, per `AGENTS.md`'s "Extend, don't duplicate."
+
+| Need | Existing mechanism | Location |
+|---|---|---|
+| Normalized cross-platform identity | `gateway.session.SessionSource` (`platform`, `chat_id`, `chat_type`, `thread_id`, `parent_chat_id`, `scope_id`, `profile`) | `gateway/session.py:148-309` |
+| Per-thread session key | `build_session_key()` | `gateway/session.py:1046-1155` |
+| Profile isolation for on-disk state | `get_hermes_home()` / `get_process_hermes_home()` | `hermes_constants.py:114,142` |
+| Atomic, mode-aware file writes | `atomic_json_write(path, data, mode=0o600)` → `atomic_replace()` | `utils.py:174,91` |
+| Advisory cross-platform file lock | `_FileLock` (`fcntl.flock` / `msvcrt.locking`) | `hermes_cli/active_sessions.py:129` |
+| Fail-closed corrupt-state handling | `_read_entries()` — catch, warn, return `[]`, never trust partial data | `hermes_cli/active_sessions.py:182-194` |
+| Positive-proof ownership filtering | `process_registry.py` requeue-for-owner logic (`owns_event()` vs. bare key equality) | `tools/process_registry.py:1276-1348` |
+| Delegation identity | `async_delegations.origin_session` / `origin_ui_session_id` / `parent_delegation_id` | `tools/async_delegation.py:142-161,220,293,497` |
+| tmux/terminal session identity | `ProcessSession.session_key` | `tools/process_registry.py:97,1815,1887-1912` |
+| Cron job origin | `create_job(origin=...)`, built from `HERMES_SESSION_*` env vars | `cron/jobs.py:1246,1426`; `tools/cronjob_tools.py:315-338` |
+| CLI subcommand family pattern | `register_cli(subs)` + `hermes_cli/main.py` wiring | `hermes_cli/curator.py:680` |
+| Schema migration pattern | version-gated `CREATE TABLE IF NOT EXISTS`, `SCHEMA_VERSION` bump | `hermes_state_schema.py:508,536,750-763`; `SCHEMA_VERSION = 23` at `hermes_state_common.py:105` |
+
+Confirmed **absent** (no design conflict, but no shortcut either):
+- No scope/project/goal concept anywhere in the session schema.
+- Todos (`tools/todo_tool.py`) carry no session/scope identity — in-memory
+  per `AIAgent` instance only.
+- No durable git branch/worktree registry — git state is queried live.
+- No PR-ownership tracking anywhere.
+- Discord guild `scope_id` is **deliberately excluded** from
+  `build_session_key()` (comment at `gateway/session.py:1062-1064`) — thread
+  isolation today rests on `thread_id` alone, with no durable object above it
+  representing "the piece of work this thread is for."
+
+## Design
+
+### 1. Scope identity (normalization, not a new ID scheme)
+
+A scope is identified by the same fields `SessionSource`/`build_session_key`
+already resolve — **never** by display name (channel name, thread title,
+user nickname). The scope identity tuple is:
+
+```
+(profile, platform, account_id, guild/workspace scope_id, chat_id, thread_id, topic)
+```
+
+`account_id` (the bot/credential identity) and `topic` are included because
+the same platform+guild+channel can host more than one active piece of work
+(e.g. two threads under one channel, or one thread revisited for two
+unrelated goals over time) — `topic` is an explicit, user- or
+Hermes-assigned label at `scope create` time, never inferred from message
+text. Any field that is missing, unresolvable, or ambiguous (e.g. adapter
+didn't supply a `thread_id` where the platform has threads) causes scope
+resolution to fail closed — see "Fail-closed rules" below — rather than
+guessing.
+
+A `scope_id` is a stable hash of the normalized identity tuple, computed
+once at scope creation and stored in the manifest; conversation-side lookups
+always re-derive the same tuple from live adapter-supplied identity and hash
+it to find the manifest, never trusting a cached/remembered scope_id from
+prior conversation text.
+
+### 2. Storage: per-scope manifest file, not a new SQLite table
+
+Per the brief's "Persist a mode-0600 atomic locked scope manifest under the
+active Hermes profile," and per the Footprint Ladder (extend existing code
+first): reuse the `active_sessions.py` pattern exactly, not
+`hermes_state_common.py`'s SQLite schema. A scope manifest is authored and
+read far less often than session/message rows, doesn't need FTS, and a
+SQLite migration bump (`SCHEMA_VERSION` → 24) is unnecessary machinery for
+what's fundamentally a small, infrequently-written JSON document per scope.
+
+```
+$HERMES_HOME/scopes/<scope_id>.json       # mode 0600, atomic_json_write
+$HERMES_HOME/scopes/<scope_id>.lock       # _FileLock, mirrors active_sessions.py
+$HERMES_HOME/scopes/index.json           # identity-tuple-hash -> scope_id, same pattern
+```
+
+`$HERMES_HOME` is already profile-scoped (`get_hermes_home()`), so this
+gives profile isolation for free — a scope created under one profile is
+invisible to another, and Fleet-project isolation follows the same
+mechanism once Fleet parity work begins (out of scope for the Mac-host
+phase).
+
+Manifest fields (draft; finalized in the implementation PR):
+
+```json
+{
+  "scope_id": "sha256:...",
+  "identity": {"profile": "...", "platform": "discord", "account_id": "...",
+               "guild_scope_id": "...", "chat_id": "...", "thread_id": "...", "topic": "..."},
+  "goal": "free text set at creation",
+  "included_topics": [], "excluded_topics": [],
+  "lifecycle": "active | completed | archived",
+  "created_at": "...", "updated_at": "...",
+  "owned": {
+    "session_keys": [],
+    "branches": [], "worktrees": [],
+    "tmux_session_keys": [],
+    "delegation_ids": [],
+    "background_task_ids": [],
+    "cron_job_ids": [],
+    "prs": []
+  },
+  "external_dependencies": [{"description": "...", "linked_at": "..."}]
+}
+```
+
+No raw command text, pane contents, credentials, or full unnecessary paths
+are ever written into a manifest — only IDs and the identity tuple, per the
+brief's privacy requirement. Routing IDs are redacted in ordinary reports
+(scope status output shows a short opaque suffix, not the full ID) and only
+shown unredacted in `scope audit`.
+
+### 3. Auto-registration vs. manual linking
+
+Auto-register where the artifact's creation path already runs through
+Hermes with the current session's identity in hand:
+
+- **tmux/terminal sessions** — `process_registry.py` already stamps
+  `session_key` at creation; add a scope-manifest append at the same site,
+  resolved from the current session's identity tuple.
+- **Delegations** (background and sync) — `async_delegation.py` already
+  records `origin_session`; append `delegation_id`/`child_session_id` to the
+  owning scope's manifest at creation.
+- **Cron jobs** — `cronjob_tools.py::_origin_from_env()` already builds the
+  origin dict from `HERMES_SESSION_*`; append the job id to the owning
+  scope's manifest at `create_job()` time.
+
+Everything else — **branches, worktrees, PRs** — has no existing
+Hermes-owned creation hook (git state is queried live; PRs aren't tracked at
+all). Per the brief ("manually created artifacts remain orphaned until
+explicitly linked"), these stay manual: `hermes scope link branch <name>`,
+`hermes scope link worktree <path>`, `hermes scope link pr <url>`. This is
+intentional, not a gap — inventing a git-operation-interception layer to
+auto-detect every branch creation is exactly the kind of speculative
+infrastructure `AGENTS.md` tells us not to build for a single feature.
+
+### 4. Scoped progress resolution (fail-closed)
+
+The literal root-cause fix: extend `session_search_tool.py` so that, by
+default, `_discover()`/`_list_recent_sessions()` filter to the calling
+session's resolved scope — computed via the positive-proof pattern already
+used in `process_registry.py` (`owns_event()`-style check), not bare
+string equality on a remembered ID. An explicit `include_unscoped=True`
+argument (documented in the tool schema as "search other conversations too")
+opens it back up — this keeps `session_search` as one tool (extend, don't
+duplicate) rather than adding a second core tool.
+
+A new `hermes scope status` (and the equivalent slash command) walks the
+manifest's `owned.*` id lists and checks *live* state for each — is the
+tmux session still running, is the delegation still pending, is the cron job
+still scheduled — never trusting the manifest's last-known state as current
+truth. `session_search` results, if the agent still consults them, are
+always labeled conversation evidence, never presented as proof of live
+state or artifact ownership, matching the brief's explicit requirement.
+
+**Fail-closed rules** (apply uniformly across resolution, not just at scope
+creation):
+- Missing/unresolvable identity field → cannot compute a scope tuple →
+  report "scope unknown," do not fall back to unscoped search silently.
+- Manifest read fails JSON parse, or lock can't be acquired within a short
+  timeout → treat as absent, report uncertainty (mirrors
+  `active_sessions.py`'s `_read_entries()` fail-closed catch).
+- Cross-profile or cross-scope artifact reference found during a live check
+  → excluded from the report, logged, never silently merged in.
+- Ambiguous match (identity tuple hashes to more than one manifest — should
+  be impossible by construction, but checked) → exclude both, report
+  ambiguity rather than picking one.
+
+### 5. Continuity across compaction/resume/restart/`/clear`/handoff/cron
+
+Scope identity is re-derived from adapter-supplied identity on every turn,
+not stored in conversation text or carried through compaction summaries —
+compaction summaries are exactly the contamination vector in the root-cause
+incident, so scope must never be inferable from them. `/new` and `/clear`
+start a new session_key under the same thread identity; whether that new
+session inherits the existing scope's manifest (same thread → same scope)
+or requires a fresh `scope create` is a per-adapter decision resolved by
+whether the platform's `thread_id` is stable across the new session — for
+Discord, yes (thread identity survives `/clear`); for a DM, there is no
+thread so the scope is chat-level. Gateway restart is a non-event for scope,
+since the manifest lives on disk under the profile directory, independent of
+process lifetime.
+
+### 6. CLI surface
+
+New file `hermes_cli/scope.py`, mirroring `hermes_cli/curator.py`'s
+`register_cli(subs)` structure exactly (one `add_parser` per verb: `status`,
+`create`, `link`, `unlink`, `dependency`, `audit`, `complete`, `archive`),
+wired into `hermes_cli/main.py` the same way curator is. A parallel
+`CommandDef` entry in `hermes_cli/commands.py` gives conversation-side
+`/scope status` etc. for free across CLI/gateway/Telegram/Slack per the
+existing slash-command registry. No new core model tool — this is
+Footprint Ladder rung 2 (CLI command + skill), the same rung `hermes cron`
+and `hermes curator` already occupy.
+
+## Test plan (TDD — failing reproduction first)
+
+Mirrors `tests/hermes_cli/test_active_sessions.py` / `test_curator_*.py`'s
+per-behavior file split rather than one giant file.
+
+1. `tests/hermes_cli/test_scope_repro.py` — failing reproduction of the
+   root-cause incident: two Discord threads under one channel, one has
+   activity, a progress question asked in the *other* thread must not see
+   it. Written and run first, expected to fail against current `main`.
+2. `test_scope_identity.py` — normalization, hashing, missing-field
+   fail-closed behavior, display-name-never-used-as-identity.
+3. `test_scope_manifest.py` — atomic write/lock reuse, mode 0600, corrupt
+   JSON fail-closed, concurrent writers.
+4. `test_scope_ownership.py` — two scopes sharing one repo; same tmux
+   session *name* in different projects; owned vs. orphaned artifacts;
+   cross-profile isolation; cross-Fleet-project isolation (manifest path
+   only, no Fleet runtime changes yet).
+5. `test_scope_search_filter.py` — `session_search` default-scoped
+   behavior vs. explicit `include_unscoped=True`; compaction-summary
+   contamination must not leak into scope determination.
+6. `test_scope_dependencies.py` — external dependencies tracked separately
+   from verified progress.
+7. `test_scope_lifecycle.py` — restart/resume/`/clear`/handoff continuity;
+   `/new` under the same thread; profile separation.
+8. `test_scope_privacy.py` — no raw command/pane/env/credential content in
+   a manifest; routing IDs redacted in default `scope status` output.
+9. `tests/gateway/test_discord_scope_isolation.py` — adapter-level version
+   of scenario 1, plus the "prospective thread" continuity case
+   (`gateway/session.py:194-204`).
+
+## Explicit non-goals (this phase)
+
+- No Gateway/production Discord routing changes until backup/rollback/canary
+  gates exist (per the task's boundaries).
+- No Fleet runtime changes until Mac-host E2E is green; Fleet gets a
+  separate branch/PR with strict schema, dry-run, rollback, one-project
+  canary.
+- No new core model tool; `session_search` is extended, not duplicated.
+- No auto-detection of git branch/worktree/PR creation — manual linking only.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1730,6 +1730,28 @@ class CLICommandsMixin:
         except Exception as exc:
             print(f"(._.) curator: {exc}")
 
+    def _handle_scope_command(self, cmd: str):
+        """Handle /scope slash command.
+
+        Delegates to hermes_cli.scope so the CLI/gateway and the `hermes
+        scope` subcommand share the same handler set.
+        """
+        import shlex
+
+        tokens = shlex.split(cmd)[1:] if cmd else []
+        if not tokens:
+            tokens = ["status"]
+
+        try:
+            from hermes_cli.scope import cli_main
+            cli_main(tokens)
+        except SystemExit:
+            # argparse calls sys.exit() on --help or errors; swallow so we
+            # don't kill the interactive session.
+            pass
+        except Exception as exc:
+            print(f"(._.) scope: {exc}")
+
     def _handle_kanban_command(self, cmd: str):
         """Handle the /kanban command — delegate to the shared kanban CLI.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -273,6 +273,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),
+    CommandDef("scope", "Thread-scope status, create, link, dependency, complete, archive",
+               "Session", args_hint="[subcommand]",
+               subcommands=("status", "create", "link", "unlink", "dependency", "audit",
+                            "complete", "archive")),
     CommandDef("kanban", "Multi-profile collaboration board (tasks, links, comments)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("init", "boards", "create", "list", "ls", "show", "assign",
@@ -1257,7 +1261,11 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     /hermes update on Slack. Demoted to free the native slot /approvals now
 #     claims — without this entry /approvals tips the registry past the 50-cap
 #     and silently clamps /update off, breaking Telegram parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update"})
+#   - scope: thread-scope status/create/link management — infrequent relative
+#     to everyday chat commands; reached via /hermes scope on Slack so it
+#     doesn't tip the registry past the 50-command cap and silently clamp an
+#     existing native slash (see thread-scope-isolation design doc).
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "scope"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11659,6 +11659,27 @@ def main():
         logging.getLogger(__name__).debug("curator CLI wiring failed: %s", _exc)
 
     # =========================================================================
+    # scope command — durable per-thread scope identity and ownership
+    # =========================================================================
+    scope_parser = subparsers.add_parser(
+        "scope",
+        help="Thread-scope identity — status, create, link, dependency, complete, archive",
+        description=(
+            "A scope is the durable object representing one piece of work "
+            "(one Discord thread, one DM, one CLI project). Progress/status "
+            "questions should be answered from a scope's own owned "
+            "artifacts, not from unrelated activity sharing the same "
+            "profile or repository. See docs/design/thread-scope-isolation.md."
+        ),
+    )
+    try:
+        from hermes_cli.scope import register_cli as _register_scope_cli
+
+        _register_scope_cli(scope_parser)
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("scope CLI wiring failed: %s", _exc)
+
+    # =========================================================================
     # pets command — petdex animated mascots (CLI / TUI / desktop display)
     # =========================================================================
     pets_parser = subparsers.add_parser(

--- a/hermes_cli/scope.py
+++ b/hermes_cli/scope.py
@@ -36,6 +36,68 @@ def _resolve_scope_id(args) -> Optional[str]:
     return hermes_scope.resolve_current_scope_id()
 
 
+def _liveness_summary(manifest: dict) -> dict:
+    """Best-effort live-state check for owned artifacts.
+
+    Per docs/design/thread-scope-isolation.md: status must check live state
+    for owned artifacts rather than trusting the manifest's last-known state
+    as current truth (a tmux session, delegation, or cron job the manifest
+    still lists may have exited/completed/been removed hours ago). Lives
+    here rather than in hermes_scope.py -- process_registry/async_delegation/
+    cron.jobs are heavier deps than the storage layer needs, and
+    process_registry.py already imports hermes_scope for auto-registration,
+    so importing them back from there would be circular.
+
+    Returns {category: {"count": N, "active": M or None}}. ``active`` is
+    None (not 0) when liveness genuinely can't be determined for that
+    category, so a caller can tell "checked, none active" apart from
+    "couldn't check" -- fail closed to unknown, never to "still active."
+    Only categories with a liveness check and at least one owned id are
+    included.
+    """
+    owned = manifest.get("owned", {})
+    summary: dict = {}
+
+    tmux_keys = owned.get("tmux_session_keys") or []
+    if tmux_keys:
+        try:
+            from tools.process_registry import process_registry
+
+            active = sum(1 for k in tmux_keys if process_registry.has_active_for_session(k))
+        except Exception:
+            active = None
+        summary["tmux_session_keys"] = {"count": len(tmux_keys), "active": active}
+
+    delegation_ids = owned.get("delegation_ids") or []
+    if delegation_ids:
+        try:
+            from tools.async_delegation import get_durable_delegation
+
+            active = 0
+            for delegation_id in delegation_ids:
+                record = get_durable_delegation(delegation_id)
+                if record and (
+                    record.get("state") in ("running", "finalizing")
+                    or record.get("delivery_state") == "pending"
+                ):
+                    active += 1
+        except Exception:
+            active = None
+        summary["delegation_ids"] = {"count": len(delegation_ids), "active": active}
+
+    cron_job_ids = owned.get("cron_job_ids") or []
+    if cron_job_ids:
+        try:
+            from cron.jobs import get_job
+
+            active = sum(1 for job_id in cron_job_ids if (get_job(job_id) or {}).get("enabled", False))
+        except Exception:
+            active = None
+        summary["cron_job_ids"] = {"count": len(cron_job_ids), "active": active}
+
+    return summary
+
+
 def _identity_from_args_or_env(args) -> Optional[dict]:
     """Build the identity tuple from explicit flags, falling back to the
     live session context. Explicit flags let `hermes scope create` be used
@@ -74,6 +136,21 @@ def _cmd_create(args) -> int:
         included_topics=args.included_topics or [],
         excluded_topics=args.excluded_topics or [],
     )
+    if identity.get("account_id") or identity.get("guild_scope_id"):
+        # No live-session field currently carries account_id/guild_scope_id
+        # (see hermes_scope.identity_from_session_env) -- a scope created
+        # with either set can only ever be resolved again via an explicit
+        # --scope-id. Warn instead of letting it silently become
+        # unreachable to the auto-registration hooks and to a bare
+        # `hermes scope status`/`link`/... in a later turn.
+        print(
+            "warning: --account-id/--guild-scope-id are not carried by the "
+            "live session context, so this scope can only be reached again "
+            "via --scope-id " + _redact(manifest["scope_id"]) + " -- it will "
+            "not be found by auto-registration hooks or by a bare "
+            "`hermes scope status`/`link`.",
+            file=sys.stderr,
+        )
     print(f"scope {_redact(manifest['scope_id'])}: {manifest['goal']} ({manifest['lifecycle']})")
     return 0
 
@@ -93,9 +170,16 @@ def _cmd_status(args) -> int:
     print(f"created:  {manifest['created_at']}")
     print(f"updated:  {manifest['updated_at']}")
     owned = manifest.get("owned", {})
+    liveness = _liveness_summary(manifest)
     print("owned artifacts:")
     for category, values in owned.items():
-        print(f"  {category}: {len(values)}")
+        live = liveness.get(category)
+        if live is None:
+            print(f"  {category}: {len(values)}")
+        elif live["active"] is None:
+            print(f"  {category}: {live['count']} (liveness unknown)")
+        else:
+            print(f"  {category}: {live['count']} ({live['active']} still active)")
     deps = manifest.get("external_dependencies", [])
     if deps:
         print("external dependencies (not verified progress):")

--- a/hermes_cli/scope.py
+++ b/hermes_cli/scope.py
@@ -1,0 +1,269 @@
+"""CLI subcommand: `hermes scope <subcommand>`.
+
+Thin shell around hermes_scope.py — status/create/link/unlink/dependency/
+audit/complete/archive for the durable per-thread scope object described in
+docs/design/thread-scope-isolation.md.
+
+This module intentionally has no side effects at import time — main.py wires
+the argparse subparsers on demand, mirroring hermes_cli/curator.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+import hermes_scope
+
+
+def _redact(value: str, keep: int = 6) -> str:
+    """Shorten a routing id for default (non-audit) display."""
+    if not value:
+        return value
+    if len(value) <= keep:
+        return value
+    return f"...{value[-keep:]}"
+
+
+def _resolve_scope_id(args) -> Optional[str]:
+    """Explicit --scope-id wins; otherwise resolve from the live session
+    context. Never guesses -- returns None (caller reports "scope unknown")
+    when neither is available."""
+    explicit = getattr(args, "scope_id", None)
+    if explicit:
+        return explicit
+    return hermes_scope.resolve_current_scope_id()
+
+
+def _identity_from_args_or_env(args) -> Optional[dict]:
+    """Build the identity tuple from explicit flags, falling back to the
+    live session context. Explicit flags let `hermes scope create` be used
+    from a plain shell (no HERMES_SESSION_* context) for scripting/testing."""
+    platform = getattr(args, "platform", None)
+    chat_id = getattr(args, "chat_id", None)
+    if platform and chat_id:
+        try:
+            return hermes_scope.normalize_scope_identity(
+                profile=getattr(args, "profile", None) or "main",
+                platform=platform,
+                chat_id=chat_id,
+                account_id=getattr(args, "account_id", None),
+                guild_scope_id=getattr(args, "guild_scope_id", None),
+                thread_id=getattr(args, "thread_id", None),
+                topic=getattr(args, "topic", None),
+            )
+        except hermes_scope.ScopeIdentityError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return None
+    return hermes_scope.identity_from_session_env()
+
+
+def _cmd_create(args) -> int:
+    identity = _identity_from_args_or_env(args)
+    if identity is None:
+        print(
+            "error: could not resolve scope identity — no live session context "
+            "and no --platform/--chat-id given",
+            file=sys.stderr,
+        )
+        return 1
+    manifest = hermes_scope.create_scope(
+        identity,
+        goal=args.goal,
+        included_topics=args.included_topics or [],
+        excluded_topics=args.excluded_topics or [],
+    )
+    print(f"scope {_redact(manifest['scope_id'])}: {manifest['goal']} ({manifest['lifecycle']})")
+    return 0
+
+
+def _cmd_status(args) -> int:
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    manifest = hermes_scope.load_scope(scope_id)
+    if manifest is None:
+        print(f"scope unknown or unreadable: {_redact(scope_id)}", file=sys.stderr)
+        return 1
+    print(f"scope:    {_redact(manifest['scope_id'])}")
+    print(f"goal:     {manifest['goal']}")
+    print(f"lifecycle: {manifest['lifecycle']}")
+    print(f"created:  {manifest['created_at']}")
+    print(f"updated:  {manifest['updated_at']}")
+    owned = manifest.get("owned", {})
+    print("owned artifacts:")
+    for category, values in owned.items():
+        print(f"  {category}: {len(values)}")
+    deps = manifest.get("external_dependencies", [])
+    if deps:
+        print("external dependencies (not verified progress):")
+        for dep in deps:
+            print(f"  - {dep.get('description')} (linked {dep.get('linked_at')})")
+    return 0
+
+
+def _cmd_audit(args) -> int:
+    """Unredacted dump — the explicit opt-in to see raw routing IDs."""
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    manifest = hermes_scope.load_scope(scope_id)
+    if manifest is None:
+        print(f"scope unknown or unreadable: {scope_id}", file=sys.stderr)
+        return 1
+    import json
+
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_link(args) -> int:
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    try:
+        hermes_scope.link_artifact(scope_id, args.category, args.value)
+    except hermes_scope.ScopeIdentityError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"linked {args.category}={args.value} to scope {_redact(scope_id)}")
+    return 0
+
+
+def _cmd_unlink(args) -> int:
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    try:
+        hermes_scope.unlink_artifact(scope_id, args.category, args.value)
+    except hermes_scope.ScopeIdentityError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"unlinked {args.category}={args.value} from scope {_redact(scope_id)}")
+    return 0
+
+
+def _cmd_dependency(args) -> int:
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    try:
+        hermes_scope.add_dependency(scope_id, args.description)
+    except hermes_scope.ScopeIdentityError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"recorded external dependency on scope {_redact(scope_id)}: {args.description}")
+    return 0
+
+
+def _cmd_complete(args) -> int:
+    return _set_lifecycle(args, "completed")
+
+
+def _cmd_archive(args) -> int:
+    return _set_lifecycle(args, "archived")
+
+
+def _set_lifecycle(args, lifecycle: str) -> int:
+    scope_id = _resolve_scope_id(args)
+    if scope_id is None:
+        print("scope unknown — no live session context and no --scope-id given", file=sys.stderr)
+        return 1
+    try:
+        hermes_scope.set_lifecycle(scope_id, lifecycle)
+    except hermes_scope.ScopeIdentityError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"scope {_redact(scope_id)} -> {lifecycle}")
+    return 0
+
+
+def _add_scope_id_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--scope-id", dest="scope_id", default=None,
+        help="Target scope id. Omit to use the current conversation's scope.",
+    )
+
+
+def register_cli(parent: argparse.ArgumentParser) -> None:
+    """Attach `scope` subcommands to *parent*.
+
+    main.py calls this with the ArgumentParser returned by
+    ``subparsers.add_parser("scope", ...)``.
+    """
+    parent.set_defaults(func=lambda a: (parent.print_help(), 0)[1])
+    subs = parent.add_subparsers(dest="scope_command")
+
+    p_create = subs.add_parser("create", help="Create the scope for this conversation")
+    p_create.add_argument("--goal", required=True, help="Free-text goal for this scope")
+    p_create.add_argument("--topic", default=None, help="Disambiguating topic label")
+    p_create.add_argument("--included-topics", nargs="*", default=None)
+    p_create.add_argument("--excluded-topics", nargs="*", default=None)
+    p_create.add_argument("--platform", default=None, help="Override: identity platform (for scripted use)")
+    p_create.add_argument("--chat-id", default=None, help="Override: identity chat id")
+    p_create.add_argument("--thread-id", default=None, help="Override: identity thread id")
+    p_create.add_argument("--account-id", default=None, help="Override: identity account id")
+    p_create.add_argument("--guild-scope-id", default=None, help="Override: identity guild/workspace id")
+    p_create.add_argument("--profile", default=None, help="Override: profile name")
+    p_create.set_defaults(func=_cmd_create)
+
+    p_status = subs.add_parser("status", help="Show this conversation's scope and owned artifacts")
+    _add_scope_id_arg(p_status)
+    p_status.set_defaults(func=_cmd_status)
+
+    p_audit = subs.add_parser("audit", help="Dump the full scope manifest, unredacted")
+    _add_scope_id_arg(p_audit)
+    p_audit.set_defaults(func=_cmd_audit)
+
+    p_link = subs.add_parser("link", help="Manually link an artifact this scope owns")
+    _add_scope_id_arg(p_link)
+    p_link.add_argument(
+        "category",
+        choices=sorted(hermes_scope._OWNED_CATEGORIES),
+        help="Artifact category",
+    )
+    p_link.add_argument("value", help="Artifact id/name (e.g. branch name, PR url)")
+    p_link.set_defaults(func=_cmd_link)
+
+    p_unlink = subs.add_parser("unlink", help="Remove an artifact link from this scope")
+    _add_scope_id_arg(p_unlink)
+    p_unlink.add_argument("category", choices=sorted(hermes_scope._OWNED_CATEGORIES))
+    p_unlink.add_argument("value", help="Artifact id/name to unlink")
+    p_unlink.set_defaults(func=_cmd_unlink)
+
+    p_dependency = subs.add_parser(
+        "dependency", help="Record an external dependency (tracked separately from owned progress)"
+    )
+    _add_scope_id_arg(p_dependency)
+    p_dependency.add_argument("description", help="What this scope is waiting on")
+    p_dependency.set_defaults(func=_cmd_dependency)
+
+    p_complete = subs.add_parser("complete", help="Mark this scope's work complete")
+    _add_scope_id_arg(p_complete)
+    p_complete.set_defaults(func=_cmd_complete)
+
+    p_archive = subs.add_parser("archive", help="Archive this scope")
+    _add_scope_id_arg(p_archive)
+    p_archive.set_defaults(func=_cmd_archive)
+
+
+def cli_main(argv=None) -> int:
+    """Standalone entry (also usable by hermes_cli.main fallthrough)."""
+    parser = argparse.ArgumentParser(prog="hermes scope")
+    register_cli(parser)
+    args = parser.parse_args(argv)
+    fn = getattr(args, "func", None)
+    if fn is None:
+        parser.print_help()
+        return 0
+    return int(fn(args) or 0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(cli_main())

--- a/hermes_scope.py
+++ b/hermes_scope.py
@@ -1,0 +1,416 @@
+"""Thread-scope identity, manifest storage, and fail-closed resolution.
+
+A "scope" is the durable object representing one piece of work — one
+Discord thread, one DM, one CLI project — so that a progress/status
+question asked inside it can be answered from artifacts *that scope
+actually owns*, not from whatever else is active in the same profile or
+repository. See docs/design/thread-scope-isolation.md for the full design
+and root-cause writeup.
+
+Storage layout under the active profile's ``$HERMES_HOME``:
+
+    scopes/<scope_id>.json   # manifest, mode 0600, atomic_json_write
+    scopes/<scope_id>.lock   # advisory file lock (mirrors active_sessions.py)
+    scopes/index.json        # identity-hash -> scope_id, same write pattern
+
+Every read is fail-closed: a missing, corrupt, ambiguous, or
+cross-profile/cross-scope reference is treated as absent and logged, never
+guessed at. Identity is always derived from adapter-supplied fields
+(platform, account, guild/workspace, chat, thread) — never from a display
+name.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_MODE = 0o600
+
+_OWNED_CATEGORIES = (
+    "session_keys",
+    "branches",
+    "worktrees",
+    "tmux_session_keys",
+    "delegation_ids",
+    "background_task_ids",
+    "cron_job_ids",
+    "prs",
+)
+
+_LIFECYCLES = ("active", "completed", "archived")
+
+
+class ScopeIdentityError(ValueError):
+    """Raised when a scope identity tuple can't be resolved.
+
+    Callers must treat this as "scope unknown" and fail closed — never
+    fall back to an unscoped search silently.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Identity normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_scope_identity(
+    *,
+    profile: str,
+    platform: str,
+    chat_id: str,
+    account_id: Optional[str] = None,
+    guild_scope_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    topic: Optional[str] = None,
+) -> dict:
+    """Build the canonical identity tuple a scope is keyed on.
+
+    ``profile``, ``platform``, and ``chat_id`` are required — without them
+    there is no durable identity to hash. Everything else is optional but
+    included verbatim when present so two scopes that differ only by
+    thread/topic never collide. Raises ScopeIdentityError (fail closed) on
+    a missing required field or a value that is empty after stripping.
+    """
+    required = {"profile": profile, "platform": platform, "chat_id": chat_id}
+    for name, value in required.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ScopeIdentityError(f"missing or empty required identity field: {name}")
+
+    def _clean(value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value or None
+
+    return {
+        "profile": profile.strip(),
+        "platform": platform.strip(),
+        "account_id": _clean(account_id),
+        "guild_scope_id": _clean(guild_scope_id),
+        "chat_id": chat_id.strip(),
+        "thread_id": _clean(thread_id),
+        "topic": _clean(topic),
+    }
+
+
+def compute_scope_id(identity: dict) -> str:
+    """Stable hash of the normalized identity tuple.
+
+    Recomputed from live identity on every lookup — never trust a
+    scope_id remembered from prior conversation text (that is exactly the
+    compaction-summary contamination vector this feature exists to close).
+    """
+    canonical = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Storage paths
+# ---------------------------------------------------------------------------
+
+
+def _scopes_dir(hermes_home: Optional[Path] = None) -> Path:
+    base = Path(hermes_home) if hermes_home is not None else Path(get_hermes_home())
+    return base / "scopes"
+
+
+def _manifest_path(scope_id: str, hermes_home: Optional[Path] = None) -> Path:
+    return _scopes_dir(hermes_home) / f"{_safe_filename(scope_id)}.json"
+
+
+def _lock_path(scope_id: str, hermes_home: Optional[Path] = None) -> Path:
+    return _scopes_dir(hermes_home) / f"{_safe_filename(scope_id)}.lock"
+
+
+def _index_path(hermes_home: Optional[Path] = None) -> Path:
+    return _scopes_dir(hermes_home) / "index.json"
+
+
+def _index_lock_path(hermes_home: Optional[Path] = None) -> Path:
+    return _scopes_dir(hermes_home) / "index.lock"
+
+
+def _safe_filename(scope_id: str) -> str:
+    # scope_id is "sha256:<hex>" — drop the colon so it's a plain filename.
+    return scope_id.replace(":", "_")
+
+
+class _FileLock:
+    """Advisory cross-platform exclusive lock. Mirrors hermes_cli/active_sessions.py."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._fh = None
+
+    def __enter__(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+b")
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("scope manifest lock unavailable") from exc
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+            except Exception as exc:
+                self._fh.close()
+                self._fh = None
+                raise RuntimeError("scope manifest lock unavailable") from exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._fh is None:
+            return
+        if os.name == "nt":
+            try:
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+            except Exception:
+                pass
+        else:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+        try:
+            self._fh.close()
+        finally:
+            self._fh = None
+
+
+# ---------------------------------------------------------------------------
+# Manifest read/write (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def _read_json_fail_closed(path: Path) -> Optional[dict]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        logger.warning("Ignoring corrupt scope state at %s", path)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Ignoring malformed (non-object) scope state at %s", path)
+        return None
+    return data
+
+
+def load_scope(scope_id: str, hermes_home: Optional[Path] = None) -> Optional[dict]:
+    """Fail-closed manifest read: missing/corrupt -> None, never raises."""
+    return _read_json_fail_closed(_manifest_path(scope_id, hermes_home))
+
+
+def _write_manifest(manifest: dict, hermes_home: Optional[Path] = None) -> None:
+    path = _manifest_path(manifest["scope_id"], hermes_home)
+    with _FileLock(_lock_path(manifest["scope_id"], hermes_home)):
+        atomic_json_write(path, manifest, mode=MANIFEST_MODE)
+
+
+def _load_index(hermes_home: Optional[Path] = None) -> dict:
+    data = _read_json_fail_closed(_index_path(hermes_home))
+    if data is None:
+        return {}
+    entries = data.get("entries")
+    return entries if isinstance(entries, dict) else {}
+
+
+def _write_index(entries: dict, hermes_home: Optional[Path] = None) -> None:
+    atomic_json_write(_index_path(hermes_home), {"entries": entries}, mode=MANIFEST_MODE)
+
+
+def resolve_scope_id(identity: dict, hermes_home: Optional[Path] = None) -> Optional[str]:
+    """Look up an existing scope_id for a freshly-derived identity tuple.
+
+    Never trusts a scope_id passed in from conversation text — always
+    re-derives from live identity and looks it up here.
+    """
+    scope_id = compute_scope_id(identity)
+    index = _load_index(hermes_home)
+    entry = index.get(scope_id)
+    if entry is None:
+        return None
+    # Ambiguity guard: by construction the hash key IS the scope_id, so a
+    # mismatched stored value means index corruption -- fail closed.
+    if entry != scope_id:
+        logger.warning("Scope index entry mismatch for %s -- treating as absent", scope_id)
+        return None
+    return scope_id
+
+
+# ---------------------------------------------------------------------------
+# Public CRUD API
+# ---------------------------------------------------------------------------
+
+
+def create_scope(
+    identity: dict,
+    goal: str,
+    *,
+    included_topics: Optional[list] = None,
+    excluded_topics: Optional[list] = None,
+    hermes_home: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict:
+    """Create (or return the existing) manifest for this identity tuple.
+
+    Idempotent by identity: creating a scope twice for the same identity
+    tuple returns the existing manifest rather than silently forking a
+    duplicate scope for the same conversation.
+    """
+    scope_id = compute_scope_id(identity)
+    existing = load_scope(scope_id, hermes_home)
+    if existing is not None:
+        return existing
+
+    ts = _iso(now)
+    manifest = {
+        "scope_id": scope_id,
+        "identity": identity,
+        "goal": goal,
+        "included_topics": list(included_topics or []),
+        "excluded_topics": list(excluded_topics or []),
+        "lifecycle": "active",
+        "created_at": ts,
+        "updated_at": ts,
+        "owned": {category: [] for category in _OWNED_CATEGORIES},
+        "external_dependencies": [],
+    }
+    _write_manifest(manifest, hermes_home)
+
+    index = _load_index(hermes_home)
+    index[scope_id] = scope_id
+    _write_index(index, hermes_home)
+    return manifest
+
+
+def _iso(now: Optional[float] = None) -> str:
+    ts = time.time() if now is None else now
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
+
+
+def link_artifact(
+    scope_id: str,
+    category: str,
+    value: str,
+    hermes_home: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict:
+    """Append an owned-artifact id to a scope manifest. Dedupes; fail-closed on unknown scope/category."""
+    if category not in _OWNED_CATEGORIES:
+        raise ScopeIdentityError(f"unknown owned-artifact category: {category}")
+    with _FileLock(_lock_path(scope_id, hermes_home)):
+        manifest = load_scope(scope_id, hermes_home)
+        if manifest is None:
+            raise ScopeIdentityError(f"unknown scope_id: {scope_id}")
+        bucket = manifest["owned"].setdefault(category, [])
+        if value not in bucket:
+            bucket.append(value)
+            manifest["updated_at"] = _iso(now)
+            atomic_json_write(
+                _manifest_path(scope_id, hermes_home), manifest, mode=MANIFEST_MODE
+            )
+        return manifest
+
+
+def unlink_artifact(
+    scope_id: str,
+    category: str,
+    value: str,
+    hermes_home: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict:
+    if category not in _OWNED_CATEGORIES:
+        raise ScopeIdentityError(f"unknown owned-artifact category: {category}")
+    with _FileLock(_lock_path(scope_id, hermes_home)):
+        manifest = load_scope(scope_id, hermes_home)
+        if manifest is None:
+            raise ScopeIdentityError(f"unknown scope_id: {scope_id}")
+        bucket = manifest["owned"].setdefault(category, [])
+        if value in bucket:
+            bucket.remove(value)
+            manifest["updated_at"] = _iso(now)
+            atomic_json_write(
+                _manifest_path(scope_id, hermes_home), manifest, mode=MANIFEST_MODE
+            )
+        return manifest
+
+
+def add_dependency(
+    scope_id: str,
+    description: str,
+    hermes_home: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict:
+    """External dependencies are tracked separately from verified progress."""
+    with _FileLock(_lock_path(scope_id, hermes_home)):
+        manifest = load_scope(scope_id, hermes_home)
+        if manifest is None:
+            raise ScopeIdentityError(f"unknown scope_id: {scope_id}")
+        ts = _iso(now)
+        manifest["external_dependencies"].append({"description": description, "linked_at": ts})
+        manifest["updated_at"] = ts
+        atomic_json_write(_manifest_path(scope_id, hermes_home), manifest, mode=MANIFEST_MODE)
+        return manifest
+
+
+def set_lifecycle(
+    scope_id: str,
+    lifecycle: str,
+    hermes_home: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict:
+    if lifecycle not in _LIFECYCLES:
+        raise ScopeIdentityError(f"invalid lifecycle: {lifecycle}")
+    with _FileLock(_lock_path(scope_id, hermes_home)):
+        manifest = load_scope(scope_id, hermes_home)
+        if manifest is None:
+            raise ScopeIdentityError(f"unknown scope_id: {scope_id}")
+        manifest["lifecycle"] = lifecycle
+        manifest["updated_at"] = _iso(now)
+        atomic_json_write(_manifest_path(scope_id, hermes_home), manifest, mode=MANIFEST_MODE)
+        return manifest
+
+
+def owns(scope_id: str, category: str, value: str, hermes_home: Optional[Path] = None) -> bool:
+    """Positive-proof ownership check -- the only way callers should gate
+    "is this artifact part of this scope's verified progress."
+
+    Fail-closed: any error resolving the manifest returns False rather
+    than raising, so a caller that forgets to catch an exception can't
+    accidentally treat "unknown" as "owned."
+    """
+    try:
+        manifest = load_scope(scope_id, hermes_home)
+    except Exception:
+        logger.warning("owns() failed to load scope %s", scope_id, exc_info=True)
+        return False
+    if manifest is None:
+        return False
+    bucket = manifest.get("owned", {}).get(category, [])
+    return value in bucket

--- a/hermes_scope.py
+++ b/hermes_scope.py
@@ -284,29 +284,35 @@ def create_scope(
     duplicate scope for the same conversation.
     """
     scope_id = compute_scope_id(identity)
-    existing = load_scope(scope_id, hermes_home)
-    if existing is not None:
-        return existing
+    # Hold the index lock across the existing-check + manifest write + index
+    # update so two concurrent create_scope() calls for the same identity
+    # can't both pass the existence check and race the index read-modify-
+    # write (a lost index entry would leave a valid manifest on disk that
+    # resolve_scope_id() could never find again).
+    with _FileLock(_index_lock_path(hermes_home)):
+        existing = load_scope(scope_id, hermes_home)
+        if existing is not None:
+            return existing
 
-    ts = _iso(now)
-    manifest = {
-        "scope_id": scope_id,
-        "identity": identity,
-        "goal": goal,
-        "included_topics": list(included_topics or []),
-        "excluded_topics": list(excluded_topics or []),
-        "lifecycle": "active",
-        "created_at": ts,
-        "updated_at": ts,
-        "owned": {category: [] for category in _OWNED_CATEGORIES},
-        "external_dependencies": [],
-    }
-    _write_manifest(manifest, hermes_home)
+        ts = _iso(now)
+        manifest = {
+            "scope_id": scope_id,
+            "identity": identity,
+            "goal": goal,
+            "included_topics": list(included_topics or []),
+            "excluded_topics": list(excluded_topics or []),
+            "lifecycle": "active",
+            "created_at": ts,
+            "updated_at": ts,
+            "owned": {category: [] for category in _OWNED_CATEGORIES},
+            "external_dependencies": [],
+        }
+        _write_manifest(manifest, hermes_home)
 
-    index = _load_index(hermes_home)
-    index[scope_id] = scope_id
-    _write_index(index, hermes_home)
-    return manifest
+        index = _load_index(hermes_home)
+        index[scope_id] = scope_id
+        _write_index(index, hermes_home)
+        return manifest
 
 
 def _iso(now: Optional[float] = None) -> str:

--- a/hermes_scope.py
+++ b/hermes_scope.py
@@ -414,3 +414,53 @@ def owns(scope_id: str, category: str, value: str, hermes_home: Optional[Path] =
         return False
     bucket = manifest.get("owned", {}).get(category, [])
     return value in bucket
+
+
+# ---------------------------------------------------------------------------
+# Live-session identity bridge
+# ---------------------------------------------------------------------------
+
+
+def identity_from_session_env() -> Optional[dict]:
+    """Normalize the current turn's identity from ``HERMES_SESSION_*``.
+
+    Mirrors ``tools/cronjob_tools.py::_origin_from_env`` -- the same
+    ContextVar/env-var bridge (``gateway.session_context.get_session_env``)
+    already used to carry live session identity across tool-call boundaries.
+    Returns None (fail closed) when the required fields aren't resolvable
+    (e.g. a bare CLI/TUI session with no messaging origin) rather than
+    guessing at a scope.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM") or None
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID") or None
+    profile = get_session_env("HERMES_SESSION_PROFILE") or "main"
+    if not platform or not chat_id:
+        return None
+
+    try:
+        return normalize_scope_identity(
+            profile=profile,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=get_session_env("HERMES_SESSION_THREAD_ID") or None,
+        )
+    except ScopeIdentityError:
+        return None
+
+
+def resolve_current_scope_id(hermes_home: Optional[Path] = None) -> Optional[str]:
+    """Resolve (never create) the scope owning the current turn, if any.
+
+    Fail-closed: returns None on any missing/ambiguous identity or absent
+    scope -- callers must treat that as "scope unknown," never fall back
+    to unscoped behavior silently.
+    """
+    identity = identity_from_session_env()
+    if identity is None:
+        return None
+    return resolve_scope_id(identity, hermes_home=hermes_home)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3163,6 +3163,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return None
         return str(rows[0]["id"])
 
+    def session_ids_for_thread_scope(
+        self,
+        *,
+        source: str,
+        chat_id: str,
+        thread_id: Optional[str] = None,
+    ) -> set:
+        """All session ids (any lifecycle state) sharing one thread origin.
+
+        Unlike find_session_by_origin (latest *live* session only), this
+        returns every session id that ever ran under this exact
+        platform + chat + thread, so a caller can filter a result set down
+        to "this scope's own sessions" -- see tools/session_search_tool.py's
+        default-scoped discovery/browse filtering and
+        docs/design/thread-scope-isolation.md.
+        """
+        if not source or chat_id in (None, ""):
+            return set()
+        query = "SELECT id FROM sessions WHERE LOWER(source) = LOWER(?) AND chat_id = ?"
+        params: list = [source, str(chat_id)]
+        query += " AND COALESCE(thread_id, '') = COALESCE(?, '')"
+        params.append(str(thread_id) if thread_id else None)
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+        return {str(r["id"]) for r in rows}
+
     def find_latest_gateway_session_for_peer(
         self,
         *,

--- a/skills/software-development/thread-scope/SKILL.md
+++ b/skills/software-development/thread-scope/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: thread-scope
+description: "Ground progress answers in this scope's own tracked work."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [scope, session, progress, discord, gateway]
+    related_skills: []
+---
+
+# Thread Scope Skill
+
+Hermes conversations that share a repository, a profile, or even a Discord
+channel are not automatically the same piece of work. This skill governs
+when to check or update the current conversation's **scope** — the durable
+record of what this specific thread/session owns — so a progress question
+gets answered from artifacts this conversation actually produced, never
+from activity that merely happens to be nearby (another thread, another
+tmux session, another branch in the same repo).
+
+## When to Use
+
+- The user asks a progress/status question: "where are we on this", "is
+  this done", "what's left", "what have you done so far".
+- You are about to start non-trivial work spanning more than one turn (a
+  bug fix, a feature, a multi-step task) and there is no scope yet for this
+  conversation.
+- You manually created an artifact `hermes scope`'s auto-registration
+  cannot see — a git branch, a worktree, or a PR (see Prerequisites).
+
+Do NOT create a scope for every message — only when the user is opening a
+real piece of work you might later be asked to report progress on.
+
+## Prerequisites
+
+- `hermes scope` is a CLI subcommand (see `terminal`), not a model tool —
+  there is no dedicated tool call for it.
+- Auto-registration already links tmux/terminal sessions, delegations, and
+  cron jobs you create through Hermes's own paths to the active scope — you
+  do not need to link those manually.
+- Branches, worktrees, and PRs are **never** auto-linked (Hermes has no
+  durable registry for them). Link them yourself with `hermes scope link`
+  whenever you create one as part of this scope's work.
+
+## How to Run
+
+Check whether this conversation already has a scope:
+
+```bash
+hermes scope status
+```
+
+If it reports "scope unknown" and you're starting real work, create one:
+
+```bash
+hermes scope create --goal "<one-line description of what this conversation is for>"
+```
+
+Link a manually created artifact:
+
+```bash
+hermes scope link branches "fix/ssl-cert-bug"
+hermes scope link worktrees "/path/to/worktree"
+hermes scope link prs "https://github.com/org/repo/pull/123"
+```
+
+Record something you're blocked on (kept separate from verified progress):
+
+```bash
+hermes scope dependency "waiting on infra team to rotate the cert"
+```
+
+Close it out when the work is done:
+
+```bash
+hermes scope complete   # or: hermes scope archive
+```
+
+## Quick Reference
+
+| Situation | Command |
+|---|---|
+| "What's the status of this?" | `hermes scope status` |
+| Starting a new multi-turn task | `hermes scope create --goal "..."` |
+| Just created a branch/worktree/PR | `hermes scope link <category> <value>` |
+| Blocked on something external | `hermes scope dependency "<description>"` |
+| Work is done | `hermes scope complete` |
+| Full unredacted detail (debugging) | `hermes scope audit` |
+
+## Procedure
+
+1. Before answering a progress/status question, run `hermes scope status`.
+   Its `owned artifacts` section is this conversation's verified progress —
+   report from there, not from `session_search` results or from other
+   tmux sessions/branches you happen to notice in the repository.
+2. `session_search` results are conversation history, not proof of live
+   state or of what this conversation owns — never cite a hit from another
+   thread/session as if it were this conversation's own work, even when
+   it looks directly relevant. `session_search` already scopes discovery
+   to this thread by default on platforms with threads; only pass
+   `include_unscoped=true` when the user explicitly asks you to search
+   other conversations.
+3. If `hermes scope status` reports "scope unknown," say so plainly rather
+   than substituting a guess built from whatever else is active in the
+   repo or profile — that guess is exactly the failure this skill exists
+   to prevent.
+4. When you create a branch, worktree, or PR as part of this scope's work,
+   link it immediately with `hermes scope link` — don't wait until a
+   status question forces you to reconstruct what happened.
+5. An external dependency (waiting on another team, a pending review, an
+   infra change) is not progress — record it with `hermes scope
+   dependency` and keep it out of your progress claims.
+
+## Pitfalls
+
+- Don't create a new scope for every turn — reuse the existing one for the
+  life of the conversation/thread; `hermes scope create` is idempotent by
+  identity, so calling it again on an existing scope is harmless but
+  usually unnecessary.
+- Don't pass `--account-id`/`--guild-scope-id` to `hermes scope create`
+  unless you will always address this scope by its explicit `--scope-id`
+  afterward — the live session context does not carry those fields, so a
+  scope created with either set cannot be found again by a bare `hermes
+  scope status` or by auto-registration.
+- Don't treat a `hermes scope status` artifact count as proof something is
+  still running — the counts include a best-effort liveness check for
+  tmux sessions, delegations, and cron jobs, but branches/worktrees/PRs
+  have no liveness signal at all; verify those against the actual source
+  (`git branch`, the PR page) before reporting them as current.
+
+## Verification
+
+```bash
+hermes scope status
+```
+
+If it prints a goal, lifecycle, and owned-artifact counts, the scope is
+tracked correctly. "scope unknown" with no `--scope-id` means either no
+scope has been created for this conversation yet, or you're on a platform
+(bare CLI, some DMs) with no thread identity to key one on.

--- a/tests/gateway/test_discord_scope_isolation.py
+++ b/tests/gateway/test_discord_scope_isolation.py
@@ -1,0 +1,84 @@
+"""Adapter-level thread-scope isolation checks.
+
+Verifies that gateway/session.py's build_session_key() -- the single source
+of truth for session identity -- produces the distinct session_keys that
+hermes_scope's thread-scope filtering depends on: two Discord threads under
+one channel/guild must key to different sessions, while a channel message
+that auto-threads (the "prospective thread" case) must key to the SAME
+session as its later thread follow-ups, so it stays one scope rather than
+splitting into two. See docs/design/thread-scope-isolation.md.
+"""
+import hermes_scope as scope
+from gateway.session import Platform, SessionSource, build_session_key
+
+
+def _thread_source(thread_id, chat_id="channel-99"):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type="thread",
+        thread_id=thread_id,
+    )
+
+
+class TestDistinctThreadsGetDistinctSessionKeys:
+    def test_two_threads_same_channel_different_session_keys(self):
+        key_a = build_session_key(_thread_source("thread-A"))
+        key_b = build_session_key(_thread_source("thread-B"))
+        assert key_a != key_b
+
+    def test_scope_identity_derived_from_distinct_threads_is_distinct(self, tmp_path):
+        identity_a = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-99", thread_id="thread-A",
+        )
+        identity_b = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-99", thread_id="thread-B",
+        )
+        scope_a = scope.create_scope(identity_a, goal="a", hermes_home=tmp_path)
+        scope_b = scope.create_scope(identity_b, goal="b", hermes_home=tmp_path)
+        assert scope_a["scope_id"] != scope_b["scope_id"]
+
+
+class TestProspectiveThreadContinuity:
+    def test_channel_initiator_and_thread_followup_share_one_session_key(self):
+        # The channel-initiating message has no real thread_id yet -- only
+        # the connector's prospective_thread_id (the message id that WILL
+        # become the thread id once Discord auto-threads it).
+        initiator = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-99",
+            chat_type="group",
+            thread_id=None,
+            prospective_thread_id="msg-12345",
+        )
+        followup = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-99",
+            chat_type="thread",
+            thread_id="msg-12345",
+        )
+        assert build_session_key(initiator) == build_session_key(followup)
+
+    def test_prospective_continuity_means_one_scope_not_two(self, tmp_path):
+        # Because both messages resolve to the same session_key, they persist
+        # as the SAME session_id/session row (upsert-by-session_key), which
+        # carries one thread_id once enriched -- so exactly one scope covers
+        # both the kickoff message and its threaded follow-ups, never two.
+        initiator = SessionSource(
+            platform=Platform.DISCORD, chat_id="channel-99", chat_type="group",
+            thread_id=None, prospective_thread_id="msg-12345",
+        )
+        followup = SessionSource(
+            platform=Platform.DISCORD, chat_id="channel-99", chat_type="thread",
+            thread_id="msg-12345",
+        )
+        assert build_session_key(initiator) == build_session_key(followup)
+
+        # Once the real thread exists, scope identity is keyed on the real
+        # (now-resolved) thread_id -- exactly one scope for this thread.
+        identity = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-99", thread_id="msg-12345",
+        )
+        created = scope.create_scope(identity, goal="investigate the bug", hermes_home=tmp_path)
+        resolved_again = scope.resolve_scope_id(identity, hermes_home=tmp_path)
+        assert resolved_again == created["scope_id"]

--- a/tests/gateway/test_discord_scope_isolation.py
+++ b/tests/gateway/test_discord_scope_isolation.py
@@ -3,10 +3,12 @@
 Verifies that gateway/session.py's build_session_key() -- the single source
 of truth for session identity -- produces the distinct session_keys that
 hermes_scope's thread-scope filtering depends on: two Discord threads under
-one channel/guild must key to different sessions, while a channel message
-that auto-threads (the "prospective thread" case) must key to the SAME
-session as its later thread follow-ups, so it stays one scope rather than
-splitting into two. See docs/design/thread-scope-isolation.md.
+one channel/guild must key to different session_keys. Also verifies (and
+documents a currently-open gap in) the "prospective thread" case: a channel
+message that auto-threads keys to the SAME session_key as its later thread
+follow-ups, but hermes_scope's own identity does NOT yet inherit that same
+continuity -- see TestProspectiveThreadContinuity's KNOWN_GAP test. See
+docs/design/thread-scope-isolation.md.
 """
 import hermes_scope as scope
 from gateway.session import Platform, SessionSource, build_session_key
@@ -43,7 +45,8 @@ class TestProspectiveThreadContinuity:
     def test_channel_initiator_and_thread_followup_share_one_session_key(self):
         # The channel-initiating message has no real thread_id yet -- only
         # the connector's prospective_thread_id (the message id that WILL
-        # become the thread id once Discord auto-threads it).
+        # become the thread id once Discord auto-threads it). At the
+        # session_key layer, both resolve to the SAME key -- confirmed here.
         initiator = SessionSource(
             platform=Platform.DISCORD,
             chat_id="channel-99",
@@ -59,26 +62,44 @@ class TestProspectiveThreadContinuity:
         )
         assert build_session_key(initiator) == build_session_key(followup)
 
-    def test_prospective_continuity_means_one_scope_not_two(self, tmp_path):
-        # Because both messages resolve to the same session_key, they persist
-        # as the SAME session_id/session row (upsert-by-session_key), which
-        # carries one thread_id once enriched -- so exactly one scope covers
-        # both the kickoff message and its threaded follow-ups, never two.
-        initiator = SessionSource(
-            platform=Platform.DISCORD, chat_id="channel-99", chat_type="group",
-            thread_id=None, prospective_thread_id="msg-12345",
-        )
-        followup = SessionSource(
-            platform=Platform.DISCORD, chat_id="channel-99", chat_type="thread",
-            thread_id="msg-12345",
-        )
-        assert build_session_key(initiator) == build_session_key(followup)
-
-        # Once the real thread exists, scope identity is keyed on the real
-        # (now-resolved) thread_id -- exactly one scope for this thread.
+    def test_once_the_real_thread_resolves_its_scope_identity_is_stable(self, tmp_path):
+        # After Discord auto-threads (real thread_id now known), scope
+        # identity keyed on that real thread_id resolves consistently across
+        # repeat lookups -- exactly one scope for the thread going forward.
         identity = scope.normalize_scope_identity(
             profile="main", platform="discord", chat_id="channel-99", thread_id="msg-12345",
         )
         created = scope.create_scope(identity, goal="investigate the bug", hermes_home=tmp_path)
         resolved_again = scope.resolve_scope_id(identity, hermes_home=tmp_path)
         assert resolved_again == created["scope_id"]
+
+    def test_KNOWN_GAP_scope_identity_does_not_yet_track_prospective_continuity(self, tmp_path):
+        """Documents a real, currently-unresolved gap -- NOT a passing guarantee.
+
+        build_session_key() treats the channel-initiating message and its
+        real-thread follow-up as the SAME session (via prospective_thread_id,
+        see the test above). hermes_scope's identity, however, is normalized
+        from HERMES_SESSION_THREAD_ID at each call
+        (hermes_scope.identity_from_session_env), which is None during the
+        initiating message (only the adapter's internal prospective_thread_id
+        is set, not exposed through session env) and becomes "msg-12345" only
+        once the real thread exists. So a scope created (or auto-linked to)
+        during the initiating-message turn and one created after the thread
+        resolves are, TODAY, two different identity tuples -- unlike
+        session_key, which already unifies them.
+
+        docs/design/thread-scope-isolation.md ("Continuity across
+        compaction/resume/...") calls this exact case a "per-adapter
+        decision" left open for the Discord adapter; this test exists so a
+        future fix flips this assertion (proving the gap is closed) instead
+        of the gap being silently forgotten.
+        """
+        identity_during_initiator = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-99", thread_id=None,
+        )
+        identity_after_thread_resolves = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-99", thread_id="msg-12345",
+        )
+        assert scope.compute_scope_id(identity_during_initiator) != scope.compute_scope_id(
+            identity_after_thread_resolves
+        )

--- a/tests/hermes_cli/test_scope_cli.py
+++ b/tests/hermes_cli/test_scope_cli.py
@@ -1,0 +1,140 @@
+"""Tests for `hermes scope <subcommand>` (hermes_cli/scope.py).
+
+Mirrors hermes_cli/curator.py's argparse subcommand structure and test
+conventions (see tests/hermes_cli/test_curator_status.py).
+"""
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+import pytest
+
+import hermes_scope as scope
+from hermes_cli.scope import cli_main
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = cli_main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+class TestCreate:
+    def test_create_with_explicit_identity(self, hermes_home):
+        rc, out, _ = _run([
+            "create", "--goal", "fix the bug",
+            "--platform", "discord", "--chat-id", "chan-1", "--thread-id", "thread-A",
+        ])
+        assert rc == 0
+        assert "fix the bug" in out
+
+    def test_create_without_identity_fails_closed(self, hermes_home):
+        rc, _, err = _run(["create", "--goal", "fix the bug"])
+        assert rc == 1
+        assert "could not resolve scope identity" in err
+
+
+class TestStatusAndAudit:
+    def _create(self, hermes_home):
+        identity = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="chan-1", thread_id="thread-A",
+        )
+        return scope.create_scope(identity, goal="fix the bug", hermes_home=hermes_home)["scope_id"]
+
+    def test_status_without_scope_id_or_context_fails_closed(self, hermes_home):
+        rc, _, err = _run(["status"])
+        assert rc == 1
+        assert "scope unknown" in err
+
+    def test_status_shows_goal_and_owned_counts(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        scope.link_artifact(scope_id, "branches", "feat/x", hermes_home=hermes_home)
+        rc, out, _ = _run(["status", "--scope-id", scope_id])
+        assert rc == 0
+        assert "fix the bug" in out
+        assert "branches: 1" in out
+
+    def test_status_redacts_scope_id(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        rc, out, _ = _run(["status", "--scope-id", scope_id])
+        assert rc == 0
+        assert scope_id not in out
+
+    def test_audit_shows_unredacted_identity(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        rc, out, _ = _run(["audit", "--scope-id", scope_id])
+        assert rc == 0
+        assert scope_id in out
+        assert "chan-1" in out
+        assert "thread-A" in out
+
+
+class TestLinkUnlinkDependencyLifecycle:
+    def _create(self, hermes_home):
+        identity = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="chan-1", thread_id="thread-A",
+        )
+        return scope.create_scope(identity, goal="fix the bug", hermes_home=hermes_home)["scope_id"]
+
+    def test_link_and_unlink(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        rc, out, _ = _run(["link", "prs", "https://x/1", "--scope-id", scope_id])
+        assert rc == 0
+        assert scope.owns(scope_id, "prs", "https://x/1", hermes_home=hermes_home)
+
+        rc, out, _ = _run(["unlink", "prs", "https://x/1", "--scope-id", scope_id])
+        assert rc == 0
+        assert not scope.owns(scope_id, "prs", "https://x/1", hermes_home=hermes_home)
+
+    def test_link_unknown_category_rejected_by_argparse(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        with pytest.raises(SystemExit):
+            _run(["link", "not_a_category", "x", "--scope-id", scope_id])
+
+    def test_dependency_recorded_separately(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        rc, _, _ = _run(["dependency", "waiting on infra team", "--scope-id", scope_id])
+        assert rc == 0
+        manifest = scope.load_scope(scope_id, hermes_home=hermes_home)
+        assert manifest["external_dependencies"][0]["description"] == "waiting on infra team"
+
+    def test_complete_and_archive(self, hermes_home):
+        scope_id = self._create(hermes_home)
+        rc, _, _ = _run(["complete", "--scope-id", scope_id])
+        assert rc == 0
+        assert scope.load_scope(scope_id, hermes_home=hermes_home)["lifecycle"] == "completed"
+
+        rc, _, _ = _run(["archive", "--scope-id", scope_id])
+        assert rc == 0
+        assert scope.load_scope(scope_id, hermes_home=hermes_home)["lifecycle"] == "archived"
+
+
+class TestParserWiring:
+    def test_register_cli_builds_all_verbs(self):
+        import argparse
+
+        from hermes_cli.scope import register_cli
+
+        parser = argparse.ArgumentParser()
+        register_cli(parser)
+        # argparse raises SystemExit(2) on an unknown subcommand -- if this
+        # doesn't raise, "definitely-not-a-verb" was silently accepted.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["definitely-not-a-verb"])
+        for verb in ("status", "create", "link", "unlink", "dependency", "audit", "complete", "archive"):
+            if verb == "create":
+                extra = ["--goal", "x", "--platform", "p", "--chat-id", "c"]
+            elif verb in ("link", "unlink"):
+                extra = ["branches", "val"]
+            elif verb == "dependency":
+                extra = ["desc"]
+            else:
+                extra = []
+            ns = parser.parse_args([verb] + extra)
+            assert ns.func is not None

--- a/tests/hermes_cli/test_scope_repro.py
+++ b/tests/hermes_cli/test_scope_repro.py
@@ -1,0 +1,71 @@
+"""Reproduction of the thread-scope-isolation root-cause incident.
+
+A progress question asked in one Discord thread was answered using work
+that belonged to a *different* thread in the same channel/repo. This test
+reconstructs the minimal shape of that failure at the ownership layer: two
+scopes derived from two threads under one channel, artifacts (a tmux
+session and a delegation) belong only to the thread that actually did the
+work, and asking "does scope A own this artifact" must say no for anything
+that belongs to scope B -- even though both threads share every other
+identity field (profile, platform, guild, channel).
+
+See docs/design/thread-scope-isolation.md for the full root-cause writeup.
+"""
+import hermes_scope as scope
+
+
+def _thread_identity(thread_id):
+    return scope.normalize_scope_identity(
+        profile="main",
+        platform="discord",
+        account_id="bot-1",
+        guild_scope_id="guild-42",
+        chat_id="channel-99",
+        thread_id=thread_id,
+    )
+
+
+class TestCrossThreadProgressContamination:
+    def test_work_in_one_thread_is_not_visible_as_progress_in_another(self, tmp_path):
+        thread_a = scope.create_scope(
+            _thread_identity("thread-A"),
+            goal="investigate the SSL cert bug",
+            hermes_home=tmp_path,
+        )
+        thread_b = scope.create_scope(
+            _thread_identity("thread-B"),
+            goal="unrelated feature request",
+            hermes_home=tmp_path,
+        )
+
+        # Thread A did real work: a tmux session and a background delegation.
+        scope.link_artifact(thread_a["scope_id"], "tmux_session_keys", "agent:main:discord:thread:guild-42:channel-99:thread-A", hermes_home=tmp_path)
+        scope.link_artifact(thread_a["scope_id"], "delegation_ids", "deleg-abc123", hermes_home=tmp_path)
+        scope.link_artifact(thread_a["scope_id"], "branches", "fix/ssl-cert-bug", hermes_home=tmp_path)
+
+        # A progress question asked from thread B must not see thread A's work,
+        # even though both threads share profile/platform/guild/channel identity.
+        assert not scope.owns(thread_b["scope_id"], "tmux_session_keys", "agent:main:discord:thread:guild-42:channel-99:thread-A", hermes_home=tmp_path)
+        assert not scope.owns(thread_b["scope_id"], "delegation_ids", "deleg-abc123", hermes_home=tmp_path)
+        assert not scope.owns(thread_b["scope_id"], "branches", "fix/ssl-cert-bug", hermes_home=tmp_path)
+
+        # And thread A's own status check does see it.
+        assert scope.owns(thread_a["scope_id"], "tmux_session_keys", "agent:main:discord:thread:guild-42:channel-99:thread-A", hermes_home=tmp_path)
+        assert scope.owns(thread_a["scope_id"], "delegation_ids", "deleg-abc123", hermes_home=tmp_path)
+        assert scope.owns(thread_a["scope_id"], "branches", "fix/ssl-cert-bug", hermes_home=tmp_path)
+
+    def test_scopes_resolve_independently_from_live_identity_not_remembered_ids(self, tmp_path):
+        # Re-derive both scope_ids fresh, exactly as a live progress-question
+        # handler would (never trusting a scope_id parsed out of prior
+        # conversation/compaction text).
+        identity_a = _thread_identity("thread-A")
+        identity_b = _thread_identity("thread-B")
+        created_a = scope.create_scope(identity_a, goal="investigate the SSL cert bug", hermes_home=tmp_path)
+        scope.link_artifact(created_a["scope_id"], "branches", "fix/ssl-cert-bug", hermes_home=tmp_path)
+
+        resolved_a = scope.resolve_scope_id(identity_a, hermes_home=tmp_path)
+        resolved_b = scope.resolve_scope_id(identity_b, hermes_home=tmp_path)
+
+        assert resolved_a == created_a["scope_id"]
+        assert resolved_b is None  # thread B never created a scope -- must not fall back to A's
+        assert scope.owns(resolved_a, "branches", "fix/ssl-cert-bug", hermes_home=tmp_path)

--- a/tests/skills/test_thread_scope_skill.py
+++ b/tests/skills/test_thread_scope_skill.py
@@ -1,0 +1,65 @@
+"""Metadata checks for skills/software-development/thread-scope/SKILL.md.
+
+Mirrors the authoring-standards verification snippet in AGENTS.md
+("Skill authoring standards (HARDLINE)").
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+SKILL_PATH = Path("skills/software-development/thread-scope/SKILL.md")
+
+
+def _frontmatter():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.DOTALL)
+    assert match, "SKILL.md must start with a --- frontmatter block"
+    return yaml.safe_load(match.group(1)), match.group(2)
+
+
+class TestFrontmatter:
+    def test_description_at_most_60_chars(self):
+        text = SKILL_PATH.read_text(encoding="utf-8")
+        m = re.search(r'^description: (.*)$', text, re.MULTILINE)
+        assert m is not None
+        assert len(m.group(1)) <= 60, len(m.group(1))
+
+    def test_description_does_not_repeat_skill_name(self):
+        frontmatter, _ = _frontmatter()
+        assert frontmatter["name"] not in frontmatter["description"]
+
+    def test_required_fields_present(self):
+        frontmatter, _ = _frontmatter()
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in frontmatter, field
+
+    def test_name_matches_directory(self):
+        frontmatter, _ = _frontmatter()
+        assert frontmatter["name"] == SKILL_PATH.parent.name
+
+
+class TestSkillBody:
+    def test_section_order(self):
+        _, body = _frontmatter()
+        required_sections = [
+            "## When to Use",
+            "## Prerequisites",
+            "## How to Run",
+            "## Quick Reference",
+            "## Procedure",
+            "## Pitfalls",
+            "## Verification",
+        ]
+        positions = [body.index(s) for s in required_sections]
+        assert positions == sorted(positions)
+
+    def test_references_only_real_commands_not_shell_utilities(self):
+        _, body = _frontmatter()
+        for banned in ("`grep `", "`cat `", "`sed `", "`awk `"):
+            assert banned not in body
+
+    def test_references_hermes_scope_cli(self):
+        _, body = _frontmatter()
+        assert "hermes scope status" in body
+        assert "hermes scope create" in body

--- a/tests/test_hermes_scope.py
+++ b/tests/test_hermes_scope.py
@@ -1,0 +1,207 @@
+"""Tests for hermes_scope.py -- identity normalization, manifest storage,
+fail-closed reads, and ownership queries.
+
+See docs/design/thread-scope-isolation.md for the design this implements.
+"""
+import json
+import stat
+
+import pytest
+
+import hermes_scope as scope
+
+
+def _identity(**overrides):
+    base = dict(
+        profile="main",
+        platform="discord",
+        chat_id="channel-1",
+        account_id="bot-1",
+        guild_scope_id="guild-1",
+        thread_id="thread-A",
+        topic="thread-scope-isolation",
+    )
+    base.update(overrides)
+    return scope.normalize_scope_identity(**base)
+
+
+class TestIdentityNormalization:
+    def test_normalizes_required_and_optional_fields(self):
+        identity = _identity()
+        assert identity["profile"] == "main"
+        assert identity["platform"] == "discord"
+        assert identity["chat_id"] == "channel-1"
+        assert identity["thread_id"] == "thread-A"
+        assert identity["topic"] == "thread-scope-isolation"
+
+    def test_optional_fields_default_to_none(self):
+        identity = scope.normalize_scope_identity(
+            profile="main", platform="discord", chat_id="channel-1"
+        )
+        assert identity["account_id"] is None
+        assert identity["guild_scope_id"] is None
+        assert identity["thread_id"] is None
+        assert identity["topic"] is None
+
+    @pytest.mark.parametrize("field", ["profile", "platform", "chat_id"])
+    def test_missing_required_field_fails_closed(self, field):
+        kwargs = dict(profile="main", platform="discord", chat_id="channel-1")
+        kwargs[field] = ""
+        with pytest.raises(scope.ScopeIdentityError):
+            scope.normalize_scope_identity(**kwargs)
+
+    def test_whitespace_only_required_field_fails_closed(self):
+        with pytest.raises(scope.ScopeIdentityError):
+            scope.normalize_scope_identity(profile="   ", platform="discord", chat_id="c1")
+
+    def test_identity_never_carries_display_name_fields(self):
+        # normalize_scope_identity has no display-name parameter at all --
+        # this test documents that constraint so a future edit that adds
+        # e.g. `channel_name`/`user_nickname` as an identity input is caught.
+        import inspect
+
+        params = set(inspect.signature(scope.normalize_scope_identity).parameters)
+        assert not (params & {"channel_name", "user_nickname", "display_name", "username"})
+
+
+class TestScopeIdHashing:
+    def test_same_identity_same_scope_id(self):
+        assert scope.compute_scope_id(_identity()) == scope.compute_scope_id(_identity())
+
+    def test_different_thread_different_scope_id(self):
+        a = scope.compute_scope_id(_identity(thread_id="thread-A"))
+        b = scope.compute_scope_id(_identity(thread_id="thread-B"))
+        assert a != b
+
+    def test_different_profile_different_scope_id(self):
+        a = scope.compute_scope_id(_identity(profile="main"))
+        b = scope.compute_scope_id(_identity(profile="work"))
+        assert a != b
+
+    def test_different_topic_different_scope_id(self):
+        a = scope.compute_scope_id(_identity(topic="topic-a"))
+        b = scope.compute_scope_id(_identity(topic="topic-b"))
+        assert a != b
+
+
+class TestManifestStorage:
+    def test_create_scope_writes_mode_0600(self, tmp_path):
+        manifest = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        path = scope._manifest_path(manifest["scope_id"], tmp_path)
+        assert path.exists()
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_create_scope_is_idempotent_by_identity(self, tmp_path):
+        first = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        second = scope.create_scope(_identity(), goal="a different goal text", hermes_home=tmp_path)
+        assert first["scope_id"] == second["scope_id"]
+        assert second["goal"] == "fix the bug"  # first write wins, not silently overwritten
+
+    def test_load_scope_roundtrips(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        loaded = scope.load_scope(created["scope_id"], hermes_home=tmp_path)
+        assert loaded == created
+
+    def test_load_missing_scope_returns_none(self, tmp_path):
+        assert scope.load_scope("sha256:doesnotexist", hermes_home=tmp_path) is None
+
+    def test_load_corrupt_manifest_fails_closed(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        path = scope._manifest_path(created["scope_id"], tmp_path)
+        path.write_text("{not valid json", encoding="utf-8")
+        assert scope.load_scope(created["scope_id"], hermes_home=tmp_path) is None
+
+    def test_resolve_scope_id_finds_created_scope(self, tmp_path):
+        identity = _identity()
+        created = scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)
+        resolved = scope.resolve_scope_id(identity, hermes_home=tmp_path)
+        assert resolved == created["scope_id"]
+
+    def test_resolve_scope_id_unknown_identity_returns_none(self, tmp_path):
+        assert scope.resolve_scope_id(_identity(thread_id="never-created"), hermes_home=tmp_path) is None
+
+    def test_resolve_scope_id_corrupt_index_fails_closed(self, tmp_path):
+        identity = _identity()
+        scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)
+        scope._index_path(tmp_path).write_text("not json", encoding="utf-8")
+        assert scope.resolve_scope_id(identity, hermes_home=tmp_path) is None
+
+
+class TestOwnedArtifacts:
+    def test_link_and_query_ownership(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        scope.link_artifact(created["scope_id"], "session_keys", "sess-123", hermes_home=tmp_path)
+        assert scope.owns(created["scope_id"], "session_keys", "sess-123", hermes_home=tmp_path)
+        assert not scope.owns(created["scope_id"], "session_keys", "sess-999", hermes_home=tmp_path)
+
+    def test_link_is_idempotent(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        scope.link_artifact(created["scope_id"], "branches", "feat/x", hermes_home=tmp_path)
+        manifest = scope.link_artifact(created["scope_id"], "branches", "feat/x", hermes_home=tmp_path)
+        assert manifest["owned"]["branches"].count("feat/x") == 1
+
+    def test_link_unknown_category_fails_closed(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        with pytest.raises(scope.ScopeIdentityError):
+            scope.link_artifact(created["scope_id"], "not_a_category", "x", hermes_home=tmp_path)
+
+    def test_link_unknown_scope_fails_closed(self, tmp_path):
+        with pytest.raises(scope.ScopeIdentityError):
+            scope.link_artifact("sha256:doesnotexist", "branches", "feat/x", hermes_home=tmp_path)
+
+    def test_unlink_removes_ownership(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        scope.link_artifact(created["scope_id"], "prs", "https://x/1", hermes_home=tmp_path)
+        scope.unlink_artifact(created["scope_id"], "prs", "https://x/1", hermes_home=tmp_path)
+        assert not scope.owns(created["scope_id"], "prs", "https://x/1", hermes_home=tmp_path)
+
+    def test_owns_unknown_scope_is_false_not_raise(self, tmp_path):
+        assert scope.owns("sha256:doesnotexist", "branches", "x", hermes_home=tmp_path) is False
+
+    def test_two_scopes_same_repo_do_not_share_ownership(self, tmp_path):
+        # Two threads referencing the same repository must stay isolated --
+        # sharing a repo is not sharing ownership.
+        scope_a = scope.create_scope(_identity(thread_id="thread-A"), goal="a", hermes_home=tmp_path)
+        scope_b = scope.create_scope(_identity(thread_id="thread-B"), goal="b", hermes_home=tmp_path)
+        scope.link_artifact(scope_a["scope_id"], "branches", "shared-repo-branch", hermes_home=tmp_path)
+        assert scope.owns(scope_a["scope_id"], "branches", "shared-repo-branch", hermes_home=tmp_path)
+        assert not scope.owns(scope_b["scope_id"], "branches", "shared-repo-branch", hermes_home=tmp_path)
+
+    def test_same_tmux_name_different_projects_isolated(self, tmp_path):
+        scope_a = scope.create_scope(_identity(chat_id="proj-a"), goal="a", hermes_home=tmp_path)
+        scope_b = scope.create_scope(_identity(chat_id="proj-b"), goal="b", hermes_home=tmp_path)
+        scope.link_artifact(scope_a["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        scope.link_artifact(scope_b["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        assert scope.owns(scope_a["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        assert scope.owns(scope_b["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        # Unlinking from A must not affect B's independently-stored copy.
+        scope.unlink_artifact(scope_a["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        assert not scope.owns(scope_a["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+        assert scope.owns(scope_b["scope_id"], "tmux_session_keys", "main", hermes_home=tmp_path)
+
+
+class TestDependenciesAndLifecycle:
+    def test_dependencies_tracked_separately_from_owned_artifacts(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        manifest = scope.add_dependency(created["scope_id"], "waiting on infra team", hermes_home=tmp_path)
+        assert manifest["external_dependencies"][0]["description"] == "waiting on infra team"
+        assert all(not v for v in manifest["owned"].values())
+
+    def test_lifecycle_transitions(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        manifest = scope.set_lifecycle(created["scope_id"], "completed", hermes_home=tmp_path)
+        assert manifest["lifecycle"] == "completed"
+
+    def test_invalid_lifecycle_fails_closed(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        with pytest.raises(scope.ScopeIdentityError):
+            scope.set_lifecycle(created["scope_id"], "vibing", hermes_home=tmp_path)
+
+
+class TestPrivacy:
+    def test_manifest_contains_no_raw_command_or_env_content(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        raw = json.dumps(created)
+        for forbidden in ("HERMES_", "os.environ", "api_key", "token", "password"):
+            assert forbidden not in raw

--- a/tests/test_hermes_scope_auto_link.py
+++ b/tests/test_hermes_scope_auto_link.py
@@ -1,0 +1,112 @@
+"""Tests for the auto-registration hooks that link freshly-created artifacts
+(tmux/terminal sessions, delegations, cron jobs) to the current turn's scope,
+without ever implicitly creating a scope. See docs/design/thread-scope-isolation.md.
+"""
+import time
+
+import pytest
+
+import hermes_scope as scope
+from gateway.session_context import clear_session_vars, set_session_vars
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def live_session(hermes_home):
+    """Set HERMES_SESSION_* context vars so identity_from_session_env() resolves."""
+    tokens = set_session_vars(
+        platform="discord",
+        chat_id="channel-1",
+        thread_id="thread-A",
+        profile="main",
+        session_key="agent:main:discord:thread:channel-1:thread-A",
+    )
+    yield
+    clear_session_vars(tokens)
+
+
+class TestIdentityFromSessionEnv:
+    def test_resolves_from_live_context(self, live_session):
+        identity = scope.identity_from_session_env()
+        assert identity["platform"] == "discord"
+        assert identity["chat_id"] == "channel-1"
+        assert identity["thread_id"] == "thread-A"
+
+    def test_no_context_returns_none(self, hermes_home):
+        assert scope.identity_from_session_env() is None
+
+
+class TestResolveCurrentScopeId:
+    def test_returns_none_when_no_scope_created_yet(self, live_session, hermes_home):
+        assert scope.resolve_current_scope_id(hermes_home=hermes_home) is None
+
+    def test_resolves_existing_scope(self, live_session, hermes_home):
+        identity = scope.identity_from_session_env()
+        created = scope.create_scope(identity, goal="do the thing", hermes_home=hermes_home)
+        assert scope.resolve_current_scope_id(hermes_home=hermes_home) == created["scope_id"]
+
+    def test_never_creates_a_scope(self, live_session, hermes_home):
+        scope.resolve_current_scope_id(hermes_home=hermes_home)
+        # index must still be empty -- resolution is read-only
+        index = scope._load_index(hermes_home)
+        assert index == {}
+
+
+class TestProcessRegistryAutoLink:
+    def test_spawn_local_links_owning_scope(self, live_session, hermes_home):
+        from tools.process_registry import ProcessRegistry
+
+        identity = scope.identity_from_session_env()
+        created = scope.create_scope(identity, goal="do the thing", hermes_home=hermes_home)
+
+        registry = ProcessRegistry()
+        session_key = "agent:main:discord:thread:channel-1:thread-A"
+        session = registry.spawn_local("echo hello", session_key=session_key)
+        registry.wait(session.id, timeout=5)
+
+        assert scope.owns(created["scope_id"], "tmux_session_keys", session_key, hermes_home=hermes_home)
+
+    def test_spawn_without_scope_created_is_a_noop(self, live_session, hermes_home):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        session_key = "agent:main:discord:thread:channel-1:thread-A"
+        session = registry.spawn_local("echo hello", session_key=session_key)
+        registry.wait(session.id, timeout=5)
+        # No exception, and nothing to check ownership against -- the point
+        # is this must not create a scope implicitly.
+        assert scope._load_index(hermes_home) == {}
+
+
+class TestAsyncDelegationAutoLink:
+    def test_persist_dispatch_links_owning_scope(self, live_session, hermes_home):
+        from tools import async_delegation as ad
+
+        identity = scope.identity_from_session_env()
+        created = scope.create_scope(identity, goal="do the thing", hermes_home=hermes_home)
+
+        record = {
+            "delegation_id": "deleg-test-1",
+            "session_key": "agent:main:discord:thread:channel-1:thread-A",
+            "dispatched_at": time.time(),
+        }
+        ad._persist_dispatch(record)
+
+        assert scope.owns(created["scope_id"], "delegation_ids", "deleg-test-1", hermes_home=hermes_home)
+
+
+class TestCronJobAutoLink:
+    def test_create_job_links_owning_scope(self, live_session, hermes_home):
+        from cron import jobs as cron_jobs
+
+        identity = scope.identity_from_session_env()
+        created = scope.create_scope(identity, goal="do the thing", hermes_home=hermes_home)
+
+        job = cron_jobs.create_job(prompt="do a thing", schedule="0 9 * * *")
+
+        assert scope.owns(created["scope_id"], "cron_job_ids", job["id"], hermes_home=hermes_home)

--- a/tests/test_hermes_scope_lifecycle.py
+++ b/tests/test_hermes_scope_lifecycle.py
@@ -1,0 +1,112 @@
+"""Lifecycle, concurrency, and cross-profile isolation tests for hermes_scope.
+
+Covers the remaining mandatory scenarios from
+docs/design/thread-scope-isolation.md not exercised by test_hermes_scope.py:
+concurrent writers, restart/resume continuity (fresh re-derivation from live
+identity, never from remembered state), and profile separation.
+"""
+import concurrent.futures
+
+import hermes_scope as scope
+
+
+def _identity(**overrides):
+    base = dict(profile="main", platform="discord", chat_id="channel-1", thread_id="thread-A")
+    base.update(overrides)
+    return scope.normalize_scope_identity(**base)
+
+
+class TestConcurrentWriters:
+    def test_concurrent_link_calls_do_not_lose_updates(self, tmp_path):
+        created = scope.create_scope(_identity(), goal="fix the bug", hermes_home=tmp_path)
+        scope_id = created["scope_id"]
+        values = [f"branch-{i}" for i in range(20)]
+
+        def _link(value):
+            scope.link_artifact(scope_id, "branches", value, hermes_home=tmp_path)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(_link, values))
+
+        manifest = scope.load_scope(scope_id, hermes_home=tmp_path)
+        assert sorted(manifest["owned"]["branches"]) == sorted(values)
+
+    def test_concurrent_create_scope_is_idempotent(self, tmp_path):
+        identity = _identity()
+
+        def _create(_):
+            return scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)["scope_id"]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            scope_ids = list(pool.map(_create, range(8)))
+
+        assert len(set(scope_ids)) == 1
+
+    def test_concurrent_create_of_distinct_scopes_all_survive_in_the_index(self, tmp_path):
+        identities = [_identity(thread_id=f"thread-{i}") for i in range(12)]
+
+        def _create(identity):
+            return scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)["scope_id"]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            scope_ids = list(pool.map(_create, identities))
+
+        assert len(set(scope_ids)) == len(identities)
+        for identity, scope_id in zip(identities, scope_ids):
+            assert scope.resolve_scope_id(identity, hermes_home=tmp_path) == scope_id
+
+
+class TestRestartResumeContinuity:
+    def test_scope_survives_reimport_of_the_module(self, tmp_path):
+        """Simulates a process restart: identity is re-derived from live
+        fields and the manifest is found fresh from disk, never from
+        anything cached in the module."""
+        identity = _identity()
+        created = scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)
+        scope.link_artifact(created["scope_id"], "branches", "feat/x", hermes_home=tmp_path)
+
+        import importlib
+
+        reloaded = importlib.reload(scope)
+        try:
+            resolved_id = reloaded.resolve_scope_id(identity, hermes_home=tmp_path)
+            assert resolved_id == created["scope_id"]
+            assert reloaded.owns(resolved_id, "branches", "feat/x", hermes_home=tmp_path)
+        finally:
+            importlib.reload(scope)
+
+    def test_clear_preserves_scope_when_thread_identity_is_stable(self, tmp_path):
+        # /clear starts a new session_key but the platform's thread_id is
+        # unchanged -- the scope (keyed on thread identity, not session_key)
+        # must resolve to the same manifest before and after.
+        identity = _identity(thread_id="thread-A")
+        created = scope.create_scope(identity, goal="fix the bug", hermes_home=tmp_path)
+        scope.link_artifact(created["scope_id"], "session_keys", "session-before-clear", hermes_home=tmp_path)
+
+        # Re-derive identity exactly as a fresh turn after /clear would.
+        post_clear_identity = _identity(thread_id="thread-A")
+        resolved = scope.resolve_scope_id(post_clear_identity, hermes_home=tmp_path)
+        assert resolved == created["scope_id"]
+        scope.link_artifact(resolved, "session_keys", "session-after-clear", hermes_home=tmp_path)
+
+        manifest = scope.load_scope(resolved, hermes_home=tmp_path)
+        assert set(manifest["owned"]["session_keys"]) == {"session-before-clear", "session-after-clear"}
+
+
+class TestProfileSeparation:
+    def test_same_identity_different_profile_are_different_scopes(self, tmp_path):
+        main_scope = scope.create_scope(_identity(profile="main"), goal="a", hermes_home=tmp_path)
+        work_scope = scope.create_scope(_identity(profile="work"), goal="b", hermes_home=tmp_path)
+        assert main_scope["scope_id"] != work_scope["scope_id"]
+
+    def test_separate_hermes_home_directories_never_cross_resolve(self, tmp_path):
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        identity = _identity()
+        created = scope.create_scope(identity, goal="fix the bug", hermes_home=home_a)
+
+        # Same identity tuple, but a different HERMES_HOME (as a Fleet
+        # project or a different profile's root would be) must not resolve
+        # -- storage isolation must hold even before identity comparison.
+        assert scope.resolve_scope_id(identity, hermes_home=home_b) is None
+        assert scope.load_scope(created["scope_id"], hermes_home=home_b) is None

--- a/tests/tools/test_session_search_scope_filter.py
+++ b/tests/tools/test_session_search_scope_filter.py
@@ -1,0 +1,136 @@
+"""Root-cause fix: session_search's discovery/browse shapes default to the
+calling session's own thread scope on thread-bearing platforms, so a
+progress question asked in one Discord thread can't surface another
+thread's unrelated work under the same channel. See
+docs/design/thread-scope-isolation.md.
+"""
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed_thread(db, session_id, *, thread_id, started_at, first_msg, second_msg):
+    db.create_session(
+        session_id, source="discord", chat_id="channel-99", thread_id=thread_id,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (started_at, f"Thread {thread_id}", session_id),
+    )
+    db.append_message(session_id, role="user", content=first_msg)
+    db.append_message(session_id, role="assistant", content=second_msg)
+    db._conn.commit()
+
+
+@pytest.fixture
+def two_threads(db):
+    now = int(time.time())
+    _seed_thread(
+        db, "s_thread_a", thread_id="thread-A", started_at=now - 5000,
+        first_msg="investigate the ssl cert bug",
+        second_msg="fixed by validating the CA bundle before provider calls",
+    )
+    _seed_thread(
+        db, "s_thread_b", thread_id="thread-B", started_at=now - 1000,
+        first_msg="unrelated feature request about ssl cert renewal automation",
+        second_msg="shipped the renewal automation script",
+    )
+    return db
+
+
+class TestDiscoveryDefaultsToOwnThread:
+    def test_progress_query_from_thread_b_does_not_see_thread_a(self, two_threads):
+        result = session_search(
+            query="ssl cert", db=two_threads, current_session_id="s_thread_b",
+        )
+        import json
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is True
+        session_ids = {r["session_id"] for r in payload["results"]}
+        assert "s_thread_a" not in session_ids
+
+    def test_include_unscoped_restores_cross_thread_search(self, two_threads):
+        import json
+        result = session_search(
+            query="ssl cert", db=two_threads, current_session_id="s_thread_b",
+            include_unscoped=True,
+        )
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is False
+        session_ids = {r["session_id"] for r in payload["results"]}
+        assert "s_thread_a" in session_ids
+
+    def test_no_current_session_id_is_unscoped(self, two_threads):
+        import json
+        result = session_search(query="ssl cert", db=two_threads, current_session_id=None)
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is False
+
+
+class TestBrowseDefaultsToOwnThread:
+    def test_browse_from_thread_b_excludes_thread_a(self, two_threads):
+        import json
+        result = session_search(db=two_threads, current_session_id="s_thread_b")
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is True
+        session_ids = {r["session_id"] for r in payload["results"]}
+        assert "s_thread_a" not in session_ids
+
+    def test_browse_include_unscoped_sees_all_threads(self, two_threads):
+        import json
+        result = session_search(
+            db=two_threads, current_session_id="s_thread_b", include_unscoped=True,
+        )
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is False
+        session_ids = {r["session_id"] for r in payload["results"]}
+        assert "s_thread_a" in session_ids
+
+
+class TestThreadlessPlatformsUnaffected:
+    def test_cli_session_with_no_thread_id_stays_unscoped(self, db):
+        now = int(time.time())
+        db.create_session("s_cli_a", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (now - 5000, "CLI session A", "s_cli_a"),
+        )
+        db.append_message("s_cli_a", role="user", content="let's talk about modpack building")
+        db.append_message("s_cli_a", role="assistant", content="sure, modpack scaffolded")
+        db.create_session("s_cli_b", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (now - 1000, "CLI session B", "s_cli_b"),
+        )
+        db.append_message("s_cli_b", role="user", content="continue with modpack quests")
+        db.append_message("s_cli_b", role="assistant", content="modpack quests added")
+        db._conn.commit()
+
+        import json
+        result = session_search(query="modpack", db=db, current_session_id="s_cli_b")
+        payload = json.loads(result)
+        assert payload["scoped_to_current_thread"] is False
+        session_ids = {r["session_id"] for r in payload["results"]}
+        assert "s_cli_a" in session_ids
+
+
+class TestSessionIdsForThreadScope:
+    def test_matches_only_same_platform_chat_and_thread(self, db):
+        db.create_session("s1", source="discord", chat_id="chan-1", thread_id="t-A")
+        db.create_session("s2", source="discord", chat_id="chan-1", thread_id="t-B")
+        db.create_session("s3", source="discord", chat_id="chan-2", thread_id="t-A")
+        db.create_session("s4", source="telegram", chat_id="chan-1", thread_id="t-A")
+
+        ids = db.session_ids_for_thread_scope(source="discord", chat_id="chan-1", thread_id="t-A")
+        assert ids == {"s1"}
+
+    def test_empty_chat_id_returns_empty_set(self, db):
+        assert db.session_ids_for_thread_scope(source="discord", chat_id="") == set()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -224,6 +224,23 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
              record.get("origin_session_id", "")),
         )
     _prune_durable_records()
+    _auto_link_scope(record.get("delegation_id", ""))
+
+
+def _auto_link_scope(delegation_id: str) -> None:
+    """Best-effort: link a dispatched delegation to the current thread's
+    scope, if one has already been created. Never raises, never creates a
+    scope implicitly. See hermes_scope.py / docs/design/thread-scope-isolation.md."""
+    if not delegation_id:
+        return
+    try:
+        import hermes_scope
+
+        scope_id = hermes_scope.resolve_current_scope_id()
+        if scope_id:
+            hermes_scope.link_artifact(scope_id, "delegation_ids", delegation_id)
+    except Exception:
+        logger.debug("Scope auto-link skipped for delegation_id=%s", delegation_id, exc_info=True)
 
 
 def _delete_durable_delegation(delegation_id: str) -> None:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -215,6 +215,27 @@ class ProcessRegistry:
         self.on_close = None
 
     @staticmethod
+    def _auto_link_scope(session_key: str) -> None:
+        """Best-effort: link a freshly spawned tmux/terminal session to the
+        current thread's scope, if one has already been created.
+
+        Never raises and never creates a scope implicitly — scope creation
+        is a deliberate ``hermes scope create``/``/scope create`` action.
+        This only records ownership when a scope already exists for the
+        live identity of the session that spawned the process.
+        """
+        if not session_key:
+            return
+        try:
+            import hermes_scope
+
+            scope_id = hermes_scope.resolve_current_scope_id()
+            if scope_id:
+                hermes_scope.link_artifact(scope_id, "tmux_session_keys", session_key)
+        except Exception:
+            logger.debug("Scope auto-link skipped for session_key=%s", session_key, exc_info=True)
+
+    @staticmethod
     def _clean_shell_noise(text: str) -> str:
         """Strip shell startup warnings from the beginning of output."""
         lines = text.split("\n")
@@ -760,6 +781,7 @@ class ProcessRegistry:
                     self._running[session.id] = session
 
                 self._write_checkpoint()
+                self._auto_link_scope(session.session_key)
                 return session
 
             except ImportError:
@@ -812,6 +834,7 @@ class ProcessRegistry:
                 self._running[session.id] = session
 
             self._write_checkpoint()
+            self._auto_link_scope(session.session_key)
         except Exception:
             # Post-Popen setup failed — kill the orphaned subprocess (and any
             # descendants spawned via setsid) before re-raising so they do not
@@ -931,6 +954,7 @@ class ProcessRegistry:
                 self._running[session.id] = session
 
         if not session.exited:
+            self._auto_link_scope(session.session_key)
             self._write_checkpoint()
 
         return session

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -139,6 +139,36 @@ def _resolve_lineage(db, session_id: str) -> str:
     return _resolve_to_parent(db, session_id)[0]
 
 
+def _resolve_thread_scope_ids(db, current_session_id: Optional[str]) -> Optional[set]:
+    """Session ids sharing the caller's thread origin, or None when unscoped.
+
+    Root-cause fix for cross-thread progress contamination (see
+    docs/design/thread-scope-isolation.md): on a thread-bearing platform
+    (Discord, etc.), two threads under the same channel must not surface
+    each other's sessions as discovery/browse hits by default. Returns
+    None (no filter applied) when the calling session has no thread_id --
+    CLI/DM conversations have no sibling-thread ambiguity to guard against,
+    and unscoped cross-session recall there is the tool's intended job.
+    """
+    if not current_session_id:
+        return None
+    try:
+        current = db.get_session(current_session_id)
+    except Exception:
+        return None
+    if not current:
+        return None
+    thread_id = current.get("thread_id")
+    source = current.get("source")
+    chat_id = current.get("chat_id")
+    if not thread_id or not source or not chat_id:
+        return None
+    try:
+        return db.session_ids_for_thread_scope(source=source, chat_id=chat_id, thread_id=thread_id)
+    except Exception:
+        return None
+
+
 def _is_compression_ended(db, session_id: str) -> bool:
     """Return True if *session_id* itself ended with ``end_reason='compression'``.
 
@@ -416,9 +446,18 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    link_profile: str = None,
+    include_unscoped: bool = False,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
+        scope_ids = (
+            None if include_unscoped else _resolve_thread_scope_ids(db, current_session_id)
+        )
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
@@ -431,6 +470,8 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
         for s in sessions:
             sid = s.get("id", "")
             if current_root and (sid == current_root or sid == current_session_id):
+                continue
+            if scope_ids is not None and sid not in scope_ids:
                 continue
             # Skip child / delegation sessions
             if s.get("parent_session_id"):
@@ -453,6 +494,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
             "mode": "browse",
             "results": results,
             "count": len(results),
+            "scoped_to_current_thread": scope_ids is not None,
             "message": f"Showing {len(results)} most recent sessions. Pass a query= to search, or session_id+around_message_id to scroll.",
         }, ensure_ascii=False)
     except Exception as e:
@@ -606,6 +648,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    scope_ids: Optional[set] = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -622,6 +665,8 @@ def _title_match_result(
 
     lineage_root = _resolve_lineage(db, session_id)
     if current_lineage_root and lineage_root == current_lineage_root:
+        return None
+    if scope_ids is not None and lineage_root not in scope_ids and session_id not in scope_ids:
         return None
 
     try:
@@ -677,11 +722,13 @@ def _discover(
     sort: Optional[str],
     current_session_id: str = None,
     link_profile: str = None,
+    include_unscoped: bool = False,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    scope_ids = None if include_unscoped else _resolve_thread_scope_ids(db, current_session_id)
+    title_result = _title_match_result(db, query, current_lineage_root, scope_ids=scope_ids)
 
     try:
         raw_results = db.search_messages(
@@ -759,6 +806,8 @@ def _discover(
             # that's been summarised away — let them through.
             if not is_compacted_hit:
                 continue
+        if scope_ids is not None and resolved_sid not in scope_ids and raw_sid not in scope_ids:
+            continue
         if resolved_sid not in seen_sessions:
             row = dict(r)
             row["_lineage_root"] = resolved_sid
@@ -821,6 +870,7 @@ def _discover(
         "results": results,
         "count": len(results),
         "sessions_searched": len(seen_sessions),
+        "scoped_to_current_thread": scope_ids is not None,
     }
     _annotate_rebuild_status(db, _final_payload)
     return json.dumps(_final_payload, ensure_ascii=False)
@@ -840,6 +890,7 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    include_unscoped: bool = False,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -851,6 +902,15 @@ def session_search(
     Pass ``profile`` to read another profile's sessions (e.g. resolving an
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
     anchor is set — the agent has asked for a specific slice.
+
+    Discovery and browse default to the CALLING session's own thread scope
+    when the platform has one (e.g. a Discord thread): other threads under
+    the same channel are excluded, so a progress question asked in one
+    thread can't surface another thread's unrelated work as if it were this
+    conversation's own history. Pass ``include_unscoped=True`` to search
+    across every thread/session in the profile instead — do this only when
+    the user explicitly asks to search other conversations, not by default
+    when answering "what's the status of this."
     """
     if db is None:
         try:
@@ -926,7 +986,10 @@ def session_search(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(
+            db, limit, current_session_id, link_profile=profile,
+            include_unscoped=include_unscoped,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -948,6 +1011,7 @@ def session_search(
         sort=sort_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        include_unscoped=include_unscoped,
     )
 
 
@@ -1112,6 +1176,19 @@ SESSION_SEARCH_SCHEMA = {
                     "Omit to use the current profile."
                 ),
             },
+            "include_unscoped": {
+                "type": "boolean",
+                "description": (
+                    "Discovery/browse shapes only. On a thread-bearing platform (e.g. "
+                    "Discord), discovery/browse default to THIS conversation's own "
+                    "thread — other threads in the same channel are excluded so their "
+                    "unrelated work never reads as this thread's own history or "
+                    "progress. Set True only when the user explicitly asks to search "
+                    "other conversations/threads too. Never set True to answer a "
+                    "'what's the status of this' question — that must stay scoped."
+                ),
+                "default": False,
+            },
         },
         "required": [],
     },
@@ -1134,6 +1211,7 @@ registry.register(
         window=args.get("window", 5),
         sort=args.get("sort"),
         profile=args.get("profile"),
+        include_unscoped=bool(args.get("include_unscoped", False)),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
     ),


### PR DESCRIPTION
## Summary
- add profile-aware, fail-closed conversation scope identity and mode-0600 manifest storage
- auto-register owned tmux/process, delegation, and cron artifacts without implicitly creating scopes
- scope Discord `session_search` discovery/browse to the caller's thread by default
- add `hermes scope` and `/scope` lifecycle, ownership, dependency, and audit surfaces
- add regression coverage for cross-thread contamination, lifecycle, concurrency, profile isolation, privacy, and adapter continuity

## Root cause addressed
Progress questions in one Discord thread could be answered from broad session-search summaries and unrelated artifacts in another thread sharing the same repository. Repository proximity was incorrectly treated as ownership.

## Verification
- focused scope suite: `80 passed`
- full worker suite: `4788 passed`; two pre-existing macOS/systemd environmental failures reproduced on clean `origin/main`
- `ruff` passes on changed implementation and representative tests
- independent review completed; all four actionable findings fixed
- privacy scan completed: manifests exclude raw commands, credentials, prompt/pane content, and redact routing IDs in ordinary status output

## Known gap
Prospective Discord-thread session continuity is documented and covered by an explicit `KNOWN_GAP` test; this PR does not silently infer that identity.

## Safety boundaries
- no live Gateway or production Discord routing changes
- no Fleet repository/runtime changes
- Mac-host E2E and Fleet canary remain separately gated
