### PR TITLE
feat(desktop): add continuous voice idle timeout

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -9,7 +9,12 @@ import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/st
 import { resetBrowseState } from '@/store/composer-input-history'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $autoSpeakReplies, $voiceStopPhrase, setAutoSpeakReplies } from '@/store/voice-prefs'
+import {
+  $autoSpeakReplies,
+  $voiceConversationIdleTimeoutMs,
+  $voiceStopPhrase,
+  setAutoSpeakReplies
+} from '@/store/voice-prefs'
 import { resumeWakeAfterVoice } from '@/store/wake-word'
 
 import type { ComposerTarget } from '../focus'
@@ -62,6 +67,7 @@ export function useComposerVoice({
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
+  const voiceConversationIdleTimeoutMs = useStore($voiceConversationIdleTimeoutMs)
   const lastSpokenIdRef = useRef<string | null>(null)
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
@@ -134,7 +140,9 @@ export function useComposerVoice({
     busy,
     consumePendingResponse,
     enabled: voiceConversationActive,
+    idleTimeoutMs: voiceConversationIdleTimeoutMs,
     onFatalError: () => setVoiceConversationActive(false),
+    onIdleTimeout: () => setVoiceConversationActive(false),
     // Speaking over the model mid-generation interrupts the in-flight turn —
     // the same seam as the Stop button — so the interjection becomes the next
     // turn instead of waiting behind a reply the user already rejected.

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -34,6 +34,7 @@ function fakeStream() {
 }
 
 class FakeMediaRecorder {
+  static deferStopEvent = false
   static instances: FakeMediaRecorder[] = []
   static isTypeSupported = vi.fn(() => true)
 
@@ -47,7 +48,10 @@ class FakeMediaRecorder {
   state: RecordingState = 'inactive'
   stop = vi.fn(() => {
     this.state = 'inactive'
-    this.onstop?.()
+
+    if (!FakeMediaRecorder.deferStopEvent) {
+      this.onstop?.()
+    }
   })
 
   constructor(readonly stream: MediaStream) {
@@ -57,6 +61,7 @@ class FakeMediaRecorder {
 
 describe('useMicRecorder async acquisition ownership', () => {
   beforeEach(() => {
+    FakeMediaRecorder.deferStopEvent = false
     FakeMediaRecorder.instances = []
     vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
     Object.defineProperty(navigator, 'mediaDevices', {
@@ -144,4 +149,57 @@ describe('useMicRecorder async acquisition ownership', () => {
     expect(staleStream.stop).toHaveBeenCalledTimes(1)
     expect(FakeMediaRecorder.instances).toHaveLength(0)
   })
+
+  it.each(['stop', 'error'] as const)(
+    'ignores a stale recorder %s callback after cancellation starts a replacement',
+    async staleEvent => {
+      FakeMediaRecorder.deferStopEvent = true
+      const streamA = fakeStream()
+      const streamB = fakeStream()
+      const onErrorA = vi.fn()
+      vi.mocked(navigator.mediaDevices.getUserMedia)
+        .mockResolvedValueOnce(streamA.stream)
+        .mockResolvedValueOnce(streamB.stream)
+
+      const hook = renderHook(() => useMicRecorder(copy))
+
+      await act(async () => hook.result.current.handle.start({ onError: onErrorA }))
+      const recorderA = FakeMediaRecorder.instances[0]
+      const staleData = recorderA?.ondataavailable
+      const staleStop = recorderA?.onstop
+      const staleError = recorderA?.onerror
+      const stoppingA = hook.result.current.handle.stop()
+
+      act(() => hook.result.current.handle.cancel())
+      await expect(stoppingA).resolves.toBeNull()
+      await act(async () => hook.result.current.handle.start())
+
+      const recorderB = FakeMediaRecorder.instances[1]
+
+      act(() => {
+        staleData?.({ data: new Blob(['stale']) } as BlobEvent)
+
+        if (staleEvent === 'stop') {
+          staleStop?.()
+        } else {
+          staleError?.({ error: new Error('stale') } as Event & { error: Error })
+        }
+      })
+
+      expect(onErrorA).not.toHaveBeenCalled()
+      expect(streamB.stop).not.toHaveBeenCalled()
+      expect(recorderB?.state).toBe('recording')
+      expect(hook.result.current.recording).toBe(true)
+
+      let stoppingB!: Promise<unknown>
+
+      act(() => {
+        stoppingB = hook.result.current.handle.stop()
+        recorderB?.ondataavailable?.({ data: new Blob(['b']) } as BlobEvent)
+        recorderB?.onstop?.()
+      })
+
+      await expect(stoppingB).resolves.toMatchObject({ audio: { size: 1 } })
+    }
+  )
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -1,0 +1,147 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type MicRecorderErrorCopy, useMicRecorder } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: 'access denied',
+  microphoneConstraintsUnsupported: 'constraints unsupported',
+  microphoneInUse: 'in use',
+  microphonePermissionDenied: 'permission denied',
+  microphoneStartFailed: 'start failed',
+  microphoneUnsupported: 'unsupported',
+  noMicrophone: 'no microphone'
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+
+  return { promise, resolve }
+}
+
+function fakeStream() {
+  const stop = vi.fn()
+
+  const stream = {
+    getTracks: () => [{ stop }]
+  } as unknown as MediaStream
+
+  return { stop, stream }
+}
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static isTypeSupported = vi.fn(() => true)
+
+  mimeType = 'audio/webm'
+  ondataavailable: ((event: BlobEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onstop: (() => void) | null = null
+  start = vi.fn(() => {
+    this.state = 'recording'
+  })
+  state: RecordingState = 'inactive'
+  stop = vi.fn(() => {
+    this.state = 'inactive'
+    this.onstop?.()
+  })
+
+  constructor(readonly stream: MediaStream) {
+    FakeMediaRecorder.instances.push(this)
+  }
+}
+
+describe('useMicRecorder async acquisition ownership', () => {
+  beforeEach(() => {
+    FakeMediaRecorder.instances = []
+    vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn() }
+    })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { requestMicrophoneAccess: vi.fn(async () => true) }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it.each(['stale-first', 'current-first'] as const)(
+    'keeps only the current start active when streams resolve %s',
+    async resolveOrder => {
+      const acquisitionA = deferred<MediaStream>()
+      const acquisitionB = deferred<MediaStream>()
+      const streamA = fakeStream()
+      const streamB = fakeStream()
+      vi.mocked(navigator.mediaDevices.getUserMedia)
+        .mockReturnValueOnce(acquisitionA.promise)
+        .mockReturnValueOnce(acquisitionB.promise)
+
+      const hook = renderHook(() => useMicRecorder(copy))
+      let startA!: Promise<void>
+      let startB!: Promise<void>
+
+      await act(async () => {
+        startA = hook.result.current.handle.start()
+        await Promise.resolve()
+        hook.result.current.handle.cancel()
+        startB = hook.result.current.handle.start()
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        if (resolveOrder === 'stale-first') {
+          acquisitionA.resolve(streamA.stream)
+          await startA
+          acquisitionB.resolve(streamB.stream)
+          await startB
+        } else {
+          acquisitionB.resolve(streamB.stream)
+          await startB
+          acquisitionA.resolve(streamA.stream)
+          await startA
+        }
+      })
+
+      const recorderA = FakeMediaRecorder.instances.find(recorder => recorder.stream === streamA.stream)
+      const recorderB = FakeMediaRecorder.instances.find(recorder => recorder.stream === streamB.stream)
+
+      expect(streamA.stop).toHaveBeenCalledTimes(1)
+      expect(recorderA).toBeUndefined()
+      expect(streamB.stop).not.toHaveBeenCalled()
+      expect(recorderB?.state).toBe('recording')
+      expect(hook.result.current.recording).toBe(true)
+    }
+  )
+
+  it('stops a stream acquired after the hook unmounts', async () => {
+    const acquisition = deferred<MediaStream>()
+    const staleStream = fakeStream()
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockReturnValueOnce(acquisition.promise)
+
+    const hook = renderHook(() => useMicRecorder(copy))
+    let start!: Promise<void>
+
+    await act(async () => {
+      start = hook.result.current.handle.start()
+      await Promise.resolve()
+    })
+    hook.unmount()
+
+    await act(async () => {
+      acquisition.resolve(staleStream.stream)
+      await start
+    })
+
+    expect(staleStream.stop).toHaveBeenCalledTimes(1)
+    expect(FakeMediaRecorder.instances).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -263,12 +263,20 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       startedAtRef.current = Date.now()
 
       recorder.ondataavailable = event => {
+        if (recorderRef.current !== recorder) {
+          return
+        }
+
         if (event.data.size > 0) {
           chunksRef.current.push(event.data)
         }
       }
 
       recorder.onstop = () => {
+        if (recorderRef.current !== recorder) {
+          return
+        }
+
         const chunks = chunksRef.current
         const recordingType = recorder.mimeType || mimeType || 'audio/webm'
         const durationMs = Date.now() - startedAtRef.current
@@ -294,6 +302,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       }
 
       recorder.onerror = event => {
+        if (recorderRef.current !== recorder) {
+          return
+        }
+
         const error = micError((event as Event & { error?: unknown }).error, copy)
         const resolver = stopResolverRef.current
         stopResolverRef.current = null
@@ -338,11 +350,14 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     const resolver = stopResolverRef.current
     stopResolverRef.current = null
 
-    if (recorder && recorder.state !== 'inactive') {
+    if (recorder) {
       recorder.ondataavailable = null
       recorder.onerror = null
       recorder.onstop = null
-      recorder.stop()
+
+      if (recorder.state !== 'inactive') {
+        recorder.stop()
+      }
     }
 
     cleanup()

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -9,6 +9,7 @@ export interface MicRecorderOptions {
   silenceLevel?: number
   silenceMs?: number
   idleSilenceMs?: number
+  signal?: AbortSignal
 }
 
 export interface MicRecording {
@@ -31,6 +32,10 @@ interface MicRecorderHandle {
   start: (options?: MicRecorderOptions) => Promise<void>
   stop: () => Promise<MicRecording | null>
   cancel: () => void
+}
+
+interface MicStartAttempt {
+  cancelled: boolean
 }
 
 function micError(error: unknown, copy: MicRecorderErrorCopy): Error {
@@ -77,6 +82,13 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const pendingStartAttemptsRef = useRef(new Set<MicStartAttempt>())
+
+  const cancelPendingStarts = () => {
+    for (const attempt of pendingStartAttemptsRef.current) {
+      attempt.cancelled = true
+    }
+  }
 
   const cleanup = () => {
     if (animationRef.current) {
@@ -94,7 +106,13 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     silenceTriggeredRef.current = false
   }
 
-  useEffect(() => () => cleanup(), [])
+  useEffect(
+    () => () => {
+      cancelPendingStarts()
+      cleanup()
+    },
+    []
+  )
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -175,87 +193,128 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       throw new Error(copy.microphoneUnsupported)
     }
 
-    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    const attempt: MicStartAttempt = { cancelled: options.signal?.aborted ?? false }
 
-    if (permitted === false) {
-      throw new Error(copy.microphoneAccessDenied)
+    const cancelAttempt = () => {
+      attempt.cancelled = true
     }
 
-    let stream: MediaStream
+    pendingStartAttemptsRef.current.add(attempt)
+    options.signal?.addEventListener('abort', cancelAttempt, { once: true })
 
     try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: true, noiseSuppression: true }
-      })
-    } catch (error) {
-      throw micError(error, copy)
-    }
-
-    const mimeType =
-      ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus', 'audio/ogg', 'audio/wav'].find(
-        type => MediaRecorder.isTypeSupported(type)
-      ) ?? ''
-
-    let recorder: MediaRecorder
-
-    try {
-      recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
-    } catch (error) {
-      stream.getTracks().forEach(track => track.stop())
-      throw micError(error, copy)
-    }
-
-    chunksRef.current = []
-    streamRef.current = stream
-    recorderRef.current = recorder
-    heardSpeechRef.current = false
-    silenceTriggeredRef.current = false
-    silenceStartedAtRef.current = null
-    startedAtRef.current = Date.now()
-
-    recorder.ondataavailable = event => {
-      if (event.data.size > 0) {
-        chunksRef.current.push(event.data)
+      if (attempt.cancelled) {
+        return
       }
-    }
 
-    recorder.onstop = () => {
-      const chunks = chunksRef.current
-      const recordingType = recorder.mimeType || mimeType || 'audio/webm'
-      const durationMs = Date.now() - startedAtRef.current
-      const heardSpeech = heardSpeechRef.current
+      const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
 
-      chunksRef.current = []
-      cleanup()
+      if (attempt.cancelled) {
+        return
+      }
 
-      const resolver = stopResolverRef.current
-      stopResolverRef.current = null
+      if (permitted === false) {
+        throw new Error(copy.microphoneAccessDenied)
+      }
 
-      if (!chunks.length) {
-        resolver?.(null)
+      let stream: MediaStream
+
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: true, noiseSuppression: true }
+        })
+      } catch (error) {
+        if (attempt.cancelled) {
+          return
+        }
+
+        throw micError(error, copy)
+      }
+
+      // This acquisition belongs only to this start attempt. A cancel/end may
+      // have happened while permission or getUserMedia was pending, and a
+      // newer attempt may already own the recorder by the time this resolves.
+      if (attempt.cancelled || recorderRef.current) {
+        stream.getTracks().forEach(track => track.stop())
 
         return
       }
 
-      resolver?.({
-        audio: new Blob(chunks, { type: recordingType }),
-        durationMs,
-        heardSpeech
-      })
-    }
+      const mimeType =
+        ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus', 'audio/ogg', 'audio/wav'].find(
+          type => MediaRecorder.isTypeSupported(type)
+        ) ?? ''
 
-    recorder.onerror = event => {
-      const error = micError((event as Event & { error?: unknown }).error, copy)
-      const resolver = stopResolverRef.current
-      stopResolverRef.current = null
-      cleanup()
-      options.onError?.(error)
-      resolver?.(null)
-    }
+      let recorder: MediaRecorder
 
-    recorder.start()
-    setRecording(true)
-    startMeter(stream, options)
+      try {
+        recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
+      } catch (error) {
+        stream.getTracks().forEach(track => track.stop())
+        throw micError(error, copy)
+      }
+
+      chunksRef.current = []
+      streamRef.current = stream
+      recorderRef.current = recorder
+      heardSpeechRef.current = false
+      silenceTriggeredRef.current = false
+      silenceStartedAtRef.current = null
+      startedAtRef.current = Date.now()
+
+      recorder.ondataavailable = event => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data)
+        }
+      }
+
+      recorder.onstop = () => {
+        const chunks = chunksRef.current
+        const recordingType = recorder.mimeType || mimeType || 'audio/webm'
+        const durationMs = Date.now() - startedAtRef.current
+        const heardSpeech = heardSpeechRef.current
+
+        chunksRef.current = []
+        cleanup()
+
+        const resolver = stopResolverRef.current
+        stopResolverRef.current = null
+
+        if (!chunks.length) {
+          resolver?.(null)
+
+          return
+        }
+
+        resolver?.({
+          audio: new Blob(chunks, { type: recordingType }),
+          durationMs,
+          heardSpeech
+        })
+      }
+
+      recorder.onerror = event => {
+        const error = micError((event as Event & { error?: unknown }).error, copy)
+        const resolver = stopResolverRef.current
+        stopResolverRef.current = null
+        cleanup()
+        options.onError?.(error)
+        resolver?.(null)
+      }
+
+      try {
+        recorder.start()
+      } catch (error) {
+        cleanup()
+        throw micError(error, copy)
+      }
+
+      setRecording(true)
+      startMeter(stream, options)
+    } finally {
+      pendingStartAttemptsRef.current.delete(attempt)
+      options.signal?.removeEventListener('abort', cancelAttempt)
+    }
   }
 
   const stop: MicRecorderHandle['stop'] = () =>
@@ -274,6 +333,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     })
 
   const cancel: MicRecorderHandle['cancel'] = () => {
+    cancelPendingStarts()
     const recorder = recorderRef.current
     const resolver = stopResolverRef.current
     stopResolverRef.current = null

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BargeMonitorCallbacks } from '@/lib/voice-barge-in'
 
-import type { MicRecording } from './use-mic-recorder'
+import type { MicRecorderOptions, MicRecording } from './use-mic-recorder'
 import { useVoiceConversation } from './use-voice-conversation'
 
 // The full-duplex contract: the barge monitor is live across the WHOLE agent
@@ -41,12 +41,13 @@ vi.mock('@/lib/thinking-sound', () => ({
 
 const micHandle = {
   cancel: vi.fn(),
-  start: vi.fn(async () => undefined),
+  start: vi.fn<(options?: MicRecorderOptions) => Promise<void>>(async () => undefined),
   stop: vi.fn<() => Promise<MicRecording | null>>(async () => null)
 }
 
 vi.mock('./use-mic-recorder', () => ({
-  useMicRecorder: () => ({ handle: micHandle, level: 0, recording: false })
+  // The real hook returns a fresh handle object on every render.
+  useMicRecorder: () => ({ handle: { ...micHandle }, level: 0, recording: false })
 }))
 
 vi.mock('@/i18n', () => ({
@@ -73,6 +74,16 @@ vi.mock('@/store/notifications', () => ({
 
 interface HookProps {
   busy: boolean
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+
+  return { promise, resolve }
 }
 
 function renderConversation(overrides: { onInterrupt?: () => void; transcript?: string } = {}) {
@@ -262,5 +273,407 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     hook.rerender({ busy: true })
 
     expect(monitorCalls.length).toBe(armed)
+  })
+
+  it('ends the conversation after the configured interval without user speech', async () => {
+    vi.useFakeTimers()
+    const onIdleTimeout = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 1_000,
+        onIdleTimeout,
+        onSubmit: vi.fn(),
+        onTranscribeAudio: vi.fn(async () => ''),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+      })
+      expect(hook.result.current.status).toBe('listening')
+
+      await act(async () => {
+        vi.advanceTimersByTime(999)
+      })
+      expect(onIdleTimeout).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(onIdleTimeout).toHaveBeenCalledTimes(1)
+      expect(micHandle.cancel).toHaveBeenCalled()
+      expect(hook.result.current.status).toBe('idle')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('restarts the inactivity interval after transcribed user speech', async () => {
+    vi.useFakeTimers()
+    const onIdleTimeout = vi.fn()
+    const onSubmit = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 1_000,
+        onIdleTimeout,
+        onSubmit,
+        onTranscribeAudio: vi.fn(async () => 'still here'),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+        vi.advanceTimersByTime(600)
+      })
+      micHandle.stop.mockResolvedValueOnce({
+        audio: new Blob(['speech'], { type: 'audio/webm' }),
+        durationMs: 400,
+        heardSpeech: true
+      })
+
+      await act(async () => {
+        hook.result.current.stopTurn()
+        await Promise.resolve()
+      })
+      expect(onSubmit).toHaveBeenCalledWith('still here')
+
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      expect(onIdleTimeout).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(600)
+      })
+      expect(onIdleTimeout).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears the inactivity interval on unmount without later callbacks or resource actions', async () => {
+    vi.useFakeTimers()
+    const onIdleTimeout = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 1_000,
+        onIdleTimeout,
+        onSubmit: vi.fn(),
+        onTranscribeAudio: vi.fn(async () => ''),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+      })
+      hook.unmount()
+      const cancelCallsAfterUnmount = micHandle.cancel.mock.calls.length
+      const playbackStopsAfterUnmount = stopVoicePlayback.mock.calls.length
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_000)
+      })
+
+      expect(onIdleTimeout).not.toHaveBeenCalled()
+      expect(micHandle.cancel).toHaveBeenCalledTimes(cancelCallsAfterUnmount)
+      expect(stopVoicePlayback).toHaveBeenCalledTimes(playbackStopsAfterUnmount)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(['stale-first', 'current-first'] as const)(
+    'scopes overlapping lifecycle microphone starts when they resolve %s',
+    async resolveOrder => {
+      const microphoneA = deferred<undefined>()
+      const microphoneB = deferred<undefined>()
+      const startSignals: AbortSignal[] = []
+      micHandle.start
+        .mockImplementationOnce(options => {
+          startSignals.push(options?.signal as AbortSignal)
+
+          return microphoneA.promise
+        })
+        .mockImplementationOnce(options => {
+          startSignals.push(options?.signal as AbortSignal)
+
+          return microphoneB.promise
+        })
+
+      const hook = renderHook(() =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(),
+          onTranscribeAudio: vi.fn(async () => ''),
+          pendingResponse: () => null
+        })
+      )
+
+      let startA!: Promise<void>
+      let startB!: Promise<void>
+      act(() => {
+        startA = hook.result.current.start()
+      })
+      await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(1))
+
+      await act(async () => hook.result.current.end())
+      act(() => {
+        startB = hook.result.current.start()
+      })
+      await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(2))
+
+      expect(startSignals[0]?.aborted).toBe(true)
+      expect(startSignals[1]?.aborted).toBe(false)
+
+      await act(async () => {
+        if (resolveOrder === 'stale-first') {
+          microphoneA.resolve(undefined)
+          await startA
+          microphoneB.resolve(undefined)
+          await startB
+        } else {
+          microphoneB.resolve(undefined)
+          await startB
+          microphoneA.resolve(undefined)
+          await startA
+        }
+      })
+
+      expect(startSignals[1]?.aborted).toBe(false)
+      expect(hook.result.current.status).toBe('listening')
+    }
+  )
+
+  it('aborts a pending microphone start on unmount', async () => {
+    const microphoneStarted = deferred<undefined>()
+    let startSignal: AbortSignal | undefined
+    micHandle.start.mockImplementationOnce(options => {
+      startSignal = options?.signal
+
+      return microphoneStarted.promise
+    })
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        onSubmit: vi.fn(),
+        onTranscribeAudio: vi.fn(async () => ''),
+        pendingResponse: () => null
+      })
+    )
+
+    let startPromise!: Promise<void>
+    act(() => {
+      startPromise = hook.result.current.start()
+    })
+    await waitFor(() => expect(startSignal).toBeDefined())
+
+    hook.unmount()
+    expect(startSignal?.aborted).toBe(true)
+
+    await act(async () => {
+      microphoneStarted.resolve(undefined)
+      await startPromise
+    })
+  })
+
+  it('expires while microphone startup is pending without reviving listening or arming a stale timer', async () => {
+    vi.useFakeTimers()
+    const microphoneStarted = deferred<undefined>()
+    const onIdleTimeout = vi.fn()
+    micHandle.start.mockImplementationOnce(() => microphoneStarted.promise)
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 1_000,
+        onIdleTimeout,
+        onSubmit: vi.fn(),
+        onTranscribeAudio: vi.fn(async () => ''),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      let startPromise!: Promise<void>
+      act(() => {
+        startPromise = hook.result.current.start()
+      })
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_000)
+      })
+      expect(onIdleTimeout).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        microphoneStarted.resolve(undefined)
+        await startPromise
+      })
+
+      expect(hook.result.current.status).toBe('idle')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores normal transcription that resolves after inactivity expiry', async () => {
+    vi.useFakeTimers()
+    const transcription = deferred<string>()
+    const onIdleTimeout = vi.fn()
+    const onSubmit = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 1_000,
+        onIdleTimeout,
+        onSubmit,
+        onTranscribeAudio: vi.fn(() => transcription.promise),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+      })
+      micHandle.stop.mockResolvedValueOnce({
+        audio: new Blob(['speech'], { type: 'audio/webm' }),
+        durationMs: 400,
+        heardSpeech: true
+      })
+      act(() => hook.result.current.stopTurn())
+      expect(hook.result.current.status).toBe('transcribing')
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_000)
+      })
+      expect(onIdleTimeout).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        transcription.resolve('too late')
+        await transcription.promise
+      })
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(hook.result.current.status).toBe('idle')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores barge-in transcription that resolves after inactivity expiry', async () => {
+    const bargeTranscription = deferred<string>()
+    const onIdleTimeout = vi.fn()
+    const busyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+    const onSubmit = vi.fn(async () => busyChange.current(true))
+    let transcriptions = 0
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          idleTimeoutMs: 200,
+          onIdleTimeout,
+          onSubmit,
+          onTranscribeAudio: vi.fn(() =>
+            transcriptions++ === 0 ? Promise.resolve('start the task') : bargeTranscription.promise
+          ),
+          pendingResponse: () => null
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    busyChange.current = busy => hook.rerender({ busy })
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+      })
+      micHandle.stop.mockResolvedValueOnce({
+        audio: new Blob(['first'], { type: 'audio/webm' }),
+        durationMs: 400,
+        heardSpeech: true
+      })
+      await act(async () => hook.result.current.stopTurn())
+      await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
+
+      const monitor = monitorCalls.at(-1)
+      act(() => monitor?.onSpeech())
+      hook.rerender({ busy: false })
+      act(() => monitor?.onUtterance?.(new Blob(['barge'], { type: 'audio/webm' })))
+      expect(hook.result.current.status).toBe('transcribing')
+
+      await waitFor(() => expect(onIdleTimeout).toHaveBeenCalledTimes(1))
+
+      await act(async () => {
+        bargeTranscription.resolve('too late')
+        await bargeTranscription.promise
+      })
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(hook.result.current.status).toBe('idle')
+      expect(micHandle.start).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not arm the inactivity interval when configured with zero', async () => {
+    vi.useFakeTimers()
+    const onIdleTimeout = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        idleTimeoutMs: 0,
+        onIdleTimeout,
+        onSubmit: vi.fn(),
+        onTranscribeAudio: vi.fn(async () => ''),
+        pendingResponse: () => null
+      })
+    )
+
+    try {
+      await act(async () => {
+        await hook.result.current.start()
+        vi.advanceTimersByTime(60_001)
+      })
+
+      expect(onIdleTimeout).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -155,6 +155,72 @@ describe('useVoiceConversation full-duplex barge-in', () => {
 
   afterEach(cleanup)
 
+  it.each(['stale-first', 'replacement-first'] as const)(
+    'keeps a stale cancelled start inert when unmuting starts its replacement (%s)',
+    async resolveOrder => {
+      const staleStart = deferred<void>()
+      const replacementStart = deferred<void>()
+      const startSignals: AbortSignal[] = []
+
+      micHandle.start
+        .mockImplementationOnce(options => {
+          startSignals.push(options?.signal as AbortSignal)
+
+          return staleStart.promise
+        })
+        .mockImplementationOnce(options => {
+          startSignals.push(options?.signal as AbortSignal)
+
+          return replacementStart.promise
+        })
+
+      const hook = renderHook(() =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(),
+          onTranscribeAudio: vi.fn(async () => ''),
+          pendingResponse: () => null
+        })
+      )
+
+      let starting!: Promise<void>
+
+      act(() => {
+        starting = hook.result.current.start()
+      })
+      await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(1))
+
+      act(() => hook.result.current.toggleMute())
+      expect(hook.result.current).toMatchObject({ muted: true, status: 'idle' })
+      expect(micHandle.cancel).toHaveBeenCalled()
+
+      act(() => hook.result.current.toggleMute())
+      await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(2))
+      expect(startSignals[0]?.aborted).toBe(true)
+      expect(startSignals[1]?.aborted).toBe(false)
+
+      await act(async () => {
+        if (resolveOrder === 'stale-first') {
+          staleStart.resolve()
+          await starting
+          expect(hook.result.current).toMatchObject({ muted: false, status: 'idle' })
+          replacementStart.resolve()
+          await replacementStart.promise
+        } else {
+          replacementStart.resolve()
+          await replacementStart.promise
+          staleStart.resolve()
+          await starting
+        }
+      })
+
+      expect(startSignals[1]?.aborted).toBe(false)
+      await waitFor(() => expect(hook.result.current).toMatchObject({ muted: false, status: 'listening' }))
+    }
+  )
+
   it('arms the barge monitor during generation (before any reply audio exists)', async () => {
     const { hook } = renderConversation()
 
@@ -463,6 +529,42 @@ describe('useVoiceConversation full-duplex barge-in', () => {
       expect(hook.result.current.status).toBe('listening')
     }
   )
+
+  it('releases a microphone acquired after the conversation becomes busy', async () => {
+    const microphoneStarted = deferred<undefined>()
+    micHandle.start.mockImplementationOnce(() => microphoneStarted.promise)
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(),
+          onTranscribeAudio: vi.fn(async () => ''),
+          pendingResponse: () => null
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    let starting!: Promise<void>
+
+    act(() => {
+      starting = hook.result.current.start()
+    })
+    await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(1))
+
+    hook.rerender({ busy: true })
+    const cancelCallsBeforeAcquisition = micHandle.cancel.mock.calls.length
+
+    await act(async () => {
+      microphoneStarted.resolve(undefined)
+      await starting
+    })
+
+    expect(hook.result.current.status).toBe('idle')
+    expect(micHandle.cancel).toHaveBeenCalledTimes(cancelCallsBeforeAcquisition + 1)
+  })
 
   it('aborts a pending microphone start on unmount', async () => {
     const microphoneStarted = deferred<undefined>()

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -27,7 +27,9 @@ interface PendingVoiceResponse {
 interface VoiceConversationOptions {
   busy: boolean
   enabled: boolean
+  idleTimeoutMs?: number
   onFatalError?: () => void
+  onIdleTimeout?: () => void
   /** Interrupt the in-flight agent turn (the same seam as the Stop button).
    *  Fired when the user speaks while the model is still generating. */
   onInterrupt?: () => Promise<void> | void
@@ -48,7 +50,9 @@ const INTERRUPT_SETTLE_TIMEOUT_MS = 5_000
 export function useVoiceConversation({
   busy,
   enabled,
+  idleTimeoutMs = 0,
   onFatalError,
+  onIdleTimeout,
   onInterrupt,
   onStopWord,
   onSubmit,
@@ -62,7 +66,12 @@ export function useVoiceConversation({
   const { handle, level } = useMicRecorder(voiceCopy)
   const [status, setStatus] = useState<ConversationStatus>('idle')
   const [muted, setMuted] = useState(false)
+  const idleTimeoutRef = useRef<number | null>(null)
   const turnTimeoutRef = useRef<number | null>(null)
+  const lifecycleGenerationRef = useRef(0)
+  const conversationActiveRef = useRef(false)
+  const micStartControllersRef = useRef(new Set<AbortController>())
+  const handleRef = useRef(handle)
   const pendingStartRef = useRef(false)
   const turnClosingRef = useRef(false)
   const awaitingSpokenResponseRef = useRef(false)
@@ -80,6 +89,11 @@ export function useVoiceConversation({
   const wasEnabledRef = useRef(enabled)
   const onStopWordRef = useRef(onStopWord)
   const onInterruptRef = useRef(onInterrupt)
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    handleRef.current = handle
+  }, [handle])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -125,6 +139,13 @@ export function useVoiceConversation({
     }
   }
 
+  const clearIdleTimeout = () => {
+    if (idleTimeoutRef.current) {
+      window.clearTimeout(idleTimeoutRef.current)
+      idleTimeoutRef.current = null
+    }
+  }
+
   const dropSpeechSession = () => {
     stopBargeMonitorRef.current?.()
     stopBargeMonitorRef.current = null
@@ -135,8 +156,48 @@ export function useVoiceConversation({
     spokenSourceLengthRef.current = 0
   }
 
+  const end = useCallback(async () => {
+    lifecycleGenerationRef.current += 1
+    conversationActiveRef.current = false
+    pendingStartRef.current = false
+    clearIdleTimeout()
+    clearTurnTimeout()
+    stopVoicePlayback()
+
+    for (const controller of micStartControllersRef.current) {
+      controller.abort()
+    }
+
+    handle.cancel()
+    turnClosingRef.current = false
+    awaitingSpokenResponseRef.current = false
+    dropSpeechSession()
+    consumePendingResponse()
+    setMuted(false)
+    setStatus('idle')
+  }, [consumePendingResponse, handle])
+
+  const armIdleTimeout = useCallback((generation = lifecycleGenerationRef.current) => {
+    clearIdleTimeout()
+
+    if (idleTimeoutMs <= 0) {
+      return
+    }
+
+    idleTimeoutRef.current = window.setTimeout(() => {
+      if (lifecycleGenerationRef.current !== generation) {
+        return
+      }
+
+      void end()
+      onIdleTimeout?.()
+    }, idleTimeoutMs)
+  }, [end, idleTimeoutMs, onIdleTimeout])
+
   const handleTurn = useCallback(
     async (forceTranscribe = false) => {
+      const generation = lifecycleGenerationRef.current
+
       if (turnClosingRef.current) {
         return
       }
@@ -147,6 +208,10 @@ export function useVoiceConversation({
 
       try {
         const result = await handle.stop()
+
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
 
         if (!result || (!result.heardSpeech && !forceTranscribe) || !onTranscribeAudio) {
           if (enabledRef.current && !mutedRef.current && !busyRef.current && statusRef.current !== 'speaking') {
@@ -161,6 +226,10 @@ export function useVoiceConversation({
         try {
           const transcript = (await onTranscribeAudio(result.audio)).trim()
 
+          if (lifecycleGenerationRef.current !== generation) {
+            return
+          }
+
           if (!transcript) {
             if (enabledRef.current) {
               pendingStartRef.current = true
@@ -170,6 +239,8 @@ export function useVoiceConversation({
 
             return
           }
+
+          armIdleTimeout(generation)
 
           // A spoken "stop" (or "never mind", "goodbye", …) ends the
           // conversation instead of being submitted as a turn. Only whole-
@@ -186,8 +257,17 @@ export function useVoiceConversation({
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
           await onSubmit(transcript)
+
+          if (lifecycleGenerationRef.current !== generation) {
+            return
+          }
+
           setStatus('thinking')
         } catch (error) {
+          if (lifecycleGenerationRef.current !== generation) {
+            return
+          }
+
           notifyError(error, voiceCopy.transcriptionFailed)
 
           if (enabledRef.current && !mutedRef.current && !busyRef.current) {
@@ -197,13 +277,16 @@ export function useVoiceConversation({
           setStatus('idle')
         }
       } finally {
-        turnClosingRef.current = false
+        if (lifecycleGenerationRef.current === generation) {
+          turnClosingRef.current = false
+        }
       }
     },
-    [handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
+    [armIdleTimeout, handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
   )
 
   const startListening = useCallback(async () => {
+    const generation = lifecycleGenerationRef.current
     pendingStartRef.current = false
 
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
@@ -227,6 +310,10 @@ export function useVoiceConversation({
       // A pause failure shouldn't block the user's explicit start.
     }
 
+    if (lifecycleGenerationRef.current !== generation) {
+      return
+    }
+
     // enabled/muted/busy or an interleaved turn may have changed while we waited.
     if (!enabledRef.current || mutedRef.current || busyRef.current || statusRef.current !== 'idle') {
       return
@@ -234,17 +321,38 @@ export function useVoiceConversation({
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
-      await handle.start({
-        silenceLevel: 0.075,
-        silenceMs: 1_250,
-        idleSilenceMs: 12_000,
-        onError: error => {
-          notifyError(error, voiceCopy.microphoneFailed)
-          pendingStartRef.current = false
-          onFatalError?.()
-        },
-        onSilence: () => void handleTurn()
-      })
+      const micStartController = new AbortController()
+      micStartControllersRef.current.add(micStartController)
+
+      try {
+        await handle.start({
+          signal: micStartController.signal,
+          silenceLevel: 0.075,
+          silenceMs: 1_250,
+          idleSilenceMs: 12_000,
+          onError: error => {
+            if (lifecycleGenerationRef.current !== generation) {
+              return
+            }
+
+            notifyError(error, voiceCopy.microphoneFailed)
+            pendingStartRef.current = false
+            onFatalError?.()
+          },
+          onSilence: () => {
+            if (lifecycleGenerationRef.current === generation) {
+              void handleTurn()
+            }
+          }
+        })
+      } finally {
+        micStartControllersRef.current.delete(micStartController)
+      }
+
+      if (lifecycleGenerationRef.current !== generation) {
+        return
+      }
+
       setStatus('listening')
       // Clear any prior turn-timeout before arming a fresh one. Each listen
       // cycle reassigns turnTimeoutRef; without clearing first, a stale 60s
@@ -254,6 +362,10 @@ export function useVoiceConversation({
       clearTurnTimeout()
       turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), 60_000)
     } catch (error) {
+      if (lifecycleGenerationRef.current !== generation) {
+        return
+      }
+
       notifyError(error, voiceCopy.couldNotStartSession)
       pendingStartRef.current = false
       setStatus('idle')
@@ -307,7 +419,13 @@ export function useVoiceConversation({
    */
   const submitCapturedUtterance = useCallback(
     async (audio: Blob | null) => {
+      const generation = lifecycleGenerationRef.current
+
       const resumeListening = () => {
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         if (enabledRef.current && !mutedRef.current) {
           pendingStartRef.current = true
         }
@@ -326,11 +444,17 @@ export function useVoiceConversation({
       try {
         const transcript = (await onTranscribeAudio(audio)).trim()
 
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         if (!transcript) {
           resumeListening()
 
           return
         }
+
+        armIdleTimeout(generation)
 
         // A spoken stop command while barging means "stop everything" — the
         // turn/playback was already cut at trip time; now end the conversation
@@ -349,19 +473,36 @@ export function useVoiceConversation({
 
         while (busyRef.current && Date.now() < deadline) {
           await new Promise(resolve => window.setTimeout(resolve, 100))
+
+          if (lifecycleGenerationRef.current !== generation) {
+            return
+          }
+        }
+
+        if (lifecycleGenerationRef.current !== generation) {
+          return
         }
 
         awaitingSpokenResponseRef.current = true
         dropSpeechSession()
         consumePendingResponse()
         await onSubmit(transcript)
+
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         setStatus('thinking')
       } catch (error) {
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         notifyError(error, voiceCopy.transcriptionFailed)
         resumeListening()
       }
     },
-    [consumePendingResponse, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
+    [armIdleTimeout, consumePendingResponse, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
   )
 
   /**
@@ -379,6 +520,8 @@ export function useVoiceConversation({
    * all call this).
    */
   const ensureBargeMonitor = useCallback(() => {
+    const generation = lifecycleGenerationRef.current
+
     if (stopBargeMonitorRef.current) {
       return
     }
@@ -386,6 +529,10 @@ export function useVoiceConversation({
     stopBargeMonitorRef.current = monitorSpeechDuringPlayback({
       isPlaying: () => $voicePlayback.get().status === 'speaking',
       onSpeech: () => {
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         bargeCapturePendingRef.current = true
         bargedRef.current = true
         markVoicePlaybackInterrupted()
@@ -398,6 +545,10 @@ export function useVoiceConversation({
         }
       },
       onUtterance: audio => {
+        if (lifecycleGenerationRef.current !== generation) {
+          return
+        }
+
         bargeCapturePendingRef.current = false
         stopBargeMonitorRef.current = null
         void submitCapturedUtterance(audio)
@@ -573,6 +724,14 @@ export function useVoiceConversation({
   )
 
   const start = useCallback(async () => {
+    if (conversationActiveRef.current) {
+      return
+    }
+
+    const generation = lifecycleGenerationRef.current + 1
+    lifecycleGenerationRef.current = generation
+    conversationActiveRef.current = true
+
     if (!onTranscribeAudio) {
       notify({
         kind: 'warning',
@@ -589,8 +748,14 @@ export function useVoiceConversation({
     dropSpeechSession()
     consumePendingResponse()
     pendingStartRef.current = true
+    armIdleTimeout(generation)
     await startListening()
+
+    if (lifecycleGenerationRef.current !== generation) {
+      return
+    }
   }, [
+    armIdleTimeout,
     consumePendingResponse,
     onFatalError,
     onTranscribeAudio,
@@ -598,19 +763,6 @@ export function useVoiceConversation({
     voiceCopy.configureSpeechToText,
     voiceCopy.unavailable
   ])
-
-  const end = useCallback(async () => {
-    pendingStartRef.current = false
-    clearTurnTimeout()
-    stopVoicePlayback()
-    handle.cancel()
-    turnClosingRef.current = false
-    awaitingSpokenResponseRef.current = false
-    dropSpeechSession()
-    consumePendingResponse()
-    setMuted(false)
-    setStatus('idle')
-  }, [consumePendingResponse, handle])
 
   const stopTurn = useCallback(() => {
     if (statusRef.current === 'listening') {
@@ -731,6 +883,42 @@ export function useVoiceConversation({
 
     wasEnabledRef.current = enabled
   }, [enabled, end, start])
+
+  useEffect(
+    () => () => {
+      lifecycleGenerationRef.current += 1
+      conversationActiveRef.current = false
+      pendingStartRef.current = false
+
+      if (idleTimeoutRef.current) {
+        window.clearTimeout(idleTimeoutRef.current)
+        idleTimeoutRef.current = null
+      }
+
+      if (turnTimeoutRef.current) {
+        window.clearTimeout(turnTimeoutRef.current)
+        turnTimeoutRef.current = null
+      }
+
+      stopVoicePlayback()
+
+      for (const controller of micStartControllersRef.current) {
+        controller.abort()
+      }
+
+      handleRef.current.cancel()
+      turnClosingRef.current = false
+      awaitingSpokenResponseRef.current = false
+      stopBargeMonitorRef.current?.()
+      stopBargeMonitorRef.current = null
+      bargeCapturePendingRef.current = false
+      bargedRef.current = false
+      speechSessionRef.current = null
+      responseIdRef.current = null
+      spokenSourceLengthRef.current = 0
+    },
+    []
+  )
 
   return { end, level, muted, start, status, stopTurn, toggleMute }
 }

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -70,6 +70,7 @@ export function useVoiceConversation({
   const turnTimeoutRef = useRef<number | null>(null)
   const lifecycleGenerationRef = useRef(0)
   const conversationActiveRef = useRef(false)
+  const micStartAttemptRef = useRef(0)
   const micStartControllersRef = useRef(new Set<AbortController>())
   const handleRef = useRef(handle)
   const pendingStartRef = useRef(false)
@@ -173,6 +174,7 @@ export function useVoiceConversation({
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
     consumePendingResponse()
+    mutedRef.current = false
     setMuted(false)
     setStatus('idle')
   }, [consumePendingResponse, handle])
@@ -301,6 +303,17 @@ export function useVoiceConversation({
       return
     }
 
+    const attempt = micStartAttemptRef.current + 1
+    micStartAttemptRef.current = attempt
+
+    for (const controller of micStartControllersRef.current) {
+      controller.abort()
+    }
+
+    // A newer attempt owns microphone startup. Release pending acquisition and
+    // any recorder that an older attempt activated before its continuation ran.
+    handle.cancel()
+
     // Let the wake-word listener fully release the capture device before we
     // open ours — opening the mic while wake still holds it makes getUserMedia
     // fail (the "clicked voice but it never starts listening" bug).
@@ -310,7 +323,7 @@ export function useVoiceConversation({
       // A pause failure shouldn't block the user's explicit start.
     }
 
-    if (lifecycleGenerationRef.current !== generation) {
+    if (lifecycleGenerationRef.current !== generation || micStartAttemptRef.current !== attempt) {
       return
     }
 
@@ -331,7 +344,7 @@ export function useVoiceConversation({
           silenceMs: 1_250,
           idleSilenceMs: 12_000,
           onError: error => {
-            if (lifecycleGenerationRef.current !== generation) {
+            if (lifecycleGenerationRef.current !== generation || micStartAttemptRef.current !== attempt) {
               return
             }
 
@@ -340,7 +353,7 @@ export function useVoiceConversation({
             onFatalError?.()
           },
           onSilence: () => {
-            if (lifecycleGenerationRef.current === generation) {
+            if (lifecycleGenerationRef.current === generation && micStartAttemptRef.current === attempt) {
               void handleTurn()
             }
           }
@@ -349,7 +362,13 @@ export function useVoiceConversation({
         micStartControllersRef.current.delete(micStartController)
       }
 
-      if (lifecycleGenerationRef.current !== generation) {
+      if (lifecycleGenerationRef.current !== generation || micStartAttemptRef.current !== attempt) {
+        return
+      }
+
+      if (!enabledRef.current || mutedRef.current || busyRef.current || statusRef.current !== 'idle') {
+        handle.cancel()
+
         return
       }
 
@@ -362,7 +381,7 @@ export function useVoiceConversation({
       clearTurnTimeout()
       turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), 60_000)
     } catch (error) {
-      if (lifecycleGenerationRef.current !== generation) {
+      if (lifecycleGenerationRef.current !== generation || micStartAttemptRef.current !== attempt) {
         return
       }
 
@@ -743,6 +762,7 @@ export function useVoiceConversation({
       return
     }
 
+    mutedRef.current = false
     setMuted(false)
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
@@ -771,19 +791,24 @@ export function useVoiceConversation({
   }, [handleTurn])
 
   const toggleMute = useCallback(() => {
-    setMuted(value => {
-      const next = !value
+    const next = !mutedRef.current
 
-      if (next) {
-        clearTurnTimeout()
-        handle.cancel()
-        setStatus('idle')
-      } else if (enabledRef.current && !busyRef.current && statusRef.current === 'idle') {
-        pendingStartRef.current = true
+    mutedRef.current = next
+    setMuted(next)
+
+    if (next) {
+      micStartAttemptRef.current += 1
+
+      for (const controller of micStartControllersRef.current) {
+        controller.abort()
       }
 
-      return next
-    })
+      clearTurnTimeout()
+      handle.cancel()
+      setStatus('idle')
+    } else if (enabledRef.current && !busyRef.current && statusRef.current === 'idle') {
+      pendingStartRef.current = true
+    }
   }, [handle])
 
   useEffect(() => {

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -18,6 +18,7 @@ import {
 import {
   applyAutoSpeakFromConfig,
   applyThinkingSoundFromConfig,
+  applyVoiceConversationIdleTimeoutFromConfig,
   applyVoiceStopPhraseFromConfig
 } from '@/store/voice-prefs'
 
@@ -113,6 +114,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         applyAutoSpeakFromConfig(config)
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)
+        applyVoiceConversationIdleTimeoutFromConfig(config)
       } catch {
         // Config is nice-to-have; chat still works without it.
       }

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -747,7 +747,8 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
       'voice.record_key',
-      'voice.max_recording_seconds'
+      'voice.max_recording_seconds',
+      'voice.conversation_idle_timeout_seconds'
     ]
   },
   {

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -5,7 +5,12 @@ vi.mock('@/hermes', () => ({
   saveHermesConfig: vi.fn(async () => undefined)
 }))
 
-import { $voiceStopPhrase, applyVoiceStopPhraseFromConfig } from './voice-prefs'
+import {
+  $voiceConversationIdleTimeoutMs,
+  $voiceStopPhrase,
+  applyVoiceConversationIdleTimeoutFromConfig,
+  applyVoiceStopPhraseFromConfig
+} from './voice-prefs'
 
 describe('applyVoiceStopPhraseFromConfig', () => {
   it('defaults to "stop" when the key is absent (backend default applies)', () => {
@@ -35,4 +40,24 @@ describe('applyVoiceStopPhraseFromConfig', () => {
     applyVoiceStopPhraseFromConfig({ voice: { stop_phrases: ['  ', ''] } })
     expect($voiceStopPhrase.get()).toBeNull()
   })
+})
+
+describe('applyVoiceConversationIdleTimeoutFromConfig', () => {
+  it('converts the configured inactivity limit from seconds to milliseconds', () => {
+    applyVoiceConversationIdleTimeoutFromConfig({ voice: { conversation_idle_timeout_seconds: 600 } })
+    expect($voiceConversationIdleTimeoutMs.get()).toBe(600_000)
+  })
+
+  it.each([undefined, null, {}, { voice: {} }])('uses the backend default when absent (%j)', config => {
+    applyVoiceConversationIdleTimeoutFromConfig(config)
+    expect($voiceConversationIdleTimeoutMs.get()).toBe(600_000)
+  })
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, '30', null])(
+    'uses the backend default for malformed values (%j)',
+    value => {
+      applyVoiceConversationIdleTimeoutFromConfig({ voice: { conversation_idle_timeout_seconds: value } })
+      expect($voiceConversationIdleTimeoutMs.get()).toBe(600_000)
+    }
+  )
 })

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -60,4 +60,12 @@ describe('applyVoiceConversationIdleTimeoutFromConfig', () => {
       expect($voiceConversationIdleTimeoutMs.get()).toBe(600_000)
     }
   )
+
+  it('uses the backend default when the configured delay exceeds the browser timer range', () => {
+    applyVoiceConversationIdleTimeoutFromConfig({
+      voice: { conversation_idle_timeout_seconds: Number.MAX_SAFE_INTEGER }
+    })
+
+    expect($voiceConversationIdleTimeoutMs.get()).toBe(600_000)
+  })
 })

--- a/apps/desktop/src/store/voice-prefs.ts
+++ b/apps/desktop/src/store/voice-prefs.ts
@@ -42,6 +42,7 @@ export function applyVoiceStopPhraseFromConfig(
 export const $thinkingSoundEnabled = atom<boolean>(true)
 
 const DEFAULT_VOICE_CONVERSATION_IDLE_TIMEOUT_SECONDS = 600
+const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647
 
 // Continuous Desktop voice mode closes its microphone after this much time
 // without a successfully transcribed user utterance. Zero disables the limit.
@@ -55,7 +56,7 @@ export function applyVoiceConversationIdleTimeoutFromConfig(
   const raw = config?.voice?.conversation_idle_timeout_seconds
 
   const seconds =
-    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 && raw <= MAX_BROWSER_TIMEOUT_MS / 1_000
       ? raw
       : DEFAULT_VOICE_CONVERSATION_IDLE_TIMEOUT_SECONDS
 

--- a/apps/desktop/src/store/voice-prefs.ts
+++ b/apps/desktop/src/store/voice-prefs.ts
@@ -41,6 +41,27 @@ export function applyVoiceStopPhraseFromConfig(
 // voice conversation (default on, matching the backend default).
 export const $thinkingSoundEnabled = atom<boolean>(true)
 
+const DEFAULT_VOICE_CONVERSATION_IDLE_TIMEOUT_SECONDS = 600
+
+// Continuous Desktop voice mode closes its microphone after this much time
+// without a successfully transcribed user utterance. Zero disables the limit.
+export const $voiceConversationIdleTimeoutMs = atom<number>(
+  DEFAULT_VOICE_CONVERSATION_IDLE_TIMEOUT_SECONDS * 1_000
+)
+
+export function applyVoiceConversationIdleTimeoutFromConfig(
+  config: { voice?: { conversation_idle_timeout_seconds?: unknown } | null } | null | undefined
+) {
+  const raw = config?.voice?.conversation_idle_timeout_seconds
+
+  const seconds =
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0
+      ? raw
+      : DEFAULT_VOICE_CONVERSATION_IDLE_TIMEOUT_SECONDS
+
+  $voiceConversationIdleTimeoutMs.set(seconds * 1_000)
+}
+
 /** Seed the thinking-sound gate from a loaded config payload. */
 export function applyThinkingSoundFromConfig(
   config: { voice?: { thinking_sound?: unknown } | null } | null | undefined

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -346,6 +346,7 @@ export interface HermesConfig {
   }
   voice?: {
     max_recording_seconds?: number
+    conversation_idle_timeout_seconds?: number
     auto_tts?: boolean
     stop_phrases?: unknown
     thinking_sound?: unknown

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1521,6 +1521,7 @@ DEFAULT_CONFIG = {
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
+        "conversation_idle_timeout_seconds": 600,  # Desktop continuous voice: close mic after this many seconds without user speech (0 = disabled)
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "beep_volume": 0.3,           # Beep amplitude multiplier (0.0-1.0, default keeps prior hardcoded value)

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -167,6 +167,7 @@ If you skip that install or it fails, the wizard falls back to Edge TTS.
 voice:
   record_key: "ctrl+b"
   max_recording_seconds: 120
+  conversation_idle_timeout_seconds: 600 # Desktop continuous voice inactivity limit; 0 disables
   auto_tts: false
   beep_enabled: true
   silence_threshold: 200

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1816,6 +1816,7 @@ STT_OPENAI_BASE_URL=https://api.openai.com/v1
 voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
+  conversation_idle_timeout_seconds: 600 # Desktop continuous voice: close mic after no user speech (0 = disabled)
   auto_tts: false               # Enable spoken replies automatically when /voice on
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -411,6 +411,7 @@ DISCORD_ALLOWED_USERS=284102345871466496
 voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
+  conversation_idle_timeout_seconds: 600 # Desktop continuous voice inactivity limit; 0 disables
   auto_tts: false                  # Auto-enable TTS when voice mode starts
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence


### PR DESCRIPTION
## Summary

- add `voice.conversation_idle_timeout_seconds` for Desktop continuous voice, defaulting to 600 seconds; `0` disables the timeout
- reset the deadline only after a successful user transcription, not from microphone activity or assistant playback
- end continuous voice, stop recording and playback, and clear the active voice UI when the deadline expires
- prevent stale microphone acquisitions and `MediaRecorder` callbacks from reopening the session or interfering with a newer recorder
- expose the setting in Desktop Voice settings and document it in the voice guides

## Motivation

Continuous voice can leave the microphone open indefinitely when someone walks away without ending the conversation. This adds a configurable inactivity deadline with a default of 10 minutes.

## Behavior

- stop phrases, VAD, barge-in, rearming, and manual end continue to work as before
- timeout expiry invalidates pending microphone, transcription, barge-in, and submission work
- configured delays beyond the browser's reliable timer range fall back to the 600-second default

## Test plan

- [x] focused microphone, conversation, and preference tests — 40/40 passed
- [x] `npm run check`
- [x] `python3 -m py_compile hermes_cli/config_defaults.py`
- [x] `git diff --check origin/main...HEAD`
- [x] manually tested with a 15-second deadline: completed a successful transcription, remained silent, and confirmed continuous voice closed
