### PR TITLE
fix(vision): wait for sandbox registration on first container read (#76566)

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -10,7 +10,7 @@ import base64
 import importlib
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -147,7 +147,9 @@ class TestNonLocalBackendConfinement:
         secret = tmp_path / "id_rsa"
         secret.write_bytes(b"HOST-PRIVATE-KEY")
 
-        with patch("tools.image_source._get_active_env", return_value=None):
+        with patch("tools.image_source._get_active_env", return_value=None), \
+                patch("tools.image_source._wait_for_env_registration",
+                      new=AsyncMock(return_value=None)):
             with pytest.raises(isrc.SourceNotFound):
                 await isrc.resolve_image_source(str(secret), isrc.ResolveContext(task_id="t1"))
 
@@ -248,3 +250,45 @@ class TestSvgNormalization:
             path, mime, err = vt._normalize_to_supported_image(svg, "image/svg+xml")
         assert path is None
         assert "rasterizer" in err
+
+
+class TestFirstUseSandboxRegistration:
+    """#76566: the very first vision_analyze can fire before the sandbox
+    session is registered (envs are created lazily on first terminal
+    activity). The resolver must wait briefly for registration instead of
+    failing the first call deterministically."""
+
+    @pytest.mark.asyncio
+    async def test_first_use_waits_for_env_registration(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        isrc = _reload(monkeypatch, home)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        secret = tmp_path / "id_rsa"
+        secret.write_bytes(b"HOST-PRIVATE-KEY")
+
+        container_png_b64 = base64.b64encode(PNG).decode()
+        env = SimpleNamespace(
+            execute=lambda cmd, **kw: {"returncode": 0, "output": container_png_b64}
+        )
+
+        # First lookup: not registered yet. Second lookup (after the wait
+        # loop) — registered. The wait must bridge the gap.
+        lookups = {"n": 0}
+
+        def flaky_lookup(task_id):
+            lookups["n"] += 1
+            return None if lookups["n"] == 1 else env
+
+        with patch("tools.image_source._get_active_env", side_effect=flaky_lookup):
+            res = await isrc.resolve_image_source(str(secret), isrc.ResolveContext(task_id="t1"))
+
+        assert res.origin == "container"
+        assert res.data == PNG
+        assert lookups["n"] >= 2
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out_and_still_fails_closed(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        with patch("tools.image_source._get_active_env", return_value=None):
+            env = await isrc._wait_for_env_registration("t1", timeout=0.1)
+        assert env is None

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -281,6 +281,28 @@ def _get_active_env(task_id: Optional[str]):
         return None
 
 
+async def _wait_for_env_registration(task_id: Optional[str], timeout: float = 5.0):
+    """Wait briefly for the sandbox session to register.
+
+    The sandbox environment is created lazily on first terminal activity.
+    When the very first ``vision_analyze`` fires before any terminal
+    command ran, ``_get_active_env`` returns None even though the
+    environment is about to be (or is being) registered — the identical
+    call succeeds on retry (#76566). Poll for a short window so the
+    first call does not deterministically fail.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout
+    while True:
+        env = _get_active_env(task_id)
+        if env is not None:
+            return env
+        if time.monotonic() >= deadline:
+            return None
+        await asyncio.sleep(0.25)
+
+
 async def _resolve_container_fallback(
     p: Path, ctx: ResolveContext, src: str, permitted: tuple = ("image",)
 ) -> ResolvedImage:
@@ -300,6 +322,11 @@ async def _resolve_container_fallback(
     import shlex
 
     env = _get_active_env(ctx.task_id)
+    if env is None:
+        # First-use race (#76566): the sandbox may still be initializing
+        # when the first vision_analyze fires (no terminal activity yet).
+        # Wait briefly for registration; still fail-closed on timeout.
+        env = await _wait_for_env_registration(ctx.task_id)
     if env is None:
         raise SourceNotFound(
             f"'{p}' is not reachable inside the sandbox and no active sandbox "


### PR DESCRIPTION
## Summary

Under a container terminal backend (docker etc.), `vision_analyze` fails on the **first** call with `could not read '<path>' inside the sandbox`, but the identical call succeeds on retry.

Root cause: the sandbox environment is created **lazily on first terminal activity**. When the very first `vision_analyze` fires before any terminal command ran, `_get_active_env()` returns `None` (no session registered yet), and `_resolve_container_fallback` raises `SourceNotFound` deterministically — even though the environment is being (or about to be) registered.

Fix: when no active env is found, wait briefly (up to 5s, 250ms polls) for the sandbox session to register before failing. On timeout the fail-closed `SourceNotFound` is unchanged — the confinement security model (never fall back to a host read for non-cache paths) is fully preserved.

Single-file change (+ 2 regression tests). No public API change.

NOT doing X: not creating an environment on demand (heavy container startup belongs to the terminal path, not the image resolver), not relaxing the fail-closed behavior — only bridging the first-use registration race.

## Test plan

```
python -m pytest tests/tools/test_image_source.py -q
# 14 passed, 1 skipped — new tests:
#  - first lookup returns None then a registered env: resolve succeeds
#    (polling bridged the gap)
#  - _wait_for_env_registration times out -> None (fail-closed preserved)
```
