### PR TITLE
fix(desktop): recover from slow Windows cold starts

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  DEFAULT_BACKEND_READY_TIMEOUT_MS,
   DEFAULT_HEALTH_PROBE_TIMEOUT_MS,
   isAuthRejectionError,
   isGatedMissingHealthError,
@@ -12,6 +13,33 @@ import {
 } from './backend-health'
 
 const GATE_401 = '401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}'
+
+test('allows a Windows cold backend up to 90 seconds to become ready', async () => {
+  let currentTime = 0
+  let attempts = 0
+
+  await waitForHermesReady('http://127.0.0.1:9000', {
+    fetchPublicJson: async () => {
+      attempts += 1
+
+      if (currentTime < 60_000) {
+        throw new Error('event loop stalled during cold import')
+      }
+
+      return { ok: true }
+    },
+    fetchJson: async () => {
+      throw new Error('status should not be called')
+    },
+    sleep: async ms => {
+      currentTime += ms
+    },
+    now: () => currentTime
+  })
+
+  assert.equal(DEFAULT_BACKEND_READY_TIMEOUT_MS, 90_000)
+  assert.ok(attempts > 1)
+})
 
 test('uses lightweight /api/health for current backends', async () => {
   const calls: string[][] = []

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BACKEND_READY_TIMEOUT_MS = 45_000
+export const DEFAULT_BACKEND_READY_TIMEOUT_MS = 90_000
 export const DEFAULT_BACKEND_READY_POLL_MS = 500
 // A cold backend can stall its event loop for tens of seconds while Windows
 // scans and byte-compiles the gateway import tree. At the default 15s socket

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -236,6 +236,23 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().error).toBeTruthy()
   })
 
+  it('retries a transient initial gateway failure and completes boot when it recovers', async () => {
+    FakeWebSocket.mode = 'fail'
+    render(<Harness />)
+    await flushAsync()
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
+  })
+
   it('resets the old machine context before connecting an applied gateway', async () => {
     const beforeConnectionSwitch = vi.fn()
     render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -530,6 +530,16 @@ export function useGatewayBoot({
           failDesktopBoot(message)
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
           setSessionsLoading(false)
+
+          // A cold Windows backend can accept the WebSocket while its Python
+          // event loop is still busy importing, then miss the ready-frame
+          // deadline. Treat that first transport failure like a post-boot drop:
+          // keep the recovery overlay available while the existing bounded
+          // reconnect loop retries. Auth rejection remains terminal.
+          if (!isGatewayReauthRequired(err)) {
+            bootCompleted = true
+            scheduleReconnect()
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- allow the desktop backend up to 90 seconds to become ready during a Windows cold start
- route an initial transient gateway connection failure through the existing bounded reconnect loop
- keep authentication failures terminal instead of retrying them
- cover delayed backend readiness and initial gateway recovery with behavioral tests

## Why

On Windows, antivirus scanning and Python import/byte-compilation can stall the backend event loop for tens of seconds. The HTTP health check may eventually succeed, but the first WebSocket can disconnect before the backend sends its ready frame. The initial boot path currently latches the recovery overlay, while the same transport failure after a successful boot already uses bounded exponential backoff.

This change gives a cold backend a larger readiness budget and reuses the existing reconnect policy for the first transient connection failure. It does not introduce an infinite retry loop: the current retry cap and recoverable failure surface remain in place.

## Validation

- `npx vitest run electron/backend-health.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx` — 21 tests passed
- `npm run typecheck` — passed
- targeted ESLint — passed
- production renderer/Electron build — passed
- Windows unpacked package — passed
- two manual cold starts — `/api/health` returned `ok=true`
- simulated update overwrite followed by automatic patch reapplication, rebuild and cold-start verification — passed

## Scope

The commit changes only four desktop source/test files. It contains no machine-specific paths, scheduled-task code, local logs, user data or unrelated working-tree files.
