### PR TITLE
chore: contributor email mapping for aider4ryder

### DIFF
--- a/contributors/emails/RyderFreeman4Logos@gmail.com
+++ b/contributors/emails/RyderFreeman4Logos@gmail.com
@@ -1,0 +1,1 @@
+aider4ryder


### PR DESCRIPTION
Maps RyderFreeman4Logos@gmail.com -> aider4ryder for release attribution. Needed by the #66355 salvage.