### PR TITLE
chore: add contributor email mapping for nkreadly07

### DIFF
--- a/contributors/emails/nkreadly@gmail.com
+++ b/contributors/emails/nkreadly@gmail.com
@@ -1,0 +1,1 @@
+nkreadly07


### PR DESCRIPTION
Attribution mapping for @nkreadly07 (nkreadly@gmail.com), needed by the #67351 salvage. First line = GitHub login per contributors/README.