### PR TITLE
fix(anthropic): keep MiniMax thinking blocks on replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2467,13 +2467,15 @@ def _manage_thinking_signatures(
     stripping, message merging) invalidates the signature, causing HTTP 400
     "Invalid signature in thinking block".
 
-    Signatures are Anthropic-proprietary.  Third-party endpoints (MiniMax,
-    Azure AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
+    Signatures are Anthropic-proprietary.  Third-party endpoints (Azure
+    AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
     and will reject them outright.  Kimi's /coding and DeepSeek's /anthropic
     endpoints speak the Anthropic protocol upstream but require unsigned
     thinking blocks (synthesised from ``reasoning_content``) to round-trip on
     replayed assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
-    hermes-agent#16748 (DeepSeek).
+    hermes-agent#16748 (DeepSeek).  MiniMax's /anthropic endpoints accept
+    signed thinking blocks verbatim or mutated (live-probed 2026-08-01), so
+    they replay as-is like Kimi.
 
     Nous Portal's ``/v1/messages`` route is the exception among third-party
     hosts: it proxies Claude to Anthropic/Vertex/Bedrock and validates the
@@ -2518,6 +2520,13 @@ def _manage_thinking_signatures(
                     continue
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+        elif _is_minimax_anthropic_endpoint(base_url):
+            # MiniMax does not enforce thinking signatures (live-probed
+            # 2026-08-01: verbatim AND content-mutated signed blocks both
+            # replay with HTTP 200).  Replay as-is — stripping silently
+            # dropped the prior turn's chain-of-thought and broke interleaved
+            # reasoning on multi-turn / tool-loop work.
+            pass
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party: strip ALL thinking blocks (signatures are proprietary).
             # Direct Anthropic: strip from non-latest assistant messages only.

--- a/tests/agent/test_anthropic_minimax_thinking_replay.py
+++ b/tests/agent/test_anthropic_minimax_thinking_replay.py
@@ -1,0 +1,73 @@
+"""MiniMax /anthropic endpoints don't enforce thinking signatures — replay as-is.
+
+Live-probed 2026-08-01 against api.minimax.io/anthropic: verbatim AND
+content-mutated signed thinking blocks both replay with HTTP 200, so the
+third-party strip-all path (pre-fix) silently dropped the prior turn's
+chain-of-thought and broke interleaved reasoning on multi-turn work.
+"""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-minimax"
+
+MINIMAX_IO = "https://api.minimax.io/anthropic"
+MINIMAX_CN = "https://api.minimaxi.com/anthropic"
+
+
+def _thinking_on_replay(base_url, with_tool_use=False):
+    """Normalize a thinking(+tool_use) turn, store it, convert to the next-turn
+    request, and return its thinking blocks."""
+    content = [
+        SimpleNamespace(type="thinking", thinking="five: 5 11 27 63 88", signature=SIG),
+        SimpleNamespace(type="text", text="5 27 88"),
+    ]
+    if with_tool_use:
+        content.append(SimpleNamespace(type="tool_use", id="toolu_1", name="read_file", input={"path": "a.py"}))
+    response = SimpleNamespace(
+        content=content,
+        stop_reason="tool_use" if with_tool_use else "end_turn",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    provider_data = normalized.provider_data or {}
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+        "tool_calls": [
+            {"id": tc.id, "type": "function", "function": {"name": tc.name, "arguments": tc.arguments}}
+            for tc in (normalized.tool_calls or [])
+        ],
+    }
+    if provider_data.get("anthropic_content_blocks"):
+        stored["anthropic_content_blocks"] = provider_data["anthropic_content_blocks"]
+    messages = [
+        {"role": "user", "content": "q1"},
+        stored,
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"} if with_tool_use else {"role": "user", "content": "q2"},
+    ]
+    if not with_tool_use:
+        messages = messages[:2] + [{"role": "user", "content": "q2"}]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=base_url, model="MiniMax-M3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    return [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"]
+
+
+def test_minimax_io_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MINIMAX_IO)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_minimax_cn_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MINIMAX_CN)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_minimax_interleaved_tool_turn_keeps_thinking():
+    """Thinking + tool_use turn replayed into the next API call (the tool loop)
+    must keep its thinking block — the exact multi-turn failure the strip caused."""
+    thinking = _thinking_on_replay(MINIMAX_IO, with_tool_use=True)
+    assert thinking and thinking[0].get("signature") == SIG


### PR DESCRIPTION
## Problem

MiniMax's `/anthropic` endpoints were classified as generic third-party in `_manage_thinking_signatures`, so ALL thinking blocks were stripped from every replayed assistant turn. The model's prior chain of thought silently disappeared between turns and inside tool loops, breaking interleaved reasoning on multi-turn agentic work after the 2nd or 3rd turn. Same bug class as the Kimi fix in #13848 / ddd81e935, which MiniMax was left out of.

## Evidence (live probe, 2026-08-01, MiniMax-M3 via api.minimax.io/anthropic)

- Turn 1 returns a signed thinking block (64-char signature)
- Replay verbatim (signed block included): HTTP 200
- Replay stripped: HTTP 200
- Replay with content-mutated thinking, stale signature: HTTP 200

MiniMax does not enforce thinking signatures at all, so the strip was pure loss, no 400 protection.

## Fix

Replay MiniMax thinking blocks as-is, mirroring the Kimi family rule. Two files:

- `agent/anthropic_adapter.py`: add `_is_minimax_anthropic_endpoint` branch to `_manage_thinking_signatures` (pass-through), update the docstring
- `tests/agent/test_anthropic_minimax_thinking_replay.py`: new, pins both MiniMax endpoints (io + cn) and the interleaved tool-loop turn

## Verification

12/12 tests pass: new MiniMax suite (3), Kimi replay suite (3), DeepSeek thinking (3), thinking block order (3).