### PR TITLE
fix(session): auto-title ignores technical user entries (#76842)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -353,6 +353,15 @@ def _auto_title_session(
         logger.debug("Failed to set auto-generated title: %s", e)
 
 
+# Process-local in-flight guard: prevents a second title-generation worker
+# from being spawned for the same session while one is still running. The
+# set is keyed by session_id and entries are removed in the worker's
+# finally block, so a stale entry can only linger if the daemon thread is
+# killed mid-flight (process exit), which makes the whole set moot anyway.
+_title_in_flight: set = set()
+_title_in_flight_lock = threading.Lock()
+
+
 def maybe_auto_title(
     session_db,
     session_id: str,
@@ -364,39 +373,71 @@ def maybe_auto_title(
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
 ) -> None:
-    """Fire-and-forget title generation after the first exchange.
+    """Fire-and-forget title generation.
 
-    Only generates a title when:
-    - This appears to be the first user→assistant exchange
-    - No title is already set
+    Generates a title for any session that does not have one yet, using the
+    persisted title as the single source of truth instead of a first-exchange
+    message-count heuristic. The count heuristic assumed every
+    ``role="user"`` history entry is a real user turn, but gateway/desktop
+    histories persist system-injected markers with ``role="user"`` —
+    context-compaction placeholders, background-process notifications,
+    image-attachment descriptions, and replay duplicates. Once any of those
+    appeared before the first clean response, the session was permanently
+    left untitled with no log line and no retry (#76842).
+
+    A process-local in-flight guard (``_title_in_flight``) prevents a second
+    worker from being spawned for the same session while one is running.
+    The worker re-checks the DB title itself, so a manual ``/title`` set
+    after this guard still wins (see ``auto_title_session``).
+
+    ``conversation_history`` is kept in the signature for backward
+    compatibility with existing callers but is deliberately not used as a
+    first-exchange heuristic.
     """
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
-    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
-    if user_msg_count > 2:
-        return
+    with _title_in_flight_lock:
+        if session_id in _title_in_flight:
+            logger.debug(
+                "Auto-title skipped: worker already in flight for session %s",
+                session_id,
+            )
+            return
+        try:
+            existing = session_db.get_session_title(session_id)
+        except Exception:
+            return
+        if existing:
+            logger.debug(
+                "Auto-title skipped: session %s already titled", session_id
+            )
+            return
+        _title_in_flight.add(session_id)
 
-    # Config read comes after the cheap first-exchange guard so the file
-    # isn't touched on every subsequent turn of a long session.
+    # Config read happens after the cheap guards so the file isn't touched
+    # on every turn of a long session.
     if not _auto_title_enabled():
+        with _title_in_flight_lock:
+            _title_in_flight.discard(session_id)
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
-    thread = threading.Thread(
-        target=auto_title_session,
-        args=(session_db, session_id, user_message, assistant_response),
-        kwargs={
-            "failure_callback": failure_callback,
-            "main_runtime": main_runtime,
-            "title_callback": title_callback,
-            "runtime_validator": runtime_validator,
-        },
-        daemon=True,
-        name="auto-title",
-    )
+    def _run() -> None:
+        try:
+            auto_title_session(
+                session_db,
+                session_id,
+                user_message,
+                assistant_response,
+                failure_callback=failure_callback,
+                main_runtime=main_runtime,
+                title_callback=title_callback,
+                runtime_validator=runtime_validator,
+            )
+        finally:
+            with _title_in_flight_lock:
+                _title_in_flight.discard(session_id)
+
+    thread = threading.Thread(target=_run, daemon=True, name="auto-title")
     thread.start()

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -189,13 +189,15 @@ class TestAutoTitleSession:
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
-    def test_skips_if_not_first_exchange(self):
-        """Should not fire for conversations with more than 2 user messages."""
+    def test_skips_when_session_already_titled(self):
+        """A titled session is never re-titled, no matter how many
+        role=user entries the history carries."""
         db = MagicMock()
+        db.get_session_title.return_value = "Existing Title"
         history = [
-            {"role": "user", "content": "first"},
+            {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] ..."},
             {"role": "assistant", "content": "response 1"},
-            {"role": "user", "content": "second"},
+            {"role": "user", "content": "[IMPORTANT: Background process 42 exited (exit code 1). Command: sleep 30]"},
             {"role": "assistant", "content": "response 2"},
             {"role": "user", "content": "third"},
             {"role": "assistant", "content": "response 3"},
@@ -203,10 +205,63 @@ class TestMaybeAutoTitle:
 
         with patch("agent.title_generator.auto_title_session") as mock_auto:
             maybe_auto_title(db, "sess-1", "third", "response 3", history)
-            # Wait briefly for any thread to start
-            import time
-            time.sleep(0.1)
             mock_auto.assert_not_called()
+
+    def test_fires_despite_technical_user_entries(self):
+        """Regression for #76842: technical role=user markers (compaction
+        placeholders, background notifications, image attachments) must not
+        suppress titling — the persisted title is the single source of
+        truth, not a message-count heuristic."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        history = [
+            {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] older turns"},
+            {"role": "assistant", "content": "compacted response"},
+            {"role": "user", "content": "[IMPORTANT: Background process 42 exited (exit code 1). Command: sleep 30]"},
+            {"role": "assistant", "content": "process notification handled"},
+            {"role": "user", "content": "[The user attached an image: screenshot.png]"},
+            {"role": "assistant", "content": "image description"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+            called = threading.Event()
+            mock_auto.side_effect = lambda *a, **k: called.set()
+            maybe_auto_title(db, "sess-2", "hello", "hi there", history)
+            assert called.wait(timeout=10), "auto_title thread never ran"
+            mock_auto.assert_called_once()
+
+    def test_no_double_fire_while_worker_in_flight(self):
+        """A second maybe_auto_title call for the same session while a
+        worker is still running must not spawn another thread."""
+        import threading
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_worker(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=10)
+
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        try:
+            with patch(
+                "agent.title_generator.auto_title_session",
+                side_effect=slow_worker,
+            ) as mock_auto:
+                maybe_auto_title(db, "sess-3", "hello", "hi there", history)
+                assert started.wait(timeout=10), "first worker never started"
+                # In-flight guard: this must return without spawning.
+                maybe_auto_title(db, "sess-3", "hello", "hi there", history)
+                mock_auto.assert_called_once()
+        finally:
+            release.set()
 
     def test_fires_on_first_exchange(self):
         """Should fire a background thread for the first exchange."""
@@ -221,13 +276,13 @@ class TestMaybeAutoTitle:
             import threading
             called = threading.Event()
             mock_auto.side_effect = lambda *a, **k: called.set()
-            maybe_auto_title(db, "sess-1", "hello", "hi there", history)
+            maybe_auto_title(db, "sess-4", "hello", "hi there", history)
             # Event-based wait: sleep-sync flaked when the daemon thread
             # wasn't scheduled within the fixed nap on a loaded runner.
             assert called.wait(timeout=10), "auto_title thread never ran"
             mock_auto.assert_called_once_with(
                 db,
-                "sess-1",
+                "sess-4",
                 "hello",
                 "hi there",
                 failure_callback=None,


### PR DESCRIPTION
Closes #76842

## Problem

Sessions permanently stay untitled when the turn history contains more than 2 `role="user"` messages, because `maybe_auto_title()` counts **all** `role="user"` entries in `conversation_history` as real user input. In gateway/desktop histories, most `role="user"` entries are not user input at all: context-compaction placeholders, background-process notifications, image-attachment descriptions, and replay duplicates. Once any of these appears before the first clean response, the session is never titled — silently, with no log line and no retry.

## Fix

Replace the message-count first-exchange heuristic with two cheap, robust guards in `maybe_auto_title()`:

- **Persisted title as the single source of truth** — the session is titled as long as it has no title yet (`session_db.get_session_title()`), regardless of how many `role="user"` history entries exist.
- **Process-local in-flight guard** (`_title_in_flight` set + lock) — prevents a second worker from being spawned for the same session while one is still running; the entry is removed in the worker's `finally` block.

`conversation_history` stays in the signature for backward compatibility with existing callers but is deliberately no longer used as a first-exchange heuristic.

## Tests

`tests/agent/test_title_generator.py` — 17 tests pass, including:

- `test_fires_despite_technical_user_entries` — regression test: history full of compaction/notification/attachment markers still triggers titling.
- `test_skips_when_session_already_titled` — a titled session is never re-titled (replaces the old count-heuristic test).
- `test_no_double_fire_while_worker_in_flight` — second call while a worker is running spawns nothing.
