### PR TITLE
fix(skills): slim research-paper-writing SKILL.md under the 100k-char limit (#67645)

### DIFF
--- a/skills/research/research-paper-writing/references/latex-preamble.md
+++ b/skills/research/research-paper-writing/references/latex-preamble.md
@@ -1,0 +1,59 @@
+# Professional LaTeX Preamble
+
+Extracted from `SKILL.md` (research-paper-writing) to keep the skill under the 100k-char limit.
+
+### Professional LaTeX Preamble
+
+Add these packages to any paper for professional quality. They are compatible with all major conference style files:
+
+```latex
+% --- Professional Packages (add after conference style file) ---
+
+% Typography
+\usepackage{microtype}              % Microtypographic improvements (protrusion, expansion)
+                                     % Makes text noticeably more polished — always include
+
+% Tables
+\usepackage{booktabs}               % Professional table rules (\toprule, \midrule, \bottomrule)
+\usepackage{siunitx}                % Consistent number formatting, decimal alignment
+                                     % Usage: \num{12345} → 12,345; \SI{3.5}{GHz} → 3.5 GHz
+                                     % Table alignment: S column type for decimal-aligned numbers
+
+% Figures
+\usepackage{graphicx}               % Include graphics (\includegraphics)
+\usepackage{subcaption}             % Subfigures with (a), (b), (c) labels
+                                     % Usage: \begin{subfigure}{0.48\textwidth} ... \end{subfigure}
+
+% Diagrams and Algorithms
+\usepackage{tikz}                   % Programmable vector diagrams
+\usetikzlibrary{arrows.meta, positioning, shapes.geometric, calc, fit, backgrounds}
+\usepackage[ruled,vlined]{algorithm2e}  % Professional pseudocode
+                                     % Alternative: \usepackage{algorithmicx} if template bundles it
+
+% Cross-references
+\usepackage{cleveref}               % Smart references: \cref{fig:x} → "Figure 1"
+                                     % MUST be loaded AFTER hyperref
+                                     % Handles: figures, tables, sections, equations, algorithms
+
+% Math (usually included by conference .sty, but verify)
+\usepackage{amsmath,amssymb}        % AMS math environments and symbols
+\usepackage{mathtools}              % Extends amsmath (dcases, coloneqq, etc.)
+
+% Colors (for figures and diagrams)
+\usepackage{xcolor}                 % Color management
+% Okabe-Ito colorblind-safe palette:
+\definecolor{okblue}{HTML}{0072B2}
+\definecolor{okorange}{HTML}{E69F00}
+\definecolor{okgreen}{HTML}{009E73}
+\definecolor{okred}{HTML}{D55E00}
+\definecolor{okpurple}{HTML}{CC79A7}
+\definecolor{okcyan}{HTML}{56B4E9}
+\definecolor{okyellow}{HTML}{F0E442}
+```
+
+**Notes:**
+- `microtype` is the single highest-impact package for visual quality. It adjusts character spacing at a sub-pixel level. Always include it.
+- `siunitx` handles decimal alignment in tables via the `S` column type — eliminates manual spacing.
+- `cleveref` must be loaded **after** `hyperref`. Most conference .sty files load hyperref, so put cleveref last.
+- Check if the conference template already loads any of these (especially `algorithm`, `amsmath`, `graphicx`). Don't double-load.
+

--- a/skills/research/research-paper-writing/references/latex-preamble.md
+++ b/skills/research/research-paper-writing/references/latex-preamble.md
@@ -56,4 +56,3 @@ Add these packages to any paper for professional quality. They are compatible wi
 - `siunitx` handles decimal alignment in tables via the `S` column type — eliminates manual spacing.
 - `cleveref` must be loaded **after** `hyperref`. Most conference .sty files load hyperref, so put cleveref last.
 - Check if the conference template already loads any of these (especially `algorithm`, `amsmath`, `graphicx`). Don't double-load.
-

--- a/skills/research/research-paper-writing/references/tikz-patterns.md
+++ b/skills/research/research-paper-writing/references/tikz-patterns.md
@@ -13,7 +13,7 @@ TikZ is the standard for method diagrams in ML papers. Common patterns:
 \centering
 \begin{tikzpicture}[
   node distance=1.8cm,
-  box/.style={rectangle, draw, rounded corners, minimum height=1cm, 
+  box/.style={rectangle, draw, rounded corners, minimum height=1cm,
               minimum width=2cm, align=center, font=\small},
   arrow/.style={-{Stealth[length=3mm]}, thick},
 ]
@@ -22,13 +22,13 @@ TikZ is the standard for method diagrams in ML papers. Common patterns:
   \node[box, fill=okgreen!20, right of=encoder] (latent) {Latent\\$z$};
   \node[box, fill=okorange!20, right of=latent] (decoder) {Decoder\\$g_\phi$};
   \node[box, fill=okred!20, right of=decoder] (output) {Output\\$\hat{x}$};
-  
+
   \draw[arrow] (input) -- (encoder);
   \draw[arrow] (encoder) -- (latent);
   \draw[arrow] (latent) -- (decoder);
   \draw[arrow] (decoder) -- (output);
 \end{tikzpicture}
-\caption{Architecture overview. The encoder maps input $x$ to latent 
+\caption{Architecture overview. The encoder maps input $x$ to latent
 representation $z$, which the decoder reconstructs.}
 \label{fig:architecture}
 \end{figure}
@@ -38,7 +38,7 @@ representation $z$, which the decoder reconstructs.}
 
 ```latex
 \begin{tikzpicture}[
-  cell/.style={rectangle, draw, minimum width=2.5cm, minimum height=1cm, 
+  cell/.style={rectangle, draw, minimum width=2.5cm, minimum height=1cm,
                align=center, font=\small},
   header/.style={cell, fill=gray!20, font=\small\bfseries},
 ]
@@ -64,7 +64,7 @@ representation $z$, which the decoder reconstructs.}
 ```latex
 \begin{tikzpicture}[
   node distance=2cm,
-  box/.style={rectangle, draw, rounded corners, minimum height=0.8cm, 
+  box/.style={rectangle, draw, rounded corners, minimum height=0.8cm,
               minimum width=1.8cm, align=center, font=\small},
   arrow/.style={-{Stealth[length=3mm]}, thick},
   label/.style={font=\scriptsize, midway, above},
@@ -72,10 +72,9 @@ representation $z$, which the decoder reconstructs.}
   \node[box, fill=okblue!20] (gen) {Generator};
   \node[box, fill=okred!20, right=2.5cm of gen] (critic) {Critic};
   \node[box, fill=okgreen!20, below=1.5cm of $(gen)!0.5!(critic)$] (judge) {Judge Panel};
-  
+
   \draw[arrow] (gen) -- node[label] {output $A$} (critic);
   \draw[arrow] (critic) -- node[label, right] {critique $C$} (judge);
   \draw[arrow] (judge) -| node[label, left, pos=0.3] {winner} (gen);
 \end{tikzpicture}
 ```
-

--- a/skills/research/research-paper-writing/references/tikz-patterns.md
+++ b/skills/research/research-paper-writing/references/tikz-patterns.md
@@ -1,0 +1,81 @@
+# TikZ Diagram Patterns
+
+Extracted from `SKILL.md` (research-paper-writing) to keep the skill under the 100k-char limit.
+
+### TikZ Diagram Patterns
+
+TikZ is the standard for method diagrams in ML papers. Common patterns:
+
+**Pipeline/Flow Diagram** (most common in ML papers):
+
+```latex
+\begin{figure}[t]
+\centering
+\begin{tikzpicture}[
+  node distance=1.8cm,
+  box/.style={rectangle, draw, rounded corners, minimum height=1cm, 
+              minimum width=2cm, align=center, font=\small},
+  arrow/.style={-{Stealth[length=3mm]}, thick},
+]
+  \node[box, fill=okcyan!20] (input) {Input\\$x$};
+  \node[box, fill=okblue!20, right of=input] (encoder) {Encoder\\$f_\theta$};
+  \node[box, fill=okgreen!20, right of=encoder] (latent) {Latent\\$z$};
+  \node[box, fill=okorange!20, right of=latent] (decoder) {Decoder\\$g_\phi$};
+  \node[box, fill=okred!20, right of=decoder] (output) {Output\\$\hat{x}$};
+  
+  \draw[arrow] (input) -- (encoder);
+  \draw[arrow] (encoder) -- (latent);
+  \draw[arrow] (latent) -- (decoder);
+  \draw[arrow] (decoder) -- (output);
+\end{tikzpicture}
+\caption{Architecture overview. The encoder maps input $x$ to latent 
+representation $z$, which the decoder reconstructs.}
+\label{fig:architecture}
+\end{figure}
+```
+
+**Comparison/Matrix Diagram** (for showing method variants):
+
+```latex
+\begin{tikzpicture}[
+  cell/.style={rectangle, draw, minimum width=2.5cm, minimum height=1cm, 
+               align=center, font=\small},
+  header/.style={cell, fill=gray!20, font=\small\bfseries},
+]
+  % Headers
+  \node[header] at (0, 0) {Method};
+  \node[header] at (3, 0) {Converges?};
+  \node[header] at (6, 0) {Quality?};
+  % Rows
+  \node[cell] at (0, -1) {Single Pass};
+  \node[cell, fill=okgreen!15] at (3, -1) {N/A};
+  \node[cell, fill=okorange!15] at (6, -1) {Baseline};
+  \node[cell] at (0, -2) {Critique+Revise};
+  \node[cell, fill=okred!15] at (3, -2) {No};
+  \node[cell, fill=okred!15] at (6, -2) {Degrades};
+  \node[cell] at (0, -3) {Ours};
+  \node[cell, fill=okgreen!15] at (3, -3) {Yes ($k$=2)};
+  \node[cell, fill=okgreen!15] at (6, -3) {Improves};
+\end{tikzpicture}
+```
+
+**Iterative Loop Diagram** (for methods with feedback):
+
+```latex
+\begin{tikzpicture}[
+  node distance=2cm,
+  box/.style={rectangle, draw, rounded corners, minimum height=0.8cm, 
+              minimum width=1.8cm, align=center, font=\small},
+  arrow/.style={-{Stealth[length=3mm]}, thick},
+  label/.style={font=\scriptsize, midway, above},
+]
+  \node[box, fill=okblue!20] (gen) {Generator};
+  \node[box, fill=okred!20, right=2.5cm of gen] (critic) {Critic};
+  \node[box, fill=okgreen!20, below=1.5cm of $(gen)!0.5!(critic)$] (judge) {Judge Panel};
+  
+  \draw[arrow] (gen) -- node[label] {output $A$} (critic);
+  \draw[arrow] (critic) -- node[label, right] {critique $C$} (judge);
+  \draw[arrow] (judge) -| node[label, left, pos=0.3] {winner} (gen);
+\end{tikzpicture}
+```
+


### PR DESCRIPTION
## Summary

The bundled `research/research-paper-writing/SKILL.md` shipped at **102,716 characters** — over the `MAX_SKILL_CONTENT_CHARS = 100_000` guard (`tools/skill_manager_tool.py:488`), so `skill_manage` refuses to edit it and the `skills_hub` size guard (`tools/skills_hub.py:3608`) trips. The agent cannot maintain or self-improve the skill.

Fix: move the two self-contained reference blocks — **Professional LaTeX Preamble** (2,771 chars) and **TikZ Diagram Patterns** (2,740 chars) — into `references/latex-preamble.md` and `references/tikz-patterns.md`, replacing each in SKILL.md with a one-line link. No content lost, section structure unchanged.

SKILL.md: **102,716 → 97,704 chars** (2.3k headroom under the limit).

NOT doing X: not trimming guidance or examples — the moved blocks are purely additive reference material (LaTeX/TikZ code), and the skill's prose workflow is untouched.

## Test plan

```
python -c "print(len(open('skills/research/research-paper-writing/SKILL.md',encoding='utf-8').read()))"
# 97704 < 100000 ✓ (was 102716)
```
