### PR TITLE
fix(skills): resolve install path against resolved skills dir (Windows junction)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -737,7 +737,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR.resolve())}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3821,7 +3821,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        install_path=str(install_dir.relative_to(_skills_dir().resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),


### PR DESCRIPTION
## Summary
Fixes skills-hub installs failing with:
```
Installation blocked: 'D:\hermes\skills\web-pentest' is not in the subpath of 'C:\Users\...\hermes\skills' OR one path is relative and the other is absolute.
```

**Root cause:** When `HERMES_HOME` lives on a Windows directory junction (e.g. `C:\Users\<user>\AppData\Local\hermes` → `D:\hermes`), `_resolve_lock_install_path()` returns the **physical** path (`D:\hermes\skills\<skill>`) after `.resolve()`, but the subsequent `relative_to()` calls compared it against the **junction-form** skills dir (`C:\Users\<user>\AppData\Local\hermes\skills`). The drive-letter mismatch makes `Path.relative_to()` raise `ValueError`, blocking every skills-hub install for junction/symlinked-home users.

**Fix:** Resolve the base dir too (`_skills_dir().resolve()` / `SKILLS_DIR.resolve()`), so both sides compare physical paths. Applies to both:
- `tools/skills_hub.py` — the lock-file `install_path` record (`install_from_quarantine`)
- `hermes_cli/skills_hub.py` — the post-install display path

## Test Plan
- On a junction-based HERMES_HOME (repro environment): `hermes skills install official/security/web-pentest` previously failed for **every** skill; now installs successfully (verified with 7 official skills).
- `scripts/run_tests.sh tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py`: 57 passed, 2 pre-existing failures (binary-asset KeyError, unrelated to this change — fails on clean main too).