### PR TITLE
perf(memory): hoist loop-invariant HRR encodes out of retrieval loops (#76142 salvage)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -70,6 +70,15 @@ class FactRetriever:
 
         # Stage 2: Rerank with Jaccard + trust + optional decay
         query_tokens = self._tokenize(query)
+        # The query vector is loop-invariant — encode it at most once, on
+        # the first candidate that actually carries an HRR vector. Lazy on
+        # purpose: migrated stores can have FTS candidates whose hrr_vector
+        # was never backfilled (MemoryStore._init_db adds the column
+        # without backfilling), and those must not pay for an encode
+        # nothing will use. encode_text is deterministic (SHA-256 counter
+        # blocks), so the hoisted vector is bit-identical to what the
+        # per-candidate calls produced.
+        query_vec = None
         scored = []
 
         for fact in candidates:
@@ -83,7 +92,8 @@ class FactRetriever:
             # HRR similarity
             if self.hrr_weight > 0 and fact.get("hrr_vector"):
                 fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
-                query_vec = hrr.encode_text(query, self.hrr_dim)
+                if query_vec is None:
+                    query_vec = hrr.encode_text(query, self.hrr_dim)
                 hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
             else:
                 hrr_sim = 0.5  # neutral
@@ -173,6 +183,9 @@ class FactRetriever:
             # Final fallback: keyword search
             return self.search(entity, category=category, limit=limit)
 
+        # role_content is loop-invariant — encode it once (deterministic
+        # SHA-256-based atom) instead of once per fact row.
+        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
         scored = []
         for row in rows:
             fact = dict(row)
@@ -180,7 +193,6 @@ class FactRetriever:
             # Unbind probe key from fact to see if entity is structurally present
             residual = hrr.unbind(fact_vec, probe_key)
             # Compare residual against content signal
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
             content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
             sim = hrr.similarity(residual, content_vec)
             fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
@@ -234,6 +246,10 @@ class FactRetriever:
 
         # Score each fact by how much the entity's atom appears in its vector
         # This catches both role-bound entity matches AND content word matches
+        # Both role atoms are loop-invariant — encode them once here
+        # (deterministic SHA-256-based atoms) instead of twice per fact row.
+        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
         scored = []
         for row in rows:
             fact = dict(row)
@@ -243,8 +259,6 @@ class FactRetriever:
             residual = hrr.unbind(fact_vec, entity_vec)
             # A high-similarity residual to ANY known role vector means this entity
             # plays a structural role in the fact
-            role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
 
             entity_role_sim = hrr.similarity(residual, role_entity)
             content_role_sim = hrr.similarity(residual, role_content)

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -95,3 +95,141 @@ def test_prefetch_recovers_prose_query(retriever_with_facts):
     assert "deployment rollback" in results[0]["content"].lower()
 
 
+
+
+# ---------------------------------------------------------------------------
+# Loop-invariant encode hoists (perf) — search/probe/related must encode
+# constant vectors ONCE per call, not once per candidate/row.
+# encode_text/encode_atom are deterministic (SHA-256 counter blocks), so the
+# hoisted vectors are bit-identical to the per-iteration values they replace.
+# ---------------------------------------------------------------------------
+
+from plugins.memory.holographic import holographic as hrr
+
+
+@pytest.fixture
+def hoisted_retriever():
+    """30 facts with HRR vectors, default dim (smaller dims trip an
+    inhomogeneous-shape edge in the fact encoder)."""
+    store = MemoryStore(":memory:")
+    for i in range(30):
+        store.add_fact(
+            content=f"deploy target {i} setting alpha beta gamma option {i % 7}",
+            category="fact" if i % 2 else "preference",
+            tags=f"entity_{i % 5} deploy",
+        )
+    retriever = FactRetriever(store=store)
+    yield retriever
+    store.close()
+
+
+def _counting_spy(monkeypatch, attr):
+    calls = []
+    real = getattr(hrr, attr)
+
+    def wrapper(*args, **kwargs):
+        calls.append(args)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(hrr, attr, wrapper)
+    return calls
+
+
+def test_encode_functions_are_deterministic():
+    """Soundness premise of the hoists: same input -> identical vector."""
+    import numpy as np
+
+    assert np.array_equal(hrr.encode_text("deploy target", 1024),
+                          hrr.encode_text("deploy target", 1024))
+    assert np.array_equal(hrr.encode_atom("__hrr_role_content__", 1024),
+                          hrr.encode_atom("__hrr_role_content__", 1024))
+
+
+def test_search_encodes_query_vector_once(hoisted_retriever, monkeypatch):
+    calls = _counting_spy(monkeypatch, "encode_text")
+    results = hoisted_retriever.search("deploy target setting")
+    assert results  # the HRR path actually engaged
+    assert len(calls) == 1, (
+        f"query vector encoded {len(calls)}x in one search() — "
+        "loop-invariant hoist regressed"
+    )
+
+
+def test_search_results_bit_identical_to_unhoisted(hoisted_retriever):
+    """Parity: hoisted search() must produce the exact pre-fix results.
+
+    Replicates the pre-fix loop (query vector encoded per candidate) as the
+    reference and compares full scored output for exact equality.
+    """
+    r = hoisted_retriever
+    query = "deploy target setting"
+    new_results = r.search(query)
+
+    # --- pre-fix reference ---
+    candidates = r._fts_candidates(query, None, 0.3, 10 * 3)
+    query_tokens = r._tokenize(query)
+    scored = []
+    for fact in candidates:
+        content_tokens = r._tokenize(fact["content"])
+        tag_tokens = r._tokenize(fact.get("tags", ""))
+        all_tokens = content_tokens | tag_tokens
+        jaccard = r._jaccard_similarity(query_tokens, all_tokens)
+        fts_score = fact.get("fts_rank", 0.0)
+        if r.hrr_weight > 0 and fact.get("hrr_vector"):
+            fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
+            query_vec = hrr.encode_text(query, r.hrr_dim)  # per-candidate
+            hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0
+        else:
+            hrr_sim = 0.5
+        relevance = (r.fts_weight * fts_score
+                     + r.jaccard_weight * jaccard
+                     + r.hrr_weight * hrr_sim)
+        fact["score"] = relevance * fact["trust_score"]
+        scored.append(fact)
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    old_results = scored[:10]
+    for fact in old_results:
+        fact.pop("hrr_vector", None)
+
+    assert new_results == old_results
+
+
+def test_related_encodes_role_atoms_once(hoisted_retriever, monkeypatch):
+    calls = _counting_spy(monkeypatch, "encode_atom")
+    results = hoisted_retriever.related("entity_1")
+    assert results
+    role_calls = [a for a in calls
+                  if a and str(a[0]).startswith("__hrr_role_")]
+    assert len(role_calls) == 2, (
+        f"role atoms encoded {len(role_calls)}x in one related() — "
+        "expected exactly 2 (role_entity + role_content, hoisted)"
+    )
+
+
+def test_probe_encodes_role_atom_once(hoisted_retriever, monkeypatch):
+    calls = _counting_spy(monkeypatch, "encode_atom")
+    results = hoisted_retriever.probe("entity_1")
+    assert results
+    role_content_calls = [a for a in calls
+                          if a and a[0] == "__hrr_role_content__"]
+    assert len(role_content_calls) == 1, (
+        f"role_content atom encoded {len(role_content_calls)}x in one "
+        "probe() — loop-invariant hoist regressed"
+    )
+
+
+def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
+    """Migrated DBs can have FTS candidates with NULL hrr_vector
+    (MemoryStore._init_db adds the column without backfilling existing
+    facts). The lazy hoist must not encode a query vector nothing will
+    use — pre-fix main encoded only beneath fact.get('hrr_vector')."""
+    store = hoisted_retriever.store
+    store._conn.execute("UPDATE facts SET hrr_vector = NULL")
+    store._conn.commit()
+    calls = _counting_spy(monkeypatch, "encode_text")
+    results = hoisted_retriever.search("deploy target setting")
+    assert results  # candidates exist; neutral hrr_sim=0.5 path
+    assert calls == [], (
+        f"encode_text called {len(calls)}x with zero vector candidates — "
+        "lazy hoist regressed to eager"
+    )

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -108,10 +108,15 @@ from plugins.memory.holographic import holographic as hrr
 
 
 @pytest.fixture
-def hoisted_retriever():
+def hoisted_retriever(tmp_path):
     """30 facts with HRR vectors, default dim (smaller dims trip an
-    inhomogeneous-shape edge in the fact encoder)."""
-    store = MemoryStore(":memory:")
+    inhomogeneous-shape edge in the fact encoder).
+
+    NOTE: a real tmp_path db, NOT ":memory:" — MemoryStore resolves the
+    path and shares one process-wide connection per file, so ":memory:"
+    becomes a literal ./:memory: file that leaks state across runs (and
+    the NULL-vector test below would permanently corrupt it)."""
+    store = MemoryStore(str(tmp_path / "hoist_store.db"))
     for i in range(30):
         store.add_fact(
             content=f"deploy target {i} setting alpha beta gamma option {i % 7}",


### PR DESCRIPTION
Salvage of #76142 by @spfcraze — cherry-picked to preserve authorship, plus one review follow-up commit.

## Context — what this changes for users

The holographic memory plugin's retrieval loops re-encoded loop-invariant vectors on every candidate/row: `search()` re-encoded the query vector per candidate, `probe()`/`related()` re-encoded constant role atoms per row. Each encode is SHA-256 counter-block work, so memory retrieval paid O(N) redundant hashing per call. Hoisted once per call — memory lookups get proportionally faster as the fact store grows.

The `search()` hoist is deliberately lazy (encode on first candidate that carries an HRR vector): migrated stores can have FTS candidates whose `hrr_vector` was never backfilled, and those must not pay for an encode nothing uses — pinned by a dedicated test.

## Review & verification (full pipeline run)

- 13/13 retrieval tests + full `tests/plugins/memory/` (234) green, ruff clean.
- Soundness: `encode_text`/`encode_atom` are deterministic (test-pinned), so hoisted vectors are bit-identical; the PR's parity test replicates the exact pre-fix per-candidate loop and asserts equal output.
- Loop bodies audited: all remaining per-row calls genuinely depend on the row; the hoisted atoms sit AFTER the `if not rows: return` early-outs (no wasted encode).
- Mutation check: reverting production makes the 3 spy tests fail (encode counts explode), parity tests correctly pass either way; restored → green.

## Follow-up commit (review finding folded — the PR's own test had a real defect)

`MemoryStore(":memory:")` isn't in-memory: the store path-resolves and shares one process-wide connection per file, so the fixture created a literal `./:memory:` FILE whose state leaked across test runs — the NULL-vector test permanently wiped `hrr_vector` in it, and every SECOND run of the file failed all three spy tests. Reproduced (run 1 green, run 2 red), fixed the fixture to a `tmp_path` db, verified two consecutive runs + the full memory suite green.

Closes #76142.
