### PR TITLE
fix(auxiliary): read key_env through the secret scope, not raw os.getenv (#76574)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5780,7 +5780,12 @@ def resolve_provider_client(
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                from agent.secret_scope import get_secret
+
+                # Scope-aware read (#76574): same reasoning as
+                # _fallback_entry_api_key — never read another profile's
+                # value through the sticky process env.
+                custom_key = (get_secret(custom_key_env) or "").strip()
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -408,3 +408,57 @@ class TestResolveProviderClientMainRuntimeCustom:
         assert model == "explicit-model"
         assert "explicit.example.com" in str(client.base_url)
         assert client.api_key == "sk-explicit"
+
+
+class TestKeyEnvReadsThroughSecretScope:
+    """#76574 residual #3: auxiliary_client key_env reads must honor the
+    active profile secret scope instead of the sticky process env."""
+
+    def test_fallback_entry_api_key_prefers_scope_over_environ(self, monkeypatch):
+        from agent.auxiliary_client import _fallback_entry_api_key
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("MYRELAY_API_KEY", "from-process-env")
+        token = set_secret_scope({"MYRELAY_API_KEY": "from-profile-scope"})
+        try:
+            key = _fallback_entry_api_key({"key_env": "MYRELAY_API_KEY"})
+        finally:
+            reset_secret_scope(token)
+
+        assert key == "from-profile-scope"
+
+    def test_fallback_entry_api_key_falls_back_to_environ_without_scope(self, monkeypatch):
+        from agent.auxiliary_client import _fallback_entry_api_key
+
+        monkeypatch.setenv("MYRELAY_API_KEY", "from-process-env")
+        assert _fallback_entry_api_key({"key_env": "MYRELAY_API_KEY"}) == "from-process-env"
+
+    def test_named_custom_provider_key_env_reads_scope(self, tmp_path, monkeypatch):
+        """resolve_provider_client with a key_env-only provider must resolve
+        the key through the scope when one is installed."""
+        from agent.auxiliary_client import resolve_provider_client
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.delenv("SCOPED_RELAY_KEY", raising=False)
+        _write_config(tmp_path, {
+            "providers": {
+                "scoped-relay": {
+                    "name": "scoped-relay",
+                    "base_url": "https://scoped-relay.test/v1",
+                    "key_env": "SCOPED_RELAY_KEY",
+                    "default_model": "m1",
+                },
+            },
+        })
+        token = set_secret_scope({"SCOPED_RELAY_KEY": "scope-key-123"})
+        try:
+            client, _model = resolve_provider_client(
+                provider="scoped-relay", model="m1"
+            )
+        finally:
+            reset_secret_scope(token)
+
+        # The key must come from the profile scope (process env has no
+        # SCOPED_RELAY_KEY at all), proving the scope-aware read works.
+        assert client is not None
+        assert getattr(client, "api_key", None) == "scope-key-123"


### PR DESCRIPTION
## Summary

Residual #3 from #76574: two `key_env` read sites in `agent/auxiliary_client.py` used raw `os.getenv`, bypassing the profile secret scope:

1. `_fallback_entry_api_key` (fallback-chain entries)
2. the named-custom-provider branch of `resolve_provider_client` (`custom_key_env`)

Under a multiplexed profile turn, `os.getenv` can resolve **another profile's** value or the sticky process env. Both sites now route through `agent.secret_scope.get_secret`, which honors the installed scope and preserves the legacy `os.environ` behavior when no scope is installed (single-profile deployments keep working exactly as before).

Single-file change (+ 3 regression tests). No public API change.

NOT doing X: not touching the other three residuals in #76574 (insights executor hop, camofox caches, WhatsApp startup guard) — this PR is scoped to the auxiliary_client key_env reads only.

## Test plan

```
python -m pytest tests/agent/test_auxiliary_named_custom_providers.py -q
# 22 passed (19 existing + 3 new:
#  - _fallback_entry_api_key prefers the installed scope over os.environ
#  - _fallback_entry_api_key falls back to os.environ with no scope
#  - resolve_provider_client resolves key_env through the scope)
```
