### PR TITLE
fix(vision): reject truncated images before embedding

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3648,6 +3648,12 @@ def run_conversation(
                     "does not support multimodal",
                     "does not support vision",
                     "model does not support image",
+                    # OpenAI/Codex rejects corrupt or truncated image bytes
+                    # with this 400. Strip retained image parts so the
+                    # conversation can recover instead of replaying the same
+                    # malformed payload forever. Proactive full-decode
+                    # validation in vision_tools prevents new occurrences.
+                    "does not represent a valid image",
                     # ChatGPT-account Codex backend
                     # (https://chatgpt.com/backend-api/codex) rejects
                     # data:image/...base64 URLs in input_image fields

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -102,6 +102,59 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+_IMAGE_REJECTION_PHRASES = (
+    "only 'text' content type is supported",
+    "only text content type is supported",
+    "image_url is not supported",
+    "image content is not supported",
+    "multimodal is not supported",
+    "multimodal content is not supported",
+    "multimodal input is not supported",
+    "vision is not supported",
+    "vision input is not supported",
+    "does not support images",
+    "does not support image input",
+    "does not support multimodal",
+    "does not support vision",
+    "model does not support image",
+    # OpenAI/Codex rejects corrupt or truncated image bytes with this 400.
+    "does not represent a valid image",
+    # ChatGPT-account Codex rejects data:image/...base64 URLs with a narrow
+    # image_url field-path validation error (issue #23570).
+    "image_url'. expected",
+    # DeepSeek's OpenAI-compatible API reports text-only request variants as:
+    # "unknown variant `image_url`, expected `text`".
+    "unknown variant `image_url`, expected `text`",
+    "unknown variant image_url, expected text",
+    # OpenRouter returns this 404 when no candidate endpoint accepts images
+    # (issue #21160). The 4xx gate in _is_image_rejection_error allows it.
+    "no endpoints found that support image input",
+)
+
+
+def _is_image_rejection_error(api_error: Any) -> bool:
+    """Return whether a provider 4xx says the request's image content was rejected."""
+    try:
+        body = str(
+            getattr(api_error, "body", None)
+            or getattr(api_error, "message", None)
+            or str(api_error)
+        )
+    except Exception:
+        body = ""
+
+    status = getattr(api_error, "status_code", None)
+    if status is not None:
+        try:
+            if not 400 <= int(status) < 500:
+                return False
+        except (TypeError, ValueError):
+            return False
+
+    lower = body.lower()
+    return any(phrase in lower for phrase in _IMAGE_REJECTION_PHRASES)
+
+
 # Scaffold marker used by _apply_active_turn_redirect and the ghost-row filter
 # in the api_messages loop. Module-level so both sites can never drift.
 _INTERRUPT_SCAFFOLD_MARKER = "[This response was interrupted by a user correction.]"
@@ -4477,71 +4530,9 @@ def run_conversation(
                 # will bypass this guard and fall through to the normal
                 # error handler.  Expand the phrase list when new
                 # provider wordings are observed in the wild.
-                _err_body = ""
-                try:
-                    _err_body = str(getattr(api_error, "body", None) or
-                                    getattr(api_error, "message", None) or
-                                    str(api_error))
-                except Exception:
-                    pass
-                _err_status = getattr(api_error, "status_code", None)
-                _IMAGE_REJECTION_PHRASES = (
-                    "only 'text' content type is supported",
-                    "only text content type is supported",
-                    "image_url is not supported",
-                    "image content is not supported",
-                    "multimodal is not supported",
-                    "multimodal content is not supported",
-                    "multimodal input is not supported",
-                    "vision is not supported",
-                    "vision input is not supported",
-                    "does not support images",
-                    "does not support image input",
-                    "does not support multimodal",
-                    "does not support vision",
-                    "model does not support image",
-                    # ChatGPT-account Codex backend
-                    # (https://chatgpt.com/backend-api/codex) rejects
-                    # data:image/...base64 URLs in input_image fields
-                    # with HTTP 400 "Invalid 'input[N].content[K].image_url'.
-                    # Expected a valid URL, but got a value with an
-                    # invalid format." The OpenAI Responses API on the
-                    # public endpoint accepts data URLs, but the
-                    # ChatGPT-account variant does not. Without this
-                    # phrase the agent cascaded into compression /
-                    # context-too-large recovery instead of just
-                    # stripping the images. Match is narrow on
-                    # purpose — keyed on the field-path apostrophe so
-                    # we don't false-trip on other URL validation
-                    # errors. (issue #23570)
-                    "image_url'. expected",
-                    # DeepSeek's OpenAI-compatible API reports text-only
-                    # request-body variants as:
-                    # "unknown variant `image_url`, expected `text`".
-                    "unknown variant `image_url`, expected `text`",
-                    "unknown variant image_url, expected text",
-                    # OpenRouter routes a request to upstream endpoints and,
-                    # when none of the candidate endpoints for the model accept
-                    # image input, returns HTTP 404 "No endpoints found that
-                    # support image input". Without this phrase the agent never
-                    # strips the images, the retry loop re-sends the same
-                    # rejected request until exhaustion, and the gateway leaves
-                    # every subsequent message queued behind the stuck turn —
-                    # the P1 in issue #21160. The 404 passes the 4xx gate below.
-                    "no endpoints found that support image input",
-                )
-                _err_lower = _err_body.lower()
-                _looks_like_image_rejection = any(
-                    p in _err_lower for p in _IMAGE_REJECTION_PHRASES
-                )
-                # 4xx-only gate: never interpret 5xx/timeout as "server
-                # said no to images" — those are transient and must
-                # route to the normal retry path.
-                _status_ok = _err_status is None or (400 <= int(_err_status) < 500)
                 if (
                     getattr(agent, "_vision_supported", True)
-                    and _looks_like_image_rejection
-                    and _status_ok
+                    and _is_image_rejection_error(api_error)
                 ):
                     agent._vision_supported = False
                     _imgs_removed = _strip_images_from_messages(messages)

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -137,6 +137,7 @@ class TestImageRejectionPhraseIsolation:
         "does not support multimodal",
         "does not support vision",
         "model does not support image",
+        "does not represent a valid image",
         "image_url'. expected",
         "no endpoints found that support image input",
     )
@@ -144,6 +145,10 @@ class TestImageRejectionPhraseIsolation:
     def _matches(self, body: str) -> bool:
         low = body.lower()
         return any(p in low for p in self._REJECTION_PHRASES)
+
+    def test_openai_malformed_image_trips_recovery(self):
+        body = "The image data you provided does not represent a valid image."
+        assert self._matches(body) is True
 
     def test_anthropic_image_too_large_does_not_trip(self):
         # From agent/error_classifier.py _IMAGE_TOO_LARGE_PATTERNS —

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -6,6 +6,9 @@ verify that stripping preserves the role-alternation invariants providers
 require, and that the phrase detector fires on the expected error bodies.
 """
 
+from types import SimpleNamespace
+
+from agent.conversation_loop import _is_image_rejection_error
 from run_agent import _strip_images_from_messages
 
 
@@ -116,34 +119,20 @@ class TestStripImagesPreservesAlternation:
 
 
 class TestImageRejectionPhraseIsolation:
-    """The image-rejection phrase list must NOT false-match on other
-    image-related error categories (size-too-large, format errors, etc.)
-    so they route to the correct recovery handler (e.g. _try_shrink_image_parts).
-    """
+    """Exercise the production matcher without false-matching other categories."""
 
-    # Reproduces the phrase list used in run_agent.py's error-handler block.
-    _REJECTION_PHRASES = (
-        "only 'text' content type is supported",
-        "only text content type is supported",
-        "image_url is not supported",
-        "image content is not supported",
-        "multimodal is not supported",
-        "multimodal content is not supported",
-        "multimodal input is not supported",
-        "vision is not supported",
-        "vision input is not supported",
-        "does not support images",
-        "does not support image input",
-        "does not support multimodal",
-        "does not support vision",
-        "model does not support image",
-        "image_url'. expected",
-        "no endpoints found that support image input",
-    )
+    @staticmethod
+    def _matches(body: str, status_code: int | None = 400) -> bool:
+        error = SimpleNamespace(body=body, status_code=status_code)
+        return _is_image_rejection_error(error)
 
-    def _matches(self, body: str) -> bool:
-        low = body.lower()
-        return any(p in low for p in self._REJECTION_PHRASES)
+    def test_openai_malformed_image_trips_production_recovery_matcher(self):
+        body = "The image data you provided does not represent a valid image."
+        assert self._matches(body) is True
+
+    def test_openai_malformed_image_5xx_stays_on_transient_error_path(self):
+        body = "The image data you provided does not represent a valid image."
+        assert self._matches(body, status_code=503) is False
 
     def test_anthropic_image_too_large_does_not_trip(self):
         # From agent/error_classifier.py _IMAGE_TOO_LARGE_PATTERNS —

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from io import BytesIO
 from unittest.mock import patch
 
 
@@ -26,6 +27,47 @@ from tools.vision_tools import (
 _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
+
+
+def _animated_gif_bytes(colors, *, size=(4, 4)):
+    from PIL import Image
+
+    frames = [Image.new("RGB", size, color) for color in colors]
+    encoded = BytesIO()
+    frames[0].save(
+        encoded,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=100,
+        loop=0,
+    )
+    return encoded.getvalue()
+
+
+def _track_validated_frame_loads(monkeypatch):
+    from PIL import ImageSequence
+
+    loaded_frames = []
+    real_iterator = ImageSequence.Iterator
+
+    class TrackedFrame:
+        def __init__(self, frame, frame_number):
+            self.frame = frame
+            self.frame_number = frame_number
+            self.width = frame.width
+            self.height = frame.height
+
+        def load(self):
+            loaded_frames.append(self.frame_number)
+            return self.frame.load()
+
+    def tracking_iterator(image):
+        for frame_number, frame in enumerate(real_iterator(image), start=1):
+            yield TrackedFrame(frame, frame_number)
+
+    monkeypatch.setattr(ImageSequence, "Iterator", tracking_iterator)
+    return loaded_frames
 
 
 # ─── _supports_media_in_tool_results ─────────────────────────────────────────
@@ -94,6 +136,121 @@ class TestVisionAnalyzeNative:
         url = next(p["image_url"]["url"] for p in parts if p.get("type") == "image_url")
         assert url.startswith("data:image/")
 
+    def test_truncated_supported_image_is_rejected_before_embedding(self, tmp_path):
+        """A valid header must not let partially downloaded bytes poison history."""
+        pytest = __import__("pytest")
+        Image = pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        truncated = tmp_path / "truncated.png"
+        truncated.write_bytes(_TINY_PNG[:-22])
+
+        # This is the production failure shape: header parsing succeeds, but a
+        # complete decode fails after the partial download is read.
+        with Image.open(truncated) as image:
+            assert image.format == "PNG"
+            with pytest.raises(OSError, match="truncated"):
+                image.load()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(truncated), "describe")
+        )
+
+        assert isinstance(result, str), "corrupt image must not return a multimodal envelope"
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "decode" in payload["error"].lower()
+
+    def test_truncated_animated_gif_frame_is_rejected_before_embedding(
+        self, tmp_path, monkeypatch
+    ):
+        """Every frame must decode before an animated raster enters history."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+        from PIL import Image, ImageSequence
+
+        truncated = tmp_path / "truncated.gif"
+        truncated.write_bytes(_animated_gif_bytes(["red", "blue"])[:-3])
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_FRAME_COUNT", 2
+        )
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_AGGREGATE_PIXELS", 32
+        )
+
+        with Image.open(truncated) as image:
+            assert image.format == "GIF"
+            assert getattr(image, "n_frames", 1) == 2
+            with pytest.raises(OSError, match="truncated"):
+                for frame in ImageSequence.Iterator(image):
+                    frame.load()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(truncated), "describe")
+        )
+
+        assert isinstance(result, str), "corrupt animation must not return a multimodal envelope"
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "decode" in payload["error"].lower()
+
+    def test_animation_over_frame_validation_limit_is_rejected(
+        self, tmp_path, monkeypatch
+    ):
+        """A small animation is rejected before an excess frame is decoded."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        animation = tmp_path / "too-many-frames.gif"
+        animation.write_bytes(_animated_gif_bytes(["red", "green", "blue"]))
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_FRAME_COUNT", 2
+        )
+        loaded_frames = _track_validated_frame_loads(monkeypatch)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(animation), "describe")
+        )
+
+        assert isinstance(result, str)
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "frame 3" in payload["error"].lower()
+        assert "maximum 2" in payload["error"].lower()
+        assert loaded_frames == [1, 2]
+
+    def test_animation_over_aggregate_pixel_validation_limit_is_rejected(
+        self, tmp_path, monkeypatch
+    ):
+        """Aggregate decoded pixels are bounded independently of file size."""
+        pytest = __import__("pytest")
+        pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        animation = tmp_path / "too-many-pixels.gif"
+        animation.write_bytes(_animated_gif_bytes(["red", "blue"]))
+        monkeypatch.setattr(
+            "tools.vision_tools._VISION_MAX_VALIDATED_AGGREGATE_PIXELS", 31
+        )
+        loaded_frames = _track_validated_frame_loads(monkeypatch)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(animation), "describe")
+        )
+
+        assert isinstance(result, str)
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "aggregate decoded pixel" in payload["error"].lower()
+        assert "32" in payload["error"]
+        assert "maximum 31" in payload["error"].lower()
+        assert loaded_frames == [1]
 
     def test_file_url_scheme_resolves(self, tmp_path):
         img = tmp_path / "t.png"

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -94,6 +94,31 @@ class TestVisionAnalyzeNative:
         url = next(p["image_url"]["url"] for p in parts if p.get("type") == "image_url")
         assert url.startswith("data:image/")
 
+    def test_truncated_supported_image_is_rejected_before_embedding(self, tmp_path):
+        """A valid header must not let partially downloaded bytes poison history."""
+        pytest = __import__("pytest")
+        Image = pytest.importorskip(
+            "PIL.Image", reason="Pillow is required for full raster decode validation"
+        )
+
+        truncated = tmp_path / "truncated.png"
+        truncated.write_bytes(_TINY_PNG[:-22])
+
+        # This is the production failure shape: header parsing succeeds, but a
+        # complete decode fails after the partial download is read.
+        with Image.open(truncated) as image:
+            assert image.format == "PNG"
+            with pytest.raises(OSError, match="truncated"):
+                image.load()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(truncated), "describe")
+        )
+
+        assert isinstance(result, str), "corrupt image must not return a multimodal envelope"
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "decode" in payload["error"].lower()
 
     def test_file_url_scheme_resolves(self, tmp_path):
         img = tmp_path / "t.png"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -379,6 +379,30 @@ def _normalize_to_supported_image(
     )
 
 
+def _validate_raster_image_decodable(image_path: Path) -> Optional[str]:
+    """Return an error when Pillow cannot completely decode every image frame.
+
+    Magic-byte MIME sniffing and ``Image.open`` only inspect container headers.
+    A timed-out download can therefore look like a supported PNG/JPEG/GIF/WebP
+    while its pixel stream is truncated. Native vision results are retained in
+    conversation history, so embedding those bytes poisons every later provider
+    request. Verify structure, then reopen and force every frame to decode before
+    the image can enter history.
+    """
+    try:
+        from PIL import Image as _PILImage
+        from PIL import ImageSequence as _PILImageSequence
+
+        with _PILImage.open(image_path) as image:
+            image.verify()
+        with _PILImage.open(image_path) as image:
+            for frame in _PILImageSequence.Iterator(image):
+                frame.load()
+    except Exception as exc:
+        return f"Image could not be fully decoded: {exc}"
+    return None
+
+
 def _is_retryable_download_error(error: Exception) -> bool:
     """Return True only for transient image-download failures worth retrying.
 
@@ -1025,6 +1049,12 @@ async def _vision_analyze_native(
             temp_image_path = normalized_path
             should_cleanup = True
             image_size_bytes = temp_image_path.stat().st_size
+
+        decode_error = await _run_encode_on_cpu_executor(
+            _validate_raster_image_decodable, temp_image_path,
+        )
+        if decode_error:
+            return tool_error(decode_error, success=False)
 
         image_data_url = await _run_encode_on_cpu_executor(
             _image_to_base64_data_url,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -379,6 +379,62 @@ def _normalize_to_supported_image(
     )
 
 
+# Full raster validation runs on untrusted images in a shared CPU executor.
+# Bound animated-image work by both iteration count and total decoded area so a
+# compact file cannot monopolize a worker with an effectively unbounded number
+# of frames. Images at or below both limits still have every frame decoded.
+_VISION_MAX_VALIDATED_FRAME_COUNT = 100
+_VISION_MAX_VALIDATED_AGGREGATE_PIXELS = 100_000_000
+
+
+def _validate_raster_image_decodable(image_path: Path) -> Optional[str]:
+    """Return an error when Pillow cannot completely decode every image frame.
+
+    Magic-byte MIME sniffing and ``Image.open`` only inspect container headers.
+    A timed-out download can therefore look like a supported PNG/JPEG/GIF/WebP
+    while its pixel stream is truncated. Native vision results are retained in
+    conversation history, so embedding those bytes poisons every later provider
+    request. Verify structure, then reopen and force every frame within the
+    validation resource limits to decode before the image can enter history.
+    """
+    try:
+        from PIL import Image as _PILImage
+        from PIL import ImageSequence as _PILImageSequence
+
+        with _PILImage.open(image_path) as image:
+            image.verify()
+        with _PILImage.open(image_path) as image:
+            validated_pixels = 0
+            for frame_number, frame in enumerate(
+                _PILImageSequence.Iterator(image), start=1
+            ):
+                if frame_number > _VISION_MAX_VALIDATED_FRAME_COUNT:
+                    return (
+                        "Image validation rejected animation: "
+                        f"frame {frame_number} exceeds the maximum "
+                        f"{_VISION_MAX_VALIDATED_FRAME_COUNT} validated frames."
+                    )
+
+                frame_pixels = frame.width * frame.height
+                next_validated_pixels = validated_pixels + frame_pixels
+                if (
+                    next_validated_pixels
+                    > _VISION_MAX_VALIDATED_AGGREGATE_PIXELS
+                ):
+                    return (
+                        "Image validation rejected animation: aggregate decoded "
+                        f"pixel count would reach {next_validated_pixels} at frame "
+                        f"{frame_number}, exceeding the maximum "
+                        f"{_VISION_MAX_VALIDATED_AGGREGATE_PIXELS}."
+                    )
+
+                frame.load()
+                validated_pixels = next_validated_pixels
+    except Exception as exc:
+        return f"Image could not be fully decoded: {exc}"
+    return None
+
+
 def _is_retryable_download_error(error: Exception) -> bool:
     """Return True only for transient image-download failures worth retrying.
 
@@ -1212,6 +1268,12 @@ async def _vision_analyze_native(
             temp_image_path = normalized_path
             should_cleanup = True
             image_size_bytes = temp_image_path.stat().st_size
+
+        decode_error = await _run_encode_on_cpu_executor(
+            _validate_raster_image_decodable, temp_image_path,
+        )
+        if decode_error:
+            return tool_error(decode_error, success=False)
 
         # Optional region zoom: crop BEFORE the downscale/embed-cap pipeline
         # so the cropped area gets the full resolution budget.


### PR DESCRIPTION
## Summary

- fully decode supported raster images before native `vision_analyze` embeds them into retained tool-result history
- reject truncated or corrupt PNG, JPEG, GIF, and WebP data with a normal tool error
- bound animated-image validation to 100 frames and 100,000,000 aggregate decoded pixels before loading excess work
- recognize OpenAI/Codex's malformed-image 4xx through the production image-rejection matcher so existing image-stripping recovery can unblock poisoned sessions
- cover truncated PNG ingestion, animated GIF frame iteration, validation resource limits, the production recovery matcher, and its 4xx-only gate

## Root cause

Hermes validated image magic bytes and dimensions but did not force a full raster decode before building a native multimodal tool result. A timed-out download could therefore leave a valid raster header plus truncated pixel data. The incomplete bytes were embedded into conversation history, OpenAI Codex returned `The image data you provided does not represent a valid image`, and every later turn replayed the same invalid image.

The validation runs on the existing bounded vision CPU executor. It verifies the container, reopens the image, and loads every frame within explicit frame-count and aggregate-pixel limits so header-only success cannot admit a partial download without letting a compact animation monopolize the shared executor.

## Review follow-up

- extracted the production 4xx image-rejection matcher and made the regression test call that helper instead of a test-local phrase copy
- added a truncated two-frame GIF regression to exercise `ImageSequence.Iterator`
- added frame-count and aggregate-pixel guards plus tests proving the first excess frame is rejected before `frame.load()`
- rebased the PR onto current `main` after the upstream history rewrite

## Tests

- `scripts/run_tests.sh tests/run_agent/test_image_rejection_fallback.py tests/tools/test_vision_native_fast_path.py -q` — 23 passed
- related vision regression suite (`test_vision_tools`, scale disclosure, region, tool messages, gateway preprocessing) — 63 passed
- `.venv/bin/ruff check tools/vision_tools.py agent/conversation_loop.py tests/tools/test_vision_native_fast_path.py tests/run_agent/test_image_rejection_fallback.py` — passed
- `.venv/bin/python scripts/check-windows-footguns.py --diff origin/main` — passed
- `git diff --check origin/main` — passed
- `.venv/bin/ty check ...` — existing diagnostics remain on untouched lines; no diagnostic points to the added matcher, decoder, bounds, or regressions

Closes #76884.
