### PR TITLE
fix(tools): check POSIX-normalized paths in sensitive-path guard (#76246)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -683,10 +683,21 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    # On Windows, os.path.normpath converts POSIX paths like /etc/hosts to
+    # backslash forms (\\etc\\hosts) which miss the /-prefixed denylist.
+    # Always check the POSIX-normalized form so POSIX system targets are
+    # caught regardless of host OS.
+    posix_resolved = resolved.replace("\\", "/")
+    posix_normalized = normalized.replace("\\", "/")
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if (resolved.startswith(prefix) or normalized.startswith(prefix)
+                or posix_resolved.startswith(prefix)
+                or posix_normalized.startswith(prefix)):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if (resolved in _SENSITIVE_EXACT_PATHS
+            or normalized in _SENSITIVE_EXACT_PATHS
+            or posix_resolved in _SENSITIVE_EXACT_PATHS
+            or posix_normalized in _SENSITIVE_EXACT_PATHS):
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or


### PR DESCRIPTION
## Summary

Fixes #76246 — `_check_sensitive_path` in `tools/file_tools.py` fails open on Windows for POSIX system targets (`/etc/`, `/boot/`, `/var/run/docker.sock`).

## Root Cause

On Windows, `os.path.normpath("/etc/hosts")` produces `\\etc\\hosts` (backslash form). The sensitive-path denylist uses POSIX `/`-prefixed prefixes, so the backslash-normalized path never matches. `_resolve_path_for_task` similarly returns Windows-normalized paths via `ntpath.normpath`.

This means `write_file` and `patch` tools can target sensitive system locations when running on a Windows host with a Git Bash or SSH-to-Linux terminal backend.

## Fix

After computing `resolved` and `normalized`, also compute POSIX-normalized forms (backslash → forward slash) and check those against the prefix and exact-path denylists. This is a defense-in-depth improvement — the fix has zero impact on Linux/macOS where paths already use forward slashes.

## Testing

- All 37 existing `tests/tools/test_file_tools.py` tests pass
- Manual verification: `/etc/hosts`, `/boot/grub/grub.cfg`, `/var/run/docker.sock`, `/run/docker.sock` all correctly blocked
- Normal paths (`/tmp/test.txt`, `./myfile.txt`) correctly allowed

## Changes

- `tools/file_tools.py`: Added POSIX-normalized path checks in `_check_sensitive_path`