### PR TITLE
feat(tui/widgets): config soft refresh period + soft value redraw

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1152,6 +1152,12 @@ DEFAULT_CONFIG = {
         # Set 0 to disable the background refresh if it fights terminal
         # auto-scroll in non-fullscreen mode on some emulators (#48309).
         "cli_refresh_interval": 1.0,
+        # Ambient TUI widget soft-refresh period (milliseconds). User widgets
+        # and the widget SDK read this for countdown / value ticks so they do
+        # not each hardcode an interval. Default 30000 (30s). Set 0 to mean
+        # "no host-suggested UI tick" (widgets still refresh on their own
+        # network cadence). Values below 1000 clamp to 1000 at the TUI unless 0.
+        "tui_widget_refresh_ms": 30000,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1579,6 +1579,12 @@ DEFAULT_CONFIG = {
         # Set 0 to disable the background refresh if it fights terminal
         # auto-scroll in non-fullscreen mode on some emulators (#48309).
         "cli_refresh_interval": 1.0,
+        # Ambient TUI widget soft-refresh period (milliseconds). User widgets
+        # and the widget SDK read this for countdown / value ticks so they do
+        # not each hardcode an interval. Default 30000 (30s). Set 0 to mean
+        # "no host-suggested UI tick" (widgets still refresh on their own
+        # network cadence). Values below 1000 clamp to 1000 at the TUI unless 0.
+        "tui_widget_refresh_ms": 30000,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/ui-tui/src/__tests__/widgetSoftRefresh.composition.test.tsx
+++ b/ui-tui/src/__tests__/widgetSoftRefresh.composition.test.tsx
@@ -1,0 +1,107 @@
+import { PassThrough } from 'node:stream'
+
+import { Box, render, Text } from '@hermes/ink'
+import { createElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { resetOverlayState } from '../app/overlayStore.js'
+import { AmbientDock, openWidget, softUpdateWidget } from '../sdk/host.js'
+import { defineWidgetApp } from '../sdk/registry.js'
+
+const makeStdout = () => {
+  const s = new PassThrough()
+  Object.defineProperty(s, 'columns', { configurable: true, value: 100 })
+  Object.defineProperty(s, 'rows', { configurable: true, value: 20 })
+  Object.defineProperty(s, 'isTTY', { configurable: true, value: false })
+  let captured = ''
+  s.on('data', (c: Buffer) => {
+    captured += c.toString()
+  })
+
+  return {
+    read: () => captured,
+    stdout: s as unknown as NodeJS.WriteStream
+  }
+}
+
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+describe('AmbientDock soft value redraw (composition)', () => {
+  beforeEach(() => {
+    resetOverlayState()
+  })
+
+  afterEach(() => {
+    resetOverlayState()
+  })
+
+  it('updates only the changed ambient card text while siblings stay mounted', async () => {
+    const renders = { a: 0, b: 0 }
+
+    const appA = defineWidgetApp<{ v: string }>({
+      help: 'a',
+      id: 'soft-a',
+      mode: 'ambient',
+      zone: 'dock-bottom',
+      init: () => ({ v: 'A0' }),
+      reduce: s => s,
+      render: ({ state }) => {
+        renders.a += 1
+
+        return createElement(Text, null, `CARD_A:${state.v}`)
+      }
+    })
+
+    const appB = defineWidgetApp<{ v: string }>({
+      help: 'b',
+      id: 'soft-b',
+      mode: 'ambient',
+      zone: 'dock-bottom',
+      init: () => ({ v: 'B0' }),
+      reduce: s => s,
+      render: ({ state }) => {
+        renders.b += 1
+
+        return createElement(Text, null, `CARD_B:${state.v}`)
+      }
+    })
+
+    openWidget(appA, { v: 'A0' })
+    openWidget(appB, { v: 'B0' })
+
+    const { stdout, read } = makeStdout()
+
+    const inst = await render(
+      createElement(
+        Box,
+        { flexDirection: 'column' },
+        createElement(Text, null, 'STATUS_MARKER'),
+        createElement(AmbientDock, { placement: 'dock-bottom' })
+      ),
+      { stdin: process.stdin, stderr: process.stderr, stdout }
+    )
+
+    await wait(80)
+    expect(read()).toContain('STATUS_MARKER')
+    expect(read()).toContain('CARD_A:A0')
+    expect(read()).toContain('CARD_B:B0')
+
+    const aBefore = renders.a
+    const bBefore = renders.b
+
+    softUpdateWidget(appA, { v: 'A1' })
+    await wait(80)
+
+    const frame = read()
+    expect(frame).toContain('CARD_A:A1')
+    expect(frame).toContain('CARD_B:B0')
+    expect(frame).toContain('STATUS_MARKER')
+
+    // Soft path: A re-renders with new value; B should not re-render from the value tick.
+    expect(renders.a).toBeGreaterThan(aBefore)
+    expect(renders.b).toBe(bBefore)
+
+    inst.unmount()
+    await wait(20)
+  })
+})

--- a/ui-tui/src/__tests__/widgetSoftRefresh.test.ts
+++ b/ui-tui/src/__tests__/widgetSoftRefresh.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { $uiState, resetUiState } from '../app/uiStore.js'
+import { applyDisplay, normalizeWidgetRefreshMs } from '../app/useConfigSync.js'
+import { launchWidget, softUpdateWidget, updateWidget } from '../sdk/host.js'
+import { defineWidgetApp } from '../sdk/registry.js'
+import { widgetSdk } from '../sdk/userWidgets.js'
+
+describe('normalizeWidgetRefreshMs', () => {
+  it('defaults missing/invalid to 30000 and clamps low positives to 1000', () => {
+    expect(normalizeWidgetRefreshMs(undefined)).toBe(30_000)
+    expect(normalizeWidgetRefreshMs('nope')).toBe(30_000)
+    expect(normalizeWidgetRefreshMs(-5)).toBe(30_000)
+    expect(normalizeWidgetRefreshMs(500)).toBe(1_000)
+    expect(normalizeWidgetRefreshMs(12_000)).toBe(12_000)
+    expect(normalizeWidgetRefreshMs(0)).toBe(0)
+    expect(normalizeWidgetRefreshMs('45000')).toBe(45_000)
+  })
+})
+
+describe('applyDisplay widgetRefreshMs', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('fans display.tui_widget_refresh_ms into $uiState.widgetRefreshMs', () => {
+    applyDisplay({ config: { display: { tui_widget_refresh_ms: 15_000 } } }, vi.fn())
+    expect($uiState.get().widgetRefreshMs).toBe(15_000)
+
+    applyDisplay({ config: { display: { tui_widget_refresh_ms: 0 } } }, vi.fn())
+    expect($uiState.get().widgetRefreshMs).toBe(0)
+
+    applyDisplay({ config: { display: {} } }, vi.fn())
+    expect($uiState.get().widgetRefreshMs).toBe(30_000)
+  })
+})
+
+describe('soft widget updates', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+  })
+
+  it('skips overlay writes when updateWidget returns the same state ref', () => {
+    defineWidgetApp<{ n: number }>({
+      help: 'noop',
+      id: 'soft-noop',
+      mode: 'ambient',
+      init: () => ({ n: 1 }),
+      reduce: s => s,
+      render: () => null
+    })
+
+    expect(launchWidget('soft-noop', '')).toBeNull()
+    const before = getOverlayState().ambient
+
+    const app = defineWidgetApp<{ n: number }>({
+      help: 'noop',
+      id: 'soft-noop',
+      mode: 'ambient',
+      init: () => ({ n: 1 }),
+      reduce: s => s,
+      render: () => null
+    })
+
+    updateWidget(app, s => s)
+    expect(getOverlayState().ambient).toBe(before)
+  })
+
+  it('softUpdateWidget only rewrites when a value actually changes', () => {
+    const app = defineWidgetApp<{ label: string; pct: number }>({
+      help: 'gauge',
+      id: 'soft-gauge',
+      mode: 'ambient',
+      init: () => ({ label: 'ok', pct: 10 }),
+      reduce: s => s,
+      render: () => null
+    })
+
+    expect(launchWidget('soft-gauge', '')).toBeNull()
+    const ambient0 = getOverlayState().ambient
+    const state0 = ambient0[0]?.state
+
+    softUpdateWidget(app, { pct: 10, label: 'ok' })
+    expect(getOverlayState().ambient).toBe(ambient0)
+    expect(getOverlayState().ambient[0]?.state).toBe(state0)
+
+    softUpdateWidget(app, { pct: 11 })
+    const ambient1 = getOverlayState().ambient
+    expect(ambient1).not.toBe(ambient0)
+    expect(ambient1[0]?.state).toEqual({ label: 'ok', pct: 11 })
+    // Unrelated ambient entries keep identity when present
+  })
+
+  it('exposes refreshMs from widgetSdk from ui state', () => {
+    applyDisplay({ config: { display: { tui_widget_refresh_ms: 9_000 } } }, vi.fn())
+    expect(widgetSdk.refreshMs()).toBe(9_000)
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -343,6 +343,8 @@ export interface UiState {
   status: string
   statusBar: StatusBarMode
   streaming: boolean
+  /** Host-suggested ambient widget soft UI-tick period (ms). 0 = off. */
+  widgetRefreshMs: number
   theme: Theme
   usage: Usage
 }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -351,6 +351,8 @@ export interface UiState {
   // the default set).
   statusBarFields: null | ReadonlySet<string>
   streaming: boolean
+  /** Host-suggested ambient widget soft UI-tick period (ms). 0 = off. */
+  widgetRefreshMs: number
   theme: Theme
   // `display.timestamps` — dim [HH:MM] labels on user/assistant transcript
   // rows, the same config key the classic CLI honors (#41531).

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -32,6 +32,7 @@ const buildUiState = (): UiState => ({
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,
+  widgetRefreshMs: 30_000,
   // Last session's resolved theme paints frame one (flash-free boot, like
   // the desktop's hermes-boot-* keys); DEFAULT_THEME only on first launch.
   theme: bootTheme ?? DEFAULT_THEME,

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -36,6 +36,7 @@ const buildUiState = (): UiState => ({
   statusBarFields: null,
   streaming: true,
   timestamps: false,
+  widgetRefreshMs: 30_000,
   // Last session's resolved theme paints frame one (flash-free boot, like
   // the desktop's hermes-boot-* keys); DEFAULT_THEME only on first launch.
   theme: bootTheme ?? DEFAULT_THEME,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -28,6 +28,28 @@ const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
   raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
 
+/** Default soft UI tick for ambient widgets (matches common quota countdown cadence). */
+export const DEFAULT_WIDGET_REFRESH_MS = 30_000
+
+/** Parse display.tui_widget_refresh_ms. 0 disables the host-suggested tick. */
+export const normalizeWidgetRefreshMs = (raw: unknown): number => {
+  if (raw === false || raw === null || raw === undefined || raw === '') {
+    return DEFAULT_WIDGET_REFRESH_MS
+  }
+
+  const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw.trim()) : Number.NaN
+
+  if (!Number.isFinite(n) || n < 0) {
+    return DEFAULT_WIDGET_REFRESH_MS
+  }
+
+  if (n === 0) {
+    return 0
+  }
+
+  return Math.max(1_000, Math.floor(n))
+}
+
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 
 // TUI defaults to `queue` even though the framework default
@@ -284,7 +306,8 @@ export const applyDisplay = (
     sections: resolveSections(d.sections),
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
-    streaming: d.streaming !== false
+    streaming: d.streaming !== false,
+    widgetRefreshMs: normalizeWidgetRefreshMs(d.tui_widget_refresh_ms)
   })
 }
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -311,7 +311,8 @@ export const applyDisplay = (
     streaming: d.streaming !== false,
     // The SAME key that stamps [HH:MM] on classic-CLI labels (#41531) —
     // no separate TUI knob.
-    timestamps: d.timestamps === true
+    timestamps: d.timestamps === true,
+    widgetRefreshMs: normalizeWidgetRefreshMs(d.tui_widget_refresh_ms)
   })
 }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -106,6 +106,8 @@ export interface ConfigDisplayConfig {
   // narrowing-and-autocomplete contract on a value that requires runtime
   // validation anyway.
   tui_status_indicator?: string
+  /** Ambient widget soft UI-tick period in ms (0 = no host-suggested tick). */
+  tui_widget_refresh_ms?: number
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
   /** Theme mode pin: 'light' / 'dark' beat background auto-detection; 'auto'
    *  (default) trusts the OSC-11 probe + env signals. */

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -114,6 +114,8 @@ export interface ConfigDisplayConfig {
   // narrowing-and-autocomplete contract on a value that requires runtime
   // validation anyway.
   tui_status_indicator?: string
+  /** Ambient widget soft UI-tick period in ms (0 = no host-suggested tick). */
+  tui_widget_refresh_ms?: number
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
   /** Theme mode pin: 'light' / 'dark' beat background auto-detection; 'auto'
    *  (default) trusts the OSC-11 probe + env signals. */

--- a/ui-tui/src/sdk/host.tsx
+++ b/ui-tui/src/sdk/host.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useStdout } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { Component, type ReactNode } from 'react'
+import { Component, memo, type ReactNode } from 'react'
 
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiTheme } from '../app/uiStore.js'
@@ -80,25 +80,70 @@ export const openWidget = <S,>(app: WidgetApp<S>, state: S): void => place(app a
 /** Async state delivery: patch the app's state ONLY while it is still active
  *  in its slot — a late fetch resolution can never resurrect a closed app or
  *  clobber a different one. This is how data-backed apps land results
- *  outside the input pipeline (see the weather reference app). */
+ *  outside the input pipeline (see the weather reference app).
+ *
+ * Soft redraw: when `fn` returns the same state reference (or shallow-equal
+ * values via softUpdateWidget), the overlay is not patched — so sibling
+ * ambient cards and the status bar do not re-render for a no-op tick. */
 export function updateWidget<S>(app: WidgetApp<S>, fn: (state: S) => S): void {
   const overlay = $overlayState.get()
 
   if (isAmbient(app as WidgetApp<never>)) {
-    if (overlay.ambient.some(active => active.appId === app.id)) {
-      patchOverlayState({
-        ambient: overlay.ambient.map(active =>
-          active.appId === app.id ? { appId: app.id, state: fn(active.state as S) } : active
-        )
-      })
+    const current = overlay.ambient.find(active => active.appId === app.id)
+
+    if (!current) {
+      return
     }
+
+    const prev = current.state as S
+    const next = fn(prev)
+
+    if (Object.is(next, prev)) {
+      return
+    }
+
+    patchOverlayState({
+      ambient: overlay.ambient.map(active => (active.appId === app.id ? { appId: app.id, state: next } : active))
+    })
 
     return
   }
 
   if (overlay.widget?.appId === app.id) {
-    patchOverlayState({ widget: { appId: app.id, state: fn(overlay.widget.state as S) } })
+    const prev = overlay.widget.state as S
+    const next = fn(prev)
+
+    if (Object.is(next, prev)) {
+      return
+    }
+
+    patchOverlayState({ widget: { appId: app.id, state: next } })
   }
+}
+
+/** Soft value patch for ambient/modal widgets: merges only the provided keys
+ *  and skips the overlay write when every value is Object.is-equal. Prefer
+ *  this for countdown / gauge ticks so only the changed widget card redraws. */
+export function softUpdateWidget<S extends object>(app: WidgetApp<S>, patch: Partial<S>): void {
+  updateWidget(app, prev => {
+    let changed = false
+    const next = { ...prev }
+
+    for (const key of Object.keys(patch) as Array<keyof S>) {
+      const value = patch[key]
+
+      if (value === undefined) {
+        continue
+      }
+
+      if (!Object.is(prev[key], value)) {
+        next[key] = value as S[keyof S]
+        changed = true
+      }
+    }
+
+    return changed ? next : prev
+  })
 }
 
 /** Feed one keypress to the active MODAL app (ambient apps capture no
@@ -196,10 +241,22 @@ const renderApp = (active: ActiveWidget, ctx: RenderCtx) => {
   )
 }
 
-const CardStack = ({ apps, ctx }: { apps: ActiveWidget[]; ctx: RenderCtx }) => (
+/** One ambient card: memoized on appId + state ref so a soft value tick on
+ *  widget A does not re-render sibling cards in the dock strip. Theme/cols
+ *  still update because the card subscribes to them internally. */
+const AmbientCard = memo(
+  function AmbientCard({ active }: { active: ActiveWidget }) {
+    const ctx = useRenderCtx()
+
+    return <Box>{renderApp(active, ctx)}</Box>
+  },
+  (prev, next) => prev.active.appId === next.active.appId && Object.is(prev.active.state, next.active.state)
+)
+
+const CardStack = ({ apps }: { apps: ActiveWidget[] }) => (
   <Box flexDirection="column" rowGap={1}>
     {apps.map(active => (
-      <Box key={active.appId}>{renderApp(active, ctx)}</Box>
+      <AmbientCard active={active} key={active.appId} />
     ))}
   </Box>
 )
@@ -218,7 +275,6 @@ export function ActiveWidgetSlot(): ReactNode {
  *  bar, `dock-bottom` above the bottom one. */
 export function AmbientDock({ placement }: { placement: 'dock-bottom' | 'dock-top' }): ReactNode {
   const overlay = useStore($overlayState)
-  const ctx = useRenderCtx()
   const docked = overlay.ambient.filter(active => zoneOf(active) === placement)
 
   if (!docked.length) {
@@ -230,7 +286,7 @@ export function AmbientDock({ placement }: { placement: 'dock-bottom' | 'dock-to
   return (
     <Box columnGap={1} flexDirection="row" justifyContent="flex-end" paddingRight={2} width="100%">
       {docked.map(active => (
-        <Box key={active.appId}>{renderApp(active, ctx)}</Box>
+        <AmbientCard active={active} key={active.appId} />
       ))}
     </Box>
   )
@@ -264,7 +320,6 @@ export function useAmbientRailWidth(side: 'left' | 'right'): number {
  *  widgets — `top-*` zones stack from its top, `bottom-*` from its bottom. */
 export function AmbientRail({ side }: { side: 'left' | 'right' }): ReactNode {
   const overlay = useStore($overlayState)
-  const ctx = useRenderCtx()
   const apps = railApps(overlay.ambient, side)
 
   if (!apps.length) {
@@ -279,8 +334,8 @@ export function AmbientRail({ side }: { side: 'left' | 'right' }): ReactNode {
       paddingX={1}
       width={ambientRailWidth(side, overlay.ambient)}
     >
-      <CardStack apps={apps.filter(active => zoneOf(active).startsWith('top'))} ctx={ctx} />
-      <CardStack apps={apps.filter(active => zoneOf(active).startsWith('bottom'))} ctx={ctx} />
+      <CardStack apps={apps.filter(active => zoneOf(active).startsWith('top'))} />
+      <CardStack apps={apps.filter(active => zoneOf(active).startsWith('bottom'))} />
     </Box>
   )
 }

--- a/ui-tui/src/sdk/index.ts
+++ b/ui-tui/src/sdk/index.ts
@@ -55,6 +55,7 @@ export {
   dispatchWidgetInput,
   launchWidget,
   openWidget,
+  softUpdateWidget,
   updateWidget
 } from './host.js'
 export { defineWidgetApp, getWidgetApp, listWidgetApps } from './registry.js'

--- a/ui-tui/src/sdk/userWidgets.ts
+++ b/ui-tui/src/sdk/userWidgets.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'url'
 import { Box, Text } from '@hermes/ink'
 import * as React from 'react'
 
+import { getUiState } from '../app/uiStore.js'
 import { Accordion } from '../components/accordion.js'
 import { Shimmer, ShimmerRows, useShimmerPhase } from '../components/loaders.js'
 import { Dialog, Overlay } from '../components/overlay.js'
@@ -14,7 +15,7 @@ import { GridAreas, WidgetGrid } from '../components/widgetGrid.js'
 import { gauge, hbars, sparkline, sparkRows } from '../lib/charts.js'
 import { recordParentLifecycle } from '../lib/parentLog.js'
 
-import { openWidget, updateWidget } from './host.js'
+import { openWidget, softUpdateWidget, updateWidget } from './host.js'
 import { defineWidgetApp, listWidgetApps, removeWidgetApp } from './registry.js'
 import { isCtrl } from './types.js'
 
@@ -50,6 +51,8 @@ export const widgetSdk = {
   hbars,
   isCtrl,
   openWidget,
+  refreshMs: () => getUiState().widgetRefreshMs,
+  softUpdateWidget,
   sparkRows,
   sparkline,
   updateWidget,

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -179,6 +179,18 @@ display:
 
 Or in-session: `/indicator emoji` (etc.). Styles ship with matched glyph widths so the rest of the status bar doesn't jitter on rotation.
 
+## Ambient widget refresh
+
+Ambient dock widgets (quota gauges, countdown labels, and other glanceable cards) can soft-refresh their **values** on a shared cadence without redrawing the whole dock strip or the main status bar.
+
+```yaml
+display:
+  tui_widget_refresh_ms: 30000   # soft UI tick period in ms; default 30000
+  # tui_widget_refresh_ms: 0     # disable the host-suggested tick (widgets may still poll networks themselves)
+```
+
+The TUI clamps values below `1000` up to `1000` (except `0`, which turns the host suggestion off). User widgets read the live value via `sdk.refreshMs()` and should prefer `sdk.softUpdateWidget(app, { field: next })` for value-only ticks so sibling cards keep their React state identity.
+
 ## Auto-resume
 
 By default, `hermes --tui` starts a fresh session each launch. To re-attach to the most recent TUI session automatically (useful when your terminal or SSH connection drops unexpectedly), opt in:

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -183,6 +183,18 @@ display:
 
 Or in-session: `/indicator emoji` (etc.). Styles ship with matched glyph widths so the rest of the status bar doesn't jitter on rotation.
 
+## Ambient widget refresh
+
+Ambient dock widgets (quota gauges, countdown labels, and other glanceable cards) can soft-refresh their **values** on a shared cadence without redrawing the whole dock strip or the main status bar.
+
+```yaml
+display:
+  tui_widget_refresh_ms: 30000   # soft UI tick period in ms; default 30000
+  # tui_widget_refresh_ms: 0     # disable the host-suggested tick (widgets may still poll networks themselves)
+```
+
+The TUI clamps values below `1000` up to `1000` (except `0`, which turns the host suggestion off). User widgets read the live value via `sdk.refreshMs()` and should prefer `sdk.softUpdateWidget(app, { field: next })` for value-only ticks so sibling cards keep their React state identity.
+
 ## Auto-resume
 
 By default, `hermes --tui` starts a fresh session each launch. To re-attach to the most recent TUI session automatically (useful when your terminal or SSH connection drops unexpectedly), opt in:


### PR DESCRIPTION
## Summary

Ambient dock widgets that tick countdown / gauge values were forcing a full strip refresh (and noisy sibling re-renders) because every `updateWidget` rewrote the ambient array even when values did not change, and every card re-rendered together.

This adds a config-driven soft refresh period and a soft value-update path so only the changed widget card redraws.

## Changes

- `display.tui_widget_refresh_ms` in `config.yaml` (default `30000`, `0` = no host-suggested tick; sub-1000 clamps to 1000)
- TUI: `applyDisplay` → `$uiState.widgetRefreshMs`; user widgets read via `sdk.refreshMs()`
- `softUpdateWidget(app, patch)` + no-op skip in `updateWidget` when state ref is unchanged
- Memoized ambient cards in the dock/rails so a value tick on A does not re-render B
- Docs: `website/docs/user-guide/tui.md`

## Validation

- `npm run fix` + `npm run typecheck` in `ui-tui`
- vitest: `widgetSoftRefresh.test.ts`, `widgetSoftRefresh.composition.test.tsx`, `widgetSdk.test.ts`, `useConfigSync.test.ts` (56 passed)

## Related

Narrow slice of the refresh lifecycle discussion in https://github.com/NousResearch/hermes-agent/issues/69277 (shared cadence + less dock thrash). Does not implement host-owned `fetch`/stale/dead lifecycle from that issue.
