### PR TITLE
fix(gateway): respect explicit platform disable for Home Assistant in env overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2082,7 +2082,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
+        ha_explicit = bool(config.platforms[Platform.HOMEASSISTANT].extra.get("_enabled_explicit", False))
+        if not ha_explicit or config.platforms[Platform.HOMEASSISTANT].enabled:
+            config.platforms[Platform.HOMEASSISTANT].enabled = True
         config.platforms[Platform.HOMEASSISTANT].token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -168,8 +168,9 @@ def test_cold_profile_hydrates_external_source_without_global_env(
 
 def test_homeassistant_explicit_disable_in_multiplex_config(monkeypatch, tmp_path):
     """Secondary profiles with platforms.homeassistant.enabled: false must remain
-    disabled even when HASS_TOKEN is present in os.environ."""
+    disabled even when HASS_TOKEN is present in os.environ or scoped secrets."""
     import yaml
+    from agent import secret_scope as ss
     from gateway.config import load_gateway_config, Platform
     from gateway.run import _profile_runtime_scope
 
@@ -183,10 +184,26 @@ def test_homeassistant_explicit_disable_in_multiplex_config(monkeypatch, tmp_pat
         yaml.dump({"platforms": {"homeassistant": {"enabled": False}}})
     )
 
+    # 1. Standard env override check
     with _profile_runtime_scope(p):
         cfg = load_gateway_config()
         ha_cfg = cfg.platforms.get(Platform.HOMEASSISTANT)
         assert ha_cfg is not None
         assert ha_cfg.enabled is False
+
+    # 2. Multiplex active check with scoped secrets
+    ss.set_multiplex_active(True)
+    with _profile_runtime_scope(p):
+        tok = ss.set_secret_scope(
+            {"HASS_TOKEN": "mock_token", "HASS_URL": "http://ha.local:8123"}
+        )
+        try:
+            cfg = load_gateway_config()
+            ha_cfg = cfg.platforms.get(Platform.HOMEASSISTANT)
+            assert ha_cfg is not None
+            assert ha_cfg.enabled is False
+        finally:
+            ss.reset_secret_scope(tok)
+
 
 

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -166,3 +166,27 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert "EXPLICIT_API_KEY" not in os.environ
 
 
+def test_homeassistant_explicit_disable_in_multiplex_config(monkeypatch, tmp_path):
+    """Secondary profiles with platforms.homeassistant.enabled: false must remain
+    disabled even when HASS_TOKEN is present in os.environ."""
+    import yaml
+    from gateway.config import load_gateway_config, Platform
+    from gateway.run import _profile_runtime_scope
+
+    monkeypatch.setenv("HASS_TOKEN", "mock_token")
+    monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+
+    p = tmp_path / "secondary_profile"
+    p.mkdir()
+    cfg_file = p / "config.yaml"
+    cfg_file.write_text(
+        yaml.dump({"platforms": {"homeassistant": {"enabled": False}}})
+    )
+
+    with _profile_runtime_scope(p):
+        cfg = load_gateway_config()
+        ha_cfg = cfg.platforms.get(Platform.HOMEASSISTANT)
+        assert ha_cfg is not None
+        assert ha_cfg.enabled is False
+
+


### PR DESCRIPTION
### Summary
Checks  on  during env override processing when  is present in .

### Problem
When running Hermes in multiplexed gateway mode (), secondary worker profiles inherit process-level environment variables (including ). Without checking , env override processing force-enables Home Assistant even when  is explicitly configured on secondary profiles, resulting in duplicate credential startup errors:
.

This matches the explicit-disable pattern used for other platforms (Telegram, Slack, API Server).

### Validation
- Unit tests run via  (passed cleanly).
- Verified on a multiplexed gateway setup with secondary worker profiles containing .
