### PR TITLE
fix(config): remove stale platform toolsets on unset and migrate

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1155,17 +1155,17 @@ def _unset_nested(config, dotted_key: str) -> bool:
     return removed
 
 
-def _drop_empty_platform_toolset_overrides(config: Dict[str, Any]) -> bool:
-    """Remove empty platform_toolsets overrides so defaults apply again."""
+def _drop_empty_platform_toolset_override(config: Dict[str, Any], platform: str) -> bool:
+    """Remove one empty platform_toolsets override so defaults apply again."""
     platform_toolsets = config.get("platform_toolsets")
     if not isinstance(platform_toolsets, dict):
         return False
 
-    cleaned = {
-        platform: raw for platform, raw in platform_toolsets.items() if raw != []
-    }
-    if cleaned == platform_toolsets:
+    if platform_toolsets.get(platform) != []:
         return False
+
+    cleaned = dict(platform_toolsets)
+    cleaned.pop(platform, None)
     if cleaned:
         config["platform_toolsets"] = cleaned
     else:
@@ -2284,9 +2284,17 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             clean_platform_toolsets,
             validate_platform_toolsets,
         )
+        configured_mcp_toolsets = {
+            f"mcp-{name}"
+            for name in (config.get("mcp_servers") or {})
+            if isinstance(name, str) and name
+        }
 
         cleaned_toolsets, ts_warnings, ts_changed = clean_platform_toolsets(
-            config.get("platform_toolsets"), validate_toolset
+            config.get("platform_toolsets"),
+            validate_toolset,
+            extra_valid_names=configured_mcp_toolsets,
+            removable_names={"messaging"},
         )
         if ts_changed:
             if cleaned_toolsets:
@@ -2297,7 +2305,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
         ts_warnings.extend(
             validate_platform_toolsets(
-                config.get("platform_toolsets"), validate_toolset
+                config.get("platform_toolsets"),
+                validate_toolset,
+                extra_valid_names=configured_mcp_toolsets,
             )
         )
         for w in ts_warnings:
@@ -5158,7 +5168,9 @@ def unset_config_value(key: str):
         sys.exit(1)
 
     if key.startswith("platform_toolsets."):
-        _drop_empty_platform_toolset_overrides(user_config)
+        parts = key.split(".", 2)
+        if len(parts) >= 3:
+            _drop_empty_platform_toolset_override(user_config, parts[1])
 
     ensure_hermes_home()
     from utils import atomic_yaml_write

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1116,8 +1116,14 @@ def _unset_nested(config, dotted_key: str) -> bool:
         try:
             current.pop(int(last))
             removed = True
-        except (TypeError, ValueError, IndexError):
+        except IndexError:
             return False
+        except (TypeError, ValueError):
+            try:
+                current.remove(last)
+                removed = True
+            except ValueError:
+                return False
     elif isinstance(current, dict):
         if last not in current:
             return False
@@ -1147,6 +1153,24 @@ def _unset_nested(config, dotted_key: str) -> bool:
         break
 
     return removed
+
+
+def _drop_empty_platform_toolset_overrides(config: Dict[str, Any]) -> bool:
+    """Remove empty platform_toolsets overrides so defaults apply again."""
+    platform_toolsets = config.get("platform_toolsets")
+    if not isinstance(platform_toolsets, dict):
+        return False
+
+    cleaned = {
+        platform: raw for platform, raw in platform_toolsets.items() if raw != []
+    }
+    if cleaned == platform_toolsets:
+        return False
+    if cleaned:
+        config["platform_toolsets"] = cleaned
+    else:
+        config.pop("platform_toolsets", None)
+    return True
 
 
 def _is_env_config_key(key: str) -> bool:
@@ -2256,10 +2280,25 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     # error or warning. Surface it loudly instead. See #38798.
     try:
         from toolsets import validate_toolset
-        from hermes_cli.toolset_validation import validate_platform_toolsets
+        from hermes_cli.toolset_validation import (
+            clean_platform_toolsets,
+            validate_platform_toolsets,
+        )
 
-        ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+        cleaned_toolsets, ts_warnings, ts_changed = clean_platform_toolsets(
+            config.get("platform_toolsets"), validate_toolset
+        )
+        if ts_changed:
+            if cleaned_toolsets:
+                config["platform_toolsets"] = cleaned_toolsets
+            else:
+                config.pop("platform_toolsets", None)
+            _persist_migration(config)
+
+        ts_warnings.extend(
+            validate_platform_toolsets(
+                config.get("platform_toolsets"), validate_toolset
+            )
         )
         for w in ts_warnings:
             results["warnings"].append(w)
@@ -5117,6 +5156,9 @@ def unset_config_value(key: str):
     if not removed:
         print(f"Config key not set: {key}", file=sys.stderr)
         sys.exit(1)
+
+    if key.startswith("platform_toolsets."):
+        _drop_empty_platform_toolset_overrides(user_config)
 
     ensure_hermes_home()
     from utils import atomic_yaml_write

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,7 +12,75 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, List
+from typing import Any, Callable, Dict, List, Tuple
+
+
+def _unknown_toolset_warning(
+    platform: str,
+    name: str,
+    is_valid_toolset: Callable[[str], bool],
+) -> str:
+    """Build a consistent warning for an invalid toolset reference."""
+    suggestion = f"hermes-{platform}"
+    hint = (
+        f" — did you mean '{suggestion}'?"
+        if is_valid_toolset(suggestion)
+        else ""
+    )
+    return (
+        f"platform '{platform}' references unknown toolset "
+        f"'{name}'{hint}"
+    )
+
+
+def clean_platform_toolsets(
+    platform_toolsets: object,
+    is_valid_toolset: Callable[[str], bool],
+) -> Tuple[object, List[str], bool]:
+    """Drop invalid toolset names while preserving all valid entries.
+
+    If removing invalid entries empties a platform's list override, the platform
+    key is removed so Hermes falls back to the platform defaults instead of
+    treating an explicit empty list as "disable the defaults".
+    """
+    if not isinstance(platform_toolsets, dict) or not platform_toolsets:
+        return platform_toolsets, [], False
+
+    cleaned: Dict[str, Any] = {}
+    warnings: List[str] = []
+    changed = False
+
+    for platform, raw in platform_toolsets.items():
+        if isinstance(raw, list):
+            kept = []
+            removed_invalid = False
+            for entry in raw:
+                if isinstance(entry, str) and entry and not is_valid_toolset(entry):
+                    warnings.append(
+                        _unknown_toolset_warning(platform, entry, is_valid_toolset)
+                    )
+                    changed = True
+                    removed_invalid = True
+                    continue
+                kept.append(entry)
+            if kept:
+                cleaned[platform] = kept
+            elif removed_invalid:
+                changed = True
+            else:
+                cleaned[platform] = raw
+            continue
+
+        if isinstance(raw, str) and raw and not is_valid_toolset(raw):
+            warnings.append(_unknown_toolset_warning(platform, raw, is_valid_toolset))
+            changed = True
+            continue
+
+        cleaned[platform] = raw
+
+    if not changed:
+        return platform_toolsets, warnings, False
+    return cleaned, warnings, True
 
 
 def validate_platform_toolsets(
@@ -55,16 +123,7 @@ def validate_platform_toolsets(
             if is_valid_toolset(name):
                 valid_count += 1
                 continue
-            suggestion = f"hermes-{platform}"
-            hint = (
-                f" — did you mean '{suggestion}'?"
-                if is_valid_toolset(suggestion)
-                else ""
-            )
-            warnings.append(
-                f"platform '{platform}' references unknown toolset "
-                f"'{name}'{hint}"
-            )
+            warnings.append(_unknown_toolset_warning(platform, name, is_valid_toolset))
 
     if valid_count == 0:
         warnings.append(

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,7 +12,7 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Collection, Dict, List, Tuple
 
 
 def _unknown_toolset_warning(
@@ -33,9 +33,21 @@ def _unknown_toolset_warning(
     )
 
 
+def _is_known_toolset(
+    name: str,
+    is_valid_toolset: Callable[[str], bool],
+    extra_valid_names: Collection[str] | None = None,
+) -> bool:
+    """Return whether a toolset name is known in the current environment."""
+    return is_valid_toolset(name) or name in (extra_valid_names or ())
+
+
 def clean_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],
+    *,
+    extra_valid_names: Collection[str] | None = None,
+    removable_names: Collection[str] | None = None,
 ) -> Tuple[object, List[str], bool]:
     """Drop invalid toolset names while preserving all valid entries.
 
@@ -49,19 +61,25 @@ def clean_platform_toolsets(
     cleaned: Dict[str, Any] = {}
     warnings: List[str] = []
     changed = False
+    removable = set(removable_names or ())
 
     for platform, raw in platform_toolsets.items():
         if isinstance(raw, list):
             kept = []
             removed_invalid = False
             for entry in raw:
-                if isinstance(entry, str) and entry and not is_valid_toolset(entry):
+                if isinstance(entry, str) and entry and not _is_known_toolset(
+                    entry,
+                    is_valid_toolset,
+                    extra_valid_names,
+                ):
                     warnings.append(
                         _unknown_toolset_warning(platform, entry, is_valid_toolset)
                     )
-                    changed = True
-                    removed_invalid = True
-                    continue
+                    if not removable or entry in removable:
+                        changed = True
+                        removed_invalid = True
+                        continue
                 kept.append(entry)
             if kept:
                 cleaned[platform] = kept
@@ -71,10 +89,15 @@ def clean_platform_toolsets(
                 cleaned[platform] = raw
             continue
 
-        if isinstance(raw, str) and raw and not is_valid_toolset(raw):
+        if isinstance(raw, str) and raw and not _is_known_toolset(
+            raw,
+            is_valid_toolset,
+            extra_valid_names,
+        ):
             warnings.append(_unknown_toolset_warning(platform, raw, is_valid_toolset))
-            changed = True
-            continue
+            if not removable or raw in removable:
+                changed = True
+                continue
 
         cleaned[platform] = raw
 
@@ -86,6 +109,8 @@ def clean_platform_toolsets(
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],
+    *,
+    extra_valid_names: Collection[str] | None = None,
 ) -> List[str]:
     """Return human-readable warnings for a ``platform_toolsets`` mapping.
 
@@ -120,7 +145,7 @@ def validate_platform_toolsets(
         for name in names:
             if not isinstance(name, str) or not name:
                 continue
-            if is_valid_toolset(name):
+            if _is_known_toolset(name, is_valid_toolset, extra_valid_names):
                 valid_count += 1
                 continue
             warnings.append(_unknown_toolset_warning(platform, name, is_valid_toolset))

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1405,6 +1405,35 @@ class TestPlatformToolsetMigrationCleanup:
         assert "platform_toolsets" not in raw
         assert any("unknown toolset 'messaging'" in warning for warning in results["warnings"])
 
+    def test_migrate_config_preserves_configured_mcp_toolsets(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "mcp_servers": {
+                        "github": {
+                            "command": "npx",
+                            "args": ["-y", "@modelcontextprotocol/server-github"],
+                        },
+                    },
+                    "platform_toolsets": {
+                        "cli": ["mcp-github", "messaging"],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["platform_toolsets"]["cli"] == ["mcp-github"]
+        assert any("unknown toolset 'messaging'" in warning for warning in results["warnings"])
+        assert not any("unknown toolset 'mcp-github'" in warning for warning in results["warnings"])
+
 
 class TestIsProviderEnabled:
     """``is_provider_enabled`` gates ``providers.<name>`` blocks for the

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1358,6 +1358,54 @@ class TestCodexAppServerAutoConfig:
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
 
 
+class TestPlatformToolsetMigrationCleanup:
+    """Migration should prune stale toolset names that current Hermes rejects."""
+
+    def test_migrate_config_removes_invalid_platform_toolsets_entries(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "platform_toolsets": {
+                        "cli": ["browser", "messaging", "terminal"],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["platform_toolsets"]["cli"] == ["browser", "terminal"]
+        assert any("unknown toolset 'messaging'" in warning for warning in results["warnings"])
+
+    def test_migrate_config_drops_empty_platform_override_after_cleanup(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "platform_toolsets": {
+                        "cli": ["messaging"],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert "platform_toolsets" not in raw
+        assert any("unknown toolset 'messaging'" in warning for warning in results["warnings"])
+
+
 class TestIsProviderEnabled:
     """``is_provider_enabled`` gates ``providers.<name>`` blocks for the
     model picker, ``/models`` listings and the runtime resolver. Default

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,55 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+class TestUnsetPlatformToolsetEntries:
+    """Regression tests for string-list removal via `config unset`."""
+
+    def test_unset_removes_platform_toolset_list_item_by_value(self, _isolated_hermes_home):
+        import yaml
+
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 33,
+                    "platform_toolsets": {
+                        "cli": ["browser", "messaging", "terminal"],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli.config import unset_config_value
+
+        unset_config_value("platform_toolsets.cli.messaging")
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["platform_toolsets"]["cli"] == ["browser", "terminal"]
+
+    def test_unset_last_platform_toolset_item_restores_default_resolution(self, _isolated_hermes_home):
+        import yaml
+
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 33,
+                    "platform_toolsets": {
+                        "cli": ["browser"],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli.config import unset_config_value
+
+        unset_config_value("platform_toolsets.cli.browser")
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved == {"_config_version": 33}

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -775,3 +775,33 @@ class TestUnsetPlatformToolsetEntries:
 
         saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert saved == {"_config_version": 33}
+
+    def test_unset_last_item_preserves_unrelated_explicit_empty_override(self, _isolated_hermes_home):
+        import yaml
+
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 33,
+                    "platform_toolsets": {
+                        "cli": ["browser"],
+                        "discord": [],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli.config import unset_config_value
+
+        unset_config_value("platform_toolsets.cli.browser")
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved == {
+            "_config_version": 33,
+            "platform_toolsets": {
+                "discord": [],
+            },
+        }

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -61,3 +61,29 @@ def test_clean_platform_toolsets_drops_invalid_entries_and_empty_overrides():
     assert any("platform 'discord'" in warning for warning in warnings)
 
 
+def test_clean_platform_toolsets_can_preserve_dynamic_and_non_removable_names():
+    cfg = {"cli": ["mcp-github", "messaging", "future-toolset"]}
+
+    cleaned, warnings, changed = clean_platform_toolsets(
+        cfg,
+        _is_valid,
+        extra_valid_names={"mcp-github"},
+        removable_names={"messaging"},
+    )
+
+    assert changed is True
+    assert cleaned == {"cli": ["mcp-github", "future-toolset"]}
+    assert len(warnings) == 2
+    assert any("unknown toolset 'messaging'" in warning for warning in warnings)
+    assert any("unknown toolset 'future-toolset'" in warning for warning in warnings)
+
+
+def test_validate_platform_toolsets_accepts_dynamic_valid_names():
+    warnings = validate_platform_toolsets(
+        {"cli": ["mcp-github"]},
+        _is_valid,
+        extra_valid_names={"mcp-github"},
+    )
+
+    assert warnings == []
+

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -6,7 +6,10 @@ tool registry nor a running Hermes.
 
 import pytest
 
-from hermes_cli.toolset_validation import validate_platform_toolsets
+from hermes_cli.toolset_validation import (
+    clean_platform_toolsets,
+    validate_platform_toolsets,
+)
 
 # A representative set of real toolset names. `hermes` is deliberately absent —
 # that is the corruption #38798 reported (`hermes-cli` rewritten to `hermes`).
@@ -46,5 +49,15 @@ def test_mixed_valid_and_invalid_flags_only_the_invalid():
     assert "unknown toolset 'bogus'" in warnings[0]
 
 
+def test_clean_platform_toolsets_drops_invalid_entries_and_empty_overrides():
+    cfg = {"cli": ["terminal", "bogus"], "discord": ["wrong"], "web": []}
+
+    cleaned, warnings, changed = clean_platform_toolsets(cfg, _is_valid)
+
+    assert changed is True
+    assert cleaned == {"cli": ["terminal"], "web": []}
+    assert len(warnings) == 2
+    assert any("platform 'cli'" in warning for warning in warnings)
+    assert any("platform 'discord'" in warning for warning in warnings)
 
 


### PR DESCRIPTION
## Summary
- allow `hermes config unset` to remove string entries from list-valued config keys such as `platform_toolsets.cli.messaging`
- prune empty `platform_toolsets.<platform>` overrides after deletion so Hermes falls back to platform defaults instead of treating `[]` as an explicit override
- make `hermes config migrate` strip invalid toolset names like legacy `messaging` entries while preserving user-authored empty overrides on other platforms
- add regression coverage for unset, migration, and platform toolset cleanup helpers

## Testing
- `.venv/bin/pytest tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_toolset_validation.py -q`
- `.venv/bin/pytest tests/hermes_cli/test_config.py -q`

Fixes #76847