### PR TITLE
fix(gateway): keep managed Node service PATH stable

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2781,14 +2781,20 @@ def _append_node_dir_for_service(
     """
     from hermes_constants import iter_hermes_node_dirs
 
+    managed_node_found = False
     for directory in iter_hermes_node_dirs(hermes_root):
         entry = str(directory)
         try:
             present = directory.is_dir()
         except OSError:
             present = False
-        if present and entry not in path_entries:
-            path_entries.append(entry)
+        if present:
+            managed_node_found = True
+            if entry not in path_entries:
+                path_entries.append(entry)
+
+    if managed_node_found:
+        return
 
     resolved_node = shutil.which("node")
     if not resolved_node:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -214,6 +214,38 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in unit
         assert str(profile_node_bin) not in unit
 
+    def test_managed_node_makes_unit_independent_of_shell_path(self, tmp_path, monkeypatch):
+        import hermes_constants
+
+        hermes_home = tmp_path / ".hermes"
+        managed_node_bin = hermes_home / "node" / "bin"
+        managed_node_bin.mkdir(parents=True)
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            hermes_constants,
+            "iter_hermes_node_dirs",
+            lambda hermes_root=None: (managed_node_bin,),
+        )
+
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda command: "/opt/node-from-install/bin/node" if command == "node" else None,
+        )
+        installed_unit = gateway_cli.generate_systemd_unit(system=False)
+
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda command: "/opt/node-from-restart/bin/node" if command == "node" else None,
+        )
+        restarted_unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert installed_unit == restarted_unit
+        assert str(managed_node_bin) in installed_unit
+        assert "/opt/node-from-" not in installed_unit
+
     def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Same #48700 regression for the macOS twin generate_launchd_plist().
         local_bin = tmp_path / ".local" / "bin"
@@ -1755,4 +1787,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-


### PR DESCRIPTION
## Summary

- stop consulting the invoking shell's `PATH` after a Hermes-managed Node directory has been found
- preserve `shutil.which("node")` as the fallback for installs without managed Node
- add a regression test proving that service generation is stable across different shell-level Node resolutions

## Root cause

`_append_node_dir_for_service()` documented `shutil.which("node")` as a fallback, but called it even after adding an existing managed Node directory. As a result, the generated systemd unit also captured whichever Node directory happened to win in the current process environment.

The install and restart paths can resolve that fallback differently. On a live Linux user service this made the unit alternate between two `PATH` definitions: `hermes gateway restart` rewrote the unit, then `hermes gateway status` immediately reported it as outdated again.

Returning once a managed Node directory is found makes the generated definition deterministic while retaining the existing fallback behavior for unmanaged installs. The shared helper also keeps launchd generation on the same rule.

## Validation

- `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k 'node and (unit or plist)' -q` — 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service_paths.py tests/test_managed_runtime_resolution.py -q` — 9 passed
- full `test_gateway_service.py` run: 70 passed; the remaining pre-existing failure is `test_systemd_restart_gracefully_restarts_running_service_and_waits`, which invokes Linux user-systemd preflight on macOS before reaching this change