### PR TITLE
fix(compression): collapse duplicated tool results to stop token inflation (#76806)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4526,6 +4526,56 @@ This compaction should PRIORITISE preserving all information related to the focu
                 if cid:
                     result_call_ids.add(cid)
 
+        # 0. Deduplicate tool results that share a tool_call_id. A single
+        # tool_call_id can only ever have ONE result; a second row with the
+        # same id means the transcript was re-appended (identity-broken
+        # re-append after in-place compaction, reload/repair that rebuilt
+        # dicts without persistence markers, or a legacy duplicated flush).
+        # Keeping both rows doubles that exchange in every subsequent API
+        # request and — because compression re-runs on the inflated
+        # transcript — lets the duplication feed on itself across
+        # compaction cycles (exponential input-token inflation, #76806).
+        # Keep the LAST occurrence (the newest copy) so no data is lost.
+        seen_result_ids: set = set()
+        duplicated_result_ids: set = set()
+        for msg in messages:
+            if msg.get("role") == "tool":
+                cid = msg.get("tool_call_id")
+                if not cid:
+                    continue
+                if cid in seen_result_ids:
+                    duplicated_result_ids.add(cid)
+                else:
+                    seen_result_ids.add(cid)
+        if duplicated_result_ids:
+            # Keep only the LAST row for each duplicated tool_call_id.
+            last_seen_index: dict = {}
+            for idx, msg in enumerate(messages):
+                if msg.get("role") == "tool" and msg.get("tool_call_id") in duplicated_result_ids:
+                    last_seen_index[msg.get("tool_call_id")] = idx
+            messages = [
+                msg for idx, msg in enumerate(messages)
+                if not (
+                    msg.get("role") == "tool"
+                    and msg.get("tool_call_id") in duplicated_result_ids
+                    and last_seen_index.get(msg.get("tool_call_id")) != idx
+                )
+            ]
+            # Rebuild the result-id set from the deduplicated list so the
+            # orphan/strip passes below reason about the same rows.
+            result_call_ids = set()
+            for msg in messages:
+                if msg.get("role") == "tool":
+                    cid = msg.get("tool_call_id")
+                    if cid:
+                        result_call_ids.add(cid)
+            if not self.quiet_mode:
+                logger.info(
+                    "Compression sanitizer: collapsed %d duplicate tool result(s) "
+                    "(same tool_call_id re-appended — #76806 inflation guard)",
+                    len(duplicated_result_ids),
+                )
+
         # 1. Remove tool results whose call_id has no matching assistant tool_call
         orphaned_results = result_call_ids - surviving_call_ids
         if orphaned_results:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2174,6 +2174,64 @@ class TestSanitizerStripsOrphanedToolCalls:
         assert len(tool_msgs) == 1
         assert tool_msgs[0]["tool_call_id"] == "tc_valid"
 
+    def test_sanitizer_dedupes_reappended_tool_results(self, compressor):
+        """Duplicate tool results sharing one tool_call_id are collapsed.
+
+        A single tool_call_id can only ever have one result; a second row
+        with the same id means the transcript was re-appended (identity-
+        broken re-append after in-place compaction / reload / repair).
+        Keeping both rows doubles that exchange in every subsequent API
+        request, and because compression re-runs on the inflated
+        transcript the duplication feeds on itself across compaction
+        cycles (exponential input-token inflation, #76806). The newest
+        occurrence is kept so no data is lost.
+        """
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "read_file", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "v1"},
+            # Re-appended copy of the same exchange (duplicate tool result)
+            {"role": "tool", "tool_call_id": "tc_1", "content": "v2"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        tool_msgs = [m for m in sanitized if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1, "duplicate tool result must be collapsed"
+        # Newest copy wins — the content is preserved, not lost.
+        assert tool_msgs[0]["content"] == "v2"
+        # The valid tool_call/result pair and the user turn survive.
+        asst = next(m for m in sanitized if m.get("role") == "assistant")
+        assert len(asst["tool_calls"]) == 1
+        assert any(m.get("role") == "user" for m in sanitized)
+
+    def test_sanitizer_keeps_distinct_tool_results(self, compressor):
+        """Tool results with different tool_call_ids are never collapsed."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "read_file", "arguments": "{}"}},
+                    {"id": "tc_2", "function": {"name": "search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "v1"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "v2"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        tool_msgs = [m for m in sanitized if m.get("role") == "tool"]
+        assert len(tool_msgs) == 2
+        assert {m["tool_call_id"] for m in tool_msgs} == {"tc_1", "tc_2"}
+
     def test_sanitizer_strips_orphaned_preserves_text_content(self, compressor):
         """When an assistant has text content AND orphaned tool_calls,
         the text is preserved and only tool_calls are stripped.  #51218"""


### PR DESCRIPTION
## Problem

Extended multi-turn sessions in v0.19.1 show exponential input-token inflation (#76806). Root cause: a tool result with the same `tool_call_id` appearing **twice** in the transcript (identity-broken re-append after in-place compaction, reload/repair rebuilding dicts without persistence markers, or legacy duplicated flush). Keeping both rows doubles that exchange in every subsequent API request — and because compression re-runs on the inflated transcript, the duplication feeds on itself across compaction cycles.

## Fix

The compression sanitizer (step 0, before orphan stripping) now **collapses duplicated tool results** that share a `tool_call_id`:
- Identifies ids that appear more than once
- Keeps only the **last** occurrence (newest copy) — no data lost
- Rebuilds the result-id set from the deduplicated list so the orphan/strip passes below reason about the same rows
- Logs a sanitizer notice when collapsing occurs

## Verification

- New regression test `test_sanitizer_dedupes_reappended_tool_results` — **fails without the fix** (both rows kept) and passes with it
- `pytest tests/agent/test_context_compressor.py -k "duplicate or sanitizer"` → 8 passed
- Syntax + related sanitizer suites green

Closes #76806