### PR TITLE
feat(skills): add hermes-self-maintenance skill with nightly health check script

### DIFF
--- a/skills/software-development/hermes-self-maintenance/SKILL.md
+++ b/skills/software-development/hermes-self-maintenance/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: hermes-self-maintenance
+description: "Set up nightly Hermes auto-update and health checks."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hermes, maintenance, auto-update, health-check, cron, self-healing]
+    related_skills: [hermes-agent]
+---
+
+# Hermes Self-Maintenance
+
+Nightly health checks and update detection for Hermes Agent — silent when healthy, actionable alerts when something needs attention. Zero LLM cost, zero core changes, works on every platform the cron system supports.
+
+## What it does
+
+A single `no_agent` Python script (`scripts/maintenance_check.py`) runs on a cron schedule and checks three things:
+
+1. **Update availability** — runs `hermes update --check` and reports how many commits behind upstream.
+2. **Gateway health** — verifies the Hermes process is alive (cross-platform PID check via `psutil` if available, fallback to `tasklist`/`pgrep`).
+3. **Cron job failures** — scans enabled cron jobs for `last_status: error` and lists the failed ones.
+
+When everything is healthy, the script exits 0 with no output (cron stays silent). When something needs attention, it prints a structured report to stdout (cron delivers it to the configured channel).
+
+## Setup
+
+Tell your agent:
+
+> "Set up nightly Hermes maintenance."
+
+The agent should:
+
+1. Verify the script exists at `skills/software-development/hermes-self-maintenance/scripts/maintenance_check.py`.
+2. Create a cron job:
+
+```
+hermes cron add \
+  --name "nightly-hermes-maintenance" \
+  --schedule "0 3 * * *" \
+  --script "maintenance_check.py" \
+  --no-agent \
+  --deliver telegram
+```
+
+Adjust `--schedule` and `--deliver` to the user's preference. Common delivery targets: `telegram`, `discord`, `origin` (back to the chat that created it).
+
+3. Run the script once manually to confirm it works:
+
+```bash
+python3 skills/software-development/hermes-self-maintenance/scripts/maintenance_check.py
+```
+
+Silent exit = healthy. Report output = something needs attention.
+
+## How the script works
+
+The script uses only the Hermes CLI's existing commands and the cron state file — no imports from `hermes_cli` or the agent runtime. This makes it portable across versions.
+
+### Update check
+
+Calls `hermes update --check` and parses stdout for the "commits behind" count. If the command is unavailable or fails, the section is skipped (degraded, not broken).
+
+### Gateway health
+
+Checks for running Python processes that look like the Hermes gateway. On Windows: `tasklist` filtered to `python.exe`. On macOS/Linux: `pgrep -f hermes` or `ps aux | grep`. The `psutil` package is used if available for a cleaner cross-platform check, but is not required.
+
+### Cron failure scan
+
+Reads the cron state database (SQLite) directly via the standard library `sqlite3` module — no Hermes import needed. Queries enabled jobs with `last_status = 'error'` and lists their names. Falls back to `hermes cron list` if the DB path is not found.
+
+## Customization
+
+The script accepts optional environment variables:
+
+- `MAINTENANCE_REPORT_ALL` — set to `1` to always print a report, even when healthy (useful for debugging).
+- `MAINTENANCE_SKIP_UPDATE` — set to `1` to skip the update check.
+- `MAINTENANCE_SKIP_GATEWAY` — set to `1` to skip the gateway health check.
+- `MAINTENANCE_SKIP_CRON` — set to `1` to skip the cron failure scan.
+
+## Report format
+
+When action is needed, the script prints:
+
+```
+⚠ Hermes Maintenance Report — 2026-08-02 03:00:12
+
+📦 Update available: 47 commits behind upstream
+   Latest: a1b2c3d feat: add model catalog menu
+
+✅ Gateway: 3 python processes running
+
+⚠ Cron: 2 failed job(s)
+   — Regime Scan (merged)
+   — flow-trader-execute
+```
+
+Each section only appears if it has something to report. Healthy sections are omitted in the default alert-only mode (set `MAINTENANCE_REPORT_ALL=1` to see all sections).
+
+## Why a skill, not a core feature
+
+Three open PRs (#33514, #56787, #8062) propose adding `hermes update auto` as core CLI subcommands. They require per-platform scheduler implementations (LaunchAgent on macOS, systemd on Linux, Task Scheduler on Windows) and touch the update/gateway lifecycle — a high-risk area that has kept them stalled.
+
+This skill takes a different approach: use the existing cross-platform cron system that Hermes already provides. The script is a `no_agent` cron job — no LLM cost, no daemon, no platform-specific scheduler code. The cron system already handles scheduling on all platforms. The script just checks and reports.
+
+## Limitations
+
+- The script does not auto-apply updates. It reports that updates are available; the user (or their agent) decides when to run `hermes update`. This is intentional — auto-updating a running gateway is the exact risk that has stalled the core PRs.
+- Gateway health is a process-alive check, not a deep probe. For deeper health checking, use `hermes doctor` or `hermes monitoring status`.
+- The cron failure scan reads the cron state database. If the database is locked (gateway is writing), the scan retries up to 3 times with backoff.

--- a/skills/software-development/hermes-self-maintenance/scripts/maintenance_check.py
+++ b/skills/software-development/hermes-self-maintenance/scripts/maintenance_check.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Nightly Hermes maintenance check — silent when healthy, reports when action is needed.
+
+Checks:
+  1. Update availability  — hermes update --check
+  2. Gateway health       — process alive check (cross-platform)
+  3. Cron job failures    — enabled jobs with last_status='error'
+
+Zero LLM cost. No imports from hermes_cli. Uses only stdlib + the Hermes CLI.
+Works on Linux, macOS, and Windows.
+
+Environment variables:
+  MAINTENANCE_REPORT_ALL    =1 to always print (even when healthy)
+  MAINTENANCE_SKIP_UPDATE   =1 to skip update check
+  MAINTENANCE_SKIP_GATEWAY  =1 to skip gateway health check
+  MAINTENANCE_SKIP_CRON     =1 to skip cron failure scan
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPORT_ALL = os.environ.get("MAINTENANCE_REPORT_ALL") == "1"
+SKIP_UPDATE = os.environ.get("MAINTENANCE_SKIP_UPDATE") == "1"
+SKIP_GATEWAY = os.environ.get("MAINTENANCE_SKIP_GATEWAY") == "1"
+SKIP_CRON = os.environ.get("MAINTENANCE_SKIP_CRON") == "1"
+
+
+def _now() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _run(cmd: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run a command and return (returncode, stdout, stderr)."""
+    try:
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return r.returncode, (r.stdout or "").strip(), (r.stderr or "").strip()
+    except FileNotFoundError:
+        return -1, "", f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -1, "", "timeout"
+    except Exception as e:
+        return -2, "", str(e)
+
+
+def _find_hermes_exe() -> str | None:
+    """Locate the hermes executable."""
+    # 1. HERMES_HOME env
+    home = os.environ.get("HERMES_HOME")
+    if home:
+        candidates = [
+            Path(home) / "hermes-agent" / "venv" / "Scripts" / "hermes.exe",
+            Path(home) / "hermes-agent" / "venv" / "bin" / "hermes",
+        ]
+        for c in candidates:
+            if c.exists():
+                return str(c)
+    # 2. On PATH
+    for name in ("hermes", "hermes.exe"):
+        rc, out, _ = _run(["which", name] if sys.platform != "win32" else ["where", name], timeout=5)
+        if rc == 0 and out:
+            return out.splitlines()[0].strip()
+    # 3. Common Windows location
+    win_path = Path(os.path.expanduser("~")) / "AppData" / "Local" / "hermes" / "hermes-agent" / "venv" / "Scripts" / "hermes.exe"
+    if win_path.exists():
+        return str(win_path)
+    # 4. Common Unix location
+    unix_path = Path(os.path.expanduser("~")) / ".hermes" / "hermes-agent" / "venv" / "bin" / "hermes"
+    if unix_path.exists():
+        return str(unix_path)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Update check
+# ---------------------------------------------------------------------------
+
+def check_updates(hermes_exe: str | None) -> dict:
+    """Run hermes update --check and parse the result."""
+    if SKIP_UPDATE:
+        return {"skipped": True}
+    if not hermes_exe:
+        return {"error": "hermes executable not found"}
+    rc, out, err = _run([hermes_exe, "update", "--check"], timeout=45)
+    if rc != 0 and not out:
+        return {"error": f"hermes update --check failed: {err or 'unknown'}"}
+    combined = f"{out}\n{err}"
+    # Parse: "Update available: N commits behind upstream/main"
+    m = re.search(r"(\d+)\s+commits?\s+behind", combined, re.IGNORECASE)
+    if m:
+        count = int(m.group(1))
+        # Try to extract latest commit info
+        latest = None
+        for line in combined.splitlines():
+            if "behind" in line.lower():
+                continue
+            stripped = line.strip()
+            if stripped and not stripped.startswith(("→", "⚕", "Run ")):
+                latest = stripped
+                break
+        return {"available": True, "commits_behind": count, "latest": latest}
+    # "Already up to date" or similar
+    if "up to date" in combined.lower() or "up-to-date" in combined.lower():
+        return {"available": False, "commits_behind": 0}
+    # Ambiguous — treat as unknown
+    return {"available": False, "commits_behind": 0, "raw": combined[:200]}
+
+
+# ---------------------------------------------------------------------------
+# Gateway health
+# ---------------------------------------------------------------------------
+
+def check_gateway() -> dict:
+    """Check if the Hermes gateway process is alive."""
+    if SKIP_GATEWAY:
+        return {"skipped": True}
+    # Try psutil first (cleanest cross-platform)
+    try:
+        import psutil
+        hermes_procs = []
+        for p in psutil.process_iter(["pid", "name", "cmdline"]):
+            try:
+                name = (p.info.get("name") or "").lower()
+                cmdline = " ".join(p.info.get("cmdline") or [])
+                if "python" in name and ("hermes" in cmdline or "hermes_cli" in cmdline):
+                    hermes_procs.append(p.info["pid"])
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return {"healthy": len(hermes_procs) > 0, "processes": len(hermes_procs)}
+    except ImportError:
+        pass
+    # Fallback: platform-specific
+    if sys.platform == "win32":
+        rc, out, _ = _run(["tasklist", "/FI", "IMAGENAME eq python.exe", "/FO", "CSV", "/NH"], timeout=10)
+        if rc != 0:
+            return {"error": f"tasklist failed: {rc}"}
+        count = sum(1 for line in out.splitlines() if "python" in line.lower())
+        return {"healthy": count > 0, "processes": count}
+    else:
+        rc, out, _ = _run(["pgrep", "-f", "hermes"], timeout=10)
+        if rc == 0 and out:
+            count = len(out.splitlines())
+            return {"healthy": count > 0, "processes": count}
+        # pgrep might not exist; try ps
+        rc, out, _ = _run(["ps", "aux"], timeout=10)
+        if rc == 0:
+            count = sum(1 for line in out.splitlines() if "hermes" in line.lower() and "grep" not in line.lower())
+            return {"healthy": count > 0, "processes": count}
+        return {"error": "could not determine process status"}
+
+
+# ---------------------------------------------------------------------------
+# Cron failure scan
+# ---------------------------------------------------------------------------
+
+def _find_cron_db() -> Path | None:
+    """Locate the Hermes cron state SQLite database."""
+    home = os.environ.get("HERMES_HOME")
+    if home:
+        candidates = [
+            Path(home) / "cron" / "cron.db",
+            Path(home) / "cron" / "cron_state.db",
+            Path(home) / "cron.db",
+        ]
+        for c in candidates:
+            if c.exists():
+                return c
+    # Default locations
+    default_home = Path(os.path.expanduser("~")) / ".hermes"
+    candidates = [
+        default_home / "cron" / "cron.db",
+        default_home / "cron" / "cron_state.db",
+        default_home / "cron.db",
+        # Windows native
+        Path(os.path.expanduser("~")) / "AppData" / "Local" / "hermes" / "cron" / "cron.db",
+        Path(os.path.expanduser("~")) / "AppData" / "Local" / "hermes" / "cron" / "cron_state.db",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def check_cron_failures(hermes_exe: str | None) -> dict:
+    """Scan enabled cron jobs for last_status='error'."""
+    if SKIP_CRON:
+        return {"skipped": True}
+    db_path = _find_cron_db()
+    if db_path:
+        # Read directly from SQLite — no Hermes import needed
+        for attempt in range(3):
+            try:
+                conn = sqlite3.connect(str(db_path), timeout=5)
+                conn.row_factory = sqlite3.Row
+                cur = conn.cursor()
+                # Find the right table name
+                tables = [r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+                cron_table = None
+                for t in ("cron_jobs", "jobs", "cron"):
+                    if t in tables:
+                        cron_table = t
+                        break
+                if not cron_table:
+                    conn.close()
+                    # Fallback to CLI
+                    return _check_cron_via_cli(hermes_exe)
+                # Query for failed enabled jobs
+                rows = cur.execute(
+                    f"SELECT * FROM {cron_table} WHERE enabled = 1 AND last_status = 'error'"
+                ).fetchall()
+                conn.close()
+                failed = []
+                for row in rows:
+                    name = dict(row).get("name") or dict(row).get("job_id", "?")
+                    failed.append(str(name))
+                return {"failed_count": len(failed), "failed_jobs": failed}
+            except sqlite3.OperationalError:
+                time.sleep(0.5 * (attempt + 1))
+                continue
+            except Exception as e:
+                return {"error": f"sqlite read failed: {e}"}
+        return {"error": "cron database locked after retries"}
+    # No DB found — try the CLI
+    return _check_cron_via_cli(hermes_exe)
+
+
+def _check_cron_via_cli(hermes_exe: str | None) -> dict:
+    """Fallback: use hermes cron list to detect failures."""
+    if not hermes_exe:
+        return {"error": "cron DB not found and hermes executable unavailable"}
+    rc, out, err = _run([hermes_exe, "cron", "list"], timeout=30)
+    if rc != 0:
+        return {"error": f"hermes cron list failed: {err[:100]}"}
+    # Parse text output for error lines
+    failed = []
+    for line in out.splitlines():
+        if "error" in line.lower() and ("last_status" in line.lower() or "│ error" in line.lower()):
+            # Try to extract job name
+            parts = line.split("│")
+            if len(parts) >= 2:
+                name = parts[1].strip()
+                if name and name != "Name":
+                    failed.append(name)
+    return {"failed_count": len(failed), "failed_jobs": failed, "method": "cli"}
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    now = _now()
+    hermes_exe = _find_hermes_exe()
+
+    updates = check_updates(hermes_exe)
+    gateway = check_gateway()
+    cron = check_cron_failures(hermes_exe)
+
+    # Determine if anything needs attention
+    update_available = updates.get("available", False)
+    gateway_down = not gateway.get("healthy", True) and "error" not in gateway
+    cron_failures = cron.get("failed_count", 0)
+    has_errors = "error" in updates or "error" in gateway or "error" in cron
+
+    needs_attention = update_available or gateway_down or cron_failures > 0 or has_errors
+
+    if not needs_attention and not REPORT_ALL:
+        # Silent — all healthy
+        return 0
+
+    # Build report
+    lines = [f"⚠ Hermes Maintenance Report — {now}", ""]
+
+    # Updates
+    if updates.get("skipped"):
+        if REPORT_ALL:
+            lines.append("⏭ Update check: skipped")
+            lines.append("")
+    elif updates.get("error"):
+        lines.append(f"❓ Update check: {updates['error']}")
+        lines.append("")
+    elif updates.get("available"):
+        lines.append(f"📦 Update available: {updates['commits_behind']} commits behind upstream")
+        if updates.get("latest"):
+            lines.append(f"   Latest: {updates['latest']}")
+        lines.append("   Run: hermes update")
+        lines.append("")
+    elif REPORT_ALL:
+        lines.append("✅ Updates: up to date")
+        lines.append("")
+
+    # Gateway
+    if gateway.get("skipped"):
+        if REPORT_ALL:
+            lines.append("⏭ Gateway: skipped")
+            lines.append("")
+    elif gateway.get("error"):
+        lines.append(f"❓ Gateway: {gateway['error']}")
+        lines.append("")
+    elif gateway.get("healthy"):
+        if REPORT_ALL or needs_attention:
+            lines.append(f"✅ Gateway: {gateway.get('processes', 0)} process(es) running")
+            lines.append("")
+    else:
+        lines.append("🔴 Gateway: no Hermes processes detected — gateway may be down")
+        lines.append("   Manual restart may be needed")
+        lines.append("")
+
+    # Cron
+    if cron.get("skipped"):
+        if REPORT_ALL:
+            lines.append("⏭ Cron: skipped")
+            lines.append("")
+    elif cron.get("error"):
+        lines.append(f"❓ Cron: {cron['error']}")
+        lines.append("")
+    elif cron.get("failed_count", 0) > 0:
+        failed = cron.get("failed_jobs", [])
+        lines.append(f"⚠ Cron: {cron['failed_count']} failed job(s)")
+        for name in failed[:10]:
+            lines.append(f"   — {name}")
+        if len(failed) > 10:
+            lines.append(f"   ... and {len(failed) - 10} more")
+        lines.append("")
+    elif REPORT_ALL:
+        lines.append("✅ Cron: no failures")
+        lines.append("")
+
+    report = "\n".join(lines).rstrip() + "\n"
+    print(report, end="")
+    return 0 if not needs_attention else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_self_maintenance.py
+++ b/tests/skills/test_self_maintenance.py
@@ -1,0 +1,202 @@
+"""Invariant tests for the bundled hermes-self-maintenance skill.
+
+Covers skills/software-development/hermes-self-maintenance — the nightly
+auto-update and health-check skill. Tests assert contracts (frontmatter
+shape, referenced scripts exist, script imports are stdlib-only, script
+runs and exits cleanly), not snapshots of skill content.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SKILL_DIR = REPO / "skills" / "software-development" / "hermes-self-maintenance"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPT = SKILL_DIR / "scripts" / "maintenance_check.py"
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match, f"{SKILL_MD} has no YAML frontmatter"
+    return yaml.safe_load(match.group(1))
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter contract
+# ---------------------------------------------------------------------------
+
+def test_skill_exists():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+
+
+def test_frontmatter_shape():
+    fm = _frontmatter()
+    assert fm["name"] == "hermes-self-maintenance"
+    assert fm["description"].strip()
+    assert len(fm["description"]) <= 60, (
+        f"description is {len(fm['description'])} chars (max 60 for system prompt index)"
+    )
+    assert fm["description"].rstrip('"').endswith(".")
+    platforms = fm.get("platforms")
+    assert platforms, "missing platforms gating"
+    assert set(platforms) <= {"linux", "macos", "windows"}
+    assert set(platforms) == {"linux", "macos", "windows"}, (
+        "self-maintenance should work on all platforms"
+    )
+
+
+def test_metadata_tags():
+    fm = _frontmatter()
+    tags = fm.get("metadata", {}).get("hermes", {}).get("tags", [])
+    assert "hermes" in tags
+    assert any("maintenance" in t or "update" in t for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# Script contract
+# ---------------------------------------------------------------------------
+
+def test_referenced_scripts_exist():
+    """Every scripts/... path mentioned in SKILL.md must exist on disk."""
+    body = SKILL_MD.read_text(encoding="utf-8")
+    refs = set(re.findall(r"scripts/[\w./-]+\.py", body))
+    assert refs, "SKILL.md references no helper scripts"
+    for ref in refs:
+        assert (SKILL_DIR / ref).exists(), f"SKILL.md references missing {ref}"
+
+
+def test_script_is_python_and_executable():
+    assert SCRIPT.exists(), f"missing {SCRIPT}"
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert text.startswith("#!/usr/bin/env python3"), "script should have a shebang"
+    assert "if __name__" in text, "script should have a main guard"
+    assert "sys.exit(main())" in text or "sys.exit(main" in text, (
+        "script should exit with main()"
+    )
+
+
+def test_script_uses_only_stdlib():
+    """The script must not import hermes_cli or any non-stdlib package at
+    module level. psutil is allowed as an optional import inside a function."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    # Check all top-level import statements
+    import_lines = re.findall(r"^(?:import|from)\s+(\S+)", text, re.MULTILINE)
+    forbidden = {"hermes_cli", "hermes_daemon", "run_agent", "agent"}
+    for imp in import_lines:
+        root = imp.split(".")[0]
+        assert root not in forbidden, f"script imports forbidden package: {imp}"
+    # psutil must be a lazy/optional import inside a function, not at module level
+    toplevel_imports = [
+        line for line in text.splitlines()
+        if re.match(r"^(?:import|from)\s+", line) and "psutil" in line
+    ]
+    assert not toplevel_imports, (
+        "psutil must be a lazy import inside a function, not at module level"
+    )
+
+
+def test_script_has_env_var_skip_flags():
+    """The script should support MAINTENANCE_SKIP_* env vars for selective checks."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "MAINTENANCE_SKIP_UPDATE" in text
+    assert "MAINTENANCE_SKIP_GATEWAY" in text
+    assert "MAINTENANCE_SKIP_CRON" in text
+    assert "MAINTENANCE_REPORT_ALL" in text
+
+
+def test_script_has_cross_platform_gateway_check():
+    """Gateway check must handle both win32 and posix."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "win32" in text
+    assert "pgrep" in text or "ps aux" in text or "psutil" in text
+
+
+def test_script_does_not_auto_update():
+    """The script must never run 'hermes update' without --check. Auto-updating
+    a running gateway is the exact risk that has stalled core PRs."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    # Find all hermes update calls
+    update_calls = re.findall(r'["\']hermes["\']\s*,\s*["\']update["\']', text)
+    for _ in update_calls:
+        pass  # At least we found them
+    # Must not contain a bare update without --check
+    assert '["hermes", "update"]' not in text.replace(" ", ""), (
+        "script must not run bare 'hermes update' — only 'hermes update --check'"
+    )
+    # Verify --check is used
+    assert '"--check"' in text or "'--check'" in text, (
+        "script must use hermes update --check, not hermes update"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Script execution contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("skip_all", [
+    {"MAINTENANCE_SKIP_UPDATE": "1", "MAINTENANCE_SKIP_GATEWAY": "1", "MAINTENANCE_SKIP_CRON": "1"},
+])
+def test_script_runs_silent_when_all_skipped(skip_all, monkeypatch):
+    """When all checks are skipped, the script should exit 0 with no output."""
+    for k, v in skip_all.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.delenv("MAINTENANCE_REPORT_ALL", raising=False)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**__import__("os").environ, **skip_all},
+    )
+    assert result.returncode == 0, f"exit {result.returncode}, stderr: {result.stderr}"
+    assert result.stdout.strip() == "", f"expected no output, got: {result.stdout[:200]}"
+
+
+def test_script_reports_all_mode(monkeypatch):
+    """MAINTENANCE_REPORT_ALL=1 with all skips should still print a header."""
+    env = {
+        "MAINTENANCE_REPORT_ALL": "1",
+        "MAINTENANCE_SKIP_UPDATE": "1",
+        "MAINTENANCE_SKIP_GATEWAY": "1",
+        "MAINTENANCE_SKIP_CRON": "1",
+    }
+    import os
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, **env},
+    )
+    assert "Hermes Maintenance Report" in result.stdout
+    assert "skipped" in result.stdout.lower()
+
+
+def test_script_does_not_crash_without_hermes_exe(monkeypatch):
+    """Script should handle missing hermes executable gracefully."""
+    env = {
+        "MAINTENANCE_SKIP_GATEWAY": "1",
+        "MAINTENANCE_SKIP_CRON": "1",
+        "MAINTENANCE_REPORT_ALL": "1",
+    }
+    # Ensure HERMES_HOME points somewhere that doesn't have hermes
+    import os
+    env["HERMES_HOME"] = "/nonexistent/path/for/test"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, **env},
+    )
+    assert result.returncode in (0, 1), f"unexpected exit {result.returncode}"
+    assert "Traceback" not in result.stderr, f"script crashed: {result.stderr[:300]}"


### PR DESCRIPTION
## What does this PR do?

Adds a bundled skill that sets up nightly Hermes auto-update detection and health checks via the existing cross-platform cron system.

The skill ships a no_agent Python script that:
- Runs hermes update --check and reports commits behind upstream
- Checks gateway process health (psutil if available, falls back to tasklist on Windows / pgrep+ps on macOS+Linux)
- Scans enabled cron jobs for last_status=error via direct SQLite read
- Stays silent when healthy; prints an actionable report only when something needs attention

## Related Issues

Addresses the feature request behind three stalled core PRs: #33514, #56787, #8062. All three propose adding hermes update auto as core CLI subcommands requiring per-platform scheduler implementations. This PR uses the existing cron system instead. Zero core changes.

## Type of Change

- [x] New skill
- [x] Tests

## How to Test

python3 -m pytest tests/skills/test_self_maintenance.py -v

Results: 12 passed on Windows 10 / Python 3.11.
