### PR TITLE
fix(cli): make 'hermes tools --summary' non-interactive

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11492,7 +11492,8 @@ def cmd_tools(args):
 
         sys.exit(run_post_setup_command(args))
     else:
-        _require_tty("tools")
+        if not getattr(args, "summary", False):
+            _require_tty("tools")
         from hermes_cli.tools_config import tools_command
 
         tools_command(args)

--- a/tests/hermes_cli/test_tools_summary_noninteractive.py
+++ b/tests/hermes_cli/test_tools_summary_noninteractive.py
@@ -1,0 +1,22 @@
+from argparse import Namespace
+
+
+def test_tools_summary_bypasses_interactive_tty_guard(monkeypatch):
+    import hermes_cli.main as main_mod
+    import hermes_cli.tools_config as tools_config
+
+    called = []
+
+    def fail_tty_guard(_command_name):
+        raise AssertionError("summary mode must not require a TTY")
+
+    def fake_tools_command(args):
+        called.append(args)
+
+    monkeypatch.setattr(main_mod, "_require_tty", fail_tty_guard)
+    monkeypatch.setattr(tools_config, "tools_command", fake_tools_command)
+
+    args = Namespace(tools_action=None, summary=True)
+    main_mod.cmd_tools(args)
+
+    assert called == [args]


### PR DESCRIPTION
## What

`hermes tools --summary` is broken: it can never run non-interactively, even though `--summary` is explicitly documented and implemented as a non-interactive mode.

## Why

- The tools parser registers `--summary` with help "Print a summary of enabled tools per platform and exit" (`hermes_cli/subcommands/tools.py`).
- `tools_config.tools_command()` already implements that non-interactive path (`tools_config.py` "Non-interactive summary mode for CLI usage").
- But `cmd_tools` unconditionally calls `_require_tty("tools")` *before* reaching it, so `--summary` exits with the interactive-TTY error whenever stdin is a pipe or non-interactive subprocess (scripts, cron, dashboards, agents).

## Fix

Skip the TTY guard when `--summary` is requested:

```python
if not getattr(args, "summary", False):
    _require_tty("tools")
```

- `hermes tools --summary </dev/null` → prints the summary, exit 0
- `hermes tools </dev/null` → still guarded (interactive path protected)
- Interactive configuration UI unchanged.

## Verification

- Added regression test `tests/hermes_cli/test_tools_summary_noninteractive.py`.
- Ruff clean; `git diff --check` clean.
- Manual pipe test confirms both behaviors.