### PR TITLE
fix(desktop): sticky project membership survives vault cwd moves

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3303,7 +3303,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"Compression lease lost before publication: {parent_session_id}"
                 )
             parent = conn.execute(
-                """SELECT ended_at, cwd, git_branch, git_repo_root,
+                """SELECT ended_at, cwd, git_branch, git_repo_root, project_id,
                           user_id, session_key, chat_id, chat_type,
                           thread_id, display_name, origin_json, profile_name
                    FROM sessions WHERE id = ?""",
@@ -3319,10 +3319,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, model, model_config, system_prompt,
-                   parent_session_id, cwd, git_branch, git_repo_root,
+                   parent_session_id, cwd, git_branch, git_repo_root, project_id,
                    profile_name, user_id, session_key, chat_id, chat_type,
                    thread_id, display_name, origin_json, started_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     child_session_id,
                     source,
@@ -3333,6 +3333,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     cwd or parent["cwd"],
                     parent["git_branch"],
                     parent["git_repo_root"],
+                    parent["project_id"],
                     # Same inheritance contract as _insert_session_row's
                     # compression-fork backfill (#59527 / cross-profile jump
                     # fix): the child stays on the parent's profile and keeps
@@ -3445,7 +3446,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return False
 
     def update_session_cwd(
-        self, session_id: str, cwd: str, git_branch: str = None, git_repo_root: str = None
+        self,
+        session_id: str,
+        cwd: str,
+        git_branch: str = None,
+        git_repo_root: str = None,
+        project_id: str = None,
+        *,
+        clear_project_id: bool = False,
     ) -> None:
         """Persist the session working directory when a frontend knows it.
 
@@ -3455,17 +3463,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (the main checkout's *current* branch is transient and would
         misattribute past sessions).
 
-        ``git_repo_root`` records the git repo this cwd belongs to — the
-        authoritative project key. Resolving it here, at the lowest level, means
-        every surface reads the same membership instead of re-probing git in the
-        GUI over a partial page. Each field is only written when non-empty so a
-        probe failure never clobbers a previously-captured value.
+        ``git_repo_root`` records the git repo this cwd belongs to. Each field is
+        only written when non-empty so a probe failure never clobbers a
+        previously-captured value.
+
+        ``project_id`` is the sticky Desktop Project membership (``p_<hex>`` from
+        projects.db). When set, the sidebar keeps the chat under that explicit
+        project even if the agent later ``cd``s into another git root (e.g. a
+        knowledge-vault checkout that is not a user Project). Omit to leave the
+        column unchanged; pass ``clear_project_id=True`` to detach.
         """
         if not session_id or not cwd:
             return
 
         branch = (git_branch or "").strip()
         repo_root = (git_repo_root or "").strip()
+        sticky = (project_id or "").strip() if project_id is not None else None
 
         sets = ["cwd = ?"]
         params: List[Any] = [cwd]
@@ -3475,6 +3488,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if repo_root:
             sets.append("git_repo_root = ?")
             params.append(repo_root)
+        if clear_project_id:
+            sets.append("project_id = NULL")
+        elif sticky:
+            sets.append("project_id = ?")
+            params.append(sticky)
         params.append(session_id)
 
         def _do(conn):

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -165,6 +165,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cwd TEXT,
     git_branch TEXT,
     git_repo_root TEXT,
+    project_id TEXT,
     billing_provider TEXT,
     billing_base_url TEXT,
     billing_mode TEXT,

--- a/tests/test_session_project_id_sticky.py
+++ b/tests/test_session_project_id_sticky.py
@@ -1,0 +1,60 @@
+"""Sticky sessions.project_id must survive cwd-only updates."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    path = tmp_path / "state.db"
+    sdb = SessionDB(db_path=path)
+    yield sdb
+    sdb.close()
+
+
+def _insert(db: SessionDB, sid: str) -> None:
+    # Minimal create via public API if available; else raw insert after schema.
+    conn = db._conn
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at, cwd) VALUES (?, ?, ?, ?)",
+        (sid, "desktop", time.time(), "/tmp"),
+    )
+    conn.commit()
+
+
+def test_update_session_cwd_sets_and_preserves_project_id(db: SessionDB, tmp_path: Path):
+    work = tmp_path / "work"
+    work.mkdir()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    sid = "sess_sticky_1"
+    _insert(db, sid)
+
+    db.update_session_cwd(sid, str(work), project_id="p_health")
+    row = db._conn.execute(
+        "SELECT cwd, project_id FROM sessions WHERE id = ?", (sid,)
+    ).fetchone()
+    assert row["cwd"] == str(work)
+    assert row["project_id"] == "p_health"
+
+    # Terminal-style cwd update without project_id must not clear sticky id.
+    db.update_session_cwd(sid, str(vault), git_repo_root=str(vault))
+    row = db._conn.execute(
+        "SELECT cwd, git_repo_root, project_id FROM sessions WHERE id = ?", (sid,)
+    ).fetchone()
+    assert row["cwd"] == str(vault)
+    assert row["git_repo_root"] == str(vault)
+    assert row["project_id"] == "p_health"
+
+    db.update_session_cwd(sid, str(work), clear_project_id=True)
+    row = db._conn.execute(
+        "SELECT project_id FROM sessions WHERE id = ?", (sid,)
+    ).fetchone()
+    assert row["project_id"] is None

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -515,3 +515,61 @@ def test_colliding_repo_basenames_disambiguate_labels():
     labels = sorted(p["label"] for p in tree["projects"])
 
     assert labels == ["x/proj", "y/proj"]
+
+
+def test_sticky_project_id_keeps_session_when_cwd_leaves_folder():
+    """Explicit project membership survives cd into a non-project git root.
+
+    Repro: user opens a chat under Health Biohacking; agent cds into a
+    knowledge-vault git checkout (~/brain). Path matching alone would drop the
+    session from the project; sticky project_id must keep it.
+    """
+    health = "/home/me/Projects/health-biohacking-research"
+    vault = "/home/me/brain"
+    projects = [_project("p_health", "Health Biohacking", [health])]
+    # Session was opened under health, then terminal cwd moved to vault.
+    sticky = _session(
+        vault,
+        branch="main",
+        repo_root=vault,
+        project_id="p_health",
+        last_active=2000,
+    )
+    resolve = _resolver(
+        {
+            health: (health, health),
+            vault: (vault, vault),
+        }
+    )
+
+    tree = pt.build_tree(projects, [sticky], [], resolve, hydrate=True)
+
+    owned = next(p for p in tree["projects"] if p["id"] == "p_health")
+    assert sticky["id"] in {s["id"] for s in _sessions_of(owned)}
+    # Vault must not mint an auto project for the sticky-owned session.
+    assert vault not in _real_project_ids(tree)
+    assert "brain" not in [p["label"] for p in tree["projects"] if p["id"] != "p_health"]
+
+
+def test_path_match_still_owns_session_without_sticky_id():
+    health = "/home/me/Projects/health-biohacking-research"
+    projects = [_project("p_health", "Health Biohacking", [health])]
+    sess = _session(health, branch="main", repo_root=health)
+    resolve = _resolver({health: (health, health)})
+
+    tree = pt.build_tree(projects, [sess], [], resolve, hydrate=True)
+    owned = next(p for p in tree["projects"] if p["id"] == "p_health")
+    assert sess["id"] in {s["id"] for s in _sessions_of(owned)}
+
+
+def test_archived_sticky_project_id_is_ignored():
+    health = "/home/me/Projects/health-biohacking-research"
+    vault = "/home/me/brain"
+    projects = [_project("p_health", "Health Biohacking", [health], archived=True)]
+    sticky = _session(vault, branch="main", repo_root=vault, project_id="p_health")
+    resolve = _resolver({vault: (vault, vault)})
+
+    tree = pt.build_tree(projects, [sticky], [], resolve, hydrate=True)
+    # Archived projects are filtered out of active_projects; sticky falls through
+    # and vault becomes an auto project (or home if junk).
+    assert "p_health" not in _real_project_ids(tree)

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -483,7 +483,23 @@ def _project_for_path(index: _FolderIndex, target: str) -> Optional[dict]:
     return index.match(target)[0]
 
 
-def _project_for_session(session: dict, index: _FolderIndex, resolve: Optional[Resolve]) -> Optional[dict]:
+def _project_for_session(
+    session: dict,
+    index: _FolderIndex,
+    resolve: Optional[Resolve],
+    projects_by_id: Optional[dict[str, dict]] = None,
+) -> Optional[dict]:
+    """Own a session: sticky project_id first, then longest folder-path match.
+
+    Sticky membership (set on project create/switch) survives incidental
+    terminal cwd moves into non-project git roots such as a knowledge vault.
+    """
+    sticky = (session.get("project_id") or "").strip()
+    if sticky and projects_by_id:
+        owned = projects_by_id.get(sticky)
+        if owned is not None and not owned.get("archived"):
+            return owned
+
     cwd = (session.get("cwd") or "").strip()
     if not cwd:
         return None
@@ -571,11 +587,12 @@ def build_tree(
     _junk_cwd = is_junk_cwd or (lambda _cwd: False)
     _exists = exists or (lambda _path: True)
     folder_index = _FolderIndex(active_projects)
+    projects_by_id = {p["id"]: p for p in active_projects if p.get("id")}
 
     by_project: dict[str, list[dict]] = {}
     unowned: list[dict] = []
     for session in sessions:
-        owner = _project_for_session(session, folder_index, resolve)
+        owner = _project_for_session(session, folder_index, resolve, projects_by_id)
         if owner:
             by_project.setdefault(owner["id"], []).append(session)
         else:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2697,6 +2697,22 @@ def _persist_session_git_meta(session: dict, cwd: str) -> None:
     threading.Thread(target=_run, name="git-meta", daemon=True).start()
 
 
+def _resolve_project_id_for_path(path: str) -> str:
+    """Return sticky projects.db id for ``path``, or empty string."""
+    path = (path or "").strip()
+    if not path:
+        return ""
+    try:
+        from hermes_cli import projects_db as pdb
+
+        with pdb.connect_closing() as conn:
+            proj = pdb.project_for_path(conn, path)
+            return proj.id if proj is not None else ""
+    except Exception:
+        logger.debug("failed to resolve project_id for path %s", path, exc_info=True)
+        return ""
+
+
 def _set_session_cwd(session: dict, cwd: str) -> str:
     from hermes_constants import translate_cwd_for_wsl_backend
 
@@ -2712,13 +2728,23 @@ def _set_session_cwd(session: dict, cwd: str) -> str:
     # the terminal wandering must not move the workspace again.
     session["cwd_from_settle"] = False
     _register_session_cwd(session)
+    sticky = (session.get("project_id") or "").strip()
+    if not sticky:
+        sticky = _resolve_project_id_for_path(resolved)
+        if sticky:
+            session["project_id"] = sticky
     with _session_db(session) as db:
         if db is not None:
             try:
-                db.update_session_cwd(session.get("session_key", ""), resolved)
+                db.update_session_cwd(
+                    session.get("session_key", ""),
+                    resolved,
+                    project_id=sticky or None,
+                )
             except Exception:
                 logger.debug("failed to persist session cwd", exc_info=True)
     # Branch/repo-root probes are git subprocesses — capture them off the hot path.
+    # Does not clear sticky project_id (update_session_cwd leaves it when omitted).
     _persist_session_git_meta(session, resolved)
     try:
         from tools.terminal_tool import cleanup_vm
@@ -5580,10 +5606,18 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
     session["cwd_from_settle"] = False
     _register_session_cwd(session)
 
+    sticky_project_id = _resolve_project_id_for_path(resolved)
+    if sticky_project_id:
+        session["project_id"] = sticky_project_id
+
     with _session_db(session) as db:
         if db is not None:
             try:
-                db.update_session_cwd(session.get("session_key", ""), resolved)
+                db.update_session_cwd(
+                    session.get("session_key", ""),
+                    resolved,
+                    project_id=sticky_project_id or None,
+                )
             except Exception:
                 logger.debug("failed to persist project workspace cwd", exc_info=True)
 
@@ -11098,9 +11132,12 @@ def _(rid, params, pdb, conn) -> dict:
 
 
 def _is_repo_junk(root: str) -> bool:
-    """A git root we never auto-surface as a project: the bare home dir or
-    anything under HERMES_HOME (~/.hermes by default) — config/sessions/skills,
-    not a workspace. User-created projects pointing there are still honored."""
+    """A git root we never auto-surface as a project: the bare home dir,
+    anything under HERMES_HOME (~/.hermes by default), or paths listed in
+    ``desktop.repo_scan_exclude_paths`` (e.g. a knowledge-vault git checkout
+    that backs GBrain but is not a user Project). User-created projects
+    pointing at those paths are still honored via sticky project_id / folders.
+    """
     if not root:
         return True
 
@@ -11110,7 +11147,20 @@ def _is_repo_junk(root: str) -> bool:
     home = os.path.realpath(os.path.expanduser("~"))
     hermes_home = os.path.realpath(str(get_hermes_home()))
 
-    return real == home or real == hermes_home or real.startswith(hermes_home + os.sep)
+    if real == home or real == hermes_home or real.startswith(hermes_home + os.sep):
+        return True
+
+    try:
+        for raw in _repo_discovery_policy().get("exclude_paths") or []:
+            if not isinstance(raw, str) or not raw.strip():
+                continue
+            ex = os.path.realpath(os.path.expanduser(raw.strip()))
+            if real == ex or real.startswith(ex + os.sep):
+                return True
+    except Exception:
+        pass
+
+    return False
 
 
 def _is_session_cwd_junk(cwd: str) -> bool:
@@ -11317,6 +11367,7 @@ def _project_tree_row(r: dict) -> dict:
         "cwd": r.get("cwd"),
         "git_branch": r.get("git_branch"),
         "git_repo_root": r.get("git_repo_root"),
+        "project_id": r.get("project_id"),
     }
 
 


### PR DESCRIPTION
## Summary

Desktop sidebar membership was driven only by live `cwd` / `git_repo_root`. When a chat was opened under an explicit Project (e.g. Health Biohacking → `~/Projects/health-biohacking-research`) and the agent later `cd`’d into a **non-project git root** used as a knowledge vault (e.g. `~/brain` for GBrain backup), the session was reassigned to an auto-project named after that vault and **disappeared from the real Project** in the sidebar.

That is incorrect product behavior: a vault git checkout is not a user Project.

## Changes

- Add sticky `sessions.project_id` (`p_<hex>` from `projects.db`), reconciled via existing schema column reconcile.
- `project_tree._project_for_session` honors sticky `project_id` **before** path matching (archived ids ignored).
- Stamp `project_id` on project workspace switch and on first cwd under a project folder; pure cwd updates **do not clear** sticky membership (`clear_project_id=` opt-out).
- `desktop.repo_scan_exclude_paths` roots are treated as auto-project junk (same class as `$HOME` / `$HERMES_HOME`).
- Compression child sessions inherit `project_id`.

## Repro (before)

1. Create Desktop Project pointing at `~/Projects/foo`.
2. Open a chat under that project.
3. Agent/tool sets session cwd to another git repo that is **not** a Project folder (knowledge vault).
4. Chat leaves Project folder → appears under auto vault / global SESSIONS.

## Test plan

- [x] `pytest tests/tui_gateway/test_project_tree.py tests/test_session_project_id_sticky.py -q`
- [ ] Manual: project chat + `cd` vault → still under Project after refresh
- [ ] Manual: `desktop.repo_scan_exclude_paths: [/path/to/vault]` → vault does not mint auto project

## Notes

House belts (exclude path + agent hygiene) remain useful; sticky membership is the durable fix.