### PR TITLE
fix(desktop): focus SSH custom host on first selection (#76825)

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,8 +1,15 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ProfileInfo } from '@/types/hermes'
+
+// Radix Select calls scrollIntoView / pointer-capture APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
 
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
@@ -117,5 +124,39 @@ describe('GatewaySettings', () => {
         })
       )
     )
+  })
+
+  it('focuses the custom SSH host input on the first "Custom" selection', async () => {
+    getConnectionConfig.mockResolvedValue({
+      ...localConnection,
+      mode: 'ssh',
+      sshHost: '',
+      sshUser: '',
+      sshPort: 22,
+      sshKeyPath: '',
+      sshRemoteHermesPath: '',
+      sshRemoteProfile: ''
+    })
+    const sshConfigHosts = vi.fn().mockResolvedValue({ hosts: ['github.com'] })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { getConnectionConfig, saveConnectionConfig, sshConfigHosts }
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+
+    // With ~/.ssh/config aliases available the host field is a dropdown.
+    const trigger = await screen.findByRole('combobox')
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole('option', { name: 'Custom (enter manually)…' }))
+
+    // The dropdown is swapped for a free-text input that must be focused and
+    // immediately typeable on the FIRST selection (no round-trip through
+    // another option) — Radix's deferred focus restoration must not steal it.
+    const hostRow = screen.getByText('Host').closest('.grid') as HTMLElement
+    const input = within(hostRow).getByRole('textbox') as HTMLInputElement
+
+    await waitFor(() => expect(document.activeElement).toBe(input))
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -159,6 +159,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   const [lastTest, setLastTest] = useState<null | string>(null)
   const [sshHostSuggestions, setSshHostSuggestions] = useState<string[]>([])
   const [sshCustomHost, setSshCustomHost] = useState(false)
+  const sshHostInputRef = useRef<HTMLInputElement>(null)
   const sshResolveSeq = useRef(0)
   const sshTestSeq = useRef(0)
   const saveSeq = useRef(0)
@@ -406,6 +407,23 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
 
     return () => void (cancelled = true)
   }, [state.mode])
+
+  // Radix Select restores focus to its trigger when the popover closes. That
+  // restoration runs after `onValueChange` has swapped the Select out for the
+  // custom-host Input, so it races with the Input's `autoFocus` and steals
+  // focus from the freshly mounted field (the trigger is already unmounted, so
+  // focus lands on <body>). Re-focus on the next frame, once the Select's
+  // deferred focus restoration has settled, so the first "Custom" selection
+  // yields a field that immediately accepts typing.
+  useEffect(() => {
+    if (!sshCustomHost) {
+      return
+    }
+
+    const frame = requestAnimationFrame(() => sshHostInputRef.current?.focus())
+
+    return () => cancelAnimationFrame(frame)
+  }, [sshCustomHost])
 
   // eslint-disable-next-line no-restricted-syntax -- monotonic request-sequence counters, not an atom mirror
   useEffect(() => {
@@ -1345,7 +1363,14 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
               action={
                 <Select
                   onValueChange={selectHost}
-                  value={sshHostSuggestions.includes(state.sshHost) ? state.sshHost : SSH_HOST_CUSTOM}
+                  // Only report an actual host here. Leaving the value at the
+                  // empty string shows the placeholder; using SSH_HOST_CUSTOM
+                  // while the dropdown is still rendered would make the FIRST
+                  // "Custom" click a no-op (Radix suppresses onValueChange when
+                  // a controlled value doesn't change), so the custom-host
+                  // input would never mount without a round-trip through
+                  // another option.
+                  value={sshHostSuggestions.includes(state.sshHost) ? state.sshHost : ''}
                 >
                   <SelectTrigger className={cn('h-8', CONTROL_TEXT)}>
                     <SelectValue placeholder={g.sshHostPick} />
@@ -1381,6 +1406,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                     void resolveSshHost(state.sshHost)
                   }}
                   onChange={event => setState(current => selectSshHost(current, event.target.value))}
+                  ref={sshHostInputRef}
                   value={state.sshHost}
                 />
               }


### PR DESCRIPTION
Closes #76825

## Summary

In the Desktop app's Gateway settings, selecting "Custom" in the SSH host dropdown was a no-op on the first attempt when the dropdown had already defaulted to the `__custom__` sentinel value: the Select is controlled, and Radix UI suppresses `onValueChange` when the controlled value doesn't change (`useControllableState` only calls `onChange` when `value2 !== prop`). Since the value prop was `SSH_HOST_CUSTOM` whenever the host was empty/not in the suggestions list, clicking "Custom" never called `selectHost('__custom__')` — the custom-host input never mounted, and the user had to round-trip through another host (which changes the value and finally fires the callback).

## Fix

- **`gateway-settings.tsx`**: the Select's `value` now stays at the empty string (showing the placeholder) unless a real suggestion is selected, so the first "Custom" click transitions `'' → '__custom__'` and reliably fires `onValueChange`.
- As a defensive measure for the focus race described in the issue (Radix Select's deferred focus restoration racing `autoFocus` when the Select unmounts mid-close), the custom-host `<Input>` now also re-focuses itself on the next animation frame via a ref when it mounts — making the field immediately typeable on the first selection.

## Tests

- Added a regression test in `gateway-settings.test.tsx` that renders the SSH panel with a populated suggestions list, selects "Custom" on the first attempt, and asserts the resulting text input is focused. The test fails without the fix and passes with it.
- Verified: `tsc --noEmit` clean, ESLint clean on the touched component, all `src/app/settings` tests pass (the 2 failures in `billing/index.test.tsx` are pre-existing on `main` in this environment, unrelated to this change).

## Checklist

- [x] Tests added/updated
- [x] Typecheck passes
- [x] Lint passes