### PR TITLE
fix(patch-parser): reflect ADD in the validation overlay

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -732,6 +732,109 @@ class TestMoveThenUpdateSameFile:
         assert "already exists" in (result.error or "")
 
 
+class TestAddThenOpSameFile:
+    """A create-then-touch patch must validate and apply (was rejected).
+
+    Sibling of TestMoveThenUpdateSameFile: _validate_operations reflected a
+    MOVE's destination into its overlay but never an ADD's, so an
+    `Add b` + `Update b` (or `Add b` + `Move b -> c`) failed validation with
+    'b: file not found' even though the two-phase apply — which writes the ADD
+    before reading it back — would have succeeded. ADD was the missed overlay
+    producer.
+    """
+
+    def test_add_then_update_same_file(self):
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: src/m.py\n"
+            "+def greet():\n"
+            '+    return "hi"\n'
+            "*** Update File: src/m.py\n"
+            "@@ def greet @@\n"
+            '-    return "hi"\n'
+            '+    return "hello"\n'
+            "*** End Patch\n"
+        )
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        fo = _DictFileOps({})  # src/m.py does not exist on disk yet
+        result = apply_v4a_operations(ops, fo)
+        assert result.success is True, getattr(result, "error", None)
+        assert fo.files["src/m.py"] == 'def greet():\n    return "hello"'
+
+    def test_add_then_move_same_file(self):
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: src/a.py\n"
+            "+x = 1\n"
+            "*** Move File: src/a.py -> src/b.py\n"
+            "*** End Patch\n"
+        )
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        fo = _DictFileOps({})
+        result = apply_v4a_operations(ops, fo)
+        assert result.success is True, getattr(result, "error", None)
+        assert "src/a.py" not in fo.files
+        assert fo.files["src/b.py"] == "x = 1"
+
+    def test_delete_then_add_then_update_same_file(self):
+        """Recreating a deleted path must read as present for a later hunk."""
+        patch = (
+            "*** Begin Patch\n"
+            "*** Delete File: src/c.py\n"
+            "*** Add File: src/c.py\n"
+            "+y = 1\n"
+            "*** Update File: src/c.py\n"
+            "@@\n"
+            "-y = 1\n"
+            "+y = 2\n"
+            "*** End Patch\n"
+        )
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        fo = _DictFileOps({"src/c.py": "old = 0\n"})
+        result = apply_v4a_operations(ops, fo)
+        assert result.success is True, getattr(result, "error", None)
+        assert fo.files["src/c.py"] == "y = 2"
+
+    def test_add_then_update_mismatch_still_rejected(self):
+        """The overlay must not blind a genuine hunk mismatch on the new file."""
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: src/m.py\n"
+            "+alpha = 1\n"
+            "*** Update File: src/m.py\n"
+            "@@\n"
+            "-DOES_NOT_EXIST\n"
+            "+z\n"
+            "*** End Patch\n"
+        )
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        fo = _DictFileOps({})
+        result = apply_v4a_operations(ops, fo)
+        assert result.success is False
+        assert "src/m.py" not in fo.files  # atomic: nothing written
+
+    def test_update_missing_file_without_add_still_rejected(self):
+        """A bare Update of a path no prior op created is still 'file not found'."""
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: ghost.py\n"
+            "@@\n"
+            "-a\n"
+            "+b\n"
+            "*** End Patch\n"
+        )
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        fo = _DictFileOps({})
+        result = apply_v4a_operations(ops, fo)
+        assert result.success is False
+        assert "file not found" in (result.error or "")
+
+
 class TestCrlfPatchBody:
     """A CRLF-encoded patch body must not inject stray carriage returns."""
 

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -373,7 +373,28 @@ def _validate_operations(
                 pending_content.pop(op.file_path, None)
                 removed_paths.add(op.file_path)
 
-        # ADD: parent directory creation handled by write_file; no pre-check needed.
+        elif op.operation == OperationType.ADD:
+            # ADD creates a file, so — exactly like a MOVE destination — a
+            # later op in the same patch that reads this path (UPDATE, a MOVE
+            # source, or DELETE) must see it in the overlay. Mirror
+            # _apply_add's content extraction (join the '+' lines) so a
+            # subsequent UPDATE validates against precisely what the apply
+            # phase will write. Also drop the path from removed_paths so a
+            # Delete-then-Add recreation reads as present.
+            #
+            # Without this, an Add-then-Update (or Add-then-Move) of the same
+            # path is rejected with "file not found" during validation even
+            # though the two-phase apply — which writes the ADD before reading
+            # it back for the UPDATE — would succeed. Same class as the
+            # Move-then-Update overlay gap; ADD was the missed producer.
+            added_content = '\n'.join(
+                line.content
+                for hunk in op.hunks
+                for line in hunk.lines
+                if line.prefix == '+'
+            )
+            pending_content[op.file_path] = added_content
+            removed_paths.discard(op.file_path)
 
     if not errors and real_change_count == 0:
         errors.append("Patch contains no changes (only context lines were provided)")


### PR DESCRIPTION
## What

`_validate_operations` simulates a V4A patch against a pending-content overlay so a later op in the same patch sees an earlier op's effect — a MOVE records its destination, a DELETE marks its path gone. **ADD, the other file-creating op, was never recorded.**

So a patch that creates a file and then touches it in the same body is rejected atomically with `file not found`, even though the two-phase apply — which writes the ADD before reading it back — would have succeeded (splitting the patch in two makes each half apply cleanly):

```
*** Begin Patch
*** Add File: src/m.py
+def greet():
+    return "hi"
*** Update File: src/m.py
@@ def greet @@
-    return "hi"
+    return "hello"
*** End Patch

→ Patch validation failed (no files were modified):
  • src/m.py: file not found
```

Same failure mode for `Add b` + `Move b -> c`, and for a `Delete b` + `Add b` recreation followed by an update. Models emitting multi-op patches (create + refine) hit this on a core tool.

This is the exact sibling of the Move-then-Update overlay gap fixed in `62f00319d` — that commit made MOVE and DELETE overlay producers but left ADD out.

## Fix

Record an ADD's content (the joined `+` lines, mirroring `_apply_add`) into `pending_content` and drop the path from `removed_paths`, so a subsequent UPDATE / MOVE-source / DELETE read in the same patch resolves.

Genuine errors still surface: an Add-then-Update whose hunk doesn't match the added content, and a bare Update of an uncreated path, are still rejected.

## Tests

`tests/tools/test_patch_parser.py::TestAddThenOpSameFile` — 5 tests:

- Add-then-Update, Add-then-Move, and Delete-then-Add-then-Update of the same path now validate and apply
- **sabotage guards**: an Add-then-Update with a non-matching hunk, and a bare Update of an uncreated path, must still be rejected (the overlay must not blind real errors)

```
scripts/run_tests.sh tests/tools/test_patch_parser.py
=== Summary: 1 files, 34 tests passed, 0 failed ===

# without the fix
=== Summary: 1 files, 31 tests passed, 3 failed ===
```

The 3 red-without-fix are the valid cross-op cases; the 2 sabotage guards stay green either way.

Broader run — `tests/tools/` patch/fuzzy/file suite: **148 passed, 14 failed**, the same 14 that fail on a clean checkout (unrelated umask/symlink/search cases). Baseline verified by stashing the change: **143 passed, 14 failed** — same set, zero new failures.