### PR TITLE
fix(desktop): window transcript feed to stop renderer OOM (#55191)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -8,6 +8,7 @@ import { useLocation } from 'react-router'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
+import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
@@ -58,7 +59,14 @@ import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
 import { ProfileTag } from './profile-tag'
-import { useRuntimeMessageRepository } from './runtime-repository'
+import {
+  getTranscriptWindowFlags,
+  nextRenderedWindowSize,
+  RENDERED_MESSAGE_CAP,
+  selectRenderedMessages,
+  threadSetMessagesOption,
+  useRuntimeMessageRepository
+} from './runtime-repository'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 import { useSessionView } from './session-view'
 import { SessionActionsMenu } from './sidebar/session-actions-menu'
@@ -220,14 +228,45 @@ function ChatRuntimeBoundary({
   onThreadMessagesChange,
   suppressMessages
 }: ChatRuntimeBoundaryProps) {
-  const storeMessages = useMessagesWhileVisible(useSessionView().$messages)
+  const view = useSessionView()
+  const runtimeId = useStore(view.$runtimeId)
+  const storeMessages = useMessagesWhileVisible(view.$messages)
   const messages = suppressMessages ? NO_MESSAGES : storeMessages
-  const runtimeMessageRepository = useRuntimeMessageRepository(messages)
+
+  const [windowSize, setWindowSize] = useState(RENDERED_MESSAGE_CAP)
+  const [windowSessionKey, setWindowSessionKey] = useState(runtimeId)
+
+  // Reset the materialized window on session swap so a large expand from the
+  // previous chat cannot leak into the next one's first paint (#55191).
+  if (windowSessionKey !== runtimeId) {
+    setWindowSessionKey(runtimeId)
+    setWindowSize(RENDERED_MESSAGE_CAP)
+  }
+
+  const renderedMessages = selectRenderedMessages(messages, windowSize)
+
+  const { windowed, olderAvailable, historyTruncated } = getTranscriptWindowFlags(
+    messages.length,
+    windowSize
+  )
+
+  const runtimeMessageRepository = useRuntimeMessageRepository(renderedMessages)
+
+  const expandWindow = useCallback(() => {
+    setWindowSize(current => nextRenderedWindowSize(current, messages.length))
+  }, [messages.length])
+
+  const transcriptWindow = useMemo(
+    () => ({ olderAvailable, historyTruncated, expandWindow }),
+    [expandWindow, historyTruncated, olderAvailable]
+  )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: runtimeMessageRepository,
     isRunning: busy,
-    setMessages: onThreadMessagesChange,
+    // When windowed, omit setMessages so switchToBranch disables cleanly
+    // (runtime keys that capability on setMessages !== undefined).
+    ...threadSetMessagesOption(windowed, onThreadMessagesChange),
     onNew: async () => {
       // Submission is handled explicitly by ChatBar.
       // Keeping this no-op avoids duplicate prompt.submit calls.
@@ -237,7 +276,11 @@ function ChatRuntimeBoundary({
     onReload
   })
 
-  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+  return (
+    <TranscriptWindowProvider value={transcriptWindow}>
+      <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+    </TranscriptWindowProvider>
+  )
 }
 
 export function ChatView({

--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -5,7 +5,17 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { syncRepositoryIncrementally } from '@/lib/incremental-external-store-runtime'
 
-import { useRuntimeMessageRepository } from './runtime-repository'
+import {
+  branchSwitchEnabled,
+  clampRenderedWindowSize,
+  getTranscriptWindowFlags,
+  nextRenderedWindowSize,
+  RENDERED_MESSAGE_CAP,
+  RENDERED_MESSAGE_WINDOW_MAX,
+  selectRenderedMessages,
+  threadSetMessagesOption,
+  useRuntimeMessageRepository
+} from './runtime-repository'
 
 const text = (id: string, role: ChatMessage['role'], body: string): ChatMessage => ({
   id,
@@ -23,6 +33,116 @@ const feedToRepository = (repository: ExportedRepository) => {
 }
 
 type ExportedRepository = ReturnType<typeof useRuntimeMessageRepository>
+
+describe('clampRenderedWindowSize', () => {
+  it('floors below the cap up to RENDERED_MESSAGE_CAP', () => {
+    expect(clampRenderedWindowSize(12)).toBe(RENDERED_MESSAGE_CAP)
+    expect(clampRenderedWindowSize(Number.NaN)).toBe(RENDERED_MESSAGE_CAP)
+  })
+
+  it('ceilings above the soft max', () => {
+    expect(clampRenderedWindowSize(RENDERED_MESSAGE_WINDOW_MAX + 50)).toBe(RENDERED_MESSAGE_WINDOW_MAX)
+  })
+})
+
+describe('nextRenderedWindowSize', () => {
+  it('grows by one CAP page', () => {
+    expect(nextRenderedWindowSize(RENDERED_MESSAGE_CAP, 5000)).toBe(RENDERED_MESSAGE_CAP * 2)
+  })
+
+  it('never exceeds total message count', () => {
+    expect(nextRenderedWindowSize(RENDERED_MESSAGE_CAP, RENDERED_MESSAGE_CAP + 10)).toBe(
+      RENDERED_MESSAGE_CAP + 10
+    )
+  })
+
+  it('never exceeds the soft max', () => {
+    expect(nextRenderedWindowSize(RENDERED_MESSAGE_WINDOW_MAX - 10, 50_000)).toBe(
+      RENDERED_MESSAGE_WINDOW_MAX
+    )
+  })
+})
+
+describe('getTranscriptWindowFlags', () => {
+  it('marks older history expandable before the soft max', () => {
+    expect(getTranscriptWindowFlags(RENDERED_MESSAGE_CAP + 50, RENDERED_MESSAGE_CAP)).toEqual({
+      windowed: true,
+      olderAvailable: true,
+      historyTruncated: false
+    })
+  })
+
+  it('marks an explicit truncated state at the soft max', () => {
+    expect(getTranscriptWindowFlags(RENDERED_MESSAGE_WINDOW_MAX + 100, RENDERED_MESSAGE_WINDOW_MAX)).toEqual(
+      {
+        windowed: true,
+        olderAvailable: false,
+        historyTruncated: true
+      }
+    )
+  })
+
+  it('is not windowed when the full transcript fits', () => {
+    expect(getTranscriptWindowFlags(12, RENDERED_MESSAGE_CAP)).toEqual({
+      windowed: false,
+      olderAvailable: false,
+      historyTruncated: false
+    })
+  })
+})
+
+describe('threadSetMessagesOption / branchSwitchEnabled', () => {
+  const persist = () => undefined
+
+  it('disables branch switching while the transcript is windowed', () => {
+    const adapter = threadSetMessagesOption(true, persist)
+
+    expect(adapter).toEqual({})
+    expect('setMessages' in adapter).toBe(false)
+    expect(branchSwitchEnabled(adapter)).toBe(false)
+  })
+
+  it('keeps normal branch persistence when the transcript is uncapped', () => {
+    const adapter = threadSetMessagesOption(false, persist)
+
+    expect(adapter).toEqual({ setMessages: persist })
+    expect(branchSwitchEnabled(adapter)).toBe(true)
+  })
+})
+
+describe('selectRenderedMessages', () => {
+  it('returns the same array when under the render window', () => {
+    const messages = [text('user-1', 'user', 'hi'), text('assistant-1', 'assistant', 'hello')]
+
+    expect(selectRenderedMessages(messages)).toBe(messages)
+  })
+
+  it('keeps only the newest RENDERED_MESSAGE_CAP messages by default', () => {
+    const messages = Array.from({ length: RENDERED_MESSAGE_CAP + 25 }, (_, index) =>
+      text(`m-${index}`, index % 2 === 0 ? 'user' : 'assistant', `body-${index}`)
+    )
+
+    const rendered = selectRenderedMessages(messages)
+
+    expect(rendered).toHaveLength(RENDERED_MESSAGE_CAP)
+    expect(rendered[0]?.id).toBe(`m-25`)
+    expect(rendered.at(-1)?.id).toBe(`m-${RENDERED_MESSAGE_CAP + 24}`)
+  })
+
+  it('honors a larger custom window size', () => {
+    const windowSize = RENDERED_MESSAGE_CAP + 50
+
+    const messages = Array.from({ length: windowSize + 20 }, (_, index) =>
+      text(`m-${index}`, index % 2 === 0 ? 'user' : 'assistant', `body-${index}`)
+    )
+
+    const rendered = selectRenderedMessages(messages, windowSize)
+
+    expect(rendered).toHaveLength(windowSize)
+    expect(rendered[0]?.id).toBe('m-20')
+    expect(rendered.at(-1)?.id).toBe(`m-${windowSize + 19}`)
+  })
+})
 
 describe('useRuntimeMessageRepository', () => {
   it('emits each id once when the transcript repeats one', () => {
@@ -50,5 +170,30 @@ describe('useRuntimeMessageRepository', () => {
     )
 
     expect(feedToRepository(result.current).map(item => item.id)).toEqual(['user-1', 'assistant-stream-1', 'user-2'])
+  })
+
+  it('stays bounded when fed a capped oversized transcript', () => {
+    const messages = Array.from({ length: RENDERED_MESSAGE_CAP + 40 }, (_, index) =>
+      text(`m-${index}`, index % 2 === 0 ? 'user' : 'assistant', `body-${index}`)
+    )
+
+    const rendered = selectRenderedMessages(messages)
+
+    const { result } = renderHook(() => useRuntimeMessageRepository(rendered))
+
+    expect(result.current.messages).toHaveLength(RENDERED_MESSAGE_CAP)
+    expect(feedToRepository(result.current)).toHaveLength(RENDERED_MESSAGE_CAP)
+  })
+
+  it('stays bounded at the soft max when the expanded window is applied', () => {
+    const messages = Array.from({ length: RENDERED_MESSAGE_WINDOW_MAX + 80 }, (_, index) =>
+      text(`m-${index}`, index % 2 === 0 ? 'user' : 'assistant', `body-${index}`)
+    )
+
+    const rendered = selectRenderedMessages(messages, RENDERED_MESSAGE_WINDOW_MAX)
+
+    const { result } = renderHook(() => useRuntimeMessageRepository(rendered))
+
+    expect(result.current.messages).toHaveLength(RENDERED_MESSAGE_WINDOW_MAX)
   })
 })

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -11,6 +11,88 @@ import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } fr
 const FALLBACK_STATUS = getAutoStatus(false, false, false, false, undefined)
 
 /**
+ * Rendering the full transcript of an oversized session (200K+-token always-on
+ * conversations) exhausts the renderer's V8 heap on each update and crash-loops
+ * the window (#55191). Only a bounded tail reaches assistant-ui; older history
+ * stays in the session store and can be pulled in via "Show earlier".
+ */
+export const RENDERED_MESSAGE_CAP = 400
+
+/** Soft ceiling so expanding the window cannot re-create the OOM (#55191). */
+export const RENDERED_MESSAGE_WINDOW_MAX = 2000
+
+/** Clamp a requested window into the allowed [CAP, MAX] band. */
+export function clampRenderedWindowSize(windowSize: number): number {
+  if (!Number.isFinite(windowSize) || windowSize < RENDERED_MESSAGE_CAP) {
+    return RENDERED_MESSAGE_CAP
+  }
+
+  return Math.min(RENDERED_MESSAGE_WINDOW_MAX, Math.floor(windowSize))
+}
+
+/** Grow the window by one CAP page, never past total or MAX. */
+export function nextRenderedWindowSize(current: number, total: number): number {
+  const base = clampRenderedWindowSize(current)
+
+  return Math.min(Math.max(0, total), RENDERED_MESSAGE_WINDOW_MAX, base + RENDERED_MESSAGE_CAP)
+}
+
+/** Return the transcript tail assistant-ui is allowed to materialize. */
+export function selectRenderedMessages(
+  messages: readonly ChatMessage[],
+  windowSize: number = RENDERED_MESSAGE_CAP
+): ChatMessage[] {
+  const size = clampRenderedWindowSize(windowSize)
+
+  if (messages.length <= size) {
+    return messages as ChatMessage[]
+  }
+
+  return messages.slice(-size)
+}
+
+export interface TranscriptWindowFlags {
+  /** Store has older messages than the current materialized window. */
+  windowed: boolean
+  /** Window can still grow via Show earlier. */
+  olderAvailable: boolean
+  /** At the soft max with older store history still unloaded. */
+  historyTruncated: boolean
+}
+
+/** Derive expand/truncated UI flags from store size + current window. */
+export function getTranscriptWindowFlags(storeCount: number, windowSize: number): TranscriptWindowFlags {
+  const size = clampRenderedWindowSize(windowSize)
+  const renderedCount = Math.min(Math.max(0, storeCount), size)
+  const windowed = storeCount > renderedCount
+  const olderAvailable = windowed && nextRenderedWindowSize(windowSize, storeCount) > size
+
+  return {
+    windowed,
+    olderAvailable,
+    historyTruncated: windowed && !olderAvailable
+  }
+}
+
+/**
+ * Adapter patch for branch persistence. When windowed, omit `setMessages` so
+ * the runtime disables `switchToBranch` (it keys that capability on
+ * `setMessages !== undefined`, so a no-op would leave the picker enabled but
+ * unable to persist).
+ */
+export function threadSetMessagesOption<T>(
+  windowed: boolean,
+  setMessages: T
+): { setMessages: T } | Record<string, never> {
+  return windowed ? {} : { setMessages }
+}
+
+/** Mirrors IncrementalExternalStoreThreadRuntimeCore capability wiring. */
+export function branchSwitchEnabled(adapter: { setMessages?: unknown }): boolean {
+  return adapter.setMessages !== undefined
+}
+
+/**
  * ChatMessage[] -> assistant-ui message repository, with a WeakMap identity
  * cache so unchanged messages convert once (and a tool-merge cache that folds
  * tool-only assistant turns into their neighbour). Shared by the main chat's

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -28,6 +28,8 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
 
+import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
+
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
 export type MessageGroup = { id: string; weight: number } & (
@@ -300,6 +302,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     resize: 'instant'
   })
 
+  const { olderAvailable, historyTruncated, expandWindow } = useTranscriptWindow()
+
   const [renderBudget, setRenderBudget] = useState(FIRST_PAINT_BUDGET)
 
   // Cut the budget during RENDER, not in the post-commit layout effect. An
@@ -525,11 +529,25 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and
-  // won't fight this manual restore.
+  // won't fight this manual restore. Prefer the DOM part-budget page first;
+  // once that is exhausted, expand the assistant-ui store window (#55191).
   const showEarlier = useCallback(() => {
+    const action = resolveShowEarlierAction(hiddenCount, olderAvailable)
+
+    if (!action) {
+      return
+    }
+
     anchorBeforePrepend()
-    setRenderBudget(budget => budget + RENDER_BUDGET)
-  }, [anchorBeforePrepend])
+
+    if (action === 'dom') {
+      setRenderBudget(budget => budget + RENDER_BUDGET)
+
+      return
+    }
+
+    expandWindow()
+  }, [anchorBeforePrepend, expandWindow, hiddenCount, olderAvailable])
 
   useLayoutEffect(() => {
     const el = scrollRef.current
@@ -538,7 +556,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       el.scrollTop = el.scrollHeight - restoreFromBottomRef.current
       restoreFromBottomRef.current = null
     }
-  }, [scrollRef, renderBudget])
+    // groups.length covers store-window expands; renderBudget covers DOM pages.
+  }, [scrollRef, renderBudget, groups.length])
 
   // The row array is memoized on the inputs the rows actually read. This
   // component re-renders on every isAtBottom flip — and use-stick-to-bottom
@@ -632,7 +651,15 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             data-slot="aui_thread-content"
             ref={contentRef as React.RefCallback<HTMLDivElement>}
           >
-            {hiddenCount > 0 && (
+            {historyTruncated && (
+              <p
+                className="mx-auto mb-(--conversation-turn-gap) max-w-md px-3 text-center text-xs text-muted-foreground"
+                data-slot="aui_thread-history-truncated"
+              >
+                {t.assistant.thread.historyTruncated}
+              </p>
+            )}
+            {(hiddenCount > 0 || olderAvailable) && (
               <button
                 className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
                 onClick={showEarlier}

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveShowEarlierAction } from './transcript-window'
+
+describe('resolveShowEarlierAction', () => {
+  it('pages the DOM budget while older rendered groups are still hidden', () => {
+    expect(resolveShowEarlierAction(3, true)).toBe('dom')
+    expect(resolveShowEarlierAction(3, false)).toBe('dom')
+  })
+
+  it('expands the store window once the DOM page is exhausted', () => {
+    expect(resolveShowEarlierAction(0, true)).toBe('window')
+  })
+
+  it('is a no-op when neither DOM nor store has older content', () => {
+    expect(resolveShowEarlierAction(0, false)).toBe(null)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext } from 'react'
+
+export interface TranscriptWindowValue {
+  /** Store still has older messages that the runtime window has not materialized. */
+  olderAvailable: boolean
+  /** At the soft max: older store history exists but cannot be loaded into the UI. */
+  historyTruncated: boolean
+  /** Expand the assistant-ui window by one page from the session store. */
+  expandWindow: () => void
+}
+
+const TranscriptWindowContext = createContext<TranscriptWindowValue>({
+  olderAvailable: false,
+  historyTruncated: false,
+  expandWindow: () => {}
+})
+
+export function TranscriptWindowProvider({
+  children,
+  value
+}: {
+  children: ReactNode
+  value: TranscriptWindowValue
+}) {
+  return <TranscriptWindowContext.Provider value={value}>{children}</TranscriptWindowContext.Provider>
+}
+
+export function useTranscriptWindow(): TranscriptWindowValue {
+  return useContext(TranscriptWindowContext)
+}
+
+/** Decide whether Show earlier pages DOM budget or expands the store window. */
+export function resolveShowEarlierAction(
+  hiddenCount: number,
+  olderAvailable: boolean
+): 'dom' | 'window' | null {
+  if (hiddenCount > 0) {
+    return 'dom'
+  }
+
+  if (olderAvailable) {
+    return 'window'
+  }
+
+  return null
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2270,6 +2270,7 @@ export const ar = defineLocale({
     thread: {
       loadingSession: 'جار تحميل الجلسة...',
       showEarlier: 'عرض الرسائل الأقدم',
+      historyTruncated: 'يتم عرض أحدث الرسائل حتى حد العرض. السجل الأقدم يبقى في هذه الجلسة.',
       loadingResponse: 'جار تحميل الرد...',
       resumeWhenBackgroundDone: count =>
         count === 1 ? 'سيُستأنف عند انتهاء المهمة الخلفية' : `سيُستأنف عند انتهاء ${count} مهام خلفية`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2699,6 +2699,8 @@ export const en: Translations = {
     thread: {
       loadingSession: 'Loading session',
       showEarlier: 'Show earlier messages',
+      historyTruncated:
+        'Showing the newest messages up to the display limit. Older history stays in this session.',
       loadingResponse: 'Hermes is loading a response',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2525,6 +2525,8 @@ export const ja = defineLocale({
     thread: {
       loadingSession: 'セッションを読み込み中',
       showEarlier: '以前のメッセージを表示',
+      historyTruncated:
+        '表示上限までの最新メッセージを表示しています。それより前の履歴はこのセッションに残っています。',
       loadingResponse: 'Hermes が応答を読み込み中',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2298,6 +2298,7 @@ export interface Translations {
     thread: {
       loadingSession: string
       showEarlier: string
+      historyTruncated: string
       loadingResponse: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2445,6 +2445,7 @@ export const zhHant = defineLocale({
     thread: {
       loadingSession: '正在載入工作階段',
       showEarlier: '顯示較早的訊息',
+      historyTruncated: '已顯示到介面上限的最新訊息。更早的紀錄仍保存在此工作階段中。',
       loadingResponse: 'Hermes 正在載入回覆',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2877,6 +2877,7 @@ export const zh: Translations = {
     thread: {
       loadingSession: '正在加载会话',
       showEarlier: '显示更早的消息',
+      historyTruncated: '已显示到界面上限的最新消息。更早的记录仍保存在此会话中。',
       loadingResponse: 'Hermes 正在加载回复',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,


### PR DESCRIPTION
## Summary
- Bound how many chat messages reach assistant-ui (default tail of 400, soft max 2000) so oversized Desktop sessions no longer rebuild an unbounded runtime repository on every update and crash-loop the Electron renderer (#55191).
- Keep older history in the session store; **Show earlier** first pages the existing DOM part-budget, then expands the store window by 400 when that page is exhausted.
- While windowed, omit `setMessages` so `switchToBranch` disables cleanly (no inert branch picker).
- At the soft max, show an explicit truncated-history notice instead of silently hiding **Show earlier**.
- This is a windowed-transcript stopgap (not a TanStack chat re-virtualization); `use-stick-to-bottom` remains the scroll owner.

## Test plan
- [x] `cd apps/desktop && npx vitest run src/app/chat/runtime-repository.test.ts src/components/assistant-ui/thread/transcript-window.test.ts src/components/assistant-ui/thread/list.test.ts`
- [x] Unit coverage for capped branch-switch off / uncapped persistence on
- [x] Unit coverage for soft-max `historyTruncated` flag
- [ ] Open a very long Desktop session that previously crash-looped near compaction
- [ ] Confirm the window stays responsive and does not freeze/blank
- [ ] Click **Show earlier** repeatedly and confirm older store messages become visible without crashing
- [ ] Confirm soft-max shows the truncated-history notice (not a silent cutoff)
- [ ] Confirm starting a new chat / switching sessions resets the window