### PR TITLE
fix(desktop): close stdin on execFileSync probes to prevent async EPIPE crash

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7322,7 +7322,15 @@ function effectiveSshConfigFingerprint(sshConfig) {
   }
 
   args.push('--', sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host)
-  const output = execFileSync(ssh, args, { encoding: 'utf8', timeout: 10_000, windowsHide: true })
+  // `-G` dumps config and exits; never reads stdin. Keep stdin closed so an
+  // abruptly-terminated ssh.exe can't surface an async EPIPE on the child
+  // socket (which escapes execFileSync's try/catch and kills the main process).
+  const output = execFileSync(ssh, args, {
+    encoding: 'utf8',
+    timeout: 10_000,
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'ignore']
+  })
 
   return crypto.createHash('sha256').update(output).digest('hex')
 }

--- a/apps/desktop/electron/windows-user-env.ts
+++ b/apps/desktop/electron/windows-user-env.ts
@@ -78,7 +78,10 @@ function readWindowsUserEnvVar(
     stdout = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
       encoding: 'utf8',
       windowsHide: true,
-      timeout: 5000
+      timeout: 5000,
+      // `reg query` never reads stdin; keep the pipe closed so an abrupt
+      // reg.exe exit can't surface an async EPIPE that escapes the try/catch.
+      stdio: ['ignore', 'pipe', 'ignore']
     })
   } catch {
     // `reg` missing, or value absent (reg exits 1) — caller falls back.

--- a/apps/desktop/electron/wsl-path-bridge.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge.test.ts
@@ -1,8 +1,13 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
 
-import { test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
-import { parseDefaultDistro, resolvePickerDefaultPath, wslPosixToWindowsAccessible } from './wsl-path-bridge'
+import { parseDefaultDistro, resolveDefaultWslDistro, resolvePickerDefaultPath, wslPosixToWindowsAccessible } from './wsl-path-bridge'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn()
+}))
 
 test('parseDefaultDistro reads the first distro from clean utf-8 output', () => {
   assert.equal(parseDefaultDistro('Ubuntu\nDebian\n'), 'Ubuntu')
@@ -38,4 +43,28 @@ test('resolvePickerDefaultPath bridges a WSL cwd but passes Windows paths and em
   assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
   assert.equal(resolvePickerDefaultPath('C:\\proj', 'Ubuntu'), 'C:\\proj')
   assert.equal(resolvePickerDefaultPath(undefined, 'Ubuntu'), undefined)
+})
+
+test('resolveDefaultWslDistro spawns wsl.exe with stdin closed (async EPIPE crash guard)', t => {
+  // Regression: wsl-path-bridge crashed the Electron main process with an
+  // uncaught `EPIPE: broken pipe, write` when wsl.exe died abruptly. With the
+  // default stdio, execFileSync opens a stdin pipe; the child's death surfaces
+  // an *asynchronous* EPIPE on that socket that escapes the synchronous
+  // try/catch. `-l -q` never reads stdin, so the pipe must stay closed.
+  vi.mocked(execFileSync).mockReturnValue('Ubuntu\n' as never)
+
+  assert.equal(resolveDefaultWslDistro(), 'Ubuntu')
+
+  if (process.platform !== 'win32') {
+    // Non-Windows short-circuits without spawning — the guard is Windows-only.
+    expect(execFileSync).not.toHaveBeenCalled()
+
+    return
+  }
+
+  expect(execFileSync).toHaveBeenCalledWith(
+    'wsl.exe',
+    ['-l', '-q'],
+    expect.objectContaining({ stdio: ['ignore', 'pipe', 'ignore'] })
+  )
 })

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -51,7 +51,13 @@ export function resolveDefaultWslDistro(): string {
       encoding: 'utf8',
       env: { ...process.env, WSL_UTF8: '1' },
       timeout: 2000,
-      windowsHide: true
+      windowsHide: true,
+      // Do not open a stdin pipe: when wsl.exe dies abruptly (broken WSL
+      // install, service hiccup), writing the stdin close can surface an
+      // asynchronous EPIPE on the child socket that escapes the synchronous
+      // try/catch above and crashes the Electron main process as an
+      // uncaughtException. `-l -q` never reads stdin anyway.
+      stdio: ['ignore', 'pipe', 'ignore']
     })
 
     cachedDistro = parseDefaultDistro(out) || 'Ubuntu'


### PR DESCRIPTION
## Bug

The Hermes Desktop app crashes with an uncaught `EPIPE: broken pipe, write` exception originating from `execFileSync` in the Electron main process. On Windows, this manifests as a spontaneous app relaunch (WS code 1006 → relaunch) when any of the WSL path / SSH config / user-env probe commands die unexpectedly while their stdin pipe is still open.

Stack trace (from `dist/electron-main.mjs`):

```
EPIPE: broken pipe, write
  at execFileSync                       (electron-main.mjs:3382)
  at resolveDefaultWslDistro            (electron-main.mjs:3382)
  at resolveLocalReadPath               (electron-main.mjs:3431)
  at readDirForIpc                      (electron-main.mjs:3498)
```

## Root cause

`child_process.execFileSync` with the default `stdio` (`'pipe'`) opens a **stdin pipe** to the child process. When the child (`wsl.exe`, `ssh.exe`, `reg.exe`) exits abruptly — e.g. WSL distro not running / no default distro, SSH key lookup interrupted, registry query killed — the parent's attempt to close/write the pipe raises `EPIPE`. This error fires **asynchronously after** the synchronous `try/catch` has already returned, so it escapes as an uncaught exception in the Electron main process and takes the whole app down.

## Fix

Close the child's stdin explicitly with `stdio: ['ignore', 'pipe', 'ignore']` on all `execFileSync` probe call sites so a crashing child can never produce an async EPIPE in the parent. Applied to the whole bug class, not just the reported site:

- `apps/desktop/electron/wsl-path-bridge.ts` — `wsl.exe -l -q` (the reported crash site, `resolveDefaultWslDistro`)
- `apps/desktop/electron/main.ts` — `ssh -G` probe
- `apps/desktop/electron/windows-user-env.ts` — `reg query` probe

This matches the existing pattern already used in `wsl-clipboard-image.ts`.

## Verification

- Regression test added: `apps/desktop/electron/wsl-path-bridge.test.ts` — mocks `node:child_process`, asserts the probe is invoked with `stdio: ['ignore', 'pipe', 'ignore']`; cross-platform (no real `wsl.exe` dependency).
- `npx tsc --build tsconfig.electron.json` — pass
- `npx vitest run --project electron` (wsl-path-bridge, fs-read-dir, windows-user-env) — 29 passed, 1 skipped
