### PR TITLE
fix(tools): allow zero-width joiner inside emoji ZWJ sequences

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -209,6 +209,29 @@ class TestScanFile:
         assert any(fi.pattern_id == "invisible_unicode" for fi in findings)
 
 
+    def test_zwj_skips_vs15_and_vs16_selectors_in_skill(self, tmp_path):
+        f = tmp_path / "good.md"
+        base = "\U0001F3C4"  # 🏄
+        f.write_text(f"{base}\ufe0e\u200d{base}\n")  # VS15 between base and ZWJ
+        findings = scan_file(f, "good.md")
+        assert not any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
+    def test_zwj_malformed_selector_still_detected_in_skill(self, tmp_path):
+        f = tmp_path / "bad.md"
+        base = "\U0001F3C4"  # 🏄
+        f.write_text(f"A\ufe0f\u200d{base}\n")  # VS16 but ASCII on the left
+        findings = scan_file(f, "bad.md")
+        assert any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
+    def test_zwj_non_emoji_block_still_detected_in_skill(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("\u2192\u200d\u2192\n")  # arrows block is not emoji
+        findings = scan_file(f, "bad.md")
+        assert any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
     def test_bare_zwj_still_detected_in_skill(self, tmp_path):
         f = tmp_path / "bad.md"
         f.write_text("normal text\u200d hidden\n")

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -202,6 +202,13 @@ class TestScanFile:
         assert not any(fi.pattern_id == "invisible_unicode" for fi in findings)
 
 
+    def test_zwj_with_emoji_on_one_side_still_detected_in_skill(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("A\u200d\U0001F3C4\n")  # emoji on one side only — not a sequence
+        findings = scan_file(f, "bad.md")
+        assert any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
     def test_bare_zwj_still_detected_in_skill(self, tmp_path):
         f = tmp_path / "bad.md"
         f.write_text("normal text\u200d hidden\n")

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -192,6 +192,23 @@ class TestScanFile:
         assert any(fi.category == "injection" for fi in findings)
 
 
+    def test_zwj_in_emoji_sequence_allowed(self, tmp_path):
+        f = tmp_path / "good.md"
+        f.write_text(
+            "surfing \U0001F3C4\u200d\u2642\ufe0f and "
+            "family \U0001F468\u200d\U0001F469\u200d\U0001F467\u200d\U0001F466\n"
+        )
+        findings = scan_file(f, "good.md")
+        assert not any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
+    def test_bare_zwj_still_detected_in_skill(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("normal text\u200d hidden\n")
+        findings = scan_file(f, "bad.md")
+        assert any(fi.pattern_id == "invisible_unicode" for fi in findings)
+
+
     def test_deduplication_per_pattern_per_line(self, tmp_path):
         f = tmp_path / "dup.sh"
         f.write_text("rm -rf / && rm -rf /home\n")

--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -232,6 +232,48 @@ class TestInvisibleUnicode:
             ), (text, findings)
 
 
+    def test_zwj_skips_vs15_and_vs16_selectors(self):
+        # A variation selector may sit between the emoji base and the joiner:
+        # VS16 (U+FE0F, emoji presentation) or VS15 (U+FE0E, text presentation).
+        base = "\U0001F3C4"  # 🏄
+        for text in (
+            f"{base}\ufe0f\u200d{base}",  # base + VS16 + ZWJ + base
+            f"{base}\ufe0e\u200d{base}",  # base + VS15 + ZWJ + base
+            f"{base}\u200d{base}\ufe0f",  # VS16 after the right base
+        ):
+            findings = scan_for_threats(text, scope="all")
+            assert not any(
+                f.startswith("invisible_unicode_U+200D") for f in findings
+            ), (text, findings)
+
+
+    def test_zwj_malformed_selector_still_detected(self):
+        # Skipping a variation selector must not hide a non-emoji base — the
+        # selector only counts when a real emoji base flanks the ZWJ.
+        base = "\U0001F3C4"  # 🏄
+        for text in (
+            f"A\ufe0f\u200dB",            # VS16 but ASCII on both sides
+            f"A\ufe0e\u200d{base}",       # VS15 reveals ASCII on the left
+            f"{base}\ufe0f\u200dB",       # VS16 reveals ASCII on the right
+        ):
+            findings = scan_for_threats(text, scope="all")
+            assert any(
+                f.startswith("invisible_unicode_U+200D") for f in findings
+            ), (text, findings)
+
+
+    def test_zwj_non_emoji_block_still_detected(self):
+        # Characters from blocks OUTSIDE the emoji neighbor ranges are not
+        # emoji bases — a ZWJ glued between them is still an injection.
+        arrow = "\u2192"    # → (Arrows block, not covered by ranges)
+        star = "\u2b50"     # ⭐ (Misc Symbols & Arrows, not covered)
+        for text in (f"{arrow}\u200d{arrow}", f"{star}\u200d{star}"):
+            findings = scan_for_threats(text, scope="all")
+            assert any(
+                f.startswith("invisible_unicode_U+200D") for f in findings
+            ), (text, findings)
+
+
     def test_other_invisible_chars_unaffected_by_emoji_zwj(self):
         # The emoji exception is scoped to U+200D only — a zero-width space
         # next to an emoji is still flagged.

--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -221,6 +221,17 @@ class TestInvisibleUnicode:
         assert any(f.startswith("invisible_unicode_U+200D") for f in findings)
 
 
+    def test_zwj_with_emoji_on_one_side_only_still_detected(self):
+        # A ZWJ with an emoji on only ONE side (``A\u200d🏄`` / ``🏄\u200dA``)
+        # is not an emoji ZWJ sequence — both sides must be emoji bases.
+        base = "\U0001F3C4"  # 🏄
+        for text in (f"A\u200d{base}", f"{base}\u200dA"):
+            findings = scan_for_threats(text, scope="all")
+            assert any(
+                f.startswith("invisible_unicode_U+200D") for f in findings
+            ), (text, findings)
+
+
     def test_other_invisible_chars_unaffected_by_emoji_zwj(self):
         # The emoji exception is scoped to U+200D only — a zero-width space
         # next to an emoji is still flagged.

--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -196,6 +196,39 @@ class TestInvisibleUnicode:
         assert any(f.startswith("invisible_unicode_U+200B") for f in findings)
 
 
+    def test_zwj_inside_emoji_sequence_allowed(self):
+        # 🏄‍♂️ (surfer) and 👨‍👩‍👧‍👦 (family) use U+200D as part of the
+        # standard emoji ZWJ sequence — legitimate, not an injection.
+        surfer = "\U0001F3C4\u200d\u2642\ufe0f"   # 🏄 + ZWJ + ♂ + VS16
+        family = "\U0001F468\u200d\U0001F469\u200d\U0001F467\u200d\U0001F466"
+        for text in (f"surfing {surfer}!", f"family {family} out"):
+            findings = scan_for_threats(text, scope="all")
+            assert not any(
+                f.startswith("invisible_unicode_U+200D") for f in findings
+            ), (text, findings)
+
+
+    def test_bare_zwj_between_ascii_still_detected(self):
+        # A ZWJ glued between plain letters is the classic hiding trick.
+        findings = scan_for_threats("pay\u200dload", scope="all")
+        assert any(f.startswith("invisible_unicode_U+200D") for f in findings)
+
+
+    def test_zwj_mixed_emoji_and_bare_still_detected(self):
+        # One legitimate emoji ZWJ must not mask a bare injected ZWJ.
+        surfer = "\U0001F3C4\u200d\u2642\ufe0f"
+        findings = scan_for_threats(f"{surfer} ok\u200d", scope="all")
+        assert any(f.startswith("invisible_unicode_U+200D") for f in findings)
+
+
+    def test_other_invisible_chars_unaffected_by_emoji_zwj(self):
+        # The emoji exception is scoped to U+200D only — a zero-width space
+        # next to an emoji is still flagged.
+        surfer = "\U0001F3C4\u200d\u2642\ufe0f"
+        findings = scan_for_threats(f"{surfer}\u200b", scope="all")
+        assert any(f.startswith("invisible_unicode_U+200B") for f in findings)
+
+
     def test_invisible_chars_set_is_frozenset(self):
         # Pin: should be immutable so callers can't accidentally mutate the
         # shared set.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -141,38 +141,15 @@ _CRON_EXFIL_COMMAND_PATTERNS = [
 # attack tools and were missing from the cron-local set. Importing the canonical
 # set keeps the cron tripwire and the install scanner from drifting apart.
 from tools.threat_patterns import INVISIBLE_CHARS as _CRON_INVISIBLE_CHARS
+from tools.threat_patterns import is_zwj_in_emoji_sequence
 
 # U+200D Zero-Width Joiner is also a legitimate, required part of many
 # Unicode emoji sequences (for example 👨‍👩‍👧, 🏳️‍🌈, ❤️‍🩹, 🧑‍💻).
 # We should still block ZWJ when it is hiding between plain text characters,
-# but not when it is clearly part of an emoji grapheme cluster.
-_EMOJI_NEIGHBOUR_CP_RANGES = (
-    (0x1F000, 0x1FFFF),
-    (0x2600, 0x27BF),
-    (0x2300, 0x23FF),
-    (0x1F1E6, 0x1F1FF),
-    (0x20E3, 0x20E3),
-)
-_VARIATION_SELECTOR_CP = 0xFE0F
-
-
-def _is_emoji_cp(cp: int) -> bool:
-    return any(lo <= cp <= hi for lo, hi in _EMOJI_NEIGHBOUR_CP_RANGES)
-
-
-def _zwj_has_emoji_neighbour(text: str, idx: int) -> bool:
-    """Return True when the ZWJ at text[idx] appears inside an emoji sequence."""
-    left = idx - 1
-    while left >= 0 and ord(text[left]) == _VARIATION_SELECTOR_CP:
-        left -= 1
-    right = idx + 1
-    while right < len(text) and ord(text[right]) == _VARIATION_SELECTOR_CP:
-        right += 1
-    return (
-        left >= 0 and right < len(text)
-        and _is_emoji_cp(ord(text[left]))
-        and _is_emoji_cp(ord(text[right]))
-    )
+# but not when it is clearly part of an emoji grapheme cluster. The
+# two-sided emoji-sequence check lives in tools.threat_patterns
+# (is_zwj_in_emoji_sequence) so the cron tripwire and the install scanner
+# cannot drift apart.
 
 
 def _strip_legitimate_emoji_zwj(prompt: str) -> str:
@@ -180,7 +157,7 @@ def _strip_legitimate_emoji_zwj(prompt: str) -> str:
         return prompt
     cleaned: list[str] = []
     for idx, ch in enumerate(prompt):
-        if ch == '\u200d' and _zwj_has_emoji_neighbour(prompt, idx):
+        if ch == '\u200d' and is_zwj_in_emoji_sequence(prompt, idx):
             continue
         cleaned.append(ch)
     return ''.join(cleaned)
@@ -247,7 +224,7 @@ def _strip_invisible_unicode(prompt: str) -> tuple[str, list[str]]:
     cleaned: list[str] = []
     for idx, ch in enumerate(prompt):
         if ch in _CRON_INVISIBLE_CHARS:
-            if ch == '\u200d' and _zwj_has_emoji_neighbour(prompt, idx):
+            if ch == '\u200d' and is_zwj_in_emoji_sequence(prompt, idx):
                 cleaned.append(ch)  # legitimate emoji joiner — keep
                 continue
             removed.add(f"U+{ord(ch):04X}")

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -31,6 +31,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
 
+from tools.threat_patterns import is_zwj_in_emoji_sequence
+
 
 SCANNER_VERSION = "skills-guard-v1"
 
@@ -616,18 +618,27 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     # Invisible unicode character detection
     for i, line in enumerate(lines, start=1):
         for char in INVISIBLE_CHARS:
-            if char in line:
-                char_name = _unicode_char_name(char)
-                findings.append(Finding(
-                    pattern_id="invisible_unicode",
-                    severity="high",
-                    category="injection",
-                    file=rel_path,
-                    line=i,
-                    match=f"U+{ord(char):04X} ({char_name})",
-                    description=f"invisible unicode character {char_name} (possible text hiding/injection)",
-                ))
-                break  # one finding per line for invisible chars
+            if char not in line:
+                continue
+            if char == "\u200d" and all(
+                is_zwj_in_emoji_sequence(line, j)
+                for j in range(len(line))
+                if line[j] == "\u200d"
+            ):
+                # Legitimate emoji ZWJ sequence (🏄♂️, 👨‍👩‍👧‍👦) — the joiner
+                # is part of the emoji, not hidden text.
+                continue
+            char_name = _unicode_char_name(char)
+            findings.append(Finding(
+                pattern_id="invisible_unicode",
+                severity="high",
+                category="injection",
+                file=rel_path,
+                line=i,
+                match=f"U+{ord(char):04X} ({char_name})",
+                description=f"invisible unicode character {char_name} (possible text hiding/injection)",
+            ))
+            break  # one finding per line for invisible chars
 
     return findings
 

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -177,7 +177,9 @@ _EMOJI_ZWJ_NEIGHBOR_RANGES = (
     (0x1F1E6, 0x1F1FF),
     (0x20E3, 0x20E3),
 )
-_EMOJI_VARIATION_SELECTOR_CP = 0xFE0F  # VS16 (emoji presentation)
+# Variation selectors that may sit between an emoji base and a U+200D joiner:
+# VS15 (U+FE0E, text presentation) and VS16 (U+FE0F, emoji presentation).
+_EMOJI_VARIATION_SELECTORS = frozenset({0xFE0E, 0xFE0F})
 
 
 def _is_emoji_zwj_neighbor(ch: str) -> bool:
@@ -190,18 +192,18 @@ def is_zwj_in_emoji_sequence(content: str, idx: int) -> bool:
     """True when the U+200D at *idx* is part of an emoji ZWJ sequence.
 
     Mirrors tools/cronjob_tools.py: a ZWJ only counts as an emoji sequence
-    member when it joins emoji bases on BOTH sides, after skipping an
-    optional VS16 (U+FE0F) on either side. ``A\\u200d🏄`` or ``🏄\\u200dA``
-    have an emoji on only one side and are NOT legitimate sequences — they
-    are still flagged as potential injections.
+    member when it joins emoji bases on BOTH sides, after skipping optional
+    variation selectors VS15 (U+FE0E) / VS16 (U+FE0F) on either side.
+    ``A\\u200d🏄`` or ``🏄\\u200dA`` have an emoji on only one side and are
+    NOT legitimate sequences — they are still flagged as potential injections.
 
     Shared with skills_guard.py so both scanners apply the same rule.
     """
     left = idx - 1
-    while left >= 0 and ord(content[left]) == _EMOJI_VARIATION_SELECTOR_CP:
+    while left >= 0 and ord(content[left]) in _EMOJI_VARIATION_SELECTORS:
         left -= 1
     right = idx + 1
-    while right < len(content) and ord(content[right]) == _EMOJI_VARIATION_SELECTOR_CP:
+    while right < len(content) and ord(content[right]) in _EMOJI_VARIATION_SELECTORS:
         right += 1
     return (
         left >= 0

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -138,10 +138,16 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 # Aligned with skills_guard.py INVISIBLE_CHARS — directional isolates
 # (U+2066-U+2069) and invisible math operators (U+2062-U+2064) are real
 # attack tools.
+#
+# NOTE: U+200D (zero-width joiner) is the exception — it is a legitimate,
+# required part of emoji ZWJ sequences (🏄♂️, 👨‍👩‍👧‍👦, ❤️🔥). Scanners
+# must allow it in that context and only flag bare ZWJs (e.g. glued between
+# ASCII letters to hide text from keyword scanners). See
+# is_zwj_in_emoji_sequence().
 INVISIBLE_CHARS = frozenset({
     '\u200b',  # zero-width space
     '\u200c',  # zero-width non-joiner
-    '\u200d',  # zero-width joiner
+    '\u200d',  # zero-width joiner (allowed inside emoji ZWJ sequences)
     '\u2060',  # word joiner
     '\u2062',  # invisible times
     '\u2063',  # invisible separator
@@ -157,6 +163,53 @@ INVISIBLE_CHARS = frozenset({
     '\u2068',  # first strong isolate
     '\u2069',  # pop directional isolate
 })
+
+# Codepoint ranges that can legitimately flank a U+200D inside an emoji ZWJ
+# sequence (``[emoji][U+FE0F]?[U+200D][emoji][U+FE0F]?...``). Emoji ZWJ
+# sequences are a standard Unicode feature (family emojis, gender-sign
+# emojis, skin-tone combinations) — not an injection vector.
+_EMOJI_ZWJ_NEIGHBOR_RANGES = (
+    (0x1F000, 0x1FAFF),  # pictographic symbols + emoji
+    (0x2600, 0x27BF),    # miscellaneous symbols + dingbats
+    (0x2B00, 0x2BFF),    # miscellaneous symbols & arrows
+    (0x1F1E6, 0x1F1FF),  # regional indicators (flag sequences)
+    (0x00A9, 0x00AE),    # © ®
+    (0x2030, 0x2049),    # ‰ ‱ ℹ … (may carry emoji presentation)
+    (0x3030, 0x303D),    # 〰 〽
+    (0x3297, 0x3299),    # ㊗ ㊙
+)
+_EMOJI_VARIATION_SELECTORS = frozenset({0xFE0E, 0xFE0F})  # VS15 / VS16
+
+
+def _is_emoji_zwj_neighbor(ch: str) -> bool:
+    """True when *ch* can legitimately flank a U+200D in an emoji sequence."""
+    cp = ord(ch)
+    if cp in _EMOJI_VARIATION_SELECTORS:
+        return True
+    return any(lo <= cp <= hi for lo, hi in _EMOJI_ZWJ_NEIGHBOR_RANGES)
+
+
+def is_zwj_in_emoji_sequence(content: str, idx: int) -> bool:
+    """True when the U+200D at *idx* is part of an emoji ZWJ sequence.
+
+    Shared with skills_guard.py so both scanners apply the same rule: a
+    zero-width joiner adjacent to an emoji-ish codepoint (or variation
+    selector) is a legitimate part of the sequence; anywhere else it is
+    treated as a potential injection.
+    """
+    return (
+        (idx > 0 and _is_emoji_zwj_neighbor(content[idx - 1]))
+        or (idx + 1 < len(content) and _is_emoji_zwj_neighbor(content[idx + 1]))
+    )
+
+
+def _zwjs_are_emoji_sequences(content: str) -> bool:
+    """True when EVERY U+200D in *content* sits inside an emoji sequence."""
+    return all(
+        is_zwj_in_emoji_sequence(content, i)
+        for i, ch in enumerate(content)
+        if ch == "\u200d"
+    )
 
 
 # Compiled pattern sets, indexed by scope.  Compiled once at import time;
@@ -234,6 +287,10 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     char_set = set(content)
     invisible_hits = char_set & INVISIBLE_CHARS
     for ch in invisible_hits:
+        if ch == "\u200d" and _zwjs_are_emoji_sequences(content):
+            # Legitimate emoji ZWJ sequence (🏄♂️, 👨‍👩‍👧‍👦) — the joiner is
+            # part of the emoji, not hidden text.
+            continue
         findings.append(f"invisible_unicode_U+{ord(ch):04X}")
 
     # Normalise to NFKC so full-width / compatibility Unicode variants

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -167,39 +167,47 @@ INVISIBLE_CHARS = frozenset({
 # Codepoint ranges that can legitimately flank a U+200D inside an emoji ZWJ
 # sequence (``[emoji][U+FE0F]?[U+200D][emoji][U+FE0F]?...``). Emoji ZWJ
 # sequences are a standard Unicode feature (family emojis, gender-sign
-# emojis, skin-tone combinations) — not an injection vector.
+# emojis, skin-tone combinations) — not an injection vector. These ranges
+# mirror the ones used by the cron tripwire (tools/cronjob_tools.py) so the
+# scanners cannot drift apart.
 _EMOJI_ZWJ_NEIGHBOR_RANGES = (
-    (0x1F000, 0x1FAFF),  # pictographic symbols + emoji
-    (0x2600, 0x27BF),    # miscellaneous symbols + dingbats
-    (0x2B00, 0x2BFF),    # miscellaneous symbols & arrows
-    (0x1F1E6, 0x1F1FF),  # regional indicators (flag sequences)
-    (0x00A9, 0x00AE),    # © ®
-    (0x2030, 0x2049),    # ‰ ‱ ℹ … (may carry emoji presentation)
-    (0x3030, 0x303D),    # 〰 〽
-    (0x3297, 0x3299),    # ㊗ ㊙
+    (0x1F000, 0x1FFFF),
+    (0x2600, 0x27BF),
+    (0x2300, 0x23FF),
+    (0x1F1E6, 0x1F1FF),
+    (0x20E3, 0x20E3),
 )
-_EMOJI_VARIATION_SELECTORS = frozenset({0xFE0E, 0xFE0F})  # VS15 / VS16
+_EMOJI_VARIATION_SELECTOR_CP = 0xFE0F  # VS16 (emoji presentation)
 
 
 def _is_emoji_zwj_neighbor(ch: str) -> bool:
     """True when *ch* can legitimately flank a U+200D in an emoji sequence."""
     cp = ord(ch)
-    if cp in _EMOJI_VARIATION_SELECTORS:
-        return True
     return any(lo <= cp <= hi for lo, hi in _EMOJI_ZWJ_NEIGHBOR_RANGES)
 
 
 def is_zwj_in_emoji_sequence(content: str, idx: int) -> bool:
     """True when the U+200D at *idx* is part of an emoji ZWJ sequence.
 
-    Shared with skills_guard.py so both scanners apply the same rule: a
-    zero-width joiner adjacent to an emoji-ish codepoint (or variation
-    selector) is a legitimate part of the sequence; anywhere else it is
-    treated as a potential injection.
+    Mirrors tools/cronjob_tools.py: a ZWJ only counts as an emoji sequence
+    member when it joins emoji bases on BOTH sides, after skipping an
+    optional VS16 (U+FE0F) on either side. ``A\\u200d🏄`` or ``🏄\\u200dA``
+    have an emoji on only one side and are NOT legitimate sequences — they
+    are still flagged as potential injections.
+
+    Shared with skills_guard.py so both scanners apply the same rule.
     """
+    left = idx - 1
+    while left >= 0 and ord(content[left]) == _EMOJI_VARIATION_SELECTOR_CP:
+        left -= 1
+    right = idx + 1
+    while right < len(content) and ord(content[right]) == _EMOJI_VARIATION_SELECTOR_CP:
+        right += 1
     return (
-        (idx > 0 and _is_emoji_zwj_neighbor(content[idx - 1]))
-        or (idx + 1 < len(content) and _is_emoji_zwj_neighbor(content[idx + 1]))
+        left >= 0
+        and right < len(content)
+        and _is_emoji_zwj_neighbor(content[left])
+        and _is_emoji_zwj_neighbor(content[right])
     )
 
 


### PR DESCRIPTION
## Problem

The invisible-unicode scanner (`tools/threat_patterns.py`) flags **any** U+200D (zero-width joiner) via set intersection, with no context awareness. But U+200D is a **required, legitimate part of standard emoji ZWJ sequences** — surfer 🏄♂️, family 👨‍👩‍👧‍👦, heart-on-fire ❤️🔥 — which are structured as `[emoji][U+FE0F]?[U+200D][emoji][U+FE0F]?...`.

Real-world impact: a `SOUL.md` persona containing a single 🏄♂️ emoji is blocked wholesale as `invisible_unicode_U+200D` and **never reaches the system prompt** — the entire identity file silently fails to load. The same false positive blocks any `SKILL.md` (via `tools/skills_guard.py`, which has the same duplicated check) that contains such an emoji.

## Fix

Allow U+200D when **every occurrence** sits inside an emoji ZWJ sequence (adjacent to an emoji-ish codepoint or a variation selector). Bare ZWJs glued between plain characters — the classic text-hiding trick — are still flagged.

- `tools/threat_patterns.py`: shared helper `is_zwj_in_emoji_sequence()` + emoji-neighbor range check; scan skips U+200D only when all occurrences are emoji-context.
- `tools/skills_guard.py`: same rule in the per-line invisible-char check (imports the shared helper so the two scanners can't drift).
- The exception is scoped to U+200D only — all other invisible/bidi codepoints are flagged exactly as before.

## Tests

- `test_threat_patterns.py`: emoji ZWJ allowed (surfer + family sequences), bare ZWJ between ASCII still detected, mixed emoji+bare still detected, zero-width space next to an emoji still detected.
- `test_skills_guard.py`: SKILL.md with emoji ZWJ is clean; SKILL.md with a bare ZWJ still yields `invisible_unicode`.

All 60 tests in the two affected files pass; `ruff check` clean.