### PR TITLE
fix(skills): preserve bundle bytes to avoid Windows false updates

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -434,6 +434,79 @@ class TestCheckForSkillUpdates:
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
 
+    def test_crlf_install_records_bundle_hash_and_reports_up_to_date(self, tmp_path):
+        """Regression for the Windows CRLF false-update bug.
+
+        On Windows the quarantined/installed text on disk uses CRLF while the
+        in-memory bundle uses LF. install_from_quarantine must record the
+        bundle (LF) hash, not content_hash(install_dir) (CRLF), so that
+        check_for_skill_updates compares like with like and reports
+        up_to_date instead of a permanent update_available.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult, content_hash
+
+        skills_dir = tmp_path / "skills"
+        hub_dir = skills_dir / ".hub"
+        quarantine_root = hub_dir / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        # Bundle content is LF in memory (what the source served).
+        lf_md = "---\nname: crlf-skill\n---\nline one\nline two\n"
+        bundle = SkillBundle(
+            name="crlf-skill",
+            files={"SKILL.md": lf_md},
+            source="github",
+            identifier="owner/repo/crlf-skill",
+            trust_level="community",
+        )
+
+        # Quarantine text is CRLF on disk (as on Windows). Written with
+        # write_bytes so the test is platform-independent.
+        q_dir = quarantine_root / "crlf-skill"
+        q_dir.mkdir()
+        crlf = chr(13) + chr(10)
+        (q_dir / "SKILL.md").write_bytes(lf_md.replace(chr(10), crlf).encode("utf-8"))
+
+        scan_result = ScanResult(
+            skill_name="crlf-skill",
+            source="github",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            install_dir = hub.install_from_quarantine(
+                q_dir, "crlf-skill", "", bundle, scan_result,
+            )
+
+            # Sanity: the CRLF-on-disk hash really differs from the LF bundle
+            # hash — otherwise this test would not exercise the bug.
+            assert content_hash(install_dir) != bundle_content_hash(bundle)
+
+            # The recorded hash must be the bundle (LF) hash, i.e. the same
+            # representation check_for_skill_updates compares against.
+            lock = HubLockFile()
+            entry = lock.get_installed("crlf-skill")
+            assert entry["content_hash"] == bundle_content_hash(bundle)
+
+            # A re-fetch of the same bundle must report up_to_date.
+            source = MagicMock()
+            source.source_id.return_value = "github"
+            source.fetch.return_value = bundle
+            results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert len(results) == 1
+        assert results[0]["name"] == "crlf-skill"
+        assert results[0]["status"] == "up_to_date"
+
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -515,9 +515,9 @@ class TestCheckForSkillUpdates:
         )
         skill_dir = tmp_path / "demo-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "SKILL.md").write_bytes(b"same content")
         (skill_dir / "references").mkdir()
-        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "checklist.md").write_bytes(b"- [ ] security\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
@@ -1009,6 +1009,38 @@ class TestOptionalSkillSourceLiveRepoFallback:
 
 
 class TestQuarantineBundleBinaryAssets:
+    def test_quarantine_bundle_preserves_text_bytes_when_text_mode_translates_newlines(
+        self, tmp_path, monkeypatch,
+    ):
+        """Bundle bytes and quarantined bytes must stay hash-symmetric on Windows."""
+        from pathlib import Path
+
+        import tools.skills_hub as hub
+        from tools.skills_guard import content_hash
+
+        def windows_text_write(path, data, encoding=None, errors=None, newline=None):
+            encoded = data.replace("\n", "\r\n").encode(encoding or "utf-8", errors or "strict")
+            return path.write_bytes(encoded)
+
+        monkeypatch.setattr(Path, "write_text", windows_text_write)
+        hub_dir = tmp_path / "skills" / ".hub"
+        source = "---\nname: demo-skill\n---\nUnicode: café\n"
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="demo-skill", files={"SKILL.md": source}, source="github",
+                identifier="owner/repo/demo-skill", trust_level="community",
+            )
+            q_path = quarantine_bundle(bundle)
+
+        assert (q_path / "SKILL.md").read_bytes() == source.encode("utf-8")
+        assert content_hash(q_path) == bundle_content_hash(bundle)
+
     def test_quarantine_bundle_writes_binary_files(self, tmp_path):
         import tools.skills_hub as hub
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3751,7 +3751,7 @@ def install_from_quarantine(
         identifier=bundle.identifier,
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
+        skill_hash=bundle_content_hash(bundle),
         install_path=str(install_dir.relative_to(_skills_dir())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,

--- a/tools/skills_hub_install.py
+++ b/tools/skills_hub_install.py
@@ -57,6 +57,11 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
+def _bundle_bytes(content: str | bytes) -> bytes:
+    """Return the exact bytes represented by an in-memory bundle entry."""
+    return content if isinstance(content, bytes) else content.encode("utf-8")
+
+
 def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
     from tools.skills_hub import _quarantine_dir, ensure_hub_dirs
@@ -71,10 +76,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     for rel_path, file_content in validated_files:
         file_dest = dest.joinpath(*rel_path.split("/"))
         file_dest.parent.mkdir(parents=True, exist_ok=True)
-        if isinstance(file_content, bytes):
-            file_dest.write_bytes(file_content)
-        else:
-            file_dest.write_text(file_content, encoding="utf-8")
+        file_dest.write_bytes(_bundle_bytes(file_content))
     return dest
 
 
@@ -236,8 +238,7 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     for rel_path in sorted(normalized):
         h.update(rel_path.encode("utf-8"))
         h.update(b"\x00")
-        content = normalized[rel_path]
-        h.update(content if isinstance(content, bytes) else content.encode("utf-8"))
+        h.update(_bundle_bytes(normalized[rel_path]))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Problem

On Windows, hub-installed skills can remain permanently `update_available` immediately after an update.

`SkillBundle` text entries are hashed as their UTF-8 bytes, but `quarantine_bundle()` wrote strings through `Path.write_text()`. Windows text mode can translate LF to CRLF before installation, so the on-disk hash recorded at install time differs from the freshly fetched bundle hash.

## Fix

Preserve the bundle's byte representation at the write seam:

- add `_bundle_bytes()` as the single string/bytes-to-bytes conversion
- write every quarantine entry with `write_bytes()`
- use the same conversion in `bundle_content_hash()`

This keeps `content_hash(install_dir)` as a real integrity hash of installed bytes instead of changing the lock entry to represent remote source bytes.

## Regression coverage

The new test simulates a platform text writer that translates LF to CRLF, then exercises the public quarantine interface and verifies:

1. quarantined bytes exactly equal the bundle's UTF-8 bytes
2. the on-disk content hash remains equal to the bundle hash

The existing hash-symmetry fixture now writes its intended bytes explicitly, so it is platform-independent.

## Verification

- Before the fix: regression test failed with LF bundle bytes becoming CRLF on disk
- After the fix: focused regression test passed
- Related selection: 7 passed
- `ruff check tools/skills_hub_install.py tests/tools/test_skills_hub.py`: passed
- Windows test file excluding one unrelated current-main `OptionalSkillSource` binary-assets failure: 99 passed, 1 skipped