### PR TITLE
fix(computer-use): install cua-driver scripts from GitHub, not cua.ai

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1377,7 +1377,9 @@ def _run_cua_driver_installer(
       GitHub raw into a temp dir and exec ``/bin/bash <dir>/install.sh``.
       ``install.sh`` prefers on-disk siblings over fetching them from the
       ``cua.ai`` vanity CDN, so shipping all three keeps the install working
-      even when that host does not resolve.
+      even when that host does not resolve. Only ``install.sh`` and
+      ``_install-rust.sh`` are required; ``_install-common.sh`` is optional
+      upstream and its download failure only warns.
     * Windows       → ``powershell -NoProfile -ExecutionPolicy Bypass -Command
       "irm …/install.ps1 | iex"``.
 
@@ -1431,7 +1433,13 @@ def _run_cua_driver_installer(
             "https://raw.githubusercontent.com/trycua/cua/main/"
             "libs/cua-driver/scripts/"
         )
-        script_names = ("install.sh", "_install-rust.sh", "_install-common.sh")
+        # install.sh and _install-rust.sh are load-bearing — without them there
+        # is nothing to exec. _install-common.sh is optional by upstream's own
+        # contract: _install-rust.sh defines no-op stubs when it cannot load
+        # that sibling, so a failed fetch there is a warning, not an abort
+        # (review on #76861).
+        required_scripts = ("install.sh", "_install-rust.sh")
+        optional_scripts = ("_install-common.sh",)
         # One pasteable line: mktemp + three GitHub raw curls + bash install.sh.
         # Keep as a single logical command so failure/timeout print sites stay
         # one _print_info each.
@@ -1445,11 +1453,8 @@ def _run_cua_driver_installer(
         )
         script_dir = _tempfile.mkdtemp(prefix="cua-driver-install-")
 
-        def _download_failed(detail: str) -> None:
-            _print_warning(f"    cua-driver installer download failed: {detail}")
-            shutil.rmtree(script_dir, ignore_errors=True)
-
-        for name in script_names:
+        def _download(name: str) -> Optional[str]:
+            """Fetch one script; None on success, else a failure detail."""
             try:
                 dl = subprocess.run(
                     ["curl", "-fsSL", "-o", os.path.join(script_dir, name),
@@ -1457,11 +1462,33 @@ def _run_cua_driver_installer(
                     capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
                 )
             except (subprocess.TimeoutExpired, OSError) as e:
-                _download_failed(f"{name}: {e}")
-                return False
+                return f"{name}: {e}"
             if dl.returncode != 0:
-                _download_failed(f"{name}: {(dl.stderr or '').strip()[:200]}")
+                return f"{name}: {(dl.stderr or '').strip()[:200]}"
+            return None
+
+        for name in required_scripts:
+            detail = _download(name)
+            if detail:
+                _print_warning(f"    cua-driver installer download failed: {detail}")
+                shutil.rmtree(script_dir, ignore_errors=True)
                 return False
+        for name in optional_scripts:
+            detail = _download(name)
+            if detail:
+                # Drop any truncated/empty artifact: an unreadable sibling that
+                # still exists would source cleanly and skip the stubs.
+                try:
+                    os.remove(os.path.join(script_dir, name))
+                except OSError:
+                    pass
+                _print_warning(
+                    f"    cua-driver installer optional download failed: {detail}"
+                )
+                _print_info(
+                    "    Continuing — upstream defines no-op stubs when "
+                    f"{name} is absent."
+                )
         install_cmd = ["/bin/bash", os.path.join(script_dir, "install.sh")]
     use_shell = False
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1420,8 +1420,11 @@ def _run_cua_driver_installer(
         # _install-common.sh from its own directory when they are present and
         # only falls back to fetching them from the cua.ai vanity CDN
         # otherwise, so the whole set is downloaded as siblings and no DNS
-        # beyond GitHub is required. The manual hint stays the upstream
-        # one-liner since that's what the docs/README teach.
+        # beyond GitHub is required.
+        #
+        # The manual recovery hint must materialize the same three siblings —
+        # a lone `curl install.sh | bash` reintroduces the cua.ai hop when
+        # public DNS for that host is NXDOMAIN (see #76860 / review on #76861).
         import tempfile as _tempfile
 
         scripts_base = (
@@ -1429,7 +1432,17 @@ def _run_cua_driver_installer(
             "libs/cua-driver/scripts/"
         )
         script_names = ("install.sh", "_install-rust.sh", "_install-common.sh")
-        manual_hint = f'/bin/bash -c "$(curl -fsSL {scripts_base}install.sh)"'
+        # One pasteable line: mktemp + three GitHub raw curls + bash install.sh.
+        # Keep as a single logical command so failure/timeout print sites stay
+        # one _print_info each.
+        manual_hint = (
+            'tmpdir=$(mktemp -d) && '
+            f'base={scripts_base.rstrip("/")} && '
+            'curl -fsSL -o "$tmpdir/install.sh" "$base/install.sh" && '
+            'curl -fsSL -o "$tmpdir/_install-rust.sh" "$base/_install-rust.sh" && '
+            'curl -fsSL -o "$tmpdir/_install-common.sh" "$base/_install-common.sh" && '
+            '/bin/bash "$tmpdir/install.sh"'
+        )
         script_dir = _tempfile.mkdtemp(prefix="cua-driver-install-")
 
         def _download_failed(detail: str) -> None:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1372,7 +1372,12 @@ def _run_cua_driver_installer(
     The scripts are idempotent: they always download the latest release, so
     re-running on an already-installed system performs an upgrade.
 
-    * macOS / Linux → ``curl -fsSL …/install.sh | /bin/bash``.
+    * macOS / Linux → download the full upstream script set (``install.sh``
+      plus its ``_install-rust.sh`` / ``_install-common.sh`` siblings) from
+      GitHub raw into a temp dir and exec ``/bin/bash <dir>/install.sh``.
+      ``install.sh`` prefers on-disk siblings over fetching them from the
+      ``cua.ai`` vanity CDN, so shipping all three keeps the install working
+      even when that host does not resolve.
     * Windows       → ``powershell -NoProfile -ExecutionPolicy Bypass -Command
       "irm …/install.ps1 | iex"``.
 
@@ -1405,46 +1410,46 @@ def _run_cua_driver_installer(
             'powershell -NoProfile -ExecutionPolicy Bypass -Command '
             f'"{ps_oneliner}"'
         )
-        script_path = None
+        script_dir = None
     else:
         # Download-then-exec instead of `bash -c "$(curl …)"`: no shell=True,
-        # no command substitution, and the script lands in a mkstemp file
-        # (unpredictable name, 0600) rather than a fixed /tmp path — avoiding
+        # no command substitution, and the scripts land in a mkdtemp directory
+        # (unpredictable name, 0700) rather than fixed /tmp paths — avoiding
         # both the shell-injection surface and a symlink/TOCTOU race on
-        # multi-user machines. The manual hint stays the upstream one-liner
-        # since that's what the docs/README teach.
+        # multi-user machines. install.sh sources _install-rust.sh /
+        # _install-common.sh from its own directory when they are present and
+        # only falls back to fetching them from the cua.ai vanity CDN
+        # otherwise, so the whole set is downloaded as siblings and no DNS
+        # beyond GitHub is required. The manual hint stays the upstream
+        # one-liner since that's what the docs/README teach.
         import tempfile as _tempfile
 
-        install_url = (
+        scripts_base = (
             "https://raw.githubusercontent.com/trycua/cua/main/"
-            "libs/cua-driver/scripts/install.sh"
+            "libs/cua-driver/scripts/"
         )
-        manual_hint = f'/bin/bash -c "$(curl -fsSL {install_url})"'
-        fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
-        os.close(fd)
-        try:
-            dl = subprocess.run(
-                ["curl", "-fsSL", "-o", script_path, install_url],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
-            )
-        except (subprocess.TimeoutExpired, OSError) as e:
-            _print_warning(f"    cua-driver installer download failed: {e}")
+        script_names = ("install.sh", "_install-rust.sh", "_install-common.sh")
+        manual_hint = f'/bin/bash -c "$(curl -fsSL {scripts_base}install.sh)"'
+        script_dir = _tempfile.mkdtemp(prefix="cua-driver-install-")
+
+        def _download_failed(detail: str) -> None:
+            _print_warning(f"    cua-driver installer download failed: {detail}")
+            shutil.rmtree(script_dir, ignore_errors=True)
+
+        for name in script_names:
             try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
-        if dl.returncode != 0:
-            _print_warning(
-                "    cua-driver installer download failed: "
-                f"{(dl.stderr or '').strip()[:200]}"
-            )
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
-        install_cmd = ["/bin/bash", script_path]
+                dl = subprocess.run(
+                    ["curl", "-fsSL", "-o", os.path.join(script_dir, name),
+                     scripts_base + name],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
+                )
+            except (subprocess.TimeoutExpired, OSError) as e:
+                _download_failed(f"{name}: {e}")
+                return False
+            if dl.returncode != 0:
+                _download_failed(f"{name}: {(dl.stderr or '').strip()[:200]}")
+                return False
+        install_cmd = ["/bin/bash", os.path.join(script_dir, "install.sh")]
     use_shell = False
 
     if show_progress:
@@ -1620,11 +1625,8 @@ def _run_cua_driver_installer(
         _print_warning(f"    cua-driver {label.lower()} failed: {e}")
         return False
     finally:
-        if script_path:
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
+        if script_dir:
+            shutil.rmtree(script_dir, ignore_errors=True)
 
 
 def _run_post_setup(post_setup_key: str):

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -722,7 +722,7 @@ class TestInstallerNoShell:
     on disk instead of curling them from the cua.ai vanity CDN, whose public
     DNS is NXDOMAIN."""
 
-    def _run(self, download_rc=0):
+    def _run(self, download_rc=0, fail_names=None, installer_rc=0):
         import subprocess
         from unittest.mock import MagicMock
         from hermes_cli import tools_config
@@ -730,14 +730,16 @@ class TestInstallerNoShell:
         calls = []
         fake_proc = MagicMock()
         fake_proc.pid = 1
-        fake_proc.returncode = 0
+        fake_proc.returncode = installer_rc
         fake_proc.communicate.return_value = ("", None)
 
         def fake_run(cmd, **kw):
             calls.append(("run", cmd, kw))
             m = MagicMock()
-            m.returncode = download_rc
-            m.stderr = "curl: (6) could not resolve" if download_rc else ""
+            name = cmd[-1].rsplit("/", 1)[-1]
+            rc = 6 if fail_names and name in fail_names else download_rc
+            m.returncode = rc
+            m.stderr = "curl: (6) could not resolve" if rc else ""
             return m
 
         def fake_popen(cmd, **kw):
@@ -747,7 +749,9 @@ class TestInstallerNoShell:
         with patch("platform.system", return_value="Linux"), \
              patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
-             patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config.shutil, "which",
+                          return_value=None if installer_rc
+                          else "/usr/local/bin/cua-driver"), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -806,6 +810,37 @@ class TestInstallerNoShell:
         ok, calls = self._run(download_rc=6)
         assert ok is False
         assert not [c for c in calls if c[0] == "popen"]
+
+    def test_required_rust_sibling_failure_returns_false_without_exec(self):
+        """_install-rust.sh is load-bearing — no stubs exist for it."""
+        ok, calls = self._run(fail_names={"_install-rust.sh"})
+        assert ok is False
+        assert not [c for c in calls if c[0] == "popen"]
+        # Aborted before the optional sibling was even attempted.
+        assert [c[1][-1].rsplit("/", 1)[-1] for c in calls if c[0] == "run"] == [
+            "install.sh", "_install-rust.sh",
+        ]
+
+    def test_optional_common_sibling_failure_still_execs_installer(self):
+        """_install-common.sh is optional upstream: _install-rust.sh defines
+        no-op stubs when it cannot load that sibling, so a failed fetch must
+        not abort an otherwise-working install (review on #76861)."""
+        ok, calls = self._run(fail_names={"_install-common.sh"})
+        assert ok is True
+        popen_calls = [c for c in calls if c[0] == "popen"]
+        assert len(popen_calls) == 1
+        assert popen_calls[0][1][1].endswith("/install.sh")
+        # All three still attempted, in order.
+        assert [c[1][-1].rsplit("/", 1)[-1] for c in calls if c[0] == "run"] == [
+            "install.sh", "_install-rust.sh", "_install-common.sh",
+        ]
+
+    def test_optional_sibling_failure_still_defers_to_installer_result(self):
+        """Warn-and-continue, not warn-and-succeed: the installer's own
+        outcome still decides the return value."""
+        ok, calls = self._run(fail_names={"_install-common.sh"}, installer_rc=1)
+        assert ok is False
+        assert len([c for c in calls if c[0] == "popen"]) == 1
 
     def test_posix_manual_hint_materializes_three_github_siblings(self):
         """Failure/timeout recovery must not re-teach the broken lone curl|bash.
@@ -882,6 +917,36 @@ class TestInstallerNoShell:
         # The whole temp dir goes, not just install.sh.
         assert not os.path.exists(os.path.dirname(captured["script"]))
         assert not os.path.exists(captured["script"])
+
+    def test_temp_script_dir_removed_on_required_download_failure(self):
+        """The fail-fast return happens before the try/finally, so that path
+        has to clean the mkdtemp directory itself."""
+        import os
+        import tempfile
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        made = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def fake_mkdtemp(*args, **kwargs):
+            path = real_mkdtemp(*args, **kwargs)
+            made.append(path)
+            return path
+
+        with patch("platform.system", return_value="Linux"), \
+             patch("tempfile.mkdtemp", side_effect=fake_mkdtemp), \
+             patch("subprocess.run",
+                   return_value=MagicMock(returncode=6, stderr="curl: (6)")), \
+             patch("subprocess.Popen") as popen, \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is False
+        popen.assert_not_called()
+        assert made and not os.path.exists(made[0])
 
 
 class TestConfirmedVersionPinning:

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -714,9 +714,13 @@ class TestInstallerTimeoutKillsProcessGroup:
 
 class TestInstallerNoShell:
     """The POSIX installer path must not use shell=True or command
-    substitution: the script is downloaded to a mkstemp file and exec'd
-    as a plain argv list (salvage of #34974's intent, without the fixed
-    /tmp path TOCTOU that PR introduced)."""
+    substitution: the upstream script set is downloaded into a mkdtemp
+    directory and install.sh is exec'd as a plain argv list (salvage of
+    #34974's intent, without the fixed /tmp path TOCTOU that PR introduced).
+
+    All three scripts come from GitHub raw so install.sh finds its siblings
+    on disk instead of curling them from the cua.ai vanity CDN, whose public
+    DNS is NXDOMAIN."""
 
     def _run(self, download_rc=0):
         import subprocess
@@ -756,22 +760,54 @@ class TestInstallerNoShell:
         assert ok is True
         run_calls = [c for c in calls if c[0] == "run"]
         popen_calls = [c for c in calls if c[0] == "popen"]
-        assert len(run_calls) == 1 and len(popen_calls) == 1
-        # Download: plain argv curl, no shell.
-        dl_cmd = run_calls[0][1]
-        assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
-        # Exec: argv list ["/bin/bash", <mkstemp path>], shell=False.
+        # One curl per upstream script: install.sh + both siblings.
+        assert len(run_calls) == 3 and len(popen_calls) == 1
+        # Downloads: plain argv curl, no shell, all from GitHub raw.
+        urls = []
+        for _, dl_cmd, _kw in run_calls:
+            assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
+            urls.append(dl_cmd[-1])
+        for url in urls:
+            assert url.startswith(
+                "https://raw.githubusercontent.com/trycua/cua/"
+            ), url
+            # The vanity CDN is NXDOMAIN — it must not be in the fetch path.
+            assert "cua.ai" not in url, url
+        assert [u.rsplit("/", 1)[-1] for u in urls] == [
+            "install.sh", "_install-rust.sh", "_install-common.sh",
+        ]
+        # Exec: argv list ["/bin/bash", <temp dir>/install.sh], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
         assert isinstance(exec_cmd, list) and exec_cmd[0] == "/bin/bash"
         assert "cua-driver-install-" in exec_cmd[1]
+        assert exec_cmd[1].endswith("/install.sh")
         assert exec_kw.get("shell") is False
 
+    def test_sibling_scripts_land_next_to_install_sh(self):
+        """install.sh only skips the cua.ai fetch when the siblings are in
+        its own directory."""
+        import os
+        ok, calls = self._run()
+        assert ok is True
+        # curl -fsSL -o <path> <url> — the target path is the arg after -o.
+        out_paths = [
+            c[1][c[1].index("-o") + 1] for c in calls if c[0] == "run"
+        ]
+        install_sh = [c[1][1] for c in calls if c[0] == "popen"][0]
+        assert {os.path.basename(p) for p in out_paths} == {
+            "install.sh", "_install-rust.sh", "_install-common.sh",
+        }
+        assert {os.path.dirname(p) for p in out_paths} == {
+            os.path.dirname(install_sh)
+        }
+
     def test_download_failure_returns_false_without_exec(self):
+        # Fail-fast: the first curl failing is enough to abort the install.
         ok, calls = self._run(download_rc=6)
         assert ok is False
         assert not [c for c in calls if c[0] == "popen"]
 
-    def test_temp_script_removed_after_run(self, tmp_path):
+    def test_temp_script_dir_removed_after_run(self, tmp_path):
         import os
         captured = {}
         import subprocess
@@ -802,6 +838,8 @@ class TestInstallerNoShell:
             tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
 
         assert "script" in captured
+        # The whole temp dir goes, not just install.sh.
+        assert not os.path.exists(os.path.dirname(captured["script"]))
         assert not os.path.exists(captured["script"])
 
 

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -807,6 +807,47 @@ class TestInstallerNoShell:
         assert ok is False
         assert not [c for c in calls if c[0] == "popen"]
 
+    def test_posix_manual_hint_materializes_three_github_siblings(self):
+        """Failure/timeout recovery must not re-teach the broken lone curl|bash.
+
+        teknium/hermes-sweeper on #76861: the old hint was
+        `curl install.sh | bash`, which has no on-disk siblings and falls
+        back to cua.ai under NXDOMAIN.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 1  # installer ran but did not leave binary
+        fake_proc.communicate.return_value = ("", None)
+        info_msgs = []
+
+        with patch("platform.system", return_value="Linux"), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config.shutil, "which", return_value=None), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info", side_effect=lambda m: info_msgs.append(m)), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is False
+        joined = "\n".join(info_msgs)
+        # Must teach the three-script sibling workflow.
+        assert "install.sh" in joined
+        assert "_install-rust.sh" in joined
+        assert "_install-common.sh" in joined
+        assert "raw.githubusercontent.com/trycua/cua" in joined
+        assert "mktemp" in joined
+        # Must not be the lone curl|bash one-liner (no siblings → cua.ai).
+        assert "cua.ai" not in joined
+        # Reject the old form: command-sub curl of install.sh alone.
+        assert '$(curl' not in joined
+        assert "curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)" not in joined
+
     def test_temp_script_dir_removed_after_run(self, tmp_path):
         import os
         captured = {}


### PR DESCRIPTION
## Bug Description

`hermes computer-use install` fails on POSIX when public DNS for `cua.ai` is NXDOMAIN, even though Hermes already downloads `install.sh` from GitHub raw and release binaries come from GitHub Releases.

Fixes #76860

## Root Cause

`_run_cua_driver_installer` downloads only `install.sh` into a lone `mkstemp` path. Upstream `install.sh` then falls back to:

```text
https://cua.ai/driver/_install-rust.sh
```

when `_install-rust.sh` / `_install-common.sh` are not siblings on disk. Public DNS for `cua.ai` currently does not resolve (Cloudflare/Google); GitHub remains reachable. The install path was half-hardened (entry script from GitHub, dependency chain still vanity-CDN).

## Fix

POSIX path only in `_run_cua_driver_installer`:

- `tempfile.mkdtemp(prefix="cua-driver-install-")`
- sequential `curl -fsSL` of `install.sh`, `_install-rust.sh`, `_install-common.sh` from
  `https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/`
- exec `/bin/bash <dir>/install.sh` so on-disk siblings are preferred
- `finally`: `shutil.rmtree(script_dir)`

Windows path unchanged. `manual_hint` still documents the GitHub raw one-liner.

Defense in depth: even if trycua restores `cua.ai` DNS, Hermes should not hard-require that host for scripts that already live on GitHub.

## How to Verify

1. With `cua.ai` unresolvable (or simulated), run the installer path — should no longer curl `cua.ai`.
2. Unit: `pytest tests/hermes_cli/test_install_cua_driver.py -q -o addopts=`
3. Optional live: call `_run_cua_driver_installer(pin_version="…")` and confirm success + `cua-driver --version`.

## Test Plan

- [x] Added/updated regression tests (`TestInstallerNoShell`: 3 GitHub raw downloads, no `cua.ai` URLs, sibling dir layout, temp dir cleanup)
- [x] Existing `test_install_cua_driver.py` suite passes (46 passed, 2 skipped locally)
- [x] Manual verification of the fix on Linux x86_64 (forced full installer run succeeded; no `cua.ai` contact)

## Risk Assessment

Low — POSIX installer download layout only; Windows untouched; fail-fast on any of the three curls; cleanup via `rmtree(ignore_errors=True)`. Blast radius limited to cua-driver install/upgrade. If trycua renames a sibling script, the download list here needs a follow-up (same class of coupling as trusting upstream `install.sh` today).