### PR TITLE
perf(state): add messages(session_id, id) index for windowed reads (#76237 salvage)

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -283,6 +283,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2698,6 +2698,48 @@ class TestGetMessagesPagination:
         messages = db.get_messages("s1")
         assert [m["content"] for m in messages] == [f"msg-{i}" for i in range(10)]
 
+
+    def test_window_query_bounded_work(self, db):
+        """Perf contract: get_messages_around must seek by index, not scan
+        the session's whole message history. Measured behaviorally via
+        SQLite progress-handler steps (behavior contracts over snapshots,
+        AGENTS.md — no EXPLAIN text). Calibrated on this seed (3000
+        messages): indexed = ~12 handler calls, unindexed full-session
+        scan = ~855. Threshold 300: >25x headroom above the indexed path,
+        ~3x below the scan. Same pattern as the loader call-count pins in
+        tests/tools/test_approval_config_readonly.py."""
+        self._seed(db, n=3000)
+        mid = db.get_messages("s1", limit=1, offset=1500)[0]["id"]
+        steps = [0]
+
+        def progress():
+            steps[0] += 1
+            return 0
+
+        db._conn.set_progress_handler(progress, 100)
+        try:
+            db.get_messages_around("s1", mid, window=20)
+        finally:
+            db._conn.set_progress_handler(None, 0)
+        assert steps[0] < 300, (
+            f"get_messages_around executed {steps[0]}x100 VM steps — the "
+            "session-history scan is back (idx_messages_session_id missing "
+            "or unused)")
+
+
+    def test_window_results_identical_with_and_without_index(self, db):
+        """The index must not change results: identical windows at probe
+        points across the session, with and without it."""
+        self._seed(db, n=500)
+        ids = [m["id"] for m in db.get_messages("s1")]
+        probes = (ids[0], ids[len(ids) // 2], ids[-1])
+        with_index = [db.get_messages_around("s1", mid, window=5)
+                      for mid in probes]
+        db._conn.execute("DROP INDEX idx_messages_session_id")
+        without_index = [db.get_messages_around("s1", mid, window=5)
+                         for mid in probes]
+        assert with_index == without_index
+
     def test_limit_pages_in_insertion_order(self, db):
         self._seed(db)
         page1 = db.get_messages("s1", limit=4, offset=0)

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS messages (
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 ```
 
 Notes:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/session-storage.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/session-storage.md
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS messages (
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 ```
 
 说明：


### PR DESCRIPTION
Salvage of #76237 by @spfcraze — cherry-picked to preserve authorship. Clean as submitted; no follow-up needed.

## Context — what this changes for users

`session_search`'s scroll shape (`get_messages_around`) — used every time the agent or a user pages through past-conversation context — currently walks the session's whole message history to find the window. On long sessions (thousands of messages) that's a full scan per call. The new `messages(session_id, id)` index turns it into an index seek: 32-307x measured, and EXPLAIN-verified (346 VM steps → 2 on the probe workload).

Bonus coverage (verified by EXPLAIN probes): the rewind query (`WHERE session_id=? AND id>=?`) and last-user-message lookups (`ORDER BY id DESC LIMIT 1`) also pick up the new index.

## Review & verification (full pipeline run)

- 142/142 `tests/test_hermes_state.py` green, ruff clean.
- Mutation check: reverting the schema makes the perf-contract test fail with the honest message ("854x100 VM steps — the session-history scan is back") and the parity test fail on the missing index; restored → green.
- Schema placement verified: both columns are base-schema, so `SCHEMA_SQL` (not `DEFERRED_INDEX_SQL`) is correct — `CREATE INDEX IF NOT EXISTS` is idempotent for existing DBs.
- Write cost honestly assessed: ~50 bytes/row (~5MB per 100K messages); inserts append at the right edge of each session's key range (monotonic id), so B-tree maintenance is cheap and sequential-ish.
- Test quality: perf contract measured via SQLite progress-handler step counts (behavior contract, not EXPLAIN-text snapshot), threshold has >25x headroom; the DROP INDEX test runs on a function-scoped fixture (no cross-test pollution).

Closes #76237.
