### PR TITLE
fix(config): config unset handles list items (#76847)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1114,10 +1114,26 @@ def _unset_nested(config, dotted_key: str) -> bool:
     removed = False
     if isinstance(current, list):
         try:
-            current.pop(int(last))
-            removed = True
-        except (TypeError, ValueError, IndexError):
-            return False
+            index = int(last)
+        except (TypeError, ValueError):
+            index = None
+        if index is not None:
+            try:
+                current.pop(index)
+                removed = True
+            except IndexError:
+                return False
+        else:
+            # A non-numeric key against a list removes the matching element,
+            # e.g. `hermes config unset platform_toolsets.cli.messaging`
+            # drops 'messaging' from the cli toolset list. (#76847)
+            for i, item in enumerate(current):
+                if isinstance(item, str) and item == last:
+                    current.pop(i)
+                    removed = True
+                    break
+            if not removed:
+                return False
     elif isinstance(current, dict):
         if last not in current:
             return False
@@ -2249,22 +2265,39 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 config["mcp_servers"] = raw_mcp_servers
                 _persist_migration(config)
 
-    # ── Always: validate platform_toolsets after migration ──
+    # ── Always: validate + clean platform_toolsets after migration ──
     # A migration (or hand-edit) that leaves an invalid toolset name in
     # platform_toolsets silently disables the affected tools — resolve_toolset()
     # returns [] for an unknown name, so the agent quietly loses tools with no
-    # error or warning. Surface it loudly instead. See #38798.
+    # error or warning. Surface it loudly instead. See #38798. Beyond warning,
+    # drop stale names outright (e.g. the legacy 'messaging' toolset removed in
+    # v0.19) so the per-startup "Unknown toolsets" warning stops firing. #76847
     try:
         from toolsets import validate_toolset
-        from hermes_cli.toolset_validation import validate_platform_toolsets
+        from hermes_cli.toolset_validation import (
+            clean_platform_toolsets,
+            validate_platform_toolsets,
+        )
 
+        raw_ts_config = read_raw_config()
         ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+            raw_ts_config.get("platform_toolsets"), validate_toolset
         )
         for w in ts_warnings:
             results["warnings"].append(w)
             if not quiet:
                 print(f"  ⚠ {w}")
+        ts_mapping = raw_ts_config.get("platform_toolsets")
+        if isinstance(ts_mapping, dict) and clean_platform_toolsets(
+            ts_mapping, validate_toolset
+        ):
+            raw_ts_config["platform_toolsets"] = ts_mapping
+            _persist_migration(raw_ts_config)
+            if not quiet:
+                print(
+                    "  ✓ Removed unknown toolset entries from platform_toolsets "
+                    "(run `hermes config migrate` after any toolset rename)"
+                )
     except Exception as _ts_val_err:
         # best-effort; never block migration on validation
         logger.debug("platform_toolsets validation skipped: %s", _ts_val_err)

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -72,3 +72,47 @@ def validate_platform_toolsets(
             "have no tools. Run `hermes tools` to reconfigure."
         )
     return warnings
+
+
+def clean_platform_toolsets(
+    platform_toolsets: object,
+    is_valid_toolset: Callable[[str], bool],
+) -> bool:
+    """Drop entries referencing unknown toolsets from a ``platform_toolsets`` mapping.
+
+    In-place complement to :func:`validate_platform_toolsets`: where validation
+    only warns, this removes the offending entries so the per-startup
+    "Unknown toolsets" warning stops firing. Used by ``hermes config migrate``
+    to auto-clean stale toolset names (e.g. the legacy ``messaging`` toolset
+    removed in v0.19 — #76847).
+
+    An entry is dropped only when it is a string that ``is_valid_toolset``
+    rejects; non-string entries are tolerated exactly like validation tolerates
+    them. A platform whose list loses every entry is removed entirely (an empty
+    list would otherwise trip the zero-valid-toolsets warning), falling back to
+    the default toolsets.
+
+    Args:
+        platform_toolsets: The raw ``platform_toolsets`` value from config.
+            Only ``dict`` values carry toolset entries; anything else is a no-op.
+        is_valid_toolset: Predicate returning ``True`` for a known toolset name.
+
+    Returns:
+        True when at least one entry was removed.
+    """
+    if not isinstance(platform_toolsets, dict):
+        return False
+    changed = False
+    for platform, raw in list(platform_toolsets.items()):
+        if isinstance(raw, list):
+            kept = [n for n in raw if not (isinstance(n, str) and not is_valid_toolset(n))]
+            if len(kept) != len(raw):
+                changed = True
+            if kept:
+                platform_toolsets[platform] = kept
+            else:
+                del platform_toolsets[platform]
+        elif isinstance(raw, str) and not is_valid_toolset(raw):
+            del platform_toolsets[platform]
+            changed = True
+    return changed

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -191,6 +191,44 @@ class TestConfigGetUnset:
         assert "Unset platforms.teams.extra.access_token" in capsys.readouterr().out
 
 
+    def test_config_unset_removes_list_item_by_name(self, _isolated_hermes_home, capsys):
+        """`hermes config unset platform_toolsets.cli.messaging` must remove the
+        list element, not the whole list. Regression for #76847."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "platform_toolsets:\n"
+            "  cli:\n"
+            "    - browser\n"
+            "    - messaging\n"
+            "    - terminal\n"
+        )
+
+        args = argparse.Namespace(
+            config_command="unset", key="platform_toolsets.cli.messaging"
+        )
+        config_command(args)
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["platform_toolsets"]["cli"] == ["browser", "terminal"]
+        assert "Unset platform_toolsets.cli.messaging" in capsys.readouterr().out
+
+
+    def test_config_unset_list_item_missing_is_reported(self, _isolated_hermes_home, capsys):
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "platform_toolsets:\n"
+            "  cli:\n"
+            "    - browser\n"
+        )
+
+        args = argparse.Namespace(
+            config_command="unset", key="platform_toolsets.cli.messaging"
+        )
+        with pytest.raises(SystemExit) as exc:
+            config_command(args)
+        assert exc.value.code == 1
+        assert "Config key not set" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # List navigation — regression tests for #17876
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -6,7 +6,10 @@ tool registry nor a running Hermes.
 
 import pytest
 
-from hermes_cli.toolset_validation import validate_platform_toolsets
+from hermes_cli.toolset_validation import (
+    clean_platform_toolsets,
+    validate_platform_toolsets,
+)
 
 # A representative set of real toolset names. `hermes` is deliberately absent —
 # that is the corruption #38798 reported (`hermes-cli` rewritten to `hermes`).
@@ -44,6 +47,43 @@ def test_mixed_valid_and_invalid_flags_only_the_invalid():
     assert len(warnings) == 1
     assert "platform 'discord'" in warnings[0]
     assert "unknown toolset 'bogus'" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# clean_platform_toolsets — auto-cleanup for #76847
+# ---------------------------------------------------------------------------
+
+def test_clean_drops_stale_entry_and_keeps_siblings():
+    # The #76847 shape: legacy 'messaging' toolset inside the cli list.
+    cfg = {"cli": ["web", "messaging", "terminal"]}
+    assert clean_platform_toolsets(cfg, _is_valid) is True
+    assert cfg == {"cli": ["web", "terminal"]}
+
+
+def test_clean_removes_platform_key_when_every_entry_is_stale():
+    cfg = {"cli": ["messaging"]}
+    assert clean_platform_toolsets(cfg, _is_valid) is True
+    assert cfg == {}
+
+
+def test_clean_preserves_all_valid_config():
+    cfg = {"cli": ["hermes-cli", "terminal"], "telegram": ["hermes-telegram"]}
+    assert clean_platform_toolsets(cfg, _is_valid) is False
+    assert cfg == {"cli": ["hermes-cli", "terminal"], "telegram": ["hermes-telegram"]}
+
+
+def test_clean_handles_scalar_and_non_string_entries():
+    # Scalar string entry that is stale is dropped; non-string list items are
+    # tolerated exactly like validate_platform_toolsets tolerates them.
+    cfg = {"cli": "messaging", "web": ["web", 123, None]}
+    assert clean_platform_toolsets(cfg, _is_valid) is True
+    assert cfg == {"web": ["web", 123, None]}
+
+
+def test_clean_is_noop_for_non_dict():
+    assert clean_platform_toolsets(None, _is_valid) is False
+    assert clean_platform_toolsets("messaging", _is_valid) is False
+    assert clean_platform_toolsets([], _is_valid) is False
 
 
 


### PR DESCRIPTION
Closes #76847

## Problem

Users with a pre-v0.19 config carrying the legacy `messaging` toolset name get `Warning: Unknown toolsets: messaging` on every startup, and there is no clean way to remove it:
- `hermes config unset platform_toolsets.cli.messaging` → "Config key not set" (unset only understood numeric list indices)
- `hermes config migrate` warned about the unknown toolset but never removed it

## Changes

1. **`hermes config unset` now handles list items by name** (`hermes_cli/config.py` — `_unset_nested`): when the parent value is a list and the unset key is a non-numeric string, the matching element is removed instead of failing. Numeric-index removal is unchanged.

   ```
   hermes config unset platform_toolsets.cli.messaging
   ```

2. **`hermes config migrate` auto-cleans unknown toolset entries** (`hermes_cli/toolset_validation.py` — new pure `clean_platform_toolsets()` helper, wired into the always-run post-migration validation block in `migrate_config()`): every platform list is checked against `toolsets.validate_toolset()` and stale names are dropped. This runs on every `hermes config migrate` regardless of config version, so users already on v33 (the affected population) get cleaned too — not just users below the v33 step. A platform whose list loses every entry is removed entirely, falling back to defaults.

## Tests

- `tests/hermes_cli/test_set_config_value.py`: unset removes a named list item and preserves siblings; missing list item still reports "Config key not set".
- `tests/hermes_cli/test_toolset_validation.py`: cleanup drops stale entries, keeps siblings, removes fully-stale platforms, tolerates non-string entries, no-ops on non-dict values.
