### PR TITLE
fix(desktop): support multi-select clarifications

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -192,7 +192,13 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
 
   const parkClarify = (sessionId: string) => {
     $clarifyRequests.set({
-      [sessionId]: { requestId: `req-${sessionId}`, question: 'which one?', choices: ['a', 'b'], sessionId }
+      [sessionId]: {
+        requestId: `req-${sessionId}`,
+        question: 'which one?',
+        choices: ['a', 'b'],
+        multiSelect: false,
+        sessionId
+      }
     })
     $gateway.set({ request: gatewayRequest } as unknown as ReturnType<typeof $gateway.get>)
   }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { clearClarifyRequest } from '@/store/clarify'
+import { $clarifyRequests, clearClarifyRequest } from '@/store/clarify'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -90,6 +90,32 @@ describe('clarify.request stream hydration', () => {
     expect(parts[0].type === 'tool-call' && parts[0].args).toMatchObject({
       choices: ['yes', 'no'],
       question: 'Ship it?'
+    })
+  })
+
+  it('preserves multi-select through the store and hydrated tool row', async () => {
+    await mountStream()
+
+    clarifyRequest({
+      choices: ['read', 'write'],
+      multi_select: true,
+      question: 'Which permissions?',
+      request_id: 'req-multi'
+    })
+
+    expect($clarifyRequests.get()[SID]?.multiSelect).toBe(true)
+
+    const part = clarifyParts()[0]
+    expect(part?.type).toBe('tool-call')
+
+    if (part?.type !== 'tool-call') {
+      throw new Error('Expected a hydrated clarify tool call')
+    }
+
+    expect(part.args).toMatchObject({
+      choices: ['read', 'write'],
+      multi_select: true,
+      question: 'Which permissions?'
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -928,6 +928,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const question = typeof payload?.question === 'string' ? payload.question : ''
         const rawChoices = payload?.choices
         const choices = normalizeChoices(rawChoices)
+        const multiSelect = payload?.multi_select === true
 
         if (requestId && question) {
           if (rawChoices != null && choices.length === 0) {
@@ -938,6 +939,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             requestId,
             question,
             choices: choices.length > 0 ? choices : null,
+            multiSelect,
             sessionId: sessionId ?? null
           })
 
@@ -949,7 +951,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // choices. Upsert a stable pending clarify tool row from the request
             // itself so the prompt stays answerable; a real tool.start/complete
             // with the same request id merges rather than duplicates.
-            upsertToolCall(sessionId, { args: { choices, question }, name: 'clarify', tool_id: requestId }, 'running')
+            upsertToolCall(
+              sessionId,
+              {
+                args: { choices, ...(multiSelect ? { multi_select: true } : {}), question },
+                name: 'clarify',
+                tool_id: requestId
+              },
+              'running'
+            )
 
             // The transcript only renders the active session, so a background
             // clarify is otherwise invisible (the row just keeps spinning like

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -71,13 +71,14 @@ function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessageP
   }
 }
 
-function renderLiveClarify() {
+function renderLiveClarify({ multiSelect = false }: { multiSelect?: boolean } = {}) {
   const request = vi.fn().mockResolvedValue({ ok: true })
 
   $activeSessionId.set('session-1')
   $gateway.set({ request } as never)
   setClarifyRequest({
     choices: ['staging', 'production'],
+    multiSelect,
     question: 'Which deployment target?',
     requestId: 'request-1',
     sessionId: 'session-1'
@@ -86,6 +87,57 @@ function renderLiveClarify() {
 
   return request
 }
+
+describe('ClarifyTool choice selection', () => {
+  it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
+    const request = renderLiveClarify({ multiSelect: true })
+    const staging = screen.getByRole('button', { name: /staging/ })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.click(staging)
+    fireEvent.click(production)
+    expect(staging.getAttribute('aria-pressed')).toBe('true')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(staging.getAttribute('aria-pressed')).toBe('true')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(staging)
+    expect(staging.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(staging)
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: JSON.stringify(['production', 'staging']),
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('keeps single-select replacement and plain-string submission', async () => {
+    const request = renderLiveClarify()
+    const staging = screen.getByRole('button', { name: /staging/ })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.click(staging)
+    fireEvent.click(production)
+
+    expect(staging.getAttribute('aria-pressed')).toBe('false')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
+})
 
 describe('readClarifyResult', () => {
   it('reads question + user_response from the tool JSON payload', () => {
@@ -315,6 +367,7 @@ describe('ClarifyTool pending marker', () => {
     $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
     setClarifyRequest({
       choices: null,
+      multiSelect: false,
       question: 'Anything else?',
       requestId: 'request-1',
       sessionId: 'session-1'

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -323,6 +323,26 @@ describe('ClarifyTool keyboard navigation', () => {
     })
   })
 
+  it('stages a highlighted multi-select choice with Enter and submits it with Continue', async () => {
+    const request = renderLiveClarify({ multiSelect: true })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+    expect(request).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: JSON.stringify(['production']),
+        request_id: 'request-1'
+      })
+    })
+  })
+
   it('focuses Other when its number is pressed and leaves typing keys alone', () => {
     renderLiveClarify()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -418,6 +418,16 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }, [pendingAnswer, respond])
 
   const activateActive = useCallback(() => {
+    const choice = choices[activeIndex]
+
+    // Multi-select Enter toggles the highlighted choice. The user confirms the
+    // staged set explicitly with Continue so this path never submits a scalar.
+    if (multiSelect && choice) {
+      selectChoice(choice, activeIndex)
+
+      return
+    }
+
     // A staged answer (picked choice or typed text) wins — confirm it.
     if (pendingAnswer) {
       submitAnswer()
@@ -427,8 +437,6 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
     // Otherwise act on the highlighted row: a choice responds immediately, and
     // the trailing "Other" row focuses the free-text field.
-    const choice = choices[activeIndex]
-
     if (choice) {
       void respond(choice)
 
@@ -436,7 +444,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     }
 
     textareaRef.current?.focus()
-  }, [activeIndex, choices, pendingAnswer, respond, submitAnswer])
+  }, [activeIndex, choices, multiSelect, pendingAnswer, respond, selectChoice, submitAnswer])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -35,6 +35,7 @@ import { parseMaybeObject } from './tool/fallback-model/format'
 interface ClarifyArgs {
   question?: string
   choices?: string[] | null
+  multiSelect?: boolean
 }
 
 interface ClarifyResult {
@@ -66,7 +67,8 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
 
   return {
     question,
-    choices: choices.length > 0 ? choices : null
+    choices: choices.length > 0 ? choices : null,
+    multiSelect: row.multi_select === true
   }
 }
 
@@ -144,7 +146,7 @@ function ChoiceButton({
   disabled,
   keyShortcuts,
   onClick,
-  selected = false,
+  selected,
   title
 }: {
   active?: boolean
@@ -169,6 +171,7 @@ function ChoiceButton({
       <button
         aria-current={active || undefined}
         aria-keyshortcuts={keyShortcuts}
+        aria-pressed={selected}
         className={cn(
           OPTION_ROW_CLASS,
           'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
@@ -181,7 +184,7 @@ function ChoiceButton({
         onClick={onClick}
         type="button"
       >
-        <KeyBadge char={char} preview={active} selected={selected} />
+        <KeyBadge char={char} preview={active} selected={Boolean(selected)} />
         <span className="flex-1 wrap-anywhere">{choice}</span>
       </button>
     </Tip>
@@ -306,10 +309,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const multiSelect = hasChoices && Boolean(matchingRequest?.multiSelect ?? fromArgs.multiSelect)
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [selectedChoices, setSelectedChoices] = useState<string[]>([])
   // The keyboard cursor. Indices 0..choices.length-1 are the options; the
   // trailing index (=== choices.length) is the "Other" free-text row.
   const [activeIndex, setActiveIndex] = useState(0)
@@ -359,14 +363,30 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // The answer is whichever input is active: a picked choice, or typed text.
   // Picking a choice no longer fires immediately — it selects, then the user
   // confirms with Continue (or Enter from the field).
-  const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string, index: number) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-    setActiveIndex(index)
-  }, [])
+  const selectedAnswer = multiSelect
+    ? selectedChoices.length > 0
+      ? JSON.stringify(selectedChoices)
+      : null
+    : (selectedChoices[0] ?? null)
+
+  const pendingAnswer = selectedAnswer ?? (trimmedDraft || null)
+
+  const selectChoice = useCallback(
+    (choice: string, index: number) => {
+      // Picking a choice and typing are mutually exclusive answers.
+      setDraft('')
+      setSelectedChoices(selected => {
+        if (!multiSelect) {
+          return [choice]
+        }
+
+        return selected.includes(choice) ? selected.filter(value => value !== choice) : [...selected, choice]
+      })
+      setActiveIndex(index)
+    },
+    [multiSelect]
+  )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
   useEffect(() => {
@@ -377,26 +397,25 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     (delta: number) => {
       const itemCount = choices.length + 1
 
-      // Arrow navigation is a move, not a pick — clear any staged answer so the
-      // cursor and the selection can't disagree.
+      // Arrow navigation is a move, not a pick. Multi-select keeps staged
+      // choices while the cursor moves so the user can build a set; the
+      // single-select path retains its existing clear-on-navigation behaviour.
       setDraft('')
-      setSelectedChoice(null)
+
+      if (!multiSelect) {
+        setSelectedChoices([])
+      }
+
       setActiveIndex(index => (index + delta + itemCount) % itemCount)
     },
-    [choices.length]
+    [choices.length, multiSelect]
   )
 
   const submitAnswer = useCallback(() => {
-    if (selectedChoice !== null) {
-      void respond(selectedChoice)
-
-      return
+    if (pendingAnswer) {
+      void respond(pendingAnswer)
     }
-
-    if (trimmedDraft) {
-      void respond(trimmedDraft)
-    }
-  }, [respond, selectedChoice, trimmedDraft])
+  }, [pendingAnswer, respond])
 
   const activateActive = useCallback(() => {
     // A staged answer (picked choice or typed text) wins — confirm it.
@@ -533,7 +552,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     // Typing is its own answer — drop any picked choice so the two inputs can't
     // both look selected.
     if (value.trim()) {
-      setSelectedChoice(null)
+      setSelectedChoices([])
     }
   }
 
@@ -571,7 +590,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 key={`${index}-${choice}`}
                 keyShortcuts={`${letterFor(index)} ${index + 1}`}
                 onClick={() => selectChoice(choice, index)}
-                selected={selectedChoice === choice}
+                selected={selectedChoices.includes(choice)}
               />
             ))}
             <label
@@ -595,7 +614,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
-                  setSelectedChoice(null)
+                  setSelectedChoices([])
                   setActiveIndex(choices.length)
                   setOtherFocused(true)
                 }}

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -73,6 +73,7 @@ export type GatewayEventPayload = {
   request_id?: string
   question?: string
   choices?: string[] | null
+  multi_select?: boolean
   // approval.request (dangerous command / execute_code) — session-keyed
   command?: string
   description?: string

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -18,6 +18,7 @@ function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
     requestId,
     question: `question-${requestId}`,
     choices: null,
+    multiSelect: false,
     sessionId
   }
 }

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -7,6 +7,7 @@ export interface ClarifyRequest {
   requestId: string
   question: string
   choices: string[] | null
+  multiSelect: boolean
   sessionId: string | null
 }
 

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -144,7 +144,7 @@ describe('$activeSessionAwaitingInput', () => {
     clearApprovalRequest('s1')
     expect($activeSessionAwaitingInput.get()).toBe(false)
 
-    setClarifyRequest({ choices: null, question: 'q', requestId: 'c1', sessionId: 's1' })
+    setClarifyRequest({ choices: null, multiSelect: false, question: 'q', requestId: 'c1', sessionId: 's1' })
     expect($activeSessionAwaitingInput.get()).toBe(true)
   })
 


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop receives `multi_select: true` from the backend for multi-select clarification requests, but it drops the flag before rendering. The clarification component therefore behaves as single-select and replaces the previous choice on every click.

This change preserves the flag through the Desktop gateway payload, stream hydration and clarify store. The live clarification card toggles choices independently when multi-select is enabled, retains selections during keyboard navigation and submits the selected values as a JSON array. Existing single-select and free-text behaviour remains unchanged.

## Related Issue

No linked issue. This Desktop rendering defect is separate from #26009, which concerns text-fallback interception.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `multi_select` to the Desktop gateway event payload in `apps/desktop/src/lib/chat-messages.ts`.
- Preserved the flag per session in `apps/desktop/src/store/clarify.ts` and during `clarify.request` hydration in `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`.
- Reworked `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` to toggle multiple choices, allow deselection, preserve selections during navigation and serialise multi-select responses as JSON arrays.
- Added regression coverage for propagation, selecting two choices, deselection, keyboard navigation, JSON-array submission and unchanged single-select submission.

## How to Test

1. Trigger a Desktop `clarify.request` with two or more choices and `multi_select: true`.
2. Select multiple choices, deselect and reselect one, then move the keyboard cursor with the arrow keys.
3. Press Continue and confirm `clarify.respond` sends the selected values as a JSON array string.
4. Trigger the same request without `multi_select` and confirm selecting a second choice replaces the first and submits a plain string.

Automated validation:

```bash
cd apps/desktop
npx vitest run --project ui src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx src/components/assistant-ui/clarify-tool.test.tsx src/store/clarify.test.ts src/store/prompts.test.ts src/app/chat/composer/hooks/use-composer-submit.test.tsx
npm run typecheck
npm run lint
npm run build
```

Result: 5 test files and 58 tests passed; type-checking and the production build passed; ESLint reported no errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on Apple Silicon

`pytest tests/ -q` was not run because this PR changes only the Desktop TypeScript application; the focused Vitest suite and Desktop type-check/build commands are listed above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing strings or documented behaviour changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no configuration changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only TypeScript with no OS-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: the backend tool schema is unchanged

## Screenshots / Logs

Manually verified in a packaged macOS Apple Silicon build: multiple choices remain selected, choices can be deselected, and submission unblocks the clarification with the expected array response.

clarify:
<img width="713" height="410" alt="image" src="https://github.com/user-attachments/assets/bf79eff3-3696-43b0-a190-b50916bd6282" />

responses:
<img width="713" height="410" alt="image" src="https://github.com/user-attachments/assets/ef46b0e7-58f0-4470-aff6-27595482ba72" />
