### PR TITLE
fix(cli): refuse an unbalanced-quote slash command instead of killing the session (supersedes #43503)

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -462,6 +462,32 @@ class CLICommandsMixin:
         agent_running = getattr(self, "_agent_running", False)
         _cprint(f"  Agent: {'running' if agent_running else 'idle'}")
 
+    def _tokenize_slash_command(
+        self, text: str, *, label: str, example: str
+    ) -> list[str] | None:
+        """Split a typed slash command into tokens, or refuse to run it.
+
+        ``shlex.split`` raises ``ValueError`` ("No closing quotation") when the
+        line has an unbalanced quote. The interactive dispatch guards
+        ``process_command`` with ``except KeyboardInterrupt`` only, so a
+        ``ValueError`` escaping a slash handler unwinds to the outer
+        prompt_toolkit loop and the session dies along with the conversation.
+
+        Returns the tokens, or ``None`` after printing a quoting hint when the
+        line cannot be parsed. Refusing is deliberate: falling back to a naive
+        ``text.split()`` keeps the session alive but lets malformed input run,
+        because ``/cron add 30m "partial`` still splits into a well-formed
+        ``add`` whose schedule (``30m``) validates.
+        """
+        import shlex
+
+        try:
+            return shlex.split(text)
+        except ValueError as exc:
+            print(f"(._.) {label}: {exc}. Nothing was run.")
+            print(f"      Close the quote, e.g. {example}")
+            return None
+
     def _handle_journey_command(self, cmd_original: str) -> None:
         """Handle /journey — the learning timeline (see `hermes journey`).
 
@@ -472,7 +498,6 @@ class CLICommandsMixin:
         """
         import argparse
         import io
-        import shlex
         from contextlib import redirect_stdout
 
         from cli import _cprint
@@ -481,8 +506,16 @@ class CLICommandsMixin:
         parser = argparse.ArgumentParser(prog="/journey", add_help=False)
         register_cli(parser)
         rest = cmd_original.split(None, 1)
+        if len(rest) > 1:
+            tokens = self._tokenize_slash_command(
+                rest[1], label="/journey", example='/journey delete "my entry"'
+            )
+            if tokens is None:
+                return
+        else:
+            tokens = []
         try:
-            args = parser.parse_args(shlex.split(rest[1]) if len(rest) > 1 else [])
+            args = parser.parse_args(tokens)
         except SystemExit:
             return
 
@@ -1414,7 +1447,6 @@ class CLICommandsMixin:
     def _handle_cron_command(self, cmd: str):
         """Handle the /cron command to manage scheduled tasks."""
         from cli import get_job
-        import shlex
         from tools.cronjob_tools import cronjob as cronjob_tool
 
         def _cron_api(**kwargs):
@@ -1484,7 +1516,11 @@ class CLICommandsMixin:
                     i += 1
             return opts
 
-        tokens = shlex.split(cmd)
+        tokens = self._tokenize_slash_command(
+            cmd, label="/cron", example='/cron add "every 2h" "Check server status"'
+        )
+        if tokens is None:
+            return
 
         if len(tokens) == 1:
             print()
@@ -1714,9 +1750,15 @@ class CLICommandsMixin:
         Delegates to hermes_cli.curator so the CLI and the `hermes curator`
         subcommand share the same handler set.
         """
-        import shlex
-
-        tokens = shlex.split(cmd)[1:] if cmd else []
+        if cmd:
+            tokens = self._tokenize_slash_command(
+                cmd, label="/curator", example='/curator note "a title"'
+            )
+            if tokens is None:
+                return
+            tokens = tokens[1:]
+        else:
+            tokens = []
         if not tokens:
             tokens = ["status"]
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -478,14 +478,21 @@ class CLICommandsMixin:
         ``text.split()`` keeps the session alive but lets malformed input run,
         because ``/cron add 30m "partial`` still splits into a well-formed
         ``add`` whose schedule (``30m``) validates.
+
+        The hint goes through ``_cli_visible_print`` because ``patch_stdout``
+        swallows bare ``print`` while the prompt_toolkit Application owns the
+        terminal — which is precisely the situation this guard exists for, so a
+        bare ``print`` would leave the refusal silent.
         """
         import shlex
+
+        from cli import _cli_visible_print
 
         try:
             return shlex.split(text)
         except ValueError as exc:
-            print(f"(._.) {label}: {exc}. Nothing was run.")
-            print(f"      Close the quote, e.g. {example}")
+            _cli_visible_print(f"(._.) {label}: {exc}. Nothing was run.")
+            _cli_visible_print(f"      Close the quote, e.g. {example}")
             return None
 
     def _handle_journey_command(self, cmd_original: str) -> None:

--- a/tests/cli/test_cli_slash_quote_refusal.py
+++ b/tests/cli/test_cli_slash_quote_refusal.py
@@ -1,0 +1,144 @@
+"""An unbalanced quote in a slash command must be refused, not executed.
+
+``/journey``, ``/cron`` and ``/curator`` tokenize the typed line with
+``shlex.split``, which raises ``ValueError: No closing quotation`` when a quote
+is left open (``/cron add 30m "partial``).  The interactive dispatch in
+``cli.py`` wraps ``process_command`` in an ``except KeyboardInterrupt`` only, so
+that ``ValueError`` unwinds to the outer prompt_toolkit loop and takes the
+session — and the conversation — with it.
+
+The fix refuses the line: print a quoting hint and return.  It is deliberately
+*not* a ``cmd.split()`` fallback, because a naive split keeps the session alive
+while letting the malformed line run — ``/cron add 30m "partial`` still splits
+into a well-formed ``add`` whose schedule (``30m``) validates, so a scheduled
+job gets created from input the user never finished typing.  These tests pin
+both halves: nothing escapes, and nothing runs.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli import HermesCLI
+
+_CRON_OK = (
+    '{"success": true, "job_id": "job-1", "schedule": "every 2h",'
+    ' "next_run_at": "in 2h"}'
+)
+
+
+def _make_cli() -> HermesCLI:
+    """A bare ``HermesCLI``.
+
+    ``__init__`` is skipped on purpose: none of the three handlers reads
+    instance state on these paths, so an uninitialized instance exercises the
+    real MRO (``HermesCLI`` -> ``CLICommandsMixin``) without standing up a
+    session, an agent or a config file.
+    """
+    return HermesCLI.__new__(HermesCLI)
+
+
+# --------------------------------------------------------------------------
+# /cron — the effectful case teknium1 called out on #43503
+# --------------------------------------------------------------------------
+
+
+def test_cron_unbalanced_quote_does_not_create_a_job(capsys):
+    cli_obj = _make_cli()
+    # A JSON return keeps the mock usable so a call would surface as the
+    # assertion below rather than as an unrelated decode error.
+    with patch("tools.cronjob_tools.cronjob", return_value=_CRON_OK) as mock_cronjob:
+        cli_obj._handle_cron_command('/cron add 30m "partial')
+    mock_cronjob.assert_not_called()
+    out = capsys.readouterr().out
+    assert "/cron" in out and "No closing quotation" in out
+
+
+def test_cron_balanced_quotes_still_group_schedule_and_prompt(capsys):
+    """The refusal path must not degrade a correctly quoted command."""
+    cli_obj = _make_cli()
+    with patch("tools.cronjob_tools.cronjob", return_value=_CRON_OK) as mock_cronjob:
+        cli_obj._handle_cron_command('/cron add "every 2h" "Check server status"')
+    mock_cronjob.assert_called_once()
+    kwargs = mock_cronjob.call_args.kwargs
+    assert kwargs["action"] == "create"
+    assert kwargs["schedule"] == "every 2h"
+    assert kwargs["prompt"] == "Check server status"
+    assert "No closing quotation" not in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# /curator — must not delegate the malformed line
+# --------------------------------------------------------------------------
+
+
+def test_curator_unbalanced_quote_does_not_delegate(capsys):
+    cli_obj = _make_cli()
+    with patch("hermes_cli.curator.cli_main") as mock_main:
+        cli_obj._handle_curator_command('/curator "unterminated')
+    mock_main.assert_not_called()
+    assert "/curator" in capsys.readouterr().out
+
+
+def test_curator_balanced_quotes_still_group_tokens():
+    cli_obj = _make_cli()
+    with patch("hermes_cli.curator.cli_main") as mock_main:
+        cli_obj._handle_curator_command('/curator note "a title"')
+    mock_main.assert_called_once()
+    assert mock_main.call_args[0][0] == ["note", "a title"]
+
+
+def test_curator_bare_command_still_defaults_to_status():
+    """The ``if cmd:`` guard must keep the bare-``/curator`` default intact."""
+    cli_obj = _make_cli()
+    with patch("hermes_cli.curator.cli_main") as mock_main:
+        cli_obj._handle_curator_command("")
+    mock_main.assert_called_once()
+    assert mock_main.call_args[0][0] == ["status"]
+
+
+# --------------------------------------------------------------------------
+# /journey — the third site, which #43503 does not cover
+# --------------------------------------------------------------------------
+
+
+def test_journey_unbalanced_quote_does_not_dispatch(capsys):
+    cli_obj = _make_cli()
+    with patch("hermes_cli.journey._cmd_delete") as mock_delete, \
+            patch("hermes_cli.journey._cmd_show") as mock_show:
+        cli_obj._handle_journey_command('/journey delete "my entry')
+    mock_delete.assert_not_called()
+    mock_show.assert_not_called()
+    assert "/journey" in capsys.readouterr().out
+
+
+def test_journey_balanced_quotes_still_group_tokens():
+    cli_obj = _make_cli()
+    with patch("hermes_cli.journey._cmd_delete") as mock_delete:
+        cli_obj._handle_journey_command('/journey delete "my entry"')
+    mock_delete.assert_called_once()
+    assert mock_delete.call_args[0][0].node == "my entry"
+
+
+# --------------------------------------------------------------------------
+# The session-survival contract the REPL cannot provide for itself
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "handler_name, line",
+    [
+        ("_handle_journey_command", '/journey delete "my entry'),
+        ("_handle_cron_command", '/cron add 30m "partial'),
+        ("_handle_curator_command", '/curator "unterminated'),
+    ],
+)
+def test_slash_handlers_survive_unbalanced_quote(handler_name, line):
+    cli_obj = _make_cli()
+    with patch("tools.cronjob_tools.cronjob", return_value=_CRON_OK), \
+            patch("hermes_cli.curator.cli_main"), \
+            patch("hermes_cli.journey._cmd_delete"), \
+            patch("hermes_cli.journey._cmd_show"):
+        # No exception may escape: cli.py's slash dispatch catches only
+        # KeyboardInterrupt, so anything else ends the interactive session.
+        getattr(cli_obj, handler_name)(line)

--- a/tests/cli/test_cli_slash_quote_refusal.py
+++ b/tests/cli/test_cli_slash_quote_refusal.py
@@ -125,6 +125,22 @@ def test_journey_balanced_quotes_still_group_tokens():
 # --------------------------------------------------------------------------
 
 
+def test_refusal_hint_uses_the_prompt_toolkit_safe_printer():
+    """The hint must survive ``patch_stdout``.
+
+    A bare ``print`` is swallowed while the prompt_toolkit Application owns the
+    terminal — exactly the situation this guard exists for — so the refusal has
+    to go through ``cli._cli_visible_print`` or it is silent where it matters.
+    """
+    cli_obj = _make_cli()
+    with patch("cli._cli_visible_print") as mock_print, \
+            patch("hermes_cli.curator.cli_main"):
+        cli_obj._handle_curator_command('/curator "unterminated')
+    printed = " ".join(str(call[0][0]) for call in mock_print.call_args_list)
+    assert "No closing quotation" in printed
+    assert "/curator" in printed
+
+
 @pytest.mark.parametrize(
     "handler_name, line",
     [


### PR DESCRIPTION
## What does this PR do?

Supersedes #43503. The diagnosis there is **@ly-wang19's** and it is correct: `shlex.split` raises `ValueError: No closing quotation` on an unbalanced quote, the interactive REPL dispatch wraps `process_command` in `except KeyboardInterrupt` **only** (`cli.py:17307-17322`), and the comment on that guard already names the consequence — anything else *"unwinds to the outer prompt_toolkit loop and the session dies."* One stray `"` ends the session and the conversation with it. That PR has had no push since the 2026-07-14 review, so this carries it forward with the two changes that review asked for.

**Delta 1 — refuse instead of degrade (the blocking review point).** #43503 catches `ValueError` and falls back to `cmd.split()`. That keeps the session alive but lets the malformed line **execute**, which is exactly what the review flagged: *"whitespace fallback can execute malformed input … `/cron add 30m "partial` can therefore create a job because `30m` is valid"*, and *"On `ValueError`, print an invalid-quoting message and return from both handlers; do not call `cmd.split()` or delegate the malformed command."* Verified on today's `main`: a naive split gives `['/cron', 'add', '30m', '"partial']`, `_handle_cron_command` takes `positionals[0]` as the schedule (`cli_commands_mixin.py:1596`) and calls `_cron_api(action="create", …)` at `:1602`, so a half-typed line silently creates a **real scheduled job**. `/curator` likewise hands `'"unterminated'` straight to `hermes_cli.curator.cli_main`. This PR returns *before* the API call and *before* the delegation.

**Delta 2 — the third live site.** #43503 covers 2 of 3. `_handle_journey_command` (`cli_commands_mixin.py:485`) has the identical unguarded `shlex.split`, sitting inside a `try:` whose only handler is `except SystemExit:`, dispatched bare from `cli.py:10209`. It was not in the handler audit on that PR — `/journey` started using `shlex` after it.

## Related Issue

No issue is filed for this; the premise is `#43503`'s and is re-verified against current `main` below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_commands_mixin.py` — new `_tokenize_slash_command(text, *, label, example)` helper: returns tokens, or prints a quoting hint and returns `None`. One helper so the three sites cannot drift apart again.
- `hermes_cli/cli_commands_mixin.py:485` `_handle_journey_command` — refuse before `parser.parse_args`; `parse_args` keeps its own separate `except SystemExit`.
- `hermes_cli/cli_commands_mixin.py:1487` `_handle_cron_command` — refuse before `subcommand = tokens[1].lower()` and before any `_cron_api(...)`.
- `hermes_cli/cli_commands_mixin.py:1719` `_handle_curator_command` — refuse before the `from hermes_cli.curator import cli_main` delegation; the bare-`/curator` → `["status"]` default is preserved.
- The now-dead per-handler `import shlex` lines are removed from all three handlers.
- The hint is emitted via `cli._cli_visible_print`, not bare `print`: `patch_stdout` swallows bare `print` while the prompt_toolkit `Application` owns the terminal (`cli.py:3200-3217`), which is exactly the situation this guard exists for.
- `tests/cli/test_cli_slash_quote_refusal.py` — new, 11 tests.

### Sibling-site sweep

`grep -rn 'shlex\.split' --include='*.py' .` over production code, then filtered to *user-typed input reaching a handler on the CLI REPL slash dispatch*. Every site is accounted for:

**Fixed — unguarded, on the slash-dispatch path, `ValueError` kills the session:**

| site | handler | slash | dispatch |
| --- | --- | --- | --- |
| `hermes_cli/cli_commands_mixin.py:485` | `_handle_journey_command` | `/journey` | `cli.py:10209` |
| `hermes_cli/cli_commands_mixin.py:1487` | `_handle_cron_command` | `/cron` | `cli.py:10040` |
| `hermes_cli/cli_commands_mixin.py:1719` | `_handle_curator_command` | `/curator` | `cli.py:10046` |

**Deliberately excluded, with reasons:**

| site | why it is not the same root cause |
| --- | --- |
| `:159` `/diff`, `:658` `/tools`, `:1670` `/suggestions`, `:1694` `/blueprint` | already `try/except ValueError`. They use the naive-split fallback, but the degraded parse there is **not effectful** — no job is created, nothing is delegated. Changing them would alter commands that work today, which is a separate behaviour question and is left out of this PR on purpose. |
| `:2607` `_compose_in_editor` | already inside `try/except Exception`, and it splits the `$EDITOR` config value, not typed input. |
| `hermes_cli/kanban.py:3171` | its caller `_handle_kanban_command` (`:1747-1750`) wraps `run_slash` in `except Exception`. |
| `hermes_cli/blueprint_cmd.py:270`, `hermes_cli/mcp_security.py:96` | already `try/except ValueError`. |
| `hermes_cli/console_engine.py:113` | raises a typed `ConsoleCommandError`, caught by its own REPL at `:527` / `:1136`. Different surface. |
| `hermes_cli/session_listing.py:23` | `parse_session_listing_args` is only reached from `gateway/slash_commands.py:4521`; `cli.py:7844` imports `query_session_listing` instead. Different dispatch, different blast radius. |
| `hermes_cli/main.py:6957` | parses the `desktop.electron_flags` config value, not typed input. |
| `agent/`, `gateway/`, `tools/`, `plugins/` sites | not on the CLI REPL slash-dispatch path. |

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/cli/test_cli_slash_quote_refusal.py -v
```

Manually: start `hermes`, type `/cron add 30m "partial` and press enter. Before this change the session exits. After it, you get a hint and the prompt is still there — and `/cron list` shows no new job.

### Fails-before / passes-after, all three states

**A — clean `main` (no guard at all):** 6 failed, 4 passed.

```
FAILED test_cron_unbalanced_quote_does_not_create_a_job     - ValueError: No closing quotation
FAILED test_curator_unbalanced_quote_does_not_delegate      - ValueError: No closing quotation
FAILED test_journey_unbalanced_quote_does_not_dispatch      - ValueError: No closing quotation
FAILED test_slash_handlers_survive_unbalanced_quote[_handle_journey_command-...]
FAILED test_slash_handlers_survive_unbalanced_quote[_handle_cron_command-...]
FAILED test_slash_handlers_survive_unbalanced_quote[_handle_curator_command-...]
```

**B — `main` + #43503's `cmd.split()` fallback:** 4 failed, 6 passed. The session survives, but the malformed input runs — this is the review's objection, reproduced:

```
E  AssertionError: Expected 'cronjob' to not have been called. Called 1 times.
E  Calls: [call(action='create', schedule='30m', prompt='"partial', name=None,
E          deliver=None, repeat=None, skills=None)].

E  AssertionError: Expected 'cli_main' to not have been called. Called 1 times.
E  Calls: [call(['"unterminated'])].
```

plus `/journey` still dying with `ValueError: No closing quotation` in 2 tests, since that site is not covered there.

**C — this PR:** 11 passed (10 at the time of the run below, plus `test_refusal_hint_uses_the_prompt_toolkit_safe_printer` added in `a25032bad`; that one fails if the helper regresses to a bare `print`).

```
tests/cli/test_cli_slash_quote_refusal.py::test_cron_unbalanced_quote_does_not_create_a_job PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_cron_balanced_quotes_still_group_schedule_and_prompt PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_curator_unbalanced_quote_does_not_delegate PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_curator_balanced_quotes_still_group_tokens PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_curator_bare_command_still_defaults_to_status PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_journey_unbalanced_quote_does_not_dispatch PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_journey_balanced_quotes_still_group_tokens PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_slash_handlers_survive_unbalanced_quote[_handle_journey_command-/journey delete "my entry] PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_slash_handlers_survive_unbalanced_quote[_handle_cron_command-/cron add 30m "partial] PASSED
tests/cli/test_cli_slash_quote_refusal.py::test_slash_handlers_survive_unbalanced_quote[_handle_curator_command-/curator "unterminated] PASSED

============================== 10 passed in 0.23s ==============================
```

Adjacent surface (every test file that imports the mixin or exercises `/cron`, `/curator`, `/journey`, `/diff`, `/focus`, `/reasoning`, curator, cron scheduling, write-approval, handoff relay) — **274 passed**, serially, on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused file plus the full adjacent surface (274 passed) and `tests/cli` + `tests/hermes_cli`; the remaining reds there reproduce identically on clean `main` and are unrelated to this change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries the rationale in its docstring; no user-facing docs describe this path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `shlex.split` raises the same `ValueError` on every platform and no platform-specific behaviour is introduced; tested on macOS only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Supersedes #43503 (@ly-wang19) — same premise, credited above; this changes the remedy from a naive-split fallback to a refusal, and adds the `/journey` site.
- No overlap with the other open PRs on this file: #75833 (`/cron edit` semantics, `@@ -1588`), #75969 (`_handle_suggestions_command`, `@@ -1678`), #75787 (extraction of `704-1245`), #76458 (`@@ -1911`), #76191 (`@@ -1158`), #75496 (`854-1173`), #75361 (`@@ -2332`), #75326 (`@@ -1970`), #75216 (`@@ -28 / -2565`). None touches 485, 1487 or 1719.
- #24597 and #40536 mention these handlers but diff against the pre-refactor root `cli.py`, which no longer defines them (it does `from hermes_cli.cli_commands_mixin import CLICommandsMixin`).
- The new test file is named `test_cli_slash_quote_refusal.py` rather than #43503's `test_cli_slash_unbalanced_quote.py` so the two never collide as an add/add if both are ever applied.
