### PR TITLE
fix(gateway): respect explicit platform disable for HA and wrap kanban auto-decompose in profile scope

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2082,7 +2082,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
+        ha_explicit = bool(config.platforms[Platform.HOMEASSISTANT].extra.get("_enabled_explicit", False))
+        if not ha_explicit or config.platforms[Platform.HOMEASSISTANT].enabled:
+            config.platforms[Platform.HOMEASSISTANT].enabled = True
         config.platforms[Platform.HOMEASSISTANT].token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1347,75 +1347,78 @@ class GatewayKanbanWatchersMixin:
             """
             try:
                 from hermes_cli import kanban_decompose as _decomp
+                from gateway.run import _profile_runtime_scope
             except Exception as exc:  # pragma: no cover
                 logger.warning(
                     "kanban auto-decompose: import failed (%s); skipping", exc,
                 )
                 return 0
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            attempted = 0
-            successes = 0
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                if attempted >= auto_decompose_per_tick:
-                    break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
+            profile_home = getattr(self, "home", None) or Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+            with _profile_runtime_scope(Path(profile_home)):
                 try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
+                    boards = _kb.list_boards(include_archived=False)
+                except Exception:
+                    boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+                attempted = 0
+                successes = 0
+                for b in boards:
+                    slug = b.get("slug") or _kb.DEFAULT_BOARD
+                    if attempted >= auto_decompose_per_tick:
+                        break
+                    # Pin this board for the duration of the call — same
+                    # pattern as the dashboard specify endpoint. The
+                    # decomposer module connects with no board kwarg and
+                    # relies on the env var.
+                    prev_env = os.environ.get("HERMES_KANBAN_BOARD")
                     try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
+                        os.environ["HERMES_KANBAN_BOARD"] = slug
                         try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
-                            )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
-                        else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
+                            triage_ids = _decomp.list_triage_ids()
+                        except Exception as exc:
                             logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
+                                "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                                slug, exc,
                             )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
-            return successes
+                            triage_ids = []
+                        for tid in triage_ids:
+                            if attempted >= auto_decompose_per_tick:
+                                break
+                            attempted += 1
+                            try:
+                                outcome = _decomp.decompose_task(
+                                    tid, author="auto-decomposer",
+                                )
+                            except Exception:
+                                logger.exception(
+                                    "kanban auto-decompose: decompose_task crashed on %s",
+                                    tid,
+                                )
+                                continue
+                            if outcome.ok:
+                                successes += 1
+                                if outcome.fanout and outcome.child_ids:
+                                    logger.info(
+                                        "kanban auto-decompose [%s]: %s → %d children",
+                                        slug, tid, len(outcome.child_ids),
+                                    )
+                                else:
+                                    logger.info(
+                                        "kanban auto-decompose [%s]: %s → single task (no fanout)",
+                                        slug, tid,
+                                    )
+                            else:
+                                # Common no-op reasons (no aux client configured) shouldn't
+                                # spam logs every tick. Log at debug.
+                                logger.debug(
+                                    "kanban auto-decompose [%s]: decompose_task failed on %s (%s)",
+                                    slug, tid, outcome.reason,
+                                )
+                    finally:
+                        if prev_env is not None:
+                            os.environ["HERMES_KANBAN_BOARD"] = prev_env
+                        else:
+                            os.environ.pop("HERMES_KANBAN_BOARD", None)
+                return successes
 
         logger.info(
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval


### PR DESCRIPTION
### Summary
Fixes two related issues when running Hermes Agent in multiplexed gateway mode ():

1. ****: Home Assistant platform overrides did not check  when  was present in the environment. In multiplexed setups, secondary worker profiles with  were force-enabled during env override processing, causing duplicate credential errors on startup.
2. ****: Embedded  ran on background threads () without entering . When  invoked LLM calls via ,  threw secret-scope errors in multiplexed mode, silently failing triage auto-decomposition every 15s.

### Validation
- Unit tests run via  (all passed cleanly).
- Verified live on multiplexed gateway setup: secondary worker profiles load without duplicate credential errors, and triage tasks automatically decompose on the 15s tick.
