### PR TITLE
fix(provider): honor base_url override for minimax (#76836)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -145,6 +145,26 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _provider_default_host(provider: str) -> str:
+    """Return the provider's declared default base-URL host, or ``""``.
+
+    Consults the resolved provider catalog (models.dev + Hermes overlays)
+    first, then the runtime credential registry's ``inference_base_url`` for
+    providers the catalog doesn't carry.
+    """
+    from hermes_cli.providers import get_provider
+
+    pdef = get_provider(provider)
+    if pdef is not None and pdef.base_url:
+        host = base_url_hostname(pdef.base_url)
+        if host:
+            return host
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.inference_base_url:
+        return base_url_hostname(pconfig.inference_base_url)
+    return ""
+
+
 def _fallback_api_mode(provider: str, base_url: str, model: str = "") -> str:
     """Resolve api_mode when no explicit/persisted mode applies.
 
@@ -153,6 +173,17 @@ def _fallback_api_mode(provider: str, base_url: str, model: str = "") -> str:
     ``providers.determine_api_mode`` — which already handles host mandates,
     dual-wire providers, and the registry transport map — and only then the
     ``chat_completions`` default for genuinely unknown providers/endpoints.
+
+    The provider-declared transport only applies while the endpoint sits on
+    the provider's own default host. A ``model.base_url`` override that points
+    at a *different* endpoint — an OpenAI-compatible relay in front of
+    MiniMax, a corporate egress gateway, a local LiteLLM instance — does not
+    inherit the declared wire protocol: the override is protocol-unknown, so
+    the safe generic ``chat_completions`` default applies. Without this gate,
+    a proxied ``minimax`` setup is resolved as ``anthropic_messages`` and
+    every request is built with Anthropic-shaped auth (``x-api-key``) against
+    an endpoint that expects ``Authorization: Bearer`` — HTTP 401, or a
+    silent reroute to a fallback provider (#76836).
 
     Before this helper the runtime paths consulted URL detection ONLY and
     silently landed reasoning providers on ``chat_completions`` whenever the
@@ -167,7 +198,19 @@ def _fallback_api_mode(provider: str, base_url: str, model: str = "") -> str:
         return detected
     from hermes_cli.providers import determine_api_mode
 
-    return determine_api_mode(provider, base_url, model) or "chat_completions"
+    declared = determine_api_mode(provider, base_url, model) or "chat_completions"
+    if declared == "chat_completions":
+        return declared
+    # Non-chat declared transports (anthropic_messages, codex_responses) are
+    # statements about the provider's own endpoint. When base_url was
+    # overridden to a foreign endpoint, do not assume the declared transport
+    # still applies — fall back to the generic OpenAI-compatible protocol
+    # instead of sending Anthropic/Responses-shaped requests (with the wrong
+    # auth header) at a relay that speaks chat/completions (#76836).
+    default_host = _provider_default_host(provider)
+    if default_host and base_url_host_matches(base_url, default_host):
+        return declared
+    return "chat_completions"
 
 
 def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> str:

--- a/tests/hermes_cli/test_runtime_transport_precedence.py
+++ b/tests/hermes_cli/test_runtime_transport_precedence.py
@@ -8,9 +8,15 @@ the provider overlay itself declares.
 
 Contract pinned here: when URL detection has no opinion, the runtime falls
 back to ``providers.determine_api_mode(provider, base_url, model)`` (the
-provider's declared transport), and only lands on ``chat_completions`` for
-genuinely unknown providers/endpoints. Covers the explicit-runtime path and
-the API-key-provider path; the pool-entry path shares the same helper.
+provider's declared transport) **only while the endpoint sits on the
+provider's own default host**, and lands on ``chat_completions`` for
+genuinely unknown providers/endpoints. A ``model.base_url`` override that
+points at a different endpoint (OpenAI-compatible relay in front of MiniMax,
+corporate egress gateway, LiteLLM, ...) is protocol-unknown: the declared
+transport must not be assumed, or a proxied ``minimax`` setup gets
+Anthropic-shaped requests / ``x-api-key`` against a chat/completions
+endpoint and 401s (#76836). Covers the explicit-runtime path and the
+API-key-provider path; the pool-entry path shares the same helper.
 """
 
 from __future__ import annotations
@@ -34,13 +40,46 @@ class TestFallbackApiMode:
     def test_openai_api_official_hosts_resolve_codex_responses(self, base_url):
         assert _fallback_api_mode("openai-api", base_url) == "codex_responses"
 
-    def test_openai_api_unknown_custom_proxy_still_uses_declared_transport(self):
-        # Explicitly selected openai-api against a custom proxy keeps the
-        # provider's declared transport (mirrors determine_api_mode semantics;
-        # host identity is a separate question from provider selection).
+    def test_openai_api_custom_proxy_override_uses_generic_chat(self):
+        # Explicitly selected openai-api against a custom proxy does NOT keep
+        # the provider's declared transport: the override points at a
+        # different endpoint whose wire protocol is unknown, so the safe
+        # generic chat_completions default applies (pre-33a2f29a6 behavior).
+        # Regression class of #76836 — the declared transport is a statement
+        # about the provider's own endpoint, not about foreign relays.
         assert (
             _fallback_api_mode("openai-api", "https://proxy.corp.test/v1")
-            == "codex_responses"
+            == "chat_completions"
+        )
+
+    def test_minimax_proxy_override_falls_back_to_chat_completions(self):
+        # #76836: minimax with model.base_url overridden to an
+        # OpenAI-compatible relay (token-optimization proxy, LiteLLM,
+        # corporate egress) must resolve chat_completions — not the
+        # provider's declared anthropic_messages transport — or every request
+        # 401s (x-api-key sent to an Authorization: Bearer endpoint).
+        assert (
+            _fallback_api_mode("minimax", "http://127.0.0.1:8787/v1", "MiniMax-M3")
+            == "chat_completions"
+        )
+
+    def test_minimax_cn_proxy_override_falls_back_to_chat_completions(self):
+        assert (
+            _fallback_api_mode("minimax-cn", "http://127.0.0.1:8788/v1")
+            == "chat_completions"
+        )
+
+    def test_declared_transport_applies_on_provider_own_host(self):
+        # The declared non-chat transport still holds on the provider's own
+        # default host — the #53054 fix is preserved for non-URL-detected
+        # endpoints (bare host, no /anthropic hint).
+        assert (
+            _fallback_api_mode("minimax", "https://api.minimax.io")
+            == "anthropic_messages"
+        )
+        assert (
+            _fallback_api_mode("minimax-cn", "https://api.minimaxi.com")
+            == "anthropic_messages"
         )
 
     def test_lookalike_host_is_not_treated_as_official(self):


### PR DESCRIPTION
## Summary

Fixes a regression from `33a2f29a6` ("fall back to the provider's declared transport, not `chat_completions`", #53054).

**Root cause:** the runtime fallback resolver (`_fallback_api_mode`) now unconditionally consults `providers.determine_api_mode()` when URL detection has no opinion — which returns the provider's *declared* transport (`anthropic_messages` for `minimax`) even when `model.base_url` was explicitly overridden to a *different* endpoint (an OpenAI-compatible relay/proxy in front of MiniMax). The endpoint behind the override speaks `chat/completions`, but requests are built with Anthropic-shaped auth (`x-api-key`) → HTTP 401 `invalid x-api-key`, or a silent reroute to a fallback provider when one is configured.

**Fix:** the declared-transport fallback now applies **only while the endpoint sits on the provider's own default host**. A `model.base_url` override pointing at a foreign endpoint is treated as protocol-unknown and falls back to the safe generic `chat_completions` (pre-`33a2f29a6` behavior). This is a class-level fix in the shared `_fallback_api_mode` helper — all three runtime lanes (pool-entry, explicit-runtime, API-key-provider) route through it, so no lane can drift.

**What is preserved:**
- #53054's fix: regional OpenAI hosts (`us./eu.api.openai.com`) still resolve `codex_responses` via URL detection, and declared transports still apply on the provider's own default host (e.g. bare-host MiniMax without an `/anthropic` hint).
- URL detection keeps top priority everywhere (`/anthropic` suffix, Kimi `/coding`, official OpenAI hosts, `api.x.ai`).
- The existing `model.api_mode` override continues to work as an explicit pin.

**Behavior change (same bug class):** `openai-api` pointed at a custom proxy (e.g. `proxy.corp.test`) now resolves `chat_completions` instead of the declared `codex_responses` — arbitrary OpenAI-compatible relays speak `chat/completions`, and the previous behavior sent Responses-API-shaped requests at them.

## Test Plan

- `tests/hermes_cli/test_runtime_transport_precedence.py` — updated contract + new regression cases:
  - `minimax` / `minimax-cn` behind an OpenAI-compatible relay → `chat_completions`
  - declared transport still applies on the provider's own host
  - official/regional OpenAI hosts → `codex_responses`
- `test_api_key_providers.py`, `test_runtime_provider_resolution.py`, `test_determine_api_mode_hostname.py`, model-switch suites, `test_minimax_provider.py` — all pass (155 + 70 targeted tests green).

Closes #76836
