### PR TITLE
fix(cron): skip file-mutation verifier footer on silence responses (#75772)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -475,9 +475,16 @@ def finalize_turn(
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
             if _failed and agent._file_mutation_verifier_enabled():
-                footer = agent._format_file_mutation_failure_footer(_failed)
-                if footer:
-                    final_response = final_response.rstrip() + "\n\n" + footer
+                # Skip the footer when the response is a silence marker
+                # ([SILENT], NO_REPLY, etc.) — the response will be
+                # suppressed by the cron scheduler, so appending a
+                # verifier footer would push the [SILENT] marker off the
+                # last line and break silence detection (#75772).
+                from gateway.response_filters import is_autonomous_silence_response
+                if not is_autonomous_silence_response(final_response):
+                    footer = agent._format_file_mutation_failure_footer(_failed)
+                    if footer:
+                        final_response = final_response.rstrip() + "\n\n" + footer
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 


### PR DESCRIPTION
## Summary

Fixes #75772 — the file-mutation verifier footer was appended AFTER the `[SILENT]` marker, pushing it off the last line and breaking `is_autonomous_silence_response()` detection. The cron scheduler then delivered the message (containing the literal `[SILENT]` plus the verifier warning) to the user.

## Root Cause

In `agent/turn_finalizer.py`, the file-mutation verifier footer is unconditionally appended to `final_response` when there are failed file mutations. When the agent emits a silence response (e.g. `explanatory prose\n\n[SILENT]`), the footer is appended after `[SILENT]`:

```
<prose explaining no change found>

[SILENT]

⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn...
```

`is_autonomous_silence_response()` only recognizes silence markers as the whole response, first line, or last line. The footer pushes `[SILENT]` off the last position, so detection fails and the message is delivered.

## Fix

Check `is_autonomous_silence_response()` before appending the footer. If the response is a silence marker, skip the footer entirely since the response will be suppressed by the scheduler anyway — appending a warning to a suppressed message is pointless.

## Testing

- 12 existing silence/silent-related tests pass
- Manual verification: `[SILENT]`, `NO_REPLY`, and `[SILENT] No changes detected` all correctly detected as silence responses

## Changes

- `agent/turn_finalizer.py`: Added silence-response guard before appending file-mutation verifier footer